### PR TITLE
fix(api import from cockpit): check context path before trying to create

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImpl.java
@@ -166,13 +166,13 @@ public class ApiServiceCockpitImpl implements ApiServiceCockpit {
         final SwaggerApiEntity api = swaggerService.createAPI(swaggerDescriptor, DefinitionVersion.V2);
         api.setPaths(null);
 
-        final ObjectNode apiDefinition = objectMapper.valueToTree(api);
-        apiDefinition.put("id", apiId);
-
-        final ApiEntity createdApi = apiService.createWithApiDefinition(api, userId, apiDefinition);
-
-        final Optional<String> result = checkContextPath(createdApi);
+        final Optional<String> result = checkContextPath(api);
         if (result.isEmpty()) {
+            final ObjectNode apiDefinition = objectMapper.valueToTree(api);
+            apiDefinition.put("id", apiId);
+
+            final ApiEntity createdApi = apiService.createWithApiDefinition(api, userId, apiDefinition);
+
             pageService.createAsideFolder(apiId, GraviteeContext.getCurrentEnvironment());
             pageService.createOrUpdateSwaggerPage(apiId, swaggerDescriptor, true);
             apiMetadataService.create(api.getMetadata(), createdApi.getId());
@@ -182,7 +182,7 @@ public class ApiServiceCockpitImpl implements ApiServiceCockpit {
         return ApiEntityResult.failure(result.get());
     }
 
-    Optional<String> checkContextPath(ApiEntity api) {
+    Optional<String> checkContextPath(SwaggerApiEntity api) {
         try {
             virtualHostService.sanitizeAndValidate(api.getProxy().getVirtualHosts());
             return Optional.empty();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImplTest.java
@@ -121,13 +121,13 @@ public class ApiServiceCockpitImplTest {
 
         SwaggerApiEntity swaggerApi = new SwaggerApiEntity();
         swaggerApi.setMetadata(new ArrayList<>());
-
-        ApiEntity api = new ApiEntity();
-        api.setId(API_ID);
         Proxy proxy = new Proxy();
         VirtualHost virtualHost = new VirtualHost();
         proxy.setVirtualHosts(List.of(virtualHost));
-        api.setProxy(proxy);
+        swaggerApi.setProxy(proxy);
+
+        ApiEntity api = new ApiEntity();
+        api.setId(API_ID);
 
         when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
         when(apiService.createWithApiDefinition(eq(swaggerApi), eq(USER_ID), any(ObjectNode.class))).thenReturn(api);
@@ -149,13 +149,13 @@ public class ApiServiceCockpitImplTest {
     public void should_not_start_a_documented_api() {
         SwaggerApiEntity swaggerApi = new SwaggerApiEntity();
         swaggerApi.setMetadata(new ArrayList<>());
-
-        ApiEntity api = new ApiEntity();
-        api.setId(API_ID);
         Proxy proxy = new Proxy();
         VirtualHost virtualHost = new VirtualHost();
         proxy.setVirtualHosts(List.of(virtualHost));
-        api.setProxy(proxy);
+        swaggerApi.setProxy(proxy);
+
+        ApiEntity api = new ApiEntity();
+        api.setId(API_ID);
 
         when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
         when(apiService.createWithApiDefinition(eq(swaggerApi), eq(USER_ID), any(ObjectNode.class))).thenReturn(api);
@@ -176,13 +176,13 @@ public class ApiServiceCockpitImplTest {
 
         SwaggerApiEntity swaggerApi = new SwaggerApiEntity();
         swaggerApi.setMetadata(new ArrayList<>());
-
-        ApiEntity api = new ApiEntity();
-        api.setId(API_ID);
         Proxy proxy = new Proxy();
         VirtualHost virtualHost = new VirtualHost();
         proxy.setVirtualHosts(List.of(virtualHost));
-        api.setProxy(proxy);
+        swaggerApi.setProxy(proxy);
+
+        ApiEntity api = new ApiEntity();
+        api.setId(API_ID);
 
         when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
         when(apiService.createWithApiDefinition(eq(swaggerApi), eq(USER_ID), any(ObjectNode.class))).thenReturn(api);
@@ -207,13 +207,13 @@ public class ApiServiceCockpitImplTest {
     public void should_start_a_mocked_api() {
         SwaggerApiEntity swaggerApi = new SwaggerApiEntity();
         swaggerApi.setMetadata(new ArrayList<>());
-
-        ApiEntity api = new ApiEntity();
-        api.setId(API_ID);
         Proxy proxy = new Proxy();
         VirtualHost virtualHost = new VirtualHost();
         proxy.setVirtualHosts(List.of(virtualHost));
-        api.setProxy(proxy);
+        swaggerApi.setProxy(proxy);
+
+        ApiEntity api = new ApiEntity();
+        api.setId(API_ID);
 
         when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
         when(apiService.createWithApiDefinition(eq(swaggerApi), eq(USER_ID), any(ObjectNode.class))).thenReturn(api);
@@ -238,13 +238,13 @@ public class ApiServiceCockpitImplTest {
 
         SwaggerApiEntity swaggerApi = new SwaggerApiEntity();
         swaggerApi.setMetadata(new ArrayList<>());
-
-        ApiEntity api = new ApiEntity();
-        api.setId(API_ID);
         Proxy proxy = new Proxy();
         VirtualHost virtualHost = new VirtualHost();
         proxy.setVirtualHosts(List.of(virtualHost));
-        api.setProxy(proxy);
+        swaggerApi.setProxy(proxy);
+
+        ApiEntity api = new ApiEntity();
+        api.setId(API_ID);
 
         when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
         when(apiService.createWithApiDefinition(eq(swaggerApi), eq(USER_ID), any(ObjectNode.class))).thenReturn(api);
@@ -272,13 +272,13 @@ public class ApiServiceCockpitImplTest {
     public void should_start_an_published_api() {
         SwaggerApiEntity swaggerApi = new SwaggerApiEntity();
         swaggerApi.setMetadata(new ArrayList<>());
-
-        ApiEntity api = new ApiEntity();
-        api.setId(API_ID);
         Proxy proxy = new Proxy();
         VirtualHost virtualHost = new VirtualHost();
         proxy.setVirtualHosts(List.of(virtualHost));
-        api.setProxy(proxy);
+        swaggerApi.setProxy(proxy);
+
+        ApiEntity api = new ApiEntity();
+        api.setId(API_ID);
 
         when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
         when(apiService.createWithApiDefinition(eq(swaggerApi), eq(USER_ID), any(ObjectNode.class))).thenReturn(api);
@@ -300,13 +300,13 @@ public class ApiServiceCockpitImplTest {
     public void should_publish_an_published_api() {
         SwaggerApiEntity swaggerApi = new SwaggerApiEntity();
         swaggerApi.setMetadata(new ArrayList<>());
-
-        ApiEntity api = new ApiEntity();
-        api.setId(API_ID);
         Proxy proxy = new Proxy();
         VirtualHost virtualHost = new VirtualHost();
         proxy.setVirtualHosts(List.of(virtualHost));
-        api.setProxy(proxy);
+        swaggerApi.setProxy(proxy);
+
+        ApiEntity api = new ApiEntity();
+        api.setId(API_ID);
 
         when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
         when(apiService.createWithApiDefinition(eq(swaggerApi), eq(USER_ID), any(ObjectNode.class))).thenReturn(api);
@@ -326,13 +326,13 @@ public class ApiServiceCockpitImplTest {
     public void should_publish_swagger_documentation_of_an_published_api() {
         SwaggerApiEntity swaggerApi = new SwaggerApiEntity();
         swaggerApi.setMetadata(new ArrayList<>());
-
-        ApiEntity api = new ApiEntity();
-        api.setId(API_ID);
         Proxy proxy = new Proxy();
         VirtualHost virtualHost = new VirtualHost();
         proxy.setVirtualHosts(List.of(virtualHost));
-        api.setProxy(proxy);
+        swaggerApi.setProxy(proxy);
+
+        ApiEntity api = new ApiEntity();
+        api.setId(API_ID);
 
         when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
         when(apiService.createWithApiDefinition(eq(swaggerApi), eq(USER_ID), any(ObjectNode.class))).thenReturn(api);
@@ -355,13 +355,13 @@ public class ApiServiceCockpitImplTest {
 
         SwaggerApiEntity swaggerApi = new SwaggerApiEntity();
         swaggerApi.setMetadata(new ArrayList<>());
-
-        ApiEntity api = new ApiEntity();
-        api.setId(API_ID);
         Proxy proxy = new Proxy();
         VirtualHost virtualHost = new VirtualHost();
         proxy.setVirtualHosts(List.of(virtualHost));
-        api.setProxy(proxy);
+        swaggerApi.setProxy(proxy);
+
+        ApiEntity api = new ApiEntity();
+        api.setId(API_ID);
 
         when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
 
@@ -527,8 +527,7 @@ public class ApiServiceCockpitImplTest {
 
     @Test
     public void should_check_context_path_unique() {
-        ApiEntity api = new ApiEntity();
-        api.setId(API_ID);
+        SwaggerApiEntity api = new SwaggerApiEntity();
         Proxy proxy = new Proxy();
         VirtualHost virtualHost = new VirtualHost();
         proxy.setVirtualHosts(List.of(virtualHost));
@@ -543,8 +542,7 @@ public class ApiServiceCockpitImplTest {
 
     @Test
     public void should_check_context_path_not_unique() {
-        ApiEntity api = new ApiEntity();
-        api.setId(API_ID);
+        SwaggerApiEntity api = new SwaggerApiEntity();
         Proxy proxy = new Proxy();
         VirtualHost virtualHost = new VirtualHost();
         proxy.setVirtualHosts(List.of(virtualHost));


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/gravitee-cockpit/issues/1306

**Description**

Checking context path before API creation from Cockpit. 
The check has to be done earlier, otherwise it will fail with `ApiContextPathAlreadyExistsException`

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zyzxrgsvph.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/1306-check-context-path-uniqueness/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
