### PR TITLE
chore: upgrade gravitee tracer jaeger version

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -109,7 +109,7 @@
         <gravitee-reporter-tcp.version>1.3.3</gravitee-reporter-tcp.version>
         <!--	Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit	-->
         <!--	<gravitee-gateway-services-ratelimit.version>1.13.0</gravitee-gateway-services-ratelimit.version>	-->
-        <gravitee-tracer-jaeger.version>1.0.0</gravitee-tracer-jaeger.version>
+        <gravitee-tracer-jaeger.version>1.0.1</gravitee-tracer-jaeger.version>
 
     </properties>
 


### PR DESCRIPTION
see https://github.com/gravitee-io/gravitee-tracer-jaeger/pull/6
see https://github.com/gravitee-io/issues/issues/6366


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6366-chore-jaegger-tracer-version/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
