### PR TITLE
fix: parse yaml contents without formating strings

### DIFF
--- a/gravitee-apim-console-webui/src/components/documentation/page/page-swagger.component.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/page/page-swagger.component.ts
@@ -19,6 +19,8 @@ import UserService from '../../../services/user.service';
 import { SwaggerUIBundle } from 'swagger-ui-dist';
 import { StateService } from '@uirouter/core';
 
+const yamlSchema = jsyaml.Schema.create(jsyaml.FAILSAFE_SCHEMA, []);
+
 const DisableTryItOutPlugin = function () {
   return {
     statePlugins: {
@@ -65,7 +67,7 @@ const PageSwaggerComponent: ng.IComponentOptions = {
       try {
         contentAsJson = JSON.parse(this.page.content);
       } catch (e) {
-        contentAsJson = jsyaml.safeLoad(this.page.content);
+        contentAsJson = jsyaml.safeLoad(this.page.content, { schema: yamlSchema });
       }
 
       let cfg: any = {

--- a/gravitee-apim-portal-webui/src/app/components/gv-page-redoc/gv-page-redoc.component.ts
+++ b/gravitee-apim-portal-webui/src/app/components/gv-page-redoc/gv-page-redoc.component.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as jsyaml from 'js-yaml';
 import { Component, HostListener, Input, OnDestroy, ViewChild, OnInit } from '@angular/core';
 import { marker as i18n } from '@biesbjerg/ngx-translate-extract-marker';
 import { NotificationService } from '../../services/notification.service';
@@ -21,6 +20,7 @@ import { getCssVar } from '@gravitee/ui-components/src/lib/style';
 import { ScrollService } from '../../services/scroll.service';
 import { GvDocumentationComponent } from '../gv-documentation/gv-documentation.component';
 import { PageService } from 'src/app/services/page.service';
+import { readYaml } from '../../utils/yaml-parser';
 
 declare let Redoc: any;
 
@@ -118,7 +118,7 @@ export class GvPageRedocComponent implements OnInit, OnDestroy {
       try {
         contentAsJson = JSON.parse(page.content);
       } catch (e) {
-        contentAsJson = jsyaml.safeLoad(page.content);
+        contentAsJson = readYaml(page.content);
       }
 
       Redoc.init(contentAsJson, options, this.redocContainer.nativeElement, (errors) => this._redocCallback(errors));

--- a/gravitee-apim-portal-webui/src/app/components/gv-page-swaggerui/gv-page-swaggerui.component.ts
+++ b/gravitee-apim-portal-webui/src/app/components/gv-page-swaggerui/gv-page-swaggerui.component.ts
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as jsyaml from 'js-yaml';
-
 import { Component, OnInit } from '@angular/core';
 import { Page, User } from '../../../../projects/portal-webclient-sdk/src/lib';
 
@@ -22,6 +20,7 @@ import { SwaggerUIBundle } from 'swagger-ui-dist';
 import { CurrentUserService } from 'src/app/services/current-user.service';
 import { PageService } from 'src/app/services/page.service';
 import { PlatformLocation } from '@angular/common';
+import { readYaml } from '../../utils/yaml-parser';
 
 @Component({
   selector: 'app-gv-page-swaggerui',
@@ -100,7 +99,7 @@ export class GvPageSwaggerUIComponent implements OnInit {
     try {
       contentAsJson = JSON.parse(page.content);
     } catch (e) {
-      contentAsJson = jsyaml.safeLoad(page.content);
+      contentAsJson = readYaml(page.content);
     }
 
     const cfg: any = {

--- a/gravitee-apim-portal-webui/src/app/utils/yaml-parser.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/utils/yaml-parser.spec.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { readYaml } from './yaml-parser';
+
+describe('yamlToJson', () => {
+  it('should not transform date format', () => {
+    const given = `
+      birthdate:
+          type: string
+          format: date
+          example: 1980-12-12
+      active:
+          type: boolean
+          example: TRUE
+      email:
+          type: string
+          format: email
+          example: john@doe.com
+      home_phone:
+          type: integer
+          example: 0606060606
+      mobile_phone:
+          type: string
+          example: +33606060606
+      budget_balance:
+          type: integer
+          example: -300
+      error_rate:
+          type: number
+          example: 0.8
+      forecast_error_rate:
+          type: number
+          example: -0.1
+      rank:
+          type: number
+          example: 05
+    `;
+
+    const expected = JSON.stringify({
+      birthdate: { type: 'string', format: 'date', example: '1980-12-12' },
+      active: { type: 'boolean', example: 'TRUE' },
+      email: { type: 'string', format: 'email', example: 'john@doe.com' },
+      home_phone: { type: 'integer', example: '0606060606' },
+      mobile_phone: { type: 'string', example: '+33606060606' },
+      budget_balance: { type: 'integer', example: '-300' },
+      error_rate: { type: 'number', example: '0.8' },
+      forecast_error_rate: { type: 'number', example: '-0.1' },
+      rank: { type: 'number', example: '05' },
+    });
+
+    const having = JSON.stringify(readYaml(given));
+
+    expect(having).toBe(expected);
+  });
+});

--- a/gravitee-apim-portal-webui/src/app/utils/yaml-parser.ts
+++ b/gravitee-apim-portal-webui/src/app/utils/yaml-parser.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as jsYAML from 'js-yaml';
+
+const schema = jsYAML.Schema.create(jsYAML.FAILSAFE_SCHEMA, []);
+
+export function readYaml(content: string): any {
+  return jsYAML.safeLoad(content, { schema });
+}


### PR DESCRIPTION
The default schema used by jsYaml applies some formating on string
fields that appear to be a date, leading to inconsistencies between
an OAS page rendered on the portal vs the same page rendered in the
console.

The revision uses the same schema accross all transformations to ensure
consistency between the components that display a, open API page.

see https://github.com/gravitee-io/issues/issues/6506
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6506-fix-yaml-date-format/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
