### PR TITLE
fix: alert permissions for api scope

### DIFF
--- a/gravitee-apim-console-webui/package-lock.json
+++ b/gravitee-apim-console-webui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gravitee-apim-console-webui",
-  "version": "3.5.24-SNAPSHOT",
+  "version": "3.5.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/gravitee-apim-console-webui/src/components/alerts/alert/alert.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/alert.component.ts
@@ -19,12 +19,14 @@ import NotificationService from '../../../services/notification.service';
 import { Alert, Scope } from '../../../entities/alert';
 import { Rule } from '../../../entities/alerts/rule.metrics';
 import { IScope } from 'angular';
+import UserService from '../../../services/user.service';
 
 const AlertComponent: ng.IComponentOptions = {
   bindings: {
     alerts: '<',
     notifiers: '<',
     status: '<',
+    mode: '<',
   },
   template: require('./alert.html'),
   controller: function (
@@ -32,6 +34,7 @@ const AlertComponent: ng.IComponentOptions = {
     $scope: IScope,
     AlertService: AlertService,
     NotificationService: NotificationService,
+    UserService: UserService,
     $state,
     $mdDialog,
   ) {
@@ -170,6 +173,20 @@ const AlertComponent: ng.IComponentOptions = {
       } else {
         $state.go('management.settings.alerts.list');
       }
+    };
+
+    this.hasPermissionForCurrentScope = (permission: string): boolean => {
+      let scope = 'environment';
+      if ($state.params.apiId) {
+        scope = 'api';
+      } else if ($state.params.applicationId) {
+        scope = 'application';
+      }
+      return UserService.isUserHasPermissions([`${scope}-${permission}`]);
+    };
+
+    this.isReadonly = (): boolean => {
+      return this.mode === 'detail' && !this.hasPermissionForCurrentScope('alert-u');
     };
   },
 };

--- a/gravitee-apim-console-webui/src/components/alerts/alert/alert.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/alert.html
@@ -48,6 +48,7 @@
                         md-maxlength="50"
                         required
                         autofocus
+                        ng-disabled="$ctrl.isReadonly()"
                         aria-label="Alert name"
                       />
                       <div class="hint" ng-if="$ctrl.formAlert.name.$valid || $ctrl.formAlert.name.$pristine">Alert name.</div>
@@ -70,6 +71,7 @@
                         aria-label="Enable this alert trigger"
                         class="md-primary md-align-top-left"
                         flex
+                        ng-disabled="$ctrl.isReadonly()"
                       >
                         Enable this alert
                       </md-checkbox>
@@ -92,7 +94,7 @@
 
                     <md-input-container class="md-block" flex="30">
                       <label>Severity</label>
-                      <md-select ng-model="$ctrl.alert.severity" required>
+                      <md-select ng-model="$ctrl.alert.severity" required ng-disabled="$ctrl.isReadonly()">
                         <md-option ng-value="severity" ng-repeat="severity in $ctrl.severities">{{severity}}</md-option>
                       </md-select>
                     </md-input-container>
@@ -101,7 +103,12 @@
                   <div layout-gt-sm="row">
                     <md-input-container class="md-block" flex-gt-sm>
                       <label>Description</label>
-                      <input ng-model="$ctrl.alert.description" name="name" aria-label="Alert description" />
+                      <input
+                        ng-model="$ctrl.alert.description"
+                        name="name"
+                        aria-label="Alert description"
+                        ng-disabled="$ctrl.isReadonly()"
+                      />
                     </md-input-container>
                   </div>
                 </div>
@@ -214,7 +221,11 @@
               </div>
 
               <!-- Additional filters -->
-              <gv-alert-trigger-filters alert="$ctrl.alert" form="$ctrl.formAlert"></gv-alert-trigger-filters>
+              <gv-alert-trigger-filters
+                alert="$ctrl.alert"
+                form="$ctrl.formAlert"
+                is-readonly="$ctrl.isReadonly()"
+              ></gv-alert-trigger-filters>
             </md-tab-body>
           </md-tab>
 
@@ -222,9 +233,9 @@
             <md-tab-label>Notifications</md-tab-label>
             <md-tab-body>
               <!-- Dampening -->
-              <gv-alert-trigger-dampening dampening="$ctrl.alert.dampening"></gv-alert-trigger-dampening>
+              <gv-alert-trigger-dampening dampening="$ctrl.alert.dampening" is-readonly="$ctrl.isReadonly()"></gv-alert-trigger-dampening>
 
-              <gv-alert-notifications alert="$ctrl.alert"></gv-alert-notifications>
+              <gv-alert-notifications alert="$ctrl.alert" is-readonly="$ctrl.isReadonly()"></gv-alert-notifications>
             </md-tab-body>
           </md-tab>
 
@@ -239,44 +250,37 @@
         <!-- Form actions -->
         <div class="md-actions gravitee-api-save-button" layout="row">
           <md-button
-            ng-if="$ctrl.updateMode"
+            ng-if="$ctrl.hasPermissionForCurrentScope('alert-u') && $ctrl.updateMode"
             class="md-raised md-primary"
             type="submit"
             ng-disabled="$ctrl.status.available_plugins === 0 || $ctrl.formAlert.$invalid || $ctrl.formAlert.$pristine"
-            permission
-            permission-only="['api-alert-u', 'application-alert-u', 'environment-alert-u']"
           >
             Update
           </md-button>
           <md-button
