### PR TITLE
feat(ssl): support native openssl on http client

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/connector/AbstractConnector.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/connector/AbstractConnector.java
@@ -193,6 +193,10 @@ public abstract class AbstractConnector<T extends HttpEndpoint> extends Abstract
             options.setSsl(true)
                     .setUseAlpn(true);
 
+            if (environment.getProperty("http.ssl.openssl", Boolean.class, false)) {
+                options.setSslEngineOptions(new OpenSSLEngineOptions());
+            }
+
             if (sslOptions != null) {
                 options
                         .setVerifyHost(sslOptions.isHostnameVerifier())

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -304,6 +304,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <version>${netty-tcnative-boringssl-static.version}</version>
             <classifier>linux-x86_64</classifier>
         </dependency>
     </dependencies>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -38,6 +38,7 @@
 #      type: jks # Supports jks, pem, pkcs12
 #      path: ${gravitee.home}/security/truststore.jks
 #      password: secret
+#    openssl: false # Used to rely on OpenSSL Engine instead of default JDK SSL Engine
 #  websocket:
 #    enabled: false
 #    subProtocols: v10.stomp, v11.stomp, v12.stomp

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,7 @@
         <xmlbeans.version>3.1.0</xmlbeans.version>
         <wiremock.version>2.26.3</wiremock.version>
         <wsdl4j.version>1.6.3</wsdl4j.version>
+        <netty-tcnative-boringssl-static.version>2.0.42.Final</netty-tcnative-boringssl-static.version>
         <!-- Plugins version -->
         <maven-assembly-plugin.version>2.6</maven-assembly-plugin.version>
         <prettier-maven-plugin.version>0.12</prettier-maven-plugin.version>


### PR DESCRIPTION
Replace https://github.com/gravitee-io/old-gravitee-api-management/pull/324

**Issue**

https://github.com/gravitee-io/issues/issues/6640

**Description**

This aims to backport an optimisation of ssl support when calling https endpoints.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-6640-backport-native-ssl-http-client/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
