### PR TITLE
fix(console): fix alerts pages documentation display

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/notifications/apis.notifications.settings.route.ts
+++ b/gravitee-apim-console-webui/src/management/api/notifications/apis.notifications.settings.route.ts
@@ -81,6 +81,9 @@ function apisNotificationsRouterConfig($stateProvider) {
         perms: {
           only: ['api-alert-r'],
         },
+        docs: {
+          page: 'management-alerts',
+        },
       },
       resolve: {
         alerts: (AlertService: AlertService, $stateParams) =>

--- a/gravitee-apim-console-webui/src/management/configuration/notifications/global.notifications.settings.route.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/notifications/global.notifications.settings.route.ts
@@ -74,6 +74,9 @@ function applicationsNotificationsRouterConfig($stateProvider) {
         perms: {
           only: ['environment-alert-r'],
         },
+        docs: {
+          page: 'management-alerts',
+        },
       },
       resolve: {
         alerts: (AlertService: AlertService) => AlertService.listAlerts(undefined, 2).then((response) => response.data),


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6680

Add documentation page to the alertsComponent route, to display relevant documentation on alerts list page.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ggwirmpafz.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-6680-alerts-page-documentation/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
