### PR TITLE
feat(portal): make promoted API mode optional in page list

### DIFF
--- a/gravitee-apim-console-webui/docs/management-configuration-apiportalheader.md
+++ b/gravitee-apim-console-webui/docs/management-configuration-apiportalheader.md
@@ -1,6 +1,6 @@
 # API Portal Informations
 
-Add a list of name/value to display in the api aside.
+Add a list of name/value to display in the API aside.
 The name could be used as is, or could be a translated key.
 
 To add a translation, you need to update the json file (see on [Github](https://github.com/gravitee-io/gravitee-portal-webui/tree/master/src/assets/i18n)).
@@ -16,4 +16,8 @@ api.endpoint | `${api.proxy.contextPath}`
 api.publishedAt | `${(api.deployedAt?date)!}`
 My hard coded name | `My hard coded value`
 
-You are able to combine api attributes, metadata and strings.
+You are able to combine API attributes, metadata and strings.
+
+Additionally, the `API List Page` section allows you to decide
+whether the top ranked API for the given environment should be emphasised
+at the top of the list.

--- a/gravitee-apim-console-webui/src/management/configuration/api-portal-header/api-portal-header.component.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/api-portal-header/api-portal-header.component.ts
@@ -125,6 +125,13 @@ const ApiPortalHeaderComponent: ng.IComponentOptions = {
       });
     };
 
+    this.savePromotedApiMode = () => {
+      PortalSettingsService.save(this.settings).then((response) => {
+        NotificationService.show('Promoted API is now ' + (this.settings.portal.apis.promotedApiMode.enabled ? 'visible' : 'hidden'));
+        this.settings = response.data;
+      });
+    };
+
     this.isReadonlySetting = (property: string): boolean => {
       return PortalSettingsService.isReadonly(this.settings, property);
     };

--- a/gravitee-apim-console-webui/src/management/configuration/api-portal-header/api-portal-header.html
+++ b/gravitee-apim-console-webui/src/management/configuration/api-portal-header/api-portal-header.html
@@ -78,6 +78,21 @@
           </tbody>
         </table>
       </md-table-container>
+
+      <h3>API List Page</h3>
+      <md-input-container class="gv-input-container-dense">
+        <md-checkbox
+          ng-model="$ctrl.settings.portal.apis.promotedApiMode.enabled"
+          aria-label="Show Promoted API"
+          ng-disabled="$ctrl.isReadonlySetting('portal.apis.promotedApiMode.enabled')"
+          ng-change="$ctrl.savePromotedApiMode()"
+        >
+          Show promoted API banner
+          <md-tooltip ng-if="$ctrl.isReadonlySetting('portal.apis.promotedApiMode.enabled')"
+            >{{$ctrl.providedConfigurationMessage}}</md-tooltip
+          >
+        </md-checkbox>
+      </md-input-container>
     </div>
   </div>
 </div>

--- a/gravitee-apim-portal-webui/src/app/model/feature.enum.ts
+++ b/gravitee-apim-portal-webui/src/app/model/feature.enum.ts
@@ -23,5 +23,6 @@ export enum FeatureEnum {
   ratingCommentMandatory = 'portal.rating.comment.mandatory',
   userRegistration = 'portal.userCreation.enabled',
   categoryMode = 'portal.apis.categoryMode.enabled',
+  promotedApiMode = 'portal.apis.promotedApiMode.enabled',
   alert = 'alert.enabled',
 }

