### PR TITLE
fix: use jks as default keystore type if not specified

### DIFF
--- a/gravitee-gateway-standalone/gravitee-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxHttpServerConfiguration.java
+++ b/gravitee-gateway-standalone/gravitee-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxHttpServerConfiguration.java
@@ -58,7 +58,7 @@ public class VertxHttpServerConfiguration implements InitializingBean {
 
     private ClientAuthMode clientAuth;
 
-    @Value("${http.ssl.keystore.type:#{null}}")
+    @Value("${http.ssl.keystore.type:jks}")
     private String keyStoreType;
 
     @Value("${http.ssl.keystore.path:#{null}}")
@@ -69,7 +69,7 @@ public class VertxHttpServerConfiguration implements InitializingBean {
     @Value("${http.ssl.keystore.password:#{null}}")
     private String keyStorePassword;
 
-    @Value("${http.ssl.truststore.type:#{null}}")
+    @Value("${http.ssl.truststore.type:jks}")
     private String trustStoreType;
 
     private List<String> trustStorePaths;

--- a/gravitee-gateway-standalone/gravitee-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxHttpServerFactory.java
+++ b/gravitee-gateway-standalone/gravitee-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxHttpServerFactory.java
@@ -92,32 +92,28 @@ public class VertxHttpServerFactory implements FactoryBean<HttpServer> {
             }
 
             if (httpServerConfiguration.getTrustStorePaths() != null && !httpServerConfiguration.getTrustStorePaths().isEmpty()) {
-                if (
-                    httpServerConfiguration.getTrustStoreType() == null ||
-                    httpServerConfiguration.getTrustStoreType().isEmpty() ||
-                    httpServerConfiguration.getTrustStoreType().equalsIgnoreCase(CERTIFICATE_FORMAT_JKS)
-                ) {
+                if (CERTIFICATE_FORMAT_JKS.equalsIgnoreCase(httpServerConfiguration.getTrustStoreType())) {
                     options.setTrustStoreOptions(
                         new JksOptions()
                             .setPath(httpServerConfiguration.getTrustStorePaths().get(0))
                             .setPassword(httpServerConfiguration.getTrustStorePassword())
                     );
-                } else if (httpServerConfiguration.getTrustStoreType().equalsIgnoreCase(CERTIFICATE_FORMAT_PEM)) {
+                } else if (CERTIFICATE_FORMAT_PEM.equalsIgnoreCase(httpServerConfiguration.getTrustStoreType())) {
                     final PemTrustOptions pemTrustOptions = new PemTrustOptions();
                     httpServerConfiguration.getTrustStorePaths().forEach(pemTrustOptions::addCertPath);
                     options.setPemTrustOptions(pemTrustOptions);
-                } else if (httpServerConfiguration.getTrustStoreType().equalsIgnoreCase(CERTIFICATE_FORMAT_PKCS12)) {
+                } else if (CERTIFICATE_FORMAT_PKCS12.equalsIgnoreCase(httpServerConfiguration.getTrustStoreType())) {
                     options.setPfxTrustOptions(
                         new PfxOptions()
                             .setPath(httpServerConfiguration.getTrustStorePaths().get(0))
                             .setPassword(httpServerConfiguration.getTrustStorePassword())
                     );
-                } else if (httpServerConfiguration.getTrustStoreType().equalsIgnoreCase(CERTIFICATE_FORMAT_SELF_SIGNED)) {
+                } else if (CERTIFICATE_FORMAT_SELF_SIGNED.equalsIgnoreCase(httpServerConfiguration.getTrustStoreType())) {
                     options.setPemTrustOptions(SelfSignedCertificate.create().trustOptions());
                 }
             }
 
-            if (httpServerConfiguration.getKeyStoreType().equalsIgnoreCase(CERTIFICATE_FORMAT_JKS)) {
+            if (CERTIFICATE_FORMAT_JKS.equalsIgnoreCase(httpServerConfiguration.getKeyStoreType())) {
                 if (httpServerConfiguration.getKeyStorePath() == null || httpServerConfiguration.getKeyStorePath().isEmpty()) {
                     logger.error("A JKS Keystore is missing. Skipping SSL keystore configuration...");
                 } else {
@@ -127,7 +123,7 @@ public class VertxHttpServerFactory implements FactoryBean<HttpServer> {
                             .setPassword(httpServerConfiguration.getKeyStorePassword())
                     );
                 }
-            } else if (httpServerConfiguration.getKeyStoreType().equalsIgnoreCase(CERTIFICATE_FORMAT_PEM)) {
+            } else if (CERTIFICATE_FORMAT_PEM.equalsIgnoreCase(httpServerConfiguration.getKeyStoreType())) {
                 if (
                     httpServerConfiguration.getKeyStoreCertificates() == null || httpServerConfiguration.getKeyStoreCertificates().isEmpty()
                 ) {
@@ -144,7 +140,7 @@ public class VertxHttpServerFactory implements FactoryBean<HttpServer> {
 
                     options.setPemKeyCertOptions(pemKeyCertOptions);
                 }
-            } else if (httpServerConfiguration.getKeyStoreType().equalsIgnoreCase(CERTIFICATE_FORMAT_PKCS12)) {
+            } else if (CERTIFICATE_FORMAT_PKCS12.equalsIgnoreCase(httpServerConfiguration.getKeyStoreType())) {
                 if (httpServerConfiguration.getKeyStorePath() == null || httpServerConfiguration.getKeyStorePath().isEmpty()) {
                     logger.error("A PKCS#12 Keystore is missing. Skipping SSL keystore configuration...");
                 } else {
@@ -154,7 +150,7 @@ public class VertxHttpServerFactory implements FactoryBean<HttpServer> {
                             .setPassword(httpServerConfiguration.getKeyStorePassword())
                     );
                 }
-            } else if (httpServerConfiguration.getKeyStoreType().equalsIgnoreCase(CERTIFICATE_FORMAT_SELF_SIGNED)) {
+            } else if (CERTIFICATE_FORMAT_SELF_SIGNED.equalsIgnoreCase(httpServerConfiguration.getKeyStoreType())) {
                 options.setPemKeyCertOptions(SelfSignedCertificate.create().keyCertOptions());
             }
         }


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6232

- default trustore type stays JKS, but default value is handled in configuration instead of code
- default keystore type value is JKS, according to 3.5 behavior