### PR TITLE
Bump cockpit connector ws to 2.0.1

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -95,7 +95,7 @@
         <gravitee-resource-oauth2-provider-generic.version>1.16.1</gravitee-resource-oauth2-provider-generic.version>
         <gravitee-service-discovery-consul.version>1.3.0</gravitee-service-discovery-consul.version>
         <!-- Management API Only -->
-        <gravitee-cockpit-connectors-ws.version>2.0.0</gravitee-cockpit-connectors-ws.version>
+        <gravitee-cockpit-connectors-ws.version>2.0.1</gravitee-cockpit-connectors-ws.version>
         <gravitee-fetcher-bitbucket.version>1.7.0</gravitee-fetcher-bitbucket.version>
         <gravitee-fetcher-git.version>1.7.0</gravitee-fetcher-git.version>
         <gravitee-fetcher-github.version>1.6.0</gravitee-fetcher-github.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6676

**Description**

Bump cockpit connector ws to 2.0.1 to fix issue with sharding tags: https://github.com/gravitee-io/gravitee-cockpit-connectors/commit/1172010abab3c5e746809ca51181dff54fac2a46
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6676-bump-cockpit-connector/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