-            ng-if="!$ctrl.updateMode"
+            ng-if="$ctrl.hasPermissionForCurrentScope('alert-c') && !$ctrl.updateMode"
             class="md-raised md-primary"
             type="submit"
             ng-disabled="$ctrl.status.available_plugins === 0 || $ctrl.formAlert.$invalid || $ctrl.formAlert.$pristine"
-            permission
-            permission-only="['api-alert-c', 'application-alert-c', 'environment-alert-c']"
           >
             Create
           </md-button>
 
           <md-button
+            ng-if="$ctrl.hasPermissionForCurrentScope('alert-d')"
             class="md-raised"
             type="button"
             ng-click="$ctrl.reset()"
-            permission
-            permission-only="['api-alert-d', 'application-alert-d', 'environment-alert-d']"
             ng-disabled="$ctrl.status.available_plugins === 0 || $ctrl.formAlert.$invalid || $ctrl.formAlert.$pristine"
           >
             Reset
           </md-button>
           <md-button
             class="md-raised md-warn float-right"
-            ng-if="$ctrl.updateMode"
+            ng-if="$ctrl.hasPermissionForCurrentScope('alert-d') && $ctrl.updateMode"
             ng-disabled="$ctrl.status.available_plugins === 0"
             type="button"
             ng-click="$ctrl.delete()"
-            permission
-            permission-only="['api-alert-d', 'application-alert-d', 'environment-alert-d']"
           >
             Delete
           </md-button>

--- a/gravitee-apim-console-webui/src/components/alerts/alert/notifications/alert-notification.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/notifications/alert-notification.html
@@ -18,12 +18,24 @@
 <div class="gv-form">
   <h2 layout="row">
     Notification
-    <ng-md-icon icon="cancel" style="top: 5px; margin-right: 10px; fill: grey" size="20px" ng-click="$ctrl.remove()"></ng-md-icon>
+    <ng-md-icon
+      icon="cancel"
+      style="top: 5px; margin-right: 10px; fill: grey"
+      size="20px"
+      ng-click="$ctrl.remove()"
+      ng-if="!$ctrl.isReadonly"
+    ></ng-md-icon>
   </h2>
   <div class="gv-form-content" layout="column">
     <md-input-container class="md-block" flex-gt-xs>
       <label>Channel</label>
-      <md-select ng-model="$ctrl.notification.type" placeholder="Channel" required ng-change="$ctrl.onNotifierChange()">
+      <md-select
+        ng-model="$ctrl.notification.type"
+        placeholder="Channel"
+        required
+        ng-change="$ctrl.onNotifierChange()"
+        ng-disabled="$ctrl.isReadonly"
+      >
         <md-option ng-repeat="type in $ctrl.parent.parent.notifiers" ng-value="type.id">{{type.name}}</md-option>
       </md-select>
     </md-input-container>

