### PR TITLE
feat(graceful): apply delay and close connection when shutdown

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/ResponseProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/ResponseProcessorChainFactory.java
@@ -34,7 +34,10 @@ import io.gravitee.gateway.handlers.api.policy.plan.PlanPolicyChainProvider;
 import io.gravitee.gateway.handlers.api.policy.plan.PlanPolicyResolver;
 import io.gravitee.gateway.handlers.api.processor.cors.CorsSimpleRequestProcessor;
 import io.gravitee.gateway.handlers.api.processor.pathmapping.PathMappingProcessor;
+import io.gravitee.gateway.handlers.api.processor.shutdown.ShutdownProcessor;
 import io.gravitee.gateway.policy.StreamType;
+import io.gravitee.node.api.Node;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -42,8 +45,13 @@ import io.gravitee.gateway.policy.StreamType;
  */
 public class ResponseProcessorChainFactory extends ApiProcessorChainFactory {
 
+    @Autowired
+    private Node node;
+
     @Override
     public void afterPropertiesSet() {
+        add(() -> new ShutdownProcessor(node));
+
         if (api.getDefinitionVersion() == DefinitionVersion.V1) {
             add(new ApiPolicyChainProvider(StreamType.ON_RESPONSE, new ApiPolicyResolver(), chainFactory));
             add(new PlanPolicyChainProvider(StreamType.ON_RESPONSE, new PlanPolicyResolver(api), chainFactory));

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/shutdown/ShutdownProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/shutdown/ShutdownProcessor.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.processor.shutdown;
+
+import io.gravitee.common.component.Lifecycle;
+import io.gravitee.common.http.HttpHeaders;
+import io.gravitee.common.http.HttpHeadersValues;
+import io.gravitee.common.http.HttpVersion;
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.core.processor.AbstractProcessor;
+import io.gravitee.node.api.Node;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ShutdownProcessor extends AbstractProcessor<ExecutionContext> {
+
+    private final Node node;
+
+    public ShutdownProcessor(final Node node) {
+        this.node = node;
+    }
+
+    @Override
+    public void handle(ExecutionContext context) {
+        if(node.lifecycleState() != Lifecycle.State.STARTED) {
+            // The node is certainly shutting down, explicitly ask for closing connection.
+            if(context.request().version() == HttpVersion.HTTP_2) {
+                // Create a fake internal header to notify the underlying layer to gracefully close the connection (aka: goAway).
+                context.response().headers().set(HttpHeaders.CONNECTION, HttpHeadersValues.CONNECTION_GO_AWAY);
+            } else {
+                context.response().headers().set(HttpHeaders.CONNECTION, HttpHeadersValues.CONNECTION_CLOSE);
+            }
+        }
+        next.handle(context);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/shutdown/ShutdownProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/shutdown/ShutdownProcessorTest.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.processor.shutdown;
+
+import io.gravitee.common.component.Lifecycle;
+import io.gravitee.common.http.HttpHeaders;
+import io.gravitee.common.http.HttpHeadersValues;
+import io.gravitee.common.http.HttpVersion;
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.node.api.Node;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ShutdownProcessorTest {
+
+    @Mock
+    private Request request;
+
+    @Mock
+    private Response response;
+
+    @Mock
+    private HttpHeaders headers;
+
+    @Mock
+    private ExecutionContext context;
+
+    @Mock
+    private Node node;
+
+    private ShutdownProcessor cut;
+
+    @Before
+    public void before() {
+        lenient().when(context.request()).thenReturn(request);
+        lenient().when(context.response()).thenReturn(response);
+        lenient().when(response.headers()).thenReturn(headers);
+
+        cut = new ShutdownProcessor(node);
+    }
+
+    @Test
+    public void shouldNotShutdownWhenNodeIsStarted() {
+        when(node.lifecycleState()).thenReturn(Lifecycle.State.STARTED);
+
+        cut.handler(context ->  {
+            verifyNoInteractions(request);
+            verifyNoInteractions(response);
+        });
+
+        cut.handle(context);
+    }
+
+    @Test
+    public void shouldShutdown_Http1_0() {
+        when(node.lifecycleState()).thenReturn(Lifecycle.State.STOPPING);
+        when(request.version()).thenReturn(HttpVersion.HTTP_1_0);
+
+        cut.handler(context -> verify(headers).set(HttpHeaders.CONNECTION, HttpHeadersValues.CONNECTION_CLOSE));
+        cut.handle(context);
+    }
+
+
+    @Test
+    public void shouldShutdown_Http1_1() {
+        when(node.lifecycleState()).thenReturn(Lifecycle.State.STOPPING);
+        when(request.version()).thenReturn(HttpVersion.HTTP_1_1);
+
+        cut.handler(context -> verify(headers).set(HttpHeaders.CONNECTION, HttpHeadersValues.CONNECTION_CLOSE));
+        cut.handle(context);
+    }
+
+    @Test
+    public void shouldShutdown_Http2() {
+        when(node.lifecycleState()).thenReturn(Lifecycle.State.STOPPING);
+        when(request.version()).thenReturn(HttpVersion.HTTP_2);
+
+        cut.handler(context -> verify(headers).set(HttpHeaders.CONNECTION, HttpHeadersValues.CONNECTION_GO_AWAY));
+        cut.handle(context);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxHttpServerResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxHttpServerResponse.java
@@ -23,6 +23,8 @@ import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.handler.Handler;
 import io.gravitee.gateway.api.stream.WriteStream;
 import io.netty.buffer.ByteBuf;
+import io.vertx.core.http.HttpConnection;
+import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 
 /**
@@ -141,5 +143,9 @@ public class VertxHttpServerResponse implements Response {
 
     protected void writeHeaders() {
         headers.forEach(serverResponse::putHeader);
+    }
+
+    public HttpConnection getNativeConnection() {
+        return ((VertxHttpServerRequest) serverRequest).getNativeServerRequest().connection();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/http2/VertxHttp2ServerResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/http2/VertxHttp2ServerResponse.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.standalone.vertx.http2;
 
 import io.gravitee.common.http.HttpHeaders;
+import io.gravitee.common.http.HttpHeadersValues;
 import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.api.http2.HttpFrame;
 import io.gravitee.gateway.standalone.vertx.VertxHttpServerResponse;
@@ -46,6 +47,9 @@ public class VertxHttp2ServerResponse extends VertxHttpServerResponse {
                     && !headerName.equalsIgnoreCase(HttpHeaders.KEEP_ALIVE)
                     && !headerName.equalsIgnoreCase(HttpHeaders.TRANSFER_ENCODING)) {
                 serverResponse.putHeader(headerName, headerValues);
+            } else if(headerName.equalsIgnoreCase(HttpHeaders.CONNECTION) && headerValues.contains(HttpHeadersValues.CONNECTION_GO_AWAY)) {
+                // 'Connection: goAway' is a special header indicating the native connection should be shutdown because of the node itself will shutdown.
+                this.getNativeConnection().shutdown();
             }
         });
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -341,3 +341,12 @@ ds:
 #  hazelcast:
 #    config:
 #      path: ${gravitee.home}/config/hazelcast.xml
+
+# Graceful shutdown.
+#gracefulShutdown:
+  # Default delay is 0 but it can be useful to set it to an adequate value depending on how much time the load balancer takes to stop routing traffic to a gateway instance which is shutting down.
+  # When SIGTERM is sent to the gateway, the shutdown process begin, each client will be explicitly asked for closing connection and the shutdown delay will be applied.
+  # The shutdown delay should allow enough time to client to close their current active connections and create new one. In the same time the load balancer should progressively stop routing traffic to the gateway.
+  # After the delay is expired, the gateway continue the shutdown process. Any pending request will have a chance to finish gracefully and the gateway will stop normally unless it takes too much time and a SIGKILL signal is sent to the gateway.
+#  delay: 0
+#  unit: MILLISECONDS

--- a/pom.xml
+++ b/pom.xml
@@ -59,12 +59,12 @@
         <!-- Gravitee dependencies version -->
         <gravitee-parent.version>19.2.3</gravitee-parent.version>
         <gravitee-alert-api.version>1.7.1</gravitee-alert-api.version>
-        <gravitee-common.version>1.19.4</gravitee-common.version>
+        <gravitee-common.version>1.19.5-SNAPSHOT</gravitee-common.version>
         <gravitee-definition.version>1.25.1</gravitee-definition.version>
         <gravitee-expression-language.version>1.5.2</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>1.23.0</gravitee-gateway-api.version>
-        <gravitee-node.version>1.10.1</gravitee-node.version>
+        <gravitee-node.version>1.10.2-SNAPSHOT</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>
         <gravitee-plugin.version>1.16.0</gravitee-plugin.version>
         <gravitee-policy-api.version>1.10.0</gravitee-policy-api.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6722

**Description**

Implement a graceful shutdown mechanism to avoid 404 or 5xx errors during rolling updates of the gateway instances.

**Additional information**

The feature needed to be develop on the supported 3.5.x version to avoid the erreur during rolling updates. 
The following table resume the merge to do for `gravitee-common` and `gravitee-node` when this feature will be merge into other branches of `gravitee-api-management`.

gravitee-api-management | gravitee-common | gravitee-node
:---:|:---:|:---:
3.5.x | 1.19.x | 1.10.x
3.10.x | 1.20.x | 1.16.x
3.13.x | 1.23.x | 1.18.x
master | 1.23.x | 1.18.x

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-6722-graceful-shutdown/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
