### PR TITLE
feat: bump ui-component to display api owner in card

### DIFF
--- a/gravitee-apim-portal-webui/README.adoc
+++ b/gravitee-apim-portal-webui/README.adoc
@@ -98,13 +98,13 @@ npm run serve:prod
 
 == Tips
 
-If you want to test with other backend like nightly :
+If you want to test with other backend like apim master :
 
 Edit `src/proxy.conf.json`
 ```json
 {
   "/portal/environments/DEFAULT": {
-    "target": "https://nightly.gravitee.io/api/",
+    "target": "https://apim-master-api.cloud.gravitee.io/",
     "secure": false,
     "changeOrigin": true
   },

--- a/gravitee-apim-portal-webui/package-lock.json
+++ b/gravitee-apim-portal-webui/package-lock.json
@@ -3526,9 +3526,9 @@
       }
     },
     "@formatjs/intl-getcanonicallocales": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-getcanonicallocales/-/intl-getcanonicallocales-1.7.3.tgz",
-      "integrity": "sha512-rbKNv16dhTiejSZnCV6VyoOkxUs6xYnYT/RbM8ILuD4CgL8KGJQjTSuYxYdfOHsjxdqbJU2+E2kF3jHKv+6ArA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-getcanonicallocales/-/intl-getcanonicallocales-1.8.0.tgz",
+      "integrity": "sha512-nBwLvOaClSPt4UrvNKHuOf3vgQ8ofZ8jS5TB54bKBw1VKe3Rt/omvze/UhiboWFxs3VCWVHswqikHS5UfUq3SA==",
       "requires": {
         "tslib": "^2.1.0"
       },
@@ -3541,15 +3541,24 @@
       }
     },
     "@formatjs/intl-locale": {
-      "version": "2.4.38",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-locale/-/intl-locale-2.4.38.tgz",
-      "integrity": "sha512-/wNNhy0k/caHDpsx19/ixowxdAakPc163qVIOcoahH3ShhU/UvJT4QTGrq+1ym3Toaa9DkIvQTPggUkzL6rUpA==",
+      "version": "2.4.40",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-locale/-/intl-locale-2.4.40.tgz",
+      "integrity": "sha512-JieIcHMfNWoE6WCieQ5Cjqmdc9mOIBaI3rjAfwzA2HOo3X7d0ov6BIDIm0dV+H6PR0nZULHgHjw+QMqcFSUjxw==",
       "requires": {
-        "@formatjs/ecma402-abstract": "1.9.9",
-        "@formatjs/intl-getcanonicallocales": "1.7.3",
+        "@formatjs/ecma402-abstract": "1.10.0",
+        "@formatjs/intl-getcanonicallocales": "1.8.0",
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "@formatjs/ecma402-abstract": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.10.0.tgz",
+          "integrity": "sha512-WNkcUHC6xw12rWY87TUw6KXzb1LnOooYBLLqtyn1kW2j197rcwpqmUOJMBED56YcLzaJPfVw1L2ShiDhL5pVnQ==",
+          "requires": {
+            "@formatjs/intl-localematcher": "0.2.21",
+            "tslib": "^2.1.0"
+          }
+        },
         "tslib": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -3590,14 +3599,14 @@
       }
     },
     "@gravitee/ui-components": {
-      "version": "3.17.6",
-      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.17.6.tgz",
-      "integrity": "sha512-AClpjxi/SvyN9bDw6nZjfH2/QfTpwOROgk5wh+HA08v6/CLTQlZO6ncOQvbRyeK0jkCFUIGqlCKFKR7v8cXdZw==",
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.23.0.tgz",
+      "integrity": "sha512-nBV1D/3EHRvazj7uX4H4xS2DtaZaVPD9NTn/n+XG21C44R7lDBefG1xRtFFU2fa0NIFkD490U88KIvu9WoUbaw==",
       "requires": {
-        "@formatjs/intl-locale": "^2.4.37",
-        "@formatjs/intl-relativetimeformat": "^9.0.0",
+        "@formatjs/intl-locale": "^2.4.40",
+        "@formatjs/intl-relativetimeformat": "^9.3.2",
         "clipboard-copy": "^4.0.0",
-        "codemirror": "^5.63.0",
+        "codemirror": "^5.63.2",
         "date-fns": "^2.24.0",
         "jdenticon": "^3.1.0",
         "jsonschema": "^1.4.0",
@@ -3608,6 +3617,25 @@
         "whatwg-fetch": "^3.4.1"
       },
       "dependencies": {
+        "@formatjs/ecma402-abstract": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.10.0.tgz",
+          "integrity": "sha512-WNkcUHC6xw12rWY87TUw6KXzb1LnOooYBLLqtyn1kW2j197rcwpqmUOJMBED56YcLzaJPfVw1L2ShiDhL5pVnQ==",
+          "requires": {
+            "@formatjs/intl-localematcher": "0.2.21",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@formatjs/intl-relativetimeformat": {
+          "version": "9.3.2",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-9.3.2.tgz",
+          "integrity": "sha512-WI1fCcPXGAVp10Dk3QziXuIqEo4VqnjJJ3uWgKxKSfMy7aVLHTD1ZWH+8M5egzkMQ4/Tyo2nkun9eIbiTjTqhg==",
+          "requires": {
+            "@formatjs/ecma402-abstract": "1.10.0",
+            "@formatjs/intl-localematcher": "0.2.21",
+            "tslib": "^2.1.0"
+          }
+        },
         "tslib": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -7332,9 +7360,9 @@
       }
     },
     "codemirror": {
-      "version": "5.63.3",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.63.3.tgz",
-      "integrity": "sha512-1C+LELr+5grgJYqwZKqxrcbPsHFHapVaVAloBsFBASbpLnQqLw1U8yXJ3gT5D+rhxIiSpo+kTqN+hQ+9ialIXw=="
+      "version": "5.64.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.64.0.tgz",
+      "integrity": "sha512-fqr6CtDQdJ6iNMbD8NX2gH2G876nNDk+TO1rrYkgWnqQdO3O1Xa9tK6q+psqhJJgE5SpbaDcgdfLmukoUVE8pg=="
     },
     "codemirror-asciidoc": {
       "version": "1.0.4",
@@ -8107,9 +8135,9 @@
       }
     },
     "date-fns": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.25.0.tgz",
-      "integrity": "sha512-ovYRFnTrbGPD4nqaEqescPEv1mNwvt+UTqI3Ay9SzNtey9NZnYu6E2qCcBBgJ6/2VF1zGGygpyTDITqpQQ5e+w=="
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.26.0.tgz",
+      "integrity": "sha512-VQI812dRi3cusdY/fhoBKvc6l2W8BPWU1FNVnFH9Nttjx4AFBRzfSVb/Eyc7jBT6e9sg1XtAGsYpBQ6c/jygbg=="
     },
     "debug": {
       "version": "4.1.1",

--- a/gravitee-apim-portal-webui/package.json
+++ b/gravitee-apim-portal-webui/package.json
@@ -35,7 +35,7 @@
     "@angular/router": "9.1.1",
     "@asyncapi/web-component": "1.0.0-next.15",
     "@formatjs/intl-relativetimeformat": "9.3.1",
-    "@gravitee/ui-components": "3.17.6",
+    "@gravitee/ui-components": "3.23.0",
     "@highcharts/map-collection": "1.1.3",
     "@ibm/plex": "5.1.3",
     "@ngx-translate/core": "12.1.2",


### PR DESCRIPTION
Replace https://github.com/gravitee-io/old-gravitee-api-management/pull/284

**Issue**

gravitee-io/issues#6485

**Description**

- [x]  to merge after this PR : https://github.com/gravitee-io/gravitee-ui-components/pull/507

**Additional context**

⚠️  DO NOT MERGE before 3.14 has been released
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ommcaqpftt.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/507-display-owner/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
