### PR TITLE
chore: run test container if jdbc repository has been modified [skip ci]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,6 +201,38 @@ jobs:
             - store_test_results:
                   path: ~/test-results
 
+    test-repository-jdbc:
+        machine:
+            image: ubuntu-2004:202107-02
+        resource_class: xlarge
+        steps:
+            - checkout
+            - run:
+                  name: Check if gravitee-apim-repository-jdbc should be built
+                  command: |
+                      ./.circleci/should_build.sh gravitee-apim-repository/gravitee-apim-repository-jdbc || circleci step halt
+            - attach_workspace:
+                  at: .
+            - restore-maven-cache
+            - run:
+                  name: Will Run JDBC testing
+                  command: echo "YES WE DID"
+        #        - run:
+        #            name: Run tests
+        #            command: |
+        #              # Need to use `package` phase to get repo-test's jar build and shared to mongodb and jdbc repos
+        #              mvn -s .artifactory.settings.xml package --no-transfer-progress -T 2C
+        #        - run:
+        #            name: Save test results
+        #            command: |
+        #              mkdir -p ~/test-results/junit/
+        #              find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
+        #            when: always
+        #        - store_test_results:
+        #            path: ~/test-results
+        #        - store_artifacts:
+        #            path: ~/test-results/junit
+
     publish-on-artifactory:
         docker:
             - image: cimg/openjdk:11.0
@@ -446,33 +478,33 @@ jobs:
                       echo "export SB_URL=$SB_URL" >> $BASH_ENV
             - gh/setup
             - run:
-                name: Edit Pull Request Description
-                command: |
-                  # First check there is an associated pull request, otherwise just stop the job here
-                  if ! gh pr view --json title;
-                  then
-                    echo "No PR found for this branch, stopping the job here."
-                    exit 0
-                  fi
-                  
-                  # If PR state is different from OPEN
-                  if [ "$(gh pr view --json state --jq .state)" != "OPEN" ];
-                  then
-                    echo "PR is not opened, stopping the job here."
-                    exit 0
-                  fi            
-                  
-                  export PR_BODY_STORYBOOK_SECTION="
-                  <!-- Storybook placeholder -->
-                  ---
-                  
-                  📚&nbsp;&nbsp;View the storybook of this branch [here](${SB_URL})
-                  <!-- Storybook placeholder end -->
-                  "
-                  
-                  export CLEAN_BODY=$(gh pr view --json body --jq .body | sed '/Storybook placeholder -->/,/Storybook placeholder end -->/d')
-                  
-                  gh pr edit --body "$CLEAN_BODY$PR_BODY_STORYBOOK_SECTION"
+                  name: Edit Pull Request Description
+                  command: |
+                      # First check there is an associated pull request, otherwise just stop the job here
+                      if ! gh pr view --json title;
+                      then
+                        echo "No PR found for this branch, stopping the job here."
+                        exit 0
+                      fi
+
+                      # If PR state is different from OPEN
+                      if [ "$(gh pr view --json state --jq .state)" != "OPEN" ];
+                      then
+                        echo "PR is not opened, stopping the job here."
+                        exit 0
+                      fi            
+
+                      export PR_BODY_STORYBOOK_SECTION="
+                      <!-- Storybook placeholder -->
+                      ---
+
+                      📚&nbsp;&nbsp;View the storybook of this branch [here](${SB_URL})
+                      <!-- Storybook placeholder end -->
+                      "
+
+                      export CLEAN_BODY=$(gh pr view --json body --jq .body | sed '/Storybook placeholder -->/,/Storybook placeholder end -->/d')
+
+                      gh pr edit --body "$CLEAN_BODY$PR_BODY_STORYBOOK_SECTION"
             - notify-on-failure
 
     console-webui-deploy-on-azure-storage:
@@ -509,14 +541,14 @@ jobs:
                         echo "No PR found for this branch, stopping the job here."
                         exit 0
                       fi
-                      
+
                       # If PR state is different from OPEN
                       if [ "$(gh pr view --json state --jq .state)" != "OPEN" ];
                       then
                         echo "PR is not opened, stopping the job here."
                         exit 0
                       fi            
