### PR TITLE
doc: update repository documentation

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/README.md
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/README.md
@@ -16,8 +16,7 @@ To use Gravitee.io snapshots, you need to declare the following repository in yo
 ## Building
 
 ```shell
-git clone https://github.com/gravitee-io/gravitee-repository-jdbc.git
-cd gravitee-repository-jdbc
+cd gravitee-apim-repository/gravitee-apim-repository-jdbc
 mvn clean package
 ```
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/README.md
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/README.md
@@ -16,8 +16,7 @@ To use Gravitee.io snapshots, you need to declare the following repository in yo
 ## Building
 
 ```shell
-git clone https://github.com/gravitee-io/gravitee-repository-mongodb.git
-cd gravitee-repository-mongodb
+cd gravitee-apim-repository/gravitee-apim-repository-mongodb
 mvn clean package
 ```
 

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/README.adoc
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/README.adoc
@@ -22,8 +22,7 @@ https://oss.sonatype.org/content/repositories/snapshots
 == Building
 
 ```
-$ git clone https://github.com/gravitee-io/gravitee-repository-redis.git
-$ cd gravitee-repository-redis
+$ cd gravitee-apim-repository/gravitee-apim-repository-redis
 $ mvn clean package
 ```
 


### PR DESCRIPTION
Update paths according to the mono repo structure and remove irrelevant
git clone commands

see https://github.com/gravitee-io/issues/issues/6140

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mjihtgqmeh.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/doc-monorepo-repository/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
