### PR TITLE
fix: bump jolt version to 0.1.5

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/pom.xml
@@ -32,10 +32,6 @@
     <artifactId>gravitee-apim-rest-api-services-dictionary</artifactId>
     <name>Gravitee.io APIM - Management API - Services - Dictionary</name>
 
-    <properties>
-        <jolt.version>0.1.1</jolt.version>
-    </properties>
-
     <dependencies>
         <!-- Vert.x -->
         <dependency>
@@ -48,18 +44,10 @@
         <dependency>
             <groupId>com.bazaarvoice.jolt</groupId>
             <artifactId>jolt-core</artifactId>
-            <version>${jolt.version}</version>
         </dependency>
         <dependency>
             <groupId>com.bazaarvoice.jolt</groupId>
             <artifactId>json-utils</artifactId>
-            <version>${jolt.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- Spring dependencies -->

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/pom.xml
@@ -32,10 +32,6 @@
     <artifactId>gravitee-apim-rest-api-services-dynamic-properties</artifactId>
     <name>Gravitee.io APIM - Management API - Services - Dynamic Properties</name>
 
-    <properties>
-        <jolt.version>0.1.1</jolt.version>
-    </properties>
-
     <dependencies>
         <!-- Vert.x -->
         <dependency>
@@ -48,18 +44,10 @@
         <dependency>
             <groupId>com.bazaarvoice.jolt</groupId>
             <artifactId>jolt-core</artifactId>
-            <version>${jolt.version}</version>
         </dependency>
         <dependency>
             <groupId>com.bazaarvoice.jolt</groupId>
             <artifactId>json-utils</artifactId>
-            <version>${jolt.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- Spring dependencies -->

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/pom.xml
@@ -45,6 +45,31 @@
         <module>gravitee-apim-rest-api-services-subscription-pre-expiration-notif</module>
     </modules>
 
+    <properties>
+        <jolt.version>0.1.5</jolt.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.bazaarvoice.jolt</groupId>
+                <artifactId>jolt-core</artifactId>
+                <version>${jolt.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.bazaarvoice.jolt</groupId>
+                <artifactId>json-utils</artifactId>
+                <version>${jolt.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>io.gravitee.apim.rest.api</groupId>


### PR DESCRIPTION
**Description**

Upgrade jolt lib to fix some vulnerabilities.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/bump-jolt-lib/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