-                    
+
                       export BRANCH_ID=$(echo "$CIRCLE_BRANCH" | sed -E 's/[~^]+//g' | sed -E 's/[^a-zA-Z0-9]+/-/g' | sed -E 's/^-+|-+$//g' | tr "[:upper:]" "[:lower:]" | cut -c -60)
                       export PR_BODY_UI_SECTION="
                       <!-- UI placeholder -->
@@ -524,9 +556,9 @@ jobs:
                       _Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
                       <!-- UI placeholder end -->
                       "
-                      
+
                       export CLEAN_BODY=$(gh pr view --json body --jq .body | sed '/UI placeholder -->/,/UI placeholder end -->/d')
-                      
+
                       gh pr edit --body "$CLEAN_BODY$PR_BODY_UI_SECTION"
 
             - notify-on-failure
@@ -772,207 +804,210 @@ workflows:
             - gravitee/d_pull_requests_secrets:
                   context: cicd-orchestrator
                   name: pr_secrets_resolution
-            - build:
-                  context: gravitee-qa
+            #            - build:
+            #                  context: gravitee-qa
+            #                  requires:
+            #                      - pr_secrets_resolution
+            #            - test:
+            #                  requires:
+            #                      - build
+            - test-repository-jdbc:
                   requires:
                       - pr_secrets_resolution
