### PR TITLE
docs: in gravitee.yml, change elasticSearch reporter default plugins comment, to indicate it's always enabled

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -173,7 +173,7 @@ reporters:
 #      refresh_interval: 5s
 #    pipeline:
 #      plugins:
-#        ingest: geoip, user_agent      # geoip and user_agent are enabled by default for elasticsearch version above 7.x
+#        ingest: geoip, user_agent      # geoip and user_agent are enabled by default
 #    security:
 #      username: user
 #      password: secret


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6683

In gravitee.yml, change elasticSearch reporter default plugins comment, to indicate it's always enabled
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hsjrljmujd.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6683-es-default-plugins-handling/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
