### PR TITLE
fix: use the right class as main class

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-bootstrap/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-bootstrap/pom.xml
@@ -40,7 +40,7 @@
                     <archive>
                         <manifest>
                             <addClasspath>false</addClasspath>
-                            <mainClass>io.gravitee.apim.gateway.standalone.boostrap.Bootstrap</mainClass>
+                            <mainClass>io.gravitee.gateway.standalone.boostrap.Bootstrap</mainClass>
                         </manifest>
                     </archive>
                 </configuration>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6732

**Description**

Fix the package name of the main class for the bootstrap jar of the gateway
