### PR TITLE
fix(mem): make sure classloader are well released

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/PolicyFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/PolicyFactory.java
@@ -24,4 +24,6 @@ import io.gravitee.policy.api.PolicyConfiguration;
 public interface PolicyFactory {
 
     Object create(PolicyMetadata policyMetadata, PolicyConfiguration policyConfiguration);
+
+    void cleanup(PolicyMetadata policyMetadata);
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/PolicyFactoryImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/PolicyFactoryImpl.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.policy.impl;
 
 import com.google.common.base.Predicate;
+import io.gravitee.gateway.policy.Policy;
 import io.gravitee.gateway.policy.PolicyFactory;
 import io.gravitee.gateway.policy.PolicyMetadata;
 import io.gravitee.policy.api.PolicyConfiguration;
@@ -27,6 +28,7 @@ import java.lang.reflect.*;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.reflections.ReflectionUtils.withModifier;
 import static org.reflections.ReflectionUtils.withParametersCount;
@@ -42,7 +44,7 @@ public class PolicyFactoryImpl implements PolicyFactory {
     /**
      * Cache of constructor by policy
      */
-    private Map<Class<?>, Constructor<?>> constructors = new HashMap<>();
+    private final Map<Class<?>, Constructor<?>> constructors = new ConcurrentHashMap<>();
 
     @Override
     public Object create(PolicyMetadata policyMetadata, PolicyConfiguration policyConfiguration) {
@@ -50,6 +52,13 @@ public class PolicyFactoryImpl implements PolicyFactory {
         LOGGER.debug("Create a new policy instance for {}", policyClass.getName());
 
         return createPolicy(policyMetadata, policyConfiguration);
+    }
+
+    @Override
+    public void cleanup(PolicyMetadata policyMetadata) {
+        if(policyMetadata != null) {
+            constructors.remove(policyMetadata.policy());
+        }
     }
 
     private Object createPolicy(PolicyMetadata policyMetadata, PolicyConfiguration policyConfiguration) {


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6678

**Description**

When deploying / undeploying apis continuously, Gravitee's ClassLoader were still referenced by a third party library.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-6678-release-classloaders/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
