### PR TITLE
Added back pressure

### DIFF
--- a/gravitee-gateway-http-client/gravitee-gateway-http-client-vertx/src/main/java/io/gravitee/gateway/http/vertx/VertxProxyConnection.java
+++ b/gravitee-gateway-http-client/gravitee-gateway-http-client-vertx/src/main/java/io/gravitee/gateway/http/vertx/VertxProxyConnection.java
@@ -21,6 +21,7 @@ import io.gravitee.gateway.api.handler.Handler;
 import io.gravitee.gateway.api.proxy.ProxyConnection;
 import io.gravitee.gateway.api.proxy.ProxyRequest;
 import io.gravitee.gateway.api.proxy.ProxyResponse;
+import io.gravitee.gateway.api.stream.WriteStream;
 import io.vertx.core.http.HttpClientRequest;
 
 import java.util.List;
@@ -102,6 +103,17 @@ class VertxProxyConnection implements ProxyConnection {
         httpClientRequest.write(io.vertx.core.buffer.Buffer.buffer(chunk.getBytes()));
 
         return this;
+    }
+
+    @Override
+    public WriteStream<Buffer> drainHandler(Handler<Void> drainHandler) {
+        httpClientRequest.drainHandler(aVoid -> drainHandler.handle(null));
+        return this;
+    }
+
+    @Override
+    public boolean writeQueueFull() {
+        return httpClientRequest.writeQueueFull();
     }
 
     private void writeHeaders() {

--- a/gravitee-gateway-standalone/gravitee-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxHttpServerResponse.java
+++ b/gravitee-gateway-standalone/gravitee-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxHttpServerResponse.java
@@ -36,7 +36,6 @@ class VertxHttpServerResponse implements Response {
 
     VertxHttpServerResponse(HttpServerResponse httpServerResponse) {
         this.httpServerResponse = httpServerResponse;
-        httpServerResponse.setWriteQueueMaxSize(16384);
     }
 
     @Override


### PR DESCRIPTION
The WriteStream control flow operation are delegated to the underlying vertx stream.
The ApiReactorHandler code has now a pump behaviour between the proxy connection and the client response, assuming that the policy chain does not have internal asynchronicity.
(I will remove the sysouts in a subsequent push after some more tests).