### PR TITLE
fix: fix owner link in API details

### DIFF
--- a/gravitee-apim-portal-webui/src/app/pages/api/api-general/api-general.component.html
+++ b/gravitee-apim-portal-webui/src/app/pages/api/api-general/api-general.component.html
@@ -118,7 +118,7 @@
             <li class="info__miscellaneous_item" *ngFor="let apiInformation of apiInformations">
               <ng-container *ngIf="isSearchable(apiInformation.name)">
                 <span>{{ apiInformation.name | translate }}</span>
-                <a href="#" (click)="goToSearch(apiInformation.name, apiInformation.value)">{{ apiInformation.value }}</a>
+                <a [href]="getSearchUrl(apiInformation.name, apiInformation.value)">{{ apiInformation.value }}</a>
               </ng-container>
               <ng-container *ngIf="!isSearchable(apiInformation.name)">
                 <span>{{ apiInformation.name | translate }}</span> {{ apiInformation.value }}

--- a/gravitee-apim-portal-webui/src/app/pages/api/api-general/api-general.component.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/api/api-general/api-general.component.spec.ts
@@ -45,15 +45,23 @@ describe('ApiGeneralComponent', () => {
   });
 
   describe('goToSearch', () => {
-    it('should navigate', () => {
-      const navigateSpy = spyOn(router, 'navigate');
+    it('should navigateByUrl with built urlTree', () => {
+      const navigateByUrlSpy = spyOn(router, 'navigateByUrl');
 
-      const key = 'labels';
+      const myTestUrlTree = {};
+      spyOn<any>(component, 'getSearchUrlTree').and.returnValue(myTestUrlTree);
 
-      expect(component.isSearchable(key)).toBeTruthy();
-      component.goToSearch(key, 'TheLabel');
+      component.goToSearch('labels', 'TheLabel');
 
-      expect(navigateSpy).toHaveBeenCalledWith(['catalog/search'], { queryParams: { q: 'labels:"TheLabel"' } });
+      expect(navigateByUrlSpy).toHaveBeenCalledWith(myTestUrlTree);
+    });
+  });
+
+  describe('getSearchUrl', () => {
+    it('should return the search url', () => {
+      const resultUrl = component.getSearchUrl('labels', 'myTestValue');
+
+      expect(resultUrl).toBe('/catalog/search?q=labels:%22myTestValue%22');
     });
   });
 });

--- a/gravitee-apim-portal-webui/src/app/pages/api/api-general/api-general.component.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/api/api-general/api-general.component.ts
@@ -274,7 +274,15 @@ export class ApiGeneralComponent implements OnInit {
   }
 
   goToSearch(key: SearchableKeys, value: string) {
-    this.router.navigate(['catalog/search'], { queryParams: { q: `${searchableKeysMapping[key]}:"${value}"` } });
+    return this.router.navigateByUrl(this.getSearchUrlTree(key, value));
+  }
+
+  getSearchUrl(key: string, value: string) {
+    return this.getSearchUrlTree(key, value).toString();
+  }
+
+  private getSearchUrlTree(key: string, value: string) {
+    return this.router.createUrlTree(['catalog/search'], { queryParams: { q: `${searchableKeysMapping[key]}:"${value}"` } });
   }
 
   goToExtern(url: string) {


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6738

**Description**

fix: fix owner link in API details
Owner link has to redirect to search page URL, not '#'.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-crtbzcbfgo.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-6738-fix-api-owner-link-to-search/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
