### PR TITLE
test: first version of new tests

### DIFF
--- a/gravitee-apim-cypress/cypress.json
+++ b/gravitee-apim-cypress/cypress.json
@@ -1,12 +1,10 @@
 {
-  "projectId": "gravitee-apim-cypress-e2e",
+  "projectId": "gravitee-apim-cypress",
   "baseUrl": "http://localhost:8083",
-  "video": true,
-  "screenshotOnRunFailure": true,
-  "integrationFolder": "cypress/integration/e2e",
+  "video": false,
+  "screenshotOnRunFailure": false,
+  "integrationFolder": "cypress/integration/nrt",
   "testFiles": "**/*.ts",
-  "viewportWidth": 1920,
-  "viewportHeight": 1080,
   "env": {
     "failOnStatusCode": false,
     "api_publisher_user_login": "api1",

--- a/gravitee-apim-cypress/cypress/commands/management/api-management-commands.ts
+++ b/gravitee-apim-cypress/cypress/commands/management/api-management-commands.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Api, ApiErrorCodes, ApiLifecycleState, PortalApi } from '@model/apis';
+import { User, BasicAuthentication } from '@model/users';
+
+export function createApi(auth: BasicAuthentication, body: Api) {
+  return cy.request({
+    method: 'POST',
+    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis`,
+    body,
+    auth,
+    failOnStatusCode: false,
+  });
+}
+
+export function publishApi(auth: BasicAuthentication, apiId: string) {
+  return cy.request({
+    method: 'PUT',
+    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}`,
+    auth,
+    failOnStatusCode: false,
+  });
+}
+
+export function deleteApi(auth: BasicAuthentication, apiId: string) {
+  return cy.request({
+    method: 'DELETE',
+    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}`,
+    auth,
+    failOnStatusCode: false,
+  });
+}

--- a/gravitee-apim-cypress/cypress/commands/management/application-management-commands.ts
+++ b/gravitee-apim-cypress/cypress/commands/management/application-management-commands.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Application } from 'model/applications';
+import { User, BasicAuthentication } from 'model/users';
+
+export function createApplication(auth: BasicAuthentication, body: Application) {
+  return cy.request({
+    method: 'POST',
+    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/applications`,
+    body,
+    auth,
+    failOnStatusCode: false,
+  });
+}
+
+export function deleteApplication(auth: BasicAuthentication, applicationId: string) {
+  return cy.request({
+    method: 'DELETE',
+    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/applications/${applicationId}`,
+    auth,
+    failOnStatusCode: false,
+  });
+}

--- a/gravitee-apim-cypress/cypress/cypress.json
+++ b/gravitee-apim-cypress/cypress/cypress.json
@@ -1,12 +1,10 @@
 {
-  "projectId": "gravitee-apim-cypress-e2e",
+  "projectId": "gravitee-apim-cypress",
   "baseUrl": "http://localhost:8083",
-  "video": true,
-  "screenshotOnRunFailure": true,
-  "integrationFolder": "cypress/integration/e2e",
+  "video": false,
+  "screenshotOnRunFailure": false,
+  "integrationFolder": "cypress/integration/nrt",
   "testFiles": "**/*.ts",
-  "viewportWidth": 1920,
-  "viewportHeight": 1080,
   "env": {
     "failOnStatusCode": false,
     "api_publisher_user_login": "api1",

--- a/gravitee-apim-cypress/cypress/fakers/applications.ts
+++ b/gravitee-apim-cypress/cypress/fakers/applications.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as faker from 'faker';
+import { Application } from '@model/applications';
+
+export class ApplicationFakers {
+  static application(attributes?: Partial<Application>): Application {
+    return <Application>{
+      ...attributes,
+      name: faker.commerce.productName(),
+      description: faker.commerce.productDescription(),
+    };
+  }
+}

--- a/gravitee-apim-cypress/cypress/integration/nrt/apis/api-tests.ts
+++ b/gravitee-apim-cypress/cypress/integration/nrt/apis/api-tests.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ADMIN_USER, API_PUBLISHER_USER, LOW_PERMISSION_USER } from 'fakers/users/users';
+import { ApiFakers } from 'fakers/apis';
+import { createApi, deleteApi } from 'commands/management/api-management-commands';
+import { Api } from 'model/apis';
+
+context('API tests', () => {
+  describe('Create APIs', function () {
+    afterEach(function () {
+      deleteApi(ADMIN_USER, this.apiId);
+    });
+    it('should create an API as admin user', function () {
+      const fakeApi: Api = ApiFakers.api();
+      createApi(ADMIN_USER, fakeApi).should((response) => {
+        expect(response.body.state).equal('STOPPED');
+        expect(response.body.visibility).equal('PRIVATE');
+        expect(response.body.lifecycle_state).equal('CREATED');
+        cy.wrap(response.body.id).as('apiId');
+      });
+    });
+
+    it('should fail to create an API if user lacks required permssions', function () {
+      const fakeApi: Api = ApiFakers.api();
+      createApi(LOW_PERMISSION_USER, fakeApi).should((response) => {
+        expect(response.status).to.equal(403);
+        expect(response.body.message).to.equal('You do not have sufficient rights to access this resource');
+      });
+    });
+  });
+
+  describe('Delete an API', function () {
+    beforeEach(function () {
+      const fakeApi: Api = ApiFakers.api();
+      createApi(ADMIN_USER, fakeApi).should((response) => {
+        expect(response.status).to.equal(201);
+        cy.wrap(response.body.id).as('apiId');
+      });
+    });
+
+    afterEach(function () {
+      deleteApi(ADMIN_USER, this.apiId);
+    });
+
+    it('should delete an API as admin user', function () {
+      deleteApi(ADMIN_USER, this.apiId).its('status').should('equal', 204);
+    });
+
+    it('should fail to delete an API as low permission user', function () {
+      deleteApi(LOW_PERMISSION_USER, this.apiId).should((response) => {
+        expect(response.status).to.be.equal(403);
+        expect(response.body.message).to.be.equal('You do not have sufficient rights to access this resource');
+      });
+    });
+  });
+});

--- a/gravitee-apim-cypress/cypress/integration/nrt/applications/application-tests.ts
+++ b/gravitee-apim-cypress/cypress/integration/nrt/applications/application-tests.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ADMIN_USER, API_PUBLISHER_USER, LOW_PERMISSION_USER } from 'fakers/users/users';
+import { ApplicationFakers } from 'fakers/applications';
+import { Application } from 'model/applications';
+import { createApplication, deleteApplication } from 'commands/management/application-management-commands';
+
+context('Application tests', () => {
+  describe.only('Create an Application', function () {
+    afterEach(function () {
+      deleteApplication(ADMIN_USER, this.applicationId);
+    });
+
+    it('should create an application as admin user', function () {
+      const fakeApplication: Application = ApplicationFakers.application();
+      createApplication(ADMIN_USER, fakeApplication).should(function (response) {
+        expect(response.status).to.equal(201);
+        expect(response.body.status).equal('ACTIVE');
+        cy.wrap(response.body.id).as('applicationId');
+      });
+    });
+
+    it('should not create an application for unauthorized user', function () {
+      const fakeApplication: Application = ApplicationFakers.application();
+      createApplication({ username: 'unknown_user', password: 'fake p@ssword' }, fakeApplication).its('status').should('equal', 401);
+    });
+  });
+
+  describe('Delete an Application', function () {
+    before(function () {
+      const fakeApplication: Application = ApplicationFakers.application();
+      createApplication(ADMIN_USER, fakeApplication)
+        .as('applicationId')
+        .should(function (response) {
+          expect(response.status).to.equal(201);
+          cy.wrap(response.body.id).as('applicationId');
+        });
+    });
+
+    it('should delete an application as admin user', function () {
+      deleteApplication(ADMIN_USER, this.applicationId).its('status').should('equal', 204);
+    });
+  });
+});

--- a/gravitee-apim-cypress/cypress/model/applications.ts
+++ b/gravitee-apim-cypress/cypress/model/applications.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export interface Application {
+  name: string;
+  description: string;
+  settings: ApplicationSettings;
+  type: string;
+  clientId: string;
+  groups: string[];
+  picture: string;
+  background: string;
+}
+
+export interface ApplicationSettings {
+  app: SimpleApplicationSettings;
+  oauth: OAuthClientSettings;
+}
+
+export interface SimpleApplicationSettings {
+  type: string;
+  client_id: string;
+}
+
+export interface OAuthClientSettings {
+  client_id: string;
+  client_secret: string;
+  redirect_uris: string[];
+  items: string;
+  client_uri: string;
+  logo_uri: string;
+  response_types: string[];
+  grant_types: string[];
+  application_type: string;
+  renew_client_secret_supported: boolean;
+}
+
+export interface ApplicationEntity {
+  id: string;
+  name: string;
+  description: string;
+  groups: string[];
+  status: string;
+  type: string;
+  picture: string;
+  background: string;
+  created_at: number;
+  updated_at: number;
+  owner: PrimaryOwnerEntity;
+  settings: ApplicationSettings;
+  disable_membership_notifications: boolean;
+}
+
+export interface PrimaryOwnerEntity {
+  id: string;
+  email: string;
+  displayName: string;
+  type: string;
+}

--- a/gravitee-apim-cypress/package.json
+++ b/gravitee-apim-cypress/package.json
@@ -4,6 +4,7 @@
     "private": true,
     "description": "Gravitee.io APIM - Cypress",
     "scripts": {
+        "test": "cypress open",
         "test:bulk": "cypress run --config-file cypress/integration/bulk/cypress-config.json",
         "test:ci": "cypress run --config-file cypress/integration/nrt/cypress-config.json",
         "test:e2e": "cypress open --config-file cypress/integration/e2e/cypress-config.json",

--- a/gravitee-apim-cypress/tsconfig.json
+++ b/gravitee-apim-cypress/tsconfig.json
@@ -2,7 +2,12 @@
   "compilerOptions": {
     "target": "ES2020",
     "lib": ["es5", "dom"],
-    "types": ["cypress", "node"]
+    "types": ["cypress", "node"],
+    "baseUrl": "./cypress",
+    "paths": {
+      "@fakers/*": ["fakers/*"],
+      "@model/*": ["model/*"]
+    }
   },
   "include": ["**/*.ts"]
 }


### PR DESCRIPTION
Replace https://github.com/gravitee-io/old-gravitee-api-management/pull/372

**Description**

This PR contains a first set of tests that represents a different way of writing test, a way that is closer to the Cypress recommendations and easier to understand and maintain for the QA team. It serve as a base for a discussion between Dev and QA teams to find the best approach for future test development.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/test-first-api-tests/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gwsczppkmv.chromatic.com)
<!-- Storybook placeholder end -->
