### PR TITLE
fix(cve83): block ungranted access to api resource

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
@@ -102,6 +102,7 @@ public class ApiResource extends AbstractResource {
         }
     )
     public Response getApi() {
+        canReadApi(api);
         ApiEntity apiEntity = apiService.findById(api);
         if (hasPermission(RolePermission.API_DEFINITION, api, RolePermissionAction.READ)) {
             setPictures(apiEntity);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiResourceNotAdminTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiResourceNotAdminTest.java
@@ -116,7 +116,69 @@ public class ApiResourceNotAdminTest extends AbstractResourceTest {
     }
 
     @Test
-    public void shouldGetApi() {
+    public void shouldNotAccessToApi_BecauseAccessIsNotGranted() {
+        final Response response = envTarget(API).request().get();
+        assertEquals(FORBIDDEN_403, response.getStatus());
+    }
+
+    @Test
+    public void shouldGetApi_BecauseDirectMember() {
+        MembershipEntity userMembership = mock(MembershipEntity.class);
+        when(userMembership.getReferenceId()).thenReturn(API);
+        when(userMembership.getReferenceType()).thenReturn(MembershipReferenceType.API);
+        when(userMembership.getMemberType()).thenReturn(MembershipMemberType.USER);
+
+        when(
+            membershipService.getMembershipsByMemberAndReference(
+                eq(MembershipMemberType.USER),
+                eq(USER_NAME),
+                eq(MembershipReferenceType.API)
+            )
+        )
+            .thenReturn(Sets.newSet(userMembership));
+
+        final Response response = envTarget(API).request().get();
+
+        assertEquals(OK_200, response.getStatus());
+
+        final ApiEntity responseApi = response.readEntity(ApiEntity.class);
+        assertNotNull(responseApi);
+        assertEquals(API, responseApi.getName());
+    }
+
+    @Test
+    public void shouldGetApi_BecauseGroupMember() {
+        final String groupId = "group_id";
+        final String roleId = "role_id";
+        MembershipEntity groupMemberShip = mock(MembershipEntity.class);
+        when(groupMemberShip.getRoleId()).thenReturn(roleId);
+        when(groupMemberShip.getReferenceId()).thenReturn(groupId);
+        when(groupMemberShip.getReferenceType()).thenReturn(MembershipReferenceType.GROUP);
+
+        RoleEntity role = mock(RoleEntity.class);
+        when(role.getScope()).thenReturn(RoleScope.API);
+
+        when(
+            membershipService.getMembershipsByMemberAndReference(
+                eq(MembershipMemberType.USER),
+                eq(USER_NAME),
+                eq(MembershipReferenceType.API)
+            )
+        )
+            .thenReturn(Collections.emptySet());
+
+        when(
+            membershipService.getMembershipsByMemberAndReference(
+                eq(MembershipMemberType.USER),
+                eq(USER_NAME),
+                eq(MembershipReferenceType.GROUP)
+            )
+        )
+            .thenReturn(Sets.newSet(groupMemberShip));
+
+        when(roleService.findById(eq(roleId))).thenReturn(role);
+        when(apiService.searchIds(any())).thenReturn(Collections.singletonList(API));
+
         final Response response = envTarget(API).request().get();
 
         assertEquals(OK_200, response.getStatus());


### PR DESCRIPTION
Replace https://github.com/gravitee-io/old-gravitee-api-management/pull/351

**Issue**

https://github.com/gravitee-io/issues/issues/6650

**Description**

Require the API_MEMBER role to perform read operations on an API.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-cve83/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
