### PR TITLE
ci: improve SonarCloud setup and add analysis of Rest API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,29 @@ jobs:
                       - .docker-tag.txt
                       - .apim-version.txt
 
+    sonarcloud-analysis:
+        description: A job that run Sonarcloud analysis
+        parameters:
+            working_directory:
+                description: "Directory where the Sonarcloud analysis will be run"
+                default: "gravitee-apim-rest-api"
+                type: string
+        docker:
+            - image: sonarsource/sonar-scanner-cli
+        resource_class: medium
+        steps:
+            - checkout
+            - attach_workspace:
+                  at: .
+            - secrethub/env-export:
+                  secret-path: graviteeio/cicd/graviteebot/infra/sonarcloud.io.token
+                  var-name: SONAR_TOKEN
+            - run:
+                  name: Run Sonarcloud Analysis
+                  command: sonar-scanner
+                  working_directory: << parameters.working_directory >>
+            - notify-on-failure
+
     build:
         docker:
             - image: cimg/openjdk:11.0
@@ -299,19 +322,6 @@ jobs:
                   working_directory: gravitee-apim-console-webui
             - notify-on-failure
 
-    console-webui-sonarcloud-analysis:
-        docker:
-            - image: sonarsource/sonar-scanner-cli
-        steps:
-            - checkout
-            - attach_workspace:
-                  at: .
-            - run:
-                  name: Run Sonarcloud Analysis
-                  command: sonar-scanner
-                  working_directory: gravitee-apim-console-webui
-            - notify-on-failure
-
     console-webui-build:
         executor:
             name: node-lts
@@ -483,19 +493,6 @@ jobs:
             - store_test_results:
                   path: gravitee-apim-portal-webui/coverage
 
-    portal-webui-sonarcloud-analysis:
-        docker:
-            - image: sonarsource/sonar-scanner-cli
-        steps:
-            - checkout
-            - attach_workspace:
-                  at: .
-            - run:
-                  name: Run Sonarcloud Analysis
-                  command: sonar-scanner
-                  working_directory: gravitee-apim-portal-webui
-            - notify-on-failure
-
     portal-webui-build:
         executor:
             name: node-lts
@@ -644,6 +641,12 @@ workflows:
             - test:
                   requires:
                       - build
+            - sonarcloud-analysis:
+                  name: Sonarcloud - REST API
+                  working_directory: gravitee-apim-rest-api
+                  context: cicd-orchestrator
+                  requires:
+                      - test
             - publish-on-artifactory:
                   filters:
                       branches:
@@ -697,12 +700,10 @@ workflows:
             - console-webui-lint-test:
                   requires:
                       - console-webui-install
-            - console-webui-sonarcloud-analysis:
+            - sonarcloud-analysis:
+                name: Sonarcloud - Console Web UI
+                  working_directory: gravitee-apim-console-webui
                   context: cicd-orchestrator
-                  pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/infra/sonarcloud.io.token
-                            var-name: SONAR_TOKEN
                   requires:
                       - console-webui-lint-test
             - console-webui-build:
@@ -759,12 +760,10 @@ workflows:
             - portal-webui-lint-test:
                   requires:
                       - portal-webui-install
-            - portal-webui-sonarcloud-analysis:
+            - sonarcloud-analysis:
+                name: Sonarcloud - Portal Web UI
+                  working_directory: gravitee-apim-portal-webui
                   context: cicd-orchestrator
-                  pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/infra/sonarcloud.io.token
-                            var-name: SONAR_TOKEN
                   requires:
                       - portal-webui-lint-test
             - portal-webui-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,9 @@ jobs:
             - image: sonarsource/sonar-scanner-cli
         resource_class: medium
         steps:
+            - run:
+                  name: Add SSH tool
+                  command: apk add --no-cache openssh
             - checkout
             - attach_workspace:
                   at: .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -379,7 +379,7 @@ jobs:
             - checkout
             - gh/setup
             - run:
-                  name: Comment Pull Request
+                  name: Edit Pull Request Description
                   command: |
                       # First check there is an associated pull request, otherwise just stop the job here
                       if ! gh pr view --json title;
@@ -387,13 +387,26 @@ jobs:
                         echo "No PR found for this branch, stopping the job here."
                         exit 0
                       fi
-
+                      
+                      # If PR state is different from OPEN
+                      if [ "$(gh pr view --json state --jq .state)" != "OPEN" ];
+                      then
+                        echo "PR is not opened, stopping the job here."
+                        exit 0
+                      fi            
+                    
                       export BRANCH_ID=$(echo "$CIRCLE_BRANCH" | sed -E 's/[~^]+//g' | sed -E 's/[^a-zA-Z0-9]+/-/g' | sed -E 's/^-+|-+$//g' | tr "[:upper:]" "[:lower:]" | cut -c -60)
