### PR TITLE
docs: in gravitee.yml, change elasticSearch reporter default plugins comment, to indicate it's always enabled

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -154,7 +154,7 @@ reporters:
 #      refresh_interval: 5s
 #    pipeline:
 #      plugins:
-#        ingest: geoip, user_agent
+#        ingest: geoip, user_agent      # geoip and user_agent are enabled by default
 #    security:
 #      username: user
 #      password: secret


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6709

**Description**

docs: in gravitee.yml, change elasticSearch reporter default plugins comment, to indicate it's always enabled