### PR TITLE
feat(alert): allow notification per api endpoint

### DIFF
--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-api-hc-endpoint-status-changed.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/trigger-api-hc-endpoint-status-changed.html
@@ -16,3 +16,14 @@
 
 -->
 <span style="font-style: italic">This rule does not require any configuration.</span>
+<span style="font-style: italic"
+  >However, it is possible to define an aggregation to receive an alert per api endpoint instead of an unique alert in case multiple
+  endpoints are concerned</span
+>
+
+<!-- Additional projections -->
+<gv-alert-trigger-projections
+  condition="$ctrl.alert.conditions[0]"
+  alert="$ctrl.alert"
+  is-readonly="$ctrl.parent.isReadonly()"
+></gv-alert-trigger-projections>

--- a/gravitee-apim-console-webui/src/entities/alerts/healthcheck.metrics.ts
+++ b/gravitee-apim-console-webui/src/entities/alerts/healthcheck.metrics.ts
@@ -31,7 +31,7 @@ export class HealthcheckMetrics extends Metrics {
     'status.old',
     'Old Status',
     [StringCondition.TYPE],
-    true,
+    false,
     undefined,
     statusloader,
   );
@@ -40,12 +40,12 @@ export class HealthcheckMetrics extends Metrics {
     'status.new',
     'New Status',
     [StringCondition.TYPE],
-    true,
+    false,
     undefined,
     statusloader,
   );
 
-  static ENDPOINT_NAME: HealthcheckMetrics = new HealthcheckMetrics('endpoint.name', 'Endpoint name', [StringCondition.TYPE]);
+  static ENDPOINT_NAME: HealthcheckMetrics = new HealthcheckMetrics('endpoint.name', 'Endpoint name', [StringCondition.TYPE], true);
 
   static RESPONSE_TIME: HealthcheckMetrics = new HealthcheckMetrics('response_time', 'Response Time (ms)', [
     ThresholdCondition.TYPE,

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <vertx.version>4.1.3</vertx.version>
         <!-- Gravitee dependencies version -->
         <gravitee-bom.version>1.4</gravitee-bom.version>
-        <gravitee-alert-api.version>1.7.1</gravitee-alert-api.version>
+        <gravitee-alert-api.version>1.9.0-SNAPSHOT</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>1.7.0</gravitee-cockpit-api.version>
         <gravitee-common.version>1.20.5</gravitee-common.version>
         <gravitee-definition.version>1.28.2</gravitee-definition.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6728

**Description**

When defining an alert on api endpoint health, we want to be able to receive a notification for each endpoint (using an aggregation).

**Additional context**

![image](https://user-images.githubusercontent.com/5955401/145891772-872abf50-2ff2-4e16-a502-65e98ab2b6f5.png)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-6728-support-alert-per-endpoint/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
