### PR TITLE
feat: http connection handling enhancement

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/connector/AbstractConnector.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/connector/AbstractConnector.java
@@ -142,7 +142,7 @@ public abstract class AbstractConnector<T extends HttpEndpoint> extends Abstract
                 port,
                 url.getHost(),
                 (url.getQuery() == null) ? url.getPath() : url.getPath() + URI_QUERY_DELIMITER_CHAR + url.getQuery(),
-                connect -> proxyConnectionHandler.handle(connection),
+                proxyConnectionHandler::handle,
                 result -> requestTracker.decrementAndGet()
             );
         } catch (MalformedURLException ex) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/connector/AbstractHttpProxyConnection.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/connector/AbstractHttpProxyConnection.java
@@ -19,6 +19,7 @@ import io.gravitee.definition.model.endpoint.HttpEndpoint;
 import io.gravitee.gateway.api.handler.Handler;
 import io.gravitee.gateway.api.proxy.ProxyConnection;
 import io.gravitee.gateway.api.proxy.ProxyResponse;
+import io.gravitee.gateway.http.connector.http.HttpProxyConnection;
 import io.vertx.core.http.HttpClient;
 
 /**
@@ -40,7 +41,7 @@ public abstract class AbstractHttpProxyConnection implements ProxyConnection {
         int port,
         String host,
         String uri,
-        Handler<Void> connectionHandler,
+        Handler<AbstractHttpProxyConnection> connectionHandler,
         Handler<Void> tracker
     );
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/connector/http/ws/WebSocketProxyConnection.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/connector/http/ws/WebSocketProxyConnection.java
@@ -64,7 +64,14 @@ public class WebSocketProxyConnection extends AbstractHttpProxyConnection {
     }
 
     @Override
-    public void connect(HttpClient httpClient, int port, String host, String uri, Handler<Void> connectionHandler, Handler<Void> tracker) {
+    public void connect(
+        HttpClient httpClient,
+        int port,
+        String host,
+        String uri,
+        Handler<AbstractHttpProxyConnection> connectionHandler,
+        Handler<Void> tracker
+    ) {
         // Remove hop-by-hop headers.
         for (CharSequence header : WS_HOP_HEADERS) {
             wsProxyRequest.headers().remove(header);
@@ -158,7 +165,7 @@ public class WebSocketProxyConnection extends AbstractHttpProxyConnection {
                                             }
                                         );
 
-                                    connectionHandler.handle(null);
+                                    connectionHandler.handle(WebSocketProxyConnection.this);
 
                                     // Tell the reactor that the request has been handled by the HTTP client
                                     sendToClient(new SwitchProtocolProxyResponse());

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravite/gateway/http/connector/http/HttpProxyConnectionTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravite/gateway/http/connector/http/HttpProxyConnectionTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravite.gateway.http.connector.http;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.common.http.HttpHeaders;
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.definition.model.HttpClientOptions;
+import io.gravitee.definition.model.endpoint.HttpEndpoint;
+import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.gateway.api.proxy.ProxyRequest;
+import io.gravitee.gateway.api.proxy.ProxyResponse;
+import io.gravitee.gateway.http.connector.AbstractHttpProxyConnection;
+import io.gravitee.gateway.http.connector.http.HttpProxyConnection;
+import io.gravitee.reporter.api.http.Metrics;
+import io.vertx.core.Future;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientRequest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class HttpProxyConnectionTest {
+
+    @Mock
+    private ProxyRequest proxyRequest;
+
+    @Mock
+    private HttpEndpoint endpoint;
+
+    @Mock
+    private Handler<ProxyResponse> responseHandler;
+
+    @Mock
+    private Handler<AbstractHttpProxyConnection> connectionHandler;
+
+    @Mock
+    private HttpClient httpClient;
+
+    private HttpProxyConnection httpProxyConnection;
+
+    @Before
+    public void setupMockedProxyConnection() {
+        when(proxyRequest.headers()).thenReturn(new HttpHeaders());
+        when(proxyRequest.method()).thenReturn(HttpMethod.CONNECT);
+        when(proxyRequest.metrics()).thenReturn(Metrics.on(123L).build());
+        when(endpoint.getHttpClientOptions()).thenReturn(new HttpClientOptions());
+        httpProxyConnection = new HttpProxyConnection(endpoint, proxyRequest);
+        httpProxyConnection.responseHandler(responseHandler);
+    }
+
+    @Test
+    public void connection_handler_is_triggered_with_connection_on_connection_success() {
+        when(httpClient.request(any())).thenReturn(Future.succeededFuture(mock(HttpClientRequest.class)));
+
+        httpProxyConnection.connect(httpClient, 80, "test.hostname", "https://test", connectionHandler, mock(Handler.class));
+
+        verify(connectionHandler, times(1)).handle(httpProxyConnection);
+    }
+
+    @Test
+    public void connection_handler_is_triggered_with_null_on_connection_failure() {
+        when(httpClient.request(any())).thenReturn(Future.failedFuture("test failed connection"));
+
+        httpProxyConnection.connect(httpClient, 80, "test.hostname", "https://test", connectionHandler, mock(Handler.class));
+
+        verify(connectionHandler, times(1)).handle(null);
+    }
+}


### PR DESCRIPTION
:warning: Keep as draft as we not checked all the impacts on AbstractHttpConnector.request() caller, getting a null connection on error :warning: 

**Issue**

https://github.com/gravitee-io/issues/issues/6025

**Description**

feat: http connection handling enhancement

This makes AbstractHttpProxyConnection trigger the connection handler with connection on success, or null if connection failed.
That permits to distinguish behaviors when connection succeeeds or fails.