--- a/gravitee-apim-portal-webui/src/app/pages/catalog/filtered-catalog/filtered-catalog.component.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/catalog/filtered-catalog/filtered-catalog.component.ts
@@ -155,7 +155,7 @@ export class FilteredCatalogComponent implements OnInit {
   }
 
   _load() {
-    if (this.page === 1) {
+    if (this.page === 1 && this.hasPromotedApiMode()) {
       this.promotedApi = this._loadPromotedApi({ size: 1, filter: this.filterApiQuery, promoted: true });
     }
     return Promise.all([this._loadRandomList(), this._loadCards()]);
@@ -207,18 +207,22 @@ export class FilteredCatalogComponent implements OnInit {
 
   _loadCategory() {
     this.category = this.activatedRoute.snapshot.data.category;
-    this.promotedApi = this._loadPromotedApi({ size: 1, category: this.currentCategory, promoted: true });
+    if (this.hasPromotedApiMode()) {
+      this.promotedApi = this._loadPromotedApi({ size: 1, category: this.currentCategory, promoted: true });
+    }
     return this._loadCards();
   }
 
   async _loadCards() {
+    const fetchPromoted = this.hasPromotedApiMode() ? false : undefined;
+
     return this.apiService
       .getApis({
         page: this.page,
         size: this.size,
         filter: this.filterApiQuery,
         category: this.currentCategory,
-        promoted: false,
+        promoted: fetchPromoted,
       })
       .toPromise()
       .then(async ({ data, metadata }) => {
@@ -319,6 +323,10 @@ export class FilteredCatalogComponent implements OnInit {
 
   get showCards() {
     return this.currentDisplay === FilteredCatalogComponent.DEFAULT_DISPLAY;
+  }
+
+  hasPromotedApiMode() {
+    return this.config.hasFeature(FeatureEnum.promotedApiMode);
   }
 
   hasCategoryMode() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -56,6 +56,7 @@ public enum Key {
         "true",
         new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))
     ),
+    PORTAL_APIS_PROMOTED_API_ENABLED("portal.apis.promotedApiMode.enabled", "true", Set.of(ENVIRONMENT)),
     PORTAL_APIS_SHOW_TAGS_IN_APIHEADER(
         "portal.apis.apiheader.showtags.enabled",
         "true",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/Portal.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/Portal.java
@@ -171,6 +171,9 @@ public class Portal {
         @ParameterKey(Key.PORTAL_APIS_CATEGORY_ENABLED)
         private Enabled categoryMode;
 
+        @ParameterKey(Key.PORTAL_APIS_PROMOTED_API_ENABLED)
+        private Enabled promotedApiMode;
+
         @ParameterKey(Key.PORTAL_APIS_SHOW_TAGS_IN_APIHEADER)
         private Enabled apiHeaderShowTags;
 
@@ -191,6 +194,14 @@ public class Portal {
 
         public void setCategoryMode(Enabled categoryMode) {
             this.categoryMode = categoryMode;
+        }
+
+        public Enabled getPromotedApiMode() {
+            return promotedApiMode;
+        }
+
+        public void setPromotedApiMode(Enabled promotedApiMode) {
+            this.promotedApiMode = promotedApiMode;
         }
 
         public Enabled getApiHeaderShowTags() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapper.java
@@ -112,6 +112,7 @@ public class ConfigurationMapper {
         configuration.setApiHeaderShowCategories(convert(apis.getApiHeaderShowCategories()));
         configuration.setTilesMode(convert(apis.getTilesMode()));
         configuration.setCategoryMode(convert(apis.getCategoryMode()));
+        configuration.setPromotedApiMode(convert(apis.getPromotedApiMode()));
         return configuration;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/openapi.yaml
@@ -4278,6 +4278,8 @@ components:
           $ref: '#/components/schemas/Enabled'
         categoryMode:
           $ref: '#/components/schemas/Enabled'
+        promotedApiMode:
+          $ref: '#/components/schemas/Enabled'
         apiHeaderShowTags:
           $ref: '#/components/schemas/Enabled'
         apiHeaderShowCategories:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/resources/io/gravitee/rest/api/portal/rest/mapper/expectedPortalConfiguration.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/resources/io/gravitee/rest/api/portal/rest/mapper/expectedPortalConfiguration.json
@@ -18,6 +18,9 @@
       "categoryMode" : {
         "enabled" : true
       },
+      "promotedApiMode": {
+        "enabled": true
+      },
       "apiHeaderShowTags" : {
         "enabled" : false
       },

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/resources/io/gravitee/rest/api/portal/rest/mapper/portalSettingsEntity.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/resources/io/gravitee/rest/api/portal/rest/mapper/portalSettingsEntity.json
@@ -116,6 +116,9 @@
       "categoryMode" : {
         "enabled" : true
       },
+      "promotedApiMode": {
+        "enabled": true
+      },
       "apiHeaderShowTags" : {
         "enabled" : false
       },


### PR DESCRIPTION
Replace https://github.com/gravitee-io/old-gravitee-api-management/pull/287

**Issue**

https://github.com/gravitee-io/issues/issues/6472

**Description**

Emphasing the promoted API in the portal catalog can now be
disabled from the environment settings in the `API Portal Informations`
menu.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fnookdzsti.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6472-configure-promoted-card/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
