### PR TITLE
Fix/6586 fix plans database

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/InstallationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/InstallationService.java
@@ -26,6 +26,7 @@ import java.util.Map;
 public interface InstallationService {
     String COCKPIT_INSTALLATION_ID = "COCKPIT_INSTALLATION_ID";
     String COCKPIT_INSTALLATION_STATUS = "COCKPIT_INSTALLATION_STATUS";
+    String PLANS_DATA_UPGRADER_STATUS = "PLANS_DATA_UPGRADER_STATUS";
 
     /**
      * Get the current installation.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/builder/EmailNotificationBuilder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/builder/EmailNotificationBuilder.java
@@ -116,6 +116,7 @@ public class EmailNotificationBuilder {
         API_REQUEST_FOR_CHANGES(ApiHook.REQUEST_FOR_CHANGES, "requestForChanges.html", "Request for changes on API"),
         API_REVIEW_OK(ApiHook.REVIEW_OK, "reviewOk.html", "API review accepted"),
         API_API_DEPRECATED(ApiHook.API_DEPRECATED, "apiDeprecated.html", "API deprecated"),
+        API_PLANS_DATA_FIXED(ApiHook.MESSAGE, "apiPlansDataFixed.html", "API plans data have been fixed"),
         APPLICATION_SUBSCRIPTION_NEW(
             ApplicationHook.SUBSCRIPTION_NEW,
             "subscriptionCreated.html",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/PlansDataFixUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/PlansDataFixUpgrader.java
@@ -1,0 +1,329 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade;
+
+import static io.gravitee.rest.api.service.impl.upgrade.PlansDataFixUpgrader.Status.*;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.api.PlanRepository;
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.repository.management.model.Plan;
+import io.gravitee.rest.api.model.InstallationEntity;
+import io.gravitee.rest.api.service.ApiService;
+import io.gravitee.rest.api.service.EmailService;
+import io.gravitee.rest.api.service.InstallationService;
+import io.gravitee.rest.api.service.Upgrader;
+import io.gravitee.rest.api.service.builder.EmailNotificationBuilder;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.common.UuidString;
+import java.util.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.Ordered;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component
+public class PlansDataFixUpgrader implements Upgrader, Ordered {
+
+    enum Status {
+        RUNNING,
+        DRY_SUCCESS,
+        SUCCESS,
+        FAILURE,
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlansDataFixUpgrader.class);
+    private static final String PLAN_DESCRIPTION =
+        "This plan has been recreated during a data fix process. See documentation : https://docs.gravitee.io/apim/3.x/apim_installguide_migration.html#upgrade_to_3_10_8";
+    private static final String PLAN_NAME_SUFFIX = "-Recreated";
+
+    @Autowired
+    private InstallationService installationService;
+
+    @Autowired
+    private ApiRepository apiRepository;
+
+    @Autowired
+    private PlanRepository planRepository;
+
+    @Autowired
+    private EmailService emailService;
+
+    @Autowired
+    private ApiService apiService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Value("${services.plans-data-fix-upgrader.enabled:true}")
+    private boolean enabled;
+
+    @Value("${services.plans-data-fix-upgrader.dryRun:true}")
+    private boolean dryRun;
+
+    @Value("${services.plans-data-fix-upgrader.notifyApiOwner:false}")
+    private boolean notifyApiOwner;
+
+    private boolean anomalyFound = false;
+
+    @Override
+    public boolean upgrade() {
+        if (!enabled) {
+            LOGGER.info("Skipping {} execution cause it's not enabled in configuration", this.getClass().getSimpleName());
+            return false;
+        }
+        InstallationEntity installation = installationService.getOrInitialize();
+        if (dryRun && isStatus(installation, DRY_SUCCESS)) {
+            LOGGER.info(
+                "Skipping {} execution cause it has already been successfully executed in dry mode",
+                this.getClass().getSimpleName()
+            );
+            return false;
+        }
+        if (isStatus(installation, SUCCESS)) {
+            LOGGER.info("Skipping {} execution cause it has already been successfully executed", this.getClass().getSimpleName());
+            return false;
+        }
+        if (isStatus(installation, RUNNING)) {
+            LOGGER.warn("Skipping {} execution cause it's already running", this.getClass().getSimpleName());
+            return false;
+        }
+
+        try {
+            LOGGER.info("Starting {} execution with dry-run {}", this.getClass().getSimpleName(), dryRun ? "enabled" : "disabled");
+            setExecutionStatus(installation, RUNNING);
+            fixPlansData();
+            setExecutionStatus(installation, dryRun ? DRY_SUCCESS : SUCCESS);
+        } catch (Throwable e) {
+            LOGGER.error("{} execution failed", this.getClass().getSimpleName(), e);
+            setExecutionStatus(installation, FAILURE);
+            return false;
+        }
+        LOGGER.info("Finishing {} execution", this.getClass().getSimpleName());
+        return true;
+    }
+
+    @Override
+    public int getOrder() {
+        return 500;
+    }
+
+    protected void fixPlansData() throws Exception {
+        for (Api api : apiRepository.findAll()) {
+            io.gravitee.definition.model.Api apiDefinition = objectMapper.readValue(
+                api.getDefinition(),
+                io.gravitee.definition.model.Api.class
+            );
+
+            if (DefinitionVersion.V2 == apiDefinition.getDefinitionVersion()) {
+                fixApiPlans(api, apiDefinition);
+            }
+        }
+        if (!anomalyFound) {
+            LOGGER.info("No plan data anomaly found");
+        }
+    }
+
+    protected void fixApiPlans(Api api, io.gravitee.definition.model.Api apiDefinition) throws Exception {
+        Set<Plan> apiPlans = planRepository.findByApi(api.getId());
+        List<io.gravitee.definition.model.Plan> definitionPlans = apiDefinition.getPlans();
+
+        if (!hasPlansDataAnomaly(apiPlans, definitionPlans)) {
+            LOGGER.debug("Skipping API {} : no plans anomaly detected", api.getId());
+            return;
+        }
+
+        if (!anomalyFound) {
+            logWarningHeaderBlock();
+            anomalyFound = true;
+        }
+
+        LOGGER.info("Plans anomalies found for API \"{}\" ({}) :", api.getName(), api.getId());
+
+        Map<String, Plan> apiPlansMap = apiPlans.stream().collect(toMap(Plan::getId, plan -> plan));
+        Map<String, io.gravitee.definition.model.Plan> definitionPlansMap = definitionPlans
+            .stream()
+            .collect(toMap(io.gravitee.definition.model.Plan::getId, plan -> plan, (plan1, plan2) -> plan1));
+
+        // close plans in plans table, which are absent from api definition
+        List<Plan> closedPlans = closeExtraApiPlans(definitionPlansMap, apiPlansMap);
+
+        // add in plans tables, all plans that are present in api definition, but not plans table
+        List<Plan> createdPlans = createMissingApiPlans(definitionPlansMap, apiPlansMap, api);
+
+        // update api definition plans (only ids and names changed)
+        updateApiDefinitionPlans(api, apiDefinition, definitionPlansMap);
+
+        // notify API owner by email
+        if (!dryRun && notifyApiOwner) {
+            sendEmailToApiOwner(api, createdPlans, closedPlans);
+        }
+    }
+
+    protected List<Plan> createMissingApiPlans(
+        Map<String, io.gravitee.definition.model.Plan> definitionPlansMap,
+        Map<String, Plan> apiPlansMap,
+        Api api
+    ) throws TechnicalException {
+        List<Plan> addedPlans = new ArrayList<>();
+        for (Map.Entry<String, io.gravitee.definition.model.Plan> definitionPlanEntry : definitionPlansMap.entrySet()) {
+            String planId = definitionPlanEntry.getKey();
+            if (!apiPlansMap.containsKey(planId)) {
+                io.gravitee.definition.model.Plan definitionPlan = definitionPlanEntry.getValue();
+                Plan newApiPlan = planFromDefinitionPlan(definitionPlan, api.getId());
+                LOGGER.info(
+                    "- Will create plan \"{}\" for API \"{}\" ({}), which is missing in plans table",
+                    newApiPlan.getName(),
+                    api.getName(),
+                    api.getId()
+                );
+                if (!dryRun) {
+                    planRepository.create(newApiPlan);
+                }
+                apiPlansMap.put(planId, newApiPlan);
+                definitionPlan.setId(newApiPlan.getId());
+                definitionPlan.setName(newApiPlan.getName());
+                addedPlans.add(newApiPlan);
+            }
+        }
+        return addedPlans;
+    }
+
+    protected List<Plan> closeExtraApiPlans(
+        Map<String, io.gravitee.definition.model.Plan> definitionPlansMap,
+        Map<String, Plan> apiPlansMap
+    ) throws TechnicalException {
+        List<Plan> extraPlans = apiPlansMap
+            .values()
+            .stream()
+            .filter(apiPlan -> apiPlan.getStatus() != Plan.Status.CLOSED)
+            .filter(apiPlan -> !definitionPlansMap.containsKey(apiPlan.getId()))
+            .collect(toList());
+        for (Plan plan : extraPlans) {
+            LOGGER.info("- Will close plan \"{}\" ({}), cause it's absent from api definition", plan.getName(), plan.getId());
+            plan.setStatus(Plan.Status.CLOSED);
+            if (!dryRun) {
+                planRepository.update(plan);
+            }
+        }
+        return extraPlans;
+    }
+
+    private Plan planFromDefinitionPlan(io.gravitee.definition.model.Plan definitionPlan, String apiId) {
+        Plan plan = new Plan();
+        plan.setId(UuidString.generateRandom());
+        plan.setType(Plan.PlanType.API);
+        plan.setValidation(Plan.PlanValidationType.MANUAL);
+        plan.setStatus(Plan.Status.DEPRECATED);
+        plan.setName(definitionPlan.getName().concat(PLAN_NAME_SUFFIX));
+        plan.setDescription(PLAN_DESCRIPTION);
+        plan.setApi(apiId);
+        plan.setSecurityDefinition(definitionPlan.getSecurityDefinition());
+        plan.setSelectionRule(definitionPlan.getSelectionRule());
+        plan.setTags(definitionPlan.getTags());
+        plan.setCreatedAt(new Date());
+        plan.setUpdatedAt(plan.getCreatedAt());
+        plan.setNeedRedeployAt(plan.getCreatedAt());
+        if (definitionPlan.getSecurity() != null) {
+            plan.setSecurity(Plan.PlanSecurityType.valueOf(definitionPlan.getSecurity()));
+        }
+        return plan;
+    }
+
+    private void updateApiDefinitionPlans(
+        Api api,
+        io.gravitee.definition.model.Api apiDefinition,
+        Map<String, io.gravitee.definition.model.Plan> definitionPlansMap
+    ) throws TechnicalException, JsonProcessingException {
+        apiDefinition.setPlans(new ArrayList<>(definitionPlansMap.values()));
+        api.setDefinition(objectMapper.writeValueAsString(apiDefinition));
+        if (!dryRun) {
+            apiRepository.update(api);
+        }
+    }
+
+    private void setExecutionStatus(InstallationEntity installation, Status status) {
+        installation.getAdditionalInformation().put(InstallationService.PLANS_DATA_UPGRADER_STATUS, status.toString());
+        installationService.setAdditionalInformation(installation.getAdditionalInformation());
+    }
+
+    private boolean isStatus(InstallationEntity installation, Status status) {
+        return status.toString().equals(installation.getAdditionalInformation().get(InstallationService.PLANS_DATA_UPGRADER_STATUS));
+    }
+
+    private boolean hasPlansDataAnomaly(Set<Plan> apiPlans, List<io.gravitee.definition.model.Plan> definitionPlans) {
+        List<String> apiPlansIds = apiPlans
+            .stream()
+            .filter(plan -> plan.getStatus() != Plan.Status.CLOSED)
+            .map(Plan::getId)
+            .collect(toList());
+        List<String> definitionPlansIds = definitionPlans.stream().map(io.gravitee.definition.model.Plan::getId).collect(toList());
+        return apiPlansIds.size() != definitionPlansIds.size() || !definitionPlansIds.containsAll(apiPlansIds);
+    }
+
+    protected void sendEmailToApiOwner(Api api, List<Plan> createdPlans, List<Plan> closedPlans) {
+        getApiOwnerEmail(api)
+            .ifPresent(
+                apiOwnerEmail -> {
+                    LOGGER.debug("Sending report email to api {} owner", api.getId());
+                    emailService.sendAsyncEmailNotification(
+                        new EmailNotificationBuilder()
+                            .params(Map.of("api", api, "closedPlans", closedPlans, "createdPlans", createdPlans))
+                            .to(apiOwnerEmail)
+                            .template(EmailNotificationBuilder.EmailTemplate.API_PLANS_DATA_FIXED)
+                            .build(),
+                        GraviteeContext.getCurrentContext()
+                    );
+                }
+            );
+    }
+
+    private Optional<String> getApiOwnerEmail(Api api) {
+        return Optional.ofNullable(apiService.getPrimaryOwner(api.getId()).getEmail());
+    }
+
+    private void logWarningHeaderBlock() {
+        LOGGER.warn("");
+        LOGGER.warn("##############################################################");
+        LOGGER.warn("#                           WARNING                          #");
+        LOGGER.warn("##############################################################");
+        LOGGER.warn("");
+        LOGGER.warn("We detected database anomalies in your plans data.");
+        LOGGER.warn("");
+        if (dryRun) {
+            LOGGER.warn("THIS IS A DRY RUN. DATABASE WON'T BE UPDATED.");
+            LOGGER.warn("To fix anomalies, disable the dry run mode.");
+            LOGGER.warn("Below, a list of changes that would happen without dry run");
+        } else {
+            LOGGER.warn("Database anomalies will be fixed.");
+        }
+        LOGGER.warn("See related documentation : https://docs.gravitee.io/apim/3.x/apim_installguide_migration.html#upgrade_to_3_10_8");
+        LOGGER.warn("");
+        LOGGER.warn("##############################################################");
+        LOGGER.warn("");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/PlansDataFixUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/PlansDataFixUpgraderTest.java
@@ -1,0 +1,268 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.api.PlanRepository;
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.repository.management.model.Plan;
+import io.gravitee.rest.api.model.InstallationEntity;
+import io.gravitee.rest.api.model.PrimaryOwnerEntity;
+import io.gravitee.rest.api.service.ApiService;
+import io.gravitee.rest.api.service.EmailService;
+import io.gravitee.rest.api.service.InstallationService;
+import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.util.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PlansDataFixUpgraderTest {
+
+    @InjectMocks
+    @Spy
+    private PlansDataFixUpgrader upgrader = new PlansDataFixUpgrader();
+
+    @Mock
+    private InstallationService installationService;
+
+    @Mock
+    private ApiRepository apiRepository;
+
+    @Mock
+    private PlanRepository planRepository;
+
+    @Mock
+    private ApiService apiService;
+
+    @Mock
+    private EmailService emailService;
+
+    @Test
+    public void upgrade_should_not_run_cause_not_enabled() {
+        ReflectionTestUtils.setField(upgrader, "enabled", false);
+
+        boolean success = upgrader.upgrade();
+
+        assertFalse(success);
+        verifyNoInteractions(installationService);
+    }
+
+    @Test
+    public void upgrade_should_not_run_cause_already_executed_successfull() {
+        ReflectionTestUtils.setField(upgrader, "enabled", true);
+        mockInstallationWithExecutionStatus("SUCCESS");
+
+        boolean success = upgrader.upgrade();
+
+        assertFalse(success);
+        verify(installationService, never()).setAdditionalInformation(any());
+    }
+
+    @Test
+    public void upgrade_should_not_run_cause_already_running() {
+        ReflectionTestUtils.setField(upgrader, "enabled", true);
+        mockInstallationWithExecutionStatus("RUNNING");
+
+        boolean success = upgrader.upgrade();
+
+        assertFalse(success);
+        verify(installationService, never()).setAdditionalInformation(any());
+    }
+
+    @Test
+    public void upgrade_should_run_and_set_failure_status_on_exception() throws Exception {
+        ReflectionTestUtils.setField(upgrader, "enabled", true);
+        InstallationEntity installation = mockInstallationWithExecutionStatus(null);
+        doThrow(new Exception("test exception")).when(upgrader).fixPlansData();
+
+        boolean success = upgrader.upgrade();
+
+        assertFalse(success);
+        verify(installation.getAdditionalInformation(), times(1)).put(InstallationService.PLANS_DATA_UPGRADER_STATUS, "RUNNING");
+        verify(installation.getAdditionalInformation(), times(1)).put(InstallationService.PLANS_DATA_UPGRADER_STATUS, "FAILURE");
+        verify(installationService, times(2)).setAdditionalInformation(installation.getAdditionalInformation());
+    }
+
+    @Test
+    public void upgrade_should_run_and_set_success_status() throws Exception {
+        ReflectionTestUtils.setField(upgrader, "enabled", true);
+        InstallationEntity installation = mockInstallationWithExecutionStatus(null);
+        doNothing().when(upgrader).fixPlansData();
+
+        boolean success = upgrader.upgrade();
+
+        assertTrue(success);
+        verify(installation.getAdditionalInformation(), times(1)).put(InstallationService.PLANS_DATA_UPGRADER_STATUS, "RUNNING");
+        verify(installation.getAdditionalInformation(), times(1)).put(InstallationService.PLANS_DATA_UPGRADER_STATUS, "SUCCESS");
+        verify(installationService, times(2)).setAdditionalInformation(installation.getAdditionalInformation());
+    }
+
+    @Test
+    public void upgrade_should_run_and_set_dry_success_status() throws Exception {
+        ReflectionTestUtils.setField(upgrader, "enabled", true);
+        ReflectionTestUtils.setField(upgrader, "dryRun", true);
+        InstallationEntity installation = mockInstallationWithExecutionStatus(null);
+        doNothing().when(upgrader).fixPlansData();
+
+        boolean success = upgrader.upgrade();
+
+        assertTrue(success);
+        verify(installation.getAdditionalInformation(), times(1)).put(InstallationService.PLANS_DATA_UPGRADER_STATUS, "RUNNING");
+        verify(installation.getAdditionalInformation(), times(1)).put(InstallationService.PLANS_DATA_UPGRADER_STATUS, "DRY_SUCCESS");
+        verify(installationService, times(2)).setAdditionalInformation(installation.getAdditionalInformation());
+    }
+
+    @Test
+    public void fixPlansData_should_fix_only_v2_apis() throws Exception {
+        ReflectionTestUtils.setField(upgrader, "objectMapper", new ObjectMapper());
+        doNothing().when(upgrader).fixApiPlans(any(), any());
+
+        Api apiv1_1 = new Api();
+        apiv1_1.setId("api1");
+        apiv1_1.setDefinition("{}");
+        Api apiv2_1 = new Api();
+        apiv2_1.setId("api2");
+        apiv2_1.setDefinition("{\"gravitee\": \"2.0.0\"}");
+        Api apiv1_2 = new Api();
+        apiv1_2.setId("api3");
+        apiv1_2.setDefinition("{\"gravitee\": \"1.0.0\"}");
+        Api apiv2_2 = new Api();
+        apiv2_2.setId("api4");
+        apiv2_2.setDefinition("{\"gravitee\": \"2.0.0\"}");
+        when(apiRepository.findAll()).thenReturn(Set.of(apiv1_1, apiv2_1, apiv1_2, apiv2_2));
+
+        upgrader.fixPlansData();
+
+        verify(upgrader, times(1)).fixApiPlans(same(apiv2_1), any());
+        verify(upgrader, times(1)).fixApiPlans(same(apiv2_2), any());
+        verify(upgrader, never()).fixApiPlans(same(apiv1_1), any());
+        verify(upgrader, never()).fixApiPlans(same(apiv1_2), any());
+    }
+
+    @Test
+    public void closeExtraApiPlans_should_close_extra_plans() throws TechnicalException {
+        Map<String, Plan> apiPlansMap = new HashMap<>(Map.of("plan12", new Plan(), "plan47", new Plan(), "plan78", new Plan()));
+        apiPlansMap.get("plan12").setId("plan12");
+        apiPlansMap.get("plan47").setId("plan47");
+        apiPlansMap.get("plan78").setId("plan78");
+
+        Map<String, io.gravitee.definition.model.Plan> definitionPlansMap = Map.of(
+            "plan78",
+            new io.gravitee.definition.model.Plan(),
+            "plan22",
+            new io.gravitee.definition.model.Plan(),
+            "plan12",
+            new io.gravitee.definition.model.Plan(),
+            "plan88",
+            new io.gravitee.definition.model.Plan()
+        );
+
+        upgrader.closeExtraApiPlans(definitionPlansMap, apiPlansMap);
+
+        verify(planRepository, times(1)).update(argThat(plan -> plan.getId().equals("plan47") && plan.getStatus() == Plan.Status.CLOSED));
+        verifyNoMoreInteractions(planRepository);
+    }
+
+    @Test
+    public void addMissingApiPlans_should_create_all_missing_plans() throws TechnicalException {
+        Map<String, Plan> apiPlansMap = new HashMap<>(Map.of("plan12", new Plan(), "plan47", new Plan(), "plan78", new Plan()));
+        Map<String, io.gravitee.definition.model.Plan> definitionPlansMap = Map.of(
+            "plan78",
+            new io.gravitee.definition.model.Plan(),
+            "plan22",
+            new io.gravitee.definition.model.Plan(),
+            "plan12",
+            new io.gravitee.definition.model.Plan(),
+            "plan88",
+            new io.gravitee.definition.model.Plan()
+        );
+        definitionPlansMap.get("plan22").setName("name plan22");
+        definitionPlansMap.get("plan88").setName("name plan88");
+
+        Api api = new Api();
+        api.setId("my-api-id");
+
+        upgrader.createMissingApiPlans(definitionPlansMap, apiPlansMap, api);
+
+        assertEquals(5, apiPlansMap.size());
+        assertEquals(4, definitionPlansMap.size());
+        assertTrue(apiPlansMap.containsKey("plan12"));
+        assertTrue(apiPlansMap.containsKey("plan78"));
+        assertTrue(apiPlansMap.containsKey("plan47"));
+        assertTrue(apiPlansMap.containsKey("plan22"));
+        assertTrue(apiPlansMap.containsKey("plan88"));
+        verify(planRepository, times(2)).create(argThat(plan -> plan.getApi().equals("my-api-id")));
+    }
+
+    @Test
+    public void sendEmailToApiOwner_should_retrieve_api_owner_from_apiService() {
+        Api api = new Api();
+        api.setId("my-api-id");
+
+        when(apiService.getPrimaryOwner("my-api-id")).thenReturn(new PrimaryOwnerEntity());
+
+        upgrader.sendEmailToApiOwner(api, Collections.emptyList(), Collections.emptyList());
+
+        verify(apiService, times(1)).getPrimaryOwner("my-api-id");
+    }
+
+    @Test
+    public void sendEmailToApiOwner_send_email_to_owner_using_mailService() {
+        Api api = new Api();
+        api.setId("my-api-id");
+
+        PrimaryOwnerEntity primaryOwner = new PrimaryOwnerEntity();
+        primaryOwner.setEmail("primary-owner-email");
+        when(apiService.getPrimaryOwner("my-api-id")).thenReturn(primaryOwner);
+
+        List<Plan> createdPlans = new ArrayList<>();
+        List<Plan> closedPlans = new ArrayList<>();
+        upgrader.sendEmailToApiOwner(api, createdPlans, closedPlans);
+
+        verify(emailService, times(1))
+            .sendAsyncEmailNotification(
+                argThat(
+                    notification ->
+                        notification.getTo()[0].equals("primary-owner-email") &&
+                        notification.getParams().get("api") == api &&
+                        notification.getParams().get("createdPlans") == createdPlans &&
+                        notification.getParams().get("closedPlans") == closedPlans
+                ),
+                any()
+            );
+    }
+
+    private InstallationEntity mockInstallationWithExecutionStatus(String status) {
+        InstallationEntity installation = mock(InstallationEntity.class);
+        Map<String, String> installationAdditionalInformations = mock(Map.class);
+        when(installation.getAdditionalInformation()).thenReturn(installationAdditionalInformations);
+        when(installationAdditionalInformations.get(InstallationService.PLANS_DATA_UPGRADER_STATUS)).thenReturn(status);
+        when(installationService.getOrInitialize()).thenReturn(installation);
+        return installation;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/logback.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/logback.xml
@@ -39,6 +39,24 @@
         </encoder>
     </appender>
 
+    <appender name="FILE-UPGRADERS" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${gravitee.management.log.dir}/gravitee-upgraders.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- monthly rollover -->
+            <fileNamePattern>${gravitee.management.log.dir}/gravitee-upgraders_%d{yyyy-MM}.log</fileNamePattern>
+
+            <!-- keep 12 months worth of history -->
+            <maxHistory>12</maxHistory>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.gravitee.rest.api.service.impl.upgrade" level="INFO">
+        <appender-ref ref="FILE-UPGRADERS" />
+    </logger>
     <logger name="io.gravitee" level="INFO" />
     <logger name="org.eclipse.jetty" level="INFO" />
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/templates/apiPlansDataFixed.html
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/templates/apiPlansDataFixed.html
@@ -1,4 +1,8 @@
+<!DOCTYPE html>
 <html>
+	<head lang="en">
+		<title>API plans data fixed</title>
+	</head>
 	<body style="text-align: center;">
 		<header>
 			<#include "header.html" />
@@ -11,7 +15,7 @@
 			</p>
 			<#if closedPlans?size != 0>
 				<p>
-					<b>Those plans have been closed :</b><br/>
+					<strong>Those plans have been closed :</strong><br/>
 					<#list closedPlans as plan>
 						- Plan <code>${plan.name}</code> (id <code>${api.id}</code>)<br/>
 					</#list>
@@ -19,7 +23,7 @@
 			</#if>
 			<#if createdPlans?size != 0>
 				<p>
-					<b>Those plans have been created :</b><br/>
+					<strong>Those plans have been created :</strong><br/>
 					<#list createdPlans as plan>
 						- Plan <code>${plan.name}</code> (id <code>${plan.id}</code>)<br/>
 					</#list>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/templates/apiPlansDataFixed.html
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/templates/apiPlansDataFixed.html
@@ -1,0 +1,30 @@
+<html>
+	<body style="text-align: center;">
+		<header>
+			<#include "header.html" />
+		</header>
+		<div style="margin-top: 50px; color: #424e5a;">
+			<h3>Hi,</h3>
+			<p>
+				We detected database anomalies in your plans data on api <code>${api.name}</code> (id <code>${api.id}</code>), and fixed it.<br/>
+				See the details in related <a href="https://docs.gravitee.io/apim/3.x/apim_installguide_migration.html#upgrade_to_3_10_8">documentation</a>
+			</p>
+			<#if closedPlans?size != 0>
+				<p>
+					<b>Those plans have been closed :</b><br/>
+					<#list closedPlans as plan>
+						- Plan <code>${plan.name}</code> (id <code>${api.id}</code>)<br/>
+					</#list>
+				</p>
+			</#if>
+			<#if createdPlans?size != 0>
+				<p>
+					<b>Those plans have been created :</b><br/>
+					<#list createdPlans as plan>
+						- Plan <code>${plan.name}</code> (id <code>${plan.id}</code>)<br/>
+					</#list>
+				</p>
+			</#if>
+		</div>
+	</body>
+</html>


### PR DESCRIPTION
Replace https://github.com/gravitee-io/old-gravitee-api-management/pull/329

**Issue**

https://github.com/gravitee-io/issues/issues/6586

**Description**

This introduces a new upgrader, running at management API startup, to fix plans data anomalies.
See related documentation :  https://github.com/gravitee-io/release/blob/d6c66be21d7951851eb3cf381e5667d280b1419b/upgrades/3.x/3.10.8/README.adoc
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-6586-fix-plans-database/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
