### PR TITLE
feat(portal): add pagination for applications page

### DIFF
--- a/gravitee-apim-portal-webui/src/app/model/pagination.ts
+++ b/gravitee-apim-portal-webui/src/app/model/pagination.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-.page__content__pagination {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 1rem;
+export interface Pagination {
+  current_page: number;
+  first: number;
+  last: number;
+  size: number;
+  total: number;
+  total_pages: number;
 }

--- a/gravitee-apim-portal-webui/src/app/pages/applications/applications.component.html
+++ b/gravitee-apim-portal-webui/src/app/pages/applications/applications.component.html
@@ -30,4 +30,15 @@
   <section *ngIf="!empty">
     <gv-card-list [items]="applications"></gv-card-list>
   </section>
+
+  <div *ngIf="paginationData" class="page__content__pagination">
+    <gv-select
+      class="page__content__pagination__size__block"
+      [options]="paginationPageSizes"
+      [value]="paginationSize"
+      small
+      (:gv-select:select)="onSelectSize($event.detail)"
+    ></gv-select>
+    <gv-pagination [data]="paginationData"></gv-pagination>
+  </div>
 </div>

--- a/gravitee-apim-portal-webui/src/app/pages/applications/applications.component.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/applications/applications.component.spec.ts
@@ -18,19 +18,35 @@ import { TranslateTestingModule } from '../../test/translate-testing-module';
 
 import { ApplicationsComponent } from './applications.component';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { Application } from 'projects/portal-webclient-sdk/src/lib';
+import { ActivatedRoute } from '@angular/router';
+import { BehaviorSubject } from 'rxjs';
 
 describe('ApplicationsComponent', () => {
+  const mockActivatedRouteQueryParamMap$ = new BehaviorSubject(new Map());
+
   let component: ApplicationsComponent;
   let fixture: ComponentFixture<ApplicationsComponent>;
+  let httpTestingController: HttpTestingController;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ApplicationsComponent],
       imports: [TranslateTestingModule, HttpClientTestingModule, RouterTestingModule],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            queryParamMap: mockActivatedRouteQueryParamMap$,
+          },
+        },
+      ],
     }).compileComponents();
+
+    httpTestingController = TestBed.inject(HttpTestingController);
   }));
 
   beforeEach(() => {
@@ -39,7 +55,86 @@ describe('ApplicationsComponent', () => {
     fixture.detectChanges();
   });
 
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
   it('should create', () => {
+    expectApplicationsGetRequest();
     expect(component).toBeTruthy();
   });
+
+  it('should get applications', () => {
+    const fakeApplication1 = {
+      id: 'application1',
+      name: 'application1',
+      description: 'application1 description',
+    };
+    expectApplicationsGetRequest([fakeApplication1]);
+    expectCurrentUserPermissionsGetRequest('application1');
+
+    expect(component.nbApplications).toEqual(1);
+    expect(component.applications).toEqual([{ item: fakeApplication1, metrics: expect.any(Promise) }]);
+  });
+
+  it('should displays page=2 with size=24', () => {
+    const fakeApplication1 = {
+      id: 'application1',
+      name: 'application1',
+      description: 'application1 description',
+    };
+    expectApplicationsGetRequest([fakeApplication1]);
+    expectCurrentUserPermissionsGetRequest('application1');
+
+    expect(component.paginationData).toEqual({ current_page: 1, first: 1, last: 42, size: 12, total: 1, total_pages: 1 });
+    expect(component.paginationSize).toEqual(12);
+    expect(component.paginationPageSizes).toEqual([6, 12, 24, 48, 96]);
+
+    mockActivatedRouteQueryParamMap$.next(
+      new Map([
+        ['page', '2'],
+        ['size', '24'],
+      ]),
+    );
+
+    expectApplicationsGetRequest([fakeApplication1], { page: 2, size: 24 });
+    expectCurrentUserPermissionsGetRequest('application1');
+
+    expect(component.paginationData).toEqual({ current_page: 2, first: 1, last: 42, size: 24, total: 1, total_pages: 1 });
+    expect(component.paginationSize).toEqual(24);
+  });
+
+  function expectApplicationsGetRequest(
+    applications: Application[] = [],
+    pagination: { page: number; size: number } = { page: 1, size: 12 },
+  ) {
+    const req = httpTestingController.expectOne({
+      method: 'GET',
+      url: `http://localhost:8083/portal/environments/DEFAULT/applications?page=${pagination.page}&size=${pagination.size}`,
+    });
+    expect(req.request.method).toEqual('GET');
+    req.flush({
+      data: applications,
+      metadata: {
+        pagination: {
+          total: applications.length,
+          size: pagination.size,
+          last: 42,
+          total_pages: 1,
+          current_page: pagination.page,
+          first: 1,
+        },
+      },
+    });
+    fixture.detectChanges();
+  }
+
+  function expectCurrentUserPermissionsGetRequest(applicationId: string) {
+    const req = httpTestingController.expectOne({
+      url: `http://localhost:8083/portal/environments/DEFAULT/permissions?applicationId=${applicationId}`,
+      method: 'GET',
+    });
+    req.flush({});
+    fixture.detectChanges();
+  }
 });


### PR DESCRIPTION
Replace https://github.com/gravitee-io/old-gravitee-api-management/pull/347

**Issue**
https://github.com/gravitee-io/issues/issues/6665

**Description**

Add pagination to avoid load all applications 

**Additional context**
![image](https://user-images.githubusercontent.com/4974420/144056031-f7ad24b3-5d76-4530-9345-6bf701a9504a.png)

![image](https://user-images.githubusercontent.com/4112568/144507620-de3e60a9-1f52-47fc-951e-0e4ef4d89533.png)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lbtpnvhfbs.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6256-application-page-list-performance-improvements/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
