### PR TITLE
fix: use proper token when fetching external page

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -2097,7 +2097,7 @@ public class PageServiceImpl extends AbstractService implements PageService, App
         previousPage.setContent(page.getContent());
         previousPage.setName(page.getName());
 
-        UpdatePageEntity updatePageEntity = convertToUpdateEntity(page);
+        UpdatePageEntity updatePageEntity = convertToUpdateEntity(page, false);
         try {
             fetchPage(updatePageEntity);
         } catch (FetcherException e) {
@@ -2264,6 +2264,10 @@ public class PageServiceImpl extends AbstractService implements PageService, App
     }
 
     private UpdatePageEntity convertToUpdateEntity(Page page) {
+        return convertToUpdateEntity(page, true);
+    }
+
+    private UpdatePageEntity convertToUpdateEntity(Page page, boolean removeSensitiveData) {
         UpdatePageEntity updatePageEntity = new UpdatePageEntity();
 
         updatePageEntity.setName(page.getName());
@@ -2271,7 +2275,7 @@ public class PageServiceImpl extends AbstractService implements PageService, App
         updatePageEntity.setLastContributor(page.getLastContributor());
         updatePageEntity.setOrder(page.getOrder());
         updatePageEntity.setPublished(page.isPublished());
-        updatePageEntity.setSource(this.convert(page.getSource()));
+        updatePageEntity.setSource(this.convert(page.getSource(), removeSensitiveData));
         updatePageEntity.setConfiguration(page.getConfiguration());
         updatePageEntity.setHomepage(page.isHomepage());
         updatePageEntity.setExcludedAccessControls(page.isExcludedAccessControls());


### PR DESCRIPTION
Removal of sensitive data was leading to error when fetching a page
from an external source.

see https://github.com/gravitee-io/issues/issues/6331
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6331-fix-external-page-fetch-error/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
