### PR TITLE
fix: bump gravitee-node version to 1.18.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>1.29.1</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
-        <gravitee-node.version>1.18.0</gravitee-node.version>
+        <gravitee-node.version>1.18.2</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>
         <gravitee-plugin.version>1.20.0</gravitee-plugin.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>


### PR DESCRIPTION

**Issue**

https://github.com/gravitee-io/issues/issues/6681

**Description**
The properties must be instances of `EnumerablePropertySource` to be grouped with the others

For https://github.com/gravitee-io/gravitee-common/blob/1.23.x/src/main/java/io/gravitee/common/util/EnvironmentUtils.java#L78 to work we need these changes https://github.com/gravitee-io/gravitee-node/pull/98 added in version >= 1.18.1


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uwrhnlynjo.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-6681-groovy-scripts-fails-to-resolve-method-even-if-w/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
