### PR TITLE
fix: bump gravitee-definition to 1.30.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <gravitee-cockpit-api.version>1.9.0</gravitee-cockpit-api.version>
         <gravitee-common.version>1.23.0</gravitee-common.version>
         <gravitee-connector-api.version>1.0.0</gravitee-connector-api.version>
-        <gravitee-definition.version>1.30.0</gravitee-definition.version>
+        <gravitee-definition.version>1.30.1-SNAPSHOT</gravitee-definition.version>
         <gravitee-expression-language.version>1.7.2</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>1.29.1</gravitee-gateway-api.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6736

**Description**

Bump gravitee-definition, to fix an import issue regarding the "healthcheck" field in an API definition.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cvcamqztty.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6736-ignore-healthcheck-field/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
