### PR TITLE
chore: bump elasticsearch reporter version

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -106,7 +106,7 @@
         <gravitee-fetcher-http.version>1.12.0</gravitee-fetcher-http.version>
         <gravitee-repository-elasticsearch.version>3.9.0</gravitee-repository-elasticsearch.version>
         <!-- Gateway Only -->
-        <gravitee-reporter-elasticsearch.version>3.9.0</gravitee-reporter-elasticsearch.version>
+        <gravitee-reporter-elasticsearch.version>3.10.0-SNAPSHOT</gravitee-reporter-elasticsearch.version>
         <gravitee-reporter-file.version>2.4.3</gravitee-reporter-file.version>
         <gravitee-reporter-tcp.version>1.3.3</gravitee-reporter-tcp.version>
         <!--	Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit	-->


### PR DESCRIPTION
Bump version to 3.10.0-SNAPSHOT to fix an issue with index name
generation on version 3.9 of the reporter with gravitee 3.13.x

see https://github.com/gravitee-io/issues/issues/6630
