### PR TITLE
feat: deprecate path based API creation

### DIFF
--- a/gravitee-apim-console-webui/src/entities/consoleSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/consoleSettings.ts
@@ -106,6 +106,9 @@ export interface ConsoleSettingsManagement {
   };
   title?: string;
   url?: string;
+  pathBasedApiCreation?: {
+    enabled: boolean;
+  };
   userCreation?: {
     enabled?: boolean;
   };

--- a/gravitee-apim-console-webui/src/management/api/creation/newApi.html
+++ b/gravitee-apim-console-webui/src/management/api/creation/newApi.html
@@ -55,7 +55,11 @@
         </div>
       </div>
 
-      <div layout="column" ng-class="{ selected: $ctrl.definitionVersion==='1.0.0', 'definition-container': true}">
+      <div
+        layout="column"
+        ng-class="{ selected: $ctrl.definitionVersion==='1.0.0', 'definition-container': true}"
+        ng-if="$ctrl.allowsPathBasedCreation"
+      >
         <div class="card" ng-click="$ctrl.definitionVersion='1.0.0'">
           <span class="title">{{$ctrl.getDefinitionVersionTitle('1.0.0')}}</span>
           <gv-image src="assets/api-design-paths.png"></gv-image>

--- a/gravitee-apim-console-webui/src/management/api/creation/newApiPortal.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/newApiPortal.controller.ts
@@ -17,6 +17,8 @@
 // eslint:disable-next-line:no-var-requires
 require('@gravitee/ui-components/wc/gv-option');
 
