### PR TITLE
fix: resolve nginx quick setup

### DIFF
--- a/docker/quick-setup/nginx/README.md
+++ b/docker/quick-setup/nginx/README.md
@@ -7,8 +7,8 @@ You can now access your component like this:
 | Component      	| URL                      	            |
 |----------------	|--------------------------	            |
 | Gateway        	| http://localhost/gateway/ 	        |
-| Management API 	| http://localhost/management-api/      |
-| Portal API 	    | http://localhost/portal-api/          |
+| Management API 	| http://localhost/console/api/      |
+| Portal API 	    | http://localhost/portal/api/          |
 | Console UI 	    | http://localhost/console/             |
 | Portal UI 	    | http://localhost/portal/              |
 |                	|                          	            |

--- a/docker/quick-setup/nginx/conf/nginx.conf
+++ b/docker/quick-setup/nginx/conf/nginx.conf
@@ -36,14 +36,8 @@ http {
                 proxy_pass http://apim-gateway/;
             }
 
-            location /management-api/ {
+            location /console/api/ {
                 proxy_pass http://apim-management-api/management/;
-                proxy_cookie_path /management /management-api;
-            }
-
-            location /portal-api/ {
-                proxy_pass http://apim-management-api/portal/;
-                proxy_cookie_path /portal /portal-api;
             }
 
             location /console/ {
@@ -51,7 +45,11 @@ http {
                 sub_filter '<base href="/"' '<base href="/console/"';
             }
 
-            location /portal/ {
+            location /portal/api/ {
+                proxy_pass http://apim-management-api/portal/;
+            }
+
+            location /portal {
                 proxy_pass http://apim-portal-dev/;
                 sub_filter '<base href="/"' '<base href="/portal/"';
             }

--- a/docker/quick-setup/nginx/docker-compose.yml
+++ b/docker/quick-setup/nginx/docker-compose.yml
@@ -77,8 +77,6 @@ services:
     image: graviteeio/apim-gateway:${APIM_VERSION:-nightly}
     container_name: gio_apim_gateway
     restart: always
-    ports:
-      - "8082:8082"
     depends_on:
       - mongodb
       - elasticsearch
@@ -96,8 +94,6 @@ services:
     image: graviteeio/apim-management-api:${APIM_VERSION:-nightly}
     container_name: gio_apim_management_api
     restart: always
-    ports:
-      - "8083:8083"
     links:
       - mongodb
       - elasticsearch
@@ -110,7 +106,7 @@ services:
       - gravitee_management_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
       - gravitee_analytics_elasticsearch_endpoints_0=http://elasticsearch:9200
       - console_ui_url=http://localhost/console
-      - console_api_url=http://localhost/management-api
+      - console_api_url=http://localhost/console/api
       - portal_ui_url=http://localhost/portal
     networks:
       - storage
@@ -123,7 +119,7 @@ services:
     depends_on:
       - management_api
     environment:
-      - MGMT_API_URL=http://localhost/management-api/organizations/DEFAULT/environments/DEFAULT/
+      - MGMT_API_URL=/console/api/organizations/DEFAULT/environments/DEFAULT/
     volumes:
       - ./.logs/apim-management-ui:/var/log/nginx
     networks:
@@ -136,7 +132,7 @@ services:
     depends_on:
       - management_api
     environment:
-      - PORTAL_API_URL=http://localhost/portal-api/environments/DEFAULT
+      - PORTAL_API_URL=/portal/api/environments/DEFAULT
     volumes:
       - ./.logs/apim-portal-ui:/var/log/nginx
     networks:


### PR DESCRIPTION
Replace https://github.com/gravitee-io/old-gravitee-api-management/pull/371
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-keiddpwbwr.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-nginx/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
