### PR TITLE
fix: use the right class as main class

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-bootstrap/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-bootstrap/pom.xml
@@ -40,7 +40,7 @@
                     <archive>
                         <manifest>
                             <addClasspath>false</addClasspath>
-                            <mainClass>io.gravitee.apim.gateway.standalone.boostrap.Bootstrap</mainClass>
+                            <mainClass>io.gravitee.gateway.standalone.boostrap.Bootstrap</mainClass>
                         </manifest>
                     </archive>
                 </configuration>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6733

**Description**

Fix the package name of the main class for the bootstrap jar of the gateway
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6733-fix-gateway-bootstrap-jar/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