-            - test:
-                  requires:
-                      - build
-            - sonarcloud-analysis:
-                  name: Sonar - << matrix.working_directory >>
-                  matrix:
-                      parameters:
-                          working_directory:
-                              - gravitee-apim-rest-api
-                              - gravitee-apim-repository
-                              - gravitee-apim-gateway
-                  context: cicd-orchestrator
-                  requires:
-                      - test
-            - publish-on-artifactory:
-                  filters:
-                      branches:
-                          only:
-                              - master
-                              - /^\d+\.\d+\.x$/
-                  requires:
-                      - test
-            - publish-on-nexus:
-                  filters:
-                      branches:
-                          only:
-                              - master
-                              - /^\d+\.\d+\.x$/
-                  requires:
-                      - test
-            - compute-apim-tag:
-                  requires:
-                      - pr_secrets_resolution
-                  filters:
-                      branches:
-                          only:
-                              - master
-                              - /^\d+\.\d+\.x$/
-            - publish-images-azure-registry:
-                  context: cicd-orchestrator
-                  requires:
-                      - test
-                      - compute-apim-tag
-                  pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/username
-                            var-name: AZURE_DOCKER_REGISTRY_USERNAME
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/password
-                            var-name: AZURE_DOCKER_REGISTRY_PASSWORD
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-name
-                            var-name: DOCKERHUB_BOT_USER_NAME
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-token
-                            var-name: DOCKERHUB_BOT_USER_TOKEN
-                  filters:
-                      branches:
-                          only:
-                              - master
-                              - /^\d+\.\d+\.x$/
-            - console-webui-install:
-                  requires:
-                      - pr_secrets_resolution
-            - console-webui-lint-test:
-                  requires:
-                      - console-webui-install
-            - console-webui-build:
-                  requires:
-                      - console-webui-install
-            - console-webui-build-storybook:
-                  requires:
-                      - console-webui-install
-            - console-webui-deploy-on-azure-storage:
-                  context: cicd-orchestrator
-                  pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/application-id
-                            var-name: AZURE_APPLICATION_ID
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/tenant
-                            var-name: AZURE_TENANT
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/application-secret
-                            var-name: AZURE_APPLICATION_SECRET
-                  requires:
-                      - console-webui-build
-            - console-webui-comment-pr-after-deployment:
-                  context: cicd-orchestrator
-                  pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/github_personal_access_token
-                            var-name: GITHUB_TOKEN
-                  requires:
-                      - console-webui-deploy-on-azure-storage
-            - console-webui-chromatic-deployment:
-                  context: cicd-orchestrator
-                  requires:
-                      - console-webui-build-storybook
-                  pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/github_personal_access_token
-                            var-name: GITHUB_TOKEN
-            - console-webui-publish-images-azure-registry:
-                  context: cicd-orchestrator
-                  pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/username
-                            var-name: AZURE_DOCKER_REGISTRY_USERNAME
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/password
-                            var-name: AZURE_DOCKER_REGISTRY_PASSWORD
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-name
-                            var-name: DOCKERHUB_BOT_USER_NAME
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-token
-                            var-name: DOCKERHUB_BOT_USER_TOKEN
-                  requires:
-                      - console-webui-build
-                      - compute-apim-tag
-                  filters:
-                      branches:
-                          only:
-                              - master
-                              - /^\d+\.\d+\.x$/
-            - portal-webui-install:
-                  requires:
-                      - pr_secrets_resolution
-            - portal-webui-lint-test:
-                  requires:
-                      - portal-webui-install
-            - sonarcloud-analysis:
-                  name: Sonar - << matrix.working_directory >>
-                  matrix:
-                      parameters:
-                          working_directory:
-                              - gravitee-apim-console-webui
-                              - gravitee-apim-portal-webui
-                  context: cicd-orchestrator
-                  requires:
-                      - console-webui-lint-test
-                      - portal-webui-lint-test
-            - portal-webui-build:
-                  requires:
-                      - portal-webui-install
-            - portal-webui-publish-images-azure-registry:
-                  context: cicd-orchestrator
-                  pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/username
-                            var-name: AZURE_DOCKER_REGISTRY_USERNAME
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/password
-                            var-name: AZURE_DOCKER_REGISTRY_PASSWORD
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-name
-                            var-name: DOCKERHUB_BOT_USER_NAME
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-token
-                            var-name: DOCKERHUB_BOT_USER_TOKEN
-                  requires:
-                      - portal-webui-build
-                      - compute-apim-tag
-                  filters:
-                      branches:
-                          only:
-                              - master
-                              - /^\d+\.\d+\.x$/
-            - deploy-on-azure-cluster:
-                  context: cicd-orchestrator
-                  pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/application-id
-                            var-name: AZURE_APPLICATION_ID
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/tenant
-                            var-name: AZURE_TENANT
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/application-secret
-                            var-name: AZURE_APPLICATION_SECRET
-                  requires:
-                      - publish-images-azure-registry
-                      - console-webui-publish-images-azure-registry
-                      - portal-webui-publish-images-azure-registry
-                  filters:
-                      branches:
-                          only:
-                              - master
-                              - /^\d+\.\d+\.x$/
-              # To be modified when testing strategy will be defined
-            - cypress-install:
-                  requires:
-                      - build
-            - cypress-lint-test:
-                  requires:
-                      - cypress-install
+    #            - sonarcloud-analysis:
+    #                  name: Sonar - << matrix.working_directory >>
+    #                  matrix:
+    #                      parameters:
+    #                          working_directory:
+    #                              - gravitee-apim-rest-api
+    #                              - gravitee-apim-repository
+    #                              - gravitee-apim-gateway
+    #                  context: cicd-orchestrator
+    #                  requires:
+    #                      - test
+    #            - publish-on-artifactory:
+    #                  filters:
+    #                      branches:
+    #                          only:
+    #                              - master
+    #                              - /^\d+\.\d+\.x$/
+    #                  requires:
+    #                      - test
+    #            - publish-on-nexus:
+    #                  filters:
+    #                      branches:
+    #                          only:
+    #                              - master
+    #                              - /^\d+\.\d+\.x$/
+    #                  requires:
+    #                      - test
+    #            - compute-apim-tag:
+    #                  requires:
+    #                      - pr_secrets_resolution
+    #                  filters:
+    #                      branches:
+    #                          only:
+    #                              - master
+    #                              - /^\d+\.\d+\.x$/
+    #            - publish-images-azure-registry:
+    #                  context: cicd-orchestrator
+    #                  requires:
+    #                      - test
+    #                      - compute-apim-tag
+    #                  pre-steps:
+    #                      - secrethub/env-export:
+    #                            secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/username
+    #                            var-name: AZURE_DOCKER_REGISTRY_USERNAME
+    #                      - secrethub/env-export:
+    #                            secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/password
+    #                            var-name: AZURE_DOCKER_REGISTRY_PASSWORD
+    #                      - secrethub/env-export:
+    #                            secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-name
+    #                            var-name: DOCKERHUB_BOT_USER_NAME
+    #                      - secrethub/env-export:
+    #                            secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-token
+    #                            var-name: DOCKERHUB_BOT_USER_TOKEN
+    #                  filters:
+    #                      branches:
+    #                          only:
+    #                              - master
+    #                              - /^\d+\.\d+\.x$/
+    #            - console-webui-install:
+    #                  requires:
+    #                      - pr_secrets_resolution
+    #            - console-webui-lint-test:
+    #                  requires:
+    #                      - console-webui-install
+    #            - console-webui-build:
+    #                  requires:
+    #                      - console-webui-install
+    #            - console-webui-build-storybook:
+    #                  requires:
+    #                      - console-webui-install
+    #            - console-webui-deploy-on-azure-storage:
+    #                  context: cicd-orchestrator
+    #                  pre-steps:
+    #                      - secrethub/env-export:
+    #                            secret-path: graviteeio/cicd/azure/application-id
+    #                            var-name: AZURE_APPLICATION_ID
+    #                      - secrethub/env-export:
+    #                            secret-path: graviteeio/cicd/azure/tenant
+    #                            var-name: AZURE_TENANT
+    #                      - secrethub/env-export:
+    #                            secret-path: graviteeio/cicd/azure/application-secret
+    #                            var-name: AZURE_APPLICATION_SECRET
+    #                  requires:
+    #                      - console-webui-build
+    #            - console-webui-comment-pr-after-deployment:
+    #                  context: cicd-orchestrator
+    #                  pre-steps:
+    #                      - secrethub/env-export:
+    #                            secret-path: graviteeio/cicd/graviteebot/github_personal_access_token
+    #                            var-name: GITHUB_TOKEN
+    #                  requires:
+    #                      - console-webui-deploy-on-azure-storage
+    #            - console-webui-chromatic-deployment:
+    #                  context: cicd-orchestrator
+    #                  requires:
+    #                      - console-webui-build-storybook
+    #                  pre-steps:
+    #                      - secrethub/env-export:
+    #                            secret-path: graviteeio/cicd/graviteebot/github_personal_access_token
+    #                            var-name: GITHUB_TOKEN
+    #            - console-webui-publish-images-azure-registry:
+    #                  context: cicd-orchestrator
+    #                  pre-steps:
+    #                      - secrethub/env-export:
+    #                            secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/username
+    #                            var-name: AZURE_DOCKER_REGISTRY_USERNAME
+    #                      - secrethub/env-export:
+    #                            secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/password
+    #                            var-name: AZURE_DOCKER_REGISTRY_PASSWORD
+    #                      - secrethub/env-export:
+    #                            secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-name
+    #                            var-name: DOCKERHUB_BOT_USER_NAME
+    #                      - secrethub/env-export:
+    #                            secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-token
+    #                            var-name: DOCKERHUB_BOT_USER_TOKEN
+    #                  requires:
+    #                      - console-webui-build
+    #                      - compute-apim-tag
+    #                  filters:
+    #                      branches:
+    #                          only:
+    #                              - master
+    #                              - /^\d+\.\d+\.x$/
+    #            - portal-webui-install:
+    #                  requires:
+    #                      - pr_secrets_resolution
+    #            - portal-webui-lint-test:
+    #                  requires:
+    #                      - portal-webui-install
+    #            - sonarcloud-analysis:
+    #                  name: Sonar - << matrix.working_directory >>
+    #                  matrix:
+    #                      parameters:
+    #                          working_directory:
+    #                              - gravitee-apim-console-webui
+    #                              - gravitee-apim-portal-webui
+    #                  context: cicd-orchestrator
+    #                  requires:
+    #                      - console-webui-lint-test
+    #                      - portal-webui-lint-test
+    #            - portal-webui-build:
+    #                  requires:
+    #                      - portal-webui-install
+    #            - portal-webui-publish-images-azure-registry:
+    #                  context: cicd-orchestrator
+    #                  pre-steps:
+    #                      - secrethub/env-export:
+    #                            secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/username
+    #                            var-name: AZURE_DOCKER_REGISTRY_USERNAME
+    #                      - secrethub/env-export:
+    #                            secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/password
+    #                            var-name: AZURE_DOCKER_REGISTRY_PASSWORD
+    #                      - secrethub/env-export:
+    #                            secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-name
+    #                            var-name: DOCKERHUB_BOT_USER_NAME
+    #                      - secrethub/env-export:
+    #                            secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-token
+    #                            var-name: DOCKERHUB_BOT_USER_TOKEN
+    #                  requires:
+    #                      - portal-webui-build
+    #                      - compute-apim-tag
+    #                  filters:
+    #                      branches:
+    #                          only:
+    #                              - master
+    #                              - /^\d+\.\d+\.x$/
+    #            - deploy-on-azure-cluster:
+    #                  context: cicd-orchestrator
+    #                  pre-steps:
+    #                      - secrethub/env-export:
+    #                            secret-path: graviteeio/cicd/azure/application-id
+    #                            var-name: AZURE_APPLICATION_ID
+    #                      - secrethub/env-export:
+    #                            secret-path: graviteeio/cicd/azure/tenant
+    #                            var-name: AZURE_TENANT
+    #                      - secrethub/env-export:
+    #                            secret-path: graviteeio/cicd/azure/application-secret
+    #                            var-name: AZURE_APPLICATION_SECRET
+    #                  requires:
+    #                      - publish-images-azure-registry
+    #                      - console-webui-publish-images-azure-registry
+    #                      - portal-webui-publish-images-azure-registry
+    #                  filters:
+    #                      branches:
+    #                          only:
+    #                              - master
+    #                              - /^\d+\.\d+\.x$/
+    #               To be modified when testing strategy will be defined
+    #            - cypress-install:
+    #                  requires:
+    #                      - build
+    #            - cypress-lint-test:
+    #                  requires:
+    #                      - cypress-install
 
     # ---
     # The 2 Workflows Below are there for the CICD Orchestrator to be able to

