### PR TITLE
fix(hc): Setup system proxy before the intiialization of the HTTP client

### DIFF
--- a/gravitee-apim-console-webui/package-lock.json
+++ b/gravitee-apim-console-webui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gravitee-apim-console-webui",
-  "version": "3.5.24",
+  "version": "3.5.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/http/HttpEndpointRuleHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/http/HttpEndpointRuleHandler.java
@@ -48,12 +48,8 @@ public class HttpEndpointRuleHandler<T extends HttpEndpoint> extends EndpointRul
     private static final String WSS_SCHEME = "wss";
     private static final String GRPCS_SCHEME = "grpcs";
 
-    private final ProxyOptions systemProxyOptions;
-
     public HttpEndpointRuleHandler(Vertx vertx, EndpointRule<T> rule, Environment environment) throws Exception {
         super(vertx, rule, environment);
-
-        this.systemProxyOptions = rule.getSystemProxyOptions();
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleHandler.java
@@ -41,6 +41,7 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.net.ProxyOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.env.Environment;
@@ -90,10 +91,12 @@ public abstract class EndpointRuleHandler<T extends Endpoint> implements Handler
     private Node node;
 
     private final HttpClient httpClient;
+    protected final ProxyOptions systemProxyOptions;
 
     public EndpointRuleHandler(Vertx vertx, EndpointRule<T> rule, Environment environment) throws Exception{
         this.rule = rule;
         this.environment = environment;
+        this.systemProxyOptions = rule.getSystemProxyOptions();
 
         endpointStatus = new EndpointStatusDecorator(rule.endpoint());
 


### PR DESCRIPTION
Closes gravitee-io/issues#6731

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-6731-hc-system-proxy/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