--- a/gravitee-apim-console-webui/src/components/alerts/alert/notifications/alert-notification.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/notifications/alert-notification.ts
@@ -20,6 +20,7 @@ const AlertNotificationComponent: ng.IComponentOptions = {
   bindings: {
     notification: '<',
     onNotificationRemove: '&',
+    isReadonly: '<',
   },
   require: {
     parent: '^gvAlertNotifications',
@@ -44,7 +45,7 @@ const AlertNotificationComponent: ng.IComponentOptions = {
     this.reloadNotifierSchema = () => {
       NotifierService.getSchema(this.notification.type).then(
         ({ data }) => {
-          this.notifierJsonSchema = data;
+          this.notifierJsonSchema = { ...data, readonly: this.isReadonly };
           return {
             schema: data,
           };

--- a/gravitee-apim-console-webui/src/components/alerts/alert/notifications/alert-notifications.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/notifications/alert-notifications.html
@@ -15,11 +15,18 @@
     limitations under the License.
 
 -->
-<a style="margin-top: 5px; margin-bottom: 5px" ng-click="$ctrl.addNotification()" style="font-style: italic">> Add a notification</a>
+<a
+  style="margin-top: 5px; margin-bottom: 5px"
+  ng-click="$ctrl.addNotification()"
+  style="font-style: italic"
+  ng-if="!$ctrl.parent.isReadonly()"
+  >> Add a notification</a
+>
 
 <gv-alert-notification
   ng-repeat="notification in $ctrl.alert.notifications"
   notification="notification"
   on-notification-remove="$ctrl.removeNotification($index)"
+  is-readonly="$ctrl.parent.isReadonly()"
 >
 </gv-alert-notification>

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-compare.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-compare.component.ts
@@ -21,6 +21,7 @@ const AlertTriggerConditionCompareComponent: ng.IComponentOptions = {
   bindings: {
     condition: '<',
     metrics: '<',
+    isReadonly: '<',
   },
   template: require('./trigger-condition-compare.html'),
   controller: function () {

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-compare.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-compare.html
@@ -25,6 +25,7 @@
       min="1"
       name="condition-compare-multiplier"
       aria-label="compare multiplier"
+      ng-disabled="$ctrl.isReadonly"
     />
     <div ng-messages="$ctrl.formAlert['condition-compare-multiplier'].$error">
       <div ng-message="required">Multiplier is required.</div>
@@ -34,7 +35,13 @@
 
   <md-input-container class="md-block" flex-gt-sm flex="30">
     <label>Property</label>
-    <md-select ng-model="$ctrl.condition.property2" required name="condition-compare-property" aria-label="compare property">
+    <md-select
+      ng-model="$ctrl.condition.property2"
+      required
+      name="condition-compare-property"
+      aria-label="compare property"
+      ng-disabled="$ctrl.isReadonly"
+    >
       <md-option ng-value="type.key" ng-repeat="type in $ctrl.metrics"> {{::type.name}} </md-option>
     </md-select>
     <div ng-messages="$ctrl.formAlert['condition-compare-property'].$error">

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-string.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-string.component.ts
@@ -21,6 +21,7 @@ const AlertTriggerConditionStringComponent: ng.IComponentOptions = {
   bindings: {
     condition: '<',
     metrics: '<',
+    isReadonly: '<',
   },
   template: require('./trigger-condition-string.html'),
   controller: function ($injector, $state) {

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-string.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-string.html
@@ -18,7 +18,14 @@
 
 <md-input-container class="md-block" ng-if="!$ctrl.displaySelect()">
   <label>Pattern</label>
-  <input ng-model="$ctrl.condition.pattern" required type="text" name="condition-string-value" aria-label="string value condition" />
+  <input
+    ng-model="$ctrl.condition.pattern"
+    required
+    type="text"
+    name="condition-string-value"
+    aria-label="string value condition"
+    ng-disabled="$ctrl.isReadonly"
+  />
   <!--
   <div class="hint">
     The pattern value to compare to.
@@ -31,7 +38,7 @@
 
 <md-input-container class="md-block" ng-if="$ctrl.displaySelect()">
   <label>Value</label>
-  <md-select ng-model="$ctrl.condition.pattern" required>
+  <md-select ng-model="$ctrl.condition.pattern" required ng-disabled="$ctrl.isReadonly">
     <md-option ng-value="type.key" ng-repeat="type in $ctrl.values"> {{::type.value}} </md-option>
   </md-select>
   <!--

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-threshold-range.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-threshold-range.component.ts
@@ -16,6 +16,7 @@
 const AlertTriggerConditionThresholdRangeComponent: ng.IComponentOptions = {
   bindings: {
     condition: '<',
+    isReadonly: '<',
   },
   template: require('./trigger-condition-threshold-range.html'),
   controller: function () {

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-threshold-range.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-threshold-range.html
@@ -19,7 +19,15 @@
 <div layout="row">
   <md-input-container>
     <label>Low threshold</label>
-    <input ng-model="$ctrl.condition.thresholdLow" required type="number" min="1" name="thresholdLow" aria-label="trigger threshold low" />
+    <input
+      ng-model="$ctrl.condition.thresholdLow"
+      required
+      type="number"
+      min="1"
+      name="thresholdLow"
+      aria-label="trigger threshold low"
+      ng-disabled="$ctrl.isReadonly"
+    />
     <!--
     <div class="hint">
       The low threshold value.
@@ -42,6 +50,7 @@
       min="{{$ctrl.condition.thresholdLow}}"
       name="thresholdHigh"
       aria-label="trigger threshold high"
+      ng-disabled="$ctrl.isReadonly"
     />
     <!--
     <div class="hint">

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-threshold.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-threshold.component.ts
@@ -16,6 +16,7 @@
 const AlertTriggerConditionThresholdComponent: ng.IComponentOptions = {
   bindings: {
     condition: '<',
+    isReadonly: '<',
   },
   template: require('./trigger-condition-threshold.html'),
   controller: function () {

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-threshold.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-threshold.html
@@ -18,7 +18,15 @@
 
 <md-input-container class="md-block" flex="30">
   <label>Threshold</label>
-  <input ng-model="$ctrl.condition.threshold" required type="number" min="1" name="threshold" aria-label="trigger threshold" />
+  <input
+    ng-model="$ctrl.condition.threshold"
+    required
+    type="number"
+    min="1"
+    name="threshold"
+    aria-label="trigger threshold"
+    ng-disabled="$ctrl.isReadonly"
+  />
   <!--
   <div class="hint">
     The threshold value to compare to.

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/projections/trigger-projection.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/projections/trigger-projection.component.ts
@@ -24,6 +24,7 @@ const AlertTriggerProjectionComponent: ng.IComponentOptions = {
     projection: '<',
     alert: '<',
     onProjectionRemove: '&',
+    isReadonly: '<',
   },
   template: require('./trigger-projection.html'),
   controller: function () {

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/projections/trigger-projection.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/projections/trigger-projection.html
@@ -17,14 +17,20 @@
 -->
 
 <div class="gv-form-content" layout="row" style="margin-bottom: 3px">
-  <div flex="5" layout="row" layout-align="center center" style="border-right: 1px solid lightgrey; margin-right: 10px">
+  <div
+    flex="5"
+    layout="row"
+    layout-align="center center"
+    style="border-right: 1px solid lightgrey; margin-right: 10px"
+    ng-if="!$ctrl.isReadonly"
+  >
     <ng-md-icon icon="close" style="fill: grey" size="20px" ng-click="$ctrl.deleteProjection()"></ng-md-icon>
   </div>
 
   <div layout-gt-sm="row" flex="30">
     <md-input-container class="md-block" flex-gt-sm flex="50">
       <label>Property</label>
-      <md-select ng-model="$ctrl.projection.property" required>
+      <md-select ng-model="$ctrl.projection.property" required ng-disabled="$ctrl.isReadonly">
         <md-option ng-value="type.key" ng-repeat="type in $ctrl.metrics"> {{::type.name}} </md-option>
       </md-select>
     </md-input-container>

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/projections/trigger-projections.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/projections/trigger-projections.component.ts
@@ -18,6 +18,7 @@ const AlertTriggerProjectionsComponent: ng.IComponentOptions = {
     alert: '<',
     condition: '<',
     metrics: '<',
+    isReadonly: '<',
   },
   template: require('./trigger-projections.html'),
   controller: function () {

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/projections/trigger-projections.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/projections/trigger-projections.html
@@ -28,7 +28,7 @@
 
   <a
     style="margin-bottom: 5px"
-    ng-if="$ctrl.condition.projections === undefined || $ctrl.condition.projections.length < 1"
+    ng-if="!$ctrl.isReadonly && ($ctrl.condition.projections === undefined || $ctrl.condition.projections.length < 1)"
     ng-click="$ctrl.addProjection()"
     style="font-style: italic"
     >> Set a projection</a
@@ -39,6 +39,7 @@
     ng-repeat="projection in $ctrl.condition.projections"
     projection="projection"
     on-projection-remove="$ctrl.removeProjection($index)"
+    is-readonly="$ctrl.isReadonly"
   >
     ></gv-alert-trigger-projection
   >

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-application-quota.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-application-quota.html
@@ -30,6 +30,7 @@
       name="threshold"
       aria-label="trigger threshold"
       ng-change="$ctrl.calculateMultiplier()"
+      ng-disabled="$ctrl.parent.isReadonly()"
     />
     <div ng-messages="$ctrl.parent.formAlert.threshold.$error">
       <div ng-message="required">Threshold is required.</div>

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-condition.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-condition.component.ts
@@ -21,6 +21,7 @@ const AlertTriggerConditionComponent: ng.IComponentOptions = {
     condition: '<',
     metrics: '<',
     label: '<',
+    isReadonly: '<',
   },
   template: require('./trigger-condition.html'),
   controller: function () {

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-condition.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-condition.html
@@ -22,7 +22,7 @@
 
   <md-input-container class="md-block" flex-gt-sm flex="15">
     <label>Metrics</label>
-    <md-select ng-model="$ctrl.condition.property" required ng-change="$ctrl.onMetricsChange(true)">
+    <md-select ng-model="$ctrl.condition.property" required ng-change="$ctrl.onMetricsChange(true)" ng-disabled="$ctrl.isReadonly">
       <md-option ng-value="type.key" ng-repeat="type in $ctrl.metrics"> {{::type.name}} </md-option>
     </md-select>
   </md-input-container>
@@ -31,7 +31,7 @@
 
   <md-input-container class="md-block" flex-gt-sm flex="15">
     <label>Type</label>
-    <md-select ng-model="$ctrl.condition.type" required ng-change="$ctrl.onConditionChange()">
+    <md-select ng-model="$ctrl.condition.type" required ng-change="$ctrl.onConditionChange()" ng-disabled="$ctrl.isReadonly">
       <md-option ng-value="type" ng-repeat="type in $ctrl.conditions"> {{::type}} </md-option>
     </md-select>
   </md-input-container>
@@ -41,7 +41,7 @@
 
     <md-input-container class="md-block" flex-gt-sm>
       <label>Operator</label>
-      <md-select ng-model="$ctrl.condition.operator" required>
+      <md-select ng-model="$ctrl.condition.operator" required ng-disabled="$ctrl.isReadonly">
         <md-option ng-value="operator.key" ng-repeat="operator in $ctrl.operators"> {{::operator.name}} </md-option>
       </md-select>
     </md-input-container>
@@ -50,20 +50,27 @@
   <span flex="5">&nbsp;</span>
 
   <div ng-if="$ctrl.condition.operator && $ctrl.condition.type" ng-switch="$ctrl.condition.type" flex>
-    <gv-alert-trigger-condition-threshold ng-switch-when="threshold" condition="$ctrl.condition"></gv-alert-trigger-condition-threshold>
+    <gv-alert-trigger-condition-threshold
+      ng-switch-when="threshold"
+      condition="$ctrl.condition"
+      is-readonly="$ctrl.isReadonly"
+    ></gv-alert-trigger-condition-threshold>
     <gv-alert-trigger-condition-threshold-range
       ng-switch-when="threshold_range"
       condition="$ctrl.condition"
+      is-readonly="$ctrl.isReadonly"
     ></gv-alert-trigger-condition-threshold-range>
     <gv-alert-trigger-condition-string
       ng-switch-when="string"
       metrics="$ctrl.metrics"
       condition="$ctrl.condition"
+      is-readonly="$ctrl.isReadonly"
     ></gv-alert-trigger-condition-string>
     <gv-alert-trigger-condition-compare
       ng-switch-when="compare"
       metrics="$ctrl.metrics"
       condition="$ctrl.condition"
+      is-readonly="$ctrl.isReadonly"
     ></gv-alert-trigger-condition-compare>
   </div>
 </div>

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-dampening.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-dampening.html
@@ -25,7 +25,7 @@
   <div class="gv-form-content" layout="column">
     <md-input-container class="md-block">
       <label>Mode</label>
-      <md-select ng-model="$ctrl.dampening.mode" required ng-change="$ctrl.onModeChange()">
+      <md-select ng-model="$ctrl.dampening.mode" required ng-change="$ctrl.onModeChange()" ng-disabled="$ctrl.parent.isReadonly()">
         <md-option ng-value="mode.type" ng-repeat="mode in $ctrl.modes"> {{::mode.description}} </md-option>
       </md-select>
       <div class="hint">Select the most appropriate dampening mode for this alert.</div>
@@ -44,6 +44,7 @@
             max="100"
             name="dampening.trueevaluations"
             aria-label="dampening true evaluations"
+            ng-disabled="$ctrl.parent.isReadonly()"
           />
           <div class="hint">The number of consecutive true evaluations.</div>
           <div ng-messages="$ctrl.parent.formAlert['dampening.trueevaluations'].$error">
@@ -65,6 +66,7 @@
             max="100"
             name="dampening.trueevaluations"
             aria-label="dampening true evaluations"
+            ng-disabled="$ctrl.parent.isReadonly()"
           />
           <div class="hint">The number of true evaluations.</div>
           <div ng-messages="$ctrl.parent.formAlert['dampening.trueevaluations'].$error">
@@ -85,6 +87,7 @@
             max="100"
             name="dampening.totalevaluations"
             aria-label="dampening total evaluations"
+            ng-disabled="$ctrl.parent.isReadonly()"
           />
           <div class="hint">The number of total evaluations.</div>
           <div ng-messages="$ctrl.parent.formAlert['dampening.totalevaluations'].$error">
@@ -106,6 +109,7 @@
             max="100"
             name="dampening.duration"
             aria-label="dampening duration"
+            ng-disabled="$ctrl.parent.isReadonly()"
           />
           <div ng-messages="$ctrl.parent.formAlert['dampening.duration'].$error">
             <div ng-message="required">Number of true evaluations is required.</div>
@@ -115,7 +119,7 @@
 
         <md-input-container class="md-block" flex-gt-sm flex="15">
           <label>TimeUnit</label>
-          <md-select ng-model="$ctrl.dampening.timeUnit" required>
+          <md-select ng-model="$ctrl.dampening.timeUnit" required ng-disabled="$ctrl.parent.isReadonly()">
             <md-option ng-value="unit.key" ng-repeat="unit in $ctrl.timeUnits"> {{::unit.name}} </md-option>
           </md-select>
         </md-input-container>
@@ -133,6 +137,7 @@
             max="100"
             name="dampening.trueevaluations"
             aria-label="dampening true evaluations"
+            ng-disabled="$ctrl.parent.isReadonly()"
           />
           <div class="hint">The number of true evaluations.</div>
           <div ng-messages="$ctrl.parent.formAlert['dampening.trueevaluations'].$error">
@@ -153,6 +158,7 @@
             max="100"
             name="dampening.duration"
             aria-label="dampening duration"
+            ng-disabled="$ctrl.parent.isReadonly()"
           />
           <div ng-messages="$ctrl.parent.formAlert['dampening.duration'].$error">
             <div ng-message="required">Number of true evaluations is required.</div>
@@ -162,7 +168,7 @@
 
         <md-input-container class="md-block" flex-gt-sm flex="15">
           <label>TimeUnit</label>
-          <md-select ng-model="$ctrl.dampening.timeUnit" required>
+          <md-select ng-model="$ctrl.dampening.timeUnit" required ng-disabled="$ctrl.parent.isReadonly()">
             <md-option ng-value="unit.key" ng-repeat="unit in $ctrl.timeUnits"> {{::unit.name}} </md-option>
           </md-select>
         </md-input-container>

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-filter.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-filter.component.ts
@@ -23,6 +23,7 @@ const AlertTriggerFilterComponent: ng.IComponentOptions = {
     condition: '<',
     alert: '<',
     onFilterRemove: '&',
+    isReadonly: '<',
   },
   template: require('./trigger-filter.html'),
   controller: function () {

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-filter.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-filter.html
@@ -18,7 +18,13 @@
 
 <div class="gv-form-content" layout="row" style="margin-bottom: 3px">
   <div flex="5" layout="row" layout-align="center center" style="border-right: 1px solid lightgrey; margin-right: 10px">
-    <ng-md-icon icon="close" style="fill: grey" size="20px" ng-click="$ctrl.deleteFilter()"></ng-md-icon>
+    <ng-md-icon icon="close" style="fill: grey" size="20px" ng-click="$ctrl.deleteFilter()" ng-if="!$ctrl.isReadonly"></ng-md-icon>
   </div>
-  <gv-alert-trigger-condition condition="$ctrl.condition" metrics="$ctrl.metrics" label="false" flex></gv-alert-trigger-condition>
+  <gv-alert-trigger-condition
+    condition="$ctrl.condition"
+    metrics="$ctrl.metrics"
+    label="false"
+    flex
+    is-readonly="$ctrl.isReadonly"
+  ></gv-alert-trigger-condition>
 </div>

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-filters.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-filters.component.ts
@@ -17,6 +17,7 @@ const AlertTriggerFiltersComponent: ng.IComponentOptions = {
   bindings: {
     alert: '<',
     form: '<',
+    isReadonly: '<',
   },
   template: require('./trigger-filters.html'),
   controller: function () {

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-filters.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-filters.html
@@ -26,13 +26,14 @@
     <br />
   </div>
 
-  <a style="margin-bottom: 5px" ng-click="$ctrl.addFilter()" style="font-style: italic">> Add a filter</a>
+  <a style="margin-bottom: 5px" ng-click="$ctrl.addFilter()" style="font-style: italic" ng-if="!$ctrl.isReadonly">> Add a filter</a>
 
   <gv-alert-trigger-filter
     alert="$ctrl.alert"
     ng-repeat="condition in $ctrl.alert.filters"
     condition="condition"
     on-filter-remove="$ctrl.removeFilter($index)"
+    is-readonly="$ctrl.isReadonly"
   >
     ></gv-alert-trigger-filter
   >

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-metrics-aggregation.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-metrics-aggregation.html
@@ -20,7 +20,7 @@
 
   <md-input-container class="md-block" flex-gt-sm flex="20">
     <label>Function</label>
-    <md-select ng-model="$ctrl.alert.conditions[0].function" required>
+    <md-select ng-model="$ctrl.alert.conditions[0].function" required ng-disabled="$ctrl.parent.isReadonly()">
       <md-option ng-value="type.key" ng-repeat="type in $ctrl.functions"> {{::type.name}} </md-option>
     </md-select>
   </md-input-container>
@@ -29,7 +29,7 @@
 
   <md-input-container class="md-block" flex-gt-sm flex="20" ng-if="$ctrl.alert.conditions[0].function !== 'count'">
     <label>Metric</label>
-    <md-select ng-model="$ctrl.alert.conditions[0].property" required>
+    <md-select ng-model="$ctrl.alert.conditions[0].property" required ng-disabled="$ctrl.parent.isReadonly()">
       <md-option ng-value="type.key" ng-repeat="type in $ctrl.metrics"> {{::type.name}} </md-option>
     </md-select>
   </md-input-container>
@@ -40,7 +40,7 @@
 
   <md-input-container class="md-block" flex-gt-sm flex="20">
     <label>Operator</label>
-    <md-select ng-model="$ctrl.alert.conditions[0].operator" required>
+    <md-select ng-model="$ctrl.alert.conditions[0].operator" required ng-disabled="$ctrl.parent.isReadonly()">
       <md-option ng-value="type.key" ng-repeat="type in $ctrl.operators"> {{::type.name}} </md-option>
     </md-select>
   </md-input-container>
@@ -49,7 +49,15 @@
 
   <md-input-container class="md-block" flex-gt-sm flex="15">
     <label>Threshold</label>
-    <input ng-model="$ctrl.alert.conditions[0].threshold" required type="number" min="1" name="threshold" aria-label="trigger threshold" />
+    <input
+      ng-model="$ctrl.alert.conditions[0].threshold"
+      required
+      type="number"
+      min="1"
+      name="threshold"
+      aria-label="trigger threshold"
+      ng-disabled="$ctrl.parent.isReadonly()"
+    />
     <div ng-messages="$ctrl.parent.formAlert.threshold.$error">
       <div ng-message="required">Threshold is required.</div>
       <div ng-message="min">Threshold must be higher than 0.</div>
@@ -57,7 +65,11 @@
   </md-input-container>
 </div>
 
-<gv-alert-trigger-window condition="$ctrl.alert.conditions[0]"></gv-alert-trigger-window>
+<gv-alert-trigger-window condition="$ctrl.alert.conditions[0]" is-readonly="$ctrl.parent.isReadonly()"></gv-alert-trigger-window>
 
 <!-- Additional projections -->
-<gv-alert-trigger-projections condition="$ctrl.alert.conditions[0]" alert="$ctrl.alert"></gv-alert-trigger-projections>
+<gv-alert-trigger-projections
+  condition="$ctrl.alert.conditions[0]"
+  alert="$ctrl.alert"
+  is-readonly="$ctrl.parent.isReadonly()"
+></gv-alert-trigger-projections>

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-metrics-rate.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-metrics-rate.html
@@ -15,14 +15,18 @@
     limitations under the License.
 
 -->
-<gv-alert-trigger-condition condition="$ctrl.alert.conditions[0].comparison" metrics="$ctrl.metrics"></gv-alert-trigger-condition>
+<gv-alert-trigger-condition
+  condition="$ctrl.alert.conditions[0].comparison"
+  metrics="$ctrl.metrics"
+  is-readonly="$ctrl.parent.isReadonly()"
+></gv-alert-trigger-condition>
 
 <div layout-gt-sm="row">
   <span flex="15" style="display: grid; align-items: center" align="center">If rate is</span>
 
   <md-input-container class="md-block" flex-gt-sm flex="20">
     <label>Operator</label>
-    <md-select ng-model="$ctrl.alert.conditions[0].operator" required>
+    <md-select ng-model="$ctrl.alert.conditions[0].operator" required ng-disabled="$ctrl.parent.isReadonly()">
       <md-option ng-value="type.key" ng-repeat="type in $ctrl.operators"> {{::type.name}} </md-option>
     </md-select>
   </md-input-container>
@@ -39,6 +43,7 @@
       max="99"
       name="threshold"
       aria-label="trigger threshold"
+      ng-disabled="$ctrl.parent.isReadonly()"
     />
     <div ng-messages="$ctrl.parent.formAlert.threshold.$error">
       <div ng-message="required">Threshold is required.</div>
@@ -48,7 +53,11 @@
   </md-input-container>
 </div>
 
-<gv-alert-trigger-window condition="$ctrl.alert.conditions[0]"></gv-alert-trigger-window>
+<gv-alert-trigger-window condition="$ctrl.alert.conditions[0]" is-readonly="$ctrl.parent.isReadonly()"></gv-alert-trigger-window>
 
 <!-- Additional projections -->
-<gv-alert-trigger-projections condition="$ctrl.alert.conditions[0]" alert="$ctrl.alert"></gv-alert-trigger-projections>
+<gv-alert-trigger-projections
+  condition="$ctrl.alert.conditions[0]"
+  alert="$ctrl.alert"
+  is-readonly="$ctrl.parent.isReadonly()"
+></gv-alert-trigger-projections>

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-metrics-simple-condition.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-metrics-simple-condition.html
@@ -15,4 +15,8 @@
     limitations under the License.
 
 -->
-<gv-alert-trigger-condition condition="$ctrl.alert.conditions[0]" metrics="$ctrl.metrics"></gv-alert-trigger-condition>
+<gv-alert-trigger-condition
+  condition="$ctrl.alert.conditions[0]"
+  metrics="$ctrl.metrics"
+  is-readonly="$ctrl.parent.isReadonly()"
+></gv-alert-trigger-condition>

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-missing-data.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-missing-data.html
@@ -15,4 +15,8 @@
     limitations under the License.
 
 -->
-<gv-alert-trigger-window label="'No event for'" condition="$ctrl.alert.conditions[0]"></gv-alert-trigger-window>
+<gv-alert-trigger-window
+  label="'No event for'"
+  condition="$ctrl.alert.conditions[0]"
+  is-readonly="$ctrl.parent.isReadonly()"
+></gv-alert-trigger-window>

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-window.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-window.component.ts
@@ -19,6 +19,7 @@ const AlertTriggerWindowComponent: ng.IComponentOptions = {
   bindings: {
     label: '<',
     condition: '<',
+    isReadonly: '<',
   },
   template: require('./trigger-window.html'),
   controller: function () {

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-window.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-window.html
@@ -34,6 +34,7 @@
       min="1"
       name="window-duration"
       aria-label="trigger time-window duration"
+      ng-disabled="$ctrl.isReadonly"
     />
     <div ng-messages="$ctrl.formAlert['window-duration'].$error">
       <div ng-message="required">Duration is required.</div>
@@ -43,7 +44,7 @@
 
   <md-input-container class="md-block" flex-gt-sm flex="15">
     <label>TimeUnit</label>
-    <md-select ng-model="$ctrl.condition.timeUnit" required>
+    <md-select ng-model="$ctrl.condition.timeUnit" required ng-disabled="$ctrl.isReadonly">
       <md-option ng-value="unit.key" ng-repeat="unit in $ctrl.timeUnits"> {{::unit.name}} </md-option>
     </md-select>
   </md-input-container>

--- a/gravitee-apim-console-webui/src/components/alerts/alerts.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alerts.component.ts
@@ -17,6 +17,7 @@ import { StateService } from '@uirouter/core';
 import { Alert, Scope } from '../../entities/alert';
 import AlertService from '../../services/alert.service';
 import NotificationService from '../../services/notification.service';
+import UserService from '../../services/user.service';
 
 const AlertsComponent: ng.IComponentOptions = {
   bindings: {
@@ -30,6 +31,7 @@ const AlertsComponent: ng.IComponentOptions = {
     $state: StateService,
     AlertService: AlertService,
     NotificationService: NotificationService,
+    UserService: UserService,
     $mdDialog,
   ) {
     'ngInject';
@@ -105,6 +107,16 @@ const AlertsComponent: ng.IComponentOptions = {
         case 'critical':
           return '#d73a49';
       }
+    };
+
+    this.hasPermissionForCurrentScope = (permission: string): boolean => {
+      let scope = 'environment';
+      if ($stateParams.apiId) {
+        scope = 'api';
+      } else if ($stateParams.applicationId) {
+        scope = 'application';
+      }
+      return UserService.isUserHasPermissions([`${scope}-${permission}`]);
     };
   },
 };

--- a/gravitee-apim-console-webui/src/components/alerts/alerts.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alerts.html
@@ -30,8 +30,8 @@
                 <th md-column>Last 5m / 1h / 1d / 1M</th>
                 <th md-column>Last alert</th>
                 <th md-column>Last message</th>
-                <th permission permission-only="'environment-alert-d'" width="48px" nowrap></th>
-                <th permission permission-only="'environment-alert-d'" width="48px" nowrap></th>
+                <th ng-if="$ctrl.hasPermissionForCurrentScope('alert-u')" width="48px" nowrap></th>
+                <th ng-if="$ctrl.hasPermissionForCurrentScope('alert-d')" width="48px" nowrap></th>
               </tr>
             </thead>
             <tbody md-body>
@@ -44,16 +44,13 @@
                     {{alert.severity}}
                   </span>
                 </td>
-                <td md-cell permission permission-only="'environment-alert-u'">
+                <td md-cell>
                   <a ng-style="alert.enabled?'':{'font-style': 'italic', 'color': 'grey'}" ng-click="$ctrl.goTo('alert', alert.id)">
                     <span ng-if="alert.template">[Template] </span>
                     {{alert.name}}
                   </a>
                 </td>
                 <td md-cell>{{alert.description}}</td>
-                <td md-cell permission permission-except="'environment-alert-u'">
-                  <span ng-style="alert.enabled?'':{'font-style': 'italic', 'color': 'grey'}">{{alert.name}}</span>
-                </td>
                 <td md-cell>
                   <span ng-if="!alert.template">
                     {{ alert.counters['5m'] }} / {{ alert.counters['1h'] }} / {{ alert.counters['1d'] }} / {{ alert.counters['1M'] }}
@@ -77,22 +74,18 @@
                 </td>
                 <td md-cell width="48px">
                   <ng-md-icon
-                    ng-if="!alert.enabled && !alert.template"
+                    ng-if="$ctrl.hasPermissionForCurrentScope('alert-u') && !alert.enabled && !alert.template"
                     icon="not_interested"
                     ng-click="$ctrl.toggleEnable(alert)"
                     style="font-size: 24px; height: 24px"
-                    permission
-                    permission-only="'environment-alert-u'"
                   >
                     <md-tooltip md-direction="top" md-visible="false">Enable this alert</md-tooltip>
                   </ng-md-icon>
                   <ng-md-icon
-                    ng-if="alert.enabled && !alert.template"
+                    ng-if="$ctrl.hasPermissionForCurrentScope('alert-u') && alert.enabled && !alert.template"
                     icon="done"
                     ng-click="$ctrl.toggleEnable(alert)"
                     style="font-size: 24px; height: 24px"
-                    permission
-                    permission-only="'environment-alert-u'"
                   >
                     <md-tooltip md-direction="top" md-visible="false">Disable this alert</md-tooltip>
                   </ng-md-icon>
@@ -100,7 +93,7 @@
                     <md-tooltip md-direction="top" md-visible="false">Alert template</md-tooltip>
                   </ng-md-icon>
                 </td>
-                <td md-cell permission permission-only="'environment-alert-d'">
+                <td md-cell ng-if="$ctrl.hasPermissionForCurrentScope('alert-d')">
                   <ng-md-icon icon="delete" ng-click="$ctrl.delete(alert)"></ng-md-icon>
                 </td>
               </tr>
@@ -120,8 +113,7 @@
   </div>
   <div ng-style="{'text-align': $ctrl.alerts.length == 0 ? 'center' : 'none' }">
     <md-button
-      permission
-      permission-only="['api-alert-c', 'application-alert-c', 'environment-alert-c']"
+      ng-if="$ctrl.hasPermissionForCurrentScope('alert-c')"
       ng-class="{'md-fab-bottom-right': $ctrl.alerts.length > 0}"
       class="md-fab"
       aria-label="create-alert"

--- a/gravitee-apim-console-webui/src/management/api/notifications/apis.notifications.settings.route.ts
+++ b/gravitee-apim-console-webui/src/management/api/notifications/apis.notifications.settings.route.ts
@@ -108,6 +108,7 @@ function apisNotificationsRouterConfig($stateProvider) {
         status: (AlertService: AlertService, $stateParams) =>
           AlertService.getStatus($stateParams.apiId, 0).then((response) => response.data),
         notifiers: (NotifierService: NotifierService) => NotifierService.list().then((response) => response.data),
+        mode: () => 'create',
       },
     })
     .state('management.apis.detail.alerts.alert', {
@@ -119,7 +120,7 @@ function apisNotificationsRouterConfig($stateProvider) {
           page: 'management-alerts',
         },
         perms: {
-          only: ['api-alert-u'],
+          only: ['api-alert-r'],
         },
       },
       resolve: {
@@ -128,6 +129,7 @@ function apisNotificationsRouterConfig($stateProvider) {
         status: (AlertService: AlertService, $stateParams) =>
           AlertService.getStatus($stateParams.apiId, 0).then((response) => response.data),
         notifiers: (NotifierService: NotifierService) => NotifierService.list().then((response) => response.data),
+        mode: () => 'detail',
       },
     });
 }

--- a/gravitee-apim-console-webui/src/management/configuration/notifications/global.notifications.settings.route.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/notifications/global.notifications.settings.route.ts
@@ -80,6 +80,7 @@ function applicationsNotificationsRouterConfig($stateProvider) {
         status: (AlertService: AlertService, $stateParams) =>
           AlertService.getStatus($stateParams.apiId, 2).then((response) => response.data),
         notifiers: (NotifierService: NotifierService) => NotifierService.list().then((response) => response.data),
+        mode: () => 'detail',
       },
     })
     .state('management.settings.alerts.alertnew', {
@@ -99,6 +100,7 @@ function applicationsNotificationsRouterConfig($stateProvider) {
         status: (AlertService: AlertService, $stateParams) =>
           AlertService.getStatus($stateParams.apiId, 2).then((response) => response.data),
         notifiers: (NotifierService: NotifierService) => NotifierService.list().then((response) => response.data),
+        mode: () => 'create',
       },
     })
     .state('management.settings.alerts.alert', {
@@ -110,7 +112,7 @@ function applicationsNotificationsRouterConfig($stateProvider) {
           page: 'management-alerts',
         },
         perms: {
-          only: ['environment-alert-u'],
+          only: ['environment-alert-r'],
         },
       },
       resolve: {


### PR DESCRIPTION
Replace https://github.com/gravitee-io/old-gravitee-api-management/pull/370

**Issue**

https://github.com/gravitee-io/issues/issues/5974
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-5974-alert-permissions/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
