### PR TITLE
refactor: an unpublish api is not sync

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -1857,33 +1857,34 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             if (!events.getContent().isEmpty()) {
                 // According to page size, we know that we have only one element in the list
                 EventEntity lastEvent = events.getContent().get(0);
+                boolean sync = false;
+                if (PUBLISH_API.equals(lastEvent.getType())) {
+                    //TODO: Done only for backward compatibility with 0.x. Must be removed later (1.1.x ?)
+                    boolean enabled = objectMapper.getDeserializationConfig().isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+                    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+                    Api payloadEntity = objectMapper.readValue(lastEvent.getPayload(), Api.class);
+                    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, enabled);
 
-                //TODO: Done only for backward compatibility with 0.x. Must be removed later (1.1.x ?)
-                boolean enabled = objectMapper.getDeserializationConfig().isEnabled(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-                objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-                Api payloadEntity = objectMapper.readValue(lastEvent.getPayload(), Api.class);
-                objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, enabled);
+                    final ApiEntity deployedApi = convert(payloadEntity);
+                    // Remove policy description from sync check
+                    removeDescriptionFromPolicies(api);
+                    removeDescriptionFromPolicies(deployedApi);
 
-                final ApiEntity deployedApi = convert(payloadEntity);
-                // Remove policy description from sync check
-                removeDescriptionFromPolicies(api);
-                removeDescriptionFromPolicies(deployedApi);
+                    sync = apiSynchronizationProcessor.processCheckSynchronization(deployedApi, api);
 
-                boolean sync = apiSynchronizationProcessor.processCheckSynchronization(deployedApi, api);
-
-                // 2_ If API definition is synchronized, check if there is any modification for API's plans
-                // but only for published or closed plan
-                if (sync) {
-                    Set<PlanEntity> plans = planService.findByApi(api.getId());
-                    sync =
-                        plans
-                            .stream()
-                            .filter(plan -> (plan.getStatus() != PlanStatus.STAGING))
-                            .filter(plan -> plan.getNeedRedeployAt().after(api.getDeployedAt()))
-                            .count() ==
-                        0;
+                    // 2_ If API definition is synchronized, check if there is any modification for API's plans
+                    // but only for published or closed plan
+                    if (sync) {
+                        Set<PlanEntity> plans = planService.findByApi(api.getId());
+                        sync =
+                            plans
+                                .stream()
+                                .filter(plan -> (plan.getStatus() != PlanStatus.STAGING))
+                                .filter(plan -> plan.getNeedRedeployAt().after(api.getDeployedAt()))
+                                .count() ==
+                            0;
+                    }
                 }
-
                 return sync;
             }
         } catch (Exception e) {


### PR DESCRIPTION
Replace https://github.com/gravitee-io/old-gravitee-api-management/pull/275
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-an-unpublish-api-is-not-sync/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
