### PR TITLE
fix: avoid errors when deleting a resource

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -1790,7 +1790,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 // Audit
                 auditService.createApiAuditLog(apiId, Collections.emptyMap(), API_DELETED, new Date(), optApi.get(), null);
                 // remove from search engine
-                searchEngineService.delete(convert(optApi.get()), false);
+                searchEngineService.delete(convert(optApi.get()));
 
                 mediaService.deleteAllByApi(apiId);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -1207,7 +1207,7 @@ public class PageServiceImpl extends AbstractService implements PageService, App
 
             // update document in search engine
             if (pageToUpdate.isPublished() && !page.isPublished()) {
-                searchEngineService.delete(convert(pageToUpdate), false);
+                searchEngineService.delete(convert(pageToUpdate));
             } else {
                 index(pageEntity);
             }
@@ -1989,7 +1989,7 @@ public class PageServiceImpl extends AbstractService implements PageService, App
             );
 
             // remove from search engine
-            searchEngineService.delete(convert(page), false);
+            searchEngineService.delete(convert(page));
         } catch (TechnicalException ex) {
             logger.error("An error occurs while trying to delete Page {}", pageId, ex);
             throw new TechnicalManagementException("An error occurs while trying to delete Page " + pageId, ex);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -1236,7 +1236,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
             userRepository.update(user);
 
             final UserEntity userEntity = convert(optionalUser.get(), false);
-            searchEngineService.delete(userEntity, false);
+            searchEngineService.delete(userEntity);
         } catch (TechnicalException ex) {
             LOGGER.error("An error occurs while trying to delete user", ex);
             throw new TechnicalManagementException("An error occurs while trying to delete user", ex);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/SearchEngineServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/SearchEngineServiceImpl.java
@@ -93,6 +93,7 @@ public class SearchEngineServiceImpl implements SearchEngineService {
     @Override
     public void index(Indexable source, boolean locally, boolean commit) {
         indexLocally(source, commit);
+
         if (!locally) {
             CommandSearchIndexerEntity content = new CommandSearchIndexerEntity();
             content.setAction(ACTION_INDEX);
@@ -105,16 +106,13 @@ public class SearchEngineServiceImpl implements SearchEngineService {
 
     @Async("indexerThreadPoolTaskExecutor")
     @Override
-    public void delete(Indexable source, boolean locally) {
-        deleteLocally(source);
-        if (!locally) {
-            CommandSearchIndexerEntity content = new CommandSearchIndexerEntity();
-            content.setAction(ACTION_DELETE);
-            content.setId(source.getId());
-            content.setClazz(source.getClass().getName());
+    public void delete(Indexable source) {
+        CommandSearchIndexerEntity content = new CommandSearchIndexerEntity();
+        content.setAction(ACTION_DELETE);
+        content.setId(source.getId());
+        content.setClazz(source.getClass().getName());
 
-            sendCommands(content);
-        }
+        sendCommands(content);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformer.java
@@ -58,10 +58,14 @@ public class ApiDocumentTransformer implements DocumentTransformer<ApiEntity> {
     public Document transform(io.gravitee.rest.api.model.api.ApiEntity api) {
         Document doc = new Document();
 
-        doc.add(new StringField(FIELD_REFERENCE_TYPE, api.getReferenceType(), Field.Store.NO));
-        doc.add(new StringField(FIELD_REFERENCE_ID, api.getReferenceId(), Field.Store.NO));
         doc.add(new StringField(FIELD_ID, api.getId(), Field.Store.YES));
         doc.add(new StringField(FIELD_TYPE, FIELD_TYPE_VALUE, Field.Store.YES));
+
+        if (api.getReferenceId() != null) {
+            doc.add(new StringField(FIELD_REFERENCE_TYPE, api.getReferenceType(), Field.Store.NO));
+            doc.add(new StringField(FIELD_REFERENCE_ID, api.getReferenceId(), Field.Store.NO));
+        }
+
         if (api.getName() != null) {
             doc.add(new StringField(FIELD_NAME, api.getName(), Field.Store.NO));
             doc.add(new StringField(FIELD_NAME_LOWERCASE, api.getName().toLowerCase(), Field.Store.NO));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/PageDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/PageDocumentTransformer.java
@@ -46,10 +46,14 @@ public class PageDocumentTransformer implements DocumentTransformer<PageEntity> 
     public Document transform(PageEntity page) {
         Document doc = new Document();
 
-        doc.add(new StringField(FIELD_REFERENCE_TYPE, page.getReferenceType(), Field.Store.NO));
-        doc.add(new StringField(FIELD_REFERENCE_ID, page.getReferenceId(), Field.Store.NO));
         doc.add(new StringField(FIELD_ID, page.getId(), Field.Store.YES));
         doc.add(new StringField(FIELD_TYPE, FIELD_TYPE_VALUE, Field.Store.YES));
+
+        if (page.getReferenceId() != null) {
+            doc.add(new StringField(FIELD_REFERENCE_TYPE, page.getReferenceType(), Field.Store.NO));
+            doc.add(new StringField(FIELD_REFERENCE_ID, page.getReferenceId(), Field.Store.NO));
+        }
+
         if (page.getName() != null) {
             doc.add(new StringField(FIELD_NAME, page.getName(), Field.Store.NO));
             doc.add(new StringField(FIELD_NAME_LOWERCASE, page.getName().toLowerCase(), Field.Store.NO));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/UserDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/UserDocumentTransformer.java
@@ -76,10 +76,14 @@ public class UserDocumentTransformer implements DocumentTransformer<UserEntity> 
     public Document transform(UserEntity user) {
         Document doc = new Document();
 
-        doc.add(new StringField(FIELD_REFERENCE_TYPE, user.getReferenceType(), Field.Store.NO));
-        doc.add(new StringField(FIELD_REFERENCE_ID, user.getReferenceId(), Field.Store.NO));
         doc.add(new StringField(FIELD_ID, user.getId(), Field.Store.YES));
         doc.add(new StringField(FIELD_TYPE, FIELD_TYPE_VALUE, Field.Store.YES));
+
+        if (user.getReferenceId() != null) {
+            doc.add(new StringField(FIELD_REFERENCE_TYPE, user.getReferenceType(), Field.Store.NO));
+            doc.add(new StringField(FIELD_REFERENCE_ID, user.getReferenceId(), Field.Store.NO));
+        }
+
         if (user.getSource() != null) {
             doc.add(new StringField(FIELD_SOURCE, user.getSource(), Field.Store.NO));
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/search/SearchEngineService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/search/SearchEngineService.java
@@ -32,7 +32,7 @@ public interface SearchEngineService {
 
     void index(Indexable source, boolean locally, boolean commit);
 
-    void delete(Indexable source, boolean locally);
+    void delete(Indexable source);
 
     void commit();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/UserServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/UserServiceTest.java
@@ -906,7 +906,7 @@ public class UserServiceTest {
             //success
             verify(membershipService, never()).removeMemberMemberships(MembershipMemberType.USER, USER_NAME);
             verify(userRepository, never()).update(any());
-            verify(searchEngineService, never()).delete(any(), eq(false));
+            verify(searchEngineService, never()).delete(any());
         }
     }
 
@@ -925,7 +925,7 @@ public class UserServiceTest {
             //success
             verify(membershipService, never()).removeMemberMemberships(MembershipMemberType.USER, USER_NAME);
             verify(userRepository, never()).update(any());
-            verify(searchEngineService, never()).delete(any(), eq(false));
+            verify(searchEngineService, never()).delete(any());
         }
     }
 
@@ -971,7 +971,7 @@ public class UserServiceTest {
                     }
                 )
             );
-        verify(searchEngineService, times(1)).delete(any(), eq(false));
+        verify(searchEngineService, times(1)).delete(any());
         verify(portalNotificationService, times(1)).deleteAll(user.getId());
         verify(portalNotificationConfigService, times(1)).deleteByUser(user.getId());
         verify(genericNotificationConfigService, times(1)).deleteByUser(eq(user));
@@ -1024,7 +1024,7 @@ public class UserServiceTest {
                     }
                 )
             );
-        verify(searchEngineService, times(1)).delete(any(), eq(false));
+        verify(searchEngineService, times(1)).delete(any());
         verify(portalNotificationService, times(1)).deleteAll(user.getId());
         verify(portalNotificationConfigService, times(1)).deleteByUser(user.getId());
         verify(genericNotificationConfigService, times(1)).deleteByUser(eq(user));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformerTest.java
@@ -49,6 +49,14 @@ public class ApiDocumentTransformerTest {
         assertDocumentMatchesInputApiEntity(toTransform, transformed);
     }
 
+    @Test
+    public void shouldTransformWithoutError_OnMissingReferenceId() {
+        ApiEntity api = new ApiEntity();
+        api.setId("api-uuid");
+        Document doc = cut.transform(api);
+        assertThat(doc.get("id")).isEqualTo(api.getId());
+    }
+
     @NotNull
     private ApiEntity getApiEntity() {
         ApiEntity toTransform = new ApiEntity();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/PageDocumentTransformerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/PageDocumentTransformerTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.search.lucene.transformer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.rest.api.model.PageEntity;
+import org.apache.lucene.document.Document;
+import org.junit.Test;
+
+/**
+ * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class PageDocumentTransformerTest {
+
+    PageDocumentTransformer transformer = new PageDocumentTransformer();
+
+    @Test
+    public void shouldTransformWithoutError_OnMissingReferenceId() {
+        PageEntity page = new PageEntity();
+        page.setId("page-uuid");
+        Document doc = transformer.transform(page);
+        assertThat(doc.get("id")).isEqualTo(page.getId());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/UserDocumentTransformerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/UserDocumentTransformerTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.search.lucene.transformer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.rest.api.model.UserEntity;
+import org.apache.lucene.document.Document;
+import org.junit.Test;
+
+/**
+ * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class UserDocumentTransformerTest {
+
+    UserDocumentTransformer transformer = new UserDocumentTransformer();
+
+    @Test
+    public void shouldTransformWithoutError_OnMissingReferenceId() {
+        UserEntity user = new UserEntity();
+        user.setId("user-uuid");
+        Document doc = transformer.transform(user);
+        assertThat(doc.get("id")).isEqualTo(user.getId());
+    }
+}


### PR DESCRIPTION
Add null checks to document transformers to avoid technical exceptions
when deleting a resource.

see https://github.com/gravitee-io/issues/issues/6583
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6583-fix-delete-command-errors/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
