### PR TITLE
fix(portal): hide application subscriptions when user have not the ri…

### DIFF
--- a/gravitee-apim-portal-webui/src/app/pages/applications/applications-routing.module.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/applications/applications-routing.module.ts
@@ -127,7 +127,7 @@ const routes: Routes = [
           icon: 'home:key',
           title: i18n('route.subscriptions'),
           animation: { type: 'slide', group: 'app', index: 3 },
-          expectedPermissions: [],
+          expectedPermissions: ['SUBSCRIPTION-R'],
         },
       },
       {

--- a/gravitee-apim-portal-webui/src/app/pages/applications/applications-routing.module.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/applications/applications-routing.module.ts
@@ -117,7 +117,7 @@ const routes: Routes = [
           icon: 'home:book-open',
           title: i18n('route.metadata'),
           animation: { type: 'slide', group: 'app', index: 2 },
-          expectedPermissions: [],
+          expectedPermissions: ['METADATA-R'],
         },
       },
       {
@@ -137,7 +137,7 @@ const routes: Routes = [
           icon: 'communication:group',
           title: i18n('route.members'),
           animation: { type: 'slide', group: 'app', index: 4 },
-          expectedPermissions: [],
+          expectedPermissions: ['MEMBER-R'],
         },
       },
       {
@@ -148,7 +148,7 @@ const routes: Routes = [
           menu: { slots: { right: GvSelectDashboardComponent } },
           title: i18n('route.analyticsApplication'),
           animation: { type: 'slide', group: 'app', index: 5 },
-          expectedPermissions: [],
+          expectedPermissions: ['ANALYTICS-R'],
         },
         resolve: {
           dashboards: DashboardsResolver,
@@ -161,7 +161,7 @@ const routes: Routes = [
           icon: 'communication:clipboard-list',
           title: i18n('route.logsApplication'),
           animation: { type: 'slide', group: 'app', index: 6 },
-          expectedPermissions: [],
+          expectedPermissions: ['LOG-R'],
         },
       },
       {
@@ -183,6 +183,7 @@ const routes: Routes = [
           title: i18n('route.alerts'),
           expectedFeature: FeatureEnum.alert,
           animation: { type: 'slide', group: 'app', index: 8 },
+          expectedPermissions: ['ALERT-R'],
         },
       },
     ],


### PR DESCRIPTION
Replace https://github.com/gravitee-io/old-gravitee-api-management/pull/367

**Issue**

https://github.com/gravitee-io/issues/issues/6021

**Description**

Improve user rights management for application

Application submenu change with role permission 
ex : 
![image](https://user-images.githubusercontent.com/4974420/144421809-c85e849d-990d-4993-a67e-2517c42b12ce.png)
![image](https://user-images.githubusercontent.com/4974420/144421853-a63bd8e5-575e-4338-b424-93e143cbc2ee.png)

**Additional context**


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-6021-fix-subscriptions-menu-access/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