-                      gh pr comment --body "**Gravitee.io Automatic Deployment**
+                      export PR_BODY_UI_SECTION="
+                      <!-- UI placeholder -->
+                      🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/${BRANCH_ID}/index.html)
+                      _Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
+                      <!-- UI placeholder end -->
+                      "
+                      
+                      export CLEAN_BODY=$(gh pr view --json body --jq .body | sed '/UI placeholder -->/,/UI placeholder end -->/d')
+                      
+                      gh pr edit --body "$CLEAN_BODY$PR_BODY_UI_SECTION"
 
-                      Congrats, all the CI steps were 🟢 . The Bot was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/${BRANCH_ID}/index.html)! 🚀
-
-                      _Notes_: The deployed app is linked to the management API of the Element Zero team's environment."
             - notify-on-failure
 
     console-webui-publish-images-azure-registry:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -642,8 +642,13 @@ workflows:
                   requires:
                       - build
             - sonarcloud-analysis:
-                  name: Sonarcloud - REST API
-                  working_directory: gravitee-apim-rest-api
+                  name: Sonar - << matrix.working_directory >>
+                  matrix:
+                      parameters:
+                          working_directory:
+                              - gravitee-apim-rest-api
+                              - gravitee-apim-repository
+                              - gravitee-apim-gateway
                   context: cicd-orchestrator
                   requires:
                       - test
@@ -700,12 +705,6 @@ workflows:
             - console-webui-lint-test:
                   requires:
                       - console-webui-install
-            - sonarcloud-analysis:
-                name: Sonarcloud - Console Web UI
-                  working_directory: gravitee-apim-console-webui
-                  context: cicd-orchestrator
-                  requires:
-                      - console-webui-lint-test
             - console-webui-build:
                   requires:
                       - console-webui-install
@@ -761,10 +760,15 @@ workflows:
                   requires:
                       - portal-webui-install
             - sonarcloud-analysis:
-                name: Sonarcloud - Portal Web UI
-                  working_directory: gravitee-apim-portal-webui
+                  name: Sonar - << matrix.working_directory >>
+                  matrix:
+                      parameters:
+                          working_directory:
+                              - gravitee-apim-console-webui
+                              - gravitee-apim-portal-webui
                   context: cicd-orchestrator
                   requires:
+                      - console-webui-lint-test
                       - portal-webui-lint-test
             - portal-webui-build:
                   requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ commands:
         steps:
             - restore_cache:
                   keys:
-                      - gravitee-api-management-v4-{{ .Branch }}-{{ checksum "pom.xml" }}
+                      - gravitee-api-management-v5-{{ .Branch }}-{{ checksum "pom.xml" }}
 
     notify-on-failure:
         steps:
@@ -165,7 +165,7 @@ jobs:
             - save_cache:
                   paths:
                       - ~/.m2
-                  key: gravitee-api-management-v4-{{ .Branch }}-{{ checksum "pom.xml" }}
+                  key: gravitee-api-management-v5-{{ .Branch }}-{{ checksum "pom.xml" }}
                   when: always
             - persist_to_workspace:
                   root: ./

--- a/gravitee-apim-console-webui/sonar-project.properties
+++ b/gravitee-apim-console-webui/sonar-project.properties
@@ -3,6 +3,9 @@ sonar.projectKey=gravitee-io_gravitee-api-management_console-webui
 sonar.organization=gravitee-io
 sonar.host.url=https://sonarcloud.io
 
+# Disable enable summary comment
+sonar.pullrequest.github.summary_comment=false
+
 # Path to sources
 sonar.sources=src
 
@@ -17,3 +20,4 @@ sonar.coverage.exclusions=**/*.stories.ts
 
 # Duplication
 sonar.cpd.exclusions=**/*.fixture.ts
+

--- a/gravitee-apim-gateway/sonar-project.properties
+++ b/gravitee-apim-gateway/sonar-project.properties
@@ -8,6 +8,7 @@ sonar.pullrequest.github.summary_comment=false
 
 # Path to sources
 sonar.sources=.
