### PR TITLE
fix: bump policy-retry in distribution

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -77,7 +77,7 @@
         <gravitee-policy-request-validation.version>1.11.0</gravitee-policy-request-validation.version>
         <gravitee-policy-resource-filtering.version>1.8.0</gravitee-policy-resource-filtering.version>
         <gravitee-policy-rest-to-soap.version>1.11.1</gravitee-policy-rest-to-soap.version>
-        <gravitee-policy-retry.version>1.0.1</gravitee-policy-retry.version>
+        <gravitee-policy-retry.version>1.0.2</gravitee-policy-retry.version>
         <gravitee-policy-role-based-access-control.version>1.1.0</gravitee-policy-role-based-access-control.version>
         <gravitee-policy-ssl-enforcement.version>1.2.0</gravitee-policy-ssl-enforcement.version>
         <gravitee-policy-transformheaders.version>1.8.2</gravitee-policy-transformheaders.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6684

**Description**

Bump policy retry in distribution so the fix can be tested on 3.5.x environment.
