### PR TITLE
fix(cve83): ensure API access control is properly enforced

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.rest.api.management.rest.resource;
 
+import static io.gravitee.rest.api.model.MembershipMemberType.USER;
+import static io.gravitee.rest.api.model.MembershipReferenceType.API;
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 
@@ -41,11 +43,13 @@ import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.security.utils.ImageUtils;
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
+import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
 import io.swagger.annotations.*;
 import java.io.ByteArrayOutputStream;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -103,6 +107,11 @@ public class ApiResource extends AbstractResource {
     )
     public Response getApi() {
         ApiEntity apiEntity = apiService.findById(api);
+
+        if (!canManageApi(apiEntity)) {
+            throw new ForbiddenAccessException();
+        }
+
         if (hasPermission(RolePermission.API_DEFINITION, api, RolePermissionAction.READ)) {
             setPictures(apiEntity);
         } else {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiResourceNotAdminTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiResourceNotAdminTest.java
@@ -50,7 +50,6 @@ import org.mockito.internal.util.collections.Sets;
 public class ApiResourceNotAdminTest extends AbstractResourceTest {
 
     private static final String API = "my-api";
-    private static final String UNKNOWN_API = "unknown";
 
     @Override
     protected String contextPath() {
@@ -116,7 +115,71 @@ public class ApiResourceNotAdminTest extends AbstractResourceTest {
     }
 
     @Test
-    public void shouldGetApi() {
+    public void shouldNotAccessToApi_BecauseAccessIsNotGranted() {
+        final Response response = envTarget(API).request().get();
+        assertEquals(FORBIDDEN_403, response.getStatus());
+    }
+
+    @Test
+    public void shouldGetApi_BecauseDirectMember() {
+        MembershipEntity userMembership = mock(MembershipEntity.class);
+        when(userMembership.getReferenceId()).thenReturn(API);
+        when(userMembership.getReferenceType()).thenReturn(MembershipReferenceType.API);
+        when(userMembership.getMemberType()).thenReturn(MembershipMemberType.USER);
+
+        when(
+            membershipService.getMembershipsByMemberAndReference(
+                eq(MembershipMemberType.USER),
+                eq(USER_NAME),
+                eq(MembershipReferenceType.API)
+            )
+        )
+            .thenReturn(Sets.newSet(userMembership));
+
+        final Response response = envTarget(API).request().get();
+
+        assertEquals(OK_200, response.getStatus());
+
+        final ApiEntity responseApi = response.readEntity(ApiEntity.class);
+        assertNotNull(responseApi);
+        assertEquals(API, responseApi.getName());
+    }
+
+    @Test
+    public void shouldGetApi_BecauseGroupMember() {
+        final String groupId = "group_id";
+        final String roleId = "role_id";
+
+        MembershipEntity groupMemberShip = mock(MembershipEntity.class);
+        RoleEntity role = mock(RoleEntity.class);
+
+        when(groupMemberShip.getRoleId()).thenReturn(roleId);
+        when(groupMemberShip.getReferenceId()).thenReturn(groupId);
+        when(groupMemberShip.getReferenceType()).thenReturn(MembershipReferenceType.GROUP);
+
+        when(
+            membershipService.getMembershipsByMemberAndReference(
+                eq(MembershipMemberType.USER),
+                eq(USER_NAME),
+                eq(MembershipReferenceType.API)
+            )
+        )
+            .thenReturn(Collections.emptySet());
+
+        when(
+            membershipService.getMembershipsByMemberAndReference(
+                eq(MembershipMemberType.USER),
+                eq(USER_NAME),
+                eq(MembershipReferenceType.GROUP)
+            )
+        )
+            .thenReturn(Sets.newSet(groupMemberShip));
+
+        when(role.getScope()).thenReturn(RoleScope.API);
+        when(roleService.findById(eq(roleId))).thenReturn(role);
+
+        mockApi.setGroups(Collections.singleton(groupId));
+
         final Response response = envTarget(API).request().get();
 
         assertEquals(OK_200, response.getStatus());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
@@ -158,4 +158,6 @@ public interface ApiService {
 
     ApiEntity migrate(String api);
     String getConfigurationSchema();
+
+    boolean canManageApi(RoleEntity role);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_FindByUserTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_FindByUserTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.PropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+import com.google.common.collect.ImmutableMap;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.repository.exceptions.TechnicalException;
@@ -34,6 +35,7 @@ import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.model.common.SortableImpl;
+import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.service.impl.ApiServiceImpl;
 import io.gravitee.rest.api.service.jackson.filter.ApiPermissionFilter;
 import java.util.*;
@@ -105,6 +107,16 @@ public class ApiService_FindByUserTest {
 
     @Test
     public void shouldFindByUser() throws TechnicalException {
+        final String userRoleId = "API_USER";
+
+        Map<String, char[]> userPermissions = ImmutableMap.of("MEMBER", "CRUD".toCharArray());
+        RoleEntity userRole = new RoleEntity();
+        userRole.setId(userRoleId);
+        userRole.setPermissions(userPermissions);
+        userRole.setScope(RoleScope.API);
+
+        when(roleService.findById(userRoleId)).thenReturn(userRole);
+
         when(apiRepository.search(new ApiCriteria.Builder().environmentId("DEFAULT").ids(api.getId()).build()))
             .thenReturn(singletonList(api));
 
@@ -114,7 +126,7 @@ public class ApiService_FindByUserTest {
         membership.setMemberType(MembershipMemberType.USER);
         membership.setReferenceId(api.getId());
         membership.setReferenceType(MembershipReferenceType.API);
-        membership.setRoleId("API_USER");
+        membership.setRoleId(userRoleId);
 
         when(membershipService.getMembershipsByMemberAndReference(MembershipMemberType.USER, USER_NAME, MembershipReferenceType.API))
             .thenReturn(Collections.singleton(membership));
@@ -146,6 +158,16 @@ public class ApiService_FindByUserTest {
 
     @Test
     public void shouldFindByUserPaginated() throws TechnicalException {
+        final String userRoleId = "API_USER";
+
+        Map<String, char[]> userPermissions = ImmutableMap.of("MEMBER", "CRUD".toCharArray());
+        RoleEntity userRole = new RoleEntity();
+        userRole.setId(userRoleId);
+        userRole.setScope(RoleScope.API);
+        userRole.setPermissions(userPermissions);
+
+        when(roleService.findById(userRoleId)).thenReturn(userRole);
+
         final Api api1 = new Api();
         api1.setId("api1");
         api1.setName("api1");
@@ -159,7 +181,7 @@ public class ApiService_FindByUserTest {
         membership1.setMemberType(MembershipMemberType.USER);
         membership1.setReferenceId(api1.getId());
         membership1.setReferenceType(MembershipReferenceType.API);
-        membership1.setRoleId("API_USER");
+        membership1.setRoleId(userRoleId);
 
         MembershipEntity membership2 = new MembershipEntity();
         membership2.setId(api2.getId());


### PR DESCRIPTION
Using the `canReadAPI` in `AbstractResource` is not sufficient
to guarantee that access control is properly enforced.

The revision adds a `canManageAPI` method to circumvent CVE83 in
an isolated manner and avoid breaking other parts of the application as
a side effect.

We should check other usages of `canReadAPI` and ensure that access
control meets our expectations.

see https://github.com/gravitee-io/issues/issues/6650


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-cve-83-access-control/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