+sonar.java.binaries=**/target/**
 
 # Source encoding
 sonar.sourceEncoding=UTF-8

--- a/gravitee-apim-gateway/sonar-project.properties
+++ b/gravitee-apim-gateway/sonar-project.properties
@@ -1,0 +1,17 @@
+sonar.projectName=Gravitee.io APIM - Gateway
+sonar.projectKey=gravitee-io_gravitee-api-management_gateway
+sonar.organization=gravitee-io
+sonar.host.url=https://sonarcloud.io
+
+# Disable enable summary comment
+sonar.pullrequest.github.summary_comment=false
+
+# Path to sources
+sonar.sources=.
+
+# Source encoding
+sonar.sourceEncoding=UTF-8
+
+# Coverage
+sonar.test=.
+sonar.test.inclusions=**/*Test.java

--- a/gravitee-apim-portal-webui/sonar-project.properties
+++ b/gravitee-apim-portal-webui/sonar-project.properties
@@ -3,6 +3,9 @@ sonar.projectKey=gravitee-io_gravitee-api-management_portal-webui
 sonar.organization=gravitee-io
 sonar.host.url=https://sonarcloud.io
 
+# Disable enable summary comment
+sonar.pullrequest.github.summary_comment=false
+
 # Path to sources
 sonar.sources=src
 sonar.exclusions=projects/portal-webclient-sdk/**

--- a/gravitee-apim-repository/sonar-project.properties
+++ b/gravitee-apim-repository/sonar-project.properties
@@ -1,0 +1,17 @@
+sonar.projectName=Gravitee.io APIM - Repository
+sonar.projectKey=gravitee-io_gravitee-api-management_repository
+sonar.organization=gravitee-io
+sonar.host.url=https://sonarcloud.io
+
+# Disable enable summary comment
+sonar.pullrequest.github.summary_comment=false
+
+# Path to sources
+sonar.sources=.
+
+# Source encoding
+sonar.sourceEncoding=UTF-8
+
+# Coverage
+sonar.test=.
+sonar.test.inclusions=**/*Test.java

--- a/gravitee-apim-repository/sonar-project.properties
+++ b/gravitee-apim-repository/sonar-project.properties
@@ -8,6 +8,7 @@ sonar.pullrequest.github.summary_comment=false
 
 # Path to sources
 sonar.sources=.
+sonar.java.binaries=**/target/**
 
 # Source encoding
 sonar.sourceEncoding=UTF-8

--- a/gravitee-apim-rest-api/sonar-project.properties
+++ b/gravitee-apim-rest-api/sonar-project.properties
@@ -8,6 +8,7 @@ sonar.pullrequest.github.summary_comment=false
 
 # Path to sources
 sonar.sources=.
+sonar.java.binaries=**/target/**
 
 # Source encoding
 sonar.sourceEncoding=UTF-8

--- a/gravitee-apim-rest-api/sonar-project.properties
+++ b/gravitee-apim-rest-api/sonar-project.properties
@@ -1,0 +1,14 @@
+sonar.projectName=Gravitee.io APIM - Rest API
+sonar.projectKey=gravitee-io_gravitee-api-management_rest-api
+sonar.organization=gravitee-io
+sonar.host.url=https://sonarcloud.io
+
+# Path to sources
+sonar.sources=.
+
+# Source encoding
+sonar.sourceEncoding=UTF-8
+
+# Coverage
+sonar.test=.
+sonar.test.inclusions=**/*Test.java

--- a/gravitee-apim-rest-api/sonar-project.properties
+++ b/gravitee-apim-rest-api/sonar-project.properties
@@ -3,6 +3,9 @@ sonar.projectKey=gravitee-io_gravitee-api-management_rest-api
 sonar.organization=gravitee-io
 sonar.host.url=https://sonarcloud.io
 
+# Disable enable summary comment
+sonar.pullrequest.github.summary_comment=false
+
 # Path to sources
 sonar.sources=.
 

--- a/pom.xml
+++ b/pom.xml
@@ -735,6 +735,7 @@
                         <exclude>**/.*</exclude>
                         <exclude>**/.*/**</exclude>
                         <exclude>**/*.adoc</exclude>
+                        <exclude>**/sonar-project.properties</exclude>
                     </excludes>
                     <mapping>
                         <ts>SLASHSTAR_STYLE</ts>


### PR DESCRIPTION
Replace https://github.com/gravitee-io/old-gravitee-api-management/pull/334

**Issue**

NA

**Description**

 - Disable SonarCloud comment on GitHub PR to avoid notif flood
 - Use CircleCI's matrix job to trigger analysis for all APIM sub projects

TODO: 
 - Make coverage work for Java projects 
<!-- UI placeholder -->
🚀 &nbsp;&nbsp;CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/add-sonar/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
