### PR TITLE
docs: in gravitee.yml, change elasticSearch reporter default plugins …

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -101,9 +101,9 @@
         <gravitee-fetcher-github.version>1.6.0</gravitee-fetcher-github.version>
         <gravitee-fetcher-gitlab.version>1.11.0</gravitee-fetcher-gitlab.version>
         <gravitee-fetcher-http.version>1.12.0</gravitee-fetcher-http.version>
-        <gravitee-repository-elasticsearch.version>3.8.1</gravitee-repository-elasticsearch.version>
+        <gravitee-repository-elasticsearch.version>3.8.2-SNAPSHOT</gravitee-repository-elasticsearch.version>
         <!-- Gateway Only -->
-        <gravitee-reporter-elasticsearch.version>3.8.1</gravitee-reporter-elasticsearch.version>
+        <gravitee-reporter-elasticsearch.version>3.8.2-SNAPSHOT</gravitee-reporter-elasticsearch.version>
         <gravitee-reporter-file.version>2.4.3</gravitee-reporter-file.version>
         <gravitee-reporter-tcp.version>1.3.3</gravitee-reporter-tcp.version>
         <!--	Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit	-->

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -173,7 +173,7 @@ reporters:
 #      refresh_interval: 5s
 #    pipeline:
 #      plugins:
-#        ingest: geoip, user_agent      # geoip and user_agent are enabled by default for elasticsearch version above 7.x
+#        ingest: geoip, user_agent      # geoip and user_agent are enabled by default
 #    security:
 #      username: user
 #      password: secret


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6710

**Description**

This backports in 3.10 : #6683
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/feat-6709-backport-es-plugins-configuration-310/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
