### PR TITLE
fix: add missing configuration for APIM to start

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/spring/StandaloneConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/spring/StandaloneConfiguration.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.standalone.spring;
 
 import io.gravitee.node.api.NodeMetadataResolver;
+import io.gravitee.node.certificates.spring.NodeCertificatesConfiguration;
 import io.gravitee.node.container.NodeFactory;
 import io.gravitee.node.vertx.spring.VertxConfiguration;
 import io.gravitee.rest.api.management.rest.spring.RestManagementConfiguration;
@@ -35,7 +36,15 @@ import org.springframework.context.annotation.Import;
  * @author GraviteeSource Team
  */
 @Configuration
-@Import({ VertxConfiguration.class, RepositoryConfiguration.class, RestManagementConfiguration.class, RestPortalConfiguration.class })
+@Import(
+    {
+        VertxConfiguration.class,
+        RepositoryConfiguration.class,
+        RestManagementConfiguration.class,
+        RestPortalConfiguration.class,
+        NodeCertificatesConfiguration.class,
+    }
+)
 public class StandaloneConfiguration {
 
     @Bean


### PR DESCRIPTION
gravitee-io/issues#5888

Add missing configuration to avoid this error message at ManagementAPI startup:

``` 
22:19:14.097 [main] ERROR i.g.r.a.s.node.GraviteeApisNode - An error occurred while pre-starting component class io.gravitee.node.certificates.KeyStoreLoaderManager
org.springframework.beans.factory.NoSuchBeanDefinitionException: No qualifying bean of type 'io.gravitee.node.certificates.KeyStoreLoaderManager' available
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.getBean(DefaultListableBeanFactory.java:351)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.getBean(DefaultListableBeanFactory.java:342)
	at org.springframework.context.support.AbstractApplicationContext.getBean(AbstractApplicationContext.java:1172)
	at io.gravitee.node.container.AbstractNode.preStartComponents(AbstractNode.java:149)
	at io.gravitee.node.container.AbstractNode.doStart(AbstractNode.java:72)
	at io.gravitee.common.component.AbstractLifecycleComponent.start(AbstractLifecycleComponent.java:32)
	at io.gravitee.node.container.AbstractContainer.doStart(AbstractContainer.java:106)
	at io.gravitee.common.component.AbstractLifecycleComponent.start(AbstractLifecycleComponent.java:32)
	at io.gravitee.rest.api.standalone.GraviteeApisContainer.main(GraviteeApisContainer.java:54)
```
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tipbkluqai.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-auto-renew-certificates/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