+import { ConsoleSettings } from '../../../entities/consoleSettings';
+
 export function getDefinitionVersionTitle(definitionVersion) {
   if (definitionVersion === '2.0.0') {
     return 'Design studio';
@@ -37,14 +39,21 @@ class NewApiController {
   isImport: boolean;
 
   getDefinitionVersionTitle = getDefinitionVersionTitle;
-  getDefinitionVersionDescription = getDefinitionVersionDescription;
   private definitionVersions: string[];
 
-  constructor(private policies, private Constants: any) {
+  private consoleSettings: ConsoleSettings;
+
+  constructor(private policies, private Constants: any, private ConsoleSettingsService: any) {
     'ngInject';
     this.definitionVersions = ['2.0.0', '1.0.0'];
     this.definitionVersion = '2.0.0';
     this.isImport = false;
+  }
+
+  $onInit() {
+    this.ConsoleSettingsService.get().then(({ data }) => {
+      this.consoleSettings = data;
+    });
   }
 
   cancelImport() {
@@ -53,6 +62,10 @@ class NewApiController {
 
   getImportTitle() {
     return `Import ${getDefinitionVersionTitle(this.definitionVersion)}`;
+  }
+
+  get allowsPathBasedCreation() {
+    return this.consoleSettings?.management?.pathBasedApiCreation?.enabled;
   }
 }
 

--- a/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.html
@@ -78,6 +78,25 @@
 
         <gio-form-slide-toggle
           [matTooltip]="providedConfigurationMessage"
+          [matTooltipDisabled]="!isReadonlySetting('console.pathBasedApiCreation.enabled')"
+          appearance="fill"
+          class="settings-general__form__card__form-field"
+          formGroupName="pathBasedApiCreation"
+        >
+          <mat-icon *ngIf="isReadonlySetting('console.pathBasedApiCreation.enabled')" gioFormPrefix>lock</mat-icon>
+          <gio-form-label>Enable path based API creation</gio-form-label>
+          <mat-slide-toggle
+            gioFormSlideToggle
+            formControlName="enabled"
+            aria-label="Enable path based API creation"
+            name="pathBasedApiCreation"
+          ></mat-slide-toggle>
+        </gio-form-slide-toggle>
+
+        <mat-divider></mat-divider>
+
+        <gio-form-slide-toggle
+          [matTooltip]="providedConfigurationMessage"
           [matTooltipDisabled]="!isReadonlySetting('management.userCreation.enabled')"
           appearance="fill"
           class="settings-general__form__card__form-field"

--- a/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.html
@@ -64,12 +64,12 @@
 
         <gio-form-slide-toggle
           [matTooltip]="providedConfigurationMessage"
-          [matTooltipDisabled]="!isReadonlySetting('management.support.enabled')"
+          [matTooltipDisabled]="!isReadonlySetting('console.support.enabled')"
           appearance="fill"
           class="settings-general__form__card__form-field"
           formGroupName="support"
         >
-          <mat-icon *ngIf="isReadonlySetting('management.support.enabled')" gioFormPrefix>lock</mat-icon>
+          <mat-icon *ngIf="isReadonlySetting('console.support.enabled')" gioFormPrefix>lock</mat-icon>
           <gio-form-label>Activate Support</gio-form-label>
           <mat-slide-toggle gioFormSlideToggle formControlName="enabled" aria-label="Activate Support" name="support"></mat-slide-toggle>
         </gio-form-slide-toggle>
@@ -97,12 +97,12 @@
 
         <gio-form-slide-toggle
           [matTooltip]="providedConfigurationMessage"
-          [matTooltipDisabled]="!isReadonlySetting('management.userCreation.enabled')"
+          [matTooltipDisabled]="!isReadonlySetting('console.userCreation.enabled')"
           appearance="fill"
           class="settings-general__form__card__form-field"
           formGroupName="userCreation"
         >
-          <mat-icon *ngIf="isReadonlySetting('management.userCreation.enabled')" gioFormPrefix>lock</mat-icon>
+          <mat-icon *ngIf="isReadonlySetting('console.userCreation.enabled')" gioFormPrefix>lock</mat-icon>
           <gio-form-label>Allow User Registration</gio-form-label>
           <mat-slide-toggle
             #managementUserCreationSlideToggle
@@ -118,12 +118,12 @@
 
           <gio-form-slide-toggle
             [matTooltip]="providedConfigurationMessage"
-            [matTooltipDisabled]="!isReadonlySetting('management.automaticValidation.enabled')"
+            [matTooltipDisabled]="!isReadonlySetting('console.userCreation.automaticValidation.enabled')"
             appearance="fill"
             class="settings-general__form__card__form-field"
             formGroupName="automaticValidation"
           >
-            <mat-icon *ngIf="isReadonlySetting('management.automaticValidation.enabled')" gioFormPrefix>lock</mat-icon>
+            <mat-icon *ngIf="isReadonlySetting('console.userCreation.automaticValidation.enabled')" gioFormPrefix>lock</mat-icon>
             <gio-form-label>Enable automatic validation of registration requests</gio-form-label>
             <mat-slide-toggle
               gioFormSlideToggle

--- a/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.spec.ts
@@ -98,6 +98,9 @@ describe('ConsoleSettingsComponent', () => {
           support: {
             enabled: false,
           },
+          pathBasedApiCreation: {
+            enabled: true,
+          },
           userCreation: {
             enabled: false,
           },
@@ -118,6 +121,9 @@ describe('ConsoleSettingsComponent', () => {
         management: {
           title: 'New Title',
           support: {
+            enabled: true,
+          },
+          pathBasedApiCreation: {
             enabled: true,
           },
           userCreation: {

--- a/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.ts
@@ -81,6 +81,7 @@ export class OrgSettingsGeneralComponent implements OnInit, OnDestroy {
             title: [toFormState(this.settings, 'management.title')],
             url: [toFormState(this.settings, 'management.url')],
             support: this.fb.group({ enabled: [toFormState(this.settings, 'management.support.enabled')] }),
+            pathBasedApiCreation: this.fb.group({ enabled: [toFormState(this.settings, 'management.pathBasedApiCreation.enabled')] }),
             userCreation: this.fb.group({ enabled: [toFormState(this.settings, 'management.userCreation.enabled')] }),
             automaticValidation: this.fb.group({ enabled: [toFormState(this.settings, 'management.automaticValidation.enabled')] }),
           }),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -296,7 +296,8 @@ public enum Key {
         "console.dashboards.apiStatus.enabled",
         "true",
         new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))
-    );
+    ),
+    CONSOLE_PATH_BASED_API_CREATION_ENABLED("console.pathBasedApiCreation.enabled", "false", Set.of(ORGANIZATION, SYSTEM));
 
     String key;
     String defaultValue;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/Management.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/Management.java
@@ -35,6 +35,9 @@ public class Management {
     @ParameterKey(Key.MANAGEMENT_URL)
     private String url;
 
+    @ParameterKey(Key.CONSOLE_PATH_BASED_API_CREATION_ENABLED)
+    private Enabled pathBasedApiCreation;
+
     @ParameterKey(Key.CONSOLE_USERCREATION_ENABLED)
     private Enabled userCreation;
 
@@ -63,6 +66,14 @@ public class Management {
 
     public void setUrl(String url) {
         this.url = url;
+    }
+
+    public Enabled getPathBasedApiCreation() {
+        return pathBasedApiCreation;
+    }
+
+    public void setPathBasedApiCreation(Enabled pathBasedApiCreation) {
+        this.pathBasedApiCreation = pathBasedApiCreation;
     }
 
     public Enabled getUserCreation() {


### PR DESCRIPTION
Replace https://github.com/gravitee-io/old-gravitee-api-management/pull/297

**Issue**

https://github.com/gravitee-io/issues/issues/6377

**Description**

From now on path based API creation is disabled by default as it
shall be deprecated in version 3.20.

The feature is still available for activation through organization
settings.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uusxqbgwcy.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6377-path-based-creation-deprecation/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
