### PR TITLE
Fix multiples login errors in APIM Portal 

### DIFF
--- a/gravitee-apim-portal-webui/src/app/app.component.ts
+++ b/gravitee-apim-portal-webui/src/app/app.component.ts
@@ -115,11 +115,11 @@ export class AppComponent implements AfterViewInit, OnInit, OnDestroy {
     this.router.events.subscribe((event) => {
       if (event instanceof NavigationStart) {
         this.notificationService.reset();
-      } else if (event instanceof NavigationEnd) {
-        if (!this.currentUserService.exist() && !this.isInLoginOrRegistration() && this.forceLogin()) {
-          const redirectUrl = this.router.routerState.snapshot.url;
+        if (!this.currentUserService.exist() && !this.isInLoginOrRegistration(event.url) && this.forceLogin()) {
+          const redirectUrl = event.url;
           this.router.navigate(['/user/login'], { replaceUrl: true, queryParams: { redirectUrl } });
         }
+      } else if (event instanceof NavigationEnd) {
         const currentRoute: ActivatedRoute = this.navRouteService.findCurrentRoute(this.activatedRoute);
         this._setBrowserTitle(currentRoute);
         this.isPreview = previewService.isActive();
@@ -472,8 +472,7 @@ export class AppComponent implements AfterViewInit, OnInit, OnDestroy {
     this.router.navigate([path]);
   }
 
-  isInLoginOrRegistration(): boolean {
-    const url = this.router.routerState.snapshot.url;
+  isInLoginOrRegistration(url: string = this.router.routerState.snapshot.url): boolean {
     return url.startsWith('/user/login') || url.startsWith('/user/registration') || url.startsWith('/user/resetPassword');
   }
 

--- a/gravitee-apim-portal-webui/src/app/pages/login/login.component.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/login/login.component.spec.ts
@@ -16,7 +16,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator';
-import { OAuthService } from 'angular-oauth2-oidc';
 import { ConfigurationService } from '../../services/configuration.service';
 import { FeatureGuardService } from '../../services/feature-guard.service';
 import { NotificationService } from '../../services/notification.service';
@@ -30,12 +29,7 @@ describe('LoginComponent', () => {
     component: LoginComponent,
     schemas: [CUSTOM_ELEMENTS_SCHEMA],
     imports: [RouterTestingModule, FormsModule, ReactiveFormsModule, HttpClientTestingModule],
-    providers: [
-      mockProvider(NotificationService),
-      mockProvider(FeatureGuardService),
-      mockProvider(ConfigurationService),
-      mockProvider(OAuthService),
-    ],
+    providers: [mockProvider(NotificationService), mockProvider(FeatureGuardService), mockProvider(ConfigurationService)],
   });
 
   let spectator: Spectator<LoginComponent>;

--- a/gravitee-apim-portal-webui/src/app/pages/login/login.component.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/login/login.component.ts
@@ -103,7 +103,7 @@ export class LoginComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   authenticate(provider) {
-    this.authService.authenticate(provider);
+    this.authService.authenticate(provider, this.redirectUrl);
   }
 
   isFormValid() {

--- a/gravitee-apim-portal-webui/src/app/pages/not-found/not-found.component.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/not-found/not-found.component.spec.ts
@@ -29,19 +29,13 @@ import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { NotificationService } from '../../services/notification.service';
 import { FeatureGuardService } from '../../services/feature-guard.service';
 import { ConfigurationService } from '../../services/configuration.service';
-import { OAuthService } from 'angular-oauth2-oidc';
 
 describe('NotFoundComponent', () => {
   const createComponent = createComponentFactory({
     component: NotFoundComponent,
     imports: [RouterTestingModule, FormsModule, ReactiveFormsModule, HttpClientTestingModule],
     schemas: [CUSTOM_ELEMENTS_SCHEMA],
-    providers: [
-      mockProvider(NotificationService),
-      mockProvider(FeatureGuardService),
-      mockProvider(ConfigurationService),
-      mockProvider(OAuthService),
-    ],
+    providers: [mockProvider(NotificationService), mockProvider(FeatureGuardService), mockProvider(ConfigurationService)],
   });
 
   let spectator: Spectator<NotFoundComponent>;

--- a/gravitee-apim-portal-webui/src/app/services/auth-guard.service.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/services/auth-guard.service.spec.ts
@@ -18,11 +18,14 @@ import { TestBed } from '@angular/core/testing';
 import { AuthGuardService } from './auth-guard.service';
 import { RouterTestingModule } from '@angular/router/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { mockProvider } from '@ngneat/spectator';
+import { OAuthService } from 'angular-oauth2-oidc';
 
 describe('AuthGuardService', () => {
   beforeEach(() =>
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule, RouterTestingModule],
+      providers: [mockProvider(OAuthService)],
     }),
   );
 

--- a/gravitee-apim-portal-webui/src/app/services/auth-guard.service.ts
+++ b/gravitee-apim-portal-webui/src/app/services/auth-guard.service.ts
@@ -15,12 +15,13 @@
  */
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, Router, UrlTree } from '@angular/router';
+import { OAuthService } from 'angular-oauth2-oidc';
 import { Role } from '../model/role.enum';
 import { CurrentUserService } from './current-user.service';
 
 @Injectable({ providedIn: 'root' })
 export class AuthGuardService implements CanActivate {
-  constructor(private currentUserService: CurrentUserService, private router: Router) {}
+  constructor(private currentUserService: CurrentUserService, private router: Router, private oauthService: OAuthService) {}
 
   canActivate(route: ActivatedRouteSnapshot): Promise<boolean | UrlTree> {
     if (route && route.data) {
@@ -29,7 +30,8 @@ export class AuthGuardService implements CanActivate {
         return new Promise((resolve) => {
           const user = this.currentUserService.get().getValue();
           if ((expectedRole === Role.AUTH_USER && user == null) || (expectedRole === Role.GUEST && user)) {
-            resolve(this.router.parseUrl('/'));
+            // 📝 Check OAuth state to find redirectUrl if exist
+            resolve(this.router.parseUrl(decodeURIComponent(this.oauthService.state ?? '/')));
           } else {
             resolve(true);
           }

--- a/gravitee-apim-portal-webui/src/app/services/auth.service.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/services/auth.service.spec.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { createServiceFactory, mockProvider, SpectatorService } from '@ngneat/spectator';
-import { OAuthService } from 'angular-oauth2-oidc';
+import { createServiceFactory, SpectatorService } from '@ngneat/spectator';
 import { AuthService } from './auth.service';
 
 describe('AuthService', () => {
@@ -23,7 +22,6 @@ describe('AuthService', () => {
   const createService = createServiceFactory({
     service: AuthService,
     imports: [HttpClientTestingModule],
-    providers: [mockProvider(OAuthService)],
   });
 
   beforeEach(() => {

--- a/gravitee-apim-portal-webui/src/app/services/auth.service.ts
+++ b/gravitee-apim-portal-webui/src/app/services/auth.service.ts
@@ -89,11 +89,12 @@ export class AuthService {
     );
   };
 
-  authenticate(provider) {
+  authenticate(provider, redirectUrl: string) {
     if (provider) {
       this.storeProviderId(provider.id);
       this._configure(provider);
-      this.oauthService.initCodeFlow();
+      // 📝 Save `redirectUrl` into OAuth state to retrieve it after redirect
+      this.oauthService.initCodeFlow(redirectUrl);
     }
   }
 

--- a/gravitee-apim-portal-webui/src/app/services/auth.service.ts
+++ b/gravitee-apim-portal-webui/src/app/services/auth.service.ts
@@ -46,7 +46,13 @@ export class AuthService {
     return new Promise((resolve) => {
       if (this.getProviderId()) {
         this._fetchProviderAndConfigure().then(() => {
-          this.oauthService.tryLoginCodeFlow().finally(() => resolve(true));
+          this.oauthService
+            .tryLoginCodeFlow({
+              // 📝 The clear of the hash doesn't work correctly and keeps a piece of string which distorts angular routing and
+              // displays a 404. Disabling it solves the problem and the clear will be done with an angular internal redirection.
+              preventClearHashAfterLogin: true,
+            })
+            .finally(() => resolve(true));
         });
       } else {
         resolve(true);

--- a/gravitee-apim-portal-webui/src/app/services/nav-route.service.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/services/nav-route.service.spec.ts
@@ -16,7 +16,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
-import { createHttpFactory, createServiceFactory, mockProvider, SpectatorService } from '@ngneat/spectator';
+import { createServiceFactory, mockProvider, SpectatorService } from '@ngneat/spectator';
 import { UserTestingModule } from '../test/user-testing-module';
 import { NavRouteService } from './nav-route.service';
 import { TranslateService } from '@ngx-translate/core';

--- a/gravitee-apim-portal-webui/src/setup-jest.ts
+++ b/gravitee-apim-portal-webui/src/setup-jest.ts
@@ -17,10 +17,13 @@ import 'jest-preset-angular';
 import './jest-global-mocks';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 
-import { defineGlobalsInjections } from '@ngneat/spectator';
-import { TranslateTestingModule } from './app/test/translate-testing-module'; // browser mocks globally available for every test
+import { defineGlobalsInjections, mockProvider } from '@ngneat/spectator';
+import { OAuthService } from 'angular-oauth2-oidc';
+import { TranslateTestingModule } from './app/test/translate-testing-module';
 
+// mocks globally available for every test
 defineGlobalsInjections({
   imports: [TranslateTestingModule],
+  providers: [mockProvider(OAuthService)],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 });


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5727

**Description**

Backport https://github.com/gravitee-io/gravitee-api-management/pull/893 to 3.5.x

Details:
 - avoid 404 after login with an idp
 - redirect to login before navigation end when "Force authentication portal" is enable
 - use redirectUrl when login with an idp

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/5727-fix-portal-login/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
