### PR TITLE
fix: rework catalog layout for promoted mode opt out

### DIFF
--- a/gravitee-apim-portal-webui/src/app/pages/catalog/filtered-catalog/filtered-catalog.component.css
+++ b/gravitee-apim-portal-webui/src/app/pages/catalog/filtered-catalog/filtered-catalog.component.css
@@ -101,36 +101,78 @@ gv-row {
   padding: 10px 5px;
 }
 
+.catalog__section__content__all__promoted {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  grid-template-rows: auto auto;
+  gap: 2em;
+  grid-template-areas:
+    'promoted promoted promoted promoted'
+    'cards    cards    cards    cards';
+}
+
+.catalog__section__content__all__no-promoted {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: auto;
+  gap: 2em;
+  grid-template-areas: 'cards';
+}
+
+.catalog__section__random-aside__no-promoted {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  grid-template-rows: auto;
+  gap: 0 2em;
+  grid-template-areas: 'cards cards cards cards';
+}
+
+.catalog__section__random-aside__promoted {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  grid-template-rows: auto auto;
+  gap: 0 2em;
+  grid-template-areas:
+    'promoted promoted promoted aside'
+    'cards   cards    cards    cards';
+}
+
+.catalog__section__promoted {
+  grid-area: promoted;
+}
+
+.catalog__section__random {
+  grid-area: aside;
+}
+
+.catalog__section__main {
+  grid-area: cards;
+}
+
 @media only screen and (max-device-width: 1280px) {
-  .catalog__section__top {
-    display: flex;
-    flex-direction: column;
-    margin-bottom: 0;
+  .catalog__section__content__all__promoted,
+  .catalog__section__content__all__no-promoted {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0;
+    grid-template-areas: 'cards';
   }
 
-  .catalog__section__content {
-    margin-top: 1rem;
+  .catalog__section__random-aside__no-promoted,
+  .catalog__section__random-aside__promoted {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: auto;
+    grid-template-areas:
+      'cards';
   }
 
-  gv-promote-api,
+  .catalog__section__promoted,
   app-gv-page {
     display: none;
   }
 
-  .catalog__cards {
-    display: flex;
-  }
-
   .catalog__cards > * {
-    flex: 0 1 auto;
-  }
-
-  .catalog__article__random {
-    padding-top: 2rem;
-    align-items: flex-start;
-  }
-
-  .categories__section > gv {
     flex: 0 1 auto;
   }
 }

--- a/gravitee-apim-portal-webui/src/app/pages/catalog/filtered-catalog/filtered-catalog.component.html
+++ b/gravitee-apim-portal-webui/src/app/pages/catalog/filtered-catalog/filtered-catalog.component.html
@@ -27,16 +27,19 @@
     </gv-message>
   </section>
 
-  <section class="catalog__section__top" *ngIf="!empty">
-    <gv-promote
-      [item]="promotedApi"
-      [metrics]="promotedMetrics"
-      [href]="this.promotedApiPath"
-      (:gv-promote:click)="goToApi(promotedApi)"
-      (:gv-tag:click)="goToSearchByTag($event.detail.tagValue)"
-    ></gv-promote>
+  <section [ngClass]="layoutClassName">
+    <section class="catalog__section__promoted">
+      <gv-promote
+        *ngIf="hasPromotedApiMode()"
+        [item]="promotedApi"
+        [metrics]="promotedMetrics"
+        [href]="this.promotedApiPath"
+        (:gv-promote:click)="goToApi(promotedApi)"
+        (:gv-tag:click)="goToSearchByTag($event.detail.tagValue)"
+      ></gv-promote>
+    </section>
 
-    <article class="catalog__article__random" *ngIf="!inCategory() && !inCategoryAll()">
+    <section class="catalog__section__random" *ngIf="hasRandomCardsAside()">
       <h3 class="title">
         {{ 'catalog.othersApi.title' | translate }}
         <p>{{ 'catalog.othersApi.subTitle' | translate }}</p>
@@ -45,40 +48,41 @@
       <div class="catalog__cards catalog__cards__random">
         <gv-card *ngFor="let api of randomList" [item]="api" (click)="goToApi(api)"></gv-card>
       </div>
-    </article>
-  </section>
+    </section>
 
-  <section class="catalog__section__top" *ngIf="inCategory() && currentCategoryDocumentationPage">
-    <div class="catalog__category__documentation" [ngClass]="{ hidden: allApis.length > 0 && isDocHidden }">
-      <gv-button *ngIf="allApis.length > 0" link (click)="toggleDocumentationPage($event)">
-        <span class="hideDoc">{{ 'catalog.category.documentation.hide' | translate }}</span>
-        <span class="showDoc">{{ 'catalog.category.documentation.show' | translate }}</span>
-      </gv-button>
-      <app-gv-page [page]="currentCategoryDocumentationPage" class="page__box"></app-gv-page>
-    </div>
-  </section>
+    <section class="catalog__section__top" *ngIf="inCategory() && currentCategoryDocumentationPage">
+      <div class="catalog__category__documentation" [ngClass]="{ hidden: allApis.length > 0 && isDocHidden }">
+        <gv-button *ngIf="allApis.length > 0" link (click)="toggleDocumentationPage($event)">
+          <span class="hideDoc">{{ 'catalog.category.documentation.hide' | translate }}</span>
+          <span class="showDoc">{{ 'catalog.category.documentation.show' | translate }}</span>
+        </gv-button>
+        <app-gv-page [page]="currentCategoryDocumentationPage" class="page__box"></app-gv-page>
+      </div>
+    </section>
 
-  <section class="catalog__section__content">
-    <div class="catalog__section__content__title" [id]="fragments.filter">
-      <h2 class="title"></h2>
-      <gv-select
-        *ngIf="canFilter"
-        [value]="this.currentCategory"
-        (input)="this.onSelectCategory($event)"
-        [attr.placeholder]="'catalog.filter' | translate"
-        [options]="this.categories"
-      >
-      </gv-select>
-      <gv-option [options]="options" *ngIf="allApis.length > 0" [value]="this.currentDisplay"></gv-option>
-    </div>
+    <section class="catalog__section__main">
+      <div class="catalog__section__content__title" [id]="fragments.filter">
+        <h2 class="title"></h2>
+        <gv-select
+          *ngIf="canFilter"
+          [value]="this.currentCategory"
+          (input)="this.onSelectCategory($event)"
+          [attr.placeholder]="'catalog.filter' | translate"
+          [options]="this.categories"
+        >
+        </gv-select>
+        <gv-option [options]="options" *ngIf="allApis.length > 0" [value]="this.currentDisplay"></gv-option>
+      </div>
 
-    <gv-card-list *ngIf="showCards" [items]="allApis" (:gv-tag:click)="goToSearchByTag($event.detail.tagValue)"></gv-card-list>
+      <gv-card-list *ngIf="showCards" [items]="allApis" (:gv-tag:click)="goToSearchByTag($event.detail.tagValue)"></gv-card-list>
 
-    <div *ngIf="!showCards" class="catalog__list catalog__list__all">
-      <gv-row *ngFor="let api of allApis" [item]="api.item" (click)="goToApi(api.item)"></gv-row>
-    </div>
-    <div class="catalog__section__content__pagination" [id]="fragments.pagination">
-      <gv-pagination [data]="paginationData" hide-empty="true"></gv-pagination>
-    </div>
+      <div *ngIf="!showCards" class="catalog__list catalog__list__all">
+        <gv-row *ngFor="let api of allApis" [item]="api.item" (click)="goToApi(api.item)"></gv-row>
+      </div>
+
+      <div class="catalog__section__content__pagination" [id]="fragments.pagination">
+        <gv-pagination [data]="paginationData" hide-empty="true"></gv-pagination>
+      </div>
+    </section>
   </section>
 </div>


### PR DESCRIPTION
Due to the promoted opt out feature, the catalog layout had to be
reworked in order to handle the empty space left when promoted
mode is disabled.

see gravitee-io/issues#6472 (feature)
see gravitee-io/issues#6740 (QA)
see gravitee-io/issues#6742 (QA)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ohkvyhqndt.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6740-fix-promoted-mode-layout/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