--- a/.circleci/should_build.sh
+++ b/.circleci/should_build.sh
@@ -1,0 +1,24 @@
+has_been_modified () {
+    target_branch=""
+    pr_number=${CIRCLE_PULL_REQUEST##*/}
+
+    # If we are on a PULL REQUEST
+    if [[ ! -z $CIRCLE_PULL_REQUEST ]]; then
+        curl -L "https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64" -o jq
+        chmod +x jq
+        url="https://api.github.com/repos/gravitee-io/${CIRCLE_PROJECT_REPONAME}/pulls/$pr_number"
+        target_branch=$(curl "$url" | ./jq '.base.ref' | tr -d '"')
+    fi
+    echo "Target branch is $target_branch"
+    # Check the diff between target branch and current branch
+    git diff --name-only origin/${target_branch}...${CIRCLE_BRANCH} | grep "^$1" > /dev/null 2>&1
+}
+
+# Build systematically master branch
+if [[ "${CIRCLE_BRANCH}" = "master" ]]; then exit 0; fi
+
+# Return true if folder has been modified -> we should build
+if has_been_modified $1; then exit 0; fi
+
+# by default, do not build
+exit 1


### PR DESCRIPTION
Replace https://github.com/gravitee-io/old-gravitee-api-management/pull/128

Add a should_build.sh to be able to check if a folder has git diff and know if we should buiild/test it


## What it does 

1. Check if we are currently building master (always execute)
2. Check if we are in a PR and get the target branch
3. Do a `git diff `between your PR and the target branch
4. Check if the folder you want to test/build has diff
5. If diffs, continue the step

## Usage

Let's say you have a `backend` folder and a `front` folder in your repo. You don't want to build the `front` if you only provides modifications in the `backend`

In your step configuration, simply use the script like that:
```
- run:
          name: Check if front should be built
          command: |
            ./.circleci/should_build.sh front || circleci step halt
```

If there is no diff in `front` folder, then the circleci step will stop here (`halt` command: https://circleci.com/docs/2.0/configuration-reference/#ending-a-job-from-within-a-step)

~~⚠️ with this version, the diff is only applied between the pull request's branch and master. So for support version (3.5.x for example) the diff will be done with master~~
✅ The git diff is done against the target branch of your PR

Here is an example with dummy steps:
- > no modification inside repository-jdbc: https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/873/workflows/d4559ee4-2105-4a53-94d2-68144452b3a3/jobs/2101
- > modifying reposiroty-jdbc: https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/874/workflows/42d1cb20-b292-43f7-870a-cf97ecd2b9d5/jobs/2105

