### PR TITLE
feat(alert): add installation, env and org to event

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandler.java
@@ -33,8 +33,10 @@ import io.gravitee.gateway.policy.PolicyManager;
 import io.gravitee.gateway.reactor.Reactable;
 import io.gravitee.gateway.reactor.handler.AbstractReactorHandler;
 import io.gravitee.gateway.resource.ResourceLifecycleManager;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -77,6 +79,8 @@ public class ApiReactorHandler extends AbstractReactorHandler {
         context.setAttribute(ExecutionContext.ATTR_API, api.getId());
         context.setAttribute(ExecutionContext.ATTR_API_DEPLOYED_AT, api.getDeployedAt().getTime());
         context.setAttribute(ExecutionContext.ATTR_INVOKER, invoker);
+        context.setAttribute(ExecutionContext.ATTR_ORGANIZATION, api.getOrganizationId());
+        context.setAttribute(ExecutionContext.ATTR_ENVIRONMENT, api.getEnvironmentId());
 
         // Prepare request metrics
         request.metrics().setApi(api.getId());

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/definition/Api.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/definition/Api.java
@@ -40,6 +40,11 @@ public class Api extends io.gravitee.definition.model.Api implements Reactable, 
     private boolean enabled = true;
     private Date deployedAt;
 
+    private String environmentId;
+    private String environmentHrid;
+    private String organizationId;
+    private String organizationHrid;
+
     private DefinitionContext definitionContext = new DefinitionContext();
 
     public Api() {}
@@ -80,6 +85,10 @@ public class Api extends io.gravitee.definition.model.Api implements Reactable, 
         this.setDefinitionVersion(definition.getDefinitionVersion());
         this.setFlows(definition.getFlows());
         this.setFlowMode(definition.getFlowMode());
+        this.setEnvironmentId(definition.getEnvironmentId());
+        this.setEnvironmentHrid(definition.getEnvironmentHrid());
+        this.setOrganizationId(definition.getOrganizationId());
+        this.setOrganizationHrid(definition.getOrganizationHrid());
     }
 
     public DefinitionContext getDefinitionContext() {
@@ -243,6 +252,38 @@ public class Api extends io.gravitee.definition.model.Api implements Reactable, 
             .stream()
             .map(virtualHost -> new VirtualHost(virtualHost.getHost(), virtualHost.getPath()))
             .collect(Collectors.toList());
+    }
+
+    public String getEnvironmentId() {
+        return environmentId;
+    }
+
+    public void setEnvironmentId(String environmentId) {
+        this.environmentId = environmentId;
+    }
+
+    public String getEnvironmentHrid() {
+        return environmentHrid;
+    }
+
+    public void setEnvironmentHrid(String environmentHrid) {
+        this.environmentHrid = environmentHrid;
+    }
+
+    public String getOrganizationId() {
+        return organizationId;
+    }
+
+    public void setOrganizationId(String organizationId) {
+        this.organizationId = organizationId;
+    }
+
+    public String getOrganizationHrid() {
+        return organizationHrid;
+    }
+
+    public void setOrganizationHrid(String organizationHrid) {
+        this.organizationHrid = organizationHrid;
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/alert/AlertProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/alert/AlertProcessor.java
@@ -43,6 +43,8 @@ public class AlertProcessor extends AbstractProcessor<ExecutionContext> {
     private static final String CONTEXT_GATEWAY_PORT = "gateway.port";
 
     private static final String PROP_TENANT = "tenant";
+    private static final String PROP_ORGANIZATION = "organization";
+    private static final String PROP_ENVIRONMENT = "environment";
 
     private static final String PROP_REQUEST_ID = "request.id";
     private static final String PROP_REQUEST_USER_AGENT = "request.user_agent";
@@ -107,6 +109,8 @@ public class AlertProcessor extends AbstractProcessor<ExecutionContext> {
                     .property(PROP_QUOTA_COUNTER, context.getAttribute(ExecutionContext.ATTR_QUOTA_COUNT))
                     .property(PROP_QUOTA_LIMIT, context.getAttribute(ExecutionContext.ATTR_QUOTA_LIMIT))
                     .property(PROP_ERROR_KEY, context.request().metrics().getErrorKey())
+                    .organization((String) context.getAttribute(ExecutionContext.ATTR_ORGANIZATION))
+                    .environment((String) context.getAttribute(ExecutionContext.ATTR_ENVIRONMENT))
                     .build()
             );
         } catch (Exception ex) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncService.java
@@ -17,26 +17,17 @@ package io.gravitee.gateway.services.sync;
 
 import io.gravitee.common.http.MediaType;
 import io.gravitee.common.service.AbstractService;
-import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.handlers.api.manager.ApiManager;
 import io.gravitee.gateway.services.sync.cache.ApiKeysCacheService;
 import io.gravitee.gateway.services.sync.cache.SubscriptionsCacheService;
 import io.gravitee.gateway.services.sync.handler.SyncHandler;
 import io.gravitee.gateway.services.sync.healthcheck.ApiSyncProbe;
+import io.gravitee.node.api.Node;
 import io.gravitee.node.api.healthcheck.ProbeManager;
-import io.gravitee.repository.exceptions.TechnicalException;
-import io.gravitee.repository.management.api.EnvironmentRepository;
-import io.gravitee.repository.management.api.OrganizationRepository;
-import io.gravitee.repository.management.model.Environment;
-import io.gravitee.repository.management.model.Organization;
 import io.vertx.ext.web.Router;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
+import java.util.ArrayList;
 import java.util.Set;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -92,15 +83,7 @@ public class SyncService extends AbstractService {
     private ApiSyncProbe apiSyncProbe;
 
     @Autowired
-    private EnvironmentRepository environmentRepository;
-
-    @Autowired
-    private OrganizationRepository organizationRepository;
-
-    @Autowired
-    private GatewayConfiguration configuration;
-
-    private Set<Environment> environments;
+    private Node node;
 
     @Override
     protected void doStart() throws Exception {
@@ -109,8 +92,6 @@ public class SyncService extends AbstractService {
                 super.doStart();
 
                 logger.info("Sync service has been initialized with delay [{}{}]", delay, unit.name());
-
-                this.environments = getTargetedEnvironments();
 
                 probeManager.register(this.apiSyncProbe);
 
@@ -132,8 +113,7 @@ public class SyncService extends AbstractService {
                 syncManager.start();
 
                 // Set environments list to syncManager
-                List<String> environmentsIds = environments.stream().map(Environment::getId).collect(Collectors.toList());
-                syncManager.setEnvironments(environmentsIds);
+                syncManager.setEnvironments(new ArrayList<>((Set<String>) node.metadata().get(Node.META_ENVIRONMENTS)));
 
                 // Run a first refresh immediately.
                 syncManager.refresh();
@@ -166,54 +146,5 @@ public class SyncService extends AbstractService {
     @Override
     protected String name() {
         return "Gateway Sync Service";
-    }
-
-    private Set<Environment> getTargetedEnvironments() throws TechnicalException {
-        final Optional<List<String>> optOrganizationsList = configuration.organizations();
-        final Optional<List<String>> optEnvironmentsList = configuration.environments();
-
-        Set<String> organizationsIds = new HashSet<>();
-        Set<String> environmentsHrids = new HashSet<>();
-
-        if (optOrganizationsList.isPresent()) {
-            List<String> organizationsHrids = optOrganizationsList.get();
-            final Set<Organization> organizations = organizationRepository.findByHrids(new HashSet<>(organizationsHrids));
-            organizationsIds = organizations.stream().map(Organization::getId).collect(Collectors.toSet());
-
-            checkOrganizations(organizationsHrids, organizations);
-        }
-
-        if (optEnvironmentsList.isPresent()) {
-            environmentsHrids = new HashSet<>(optEnvironmentsList.get());
-        }
-
-        Set<Environment> environments = environmentRepository.findByOrganizationsAndHrids(organizationsIds, environmentsHrids);
-
-        checkEnvironments(environmentsHrids, environments);
-
-        return environments;
-    }
-
-    private void checkOrganizations(List<String> organizationsHrids, Set<Organization> organizations) {
-        if (organizationsHrids.size() != organizations.size()) {
-            final Set<String> hrids = new HashSet<>(organizationsHrids);
-            final Set<String> returnedHrids = organizations.stream().flatMap(org -> org.getHrids().stream()).collect(Collectors.toSet());
-            hrids.removeAll(returnedHrids);
-            logger.warn("No organization found for hrids {}", hrids);
-        }
-    }
-
-    private void checkEnvironments(Set<String> environmentsHrids, Set<Environment> environments) {
-        final Set<String> returnedHrids = environments
-            .stream()
-            .flatMap(env -> env.getHrids().stream())
-            .filter(environmentsHrids::contains)
-            .collect(Collectors.toSet());
-
-        if (environmentsHrids.size() != returnedHrids.size()) {
-            final Set<String> hrids = new HashSet<>(environmentsHrids);
-            hrids.removeAll(returnedHrids);
-            logger.warn("No environment found for hrids {}", hrids);
-        }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/builder/RepositoryApiBuilder.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/builder/RepositoryApiBuilder.java
@@ -49,6 +49,11 @@ public class RepositoryApiBuilder {
         return this;
     }
 
+    public RepositoryApiBuilder environment(String environmentId) {
+        this.api.setEnvironmentId(environmentId);
+        return this;
+    }
+
     public Api build() {
         return this.api;
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/node/GatewayNode.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/node/GatewayNode.java
@@ -16,15 +16,14 @@
 package io.gravitee.gateway.standalone.node;
 
 import io.gravitee.common.component.LifecycleComponent;
-import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.reactor.Reactor;
 import io.gravitee.gateway.report.impl.NodeMonitoringReporterService;
 import io.gravitee.gateway.standalone.vertx.VertxEmbeddedContainer;
+import io.gravitee.node.api.NodeMetadataResolver;
 import io.gravitee.node.cluster.ClusterService;
 import io.gravitee.node.container.AbstractNode;
 import io.gravitee.plugin.alert.AlertEventProducerManager;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,7 +35,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class GatewayNode extends AbstractNode {
 
     @Autowired
-    private GatewayConfiguration configuration;
+    private NodeMetadataResolver nodeMetadataResolver;
+
+    private Map<String, Object> metadata = null;
 
     @Override
     public String name() {
@@ -50,16 +51,8 @@ public class GatewayNode extends AbstractNode {
 
     @Override
     public Map<String, Object> metadata() {
-        Map<String, Object> metadata = new HashMap<>();
-
-        if (configuration.tenant().isPresent()) {
-            metadata.put("tenant", configuration.tenant().get());
-        }
-        if (configuration.shardingTags().isPresent()) {
-            metadata.put("tags", configuration.shardingTags().get());
-        }
-        if (configuration.zone().isPresent()) {
-            metadata.put("zone", configuration.zone().get());
+        if (metadata == null) {
+            metadata = nodeMetadataResolver.resolve();
         }
 
         return metadata;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/node/GatewayNodeMetadataResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/node/GatewayNodeMetadataResolver.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.standalone.node;
+
+import static io.gravitee.node.api.Node.*;
+
+import io.gravitee.gateway.env.GatewayConfiguration;
+import io.gravitee.node.api.NodeMetadataResolver;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.EnvironmentRepository;
+import io.gravitee.repository.management.api.InstallationRepository;
+import io.gravitee.repository.management.api.OrganizationRepository;
+import io.gravitee.repository.management.model.Environment;
+import io.gravitee.repository.management.model.Installation;
+import io.gravitee.repository.management.model.Organization;
+import java.util.*;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class GatewayNodeMetadataResolver implements NodeMetadataResolver {
+
+    private final Logger logger = LoggerFactory.getLogger(GatewayNodeMetadataResolver.class);
+
+    @Lazy
+    @Autowired
+    private InstallationRepository installationRepository;
+
+    @Lazy
+    @Autowired
+    private OrganizationRepository organizationRepository;
+
+    @Lazy
+    @Autowired
+    private EnvironmentRepository environmentRepository;
+
+    @Autowired
+    private GatewayConfiguration configuration;
+
+    public Map<String, Object> resolve() {
+        final HashMap<String, Object> metadata = new HashMap<>();
+
+        final String installationId = getInstallationId();
+        final Set<String> organizationIds = getOrganizationIds();
+        final Set<String> environmentIds = getEnvironmentIds(organizationIds);
+
+        if (configuration.tenant().isPresent()) {
+            metadata.put("tenant", configuration.tenant().get());
+        }
+        if (configuration.shardingTags().isPresent()) {
+            metadata.put("tags", configuration.shardingTags().get());
+        }
+        if (configuration.zone().isPresent()) {
+            metadata.put("zone", configuration.zone().get());
+        }
+
+        metadata.put(META_INSTALLATION, installationId);
+        metadata.put(META_ORGANIZATIONS, organizationIds);
+        metadata.put(META_ENVIRONMENTS, environmentIds);
+
+        return metadata;
+    }
+
+    private String getInstallationId() {
+        try {
+            return installationRepository.find().map(Installation::getId).orElse(null);
+        } catch (TechnicalException e) {
+            logger.warn("Unable to load installation id", e);
+        }
+
+        return null;
+    }
+
+    private Set<String> getOrganizationIds() {
+        try {
+            final Optional<List<String>> optOrganizationsList = configuration.organizations();
+
+            if (optOrganizationsList.isPresent()) {
+                Set<String> organizationHrids = new HashSet<>(optOrganizationsList.get());
+                final Set<Organization> organizations = organizationRepository.findByHrids(new HashSet<>(organizationHrids));
+                final Set<String> organizationIds = organizations.stream().map(Organization::getId).collect(Collectors.toSet());
+
+                checkOrganizations(organizationHrids, organizations);
+
+                return organizationIds;
+            }
+        } catch (Exception e) {
+            logger.warn("Unable to load organization ids", e);
+        }
+
+        return new HashSet<>();
+    }
+
+    private Set<String> getEnvironmentIds(Set<String> organizationIds) {
+        try {
+            final Optional<List<String>> optEnvironmentsList = configuration.environments();
+            Set<String> environmentHrids = new HashSet<>();
+
+            if (optEnvironmentsList.isPresent()) {
+                environmentHrids = new HashSet<>(optEnvironmentsList.get());
+            }
+
+            final Set<Environment> environments = environmentRepository.findByOrganizationsAndHrids(organizationIds, environmentHrids);
+            final Set<String> environmentIds = new HashSet<>();
+
+            for (Environment env : environments) {
+                organizationIds.add(env.getOrganizationId());
+                environmentIds.add(env.getId());
+            }
+
+            checkEnvironments(environmentHrids, environments);
+
+            return environmentIds;
+        } catch (Exception e) {
+            logger.warn("Unable to load environment ids", e);
+        }
+
+        return new HashSet<>();
+    }
+
+    private void checkOrganizations(Set<String> organizationsHrids, Set<Organization> organizations) {
+        if (organizationsHrids.size() != organizations.size()) {
+            final Set<String> hrids = new HashSet<>(organizationsHrids);
+            final Set<String> returnedHrids = organizations.stream().flatMap(org -> org.getHrids().stream()).collect(Collectors.toSet());
+            hrids.removeAll(returnedHrids);
+            logger.warn("No organization found for hrids {}", hrids);
+        }
+    }
+
+    private void checkEnvironments(Set<String> environmentHrids, Set<Environment> environments) {
+        final Set<String> returnedHrids = environments
+            .stream()
+            .flatMap(env -> env.getHrids().stream())
+            .filter(environmentHrids::contains)
+            .collect(Collectors.toSet());
+
+        if (environmentHrids.size() != returnedHrids.size()) {
+            final Set<String> hrids = new HashSet<>(environmentHrids);
+            hrids.removeAll(returnedHrids);
+            logger.warn("No environment found for hrids {}", hrids);
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/spring/StandaloneConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/spring/StandaloneConfiguration.java
@@ -30,7 +30,9 @@ import io.gravitee.gateway.policy.spring.PolicyConfiguration;
 import io.gravitee.gateway.reactor.spring.ReactorConfiguration;
 import io.gravitee.gateway.report.spring.ReporterConfiguration;
 import io.gravitee.gateway.standalone.node.GatewayNode;
+import io.gravitee.gateway.standalone.node.GatewayNodeMetadataResolver;
 import io.gravitee.gateway.standalone.vertx.VertxReactorConfiguration;
+import io.gravitee.node.api.NodeMetadataResolver;
 import io.gravitee.node.cluster.spring.ClusterConfiguration;
 import io.gravitee.node.container.NodeFactory;
 import io.gravitee.node.vertx.spring.VertxConfiguration;
@@ -94,5 +96,10 @@ public class StandaloneConfiguration {
     @Bean
     public static GatewayConfiguration gatewayConfiguration() {
         return new GatewayConfiguration();
+    }
+
+    @Bean
+    public NodeMetadataResolver nodeMetadataResolver() {
+        return new GatewayNodeMetadataResolver();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/container/GatewayTestContainer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/container/GatewayTestContainer.java
@@ -18,8 +18,12 @@ package io.gravitee.gateway.standalone.container;
 import io.gravitee.gateway.standalone.GatewayContainer;
 import io.gravitee.gateway.standalone.tracer.NoOpTracer;
 import io.gravitee.node.container.NodeFactory;
+import io.gravitee.repository.management.api.EnvironmentRepository;
+import io.gravitee.repository.management.api.InstallationRepository;
+import io.gravitee.repository.management.api.OrganizationRepository;
 import io.gravitee.tracing.api.Tracer;
 import java.util.List;
+import org.mockito.Mockito;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -50,6 +54,21 @@ public class GatewayTestContainer extends GatewayContainer {
         @Bean
         public Tracer tracer() {
             return new NoOpTracer();
+        }
+
+        @Bean
+        public InstallationRepository installationRepository() {
+            return Mockito.mock(InstallationRepository.class);
+        }
+
+        @Bean
+        public OrganizationRepository organizationRepository() {
+            return Mockito.mock(OrganizationRepository.class);
+        }
+
+        @Bean
+        public EnvironmentRepository environmentRepository() {
+            return Mockito.mock(EnvironmentRepository.class);
         }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/logback.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/logback.xml
@@ -50,6 +50,7 @@
     </appender>
 
     <logger name="io.gravitee" level="INFO" />
+    <logger name="com.graviteesource" level="INFO" />
     <logger name="org.reflections" level="WARN" />
     <logger name="org.springframework" level="WARN" />
     <logger name="org.eclipse.jetty" level="WARN" />

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AlertServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AlertServiceImpl.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.rest.api.service.impl;
 
+import static io.gravitee.rest.api.service.common.GraviteeContext.ReferenceContextType.ENVIRONMENT;
+import static io.gravitee.rest.api.service.common.GraviteeContext.ReferenceContextType.ORGANIZATION;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
 
@@ -45,6 +47,7 @@ import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.service.*;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.*;
 import io.gravitee.rest.api.service.impl.alert.EmailNotifierConfiguration;
 import java.io.IOException;
@@ -543,6 +546,29 @@ public class AlertServiceImpl extends TransactionalService implements AlertServi
             case API:
             case APPLICATION:
                 filters.add(StringCondition.equals(referenceType.name().toLowerCase(), referenceId).build());
+                break;
+            case PLATFORM:
+                // Add filters to make sure we will receive alert notifications only for events on the same organization / environment.
+                // For now, it seems that alerts are managed at organization level only. The behavior will change with https://github.com/gravitee-io/issues/issues/6079).
+                // It would be preferable to use a 'in' filter but this kind of filter does not exist yet. To keep backward compatibility we will rely on pattern matching.
+                filters.add(
+                    StringCondition
+                        .matches(
+                            ORGANIZATION.name().toLowerCase(),
+                            "(?:.*,|^)" + GraviteeContext.getCurrentOrganization() + "(?:,.*|$)|\\*",
+                            true
+                        )
+                        .build()
+                );
+                filters.add(
+                    StringCondition
+                        .matches(
+                            ENVIRONMENT.name().toLowerCase(),
+                            "(?:.*|^)" + GraviteeContext.getCurrentEnvironment() + "(?:,.*|$)|\\*",
+                            true
+                        )
+                        .build()
+                );
                 break;
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EnvironmentServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EnvironmentServiceImpl.java
@@ -23,6 +23,7 @@ import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.EnvironmentNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -159,6 +160,7 @@ public class EnvironmentServiceImpl extends TransactionalService implements Envi
         Environment defaultEnvironment = new Environment();
         defaultEnvironment.setId(GraviteeContext.getDefaultEnvironment());
         defaultEnvironment.setName("Default environment");
+        defaultEnvironment.setHrids(Collections.singletonList("default"));
         defaultEnvironment.setDescription("Default environment");
         defaultEnvironment.setOrganizationId(GraviteeContext.getDefaultOrganization());
         try {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/OrganizationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/OrganizationServiceImpl.java
@@ -193,6 +193,7 @@ public class OrganizationServiceImpl extends TransactionalService implements Org
         Organization defaultOrganization = new Organization();
         defaultOrganization.setId(GraviteeContext.getDefaultOrganization());
         defaultOrganization.setName("Default organization");
+        defaultOrganization.setHrids(Collections.singletonList("default"));
         defaultOrganization.setDescription("Default organization");
         try {
             organizationRepository.create(defaultOrganization);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/node/GraviteeApisNode.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/node/GraviteeApisNode.java
@@ -16,12 +16,15 @@
 package io.gravitee.rest.api.standalone.node;
 
 import io.gravitee.common.component.LifecycleComponent;
+import io.gravitee.node.api.NodeMetadataResolver;
 import io.gravitee.node.container.AbstractNode;
 import io.gravitee.plugin.alert.AlertEventProducerManager;
 import io.gravitee.plugin.alert.AlertTriggerProviderManager;
 import io.gravitee.rest.api.service.InitializerService;
 import io.gravitee.rest.api.standalone.jetty.JettyEmbeddedContainer;
 import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -29,6 +32,11 @@ import java.util.List;
  * @author GraviteeSource Team
  */
 public class GraviteeApisNode extends AbstractNode {
+
+    @Autowired
+    private NodeMetadataResolver nodeMetadataResolver;
+
+    private Map<String, Object> metadata = null;
 
     @Override
     public String name() {
@@ -38,6 +46,15 @@ public class GraviteeApisNode extends AbstractNode {
     @Override
     public String application() {
         return "gio-apim-apis";
+    }
+
+    @Override
+    public Map<String, Object> metadata() {
+        if (metadata == null) {
+            metadata = nodeMetadataResolver.resolve();
+        }
+
+        return metadata;
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/node/GraviteeApisNodeMetadataResolver.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/node/GraviteeApisNodeMetadataResolver.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.standalone.node;
+
+import static io.gravitee.node.api.Node.META_INSTALLATION;
+
+import io.gravitee.node.api.NodeMetadataResolver;
+import io.gravitee.rest.api.service.InstallationService;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class GraviteeApisNodeMetadataResolver implements NodeMetadataResolver {
+
+    @Lazy
+    @Autowired
+    private InstallationService installationService;
+
+    public Map<String, Object> resolve() {
+        final HashMap<String, Object> metadata = new HashMap<>();
+        metadata.put(META_INSTALLATION, getInstallationId());
+        return metadata;
+    }
+
+    private String getInstallationId() {
+        return installationService.getOrInitialize().getId();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/spring/StandaloneConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/spring/StandaloneConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.standalone.spring;
 
+import io.gravitee.node.api.NodeMetadataResolver;
 import io.gravitee.node.container.NodeFactory;
 import io.gravitee.node.vertx.spring.VertxConfiguration;
 import io.gravitee.rest.api.management.rest.spring.RestManagementConfiguration;
@@ -24,6 +25,7 @@ import io.gravitee.rest.api.standalone.jetty.JettyConfiguration;
 import io.gravitee.rest.api.standalone.jetty.JettyEmbeddedContainer;
 import io.gravitee.rest.api.standalone.jetty.JettyServerFactory;
 import io.gravitee.rest.api.standalone.node.GraviteeApisNode;
+import io.gravitee.rest.api.standalone.node.GraviteeApisNodeMetadataResolver;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -54,5 +56,10 @@ public class StandaloneConfiguration {
     @Bean
     public JettyEmbeddedContainer container() {
         return new JettyEmbeddedContainer();
+    }
+
+    @Bean
+    public NodeMetadataResolver nodeMetadataResolver() {
+        return new GraviteeApisNodeMetadataResolver();
     }
 }


### PR DESCRIPTION
Replace https://github.com/gravitee-io/old-gravitee-api-management/pull/76

**Issue**

https://github.com/gravitee-io/issues/issues/6118

**Description**

Allows to include organization and environment to alert event and make alert trigger contextualised to the installation.
