### PR TITLE
fix: handle anchor navigation based on name attribute

### DIFF
--- a/gravitee-apim-portal-webui/src/app/services/scroll.service.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/services/scroll.service.spec.ts
@@ -30,21 +30,48 @@ describe('ScrollServiceService', () => {
   });
 
   it('should be call scrollToAnchor with id', (done) => {
-    document.getElementById = jest.fn(() => null);
+    document.getElementById = jest.fn(() => document.createElement('a'));
+    window.getComputedStyle = jest.fn(() => ({ height: '42' } as any));
+    window.scrollBy = jest.fn(() => null);
+
     const anchorId = 'anchorId';
+
     service.scrollToAnchor(anchorId).finally(() => {
       expect(document.getElementById).toBeCalledTimes(1);
       expect(document.getElementById).toBeCalledWith(anchorId);
+      expect(window.scrollBy).toBeCalledTimes(2);
       done();
     });
   });
 
   it('should be call scrollToAnchor with xpath', (done) => {
-    document.querySelector = jest.fn(() => null);
+    document.querySelector = jest.fn(() => document.createElement('a'));
+    window.getComputedStyle = jest.fn(() => ({ height: '42' } as any));
+    window.scrollBy = jest.fn(() => null);
+
     const anchorId = '#anchorId';
+
     service.scrollToAnchor(anchorId).finally(() => {
-      expect(document.querySelector).toBeCalledTimes(1);
       expect(document.querySelector).toBeCalledWith(anchorId);
+      expect(window.scrollBy).toBeCalledTimes(2);
+      done();
+    });
+  });
+
+  it('should be call scrollToAnchor with name attribute', (done) => {
+    window.getComputedStyle = jest.fn(() => ({ height: '42' } as any));
+    window.scrollBy = jest.fn(() => null);
+    document.querySelector = jest
+      .fn()
+      .mockImplementationOnce(() => null)
+      .mockImplementationOnce(() => document.createElement('a'));
+
+    const anchorId = '#anchorId';
+
+    service.scrollToAnchor(anchorId).finally(() => {
+      expect(document.querySelector).toBeCalledWith(anchorId);
+      expect(document.querySelector).toBeCalledWith(`a[name=${anchorId.substr(1)}]`);
+      expect(window.scrollBy).toBeCalledTimes(2);
       done();
     });
   });

--- a/gravitee-apim-portal-webui/src/app/services/scroll.service.ts
+++ b/gravitee-apim-portal-webui/src/app/services/scroll.service.ts
@@ -34,10 +34,18 @@ export class ScrollService {
     return Math.max(homepageHeaderHeight, headerHeight);
   }
 
+  static getAnchorElement(anchor: string): Element {
+    if (!anchor.startsWith('#')) {
+      return document.getElementById(anchor);
+    }
+    return document.querySelector(anchor) || document.querySelector(`a[name=${anchor.substr(1)}]`);
+  }
+
   scrollToAnchor(anchor) {
-    return new Promise((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
       setTimeout(() => {
-        const element = anchor.startsWith('#') ? document.querySelector(anchor) : document.getElementById(anchor);
+        const element = ScrollService.getAnchorElement(anchor);
+
         if (element) {
           this.scrollToStickyMenu();
           setTimeout(() => {


### PR DESCRIPTION
Despite `name` attribute being deprecated for anchors, the syntax is still valid on some platforms (such as Github). Hence the patch.


see https://github.com/gravitee-io/issues/issues/6659
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6659-fix-markdown-anchor-navigation/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
