### PR TITLE
fix: limit the number of ObjectMapper instances

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/PolicyConfigurationFactoryImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/PolicyConfigurationFactoryImpl.java
@@ -32,7 +32,7 @@ public class PolicyConfigurationFactoryImpl implements PolicyConfigurationFactor
 
     private final Logger LOGGER = LoggerFactory.getLogger(PolicyConfigurationFactoryImpl.class);
 
-    private final ObjectMapper mapper = new ObjectMapper()
+    private static final ObjectMapper mapper = new ObjectMapper()
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-resource/src/main/java/io/gravitee/gateway/resource/internal/ResourceConfigurationFactoryImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-resource/src/main/java/io/gravitee/gateway/resource/internal/ResourceConfigurationFactoryImpl.java
@@ -32,7 +32,7 @@ public class ResourceConfigurationFactoryImpl implements ResourceConfigurationFa
 
     private final Logger LOGGER = LoggerFactory.getLogger(ResourceConfigurationFactoryImpl.class);
 
-    private final ObjectMapper mapper = new ObjectMapper()
+    private static final ObjectMapper mapper = new ObjectMapper()
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     @Override


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6671

**Description**

Too many `ObjectMapper` instances are created for nothing.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-6671-limit-objectmapper-instantiations/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
