### PR TITLE
Remove calls to `GraviteeContext` from Services - Part 1

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/filter/PermissionsFilter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/filter/PermissionsFilter.java
@@ -94,6 +94,7 @@ public class PermissionsFilter implements ContainerRequestFilter {
                         case ORGANIZATION:
                             memberPermissions =
                                 membershipService.getUserMemberPermissions(
+                                    GraviteeContext.getCurrentEnvironment(),
                                     MembershipReferenceType.ORGANIZATION,
                                     GraviteeContext.getCurrentOrganization(),
                                     username
@@ -105,6 +106,7 @@ public class PermissionsFilter implements ContainerRequestFilter {
                         case ENVIRONMENT:
                             memberPermissions =
                                 membershipService.getUserMemberPermissions(
+                                    GraviteeContext.getCurrentEnvironment(),
                                     MembershipReferenceType.ENVIRONMENT,
                                     GraviteeContext.getCurrentEnvironment(),
                                     username
@@ -115,21 +117,24 @@ public class PermissionsFilter implements ContainerRequestFilter {
                             break;
                         case APPLICATION:
                             ApplicationEntity application = getApplication(requestContext);
-                            memberPermissions = membershipService.getUserMemberPermissions(application, username);
+                            memberPermissions =
+                                membershipService.getUserMemberPermissions(GraviteeContext.getCurrentEnvironment(), application, username);
                             if (roleService.hasPermission(memberPermissions, permission.value().getPermission(), permission.acls())) {
                                 return;
                             }
                             break;
                         case API:
                             ApiEntity api = getApi(requestContext);
-                            memberPermissions = membershipService.getUserMemberPermissions(api, username);
+                            memberPermissions =
+                                membershipService.getUserMemberPermissions(GraviteeContext.getCurrentEnvironment(), api, username);
                             if (roleService.hasPermission(memberPermissions, permission.value().getPermission(), permission.acls())) {
                                 return;
                             }
                             break;
                         case GROUP:
                             GroupEntity group = getGroup(requestContext);
-                            memberPermissions = membershipService.getUserMemberPermissions(group, username);
+                            memberPermissions =
+                                membershipService.getUserMemberPermissions(GraviteeContext.getCurrentEnvironment(), group, username);
                             if (roleService.hasPermission(memberPermissions, permission.value().getPermission(), permission.acls())) {
                                 return;
                             }
@@ -156,7 +161,7 @@ public class PermissionsFilter implements ContainerRequestFilter {
         if (groupId == null) {
             return null;
         }
-        return groupService.findById(groupId);
+        return groupService.findById(GraviteeContext.getCurrentEnvironment(), groupId);
     }
 
     private ApplicationEntity getApplication(ContainerRequestContext requestContext) {
@@ -164,7 +169,7 @@ public class PermissionsFilter implements ContainerRequestFilter {
         if (applicationId == null) {
             return null;
         }
-        return applicationService.findById(applicationId);
+        return applicationService.findById(GraviteeContext.getCurrentEnvironment(), applicationId);
     }
 
     private String getId(String key, ContainerRequestContext requestContext) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiAnalyticsResource.java
@@ -26,6 +26,7 @@ import io.gravitee.rest.api.model.analytics.query.*;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.AnalyticsService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.swagger.annotations.*;
 import java.util.List;
 import java.util.Map;
@@ -135,7 +136,7 @@ public class ApiAnalyticsResource extends AbstractResource {
 
             query.setAggregations(aggregationList);
         }
-        return analyticsService.execute(query);
+        return analyticsService.execute(GraviteeContext.getCurrentOrganization(), query);
     }
 
     private Analytics executeGroupBy(String api, AnalyticsParam analyticsParam) {
@@ -162,6 +163,6 @@ public class ApiAnalyticsResource extends AbstractResource {
 
             query.setGroups(rangeMap);
         }
-        return analyticsService.execute(query);
+        return analyticsService.execute(GraviteeContext.getCurrentOrganization(), query);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiEventsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiEventsResource.java
@@ -28,12 +28,9 @@ import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.EventService;
-import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.swagger.annotations.*;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.ws.rs.*;
@@ -92,7 +89,8 @@ public class ApiEventsResource extends AbstractResource {
             eventSearchParam.getFrom(),
             eventSearchParam.getTo(),
             eventSearchParam.getPage(),
-            eventSearchParam.getSize()
+            eventSearchParam.getSize(),
+            Collections.singletonList(GraviteeContext.getCurrentEnvironment())
         );
 
         apiEvents

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiHeaderResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiHeaderResource.java
@@ -23,6 +23,7 @@ import io.gravitee.rest.api.model.api.header.UpdateApiHeaderEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.ApiHeaderService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -56,7 +57,7 @@ public class ApiHeaderResource extends AbstractResource {
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API_HEADER, acls = RolePermissionAction.UPDATE) })
     public ApiHeaderEntity updateApiHeader(@PathParam("id") String id, @Valid @NotNull final UpdateApiHeaderEntity updateApiHeaderEntity) {
         updateApiHeaderEntity.setId(id);
-        return apiHeaderService.update(updateApiHeaderEntity);
+        return apiHeaderService.update(GraviteeContext.getCurrentEnvironment(), updateApiHeaderEntity);
     }
 
     @DELETE
@@ -71,6 +72,6 @@ public class ApiHeaderResource extends AbstractResource {
     )
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API_HEADER, acls = RolePermissionAction.DELETE) })
     public void deleteApiHeader(@PathParam("id") String id) {
-        apiHeaderService.delete(id);
+        apiHeaderService.delete(GraviteeContext.getCurrentEnvironment(), id);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiHeadersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiHeadersResource.java
@@ -25,6 +25,7 @@ import io.gravitee.rest.api.model.api.header.NewApiHeaderEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.ApiHeaderService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -61,7 +62,7 @@ public class ApiHeadersResource extends AbstractResource {
     )
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API_HEADER, acls = RolePermissionAction.READ) })
     public List<ApiHeaderEntity> getApiHeaders() {
-        return apiHeaderService.findAll();
+        return apiHeaderService.findAll(GraviteeContext.getCurrentEnvironment());
     }
 
     @POST
@@ -76,7 +77,7 @@ public class ApiHeadersResource extends AbstractResource {
     )
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API_HEADER, acls = RolePermissionAction.CREATE) })
     public ApiHeaderEntity createApiHeader(@Valid @NotNull final NewApiHeaderEntity newApiHeaderEntity) {
-        return apiHeaderService.create(newApiHeaderEntity);
+        return apiHeaderService.create(GraviteeContext.getCurrentEnvironment(), newApiHeaderEntity);
     }
 
     @Path("{id}")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiMediaResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiMediaResource.java
@@ -25,6 +25,7 @@ import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.security.utils.ImageUtils;
 import io.gravitee.rest.api.service.MediaService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.UploadUnauthorized;
 import io.swagger.annotations.*;
 import java.io.IOException;
@@ -72,7 +73,7 @@ public class ApiMediaResource extends AbstractResource {
     ) throws IOException {
         final String mediaId;
 
-        if (fileDetail.getSize() > this.mediaService.getMediaMaxSize()) {
+        if (fileDetail.getSize() > this.mediaService.getMediaMaxSize(GraviteeContext.getCurrentEnvironment())) {
             throw new UploadUnauthorized("Max size achieved " + fileDetail.getSize());
         } else {
             MediaEntity mediaEntity = new MediaEntity();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiPageMediaResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiPageMediaResource.java
@@ -24,6 +24,7 @@ import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.MediaService;
 import io.gravitee.rest.api.service.PageService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.UploadUnauthorized;
 import io.swagger.annotations.*;
 import java.io.IOException;
@@ -84,9 +85,13 @@ public class ApiPageMediaResource extends AbstractResource {
     ) throws IOException {
         final String mediaId;
 
-        if (request.getContentLength() > this.mediaService.getMediaMaxSize()) {
+        if (request.getContentLength() > this.mediaService.getMediaMaxSize(GraviteeContext.getCurrentEnvironment())) {
             throw new UploadUnauthorized(
-                "Max size is " + this.mediaService.getMediaMaxSize() + "bytes. Actual size is " + request.getContentLength() + "bytes."
+                "Max size is " +
+                this.mediaService.getMediaMaxSize(GraviteeContext.getCurrentEnvironment()) +
+                "bytes. Actual size is " +
+                request.getContentLength() +
+                "bytes."
             );
         }
         final String originalFileName = fileDetail.getFileName();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiPageResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiPageResource.java
@@ -30,9 +30,9 @@ import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.AccessControlService;
 import io.gravitee.rest.api.service.PageService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.*;
 import io.swagger.annotations.*;
-import java.util.Arrays;
 import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -231,7 +231,10 @@ public class ApiPageResource extends AbstractResource {
     }
 
     private boolean isDisplayable(ApiEntity api, PageEntity pageEntity) {
-        return (isAuthenticated() && isAdmin()) || accessControlService.canAccessPageFromConsole(api, pageEntity);
+        return (
+            (isAuthenticated() && isAdmin()) ||
+            accessControlService.canAccessPageFromConsole(GraviteeContext.getCurrentEnvironment(), api, pageEntity)
+        );
     }
 
     @Path("media")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiPagesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiPagesResource.java
@@ -206,6 +206,9 @@ public class ApiPagesResource extends AbstractResource {
     }
 
     private boolean isDisplayable(ApiEntity api, PageEntity page) {
-        return (isAuthenticated() && isAdmin()) || accessControlService.canAccessPageFromConsole(api, page);
+        return (
+            (isAuthenticated() && isAdmin()) ||
+            accessControlService.canAccessPageFromConsole(GraviteeContext.getCurrentEnvironment(), api, page)
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
@@ -551,7 +551,7 @@ public class ApiResource extends AbstractResource {
     public ApiQualityMetricsEntity getApiQualityMetrics() {
         canReadApi(api);
         final ApiEntity apiEntity = apiService.findById(api);
-        return qualityMetricsService.getMetrics(apiEntity);
+        return qualityMetricsService.getMetrics(apiEntity, GraviteeContext.getCurrentEnvironment());
     }
 
     @POST
@@ -564,7 +564,7 @@ public class ApiResource extends AbstractResource {
     )
     @Permissions({ @Permission(value = RolePermission.API_MESSAGE, acls = RolePermissionAction.CREATE) })
     public Response createApiMessage(final MessageEntity message) {
-        return Response.ok(messageService.create(api, message)).build();
+        return Response.ok(messageService.create(GraviteeContext.getCurrentEnvironment(), api, message)).build();
     }
 
     @GET
@@ -711,7 +711,9 @@ public class ApiResource extends AbstractResource {
     )
     @Permissions({ @Permission(value = RolePermission.API_DEFINITION, acls = RolePermissionAction.UPDATE) })
     public Response promoteAPI(@RequestBody @Valid @NotNull final PromotionRequestEntity promotionRequest) {
-        return Response.ok(promotionService.promote(this.api, promotionRequest, getAuthenticatedUser())).build();
+        return Response
+            .ok(promotionService.promote(GraviteeContext.getCurrentEnvironment(), this.api, promotionRequest, getAuthenticatedUser()))
+            .build();
     }
 
     @Path("keys")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscribersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscribersResource.java
@@ -23,6 +23,7 @@ import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.SubscriptionService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
 import io.swagger.annotations.*;
 import java.util.Collection;
@@ -85,7 +86,7 @@ public class ApiSubscribersResource extends AbstractResource {
             .stream()
             .map(SubscriptionEntity::getApplication)
             .distinct()
-            .map(application -> applicationService.findById(application))
+            .map(application -> applicationService.findById(GraviteeContext.getCurrentEnvironment(), application))
             .sorted((o1, o2) -> String.CASE_INSENSITIVE_ORDER.compare(o1.getName(), o2.getName()))
             .collect(Collectors.toList());
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionResource.java
@@ -28,6 +28,7 @@ import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.*;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.validator.CustomApiKey;
 import io.swagger.annotations.*;
 import java.util.List;
@@ -325,7 +326,10 @@ public class ApiSubscriptionResource extends AbstractResource {
         subscription.setPlan(new Subscription.Plan(plan.getId(), plan.getName()));
         subscription.getPlan().setSecurity(plan.getSecurity());
 
-        ApplicationEntity application = applicationService.findById(subscriptionEntity.getApplication());
+        ApplicationEntity application = applicationService.findById(
+            GraviteeContext.getCurrentEnvironment(),
+            subscriptionEntity.getApplication()
+        );
         subscription.setApplication(
             new Subscription.Application(
                 application.getId(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionsResource.java
@@ -33,6 +33,7 @@ import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.service.*;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.validator.CustomApiKey;
 import io.swagger.annotations.*;
 import java.util.Date;
@@ -224,7 +225,10 @@ public class ApiSubscriptionsResource extends AbstractResource {
         PlanEntity plan = planService.findById(subscriptionEntity.getPlan());
         subscription.setPlan(new Subscription.Plan(plan.getId(), plan.getName()));
 
-        ApplicationEntity application = applicationService.findById(subscriptionEntity.getApplication());
+        ApplicationEntity application = applicationService.findById(
+            GraviteeContext.getCurrentEnvironment(),
+            subscriptionEntity.getApplication()
+        );
         subscription.setApplication(
             new Subscription.Application(
                 application.getId(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
@@ -139,7 +139,7 @@ public class ApisResource extends AbstractResource {
         apiQuery.setTag(apisParam.getTag());
         apiQuery.setState(apisParam.getState());
         if (apisParam.getCategory() != null) {
-            apiQuery.setCategory(categoryService.findById(apisParam.getCategory()).getId());
+            apiQuery.setCategory(categoryService.findById(apisParam.getCategory(), GraviteeContext.getCurrentEnvironment()).getId());
         }
 
         Sortable sortable = null;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationAnalyticsResource.java
@@ -26,6 +26,7 @@ import io.gravitee.rest.api.model.analytics.query.*;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.AnalyticsService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.swagger.annotations.*;
 import java.util.List;
 import java.util.Map;
@@ -140,7 +141,7 @@ public class ApplicationAnalyticsResource extends AbstractResource {
 
             query.setAggregations(aggregationList);
         }
-        return analyticsService.execute(query);
+        return analyticsService.execute(GraviteeContext.getCurrentOrganization(), query);
     }
 
     private Analytics executeGroupBy(String application, AnalyticsParam analyticsParam) {
@@ -167,6 +168,6 @@ public class ApplicationAnalyticsResource extends AbstractResource {
 
             query.setGroups(rangeMap);
         }
-        return analyticsService.execute(query);
+        return analyticsService.execute(GraviteeContext.getCurrentOrganization(), query);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationMetadataResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationMetadataResource.java
@@ -24,8 +24,8 @@ import io.gravitee.rest.api.model.UpdateApplicationMetadataEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.ApplicationMetadataService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.swagger.annotations.*;
-import java.net.URI;
 import java.util.List;
 import javax.inject.Inject;
 import javax.validation.Valid;
@@ -107,7 +107,10 @@ public class ApplicationMetadataResource extends AbstractResource {
         // prevent creation of a metadata on an another APPLICATION
         metadata.setApplicationId(application);
 
-        final ApplicationMetadataEntity applicationMetadataEntity = metadataService.create(metadata);
+        final ApplicationMetadataEntity applicationMetadataEntity = metadataService.create(
+            GraviteeContext.getCurrentEnvironment(),
+            metadata
+        );
         return Response.created(this.getLocationHeader(applicationMetadataEntity.getKey())).entity(applicationMetadataEntity).build();
     }
 
@@ -133,7 +136,7 @@ public class ApplicationMetadataResource extends AbstractResource {
         // prevent update of a metadata on an another APPLICATION
         metadata.setApplicationId(application);
 
-        return Response.ok(metadataService.update(metadata)).build();
+        return Response.ok(metadataService.update(GraviteeContext.getCurrentEnvironment(), metadata)).build();
     }
 
     @DELETE

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationResource.java
@@ -29,6 +29,7 @@ import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.NotifierService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.configuration.application.ApplicationTypeService;
 import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
 import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
@@ -78,7 +79,7 @@ public class ApplicationResource extends AbstractResource {
     )
     @Permissions({ @Permission(value = RolePermission.APPLICATION_DEFINITION, acls = RolePermissionAction.READ) })
     public ApplicationEntity getApplication() {
-        return applicationService.findById(application);
+        return applicationService.findById(GraviteeContext.getCurrentEnvironment(), application);
     }
 
     @GET
@@ -96,7 +97,7 @@ public class ApplicationResource extends AbstractResource {
     )
     @Permissions({ @Permission(value = RolePermission.APPLICATION_DEFINITION, acls = RolePermissionAction.READ) })
     public Response getApplicationType() {
-        ApplicationEntity applicationEntity = applicationService.findById(application);
+        ApplicationEntity applicationEntity = applicationService.findById(GraviteeContext.getCurrentEnvironment(), application);
         ApplicationTypeEntity applicationType = applicationTypeService.getApplicationType(applicationEntity.getType());
         return Response.ok(applicationType).build();
     }
@@ -130,7 +131,12 @@ public class ApplicationResource extends AbstractResource {
             updatedApplication.setSettings(settings);
         }
 
-        return applicationService.update(application, updatedApplication);
+        return applicationService.update(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
+            application,
+            updatedApplication
+        );
     }
 
     @GET
@@ -141,7 +147,7 @@ public class ApplicationResource extends AbstractResource {
     )
     @Permissions({ @Permission(value = RolePermission.APPLICATION_DEFINITION, acls = RolePermissionAction.READ) })
     public Response getApplicationPicture(@Context Request request) throws ApplicationNotFoundException {
-        return getImageResponse(request, applicationService.getPicture(application));
+        return getImageResponse(request, applicationService.getPicture(GraviteeContext.getCurrentEnvironment(), application));
     }
 
     @GET
@@ -152,7 +158,7 @@ public class ApplicationResource extends AbstractResource {
     )
     @Permissions({ @Permission(value = RolePermission.APPLICATION_DEFINITION, acls = RolePermissionAction.READ) })
     public Response getApplicationBackground(@Context Request request) throws ApplicationNotFoundException {
-        return getImageResponse(request, applicationService.getBackground(application));
+        return getImageResponse(request, applicationService.getBackground(GraviteeContext.getCurrentEnvironment(), application));
     }
 
     private Response getImageResponse(final Request request, PictureEntity picture) {
@@ -200,7 +206,11 @@ public class ApplicationResource extends AbstractResource {
     )
     @Permissions({ @Permission(value = RolePermission.APPLICATION_DEFINITION, acls = RolePermissionAction.UPDATE) })
     public ApplicationEntity renewApplicationClientSecret() {
-        return applicationService.renewClientSecret(application);
+        return applicationService.renewClientSecret(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
+            application
+        );
     }
 
     @POST

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationsResource.java
@@ -84,14 +84,35 @@ public class ApplicationsResource extends AbstractResource {
         }
 
         if (query != null && !query.trim().isEmpty()) {
-            applications = applicationService.findByUserAndNameAndStatus(getAuthenticatedUser(), isAdmin(), query, status);
+            applications =
+                applicationService.findByUserAndNameAndStatus(
+                    getAuthenticatedUser(),
+                    isAdmin(),
+                    query,
+                    status,
+                    GraviteeContext.getCurrentEnvironment(),
+                    GraviteeContext.getCurrentOrganization()
+                );
         } else if (isAdmin()) {
             applications =
                 group != null
-                    ? applicationService.findByGroupsAndStatus(Collections.singletonList(group), status)
-                    : applicationService.findByStatus(status);
+                    ? applicationService.findByGroupsAndStatus(
+                        GraviteeContext.getCurrentOrganization(),
+                        Collections.singletonList(group),
+                        status
+                    )
+                    : applicationService.findByStatus(
+                        GraviteeContext.getCurrentOrganization(),
+                        GraviteeContext.getCurrentEnvironment(),
+                        status
+                    );
         } else {
-            applications = applicationService.findByUser(getAuthenticatedUser());
+            applications =
+                applicationService.findByUser(
+                    GraviteeContext.getCurrentOrganization(),
+                    GraviteeContext.getCurrentEnvironment(),
+                    getAuthenticatedUser()
+                );
             if (group != null && !group.isEmpty()) {
                 applications =
                     applications
@@ -168,7 +189,11 @@ public class ApplicationsResource extends AbstractResource {
             application.setSettings(settings);
         }
 
-        ApplicationEntity newApplication = applicationService.create(application, getAuthenticatedUser());
+        ApplicationEntity newApplication = applicationService.create(
+            GraviteeContext.getCurrentEnvironment(),
+            application,
+            getAuthenticatedUser()
+        );
         if (newApplication != null) {
             return Response.created(this.getLocationHeader(newApplication.getId())).entity(newApplication).build();
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/CategoriesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/CategoriesResource.java
@@ -79,7 +79,7 @@ public class CategoriesResource extends AbstractCategoryResource {
         );
 
         return categoryService
-            .findAll()
+            .findAll(GraviteeContext.getCurrentEnvironment())
             .stream()
             .filter(c -> All || !c.isHidden())
             .sorted(Comparator.comparingInt(CategoryEntity::getOrder))
@@ -100,7 +100,7 @@ public class CategoriesResource extends AbstractCategoryResource {
     @ApiOperation(value = "Create a category", notes = "User must have the PORTAL_CATEGORY[CREATE] permission to use this service")
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_CATEGORY, acls = RolePermissionAction.CREATE) })
     public CategoryEntity createCategory(@Valid @NotNull final NewCategoryEntity category) {
-        return categoryService.create(category);
+        return categoryService.create(GraviteeContext.getCurrentEnvironment(), category);
     }
 
     @PUT

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/CategoryResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/CategoryResource.java
@@ -28,6 +28,7 @@ import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.security.utils.ImageUtils;
 import io.gravitee.rest.api.service.CategoryService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.CategoryNotFoundException;
 import io.gravitee.rest.api.service.exceptions.UnauthorizedAccessException;
 import io.swagger.annotations.*;
@@ -63,7 +64,7 @@ public class CategoryResource extends AbstractCategoryResource {
     )
     public CategoryEntity getCategory() {
         boolean canShowCategory = hasPermission(RolePermission.ENVIRONMENT_CATEGORY, RolePermissionAction.READ);
-        CategoryEntity category = categoryService.findById(categoryId);
+        CategoryEntity category = categoryService.findById(categoryId, GraviteeContext.getCurrentEnvironment());
 
         if (!canShowCategory && category.isHidden()) {
             throw new UnauthorizedAccessException();
@@ -79,7 +80,7 @@ public class CategoryResource extends AbstractCategoryResource {
     @ApiOperation(value = "Get the category's picture", notes = "User must have the PORTAL_CATEGORY[READ] permission to use this service")
     @ApiResponses({ @ApiResponse(code = 200, message = "Category's picture"), @ApiResponse(code = 500, message = "Internal server error") })
     public Response getCategoryPicture(@Context Request request) throws CategoryNotFoundException {
-        return getImageResponse(request, categoryService.getPicture(categoryId));
+        return getImageResponse(request, categoryService.getPicture(GraviteeContext.getCurrentEnvironment(), categoryId));
     }
 
     @GET
@@ -89,12 +90,12 @@ public class CategoryResource extends AbstractCategoryResource {
         { @ApiResponse(code = 200, message = "Category's background"), @ApiResponse(code = 500, message = "Internal server error") }
     )
     public Response getCategoryBackground(@Context Request request) throws CategoryNotFoundException {
-        return getImageResponse(request, categoryService.getBackground(categoryId));
+        return getImageResponse(request, categoryService.getBackground(GraviteeContext.getCurrentEnvironment(), categoryId));
     }
 
     private Response getImageResponse(Request request, InlinePictureEntity image) {
         boolean canShowCategory = hasPermission(RolePermission.ENVIRONMENT_CATEGORY, RolePermissionAction.READ);
-        CategoryEntity category = categoryService.findById(categoryId);
+        CategoryEntity category = categoryService.findById(categoryId, GraviteeContext.getCurrentEnvironment());
 
         if (!canShowCategory && category.isHidden()) {
             throw new UnauthorizedAccessException();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentResource.java
@@ -163,7 +163,8 @@ public class EnvironmentResource extends AbstractResource {
                     permissions.put(perm.getName(), rights);
                 }
             } else {
-                permissions = membershipService.getUserMemberPermissions(environmentEntity, username);
+                permissions =
+                    membershipService.getUserMemberPermissions(GraviteeContext.getCurrentEnvironment(), environmentEntity, username);
             }
         }
         return Response.ok(permissions).build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentsResource.java
@@ -15,15 +15,10 @@
  */
 package io.gravitee.rest.api.management.rest.resource;
 
-import static io.gravitee.rest.api.model.permissions.RolePermissionAction.CREATE;
-import static io.gravitee.rest.api.model.permissions.RolePermissionAction.DELETE;
-import static io.gravitee.rest.api.model.permissions.RolePermissionAction.READ;
-import static io.gravitee.rest.api.model.permissions.RolePermissionAction.UPDATE;
-
 import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.EnvironmentPermissionsEntity;
-import io.gravitee.rest.api.model.permissions.EnvironmentPermission;
 import io.gravitee.rest.api.service.EnvironmentService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -61,7 +56,7 @@ public class EnvironmentsResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List available environments for current user organization")
     public Collection<EnvironmentEntity> getEnvironments() {
-        return this.environmentService.findByUser(getAuthenticatedUserOrNull());
+        return this.environmentService.findByUser(GraviteeContext.getCurrentOrganization(), getAuthenticatedUserOrNull());
     }
 
     @Path("{envId}")
@@ -94,7 +89,8 @@ public class EnvironmentsResource extends AbstractResource {
     public Collection<EnvironmentPermissionsEntity> getEnvironmentsPermissions(
         @ApiParam("To filter on environment id or hrid") @QueryParam("idOrHrid") String id
     ) {
-        List<EnvironmentEntity> environments = this.environmentService.findByUserAndIdOrHrid(getAuthenticatedUserOrNull(), id);
+        List<EnvironmentEntity> environments =
+            this.environmentService.findByUserAndIdOrHrid(GraviteeContext.getCurrentOrganization(), getAuthenticatedUserOrNull(), id);
 
         return environments
             .stream()
@@ -103,7 +99,8 @@ public class EnvironmentsResource extends AbstractResource {
                     Map<String, char[]> permissions = new HashMap<>();
                     if (isAuthenticated()) {
                         final String username = getAuthenticatedUser();
-                        permissions = membershipService.getUserMemberPermissions(environment, username);
+                        permissions =
+                            membershipService.getUserMemberPermissions(GraviteeContext.getCurrentEnvironment(), environment, username);
                     }
 
                     EnvironmentPermissionsEntity environmentPermissions = new EnvironmentPermissionsEntity();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupInvitationsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupInvitationsResource.java
@@ -93,7 +93,7 @@ public class GroupInvitationsResource extends AbstractResource {
     )
     public InvitationEntity createGroupInvitation(@Valid @NotNull final NewInvitationEntity invitationEntity) {
         // Check that group exists
-        final GroupEntity groupEntity = groupService.findById(group);
+        final GroupEntity groupEntity = groupService.findById(GraviteeContext.getCurrentEnvironment(), group);
         // check if user is a 'simple group admin' or a platform admin
         final boolean hasPermission = permissionService.hasPermission(
             RolePermission.ENVIRONMENT_GROUP,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupMemberResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupMemberResource.java
@@ -20,6 +20,7 @@ import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.GroupService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.swagger.annotations.*;
 import javax.inject.Inject;
 import javax.ws.rs.DELETE;
@@ -62,7 +63,7 @@ public class GroupMemberResource extends AbstractResource {
         }
     )
     public Response deleteGroupMember(@PathParam("member") String userId) {
-        groupService.deleteUserFromGroup(group, userId);
+        groupService.deleteUserFromGroup(GraviteeContext.getCurrentEnvironment(), group, userId);
 
         return Response.ok().build();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResource.java
@@ -36,7 +36,6 @@ import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.model.permissions.SystemRole;
-import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.NotifierService;
@@ -119,7 +118,7 @@ public class GroupMembersResource extends AbstractResource {
     )
     public PagedResult<GroupMemberEntity> getGroupMembers(@Valid @BeanParam Pageable pageable) {
         //check that group exists
-        groupService.findById(group);
+        groupService.findById(GraviteeContext.getCurrentEnvironment(), group);
 
         io.gravitee.rest.api.model.common.Pageable commonPageable = null;
 
@@ -184,7 +183,7 @@ public class GroupMembersResource extends AbstractResource {
     )
     public Response addOrUpdateGroupMember(@Valid @NotNull final List<GroupMembership> memberships) {
         // Check that group exists
-        final GroupEntity groupEntity = groupService.findById(group);
+        final GroupEntity groupEntity = groupService.findById(GraviteeContext.getCurrentEnvironment(), group);
 
         // check if user is a 'simple group admin' or a platform admin
         final boolean hasPermission = permissionService.hasPermission(
@@ -268,6 +267,8 @@ public class GroupMembersResource extends AbstractResource {
                     }
                     updatedMembership =
                         membershipService.addRoleToMemberOnReference(
+                            GraviteeContext.getCurrentOrganization(),
+                            GraviteeContext.getCurrentEnvironment(),
                             new MembershipService.MembershipReference(MembershipReferenceType.GROUP, group),
                             new MembershipService.MembershipMember(
                                 membership.getId(),
@@ -303,6 +304,8 @@ public class GroupMembersResource extends AbstractResource {
                     }
                     updatedMembership =
                         membershipService.addRoleToMemberOnReference(
+                            GraviteeContext.getCurrentOrganization(),
+                            GraviteeContext.getCurrentEnvironment(),
                             new MembershipService.MembershipReference(MembershipReferenceType.GROUP, group),
                             new MembershipService.MembershipMember(
                                 membership.getId(),
@@ -325,6 +328,8 @@ public class GroupMembersResource extends AbstractResource {
                 if (groupRoleEntity != null && !groupRoleEntity.equals(previousGroupRole)) {
                     updatedMembership =
                         membershipService.addRoleToMemberOnReference(
+                            GraviteeContext.getCurrentOrganization(),
+                            GraviteeContext.getCurrentEnvironment(),
                             new MembershipService.MembershipReference(MembershipReferenceType.GROUP, group),
                             new MembershipService.MembershipMember(
                                 membership.getId(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupResource.java
@@ -66,7 +66,7 @@ public class GroupResource extends AbstractResource {
     )
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_GROUP, acls = RolePermissionAction.READ) })
     public GroupEntity getGroup() {
-        return groupService.findById(group);
+        return groupService.findById(GraviteeContext.getCurrentEnvironment(), group);
     }
 
     @DELETE
@@ -77,7 +77,7 @@ public class GroupResource extends AbstractResource {
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_GROUP, acls = RolePermissionAction.DELETE) })
     public Response deleteGroup() {
         checkRights();
-        groupService.delete(group);
+        groupService.delete(GraviteeContext.getCurrentEnvironment(), group);
         return Response.noContent().build();
     }
 
@@ -121,7 +121,7 @@ public class GroupResource extends AbstractResource {
                 updateGroupEntity.getRoles().put(RoleScope.APPLICATION, groupEntity.getRoles().get(RoleScope.APPLICATION));
             }
         }
-        return groupService.update(group, updateGroupEntity);
+        return groupService.update(GraviteeContext.getCurrentEnvironment(), group, updateGroupEntity);
     }
 
     @GET
@@ -131,7 +131,7 @@ public class GroupResource extends AbstractResource {
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_GROUP, acls = RolePermissionAction.READ) })
     public Response getGroupMemberships(@QueryParam("type") String type) {
         if ("api".equalsIgnoreCase(type)) {
-            return Response.ok(groupService.getApis(group)).build();
+            return Response.ok(groupService.getApis(GraviteeContext.getCurrentEnvironment(), group)).build();
         } else if ("application".equalsIgnoreCase(type)) {
             return Response.ok(groupService.getApplications(group)).build();
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupsResource.java
@@ -22,8 +22,8 @@ import io.gravitee.rest.api.model.NewGroupEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.GroupService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.swagger.annotations.*;
-import java.net.URI;
 import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -62,7 +62,7 @@ public class GroupsResource extends AbstractResource {
     )
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_GROUP, acls = RolePermissionAction.READ) })
     public Response getGroups() {
-        return Response.ok(groupService.findAll()).build();
+        return Response.ok(groupService.findAll(GraviteeContext.getCurrentEnvironment())).build();
     }
 
     @POST
@@ -74,7 +74,7 @@ public class GroupsResource extends AbstractResource {
     )
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_GROUP, acls = RolePermissionAction.CREATE) })
     public Response createGroup(@ApiParam(name = "group", required = true) @Valid @NotNull final NewGroupEntity newGroupEntity) {
-        GroupEntity groupEntity = groupService.create(newGroupEntity);
+        GroupEntity groupEntity = groupService.create(GraviteeContext.getCurrentEnvironment(), newGroupEntity);
         if (groupEntity != null) {
             return Response.created(this.getLocationHeader(groupEntity.getId())).entity(groupEntity).build();
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/MessagesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/MessagesResource.java
@@ -22,6 +22,7 @@ import io.gravitee.rest.api.model.MessageEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.MessageService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -57,6 +58,6 @@ public class MessagesResource extends AbstractResource {
     )
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_MESSAGE, acls = RolePermissionAction.CREATE) })
     public Response createMessage(final MessageEntity message) {
-        return Response.ok(messageService.create(message)).build();
+        return Response.ok(messageService.create(GraviteeContext.getCurrentEnvironment(), message)).build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource.java
@@ -32,6 +32,7 @@ import io.gravitee.rest.api.service.AnalyticsService;
 import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.PermissionService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -85,7 +86,11 @@ public class PlatformAnalyticsResource extends AbstractResource {
                 fieldName = "application";
                 ids =
                     applicationService
-                        .findByUser(getAuthenticatedUser())
+                        .findByUser(
+                            GraviteeContext.getCurrentOrganization(),
+                            GraviteeContext.getCurrentEnvironment(),
+                            getAuthenticatedUser()
+                        )
                         .stream()
                         .filter(app -> permissionService.hasPermission(APPLICATION_ANALYTICS, app.getId(), READ))
                         .map(ApplicationListItem::getId)
@@ -179,7 +184,7 @@ public class PlatformAnalyticsResource extends AbstractResource {
             query.setAggregations(aggregationList);
         }
         addExtraFilter(query, extraFilter);
-        return analyticsService.execute(query);
+        return analyticsService.execute(GraviteeContext.getCurrentOrganization(), query);
     }
 
     private Analytics executeGroupBy(AnalyticsParam analyticsParam, String extraFilter) {
@@ -205,7 +210,7 @@ public class PlatformAnalyticsResource extends AbstractResource {
             query.setGroups(rangeMap);
         }
         addExtraFilter(query, extraFilter);
-        return analyticsService.execute(query);
+        return analyticsService.execute(GraviteeContext.getCurrentOrganization(), query);
     }
 
     private void addExtraFilter(AbstractQuery query, String extraFilter) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformEventsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformEventsResource.java
@@ -30,11 +30,13 @@ import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.EventService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -95,7 +97,8 @@ public class PlatformEventsResource extends AbstractResource {
             eventSearchParam.getFrom(),
             eventSearchParam.getTo(),
             eventSearchParam.getPage(),
-            eventSearchParam.getSize()
+            eventSearchParam.getSize(),
+            Collections.singletonList(GraviteeContext.getCurrentEnvironment())
         );
 
         events

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalMediaResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalMediaResource.java
@@ -24,6 +24,7 @@ import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.security.utils.ImageUtils;
 import io.gravitee.rest.api.service.MediaService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.UploadUnauthorized;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -64,7 +65,7 @@ public class PortalMediaResource extends AbstractResource {
     ) throws IOException {
         String mediaId;
 
-        if (fileDetail.getSize() > this.mediaService.getMediaMaxSize()) {
+        if (fileDetail.getSize() > this.mediaService.getMediaMaxSize(GraviteeContext.getCurrentEnvironment())) {
             throw new UploadUnauthorized("Max size achieved " + fileDetail.getSize());
         } else {
             MediaEntity mediaEntity = new MediaEntity();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalPageMediaResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalPageMediaResource.java
@@ -24,6 +24,7 @@ import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.MediaService;
 import io.gravitee.rest.api.service.PageService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.UploadUnauthorized;
 import io.swagger.annotations.*;
 import java.io.IOException;
@@ -78,9 +79,13 @@ public class PortalPageMediaResource extends AbstractResource {
     ) throws IOException {
         final String mediaId;
 
-        if (request.getContentLength() > this.mediaService.getMediaMaxSize()) {
+        if (request.getContentLength() > this.mediaService.getMediaMaxSize(GraviteeContext.getCurrentEnvironment())) {
             throw new UploadUnauthorized(
-                "Max size is " + this.mediaService.getMediaMaxSize() + "bytes. Actual size is " + request.getContentLength() + "bytes."
+                "Max size is " +
+                this.mediaService.getMediaMaxSize(GraviteeContext.getCurrentEnvironment()) +
+                "bytes. Actual size is " +
+                request.getContentLength() +
+                "bytes."
             );
         }
         final String originalFileName = fileDetail.getFileName();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalPagesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalPagesResource.java
@@ -332,14 +332,14 @@ public class PortalPagesResource extends AbstractResource {
     }
 
     private boolean isDisplayable(PageEntity pageEntity) {
-        if (!isAuthenticated() && configService.portalLoginForced()) {
+        if (!isAuthenticated() && configService.portalLoginForced(GraviteeContext.getCurrentEnvironment())) {
             // if portal requires login, this endpoint should hide the api pages even PUBLIC ones
             return false;
         } else if (isAuthenticated() && isAdmin()) {
             // if user is org admin
             return true;
         } else {
-            return accessControlService.canAccessPageFromPortal(pageEntity);
+            return accessControlService.canAccessPageFromPortal(GraviteeContext.getCurrentEnvironment(), pageEntity);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalResource.java
@@ -26,6 +26,7 @@ import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.settings.PortalConfigEntity;
 import io.gravitee.rest.api.model.settings.PortalSettingsEntity;
 import io.gravitee.rest.api.service.ConfigService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.swagger.annotations.*;
 import javax.inject.Inject;
 import javax.validation.constraints.NotNull;
@@ -59,7 +60,7 @@ public class PortalResource {
         }
     )
     public PortalConfigEntity getPortalConfig() {
-        return configService.getPortalConfig();
+        return configService.getPortalConfig(GraviteeContext.getCurrentEnvironment());
     }
 
     @POST
@@ -75,7 +76,7 @@ public class PortalResource {
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_SETTINGS, acls = { CREATE, UPDATE, DELETE }) })
     @Deprecated
     public Response savePortalConfig(@ApiParam(name = "config", required = true) @NotNull PortalSettingsEntity portalSettingsEntity) {
-        configService.save(portalSettingsEntity);
+        configService.save(GraviteeContext.getCurrentEnvironment(), portalSettingsEntity);
         return Response.ok().entity(portalSettingsEntity).build();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalSettingsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalSettingsResource.java
@@ -23,6 +23,7 @@ import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.settings.PortalSettingsEntity;
 import io.gravitee.rest.api.service.ConfigService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.swagger.annotations.*;
 import javax.inject.Inject;
 import javax.validation.constraints.NotNull;
@@ -60,7 +61,7 @@ public class PortalSettingsResource {
     )
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_SETTINGS, acls = READ) })
     public PortalSettingsEntity getPortalSettings() {
-        return configService.getPortalSettings();
+        return configService.getPortalSettings(GraviteeContext.getCurrentEnvironment());
     }
 
     @POST
@@ -75,7 +76,7 @@ public class PortalSettingsResource {
     )
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_SETTINGS, acls = { CREATE, UPDATE, DELETE }) })
     public Response savePortalSettings(@ApiParam(name = "config", required = true) @NotNull PortalSettingsEntity portalSettingsEntity) {
-        configService.save(portalSettingsEntity);
+        configService.save(GraviteeContext.getCurrentEnvironment(), portalSettingsEntity);
         return Response.ok().entity(portalSettingsEntity).build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PromotionResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PromotionResource.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.management.rest.resource;
 
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.promotion.PromotionService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -57,6 +58,16 @@ public class PromotionResource extends AbstractResource {
         }
     )
     public Response processPromotion(boolean accepted) {
-        return Response.ok(promotionService.processPromotion(promotion, accepted, getAuthenticatedUser())).build();
+        return Response
+            .ok(
+                promotionService.processPromotion(
+                    GraviteeContext.getCurrentOrganization(),
+                    GraviteeContext.getCurrentEnvironment(),
+                    promotion,
+                    accepted,
+                    getAuthenticatedUser()
+                )
+            )
+            .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/SubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/SubscriptionsResource.java
@@ -23,6 +23,7 @@ import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.PlanService;
 import io.gravitee.rest.api.service.SubscriptionService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -76,7 +77,10 @@ public class SubscriptionsResource {
         subscription.setReason(subscriptionEntity.getReason());
         subscription.setStatus(subscriptionEntity.getStatus());
 
-        ApplicationEntity application = applicationService.findById(subscriptionEntity.getApplication());
+        ApplicationEntity application = applicationService.findById(
+            GraviteeContext.getCurrentEnvironment(),
+            subscriptionEntity.getApplication()
+        );
         subscription.setApplication(
             new Subscription.Application(
                 application.getId(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/ConsoleResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/ConsoleResource.java
@@ -24,6 +24,7 @@ import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.settings.ConsoleConfigEntity;
 import io.gravitee.rest.api.model.settings.ConsoleSettingsEntity;
 import io.gravitee.rest.api.service.ConfigService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.swagger.annotations.*;
 import javax.inject.Inject;
 import javax.validation.constraints.NotNull;
@@ -60,7 +61,7 @@ public class ConsoleResource {
         }
     )
     public ConsoleConfigEntity getConsoleConfig() {
-        return configService.getConsoleConfig();
+        return configService.getConsoleConfig(GraviteeContext.getCurrentOrganization());
     }
 
     @Deprecated
@@ -76,7 +77,7 @@ public class ConsoleResource {
     )
     @Permissions({ @Permission(value = RolePermission.ORGANIZATION_SETTINGS, acls = { CREATE, UPDATE, DELETE }) })
     public Response saveConsoleConfig(@ApiParam(name = "config", required = true) @NotNull ConsoleSettingsEntity consoleSettingsEntity) {
-        configService.save(consoleSettingsEntity);
+        configService.save(GraviteeContext.getCurrentOrganization(), consoleSettingsEntity);
         return Response.ok().entity(consoleSettingsEntity).build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/ConsoleSettingsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/ConsoleSettingsResource.java
@@ -68,7 +68,7 @@ public class ConsoleSettingsResource {
     )
     @Permissions({ @Permission(value = RolePermission.ORGANIZATION_SETTINGS, acls = READ) })
     public ConsoleSettingsEntity getConsoleSettings() {
-        return configService.getConsoleSettings();
+        return configService.getConsoleSettings(GraviteeContext.getCurrentOrganization());
     }
 
     @POST
@@ -86,7 +86,7 @@ public class ConsoleSettingsResource {
         // reject settings update if maintenanceMode isn't disabled into the payload
         checkMaintenanceMode(consoleSettingsEntity);
 
-        configService.save(consoleSettingsEntity);
+        configService.save(GraviteeContext.getCurrentOrganization(), consoleSettingsEntity);
         return Response.ok().entity(consoleSettingsEntity).build();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/RoleUsersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/RoleUsersResource.java
@@ -27,7 +27,6 @@ import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.swagger.annotations.*;
-import java.net.URI;
 import java.util.*;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -139,6 +138,8 @@ public class RoleUsersResource extends AbstractResource {
         }
 
         membershipService.addRoleToMemberOnReference(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
             new MembershipService.MembershipReference(MembershipReferenceType.ORGANIZATION, GraviteeContext.getCurrentOrganization()),
             new MembershipService.MembershipMember(roleMembership.getId(), roleMembership.getReference(), MembershipMemberType.USER),
             new MembershipService.MembershipRole(roleScope, roleName)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/portal/PortalApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/portal/PortalApisResource.java
@@ -33,6 +33,7 @@ import io.gravitee.rest.api.model.api.ApiQuery;
 import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.ConfigService;
 import io.gravitee.rest.api.service.RatingService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.swagger.annotations.*;
 import java.util.Collection;
 import java.util.HashMap;
@@ -95,7 +96,7 @@ public class PortalApisResource extends AbstractResource {
                 apiQuery.setLifecycleStates(singletonList(PUBLISHED));
                 if (isAuthenticated()) {
                     apis = apiService.findByUser(getAuthenticatedUser(), apiQuery, true);
-                } else if (configService.portalLoginForced()) {
+                } else if (configService.portalLoginForced(GraviteeContext.getCurrentEnvironment())) {
                     // if portal requires login, this endpoint should hide the APIS even PUBLIC ones
                     return Response.ok().entity(emptyList()).build();
                 } else {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiMembersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiMembersResourceTest.java
@@ -17,10 +17,12 @@ package io.gravitee.rest.api.management.rest.resource;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.eq;
 
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.management.rest.model.ApiMembership;
 import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
@@ -70,7 +72,13 @@ public class ApiMembersResourceTest extends AbstractResourceTest {
 
         Mockito
             .verify(membershipService)
-            .addRoleToMemberOnReference(memberShipRefCaptor.capture(), memberShipUserCaptor.capture(), memberShipRoleCaptor.capture());
+            .addRoleToMemberOnReference(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
+                memberShipRefCaptor.capture(),
+                memberShipUserCaptor.capture(),
+                memberShipRoleCaptor.capture()
+            );
         assertEquals(API, memberShipRefCaptor.getValue().getId());
         assertEquals("my-api-membership-role", memberShipRoleCaptor.getValue().getName());
         assertEquals(MEMBER_1, memberShipUserCaptor.getValue().getMemberId());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiPagesResourceNotAdminTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiPagesResourceNotAdminTest.java
@@ -26,6 +26,7 @@ import io.gravitee.rest.api.model.Visibility;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.permissions.ApiPermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.io.IOException;
 import java.security.Principal;
 import javax.annotation.Priority;
@@ -67,7 +68,7 @@ public class ApiPagesResourceNotAdminTest extends AbstractResourceTest {
         pageMock.setName(PAGE_NAME);
         when(permissionService.hasPermission(any(), any(), any())).thenReturn(true);
         doReturn(pageMock).when(pageService).findById(PAGE_NAME, null);
-        doReturn(true).when(accessControlService).canAccessPageFromConsole(apiMock, pageMock);
+        doReturn(true).when(accessControlService).canAccessPageFromConsole(GraviteeContext.getCurrentEnvironment(), apiMock, pageMock);
 
         final Response response = envTarget().request().get();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionResourceTest.java
@@ -25,6 +25,7 @@ import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 import org.junit.Before;
@@ -81,7 +82,7 @@ public class ApiSubscriptionResourceTest extends AbstractResourceTest {
 
         when(userService.findById(any(), anyBoolean())).thenReturn(fakeUserEntity);
         when(planService.findById(any())).thenReturn(fakePlanEntity);
-        when(applicationService.findById(any())).thenReturn(fakeApplicationEntity);
+        when(applicationService.findById(eq(GraviteeContext.getCurrentEnvironment()), any())).thenReturn(fakeApplicationEntity);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionsResourceTest.java
@@ -24,6 +24,7 @@ import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import javax.ws.rs.core.Response;
 import org.junit.Before;
 import org.junit.Test;
@@ -79,7 +80,7 @@ public class ApiSubscriptionsResourceTest extends AbstractResourceTest {
 
         when(userService.findById(any())).thenReturn(fakeUserEntity);
         when(planService.findById(any())).thenReturn(fakePlanEntity);
-        when(applicationService.findById(any())).thenReturn(fakeApplicationEntity);
+        when(applicationService.findById(eq(GraviteeContext.getCurrentEnvironment()), any())).thenReturn(fakeApplicationEntity);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationMembersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationMembersResourceTest.java
@@ -17,10 +17,12 @@ package io.gravitee.rest.api.management.rest.resource;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.eq;
 
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.management.rest.model.ApplicationMembership;
 import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
@@ -66,7 +68,13 @@ public class ApplicationMembersResourceTest extends AbstractResourceTest {
 
         Mockito
             .verify(membershipService)
-            .addRoleToMemberOnReference(memberShipRefCaptor.capture(), memberShipUserCaptor.capture(), memberShipRoleCaptor.capture());
+            .addRoleToMemberOnReference(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
+                memberShipRefCaptor.capture(),
+                memberShipUserCaptor.capture(),
+                memberShipRoleCaptor.capture()
+            );
         assertEquals(APPLICATION, memberShipRefCaptor.getValue().getId());
         assertEquals("my-application-membership-role", memberShipRoleCaptor.getValue().getName());
         assertEquals(MEMBER_1, memberShipUserCaptor.getValue().getMemberId());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationMetadataResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationMetadataResourceTest.java
@@ -18,10 +18,12 @@ package io.gravitee.rest.api.management.rest.resource;
 import static io.gravitee.common.http.HttpStatusCode.CREATED_201;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.rest.api.model.ApplicationMetadataEntity;
 import io.gravitee.rest.api.model.NewApplicationMetadataEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
@@ -50,7 +52,7 @@ public class ApplicationMetadataResourceTest extends AbstractResourceTest {
 
         ApplicationMetadataEntity createdMetadata = new ApplicationMetadataEntity();
         createdMetadata.setKey("my-metadata-id");
-        when(applicationMetadataService.create(any())).thenReturn(createdMetadata);
+        when(applicationMetadataService.create(eq(GraviteeContext.getCurrentEnvironment()), any())).thenReturn(createdMetadata);
 
         final Response response = envTarget().path(APPLICATION).path("metadata").request().post(Entity.json(newMetadata));
         assertEquals(CREATED_201, response.getStatus());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationsResourceTest.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.management.rest.resource;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.reset;
 
@@ -24,8 +25,7 @@ import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.management.rest.JerseySpringTest;
 import io.gravitee.rest.api.model.ApplicationEntity;
 import io.gravitee.rest.api.model.NewApplicationEntity;
-import io.gravitee.rest.api.model.api.ApiEntity;
-import io.gravitee.rest.api.model.api.NewApiEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
@@ -57,7 +57,9 @@ public class ApplicationsResourceTest extends AbstractResourceTest {
 
         ApplicationEntity returnedApp = new ApplicationEntity();
         returnedApp.setId("my-beautiful-application");
-        doReturn(returnedApp).when(applicationService).create(any(NewApplicationEntity.class), Mockito.eq(JerseySpringTest.USER_NAME));
+        doReturn(returnedApp)
+            .when(applicationService)
+            .create(eq(GraviteeContext.getCurrentEnvironment()), any(NewApplicationEntity.class), eq(JerseySpringTest.USER_NAME));
 
         final Response response = envTarget().request().post(Entity.json(appEntity));
         assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
@@ -72,7 +74,9 @@ public class ApplicationsResourceTest extends AbstractResourceTest {
 
         ApplicationEntity createdApplication = new ApplicationEntity();
         createdApplication.setId("my-beautiful-application");
-        doReturn(createdApplication).when(applicationService).create(any(NewApplicationEntity.class), Mockito.eq(USER_NAME));
+        doReturn(createdApplication)
+            .when(applicationService)
+            .create(eq(GraviteeContext.getCurrentEnvironment()), any(NewApplicationEntity.class), eq(USER_NAME));
 
         final Response response = envTarget().request().post(Entity.json(newApplicationEntity));
         assertEquals(HttpStatusCode.CREATED_201, response.getStatus());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/CategoryResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/CategoryResourceTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.doReturn;
 
 import io.gravitee.rest.api.model.CategoryEntity;
 import io.gravitee.rest.api.model.UpdateCategoryEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -55,7 +56,7 @@ public class CategoryResourceTest extends AbstractResourceTest {
         mockCategory.setId(CATEGORY);
         mockCategory.setName(CATEGORY);
         mockCategory.setUpdatedAt(new Date());
-        doReturn(mockCategory).when(categoryService).findById(CATEGORY);
+        doReturn(mockCategory).when(categoryService).findById(CATEGORY, GraviteeContext.getCurrentEnvironment());
 
         updateCategoryEntity = new UpdateCategoryEntity();
         updateCategoryEntity.setDescription("toto");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ConsoleSettingsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ConsoleSettingsResourceTest.java
@@ -26,13 +26,8 @@ import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.model.settings.ConsoleSettingsEntity;
 import io.gravitee.rest.api.model.settings.Maintenance;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
-import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -69,7 +64,7 @@ public class ConsoleSettingsResourceTest extends AbstractResourceTest {
         final Response response = orgTarget().request().post(Entity.json(config));
 
         assertEquals(response.readEntity(String.class), OK_200, response.getStatus());
-        verify(configService).save(any(ConsoleSettingsEntity.class));
+        verify(configService).save(eq(GraviteeContext.getCurrentOrganization()), any(ConsoleSettingsEntity.class));
     }
 
     @Test
@@ -91,7 +86,7 @@ public class ConsoleSettingsResourceTest extends AbstractResourceTest {
         final Response response = orgTarget().request().post(Entity.json(config));
 
         assertEquals(response.readEntity(String.class), OK_200, response.getStatus());
-        verify(configService).save(any(ConsoleSettingsEntity.class));
+        verify(configService).save(eq(GraviteeContext.getCurrentOrganization()), any(ConsoleSettingsEntity.class));
     }
 
     @Test
@@ -113,7 +108,7 @@ public class ConsoleSettingsResourceTest extends AbstractResourceTest {
         final Response response = orgTarget().request().post(Entity.json(config));
 
         assertEquals(response.readEntity(String.class), SERVICE_UNAVAILABLE_503, response.getStatus());
-        verify(configService, never()).save(any(ConsoleSettingsEntity.class));
+        verify(configService, never()).save(eq(GraviteeContext.getCurrentOrganization()), any(ConsoleSettingsEntity.class));
     }
 
     @Test
@@ -132,6 +127,6 @@ public class ConsoleSettingsResourceTest extends AbstractResourceTest {
         final Response response = orgTarget().request().post(Entity.json(config));
 
         assertEquals(response.readEntity(String.class), SERVICE_UNAVAILABLE_503, response.getStatus());
-        verify(configService, never()).save(any(ConsoleSettingsEntity.class));
+        verify(configService, never()).save(eq(GraviteeContext.getCurrentOrganization()), any(ConsoleSettingsEntity.class));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/EnvironmentAnalyticsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/EnvironmentAnalyticsResourceTest.java
@@ -20,29 +20,21 @@ import static io.gravitee.rest.api.model.permissions.RolePermission.APPLICATION_
 import static io.gravitee.rest.api.model.permissions.RolePermissionAction.READ;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.common.http.HttpStatusCode;
-import io.gravitee.repository.analytics.query.DateHistogramQuery;
-import io.gravitee.rest.api.model.ApplicationEntity;
 import io.gravitee.rest.api.model.analytics.HistogramAnalytics;
 import io.gravitee.rest.api.model.analytics.TopHitsAnalytics;
 import io.gravitee.rest.api.model.analytics.query.StatsAnalytics;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
-import io.gravitee.rest.api.model.permissions.RolePermission;
-import io.gravitee.rest.api.model.permissions.RolePermissionAction;
-import io.gravitee.rest.api.model.permissions.RoleScope;
-import io.gravitee.rest.api.model.permissions.SystemRole;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.io.IOException;
 import java.security.Principal;
 import java.util.Collections;
-import java.util.HashSet;
 import javax.annotation.Priority;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
@@ -51,8 +43,6 @@ import javax.ws.rs.core.SecurityContext;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.Mockito;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -77,7 +67,10 @@ public class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldGetEmptyHistoAnalyticsWhenNotAdminAndNoApp() {
-        when(applicationService.findByUser(any())).thenReturn(Collections.emptySet());
+        when(
+            applicationService.findByUser(eq(GraviteeContext.getCurrentOrganization()), eq(GraviteeContext.getCurrentEnvironment()), any())
+        )
+            .thenReturn(Collections.emptySet());
 
         Response response = envTarget()
             .queryParam("type", "date_histo")
@@ -96,7 +89,10 @@ public class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldGetEmptyTopHitsAnalyticsWhenNotAdminAndNoApp() {
-        when(applicationService.findByUser(any())).thenReturn(Collections.emptySet());
+        when(
+            applicationService.findByUser(eq(GraviteeContext.getCurrentOrganization()), eq(GraviteeContext.getCurrentEnvironment()), any())
+        )
+            .thenReturn(Collections.emptySet());
 
         Response response = envTarget()
             .queryParam("type", "group_by")
@@ -115,7 +111,10 @@ public class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldGetEmptyCountAnalyticsWhenNotAdminAndNoApp() {
-        when(applicationService.findByUser(any())).thenReturn(Collections.emptySet());
+        when(
+            applicationService.findByUser(eq(GraviteeContext.getCurrentOrganization()), eq(GraviteeContext.getCurrentEnvironment()), any())
+        )
+            .thenReturn(Collections.emptySet());
 
         Response response = envTarget()
             .queryParam("type", "count")
@@ -133,7 +132,10 @@ public class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldGetEmptyStatsAnalyticsWhenNotAdminAndNoApp() {
-        when(applicationService.findByUser(any())).thenReturn(Collections.emptySet());
+        when(
+            applicationService.findByUser(eq(GraviteeContext.getCurrentOrganization()), eq(GraviteeContext.getCurrentEnvironment()), any())
+        )
+            .thenReturn(Collections.emptySet());
 
         Response response = envTarget()
             .queryParam("type", "stats")
@@ -253,7 +255,10 @@ public class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
         ApplicationListItem app = new ApplicationListItem();
         app.setId("appId");
 
-        when(applicationService.findByUser(any())).thenReturn(Collections.singleton(app));
+        when(
+            applicationService.findByUser(eq(GraviteeContext.getCurrentOrganization()), eq(GraviteeContext.getCurrentEnvironment()), any())
+        )
+            .thenReturn(Collections.singleton(app));
         when(permissionService.hasPermission(APPLICATION_ANALYTICS, app.getId(), READ)).thenReturn(true);
 
         Response response = envTarget()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResourceTest.java
@@ -25,6 +25,7 @@ import io.gravitee.rest.api.management.rest.model.GroupMembership;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
@@ -52,7 +53,7 @@ public class GroupMembersResourceTest extends AbstractResourceTest {
 
     private void initADDmock() {
         reset(roleService, groupService, membershipService);
-        when(groupService.findById(GROUP_ID)).thenReturn(mock(GroupEntity.class));
+        when(groupService.findById(GraviteeContext.getCurrentEnvironment(), GROUP_ID)).thenReturn(mock(GroupEntity.class));
 
         RoleEntity defaultApiRole = mock(RoleEntity.class);
         when(defaultApiRole.getName()).thenReturn(DEFAULT_API_ROLE);
@@ -75,7 +76,16 @@ public class GroupMembersResourceTest extends AbstractResourceTest {
 
         MemberEntity memberEntity = new MemberEntity();
         memberEntity.setId(USERNAME);
-        when(membershipService.addRoleToMemberOnReference(any(), any(), any())).thenReturn(memberEntity);
+        when(
+            membershipService.addRoleToMemberOnReference(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
+                any(),
+                any(),
+                any()
+            )
+        )
+            .thenReturn(memberEntity);
         when(permissionService.hasPermission(ENVIRONMENT_GROUP, "DEFAULT", CREATE, UPDATE, DELETE)).thenReturn(true);
     }
 
@@ -100,6 +110,8 @@ public class GroupMembersResourceTest extends AbstractResourceTest {
         verify(roleService, never()).findDefaultRoleByScopes(RoleScope.APPLICATION);
         verify(membershipService, times(1))
             .addRoleToMemberOnReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
                 new MembershipService.MembershipReference(MembershipReferenceType.GROUP, GROUP_ID),
                 new MembershipService.MembershipMember(USERNAME, null, MembershipMemberType.USER),
                 new MembershipService.MembershipRole(RoleScope.API, "CUSTOM_API")
@@ -107,6 +119,8 @@ public class GroupMembersResourceTest extends AbstractResourceTest {
 
         verify(membershipService, times(1))
             .addRoleToMemberOnReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
                 new MembershipService.MembershipReference(MembershipReferenceType.GROUP, GROUP_ID),
                 new MembershipService.MembershipMember(USERNAME, null, MembershipMemberType.USER),
                 new MembershipService.MembershipRole(RoleScope.APPLICATION, "CUSTOM_APP")
@@ -116,7 +130,7 @@ public class GroupMembersResourceTest extends AbstractResourceTest {
     //UPDATE
     private void initUPDATEmock() {
         reset(roleService, groupService, membershipService);
-        when(groupService.findById(GROUP_ID)).thenReturn(mock(GroupEntity.class));
+        when(groupService.findById(GraviteeContext.getCurrentEnvironment(), GROUP_ID)).thenReturn(mock(GroupEntity.class));
 
         RoleEntity customApiRole = new RoleEntity();
         customApiRole.setId("API_CUSTOM_API");
@@ -143,7 +157,14 @@ public class GroupMembersResourceTest extends AbstractResourceTest {
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
         verify(roleService, never()).findDefaultRoleByScopes(RoleScope.API);
         verify(roleService, never()).findDefaultRoleByScopes(RoleScope.APPLICATION);
-        verify(membershipService, never()).addRoleToMemberOnReference(any(), any(), any());
+        verify(membershipService, never())
+            .addRoleToMemberOnReference(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
+                any(),
+                any(),
+                any()
+            );
     }
 
     @Test
@@ -163,9 +184,18 @@ public class GroupMembersResourceTest extends AbstractResourceTest {
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
         verify(roleService, never()).findDefaultRoleByScopes(RoleScope.API);
         verify(roleService, never()).findDefaultRoleByScopes(RoleScope.APPLICATION);
-        verify(membershipService, times(1)).addRoleToMemberOnReference(any(), any(), any());
         verify(membershipService, times(1))
             .addRoleToMemberOnReference(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
+                any(),
+                any(),
+                any()
+            );
+        verify(membershipService, times(1))
+            .addRoleToMemberOnReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
                 new MembershipService.MembershipReference(MembershipReferenceType.GROUP, GROUP_ID),
                 new MembershipService.MembershipMember(USERNAME, null, MembershipMemberType.USER),
                 new MembershipService.MembershipRole(RoleScope.API, "CUSTOM_API")
@@ -189,9 +219,18 @@ public class GroupMembersResourceTest extends AbstractResourceTest {
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
         verify(roleService, never()).findDefaultRoleByScopes(RoleScope.API);
         verify(roleService, never()).findDefaultRoleByScopes(RoleScope.APPLICATION);
-        verify(membershipService, times(1)).addRoleToMemberOnReference(any(), any(), any());
         verify(membershipService, times(1))
             .addRoleToMemberOnReference(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
+                any(),
+                any(),
+                any()
+            );
+        verify(membershipService, times(1))
+            .addRoleToMemberOnReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
                 new MembershipService.MembershipReference(MembershipReferenceType.GROUP, GROUP_ID),
                 new MembershipService.MembershipMember(USERNAME, null, MembershipMemberType.USER),
                 new MembershipService.MembershipRole(RoleScope.APPLICATION, "CUSTOM_APP")
@@ -219,12 +258,16 @@ public class GroupMembersResourceTest extends AbstractResourceTest {
         verify(roleService, never()).findDefaultRoleByScopes(RoleScope.APPLICATION);
         verify(membershipService, times(1))
             .addRoleToMemberOnReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
                 new MembershipService.MembershipReference(MembershipReferenceType.GROUP, GROUP_ID),
                 new MembershipService.MembershipMember(USERNAME, null, MembershipMemberType.USER),
                 new MembershipService.MembershipRole(RoleScope.API, "CUSTOM_API")
             );
         verify(membershipService, times(1))
             .addRoleToMemberOnReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
                 new MembershipService.MembershipReference(MembershipReferenceType.GROUP, GROUP_ID),
                 new MembershipService.MembershipMember(USERNAME, null, MembershipMemberType.USER),
                 new MembershipService.MembershipRole(RoleScope.APPLICATION, "CUSTOM_APP")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/GroupsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/GroupsResourceTest.java
@@ -17,16 +17,14 @@ package io.gravitee.rest.api.management.rest.resource;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.reset;
 
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.model.GroupEntity;
 import io.gravitee.rest.api.model.NewGroupEntity;
-import io.gravitee.rest.api.model.configuration.identity.IdentityProviderEntity;
-import io.gravitee.rest.api.model.configuration.identity.IdentityProviderType;
-import io.gravitee.rest.api.model.configuration.identity.NewIdentityProviderEntity;
-import java.util.Collections;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
@@ -52,7 +50,7 @@ public class GroupsResourceTest extends AbstractResourceTest {
 
         GroupEntity createdGroup = new GroupEntity();
         createdGroup.setId("my-group-id");
-        doReturn(createdGroup).when(groupService).create(any());
+        doReturn(createdGroup).when(groupService).create(eq(GraviteeContext.getCurrentEnvironment()), any());
 
         final Response response = envTarget().request().post(Entity.json(newGroupEntity));
         assertEquals(HttpStatusCode.CREATED_201, response.getStatus());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PortalPagesResourceAnonymousTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PortalPagesResourceAnonymousTest.java
@@ -19,25 +19,15 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 
 import io.gravitee.rest.api.model.PageEntity;
-import io.gravitee.rest.api.model.PageEntity;
 import io.gravitee.rest.api.model.Visibility;
-import java.io.IOException;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.io.IOException;
 import java.security.Principal;
-import java.security.Principal;
-import java.util.Collections;
-import javax.annotation.Priority;
 import javax.annotation.Priority;
 import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
-import javax.ws.rs.container.ContainerRequestFilter;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.SecurityContext;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.Test;
 import org.junit.Test;
 
 /**
@@ -95,7 +85,7 @@ public class PortalPagesResourceAnonymousTest extends AbstractResourceTest {
         page.setPublished(true);
         page.setVisibility(Visibility.PUBLIC);
         doReturn(page).when(pageService).findById(any(), any());
-        doReturn(false).when(configService).portalLoginForced();
+        doReturn(false).when(configService).portalLoginForced(GraviteeContext.getCurrentEnvironment());
         //        final Response response = envTarget(PAGE_NAME).request().get();
         //
         //        assertNotNull("Response should be present", response);
@@ -108,7 +98,7 @@ public class PortalPagesResourceAnonymousTest extends AbstractResourceTest {
         page.setPublished(true);
         page.setVisibility(Visibility.PUBLIC);
         doReturn(page).when(pageService).findById(any(), any());
-        doReturn(true).when(configService).portalLoginForced();
+        doReturn(true).when(configService).portalLoginForced(GraviteeContext.getCurrentEnvironment());
         //        final Response response = envTarget(PAGE_NAME).request().get();
         //
         //        assertNotNull("Response should be present", response);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/RoleUsersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/RoleUsersResourceTest.java
@@ -17,10 +17,10 @@ package io.gravitee.rest.api.management.rest.resource;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.reset;
 
 import io.gravitee.common.http.HttpStatusCode;
-import io.gravitee.rest.api.management.rest.model.ApiMembership;
 import io.gravitee.rest.api.management.rest.model.RoleMembership;
 import io.gravitee.rest.api.model.MembershipReferenceType;
 import io.gravitee.rest.api.model.permissions.RoleScope;
@@ -70,7 +70,13 @@ public class RoleUsersResourceTest extends AbstractResourceTest {
 
         Mockito
             .verify(membershipService)
-            .addRoleToMemberOnReference(memberShipRefCaptor.capture(), memberShipUserCaptor.capture(), memberShipRoleCaptor.capture());
+            .addRoleToMemberOnReference(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
+                memberShipRefCaptor.capture(),
+                memberShipUserCaptor.capture(),
+                memberShipRoleCaptor.capture()
+            );
         assertEquals(GraviteeContext.getCurrentOrganization(), memberShipRefCaptor.getValue().getId());
         assertEquals(MembershipReferenceType.ORGANIZATION, memberShipRefCaptor.getValue().getType());
         assertEquals(ROLE, memberShipRoleCaptor.getValue().getName());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/auth/OAuth2AuthenticationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/auth/OAuth2AuthenticationResourceTest.java
@@ -44,6 +44,7 @@ import io.gravitee.rest.api.model.configuration.identity.RoleMappingEntity;
 import io.gravitee.rest.api.model.configuration.identity.SocialIdentityProviderEntity;
 import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.EmailRequiredException;
 import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
 import java.io.IOException;
@@ -480,10 +481,13 @@ public class OAuth2AuthenticationResourceTest extends AbstractResourceTest {
         mockUserCreation(identityProvider, userInfoBody, createdUser);
 
         //mock group search and association
-        when(groupService.findById("Example group")).thenReturn(mockGroupEntity("group_id_1", "Example group"));
-        when(groupService.findById("soft user")).thenReturn(mockGroupEntity("group_id_2", "soft user"));
-        when(groupService.findById("Others")).thenReturn(mockGroupEntity("group_id_3", "Others"));
-        when(groupService.findById("Api consumer")).thenReturn(mockGroupEntity("group_id_4", "Api consumer"));
+        when(groupService.findById(GraviteeContext.getCurrentEnvironment(), "Example group"))
+            .thenReturn(mockGroupEntity("group_id_1", "Example group"));
+        when(groupService.findById(GraviteeContext.getCurrentEnvironment(), "soft user"))
+            .thenReturn(mockGroupEntity("group_id_2", "soft user"));
+        when(groupService.findById(GraviteeContext.getCurrentEnvironment(), "Others")).thenReturn(mockGroupEntity("group_id_3", "Others"));
+        when(groupService.findById(GraviteeContext.getCurrentEnvironment(), "Api consumer"))
+            .thenReturn(mockGroupEntity("group_id_4", "Api consumer"));
 
         // mock role to add from roleMapping
         doAnswer(
@@ -576,6 +580,8 @@ public class OAuth2AuthenticationResourceTest extends AbstractResourceTest {
         //verify group creations
         verify(membershipService, times(0))
             .addRoleToMemberOnReference(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
                 any(MembershipService.MembershipReference.class),
                 any(MembershipService.MembershipMember.class),
                 any(MembershipService.MembershipRole.class)
@@ -609,10 +615,10 @@ public class OAuth2AuthenticationResourceTest extends AbstractResourceTest {
             .thenThrow(new UserNotFoundException("janedoe@example.com"));
 
         //mock group search and association
-        when(groupService.findByName("Example group")).thenReturn(Collections.emptyList());
-        when(groupService.findByName("soft user")).thenReturn(Collections.emptyList());
-        when(groupService.findByName("Others")).thenReturn(Collections.emptyList());
-        when(groupService.findByName("Api consumer")).thenReturn(Collections.emptyList());
+        when(groupService.findByName(GraviteeContext.getCurrentEnvironment(), "Example group")).thenReturn(Collections.emptyList());
+        when(groupService.findByName(GraviteeContext.getCurrentEnvironment(), "soft user")).thenReturn(Collections.emptyList());
+        when(groupService.findByName(GraviteeContext.getCurrentEnvironment(), "Others")).thenReturn(Collections.emptyList());
+        when(groupService.findByName(GraviteeContext.getCurrentEnvironment(), "Api consumer")).thenReturn(Collections.emptyList());
 
         NewExternalUserEntity newExternalUserEntity = mockNewExternalUserEntity();
         UserEntity createdUser = mockUserEntity();
@@ -636,6 +642,8 @@ public class OAuth2AuthenticationResourceTest extends AbstractResourceTest {
         //verify group creations
         verify(membershipService, times(0))
             .addRoleToMemberOnReference(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
                 any(MembershipService.MembershipReference.class),
                 any(MembershipService.MembershipMember.class),
                 any(MembershipService.MembershipRole.class)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/filter/PermissionsFilter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/filter/PermissionsFilter.java
@@ -100,7 +100,11 @@ public class PermissionsFilter implements ContainerRequestFilter {
     }
 
     protected void filter(boolean portalLoginRequired) {
-        if (portalLoginRequired && configService.portalLoginForced() && securityContext.getUserPrincipal() == null) {
+        if (
+            portalLoginRequired &&
+            configService.portalLoginForced(GraviteeContext.getCurrentEnvironment()) &&
+            securityContext.getUserPrincipal() == null
+        ) {
             sendSecurityError();
         }
     }
@@ -111,6 +115,7 @@ public class PermissionsFilter implements ContainerRequestFilter {
             case ORGANIZATION:
                 memberPermissions =
                     membershipService.getUserMemberPermissions(
+                        GraviteeContext.getCurrentEnvironment(),
                         MembershipReferenceType.ORGANIZATION,
                         GraviteeContext.getCurrentOrganization(),
                         username
@@ -119,6 +124,7 @@ public class PermissionsFilter implements ContainerRequestFilter {
             case ENVIRONMENT:
                 memberPermissions =
                     membershipService.getUserMemberPermissions(
+                        GraviteeContext.getCurrentEnvironment(),
                         MembershipReferenceType.ENVIRONMENT,
                         GraviteeContext.getCurrentEnvironment(),
                         username
@@ -126,11 +132,12 @@ public class PermissionsFilter implements ContainerRequestFilter {
                 return roleService.hasPermission(memberPermissions, permission.value().getPermission(), permission.acls());
             case APPLICATION:
                 ApplicationEntity application = getApplication(requestContext);
-                memberPermissions = membershipService.getUserMemberPermissions(application, username);
+                memberPermissions =
+                    membershipService.getUserMemberPermissions(GraviteeContext.getCurrentEnvironment(), application, username);
                 return roleService.hasPermission(memberPermissions, permission.value().getPermission(), permission.acls());
             case API:
                 ApiEntity api = getApi(requestContext);
-                memberPermissions = membershipService.getUserMemberPermissions(api, username);
+                memberPermissions = membershipService.getUserMemberPermissions(GraviteeContext.getCurrentEnvironment(), api, username);
                 return roleService.hasPermission(memberPermissions, permission.value().getPermission(), permission.acls());
             default:
                 sendSecurityError();
@@ -151,7 +158,7 @@ public class PermissionsFilter implements ContainerRequestFilter {
         if (applicationId == null) {
             return null;
         }
-        return applicationService.findById(applicationId);
+        return applicationService.findById(GraviteeContext.getCurrentEnvironment(), applicationId);
     }
 
     private String getId(String key, ContainerRequestContext requestContext) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApiMapper.java
@@ -31,6 +31,7 @@ import io.gravitee.rest.api.portal.rest.model.User;
 import io.gravitee.rest.api.service.CategoryService;
 import io.gravitee.rest.api.service.ParameterService;
 import io.gravitee.rest.api.service.RatingService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.CategoryNotFoundException;
 import java.math.BigDecimal;
 import java.time.ZoneOffset;
@@ -119,7 +120,7 @@ public class ApiMapper {
                     .filter(
                         categoryId -> {
                             try {
-                                categoryService.findNotHiddenById(categoryId);
+                                categoryService.findNotHiddenById(categoryId, GraviteeContext.getCurrentEnvironment());
                                 return true;
                             } catch (CategoryNotFoundException v) {
                                 return false;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationMapper.java
@@ -29,6 +29,7 @@ import io.gravitee.rest.api.portal.rest.model.Group;
 import io.gravitee.rest.api.portal.rest.model.User;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
@@ -64,7 +65,7 @@ public class ApplicationMapper {
         if (groupEntities != null && !groupEntities.isEmpty()) {
             List<Group> groups = groupEntities
                 .stream()
-                .map(groupService::findById)
+                .map(groupId -> groupService.findById(GraviteeContext.getCurrentEnvironment(), groupId))
                 .map(groupEntity -> new Group().id(groupEntity.getId()).name(groupEntity.getName()))
                 .collect(Collectors.toList());
             application.setGroups(groups);
@@ -119,7 +120,7 @@ public class ApplicationMapper {
         if (groupEntities != null && !groupEntities.isEmpty()) {
             List<Group> groups = groupEntities
                 .stream()
-                .map(groupService::findById)
+                .map(groupId -> groupService.findById(GraviteeContext.getCurrentEnvironment(), groupId))
                 .map(groupEntity -> new Group().id(groupEntity.getId()).name(groupEntity.getName()))
                 .collect(Collectors.toList());
             application.setGroups(groups);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiPageResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiPageResource.java
@@ -25,6 +25,7 @@ import io.gravitee.rest.api.portal.rest.utils.HttpHeadersUtil;
 import io.gravitee.rest.api.portal.rest.utils.PortalApiLinkHelper;
 import io.gravitee.rest.api.service.AccessControlService;
 import io.gravitee.rest.api.service.PageService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
 import io.gravitee.rest.api.service.exceptions.UnauthorizedAccessException;
 import java.util.Collections;
@@ -66,7 +67,7 @@ public class ApiPageResource extends AbstractResource {
 
             PageEntity pageEntity = pageService.findById(pageId, acceptedLocale);
 
-            if (accessControlService.canAccessPageFromPortal(apiId, pageEntity)) {
+            if (accessControlService.canAccessPageFromPortal(GraviteeContext.getCurrentEnvironment(), apiId, pageEntity)) {
                 pageService.transformSwagger(pageEntity, apiId);
 
                 if (!isAuthenticated() && pageEntity.getMetadata() != null) {
@@ -102,7 +103,7 @@ public class ApiPageResource extends AbstractResource {
         apiQuery.setIds(Collections.singletonList(apiId));
         if (accessControlService.canAccessApiFromPortal(apiId)) {
             PageEntity pageEntity = pageService.findById(pageId, null);
-            if (accessControlService.canAccessPageFromPortal(apiId, pageEntity)) {
+            if (accessControlService.canAccessPageFromPortal(GraviteeContext.getCurrentEnvironment(), apiId, pageEntity)) {
                 pageService.transformSwagger(pageEntity, apiId);
                 return Response.ok(pageEntity.getContent()).build();
             } else {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiPagesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiPagesResource.java
@@ -80,7 +80,7 @@ public class ApiPagesResource extends AbstractResource {
                     GraviteeContext.getCurrentEnvironment()
                 )
                 .stream()
-                .filter(page -> accessControlService.canAccessPageFromPortal(apiId, page))
+                .filter(page -> accessControlService.canAccessPageFromPortal(GraviteeContext.getCurrentEnvironment(), apiId, page))
                 .map(pageMapper::convert)
                 .map(page -> this.addPageLink(apiId, page));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiResource.java
@@ -92,7 +92,7 @@ public class ApiResource extends AbstractResource {
                 List<Page> pages = pageService
                     .search(new PageQuery.Builder().api(apiId).published(true).build(), GraviteeContext.getCurrentEnvironment())
                     .stream()
-                    .filter(page -> accessControlService.canAccessPageFromPortal(page))
+                    .filter(page -> accessControlService.canAccessPageFromPortal(GraviteeContext.getCurrentEnvironment(), page))
                     .map(pageMapper::convert)
                     .collect(Collectors.toList());
                 api.setPages(pages);
@@ -223,7 +223,7 @@ public class ApiResource extends AbstractResource {
                 GraviteeContext.getCurrentEnvironment()
             )
             .stream()
-            .filter(accessControlService::canAccessPageFromPortal)
+            .filter(pageEntity -> accessControlService.canAccessPageFromPortal(GraviteeContext.getCurrentEnvironment(), pageEntity))
             .filter(p -> !PageType.FOLDER.name().equals(p.getType()) && !PageType.MARKDOWN_TEMPLATE.name().equals(p.getType()))
             .map(
                 p -> {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApisResource.java
@@ -27,6 +27,7 @@ import io.gravitee.rest.api.portal.rest.resource.param.PaginationParam;
 import io.gravitee.rest.api.portal.rest.security.RequirePortalAuth;
 import io.gravitee.rest.api.portal.rest.utils.PortalApiLinkHelper;
 import io.gravitee.rest.api.service.CategoryService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.filtering.FilteringService;
 import java.time.OffsetDateTime;
 import java.util.*;
@@ -89,7 +90,8 @@ public class ApisResource extends AbstractResource {
             if (isCategoryMode) {
                 // If apis are searched in a category, looks for the category highlighted API (HL API) and if this HL API is in the searchResult.
                 // If it is, then the HL API becomes the promoted API
-                String highlightedApiId = this.categoryService.findById(categoryFilter).getHighlightApi();
+                String highlightedApiId =
+                    this.categoryService.findById(categoryFilter, GraviteeContext.getCurrentEnvironment()).getHighlightApi();
                 if (highlightedApiId != null) {
                     Optional<ApiEntity> highlightedApiInResult = filteredApisList
                         .stream()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationAlertsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationAlertsResource.java
@@ -29,6 +29,7 @@ import io.gravitee.rest.api.portal.rest.model.AlertInput;
 import io.gravitee.rest.api.portal.rest.security.Permission;
 import io.gravitee.rest.api.portal.rest.security.Permissions;
 import io.gravitee.rest.api.service.ApplicationAlertService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApplicationAlertMaximumException;
 import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
 import java.util.Comparator;
@@ -93,7 +94,11 @@ public class ApplicationAlertsResource extends AbstractResource {
 
         final NewAlertTriggerEntity newAlertTriggerEntity = alertMapper.convert(alertInput);
 
-        final AlertTriggerEntity alert = applicationAlertService.create(applicationId, newAlertTriggerEntity);
+        final AlertTriggerEntity alert = applicationAlertService.create(
+            GraviteeContext.getCurrentEnvironment(),
+            applicationId,
+            newAlertTriggerEntity
+        );
 
         return Response.created(this.getLocationHeader(alert.getId())).entity(alertMapper.convert(alert)).build();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationAnalyticsResource.java
@@ -31,6 +31,7 @@ import io.gravitee.rest.api.portal.rest.security.Permission;
 import io.gravitee.rest.api.portal.rest.security.Permissions;
 import io.gravitee.rest.api.service.AnalyticsService;
 import io.gravitee.rest.api.service.ApplicationService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -64,7 +65,7 @@ public class ApplicationAnalyticsResource extends AbstractResource {
     @Permissions({ @Permission(value = RolePermission.APPLICATION_ANALYTICS, acls = RolePermissionAction.READ) })
     public Response hits(@PathParam("applicationId") String applicationId, @BeanParam AnalyticsParam analyticsParam) {
         //Does application exists ?
-        applicationService.findById(applicationId);
+        applicationService.findById(GraviteeContext.getCurrentEnvironment(), applicationId);
 
         analyticsParam.validate();
 
@@ -141,7 +142,7 @@ public class ApplicationAnalyticsResource extends AbstractResource {
 
             query.setAggregations(aggregationList);
         }
-        return analyticsService.execute(query);
+        return analyticsService.execute(GraviteeContext.getCurrentOrganization(), query);
     }
 
     private Analytics executeGroupBy(String application, AnalyticsParam analyticsParam) {
@@ -168,6 +169,6 @@ public class ApplicationAnalyticsResource extends AbstractResource {
 
             query.setGroups(rangeMap);
         }
-        return analyticsService.execute(query);
+        return analyticsService.execute(GraviteeContext.getCurrentOrganization(), query);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationLogsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationLogsResource.java
@@ -32,6 +32,7 @@ import io.gravitee.rest.api.portal.rest.security.Permission;
 import io.gravitee.rest.api.portal.rest.security.Permissions;
 import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.LogsService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -65,7 +66,7 @@ public class ApplicationLogsResource extends AbstractResource {
         @BeanParam LogsParam logsParam
     ) {
         //Does application exists ?
-        applicationService.findById(applicationId);
+        applicationService.findById(GraviteeContext.getCurrentEnvironment(), applicationId);
 
         final SearchLogResponse<ApplicationRequestItem> searchLogResponse = getSearchLogResponse(applicationId, paginationParam, logsParam);
 
@@ -113,7 +114,7 @@ public class ApplicationLogsResource extends AbstractResource {
         @QueryParam("timestamp") Long timestamp
     ) {
         //Does application exists ?
-        applicationService.findById(applicationId);
+        applicationService.findById(GraviteeContext.getCurrentEnvironment(), applicationId);
 
         ApplicationRequest applicationLogs = logsService.findApplicationLog(logId, timestamp);
 
@@ -129,7 +130,7 @@ public class ApplicationLogsResource extends AbstractResource {
         @BeanParam LogsParam logsParam
     ) {
         //Does application exists ?
-        applicationService.findById(applicationId);
+        applicationService.findById(GraviteeContext.getCurrentEnvironment(), applicationId);
         final SearchLogResponse<ApplicationRequestItem> searchLogResponse = getSearchLogResponse(applicationId, paginationParam, logsParam);
         return Response
             .ok(logsService.exportAsCsv(searchLogResponse))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationMetadataResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationMetadataResource.java
@@ -28,6 +28,7 @@ import io.gravitee.rest.api.portal.rest.resource.param.PaginationParam;
 import io.gravitee.rest.api.portal.rest.security.Permission;
 import io.gravitee.rest.api.portal.rest.security.Permissions;
 import io.gravitee.rest.api.service.ApplicationMetadataService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -74,7 +75,10 @@ public class ApplicationMetadataResource extends AbstractResource {
         // prevent creation of a metadata on an another APPLICATION
         NewApplicationMetadataEntity newApplicationMetadataEntity = this.referenceMetadataMapper.convert(metadata, applicationId);
 
-        final ApplicationMetadataEntity applicationMetadataEntity = metadataService.create(newApplicationMetadataEntity);
+        final ApplicationMetadataEntity applicationMetadataEntity = metadataService.create(
+            GraviteeContext.getCurrentEnvironment(),
+            newApplicationMetadataEntity
+        );
         return Response
             .created(this.getLocationHeader(applicationMetadataEntity.getKey()))
             .entity(this.referenceMetadataMapper.convert(applicationMetadataEntity))
@@ -106,7 +110,13 @@ public class ApplicationMetadataResource extends AbstractResource {
         UpdateApplicationMetadataEntity updateApplicationMetadataEntity =
             this.referenceMetadataMapper.convert(metadata, applicationId, metadataId);
 
-        return Response.ok(this.referenceMetadataMapper.convert(metadataService.update(updateApplicationMetadataEntity))).build();
+        return Response
+            .ok(
+                this.referenceMetadataMapper.convert(
+                        metadataService.update(GraviteeContext.getCurrentEnvironment(), updateApplicationMetadataEntity)
+                    )
+            )
+            .build();
     }
 
     @DELETE

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationNotificationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationNotificationResource.java
@@ -26,6 +26,7 @@ import io.gravitee.rest.api.portal.rest.security.Permissions;
 import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.GenericNotificationConfigService;
 import io.gravitee.rest.api.service.PortalNotificationConfigService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.HashSet;
 import java.util.Set;
 import javax.validation.constraints.NotNull;
@@ -53,7 +54,7 @@ public class ApplicationNotificationResource extends AbstractResource {
     @Permissions({ @Permission(value = RolePermission.APPLICATION_NOTIFICATION, acls = RolePermissionAction.READ) })
     public Response get(@PathParam("applicationId") String applicationId) {
         //Does application exists ?
-        applicationService.findById(applicationId);
+        applicationService.findById(GraviteeContext.getCurrentEnvironment(), applicationId);
 
         final PortalNotificationConfigEntity portalConfig = portalNotificationConfigService.findById(
             getAuthenticatedUser(),
@@ -78,7 +79,7 @@ public class ApplicationNotificationResource extends AbstractResource {
         @NotNull(message = "Input must not be null.") NotificationInput notification
     ) {
         //Does application exists ?
-        applicationService.findById(applicationId);
+        applicationService.findById(GraviteeContext.getCurrentEnvironment(), applicationId);
 
         final PortalNotificationConfigEntity portalConfig = portalNotificationConfigService.findById(
             getAuthenticatedUser(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationResource.java
@@ -31,6 +31,7 @@ import io.gravitee.rest.api.portal.rest.security.Permission;
 import io.gravitee.rest.api.portal.rest.security.Permissions;
 import io.gravitee.rest.api.portal.rest.utils.PortalApiLinkHelper;
 import io.gravitee.rest.api.service.ApplicationService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.configuration.application.ApplicationTypeService;
 import java.util.Date;
 import javax.inject.Inject;
@@ -72,7 +73,10 @@ public class ApplicationResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Permissions({ @Permission(value = RolePermission.APPLICATION_DEFINITION, acls = RolePermissionAction.READ) })
     public Response getApplicationByApplicationId(@PathParam("applicationId") String applicationId) {
-        Application application = applicationMapper.convert(applicationService.findById(applicationId), uriInfo);
+        Application application = applicationMapper.convert(
+            applicationService.findById(GraviteeContext.getCurrentEnvironment(), applicationId),
+            uriInfo
+        );
 
         return Response.ok(addApplicationLinks(application)).build();
     }
@@ -82,7 +86,7 @@ public class ApplicationResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Permissions({ @Permission(value = RolePermission.APPLICATION_DEFINITION, acls = RolePermissionAction.READ) })
     public Response getApplicationType(@PathParam("applicationId") String applicationId) {
-        ApplicationEntity applicationEntity = applicationService.findById(applicationId);
+        ApplicationEntity applicationEntity = applicationService.findById(GraviteeContext.getCurrentEnvironment(), applicationId);
         ApplicationTypeEntity applicationType = applicationTypeService.getApplicationType(applicationEntity.getType());
         return Response.ok(applicationType).build();
     }
@@ -99,7 +103,7 @@ public class ApplicationResource extends AbstractResource {
             throw new BadRequestException("'applicationId' is not the same that the application in payload");
         }
 
-        ApplicationEntity appEntity = applicationService.findById(applicationId);
+        ApplicationEntity appEntity = applicationService.findById(GraviteeContext.getCurrentEnvironment(), applicationId);
 
         UpdateApplicationEntity updateApplicationEntity = new UpdateApplicationEntity();
         updateApplicationEntity.setDescription(application.getDescription());
@@ -126,7 +130,15 @@ public class ApplicationResource extends AbstractResource {
             updateApplicationEntity.setSettings(settings);
         }
 
-        Application updatedApp = applicationMapper.convert(applicationService.update(applicationId, updateApplicationEntity), uriInfo);
+        Application updatedApp = applicationMapper.convert(
+            applicationService.update(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
+                applicationId,
+                updateApplicationEntity
+            ),
+            uriInfo
+        );
         return Response
             .ok(addApplicationLinks(updatedApp))
             .tag(Long.toString(updatedApp.getUpdatedAt().toInstant().toEpochMilli()))
@@ -139,8 +151,8 @@ public class ApplicationResource extends AbstractResource {
     @Produces({ MediaType.WILDCARD, MediaType.APPLICATION_JSON })
     @Permissions({ @Permission(value = RolePermission.APPLICATION_DEFINITION, acls = RolePermissionAction.READ) })
     public Response getPictureByApplicationId(@Context Request request, @PathParam("applicationId") String applicationId) {
-        applicationService.findById(applicationId);
-        InlinePictureEntity image = applicationService.getPicture(applicationId);
+        applicationService.findById(GraviteeContext.getCurrentEnvironment(), applicationId);
+        InlinePictureEntity image = applicationService.getPicture(GraviteeContext.getCurrentEnvironment(), applicationId);
         return createPictureResponse(request, image);
     }
 
@@ -149,8 +161,8 @@ public class ApplicationResource extends AbstractResource {
     @Produces({ MediaType.WILDCARD, MediaType.APPLICATION_JSON })
     @Permissions({ @Permission(value = RolePermission.APPLICATION_DEFINITION, acls = RolePermissionAction.READ) })
     public Response getBackgroundByApplicationId(@Context Request request, @PathParam("applicationId") String applicationId) {
-        applicationService.findById(applicationId);
-        InlinePictureEntity image = applicationService.getBackground(applicationId);
+        applicationService.findById(GraviteeContext.getCurrentEnvironment(), applicationId);
+        InlinePictureEntity image = applicationService.getBackground(GraviteeContext.getCurrentEnvironment(), applicationId);
         return createPictureResponse(request, image);
     }
 
@@ -160,7 +172,14 @@ public class ApplicationResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Permissions({ @Permission(value = RolePermission.APPLICATION_DEFINITION, acls = RolePermissionAction.UPDATE) })
     public Response renewApplicationSecret(@PathParam("applicationId") String applicationId) {
-        Application renwedApplication = applicationMapper.convert(applicationService.renewClientSecret(applicationId), uriInfo);
+        Application renwedApplication = applicationMapper.convert(
+            applicationService.renewClientSecret(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
+                applicationId
+            ),
+            uriInfo
+        );
 
         return Response.ok(addApplicationLinks(renwedApplication)).build();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationSubscribersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationSubscribersResource.java
@@ -29,6 +29,7 @@ import io.gravitee.rest.api.portal.rest.resource.param.PaginationParam;
 import io.gravitee.rest.api.service.AnalyticsService;
 import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.SubscriptionService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -64,7 +65,11 @@ public class ApplicationSubscribersResource extends AbstractResource {
         @QueryParam("statuses") List<SubscriptionStatus> statuses
     ) {
         String currentUser = getAuthenticatedUserOrNull();
-        Collection<ApplicationListItem> userApplications = applicationService.findByUser(currentUser);
+        Collection<ApplicationListItem> userApplications = applicationService.findByUser(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
+            currentUser
+        );
         Optional<ApplicationListItem> optionalApplication = userApplications
             .stream()
             .filter(a -> a.getId().equals(applicationId))
@@ -127,7 +132,7 @@ public class ApplicationSubscribersResource extends AbstractResource {
         query.setRootField("application");
         query.setRootIdentifier(applicationId);
 
-        TopHitsAnalytics analytics = analyticsService.execute(query);
+        TopHitsAnalytics analytics = analyticsService.execute(GraviteeContext.getCurrentOrganization(), query);
         if (analytics != null) {
             return analytics.getValues();
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationsResource.java
@@ -32,6 +32,7 @@ import io.gravitee.rest.api.portal.rest.resource.param.PaginationParam;
 import io.gravitee.rest.api.portal.rest.security.Permission;
 import io.gravitee.rest.api.portal.rest.security.Permissions;
 import io.gravitee.rest.api.service.ApplicationService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.filtering.FilteringService;
 import io.gravitee.rest.api.service.notification.ApplicationHook;
 import io.gravitee.rest.api.service.notification.Hook;
@@ -102,7 +103,11 @@ public class ApplicationsResource extends AbstractResource {
         }
         newApplicationEntity.setSettings(newApplicationEntitySettings);
 
-        ApplicationEntity createdApplicationEntity = applicationService.create(newApplicationEntity, getAuthenticatedUser());
+        ApplicationEntity createdApplicationEntity = applicationService.create(
+            GraviteeContext.getCurrentEnvironment(),
+            newApplicationEntity,
+            getAuthenticatedUser()
+        );
 
         return Response
             .created(this.getLocationHeader(createdApplicationEntity.getId()))
@@ -123,7 +128,9 @@ public class ApplicationsResource extends AbstractResource {
         @QueryParam("forSubscription") final boolean forSubscription,
         @QueryParam("order") @DefaultValue("name") final String order
     ) {
-        Stream<ApplicationListItem> applicationStream = applicationService.findByUser(getAuthenticatedUser()).stream();
+        Stream<ApplicationListItem> applicationStream = applicationService
+            .findByUser(GraviteeContext.getCurrentOrganization(), GraviteeContext.getCurrentEnvironment(), getAuthenticatedUser())
+            .stream();
 
         if (forSubscription) {
             applicationStream =

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/CategoriesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/CategoriesResource.java
@@ -23,6 +23,7 @@ import io.gravitee.rest.api.portal.rest.model.Category;
 import io.gravitee.rest.api.portal.rest.resource.param.PaginationParam;
 import io.gravitee.rest.api.portal.rest.security.RequirePortalAuth;
 import io.gravitee.rest.api.service.CategoryService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
@@ -59,7 +60,7 @@ public class CategoriesResource extends AbstractResource {
         Set<ApiEntity> apis = apiService.findPublishedByUser(getAuthenticatedUserOrNull());
 
         List<Category> categoriesList = categoryService
-            .findAll()
+            .findAll(GraviteeContext.getCurrentEnvironment())
             .stream()
             .filter(c -> !c.isHidden())
             .sorted(Comparator.comparingInt(CategoryEntity::getOrder))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/CategoryResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/CategoryResource.java
@@ -23,6 +23,7 @@ import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.portal.rest.mapper.CategoryMapper;
 import io.gravitee.rest.api.portal.rest.security.RequirePortalAuth;
 import io.gravitee.rest.api.service.CategoryService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.Set;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -49,7 +50,7 @@ public class CategoryResource extends AbstractResource {
     @Produces(APPLICATION_JSON)
     @RequirePortalAuth
     public Response get(@PathParam("categoryId") String categoryId) {
-        CategoryEntity category = categoryService.findNotHiddenById(categoryId);
+        CategoryEntity category = categoryService.findNotHiddenById(categoryId, GraviteeContext.getCurrentEnvironment());
 
         // FIXME: retrieve all the apis of the user can be heavy because it involves a lot of data fetching. Find a way to just retrieve only necessary data.
         Set<ApiEntity> apis = apiService.findPublishedByUser(getAuthenticatedUserOrNull());
@@ -62,16 +63,16 @@ public class CategoryResource extends AbstractResource {
     @Path("picture")
     @RequirePortalAuth
     public Response picture(@Context Request request, @PathParam("categoryId") String categoryId) {
-        categoryService.findNotHiddenById(categoryId);
-        InlinePictureEntity image = categoryService.getPicture(categoryId);
+        categoryService.findNotHiddenById(categoryId, GraviteeContext.getCurrentEnvironment());
+        InlinePictureEntity image = categoryService.getPicture(GraviteeContext.getCurrentEnvironment(), categoryId);
         return createPictureResponse(request, image);
     }
 
     @GET
     @Path("background")
     public Response background(@Context Request request, @PathParam("categoryId") String categoryId) {
-        categoryService.findNotHiddenById(categoryId);
-        InlinePictureEntity image = categoryService.getBackground(categoryId);
+        categoryService.findNotHiddenById(categoryId, GraviteeContext.getCurrentEnvironment());
+        InlinePictureEntity image = categoryService.getBackground(GraviteeContext.getCurrentEnvironment(), categoryId);
         return createPictureResponse(request, image);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ConfigurationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ConfigurationResource.java
@@ -78,7 +78,14 @@ public class ConfigurationResource extends AbstractResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Response getPortalConfiguration() {
-        return Response.ok(configMapper.convert(configService.getPortalSettings(), configService.getConsoleSettings())).build();
+        return Response
+            .ok(
+                configMapper.convert(
+                    configService.getPortalSettings(GraviteeContext.getCurrentEnvironment()),
+                    configService.getConsoleSettings(GraviteeContext.getCurrentOrganization())
+                )
+            )
+            .build();
     }
 
     @GET
@@ -195,7 +202,7 @@ public class ConfigurationResource extends AbstractResource {
                     if (PageType.FOLDER.name().equals(p.getType()) || PageType.MARKDOWN_TEMPLATE.name().equals(p.getType())) {
                         return false;
                     }
-                    return accessControlService.canAccessPageFromPortal(p);
+                    return accessControlService.canAccessPageFromPortal(GraviteeContext.getCurrentEnvironment(), p);
                 }
             )
             .map(ConfigurationResource::convertToLink)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/GroupsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/GroupsResource.java
@@ -29,6 +29,7 @@ import io.gravitee.rest.api.portal.rest.resource.param.PaginationParam;
 import io.gravitee.rest.api.portal.rest.security.Permission;
 import io.gravitee.rest.api.portal.rest.security.Permissions;
 import io.gravitee.rest.api.service.GroupService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -57,7 +58,7 @@ public class GroupsResource extends AbstractResource {
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_GROUP, acls = RolePermissionAction.READ) })
     public Response findAll(@BeanParam PaginationParam paginationParam) {
         List<Group> groups = groupService
-            .findAll()
+            .findAll(GraviteeContext.getCurrentEnvironment())
             .stream()
             .map(group -> new Group().id(group.getId()).name(group.getName()))
             .collect(Collectors.toList());
@@ -70,7 +71,7 @@ public class GroupsResource extends AbstractResource {
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_GROUP, acls = RolePermissionAction.READ) })
     public Response getMembersByGroupId(@PathParam("groupId") String groupId, @BeanParam PaginationParam paginationParam) {
         //check that group exists
-        groupService.findById(groupId);
+        groupService.findById(GraviteeContext.getCurrentEnvironment(), groupId);
 
         List<Member> groupsMembers = membershipService
             .getMembersByReference(MembershipReferenceType.GROUP, groupId)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PageResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PageResource.java
@@ -24,6 +24,7 @@ import io.gravitee.rest.api.portal.rest.utils.HttpHeadersUtil;
 import io.gravitee.rest.api.portal.rest.utils.PortalApiLinkHelper;
 import io.gravitee.rest.api.service.AccessControlService;
 import io.gravitee.rest.api.service.PageService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.UnauthorizedAccessException;
 import java.util.List;
 import javax.inject.Inject;
@@ -58,7 +59,7 @@ public class PageResource extends AbstractResource {
         final String acceptedLocale = HttpHeadersUtil.getFirstAcceptedLocaleName(acceptLang);
         PageEntity pageEntity = pageService.findById(pageId, acceptedLocale);
 
-        if (accessControlService.canAccessPageFromPortal(pageEntity)) {
+        if (accessControlService.canAccessPageFromPortal(GraviteeContext.getCurrentEnvironment(), pageEntity)) {
             if (!isAuthenticated() && pageEntity.getMetadata() != null) {
                 pageEntity.getMetadata().clear();
             }
@@ -89,7 +90,7 @@ public class PageResource extends AbstractResource {
     public Response getPageContentByPageId(@PathParam("pageId") String pageId) {
         PageEntity pageEntity = pageService.findById(pageId, null);
 
-        if (accessControlService.canAccessPageFromPortal(pageEntity)) {
+        if (accessControlService.canAccessPageFromPortal(GraviteeContext.getCurrentEnvironment(), pageEntity)) {
             pageService.transformWithTemplate(pageEntity, null);
             return Response.ok(pageEntity.getContent()).build();
         } else {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PagesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PagesResource.java
@@ -73,7 +73,7 @@ public class PagesResource extends AbstractResource {
                 GraviteeContext.getCurrentEnvironment()
             )
             .stream()
-            .filter(accessControlService::canAccessPageFromPortal)
+            .filter(pageEntity -> accessControlService.canAccessPageFromPortal(GraviteeContext.getCurrentEnvironment(), pageEntity))
             .map(pageMapper::convert)
             .map(this::addPageLink);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PermissionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PermissionsResource.java
@@ -23,6 +23,7 @@ import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
 import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
 import java.util.Collections;
@@ -64,21 +65,24 @@ public class PermissionsResource extends AbstractResource {
                 .findFirst()
                 .orElseThrow(() -> new ApiNotFoundException(apiId));
             Map<String, char[]> permissions;
-            permissions = membershipService.getUserMemberPermissions(apiEntity, userId);
+            permissions = membershipService.getUserMemberPermissions(GraviteeContext.getCurrentEnvironment(), apiEntity, userId);
 
             return Response.ok(permissions).build();
         } else if (applicationId != null) {
             ApplicationListItem applicationListItem = applicationService
-                .findByUser(getAuthenticatedUser())
+                .findByUser(GraviteeContext.getCurrentOrganization(), GraviteeContext.getCurrentEnvironment(), getAuthenticatedUser())
                 .stream()
                 .filter(a -> a.getId().equals(applicationId))
                 .findFirst()
                 .orElseThrow(() -> new ApplicationNotFoundException(applicationId));
 
-            ApplicationEntity application = applicationService.findById(applicationListItem.getId());
+            ApplicationEntity application = applicationService.findById(
+                GraviteeContext.getCurrentEnvironment(),
+                applicationListItem.getId()
+            );
 
             Map<String, char[]> permissions;
-            permissions = membershipService.getUserMemberPermissions(application, userId);
+            permissions = membershipService.getUserMemberPermissions(GraviteeContext.getCurrentEnvironment(), application, userId);
 
             return Response.ok(permissions).build();
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResource.java
@@ -37,6 +37,7 @@ import io.gravitee.rest.api.portal.rest.model.SubscriptionInput;
 import io.gravitee.rest.api.portal.rest.resource.param.PaginationParam;
 import io.gravitee.rest.api.portal.rest.utils.PortalApiLinkHelper;
 import io.gravitee.rest.api.service.*;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -131,7 +132,11 @@ public class SubscriptionsResource extends AbstractResource {
 
         final Map<String, Map<String, Object>> metadata = new HashMap<>();
         if (applicationId == null) {
-            final Set<ApplicationListItem> applications = applicationService.findByUser(getAuthenticatedUser());
+            final Set<ApplicationListItem> applications = applicationService.findByUser(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
+                getAuthenticatedUser()
+            );
             if (applications == null || applications.isEmpty()) {
                 return createListResponse(emptyList(), paginationParam, !withoutPagination);
             }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/UserResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/UserResource.java
@@ -28,6 +28,7 @@ import io.gravitee.rest.api.portal.rest.model.UserInput;
 import io.gravitee.rest.api.security.cookies.CookieGenerator;
 import io.gravitee.rest.api.service.ConfigService;
 import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.UnauthorizedAccessException;
 import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
 import java.net.URI;
@@ -75,7 +76,8 @@ public class UserResource extends AbstractResource {
             User currentUser = userMapper.convert(userEntity);
             boolean withManagement = (authenticatedUser != null && permissionService.hasManagementRights(authenticatedUser));
             if (withManagement) {
-                Management managementConfig = this.configService.getConsoleSettings().getManagement();
+                Management managementConfig =
+                    this.configService.getConsoleSettings(GraviteeContext.getCurrentOrganization()).getManagement();
                 if (managementConfig != null && managementConfig.getUrl() != null) {
                     UserConfig userConfig = new UserConfig();
                     userConfig.setManagementUrl(managementConfig.getUrl());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/openapi.yaml
@@ -10,7 +10,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0
-  version: "3.10.8"
+  version: "3.10.9-SNAPSHOT"
 servers:
   - url: http://localhost:8083/portal/environments/{envId}
     description: The portal API for a given environment

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/filter/PermissionFilterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/filter/PermissionFilterTest.java
@@ -31,6 +31,7 @@ import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
 import java.security.Principal;
 import java.util.Collections;
@@ -115,9 +116,9 @@ public class PermissionFilterTest {
             permissionFilter.filter(permissions, containerRequestContext);
         } catch (ForbiddenAccessException e) {
             verify(apiService, times(1)).findById(api.getId());
-            verify(applicationService, never()).findById(any());
+            verify(applicationService, never()).findById(eq(GraviteeContext.getCurrentEnvironment()), any());
             verify(roleService, times(1)).hasPermission(any(), any(), any());
-            verify(membershipService, times(1)).getUserMemberPermissions(api, USERNAME);
+            verify(membershipService, times(1)).getUserMemberPermissions(GraviteeContext.getCurrentEnvironment(), api, USERNAME);
             verify(membershipService, never()).getRoles(any(), any(), any(), any());
             throw e;
         }
@@ -132,9 +133,9 @@ public class PermissionFilterTest {
 
         permissionFilter.filter(permissions, containerRequestContext);
         verify(apiService, times(1)).findById(api.getId());
-        verify(applicationService, never()).findById(any());
+        verify(applicationService, never()).findById(eq(GraviteeContext.getCurrentEnvironment()), any());
         verify(roleService, times(1)).hasPermission(any(), any(), any());
-        verify(membershipService, times(1)).getUserMemberPermissions(api, USERNAME);
+        verify(membershipService, times(1)).getUserMemberPermissions(GraviteeContext.getCurrentEnvironment(), api, USERNAME);
         verify(membershipService, never()).getRoles(any(), any(), any(), any());
     }
 
@@ -145,7 +146,7 @@ public class PermissionFilterTest {
         ApplicationEntity application = new ApplicationEntity();
         application.setId(APPLICATION_ID);
         Principal user = () -> USERNAME;
-        when(applicationService.findById(application.getId())).thenReturn(application);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), application.getId())).thenReturn(application);
         when(securityContext.getUserPrincipal()).thenReturn(user);
         Permission perm = mock(Permission.class);
         when(perm.value()).thenReturn(RolePermission.APPLICATION_ANALYTICS);
@@ -167,10 +168,10 @@ public class PermissionFilterTest {
         try {
             permissionFilter.filter(permissions, containerRequestContext);
         } catch (ForbiddenAccessException e) {
-            verify(applicationService, times(1)).findById(application.getId());
+            verify(applicationService, times(1)).findById(GraviteeContext.getCurrentEnvironment(), application.getId());
             verify(apiService, never()).findById(any());
             verify(roleService, times(1)).hasPermission(any(), any(), any());
-            verify(membershipService, times(1)).getUserMemberPermissions(application, USERNAME);
+            verify(membershipService, times(1)).getUserMemberPermissions(GraviteeContext.getCurrentEnvironment(), application, USERNAME);
             verify(membershipService, never()).getRoles(any(), any(), any(), any());
             throw e;
         }
@@ -185,9 +186,9 @@ public class PermissionFilterTest {
 
         permissionFilter.filter(permissions, containerRequestContext);
         verify(apiService, never()).findById(any());
-        verify(applicationService, times(1)).findById(application.getId());
+        verify(applicationService, times(1)).findById(GraviteeContext.getCurrentEnvironment(), application.getId());
         verify(roleService, times(1)).hasPermission(any(), any(), any());
-        verify(membershipService, times(1)).getUserMemberPermissions(application, USERNAME);
+        verify(membershipService, times(1)).getUserMemberPermissions(GraviteeContext.getCurrentEnvironment(), application, USERNAME);
         verify(membershipService, never()).getRoles(any(), any(), any(), any());
     }
 
@@ -214,12 +215,20 @@ public class PermissionFilterTest {
         try {
             permissionFilter.filter(permissions, containerRequestContext);
         } catch (ForbiddenAccessException e) {
-            verify(applicationService, never()).findById(any());
+            verify(applicationService, never()).findById(eq(GraviteeContext.getCurrentEnvironment()), any());
             verify(apiService, never()).findById(any());
             verify(roleService, times(1)).hasPermission(any(), any(), any());
-            verify(membershipService, never()).getUserMemberPermissions(any(ApiEntity.class), any());
-            verify(membershipService, never()).getUserMemberPermissions(any(ApplicationEntity.class), any());
-            verify(membershipService, times(1)).getUserMemberPermissions(eq(MembershipReferenceType.ENVIRONMENT), any(), any());
+            verify(membershipService, never())
+                .getUserMemberPermissions(eq(GraviteeContext.getCurrentEnvironment()), any(ApiEntity.class), any());
+            verify(membershipService, never())
+                .getUserMemberPermissions(eq(GraviteeContext.getCurrentEnvironment()), any(ApplicationEntity.class), any());
+            verify(membershipService, times(1))
+                .getUserMemberPermissions(
+                    eq(GraviteeContext.getCurrentEnvironment()),
+                    eq(MembershipReferenceType.ENVIRONMENT),
+                    any(),
+                    any()
+                );
             throw e;
         }
 
@@ -233,12 +242,15 @@ public class PermissionFilterTest {
 
         permissionFilter.filter(permissions, containerRequestContext);
 
-        verify(applicationService, never()).findById(any());
+        verify(applicationService, never()).findById(eq(GraviteeContext.getCurrentEnvironment()), any());
         verify(apiService, never()).findById(any());
         verify(roleService, times(1)).hasPermission(any(), any(), any());
-        verify(membershipService, never()).getUserMemberPermissions(any(ApiEntity.class), any());
-        verify(membershipService, never()).getUserMemberPermissions(any(ApplicationEntity.class), any());
-        verify(membershipService, times(1)).getUserMemberPermissions(eq(MembershipReferenceType.ENVIRONMENT), any(), any());
+        verify(membershipService, never())
+            .getUserMemberPermissions(eq(GraviteeContext.getCurrentEnvironment()), any(ApiEntity.class), any());
+        verify(membershipService, never())
+            .getUserMemberPermissions(eq(GraviteeContext.getCurrentEnvironment()), any(ApplicationEntity.class), any());
+        verify(membershipService, times(1))
+            .getUserMemberPermissions(eq(GraviteeContext.getCurrentEnvironment()), eq(MembershipReferenceType.ENVIRONMENT), any(), any());
     }
 
     /**
@@ -264,12 +276,20 @@ public class PermissionFilterTest {
         try {
             permissionFilter.filter(permissions, containerRequestContext);
         } catch (ForbiddenAccessException e) {
-            verify(applicationService, never()).findById(any());
+            verify(applicationService, never()).findById(eq(GraviteeContext.getCurrentEnvironment()), any());
             verify(apiService, never()).findById(any());
             verify(roleService, times(1)).hasPermission(any(), any(), any());
-            verify(membershipService, never()).getUserMemberPermissions(any(ApiEntity.class), any());
-            verify(membershipService, never()).getUserMemberPermissions(any(ApplicationEntity.class), any());
-            verify(membershipService, times(1)).getUserMemberPermissions(eq(MembershipReferenceType.ORGANIZATION), any(), any());
+            verify(membershipService, never())
+                .getUserMemberPermissions(eq(GraviteeContext.getCurrentEnvironment()), any(ApiEntity.class), any());
+            verify(membershipService, never())
+                .getUserMemberPermissions(eq(GraviteeContext.getCurrentEnvironment()), any(ApplicationEntity.class), any());
+            verify(membershipService, times(1))
+                .getUserMemberPermissions(
+                    eq(GraviteeContext.getCurrentEnvironment()),
+                    eq(MembershipReferenceType.ORGANIZATION),
+                    any(),
+                    any()
+                );
             throw e;
         }
 
@@ -283,11 +303,14 @@ public class PermissionFilterTest {
 
         permissionFilter.filter(permissions, containerRequestContext);
 
-        verify(applicationService, never()).findById(any());
+        verify(applicationService, never()).findById(eq(GraviteeContext.getCurrentEnvironment()), any());
         verify(apiService, never()).findById(any());
         verify(roleService, times(1)).hasPermission(any(), any(), any());
-        verify(membershipService, never()).getUserMemberPermissions(any(ApiEntity.class), any());
-        verify(membershipService, never()).getUserMemberPermissions(any(ApplicationEntity.class), any());
-        verify(membershipService, times(1)).getUserMemberPermissions(eq(MembershipReferenceType.ORGANIZATION), any(), any());
+        verify(membershipService, never())
+            .getUserMemberPermissions(eq(GraviteeContext.getCurrentEnvironment()), any(ApiEntity.class), any());
+        verify(membershipService, never())
+            .getUserMemberPermissions(eq(GraviteeContext.getCurrentEnvironment()), any(ApplicationEntity.class), any());
+        verify(membershipService, times(1))
+            .getUserMemberPermissions(eq(GraviteeContext.getCurrentEnvironment()), eq(MembershipReferenceType.ORGANIZATION), any(), any());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApiMapperTest.java
@@ -37,6 +37,7 @@ import io.gravitee.rest.api.service.CategoryService;
 import io.gravitee.rest.api.service.ParameterService;
 import io.gravitee.rest.api.service.RatingService;
 import io.gravitee.rest.api.service.SubscriptionService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.CategoryNotFoundException;
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -96,7 +97,9 @@ public class ApiMapperTest {
         apiEntity.setDescription(API_DESCRIPTION);
         apiEntity.setName(API_NAME);
         apiEntity.setLabels(new ArrayList<>(Arrays.asList(API_LABEL)));
-        doThrow(CategoryNotFoundException.class).when(categoryService).findNotHiddenById(API_CATEGORY_HIDDEN);
+        doThrow(CategoryNotFoundException.class)
+            .when(categoryService)
+            .findNotHiddenById(API_CATEGORY_HIDDEN, GraviteeContext.getCurrentEnvironment());
 
         apiEntity.setCategories(new HashSet<>(Arrays.asList(API_CATEGORY, API_CATEGORY_HIDDEN)));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationMapperTest.java
@@ -35,6 +35,7 @@ import io.gravitee.rest.api.portal.rest.model.Group;
 import io.gravitee.rest.api.portal.rest.model.User;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
@@ -120,7 +121,7 @@ public class ApplicationMapperTest {
         GroupEntity grpEntity = new GroupEntity();
         grpEntity.setId(APPLICATION_GROUP_ID);
         grpEntity.setName(APPLICATION_GROUP_NAME);
-        when(groupService.findById(APPLICATION_GROUP_ID)).thenReturn(grpEntity);
+        when(groupService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_GROUP_ID)).thenReturn(grpEntity);
 
         UserEntity userEntity = Mockito.mock(UserEntity.class);
         when(userEntity.getDisplayName()).thenReturn(APPLICATION_USER_DISPLAYNAME);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiPageResourceNotAuthenticatedTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiPageResourceNotAuthenticatedTest.java
@@ -26,6 +26,7 @@ import io.gravitee.rest.api.model.PageEntity;
 import io.gravitee.rest.api.model.Visibility;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.portal.rest.model.Page;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.io.IOException;
 import java.security.Principal;
 import java.util.*;
@@ -121,7 +122,9 @@ public class ApiPageResourceNotAuthenticatedTest extends AbstractResourceTest {
     @Test
     public void shouldHaveMetadataCleared() {
         doReturn(true).when(accessControlService).canAccessApiFromPortal(API);
-        doReturn(true).when(accessControlService).canAccessPageFromPortal(eq(API), any(PageEntity.class));
+        doReturn(true)
+            .when(accessControlService)
+            .canAccessPageFromPortal(eq(GraviteeContext.getCurrentEnvironment()), eq(API), any(PageEntity.class));
 
         Response anotherResponse = target(API).path("pages").path(ANOTHER_PAGE).request().get();
         assertEquals(OK_200, anotherResponse.getStatus());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiPageResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiPageResourceTest.java
@@ -29,6 +29,7 @@ import io.gravitee.rest.api.portal.rest.model.Error;
 import io.gravitee.rest.api.portal.rest.model.ErrorResponse;
 import io.gravitee.rest.api.portal.rest.model.Page;
 import io.gravitee.rest.api.portal.rest.model.PageLinks;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.PageNotFoundException;
 import java.util.*;
 import javax.ws.rs.client.Invocation.Builder;
@@ -69,7 +70,7 @@ public class ApiPageResourceTest extends AbstractResourceTest {
         page1.setVisibility(Visibility.PUBLIC);
         page1.setContent(PAGE_CONTENT);
         doReturn(page1).when(pageService).findById(PAGE, null);
-        doReturn(true).when(accessControlService).canAccessPageFromPortal(API, page1);
+        doReturn(true).when(accessControlService).canAccessPageFromPortal(GraviteeContext.getCurrentEnvironment(), API, page1);
 
         doReturn(new Page()).when(pageMapper).convert(any(), any(), any());
         doReturn(new PageLinks()).when(pageMapper).computePageLinks(any(), any());
@@ -139,7 +140,7 @@ public class ApiPageResourceTest extends AbstractResourceTest {
     @Test
     public void shouldNotGetApiPage() {
         final Builder request = target(API).path("pages").path(PAGE).request();
-        doReturn(false).when(accessControlService).canAccessPageFromPortal(eq(API), any());
+        doReturn(false).when(accessControlService).canAccessPageFromPortal(eq(GraviteeContext.getCurrentEnvironment()), eq(API), any());
 
         Response response = request.get();
         assertEquals(UNAUTHORIZED_401, response.getStatus());
@@ -215,7 +216,7 @@ public class ApiPageResourceTest extends AbstractResourceTest {
     @Test
     public void shouldNotGetApiPageContent() {
         final Builder request = target(API).path("pages").path(PAGE).path("content").request();
-        doReturn(false).when(accessControlService).canAccessPageFromPortal(eq(API), any());
+        doReturn(false).when(accessControlService).canAccessPageFromPortal(eq(GraviteeContext.getCurrentEnvironment()), eq(API), any());
 
         Response response = request.get();
         assertEquals(UNAUTHORIZED_401, response.getStatus());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiPagesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiPagesResourceTest.java
@@ -63,10 +63,10 @@ public class ApiPagesResourceTest extends AbstractResourceTest {
             .when(pageService)
             .search(any(), isNull(), eq(GraviteeContext.getCurrentEnvironment()));
 
-        when(accessControlService.canAccessPageFromPortal(eq(API), any(PageEntity.class)))
+        when(accessControlService.canAccessPageFromPortal(eq(GraviteeContext.getCurrentEnvironment()), eq(API), any(PageEntity.class)))
             .thenAnswer(
                 invocationOnMock -> {
-                    PageEntity page = invocationOnMock.getArgument(1);
+                    PageEntity page = invocationOnMock.getArgument(2);
                     return !PageType.MARKDOWN_TEMPLATE.name().equals(page.getType());
                 }
             );
@@ -115,7 +115,7 @@ public class ApiPagesResourceTest extends AbstractResourceTest {
     @Test
     public void shouldGetNoApiPage() {
         when(accessControlService.canAccessApiFromPortal(API)).thenReturn(true);
-        when(accessControlService.canAccessPageFromPortal(eq(API), any())).thenReturn(false);
+        when(accessControlService.canAccessPageFromPortal(eq(GraviteeContext.getCurrentEnvironment()), eq(API), any())).thenReturn(false);
 
         final Builder request = target(API).path("pages").request();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiResourceNotAuthenticatedTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiResourceNotAuthenticatedTest.java
@@ -132,7 +132,7 @@ public class ApiResourceNotAuthenticatedTest extends AbstractResourceTest {
         // Useful for plans
         doReturn(true).when(groupService).isUserAuthorizedToAccessApiData(any(), any(), any());
         // For pages
-        doReturn(true).when(accessControlService).canAccessPageFromPortal(any());
+        doReturn(true).when(accessControlService).canAccessPageFromPortal(eq(GraviteeContext.getCurrentEnvironment()), any());
         callResourceAndCheckResult(1, 2);
     }
 
@@ -141,7 +141,7 @@ public class ApiResourceNotAuthenticatedTest extends AbstractResourceTest {
         // Useful for plans
         doReturn(false).when(groupService).isUserAuthorizedToAccessApiData(any(), any(), any());
         // For pages
-        doReturn(false).when(accessControlService).canAccessPageFromPortal(any());
+        doReturn(false).when(accessControlService).canAccessPageFromPortal(eq(GraviteeContext.getCurrentEnvironment()), any());
         callResourceAndCheckResult(0, 0);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiResourceTest.java
@@ -41,7 +41,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 /**
@@ -127,7 +126,7 @@ public class ApiResourceTest extends AbstractResourceTest {
 
         // For pages
         doReturn(true).when(accessControlService).canAccessApiFromPortal(API);
-        doReturn(true).when(accessControlService).canAccessPageFromPortal(pagePublished);
+        doReturn(true).when(accessControlService).canAccessPageFromPortal(GraviteeContext.getCurrentEnvironment(), pagePublished);
         // For plans
         doReturn(true).when(groupService).isUserAuthorizedToAccessApiData(any(), any(), any());
 
@@ -273,7 +272,7 @@ public class ApiResourceTest extends AbstractResourceTest {
                 }
             );
 
-        when(accessControlService.canAccessPageFromPortal(any())).thenReturn(true);
+        when(accessControlService.canAccessPageFromPortal(eq(GraviteeContext.getCurrentEnvironment()), any())).thenReturn(true);
 
         final Response response = target(API).path("links").request().get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiSubscribersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiSubscribersResourceTest.java
@@ -30,13 +30,13 @@ import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.model.analytics.TopHitsAnalytics;
 import io.gravitee.rest.api.model.analytics.query.GroupByQuery;
 import io.gravitee.rest.api.model.api.ApiEntity;
-import io.gravitee.rest.api.model.api.ApiQuery;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.portal.rest.model.Application;
 import io.gravitee.rest.api.portal.rest.model.ApplicationsResponse;
 import io.gravitee.rest.api.portal.rest.model.Error;
 import io.gravitee.rest.api.portal.rest.model.ErrorResponse;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.io.IOException;
 import java.util.*;
 import javax.ws.rs.core.Response;
@@ -101,7 +101,7 @@ public class ApiSubscribersResourceTest extends AbstractResourceTest {
         mockedValues.put("B", 20L);
         mockedValues.put("C", 30L);
         mockAnalytics.setValues(mockedValues);
-        doReturn(mockAnalytics).when(analyticsService).execute(any(GroupByQuery.class));
+        doReturn(mockAnalytics).when(analyticsService).execute(eq(GraviteeContext.getCurrentOrganization()), any(GroupByQuery.class));
 
         SubscriptionEntity subA1 = new SubscriptionEntity();
         subA1.setApplication("A");
@@ -116,17 +116,17 @@ public class ApiSubscribersResourceTest extends AbstractResourceTest {
 
         ApplicationEntity appA = new ApplicationEntity();
         appA.setId("A");
-        doReturn(appA).when(applicationService).findById("A");
+        doReturn(appA).when(applicationService).findById(GraviteeContext.getCurrentEnvironment(), "A");
         doReturn(new Application().id("A")).when(applicationMapper).convert(eq(appA), any());
 
         ApplicationEntity appB = new ApplicationEntity();
         appB.setId("B");
-        doReturn(appB).when(applicationService).findById("B");
+        doReturn(appB).when(applicationService).findById(GraviteeContext.getCurrentEnvironment(), "B");
         doReturn(new Application().id("B")).when(applicationMapper).convert(eq(appB), any());
 
         ApplicationEntity appC = new ApplicationEntity();
         appC.setId("C");
-        doReturn(appC).when(applicationService).findById("C");
+        doReturn(appC).when(applicationService).findById(GraviteeContext.getCurrentEnvironment(), "C");
         doReturn(new Application().id("C")).when(applicationMapper).convert(eq(appC), any());
 
         final Response response = target(API).path("subscribers").request().get();
@@ -148,7 +148,7 @@ public class ApiSubscribersResourceTest extends AbstractResourceTest {
         mockedValues.put("C", 0L);
         mockedValues.put("B", 0L);
         mockAnalytics.setValues(mockedValues);
-        doReturn(mockAnalytics).when(analyticsService).execute(any(GroupByQuery.class));
+        doReturn(mockAnalytics).when(analyticsService).execute(eq(GraviteeContext.getCurrentOrganization()), any(GroupByQuery.class));
 
         SubscriptionEntity subA1 = new SubscriptionEntity();
         subA1.setApplication("A");
@@ -164,19 +164,19 @@ public class ApiSubscribersResourceTest extends AbstractResourceTest {
         ApplicationEntity appA = new ApplicationEntity();
         appA.setId("A");
         appA.setName("A");
-        doReturn(appA).when(applicationService).findById("A");
+        doReturn(appA).when(applicationService).findById(GraviteeContext.getCurrentEnvironment(), "A");
         doReturn(new Application().id("A").name("A")).when(applicationMapper).convert(eq(appA), any());
 
         ApplicationEntity appB = new ApplicationEntity();
         appB.setId("B");
         appB.setName("B");
-        doReturn(appB).when(applicationService).findById("B");
+        doReturn(appB).when(applicationService).findById(GraviteeContext.getCurrentEnvironment(), "B");
         doReturn(new Application().id("B").name("B")).when(applicationMapper).convert(eq(appB), any());
 
         ApplicationEntity appC = new ApplicationEntity();
         appC.setId("C");
         appC.setName("C");
-        doReturn(appC).when(applicationService).findById("C");
+        doReturn(appC).when(applicationService).findById(GraviteeContext.getCurrentEnvironment(), "C");
         doReturn(new Application().id("C").name("C")).when(applicationMapper).convert(eq(appC), any());
 
         final Response response = target(API).path("subscribers").request().get();
@@ -207,7 +207,7 @@ public class ApiSubscribersResourceTest extends AbstractResourceTest {
         mockedValues.put("B", 20L);
         mockedValues.put("C", 30L);
         mockAnalytics.setValues(mockedValues);
-        doReturn(mockAnalytics).when(analyticsService).execute(any(GroupByQuery.class));
+        doReturn(mockAnalytics).when(analyticsService).execute(eq(GraviteeContext.getCurrentOrganization()), any(GroupByQuery.class));
 
         SubscriptionEntity subA1 = new SubscriptionEntity();
         subA1.setApplication("A");
@@ -219,19 +219,21 @@ public class ApiSubscribersResourceTest extends AbstractResourceTest {
 
         ApplicationEntity appA = new ApplicationEntity();
         appA.setId("A");
-        doReturn(appA).when(applicationService).findById("A");
+        doReturn(appA).when(applicationService).findById(GraviteeContext.getCurrentEnvironment(), "A");
         doReturn(new Application().id("A")).when(applicationMapper).convert(eq(appA), any());
 
         ApplicationEntity appC = new ApplicationEntity();
         appC.setId("C");
-        doReturn(appC).when(applicationService).findById("C");
+        doReturn(appC).when(applicationService).findById(GraviteeContext.getCurrentEnvironment(), "C");
         doReturn(new Application().id("C")).when(applicationMapper).convert(eq(appC), any());
 
         ApplicationListItem appLIA = new ApplicationListItem();
         appLIA.setId("A");
         ApplicationListItem appLIC = new ApplicationListItem();
         appLIC.setId("C");
-        doReturn(new HashSet<>(Arrays.asList(appLIA, appLIC))).when(applicationService).findByUser(USER_NAME);
+        doReturn(new HashSet<>(Arrays.asList(appLIA, appLIC)))
+            .when(applicationService)
+            .findByUser(GraviteeContext.getCurrentOrganization(), GraviteeContext.getCurrentEnvironment(), USER_NAME);
 
         final Response response = target(API).path("subscribers").request().get();
         assertEquals(OK_200, response.getStatus());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApisResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApisResourceTest.java
@@ -28,6 +28,7 @@ import io.gravitee.rest.api.model.api.ApiQuery;
 import io.gravitee.rest.api.model.filtering.FilteredEntities;
 import io.gravitee.rest.api.portal.rest.model.*;
 import io.gravitee.rest.api.portal.rest.model.Error;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.*;
 import java.util.stream.Collectors;
 import javax.ws.rs.client.Entity;
@@ -285,7 +286,7 @@ public class ApisResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldHaveAllButPromotedApiIfCategoryWithoutHighLightedApi() throws TechnicalException {
-        doReturn(new CategoryEntity()).when(categoryService).findById("myCat");
+        doReturn(new CategoryEntity()).when(categoryService).findById("myCat", GraviteeContext.getCurrentEnvironment());
 
         final Response response = target()
             .queryParam("size", 3)
@@ -309,7 +310,7 @@ public class ApisResourceTest extends AbstractResourceTest {
     public void shouldHaveAllButPromotedApiIfCategoryWithHighLightedApi() throws TechnicalException {
         CategoryEntity myCatEntity = new CategoryEntity();
         myCatEntity.setHighlightApi("4");
-        doReturn(myCatEntity).when(categoryService).findById("myCat");
+        doReturn(myCatEntity).when(categoryService).findById("myCat", GraviteeContext.getCurrentEnvironment());
 
         final Response response = target()
             .queryParam("size", 3)
@@ -333,7 +334,7 @@ public class ApisResourceTest extends AbstractResourceTest {
     public void shouldHaveAllButPromotedApiIfCategoryWithHighLightedApiNotInFilteredList() throws TechnicalException {
         CategoryEntity myCatEntity = new CategoryEntity();
         myCatEntity.setHighlightApi("7");
-        doReturn(myCatEntity).when(categoryService).findById("myCat");
+        doReturn(myCatEntity).when(categoryService).findById("myCat", GraviteeContext.getCurrentEnvironment());
 
         final Response response = target()
             .queryParam("size", 3)
@@ -370,7 +371,7 @@ public class ApisResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldHavePromotedApiIfCategoryWithoutHighLightedApi() throws TechnicalException {
-        doReturn(new CategoryEntity()).when(categoryService).findById("myCat");
+        doReturn(new CategoryEntity()).when(categoryService).findById("myCat", GraviteeContext.getCurrentEnvironment());
 
         final Response response = target()
             .queryParam("size", 3)
@@ -394,7 +395,7 @@ public class ApisResourceTest extends AbstractResourceTest {
     public void shouldHavePromotedApiIfCategoryWithHighLightedApi() throws TechnicalException {
         CategoryEntity myCatEntity = new CategoryEntity();
         myCatEntity.setHighlightApi("4");
-        doReturn(myCatEntity).when(categoryService).findById("myCat");
+        doReturn(myCatEntity).when(categoryService).findById("myCat", GraviteeContext.getCurrentEnvironment());
 
         final Response response = target()
             .queryParam("size", 3)
@@ -418,7 +419,7 @@ public class ApisResourceTest extends AbstractResourceTest {
     public void shouldHavePromotedApiIfCategoryWithHighLightedApiNotInFilteredList() throws TechnicalException {
         CategoryEntity myCatEntity = new CategoryEntity();
         myCatEntity.setHighlightApi("7");
-        doReturn(myCatEntity).when(categoryService).findById("myCat");
+        doReturn(myCatEntity).when(categoryService).findById("myCat", GraviteeContext.getCurrentEnvironment());
 
         final Response response = target()
             .queryParam("size", 3)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationAnalyticsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationAnalyticsResourceTest.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.portal.rest.resource;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
 
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.model.analytics.query.Aggregation;
@@ -26,6 +27,7 @@ import io.gravitee.rest.api.model.analytics.query.CountQuery;
 import io.gravitee.rest.api.model.analytics.query.DateHistogramQuery;
 import io.gravitee.rest.api.model.analytics.query.GroupByQuery;
 import io.gravitee.rest.api.model.analytics.query.GroupByQuery.Order;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.List;
 import java.util.Map;
 import javax.ws.rs.core.Response;
@@ -62,7 +64,7 @@ public class ApplicationAnalyticsResourceTest extends AbstractResourceTest {
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
 
         ArgumentCaptor<DateHistogramQuery> queryCaptor = ArgumentCaptor.forClass(DateHistogramQuery.class);
-        Mockito.verify(analyticsService).execute(queryCaptor.capture());
+        Mockito.verify(analyticsService).execute(eq(GraviteeContext.getCurrentOrganization()), queryCaptor.capture());
         final DateHistogramQuery query = queryCaptor.getValue();
         assertEquals(0, query.getFrom());
         assertEquals(100, query.getTo());
@@ -95,7 +97,7 @@ public class ApplicationAnalyticsResourceTest extends AbstractResourceTest {
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
 
         ArgumentCaptor<GroupByQuery> queryCaptor = ArgumentCaptor.forClass(GroupByQuery.class);
-        Mockito.verify(analyticsService).execute(queryCaptor.capture());
+        Mockito.verify(analyticsService).execute(eq(GraviteeContext.getCurrentOrganization()), queryCaptor.capture());
         final GroupByQuery query = queryCaptor.getValue();
         assertEquals(0, query.getFrom());
         assertEquals(100, query.getTo());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationMembersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationMembersResourceTest.java
@@ -28,6 +28,7 @@ import io.gravitee.rest.api.model.RoleEntity;
 import io.gravitee.rest.api.portal.rest.model.*;
 import io.gravitee.rest.api.portal.rest.model.Error;
 import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
 import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
 import java.util.HashSet;
@@ -73,10 +74,16 @@ public class ApplicationMembersResourceTest extends AbstractResourceTest {
         doReturn(Sets.newSet(memberEntity1, memberEntity2))
             .when(membershipService)
             .getMembersByReference(MembershipReferenceType.APPLICATION, APPLICATION);
-        doReturn(memberEntity1).when(membershipService).getUserMember(MembershipReferenceType.APPLICATION, APPLICATION, MEMBER_1);
-        doReturn(null).when(membershipService).getUserMember(MembershipReferenceType.APPLICATION, APPLICATION, MEMBER_2);
+        doReturn(memberEntity1)
+            .when(membershipService)
+            .getUserMember(GraviteeContext.getCurrentEnvironment(), MembershipReferenceType.APPLICATION, APPLICATION, MEMBER_1);
+        doReturn(null)
+            .when(membershipService)
+            .getUserMember(GraviteeContext.getCurrentEnvironment(), MembershipReferenceType.APPLICATION, APPLICATION, MEMBER_2);
 
-        doThrow(ApplicationNotFoundException.class).when(applicationService).findById(UNKNOWN_APPLICATION);
+        doThrow(ApplicationNotFoundException.class)
+            .when(applicationService)
+            .findById(GraviteeContext.getCurrentEnvironment(), UNKNOWN_APPLICATION);
         doThrow(UserNotFoundException.class).when(userService).findById(UNKNOWN_MEMBER);
     }
 
@@ -167,7 +174,14 @@ public class ApplicationMembersResourceTest extends AbstractResourceTest {
 
         Mockito
             .verify(membershipService)
-            .deleteReferenceMember(MembershipReferenceType.APPLICATION, APPLICATION, MembershipMemberType.USER, MEMBER_1);
+            .deleteReferenceMember(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
+                MembershipReferenceType.APPLICATION,
+                APPLICATION,
+                MembershipMemberType.USER,
+                MEMBER_1
+            );
     }
 
     @Test
@@ -175,7 +189,15 @@ public class ApplicationMembersResourceTest extends AbstractResourceTest {
         MemberInput memberInput = new MemberInput().role("USER").user(MEMBER_1);
         MemberEntity returnedMemberEntity = mock(MemberEntity.class);
         doReturn(MEMBER_1).when(returnedMemberEntity).getId();
-        doReturn(returnedMemberEntity).when(membershipService).addRoleToMemberOnReference(any(), any(), any());
+        doReturn(returnedMemberEntity)
+            .when(membershipService)
+            .addRoleToMemberOnReference(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
+                any(),
+                any(),
+                any()
+            );
 
         final Response response = target(APPLICATION).path("members").request().post(Entity.json(memberInput));
         assertEquals(HttpStatusCode.CREATED_201, response.getStatus());
@@ -196,7 +218,13 @@ public class ApplicationMembersResourceTest extends AbstractResourceTest {
 
         Mockito
             .verify(membershipService)
-            .addRoleToMemberOnReference(memberShipRefCaptor.capture(), memberShipUserCaptor.capture(), memberShipRoleCaptor.capture());
+            .addRoleToMemberOnReference(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
+                memberShipRefCaptor.capture(),
+                memberShipUserCaptor.capture(),
+                memberShipRoleCaptor.capture()
+            );
         assertEquals(APPLICATION, memberShipRefCaptor.getValue().getId());
         assertEquals("USER", memberShipRoleCaptor.getValue().getName());
         assertEquals(MEMBER_1, memberShipUserCaptor.getValue().getMemberId());
@@ -220,7 +248,13 @@ public class ApplicationMembersResourceTest extends AbstractResourceTest {
 
         Mockito
             .verify(membershipService)
-            .updateRoleToMemberOnReference(memberShipRefCaptor.capture(), memberShipUserCaptor.capture(), memberShipRoleCaptor.capture());
+            .updateRoleToMemberOnReference(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
+                memberShipRefCaptor.capture(),
+                memberShipUserCaptor.capture(),
+                memberShipRoleCaptor.capture()
+            );
         assertEquals(APPLICATION, memberShipRefCaptor.getValue().getId());
         assertEquals("USER", memberShipRoleCaptor.getValue().getName());
         assertEquals(MEMBER_2, memberShipUserCaptor.getValue().getMemberId());
@@ -242,7 +276,13 @@ public class ApplicationMembersResourceTest extends AbstractResourceTest {
 
         Mockito
             .verify(membershipService)
-            .transferApplicationOwnership(applicationCaptor.capture(), memberShipUserCaptor.capture(), roleCaptor.capture());
+            .transferApplicationOwnership(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
+                applicationCaptor.capture(),
+                memberShipUserCaptor.capture(),
+                roleCaptor.capture()
+            );
         assertEquals(APPLICATION, applicationCaptor.getValue());
         assertEquals(mockRoleEntity, roleCaptor.getValue().get(0));
         assertEquals(MEMBER_1, memberShipUserCaptor.getValue().getMemberId());
@@ -263,7 +303,13 @@ public class ApplicationMembersResourceTest extends AbstractResourceTest {
 
         Mockito
             .verify(membershipService)
-            .transferApplicationOwnership(applicationCaptor.capture(), memberShipUserCaptor.capture(), roleCaptor.capture());
+            .transferApplicationOwnership(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
+                applicationCaptor.capture(),
+                memberShipUserCaptor.capture(),
+                roleCaptor.capture()
+            );
         assertEquals(APPLICATION, applicationCaptor.getValue());
         assertNotNull(roleCaptor.getValue());
         assertTrue(roleCaptor.getValue().isEmpty());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationMetadataResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationMetadataResourceTest.java
@@ -26,6 +26,7 @@ import io.gravitee.rest.api.model.NewApplicationMetadataEntity;
 import io.gravitee.rest.api.model.UpdateApplicationMetadataEntity;
 import io.gravitee.rest.api.portal.rest.model.*;
 import io.gravitee.rest.api.portal.rest.model.Error;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApplicationMetadataNotFoundException;
 import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
 import java.util.Arrays;
@@ -80,20 +81,20 @@ public class ApplicationMetadataResourceTest extends AbstractResourceTest {
         doReturn(applicationMetadataEntity1).when(applicationMetadataService).findByIdAndApplication(METADATA_1, APPLICATION);
         doReturn(null).when(applicationMetadataService).findByIdAndApplication(METADATA_2, APPLICATION);
 
-        when(applicationMetadataService.create(any()))
+        when(applicationMetadataService.create(eq(GraviteeContext.getCurrentEnvironment()), any()))
             .thenAnswer(
                 invocation -> {
-                    NewApplicationMetadataEntity newApplicationMetadataEntity = invocation.getArgument(0);
+                    NewApplicationMetadataEntity newApplicationMetadataEntity = invocation.getArgument(1);
                     if (newApplicationMetadataEntity.getApplicationId().equals(UNKNOWN_APPLICATION)) {
                         throw new ApplicationNotFoundException(UNKNOWN_APPLICATION);
                     }
                     return applicationMetadataEntity1;
                 }
             );
-        when(applicationMetadataService.update(any()))
+        when(applicationMetadataService.update(eq(GraviteeContext.getCurrentEnvironment()), any()))
             .thenAnswer(
                 invocation -> {
-                    UpdateApplicationMetadataEntity updateApplicationMetadataEntity = invocation.getArgument(0);
+                    UpdateApplicationMetadataEntity updateApplicationMetadataEntity = invocation.getArgument(1);
                     if (updateApplicationMetadataEntity.getApplicationId().equals(UNKNOWN_APPLICATION)) {
                         throw new ApplicationNotFoundException(UNKNOWN_APPLICATION);
                     }
@@ -218,7 +219,7 @@ public class ApplicationMetadataResourceTest extends AbstractResourceTest {
 
         ArgumentCaptor<NewApplicationMetadataEntity> newMetadataEntityCaptor = ArgumentCaptor.forClass(NewApplicationMetadataEntity.class);
 
-        Mockito.verify(applicationMetadataService).create(newMetadataEntityCaptor.capture());
+        Mockito.verify(applicationMetadataService).create(eq(GraviteeContext.getCurrentEnvironment()), newMetadataEntityCaptor.capture());
         final NewApplicationMetadataEntity newMetadataEntityCaptorValue = newMetadataEntityCaptor.getValue();
         assertEquals(APPLICATION, newMetadataEntityCaptorValue.getApplicationId());
         assertEquals(METADATA_1_NAME, newMetadataEntityCaptorValue.getName());
@@ -241,7 +242,9 @@ public class ApplicationMetadataResourceTest extends AbstractResourceTest {
             UpdateApplicationMetadataEntity.class
         );
 
-        Mockito.verify(applicationMetadataService).update(updateMetadataEntityCaptor.capture());
+        Mockito
+            .verify(applicationMetadataService)
+            .update(eq(GraviteeContext.getCurrentEnvironment()), updateMetadataEntityCaptor.capture());
         final UpdateApplicationMetadataEntity uodateMetadataEntityCaptorValue = updateMetadataEntityCaptor.getValue();
         assertEquals(APPLICATION, uodateMetadataEntityCaptorValue.getApplicationId());
         assertEquals(METADATA_1, uodateMetadataEntityCaptorValue.getKey());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationResourceTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.*;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.portal.rest.model.*;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -69,14 +70,14 @@ public class ApplicationResourceTest extends AbstractResourceTest {
         ApplicationEntity applicationEntity = new ApplicationEntity();
         applicationEntity.setId(APPLICATION_ID);
 
-        doReturn(applicationEntity).when(applicationService).findById(APPLICATION_ID);
+        doReturn(applicationEntity).when(applicationService).findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID);
         doReturn(new Application().id(APPLICATION_ID)).when(applicationMapper).convert(eq(applicationEntity), any());
 
         mockImage = new InlinePictureEntity();
         applicationLogoContent = Files.readAllBytes(Paths.get(this.getClass().getClassLoader().getResource("media/logo.svg").toURI()));
         mockImage.setContent(applicationLogoContent);
         mockImage.setType("image/svg");
-        doReturn(mockImage).when(applicationService).getPicture(APPLICATION_PICTURE);
+        doReturn(mockImage).when(applicationService).getPicture(GraviteeContext.getCurrentEnvironment(), APPLICATION_PICTURE);
     }
 
     @Test
@@ -99,7 +100,9 @@ public class ApplicationResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldHaveNotFoundWhileGettingApplication() {
-        doThrow(ApplicationNotFoundException.class).when(applicationService).findById(UNKNOWN_APPLICATION_ID);
+        doThrow(ApplicationNotFoundException.class)
+            .when(applicationService)
+            .findById(GraviteeContext.getCurrentEnvironment(), UNKNOWN_APPLICATION_ID);
 
         final Response response = target(UNKNOWN_APPLICATION_ID).request().get();
         assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
@@ -107,7 +110,9 @@ public class ApplicationResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldHaveNotFoundWhileUpdatingApplication() {
-        doThrow(ApplicationNotFoundException.class).when(applicationService).findById(UNKNOWN_APPLICATION_ID);
+        doThrow(ApplicationNotFoundException.class)
+            .when(applicationService)
+            .findById(GraviteeContext.getCurrentEnvironment(), UNKNOWN_APPLICATION_ID);
 
         final Response response = target(UNKNOWN_APPLICATION_ID).request().put(Entity.json(new Application().id(UNKNOWN_APPLICATION_ID)));
         assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
@@ -128,11 +133,13 @@ public class ApplicationResourceTest extends AbstractResourceTest {
         userEntity.setId(USER_NAME);
         PrimaryOwnerEntity owner = new PrimaryOwnerEntity(userEntity);
         appEntity.setPrimaryOwner(owner);
-        doReturn(appEntity).when(applicationService).findById(APPLICATION_ID);
+        doReturn(appEntity).when(applicationService).findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID);
 
         ApplicationEntity updatedEntity = new ApplicationEntity();
         updatedEntity.setId(APPLICATION_ID);
-        doReturn(updatedEntity).when(applicationService).update(eq(APPLICATION_ID), any());
+        doReturn(updatedEntity)
+            .when(applicationService)
+            .update(eq(GraviteeContext.getCurrentOrganization()), eq(GraviteeContext.getCurrentEnvironment()), eq(APPLICATION_ID), any());
 
         Instant now = Instant.now();
         Date nowDate = Date.from(now);
@@ -154,10 +161,17 @@ public class ApplicationResourceTest extends AbstractResourceTest {
         final Response response = target(APPLICATION_ID).request().put(Entity.json(appInput));
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
 
-        Mockito.verify(applicationService).findById(APPLICATION_ID);
+        Mockito.verify(applicationService).findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID);
 
         ArgumentCaptor<UpdateApplicationEntity> captor = ArgumentCaptor.forClass(UpdateApplicationEntity.class);
-        Mockito.verify(applicationService).update(eq(APPLICATION_ID), captor.capture());
+        Mockito
+            .verify(applicationService)
+            .update(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
+                eq(APPLICATION_ID),
+                captor.capture()
+            );
         UpdateApplicationEntity updateAppEntity = captor.getValue();
         assertEquals(APPLICATION_ID, updateAppEntity.getName());
         assertEquals(APPLICATION_ID, updateAppEntity.getDescription());
@@ -187,11 +201,13 @@ public class ApplicationResourceTest extends AbstractResourceTest {
         userEntity.setId(USER_NAME);
         PrimaryOwnerEntity owner = new PrimaryOwnerEntity(userEntity);
         appEntity.setPrimaryOwner(owner);
-        doReturn(appEntity).when(applicationService).findById(APPLICATION_ID);
+        doReturn(appEntity).when(applicationService).findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID);
 
         ApplicationEntity updatedEntity = new ApplicationEntity();
         updatedEntity.setId(APPLICATION_ID);
-        doReturn(updatedEntity).when(applicationService).update(eq(APPLICATION_ID), any());
+        doReturn(updatedEntity)
+            .when(applicationService)
+            .update(eq(GraviteeContext.getCurrentOrganization()), eq(GraviteeContext.getCurrentEnvironment()), eq(APPLICATION_ID), any());
 
         Instant now = Instant.now();
         Application updatedApp = new Application();
@@ -204,10 +220,17 @@ public class ApplicationResourceTest extends AbstractResourceTest {
         final Response response = target(APPLICATION_ID).request().put(Entity.json(appInput));
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
 
-        Mockito.verify(applicationService).findById(APPLICATION_ID);
+        Mockito.verify(applicationService).findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID);
 
         ArgumentCaptor<UpdateApplicationEntity> captor = ArgumentCaptor.forClass(UpdateApplicationEntity.class);
-        Mockito.verify(applicationService).update(eq(APPLICATION_ID), captor.capture());
+        Mockito
+            .verify(applicationService)
+            .update(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
+                eq(APPLICATION_ID),
+                captor.capture()
+            );
         UpdateApplicationEntity updateAppEntity = captor.getValue();
         assertEquals(APPLICATION_ID, updateAppEntity.getName());
         assertEquals(APPLICATION_ID, updateAppEntity.getDescription());
@@ -234,11 +257,13 @@ public class ApplicationResourceTest extends AbstractResourceTest {
         userEntity.setId(USER_NAME);
         PrimaryOwnerEntity owner = new PrimaryOwnerEntity(userEntity);
         appEntity.setPrimaryOwner(owner);
-        doReturn(appEntity).when(applicationService).findById(APPLICATION_ID);
+        doReturn(appEntity).when(applicationService).findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID);
 
         ApplicationEntity updatedEntity = new ApplicationEntity();
         updatedEntity.setId(APPLICATION_ID);
-        doReturn(updatedEntity).when(applicationService).update(eq(APPLICATION_ID), any());
+        doReturn(updatedEntity)
+            .when(applicationService)
+            .update(eq(GraviteeContext.getCurrentOrganization()), eq(GraviteeContext.getCurrentEnvironment()), eq(APPLICATION_ID), any());
 
         Instant now = Instant.now();
         Application updatedApp = new Application();
@@ -254,10 +279,17 @@ public class ApplicationResourceTest extends AbstractResourceTest {
         final Response response = target(APPLICATION_ID).request().put(Entity.json(appInput));
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
 
-        Mockito.verify(applicationService).findById(APPLICATION_ID);
+        Mockito.verify(applicationService).findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID);
 
         ArgumentCaptor<UpdateApplicationEntity> captor = ArgumentCaptor.forClass(UpdateApplicationEntity.class);
-        Mockito.verify(applicationService).update(eq(APPLICATION_ID), captor.capture());
+        Mockito
+            .verify(applicationService)
+            .update(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
+                eq(APPLICATION_ID),
+                captor.capture()
+            );
         UpdateApplicationEntity updateAppEntity = captor.getValue();
         assertEquals(APPLICATION_ID, updateAppEntity.getName());
         assertEquals(APPLICATION_ID, updateAppEntity.getDescription());
@@ -287,11 +319,13 @@ public class ApplicationResourceTest extends AbstractResourceTest {
         userEntity.setId(USER_NAME);
         PrimaryOwnerEntity owner = new PrimaryOwnerEntity(userEntity);
         appEntity.setPrimaryOwner(owner);
-        doReturn(appEntity).when(applicationService).findById(APPLICATION_ID);
+        doReturn(appEntity).when(applicationService).findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID);
 
         ApplicationEntity updatedEntity = new ApplicationEntity();
         updatedEntity.setId(APPLICATION_ID);
-        doReturn(updatedEntity).when(applicationService).update(eq(APPLICATION_ID), any());
+        doReturn(updatedEntity)
+            .when(applicationService)
+            .update(eq(GraviteeContext.getCurrentOrganization()), eq(GraviteeContext.getCurrentEnvironment()), eq(APPLICATION_ID), any());
 
         Instant now = Instant.now();
         Application updatedApp = new Application();
@@ -322,10 +356,17 @@ public class ApplicationResourceTest extends AbstractResourceTest {
         final Response response = target(APPLICATION_ID).request().put(Entity.json(appInput));
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
 
-        Mockito.verify(applicationService).findById(APPLICATION_ID);
+        Mockito.verify(applicationService).findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID);
 
         ArgumentCaptor<UpdateApplicationEntity> captor = ArgumentCaptor.forClass(UpdateApplicationEntity.class);
-        Mockito.verify(applicationService).update(eq(APPLICATION_ID), captor.capture());
+        Mockito
+            .verify(applicationService)
+            .update(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
+                eq(APPLICATION_ID),
+                captor.capture()
+            );
         UpdateApplicationEntity updateAppEntity = captor.getValue();
         assertEquals(APPLICATION_ID, updateAppEntity.getName());
         assertEquals(APPLICATION_ID, updateAppEntity.getDescription());
@@ -356,7 +397,7 @@ public class ApplicationResourceTest extends AbstractResourceTest {
         final Response response = target(APPLICATION_ID).request().get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
 
-        Mockito.verify(applicationService).findById(APPLICATION_ID);
+        Mockito.verify(applicationService).findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID);
 
         String expectedBasePath = target(APPLICATION_ID).getUri().toString();
         Mockito.verify(applicationMapper).computeApplicationLinks(expectedBasePath, null);
@@ -369,12 +410,16 @@ public class ApplicationResourceTest extends AbstractResourceTest {
     public void shouldRenewApplication() {
         ApplicationEntity renewedApplicationEntity = new ApplicationEntity();
         renewedApplicationEntity.setId(APPLICATION_ID);
-        doReturn(renewedApplicationEntity).when(applicationService).renewClientSecret(APPLICATION_ID);
+        doReturn(renewedApplicationEntity)
+            .when(applicationService)
+            .renewClientSecret(GraviteeContext.getCurrentOrganization(), GraviteeContext.getCurrentEnvironment(), APPLICATION_ID);
 
         final Response response = target(APPLICATION_ID).path("_renew_secret").request().post(null);
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
 
-        Mockito.verify(applicationService).renewClientSecret(APPLICATION_ID);
+        Mockito
+            .verify(applicationService)
+            .renewClientSecret(GraviteeContext.getCurrentOrganization(), GraviteeContext.getCurrentEnvironment(), APPLICATION_ID);
         Mockito.verify(applicationMapper).convert(eq(renewedApplicationEntity), any());
 
         String expectedBasePath = target(APPLICATION_ID).getUri().toString();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationsResourceTest.java
@@ -27,6 +27,7 @@ import io.gravitee.rest.api.model.application.ApplicationSettings;
 import io.gravitee.rest.api.model.filtering.FilteredEntities;
 import io.gravitee.rest.api.portal.rest.model.*;
 import io.gravitee.rest.api.portal.rest.model.Error;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.*;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.HttpHeaders;
@@ -62,14 +63,16 @@ public class ApplicationsResourceTest extends AbstractResourceTest {
         applicationListItem2.setName("B");
 
         Set<ApplicationListItem> mockApplications = new HashSet<>(Arrays.asList(applicationListItem1, applicationListItem2));
-        doReturn(mockApplications).when(applicationService).findByUser(any());
+        doReturn(mockApplications)
+            .when(applicationService)
+            .findByUser(eq(GraviteeContext.getCurrentOrganization()), eq(GraviteeContext.getCurrentEnvironment()), any());
 
         doReturn(new Application().id("A").name("A")).when(applicationMapper).convert(eq(applicationListItem1), any());
         doReturn(new Application().id("B").name("B")).when(applicationMapper).convert(eq(applicationListItem2), any());
 
         ApplicationEntity createdEntity = mock(ApplicationEntity.class);
         doReturn("NEW").when(createdEntity).getId();
-        doReturn(createdEntity).when(applicationService).create(any(), any());
+        doReturn(createdEntity).when(applicationService).create(eq(GraviteeContext.getCurrentEnvironment()), any(), any());
         doReturn(new Application().id("NEW")).when(applicationMapper).convert(eq(createdEntity), any());
     }
 
@@ -78,7 +81,9 @@ public class ApplicationsResourceTest extends AbstractResourceTest {
         final Response response = target().request().get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
 
-        Mockito.verify(applicationService).findByUser(any());
+        Mockito
+            .verify(applicationService)
+            .findByUser(eq(GraviteeContext.getCurrentOrganization()), eq(GraviteeContext.getCurrentEnvironment()), any());
 
         ArgumentCaptor<String> ac = ArgumentCaptor.forClass(String.class);
         Mockito.verify(applicationMapper, Mockito.times(2)).computeApplicationLinks(ac.capture(), eq(null));
@@ -118,7 +123,9 @@ public class ApplicationsResourceTest extends AbstractResourceTest {
         Set<ApplicationListItem> mockApplications = new HashSet<>(
             Arrays.asList(applicationListItem1, applicationListItem2, applicationListItem3, applicationListItem4)
         );
-        doReturn(mockApplications).when(applicationService).findByUser(any());
+        doReturn(mockApplications)
+            .when(applicationService)
+            .findByUser(eq(GraviteeContext.getCurrentOrganization()), eq(GraviteeContext.getCurrentEnvironment()), any());
 
         doReturn(new Application().id("A").name("A")).when(applicationMapper).convert(eq(applicationListItem1), any());
         doReturn(new Application().id("B").name("b")).when(applicationMapper).convert(eq(applicationListItem2), any());
@@ -179,7 +186,9 @@ public class ApplicationsResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldGetNoApplicationAndNoLink() {
-        doReturn(new HashSet<>()).when(applicationService).findByUser(any());
+        doReturn(new HashSet<>())
+            .when(applicationService)
+            .findByUser(eq(GraviteeContext.getCurrentOrganization()), eq(GraviteeContext.getCurrentEnvironment()), any());
 
         //Test with default limit
         final Response response = target().request().get();
@@ -211,7 +220,7 @@ public class ApplicationsResourceTest extends AbstractResourceTest {
         assertEquals(target().path("NEW").getUri().toString(), response.getHeaders().getFirst(HttpHeaders.LOCATION));
 
         ArgumentCaptor<NewApplicationEntity> captor = ArgumentCaptor.forClass(NewApplicationEntity.class);
-        Mockito.verify(applicationService).create(captor.capture(), any());
+        Mockito.verify(applicationService).create(eq(GraviteeContext.getCurrentEnvironment()), captor.capture(), any());
 
         final NewApplicationEntity value = captor.getValue();
         assertNotNull(value);
@@ -247,7 +256,7 @@ public class ApplicationsResourceTest extends AbstractResourceTest {
         assertEquals(HttpStatusCode.CREATED_201, response.getStatus());
 
         ArgumentCaptor<NewApplicationEntity> captor = ArgumentCaptor.forClass(NewApplicationEntity.class);
-        Mockito.verify(applicationService).create(captor.capture(), any());
+        Mockito.verify(applicationService).create(eq(GraviteeContext.getCurrentEnvironment()), captor.capture(), any());
 
         final NewApplicationEntity value = captor.getValue();
         assertNotNull(value);
@@ -282,7 +291,7 @@ public class ApplicationsResourceTest extends AbstractResourceTest {
         assertEquals(HttpStatusCode.CREATED_201, response.getStatus());
 
         ArgumentCaptor<NewApplicationEntity> captor = ArgumentCaptor.forClass(NewApplicationEntity.class);
-        Mockito.verify(applicationService).create(captor.capture(), any());
+        Mockito.verify(applicationService).create(eq(GraviteeContext.getCurrentEnvironment()), captor.capture(), any());
 
         final NewApplicationEntity value = captor.getValue();
         assertNotNull(value);
@@ -329,7 +338,7 @@ public class ApplicationsResourceTest extends AbstractResourceTest {
         assertEquals(HttpStatusCode.CREATED_201, response.getStatus());
 
         ArgumentCaptor<NewApplicationEntity> captor = ArgumentCaptor.forClass(NewApplicationEntity.class);
-        Mockito.verify(applicationService).create(captor.capture(), any());
+        Mockito.verify(applicationService).create(eq(GraviteeContext.getCurrentEnvironment()), captor.capture(), any());
 
         final NewApplicationEntity value = captor.getValue();
         assertNotNull(value);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/CategoriesResourceNotAuthenticatedTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/CategoriesResourceNotAuthenticatedTest.java
@@ -23,6 +23,7 @@ import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.model.CategoryEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.portal.rest.model.CategoriesResponse;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.io.IOException;
 import java.security.Principal;
 import java.util.Arrays;
@@ -108,7 +109,7 @@ public class CategoriesResourceNotAuthenticatedTest extends AbstractResourceTest
         category3.setOrder(1);
 
         List<CategoryEntity> mockCategories = Arrays.asList(category1, category2, category3);
-        doReturn(mockCategories).when(categoryService).findAll();
+        doReturn(mockCategories).when(categoryService).findAll(GraviteeContext.getCurrentEnvironment());
         doReturn(1L).when(categoryService).getTotalApisByCategory(any(), any());
 
         doReturn(false).when(ratingService).isEnabled();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/CategoriesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/CategoriesResourceTest.java
@@ -26,6 +26,7 @@ import io.gravitee.rest.api.portal.rest.model.CategoriesResponse;
 import io.gravitee.rest.api.portal.rest.model.Error;
 import io.gravitee.rest.api.portal.rest.model.ErrorResponse;
 import io.gravitee.rest.api.portal.rest.model.Links;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.*;
 import javax.ws.rs.core.Response;
 import org.junit.Before;
@@ -72,7 +73,7 @@ public class CategoriesResourceTest extends AbstractResourceTest {
 
         existingCategories = Arrays.asList(category1, category2, category3);
 
-        doReturn(existingCategories).when(categoryService).findAll();
+        doReturn(existingCategories).when(categoryService).findAll(GraviteeContext.getCurrentEnvironment());
 
         Mockito.when(categoryMapper.convert(any(), any())).thenCallRealMethod();
     }
@@ -107,7 +108,7 @@ public class CategoriesResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldGetNoPublishedApiAndNoLink() {
-        doReturn(new ArrayList<>()).when(categoryService).findAll();
+        doReturn(new ArrayList<>()).when(categoryService).findAll(GraviteeContext.getCurrentEnvironment());
 
         //Test with default limit
         final Response response = target().request().get();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/CategoryResourceNotAuthenticatedTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/CategoryResourceNotAuthenticatedTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.doReturn;
 import io.gravitee.rest.api.model.CategoryEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.portal.rest.model.Category;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.security.Principal;
@@ -94,7 +95,7 @@ public class CategoryResourceNotAuthenticatedTest extends AbstractResourceTest {
         CategoryEntity categoryEntity = new CategoryEntity();
         categoryEntity.setId(CATEGORY_ID);
         categoryEntity.setHidden(false);
-        doReturn(categoryEntity).when(categoryService).findNotHiddenById(CATEGORY_ID);
+        doReturn(categoryEntity).when(categoryService).findNotHiddenById(CATEGORY_ID, GraviteeContext.getCurrentEnvironment());
 
         Set<ApiEntity> mockApis = new HashSet<>();
         doReturn(mockApis).when(apiService).findPublishedByUser(any());
@@ -107,7 +108,7 @@ public class CategoryResourceNotAuthenticatedTest extends AbstractResourceTest {
         final Response response = target(CATEGORY_ID).request().get();
         assertEquals(OK_200, response.getStatus());
 
-        Mockito.verify(categoryService).findNotHiddenById(CATEGORY_ID);
+        Mockito.verify(categoryService).findNotHiddenById(CATEGORY_ID, GraviteeContext.getCurrentEnvironment());
         Mockito.verify(apiService).findPublishedByUser(null);
         Mockito.verify(categoryService).getTotalApisByCategory(any(), any());
         Mockito.verify(categoryMapper).convert(any(), any());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/CategoryResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/CategoryResourceTest.java
@@ -27,6 +27,7 @@ import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.portal.rest.model.Category;
 import io.gravitee.rest.api.portal.rest.model.Error;
 import io.gravitee.rest.api.portal.rest.model.ErrorResponse;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.CategoryNotFoundException;
 import java.io.File;
 import java.io.IOException;
@@ -68,7 +69,7 @@ public class CategoryResourceTest extends AbstractResourceTest {
         CategoryEntity categoryEntity = new CategoryEntity();
         categoryEntity.setId(CATEGORY_ID);
         categoryEntity.setHidden(false);
-        doReturn(categoryEntity).when(categoryService).findNotHiddenById(CATEGORY_ID);
+        doReturn(categoryEntity).when(categoryService).findNotHiddenById(CATEGORY_ID, GraviteeContext.getCurrentEnvironment());
 
         Set<ApiEntity> mockApis = new HashSet<>();
         doReturn(mockApis).when(apiService).findPublishedByUser(any());
@@ -79,7 +80,7 @@ public class CategoryResourceTest extends AbstractResourceTest {
         apiLogoContent = Files.readAllBytes(Paths.get(this.getClass().getClassLoader().getResource("media/logo.svg").toURI()));
         mockImage.setContent(apiLogoContent);
         mockImage.setType("image/svg");
-        doReturn(mockImage).when(categoryService).getPicture(CATEGORY_ID);
+        doReturn(mockImage).when(categoryService).getPicture(GraviteeContext.getCurrentEnvironment(), CATEGORY_ID);
     }
 
     @Test
@@ -87,7 +88,7 @@ public class CategoryResourceTest extends AbstractResourceTest {
         final Response response = target(CATEGORY_ID).request().get();
         assertEquals(OK_200, response.getStatus());
 
-        Mockito.verify(categoryService).findNotHiddenById(CATEGORY_ID);
+        Mockito.verify(categoryService).findNotHiddenById(CATEGORY_ID, GraviteeContext.getCurrentEnvironment());
         Mockito.verify(apiService).findPublishedByUser(USER_NAME);
         Mockito.verify(categoryService).getTotalApisByCategory(any(), any());
         Mockito.verify(categoryMapper).convert(any(), any());
@@ -98,7 +99,9 @@ public class CategoryResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldNotGetCategory() {
-        doThrow(new CategoryNotFoundException(UNKNOWN_CATEGORY)).when(categoryService).findNotHiddenById(UNKNOWN_CATEGORY);
+        doThrow(new CategoryNotFoundException(UNKNOWN_CATEGORY))
+            .when(categoryService)
+            .findNotHiddenById(UNKNOWN_CATEGORY, GraviteeContext.getCurrentEnvironment());
 
         final Response response = target(UNKNOWN_CATEGORY).request().get();
         assertEquals(NOT_FOUND_404, response.getStatus());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ConfigurationIdentitiesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ConfigurationIdentitiesResourceTest.java
@@ -27,6 +27,7 @@ import io.gravitee.rest.api.model.configuration.identity.google.GoogleIdentityPr
 import io.gravitee.rest.api.model.configuration.identity.oidc.OIDCIdentityProviderEntity;
 import io.gravitee.rest.api.model.settings.PortalSettingsEntity;
 import io.gravitee.rest.api.portal.rest.model.ConfigurationIdentitiesResponse;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -83,7 +84,7 @@ public class ConfigurationIdentitiesResourceTest extends AbstractResourceTest {
             .findAll(any());
 
         PortalSettingsEntity configEntity = new PortalSettingsEntity();
-        doReturn(configEntity).when(configService).getPortalSettings();
+        doReturn(configEntity).when(configService).getPortalSettings(GraviteeContext.getCurrentEnvironment());
 
         final Response response = target().request().get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ConfigurationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ConfigurationResourceTest.java
@@ -60,14 +60,14 @@ public class ConfigurationResourceTest extends AbstractResourceTest {
 
         PortalSettingsEntity portalConfigEntity = new PortalSettingsEntity();
         ConsoleSettingsEntity consoleSettingsEntity = new ConsoleSettingsEntity();
-        doReturn(portalConfigEntity).when(configService).getPortalSettings();
-        doReturn(consoleSettingsEntity).when(configService).getConsoleSettings();
+        doReturn(portalConfigEntity).when(configService).getPortalSettings(GraviteeContext.getCurrentEnvironment());
+        doReturn(consoleSettingsEntity).when(configService).getConsoleSettings(GraviteeContext.getCurrentOrganization());
         final Response response = target().request().get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
 
         Mockito.verify(configMapper).convert(portalConfigEntity, consoleSettingsEntity);
-        Mockito.verify(configService).getPortalSettings();
-        Mockito.verify(configService).getConsoleSettings();
+        Mockito.verify(configService).getPortalSettings(GraviteeContext.getCurrentEnvironment());
+        Mockito.verify(configService).getConsoleSettings(GraviteeContext.getCurrentOrganization());
     }
 
     @Test
@@ -134,7 +134,7 @@ public class ConfigurationResourceTest extends AbstractResourceTest {
                 }
             );
 
-        when(accessControlService.canAccessPageFromPortal(any())).thenReturn(true);
+        when(accessControlService.canAccessPageFromPortal(eq(GraviteeContext.getCurrentEnvironment()), any())).thenReturn(true);
 
         final Response response = target("/links").request().get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PageResourceNotAuthenticatedTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PageResourceNotAuthenticatedTest.java
@@ -18,13 +18,13 @@ package io.gravitee.rest.api.portal.rest.resource;
 import static io.gravitee.common.http.HttpStatusCode.OK_200;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doReturn;
 
 import io.gravitee.rest.api.model.PageEntity;
 import io.gravitee.rest.api.model.Visibility;
 import io.gravitee.rest.api.portal.rest.model.Page;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.io.IOException;
 import java.security.Principal;
 import java.util.HashMap;
@@ -106,7 +106,9 @@ public class PageResourceNotAuthenticatedTest extends AbstractResourceTest {
     @Test
     public void shouldHaveMetadataCleared() {
         doReturn(true).when(accessControlService).canAccessApiFromPortal(anyString());
-        doReturn(true).when(accessControlService).canAccessPageFromPortal(any(PageEntity.class));
+        doReturn(true)
+            .when(accessControlService)
+            .canAccessPageFromPortal(eq(GraviteeContext.getCurrentEnvironment()), any(PageEntity.class));
 
         Response anotherResponse = target(ANOTHER_PAGE).request().get();
         assertEquals(OK_200, anotherResponse.getStatus());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PageResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PageResourceTest.java
@@ -17,8 +17,7 @@ package io.gravitee.rest.api.portal.rest.resource;
 
 import static io.gravitee.common.http.HttpStatusCode.*;
 import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 
@@ -28,6 +27,7 @@ import io.gravitee.rest.api.portal.rest.model.Error;
 import io.gravitee.rest.api.portal.rest.model.ErrorResponse;
 import io.gravitee.rest.api.portal.rest.model.Page;
 import io.gravitee.rest.api.portal.rest.model.PageLinks;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.PageNotFoundException;
 import java.util.HashMap;
 import java.util.List;
@@ -84,7 +84,7 @@ public class PageResourceTest extends AbstractResourceTest {
         doReturn(new Page()).when(pageMapper).convert(any(), any(), any());
         doReturn(new PageLinks()).when(pageMapper).computePageLinks(any(), any());
         doReturn(true).when(accessControlService).canAccessApiFromPortal(anyString());
-        doReturn(true).when(accessControlService).canAccessPageFromPortal(any());
+        doReturn(true).when(accessControlService).canAccessPageFromPortal(eq(GraviteeContext.getCurrentEnvironment()), any());
     }
 
     @Test
@@ -128,7 +128,7 @@ public class PageResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldNotGetPageBecauseOfGroupService() {
-        doReturn(false).when(accessControlService).canAccessPageFromPortal(any());
+        doReturn(false).when(accessControlService).canAccessPageFromPortal(eq(GraviteeContext.getCurrentEnvironment()), any());
 
         Response response = target(PUBLISHED_PAGE).request().get();
         assertEquals(UNAUTHORIZED_401, response.getStatus());
@@ -173,7 +173,7 @@ public class PageResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldNotGetPageContentBecauseOfGroupService() {
-        doReturn(false).when(accessControlService).canAccessPageFromPortal(any());
+        doReturn(false).when(accessControlService).canAccessPageFromPortal(eq(GraviteeContext.getCurrentEnvironment()), any());
 
         Response response = target(PUBLISHED_PAGE).path("content").request().get();
         assertEquals(UNAUTHORIZED_401, response.getStatus());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PagesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PagesResourceTest.java
@@ -66,10 +66,10 @@ public class PagesResourceTest extends AbstractResourceTest {
             .when(pageService)
             .search(any(), isNull(), eq(GraviteeContext.getCurrentEnvironment()));
 
-        when(accessControlService.canAccessPageFromPortal(any(PageEntity.class)))
+        when(accessControlService.canAccessPageFromPortal(eq(GraviteeContext.getCurrentEnvironment()), any(PageEntity.class)))
             .thenAnswer(
                 invocationOnMock -> {
-                    PageEntity page = invocationOnMock.getArgument(0);
+                    PageEntity page = invocationOnMock.getArgument(1);
                     return !PageType.MARKDOWN_TEMPLATE.name().equals(page.getType());
                 }
             );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PermissionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PermissionsResourceTest.java
@@ -19,6 +19,7 @@ import static io.gravitee.common.http.HttpStatusCode.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 
 import io.gravitee.rest.api.model.ApplicationEntity;
@@ -26,6 +27,7 @@ import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.portal.rest.model.Error;
 import io.gravitee.rest.api.portal.rest.model.ErrorResponse;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.*;
 import javax.ws.rs.core.Response;
 import org.junit.Before;
@@ -56,12 +58,14 @@ public class PermissionsResourceTest extends AbstractResourceTest {
         ApplicationListItem mockAppListItem = new ApplicationListItem();
         mockAppListItem.setId(APPLICATION);
         Set<ApplicationListItem> mockApps = new HashSet<>(Arrays.asList(mockAppListItem));
-        doReturn(mockApps).when(applicationService).findByUser(any());
+        doReturn(mockApps)
+            .when(applicationService)
+            .findByUser(eq(GraviteeContext.getCurrentOrganization()), eq(GraviteeContext.getCurrentEnvironment()), any());
 
         ApplicationEntity mockAppEntity = new ApplicationEntity();
         mockAppEntity.setId(APPLICATION);
 
-        doReturn(mockAppEntity).when(applicationService).findById(any());
+        doReturn(mockAppEntity).when(applicationService).findById(eq(GraviteeContext.getCurrentEnvironment()), any());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResourceTest.java
@@ -35,7 +35,7 @@ import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.portal.rest.model.*;
-import java.util.Arrays;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.Collections;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
@@ -95,7 +95,9 @@ public class SubscriptionsResourceTest extends AbstractResourceTest {
     public void shouldGetSubscriptionsForApi() {
         final ApplicationListItem application = new ApplicationListItem();
         application.setId(APPLICATION);
-        doReturn(newSet(application)).when(applicationService).findByUser(any());
+        doReturn(newSet(application))
+            .when(applicationService)
+            .findByUser(eq(GraviteeContext.getCurrentOrganization()), eq(GraviteeContext.getCurrentEnvironment()), any());
 
         final Response response = target().queryParam("apiId", API).request().get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/UserResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/UserResourceTest.java
@@ -32,6 +32,7 @@ import io.gravitee.rest.api.portal.rest.model.User;
 import io.gravitee.rest.api.portal.rest.model.UserConfig;
 import io.gravitee.rest.api.portal.rest.model.UserInput;
 import io.gravitee.rest.api.portal.rest.model.UserLinks;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
@@ -91,7 +92,7 @@ public class UserResourceTest extends AbstractResourceTest {
     public void shouldGetCurrentUserWithEmptyManagementConfig() {
         when(userService.findByIdWithRoles(USER_NAME)).thenReturn(new UserEntity());
         when(permissionService.hasManagementRights(USER_NAME)).thenReturn(Boolean.TRUE);
-        when(configService.getConsoleSettings()).thenReturn(new ConsoleSettingsEntity());
+        when(configService.getConsoleSettings(GraviteeContext.getCurrentOrganization())).thenReturn(new ConsoleSettingsEntity());
 
         final Response response = target().request().get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
@@ -112,7 +113,7 @@ public class UserResourceTest extends AbstractResourceTest {
         when(userService.findByIdWithRoles(USER_NAME)).thenReturn(new UserEntity());
         when(permissionService.hasManagementRights(USER_NAME)).thenReturn(Boolean.TRUE);
         ConsoleSettingsEntity consoleConfigEntity = new ConsoleSettingsEntity();
-        when(configService.getConsoleSettings()).thenReturn(consoleConfigEntity);
+        when(configService.getConsoleSettings(GraviteeContext.getCurrentOrganization())).thenReturn(consoleConfigEntity);
 
         final Response response = target().request().get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
@@ -136,7 +137,7 @@ public class UserResourceTest extends AbstractResourceTest {
         Management managementConfig = new Management();
         managementConfig.setUrl("URL");
         consoleConfigEntity.setManagement(managementConfig);
-        when(configService.getConsoleSettings()).thenReturn(consoleConfigEntity);
+        when(configService.getConsoleSettings(GraviteeContext.getCurrentOrganization())).thenReturn(consoleConfigEntity);
 
         final Response response = target().request().get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/listener/AuthenticationSuccessListener.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/listener/AuthenticationSuccessListener.java
@@ -217,6 +217,8 @@ public class AuthenticationSuccessListener implements ApplicationListener<Authen
                     }
                     try {
                         membershipService.addRoleToMemberOnReference(
+                            GraviteeContext.getCurrentOrganization(),
+                            GraviteeContext.getCurrentEnvironment(),
                             membershipRef,
                             new MembershipService.MembershipMember(userId, null, MembershipMemberType.USER),
                             new MembershipService.MembershipRole(roleScope, roleName)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/listener/AuthenticationSuccessListenerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/listener/AuthenticationSuccessListenerTest.java
@@ -24,6 +24,7 @@ import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -133,6 +134,8 @@ public class AuthenticationSuccessListenerTest {
         verify(userServiceMock, times(1)).create(any(NewExternalUserEntity.class), eq(false));
         verify(membershipServiceMock, times(1))
             .addRoleToMemberOnReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
                 new MembershipService.MembershipReference(MembershipReferenceType.ENVIRONMENT, "DEFAULT"),
                 new MembershipService.MembershipMember(userDetailsMock.getUsername(), null, MembershipMemberType.USER),
                 new MembershipService.MembershipRole(RoleScope.ENVIRONMENT, "ROLE")
@@ -169,6 +172,8 @@ public class AuthenticationSuccessListenerTest {
         verify(userServiceMock, times(1)).create(any(NewExternalUserEntity.class), eq(false));
         verify(membershipServiceMock, times(1))
             .addRoleToMemberOnReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
                 new MembershipService.MembershipReference(MembershipReferenceType.ENVIRONMENT, "DEFAULT"),
                 new MembershipService.MembershipMember(userDetailsMock.getUsername(), null, MembershipMemberType.USER),
                 new MembershipService.MembershipRole(RoleScope.ENVIRONMENT, "ROLE1")
@@ -202,6 +207,8 @@ public class AuthenticationSuccessListenerTest {
         verify(userServiceMock, times(1)).create(any(NewExternalUserEntity.class), eq(false));
         verify(membershipServiceMock, times(1))
             .addRoleToMemberOnReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
                 new MembershipService.MembershipReference(MembershipReferenceType.ENVIRONMENT, "DEFAULT"),
                 new MembershipService.MembershipMember(userDetailsMock.getUsername(), null, MembershipMemberType.USER),
                 new MembershipService.MembershipRole(RoleScope.ENVIRONMENT, "ROLE")
@@ -233,6 +240,8 @@ public class AuthenticationSuccessListenerTest {
         verify(userServiceMock, times(1)).create(any(NewExternalUserEntity.class), eq(false));
         verify(membershipServiceMock, times(1))
             .addRoleToMemberOnReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
                 new MembershipService.MembershipReference(MembershipReferenceType.ENVIRONMENT, "DEFAULT"),
                 new MembershipService.MembershipMember(userDetailsMock.getUsername(), null, MembershipMemberType.USER),
                 new MembershipService.MembershipRole(RoleScope.ENVIRONMENT, "ADMIN")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/AccessControlService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/AccessControlService.java
@@ -27,11 +27,9 @@ public interface AccessControlService {
 
     boolean canAccessApiFromPortal(ApiEntity apiEntity);
 
-    boolean canAccessPageFromPortal(PageEntity pageEntity);
+    boolean canAccessPageFromPortal(final String environmentId, PageEntity pageEntity);
 
-    boolean canAccessPageFromPortal(String apiId, PageEntity pageEntity);
+    boolean canAccessPageFromPortal(final String environmentId, String apiId, PageEntity pageEntity);
 
-    boolean canAccessPageFromConsole(PageEntity pageEntity);
-
-    boolean canAccessPageFromConsole(ApiEntity apiEntity, PageEntity pageEntity);
+    boolean canAccessPageFromConsole(final String environmentId, ApiEntity apiEntity, PageEntity pageEntity);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/AnalyticsService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/AnalyticsService.java
@@ -29,6 +29,6 @@ import io.gravitee.rest.api.model.analytics.query.*;
 public interface AnalyticsService {
     StatsAnalytics execute(StatsQuery query);
     HitsAnalytics execute(CountQuery query);
-    HistogramAnalytics execute(DateHistogramQuery query);
-    TopHitsAnalytics execute(GroupByQuery query);
+    HistogramAnalytics execute(final String organizationId, DateHistogramQuery query);
+    TopHitsAnalytics execute(final String organizationId, GroupByQuery query);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiHeaderService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiHeaderService.java
@@ -25,13 +25,13 @@ import java.util.List;
  * @author GraviteeSource Team
  */
 public interface ApiHeaderService {
-    ApiHeaderEntity create(NewApiHeaderEntity newEntity);
+    ApiHeaderEntity create(final String environmentId, NewApiHeaderEntity newEntity);
 
-    void delete(String apiHeaderId);
+    void delete(final String environmentId, String apiHeaderId);
 
-    ApiHeaderEntity update(UpdateApiHeaderEntity updateEntity);
+    ApiHeaderEntity update(final String environmentId, UpdateApiHeaderEntity updateEntity);
 
-    List<ApiHeaderEntity> findAll();
+    List<ApiHeaderEntity> findAll(final String environmentId);
 
     void initialize(String environmentId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApplicationAlertService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApplicationAlertService.java
@@ -24,15 +24,21 @@ import io.gravitee.rest.api.model.alert.UpdateAlertTriggerEntity;
 import java.util.List;
 
 public interface ApplicationAlertService {
-    AlertTriggerEntity create(String applicationId, NewAlertTriggerEntity alert);
+    AlertTriggerEntity create(final String environmentId, String applicationId, NewAlertTriggerEntity alert);
+
     List<AlertTriggerEntity> findByApplication(String applicationId);
+
     AlertTriggerEntity update(String applicationId, UpdateAlertTriggerEntity alert);
+
     void delete(String alertId, String applicationId);
+
     AlertStatusEntity getStatus();
 
-    void addMemberToApplication(String applicationId, String email);
-    void deleteMemberFromApplication(String applicationId, String email);
+    void addMemberToApplication(final String environment, String applicationId, String email);
+
+    void deleteMemberFromApplication(final String environment, String applicationId, String email);
 
     void deleteAll(String applicationId);
+
     void handleEvent(Event<ApplicationAlertEventType, Object> event);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApplicationMetadataService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApplicationMetadataService.java
@@ -29,9 +29,9 @@ public interface ApplicationMetadataService {
 
     ApplicationMetadataEntity findByIdAndApplication(String metadataId, String applicationId);
 
-    ApplicationMetadataEntity create(NewApplicationMetadataEntity metadata);
+    ApplicationMetadataEntity create(final String environmentId, NewApplicationMetadataEntity metadata);
 
-    ApplicationMetadataEntity update(UpdateApplicationMetadataEntity metadata);
+    ApplicationMetadataEntity update(final String environmentId, UpdateApplicationMetadataEntity metadata);
 
     void delete(String metadataId, String application);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApplicationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApplicationService.java
@@ -29,37 +29,47 @@ import java.util.Set;
  * @author GraviteeSource Team
  */
 public interface ApplicationService {
-    ApplicationEntity findById(String applicationId);
-    Set<ApplicationListItem> findByIds(List<String> applicationIds);
+    ApplicationEntity findById(final String environment, String applicationId);
 
-    Set<ApplicationListItem> findByUser(String username);
+    Set<ApplicationListItem> findByIds(final String organizationId, final String environmentId, List<String> applicationIds);
 
-    Set<ApplicationListItem> findByUserAndNameAndStatus(String username, boolean isAdminUser, String name, String status);
+    Set<ApplicationListItem> findByUser(final String organizationId, final String environmentId, String username);
 
-    Set<ApplicationListItem> findByUserAndNameAndStatus(String username, String name, String status);
+    Set<ApplicationListItem> findByUserAndNameAndStatus(
+        String username,
+        boolean isAdminUser,
+        String name,
+        String status,
+        final String environmentId,
+        final String organizationId
+    );
 
     Set<ApplicationListItem> findByOrganization(String organizationId);
 
-    Set<ApplicationListItem> findByGroups(List<String> groupId);
-    Set<ApplicationListItem> findByGroupsAndStatus(List<String> groupId, String status);
+    Set<ApplicationListItem> findByGroups(final String organizationId, List<String> groupId);
 
-    Set<ApplicationListItem> findAll();
+    Set<ApplicationListItem> findByGroupsAndStatus(final String organizationId, List<String> groupId, String status);
 
-    Set<ApplicationListItem> findByStatus(String status);
+    Set<ApplicationListItem> findAll(final String organizationId, final String environmentId);
 
-    ApplicationEntity create(NewApplicationEntity application, String username);
+    Set<ApplicationListItem> findByStatus(final String organizationId, final String environmentId, String status);
 
-    ApplicationEntity create(NewApplicationEntity application, String username, String environmentId);
+    ApplicationEntity create(final String environmentId, NewApplicationEntity application, String username);
 
-    ApplicationEntity update(String applicationId, UpdateApplicationEntity application);
+    ApplicationEntity update(
+        final String organizationId,
+        final String environmentId,
+        String applicationId,
+        UpdateApplicationEntity application
+    );
 
-    ApplicationEntity renewClientSecret(String applicationId);
+    ApplicationEntity renewClientSecret(final String organizationId, final String environmentId, String applicationId);
 
     ApplicationEntity restore(String applicationId);
 
     void archive(String applicationId);
 
-    InlinePictureEntity getPicture(String apiId);
+    InlinePictureEntity getPicture(final String environmentId, String apiId);
 
-    InlinePictureEntity getBackground(String application);
+    InlinePictureEntity getBackground(final String environmentId, String application);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/AuditService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/AuditService.java
@@ -47,6 +47,7 @@ public interface AuditService {
     );
 
     void createEnvironmentAuditLog(
+        final String environmentId,
         Map<Audit.AuditProperties, String> properties,
         Audit.AuditEvent event,
         Date createdAt,
@@ -55,6 +56,7 @@ public interface AuditService {
     );
 
     void createOrganizationAuditLog(
+        final String organization,
         Map<Audit.AuditProperties, String> properties,
         Audit.AuditEvent event,
         Date createdAt,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/CategoryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/CategoryService.java
@@ -29,15 +29,15 @@ import java.util.Set;
  * @author GraviteeSource Team
  */
 public interface CategoryService {
-    List<CategoryEntity> findAll();
-    CategoryEntity findById(String id);
-    CategoryEntity findNotHiddenById(String id);
-    CategoryEntity create(NewCategoryEntity category);
+    List<CategoryEntity> findAll(final String environmentId);
+    CategoryEntity findById(String id, final String environment);
+    CategoryEntity findNotHiddenById(String id, final String environmentId);
+    CategoryEntity create(final String environmentId, NewCategoryEntity category);
     CategoryEntity update(String categoryId, UpdateCategoryEntity category);
     List<CategoryEntity> update(List<UpdateCategoryEntity> categories);
     void delete(String categoryId);
     long getTotalApisByCategory(Set<ApiEntity> apis, CategoryEntity category);
-    InlinePictureEntity getPicture(String categoryId);
-    InlinePictureEntity getBackground(String categoryId);
+    InlinePictureEntity getPicture(final String environmentId, String categoryId);
+    InlinePictureEntity getBackground(final String environmentId, String categoryId);
     List<CategoryEntity> findByPage(String pageId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ConfigService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ConfigService.java
@@ -26,21 +26,17 @@ import io.gravitee.rest.api.model.settings.PortalSettingsEntity;
  * @author GraviteeSource Team
  */
 public interface ConfigService {
-    boolean portalLoginForced();
+    boolean portalLoginForced(final String environmentId);
 
-    PortalSettingsEntity getPortalSettings();
+    PortalSettingsEntity getPortalSettings(final String environmentId);
 
-    PortalSettingsEntity getPortalSettings(String environmentId);
+    void save(final String environment, PortalSettingsEntity portalSettingsEntity);
 
-    void save(PortalSettingsEntity portalSettingsEntity);
+    ConsoleSettingsEntity getConsoleSettings(final String organizationId);
 
-    ConsoleSettingsEntity getConsoleSettings();
+    void save(final String organization, ConsoleSettingsEntity consoleSettingsEntity);
 
-    ConsoleSettingsEntity getConsoleSettings(String organizationId);
+    ConsoleConfigEntity getConsoleConfig(final String organizationId);
 
-    void save(ConsoleSettingsEntity consoleSettingsEntity);
-
-    ConsoleConfigEntity getConsoleConfig();
-
-    PortalConfigEntity getPortalConfig();
+    PortalConfigEntity getPortalConfig(final String environmentId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/EnvironmentService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/EnvironmentService.java
@@ -24,9 +24,9 @@ import java.util.List;
  * @author GraviteeSource Team
  */
 public interface EnvironmentService {
-    List<EnvironmentEntity> findByUser(String userId);
+    List<EnvironmentEntity> findByUser(final String organizationId, String userId);
 
-    List<EnvironmentEntity> findByUserAndIdOrHrid(String userId, String idOrHrid);
+    List<EnvironmentEntity> findByUserAndIdOrHrid(final String organizationId, String userId, String idOrHrid);
 
     List<EnvironmentEntity> findByOrganization(String organizationId);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/EventService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/EventService.java
@@ -23,6 +23,7 @@ import io.gravitee.rest.api.model.NewEventEntity;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -32,22 +33,20 @@ import java.util.function.Predicate;
 public interface EventService {
     EventEntity findById(String id);
 
-    EventEntity create(NewEventEntity event);
+    EventEntity create(final Set<String> environments, NewEventEntity event);
 
-    EventEntity create(EventType type, String payload, Map<String, String> properties);
+    EventEntity create(final Set<String> environmentsIds, EventType type, String payload, Map<String, String> properties);
 
     void delete(String eventId);
 
-    Page<EventEntity> search(List<EventType> eventTypes, Map<String, Object> properties, long from, long to, int page, int size);
-
-    <T> Page<T> search(
+    Page<EventEntity> search(
         List<EventType> eventTypes,
         Map<String, Object> properties,
         long from,
         long to,
         int page,
         int size,
-        Function<EventEntity, T> mapper
+        final List<String> environments
     );
 
     <T> Page<T> search(
@@ -58,7 +57,19 @@ public interface EventService {
         int page,
         int size,
         Function<EventEntity, T> mapper,
-        Predicate<T> filter
+        final List<String> environmentsIds
+    );
+
+    <T> Page<T> search(
+        List<EventType> eventTypes,
+        Map<String, Object> properties,
+        long from,
+        long to,
+        int page,
+        int size,
+        Function<EventEntity, T> mapper,
+        Predicate<T> filter,
+        final List<String> environmentsIds
     );
 
     Collection<EventEntity> search(EventQuery query);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/GroupService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/GroupService.java
@@ -27,21 +27,21 @@ import java.util.Set;
  * @author GraviteeSource Team
  */
 public interface GroupService {
-    GroupEntity create(NewGroupEntity group);
-    void delete(String groupId);
-    void deleteUserFromGroup(String groupId, String username);
-    List<GroupEntity> findAll();
+    GroupEntity create(final String environmentId, NewGroupEntity group);
+    void delete(final String environmentId, String groupId);
+    void deleteUserFromGroup(final String environmentId, String groupId, String username);
+    List<GroupEntity> findAll(final String environmentId);
     List<GroupSimpleEntity> findAllByOrganization(String organizationId);
-    GroupEntity findById(String groupId);
+    GroupEntity findById(final String environmentId, String groupId);
     Set<GroupEntity> findByIds(Set<String> groupIds);
     void associate(String groupId, String associationType);
-    Set<GroupEntity> findByEvent(GroupEvent event);
-    List<GroupEntity> findByName(String name);
+    Set<GroupEntity> findByEvent(final String environmentId, GroupEvent event);
+    List<GroupEntity> findByName(final String environmentId, String name);
     Set<GroupEntity> findByUser(String username);
-    List<ApiEntity> getApis(String groupId);
+    List<ApiEntity> getApis(final String environmentId, String groupId);
     List<ApplicationEntity> getApplications(String groupId);
     int getNumberOfMembers(String groupId);
     boolean isUserAuthorizedToAccessApiData(ApiEntity api, List<String> excludedGroups, String username);
-    GroupEntity update(String groupId, UpdateGroupEntity group);
+    GroupEntity update(final String environmentId, String groupId, UpdateGroupEntity group);
     void updateApiPrimaryOwner(String groupId, String newApiPrimaryOwner);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/MediaService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/MediaService.java
@@ -35,7 +35,7 @@ public interface MediaService {
     List<MediaEntity> findAllWithoutContent(List<PageMediaEntity> pageMediaEntities);
     List<MediaEntity> findAllWithoutContent(List<PageMediaEntity> pageMediaEntities, String api);
 
-    Long getMediaMaxSize();
+    Long getMediaMaxSize(final String environmentId);
 
     List<MediaEntity> findAllByApiId(String apiId);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/MembershipService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/MembershipService.java
@@ -31,8 +31,16 @@ import java.util.Set;
  * @author GraviteeSource Team
  */
 public interface MembershipService {
-    MemberEntity addRoleToMemberOnReference(MembershipReference reference, MembershipMember member, MembershipRole role);
     MemberEntity addRoleToMemberOnReference(
+        final String organizationId,
+        final String environmentId,
+        MembershipReference reference,
+        MembershipMember member,
+        MembershipRole role
+    );
+    MemberEntity addRoleToMemberOnReference(
+        final String organizationId,
+        final String environmentId,
         MembershipReferenceType referenceType,
         String referenceId,
         MembershipMemberType memberType,
@@ -40,6 +48,8 @@ public interface MembershipService {
         String role
     );
     MemberEntity addRoleToMemberOnReference(
+        final String organizationId,
+        final String environmentId,
         MembershipReferenceType referenceType,
         String referenceId,
         MembershipMemberType memberType,
@@ -47,10 +57,24 @@ public interface MembershipService {
         String role,
         String source
     );
-    void deleteMembership(String membershipId);
-    void deleteReference(MembershipReferenceType referenceType, String referenceId);
-    void deleteReferenceMember(MembershipReferenceType referenceType, String referenceId, MembershipMemberType memberType, String memberId);
+    void deleteMembership(final String organizationId, final String environmentId, String membershipId);
+    void deleteReference(
+        final String organizationId,
+        final String environmentId,
+        MembershipReferenceType referenceType,
+        String referenceId
+    );
+    void deleteReferenceMember(
+        final String organizationId,
+        final String environmentId,
+        MembershipReferenceType referenceType,
+        String referenceId,
+        MembershipMemberType memberType,
+        String memberId
+    );
     void deleteReferenceMemberBySource(
+        final String organizationId,
+        final String environmentId,
         MembershipReferenceType referenceType,
         String referenceId,
         MembershipMemberType memberType,
@@ -98,14 +122,19 @@ public interface MembershipService {
     Set<MembershipEntity> getMembershipsByReference(MembershipReferenceType referenceType, String referenceId);
     Set<MembershipEntity> getMembershipsByReferenceAndRole(MembershipReferenceType referenceType, String referenceId, String role);
     Set<MembershipEntity> getMembershipsByReferencesAndRole(MembershipReferenceType referenceType, List<String> referenceIds, String role);
-    MembershipEntity getPrimaryOwner(MembershipReferenceType referenceType, String referenceId);
+    MembershipEntity getPrimaryOwner(final String organizationId, MembershipReferenceType referenceType, String referenceId);
     Set<RoleEntity> getRoles(MembershipReferenceType referenceType, String referenceId, MembershipMemberType memberType, String memberId);
-    MemberEntity getUserMember(MembershipReferenceType referenceType, String referenceId, String userId);
-    Map<String, char[]> getUserMemberPermissions(MembershipReferenceType referenceType, String referenceId, String userId);
-    Map<String, char[]> getUserMemberPermissions(ApiEntity api, String userId);
-    Map<String, char[]> getUserMemberPermissions(ApplicationEntity application, String userId);
-    Map<String, char[]> getUserMemberPermissions(GroupEntity group, String userId);
-    Map<String, char[]> getUserMemberPermissions(EnvironmentEntity environment, String userId);
+    MemberEntity getUserMember(final String environmentId, MembershipReferenceType referenceType, String referenceId, String userId);
+    Map<String, char[]> getUserMemberPermissions(
+        final String environmentId,
+        MembershipReferenceType referenceType,
+        String referenceId,
+        String userId
+    );
+    Map<String, char[]> getUserMemberPermissions(final String environmentId, ApiEntity api, String userId);
+    Map<String, char[]> getUserMemberPermissions(final String environmentId, ApplicationEntity application, String userId);
+    Map<String, char[]> getUserMemberPermissions(final String environmentId, GroupEntity group, String userId);
+    Map<String, char[]> getUserMemberPermissions(final String environmentId, EnvironmentEntity environment, String userId);
     void removeRole(
         MembershipReferenceType referenceType,
         String referenceId,
@@ -115,10 +144,31 @@ public interface MembershipService {
     );
     void removeRoleUsage(String oldRoleId, String newRoleId);
     void removeMemberMemberships(MembershipMemberType memberType, String memberId);
-    void transferApiOwnership(String apiId, MembershipMember member, List<RoleEntity> newPrimaryOwnerRoles);
-    void transferApplicationOwnership(String applicationId, MembershipMember member, List<RoleEntity> newPrimaryOwnerRoles);
-    MemberEntity updateRoleToMemberOnReference(MembershipReference reference, MembershipMember member, MembershipRole role);
+    void transferApiOwnership(
+        final String organizationId,
+        final String environmentId,
+        String apiId,
+        MembershipMember member,
+        List<RoleEntity> newPrimaryOwnerRoles
+    );
+
+    void transferApplicationOwnership(
+        final String organizationId,
+        final String environmentId,
+        String applicationId,
+        MembershipMember member,
+        List<RoleEntity> newPrimaryOwnerRoles
+    );
+    MemberEntity updateRoleToMemberOnReference(
+        final String organizationId,
+        final String environmentId,
+        MembershipReference reference,
+        MembershipMember member,
+        MembershipRole role
+    );
     List<MemberEntity> updateRolesToMemberOnReference(
+        final String organizationId,
+        final String environmentId,
         MembershipReference reference,
         MembershipMember member,
         Collection<MembershipRole> roles,
@@ -126,6 +176,8 @@ public interface MembershipService {
         boolean notify
     );
     List<MemberEntity> updateRolesToMemberOnReferenceBySource(
+        final String organizationId,
+        final String environmentId,
         MembershipReference reference,
         MembershipMember member,
         Collection<MembershipRole> roles,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/MessageService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/MessageService.java
@@ -17,8 +17,6 @@ package io.gravitee.rest.api.service;
 
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.rest.api.model.*;
-import io.gravitee.rest.api.model.plan.PlanQuery;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -28,26 +26,29 @@ import java.util.Set;
 public interface MessageService {
     /**
      * send a message to api consumers according to recipients filters
+     * @param environmentId
      * @param apiId api id
      * @param message message
      * @return the number of recipients
      */
-    int create(String apiId, MessageEntity message);
+    int create(final String environmentId, String apiId, MessageEntity message);
 
     /**
      * send a message to all users according to recipients filters
+     * @param environmentId
      * @param message message
      * @return the number of recipients
      */
-    int create(MessageEntity message);
+    int create(final String environmentId, MessageEntity message);
 
     /**
      * get the user ids of recipients
+     * @param environment
      * @param api api
      * @param message message
      * @return a user id list
      */
-    Set<String> getRecipientsId(Api api, MessageEntity message);
+    Set<String> getRecipientsId(final String environment, Api api, MessageEntity message);
 
     /**
      * get the user ids of recipients

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/QualityMetricsService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/QualityMetricsService.java
@@ -23,6 +23,6 @@ import io.gravitee.rest.api.model.api.ApiEntity;
  * @author GraviteeSource Team
  */
 public interface QualityMetricsService {
-    ApiQualityMetricsEntity getMetrics(ApiEntity apiEntity);
+    ApiQualityMetricsEntity getMetrics(ApiEntity apiEntity, final String environmentId);
     boolean isApiMetricsEnabled();
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/MembershipCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/MembershipCommandHandler.java
@@ -98,6 +98,9 @@ public class MembershipCommandHandler implements CommandHandler<MembershipComman
             );
 
             membershipService.updateRolesToMemberOnReference(
+                // FIXME: I think both these values aren't defined in this context
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
                 membershipReference,
                 membershipMember,
                 Collections.singletonList(membershipRole),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AbstractReferenceMetadataService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AbstractReferenceMetadataService.java
@@ -31,6 +31,7 @@ import io.gravitee.repository.management.model.MetadataReferenceType;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.MetadataService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.*;
 import java.util.*;
 import java.util.function.Function;
@@ -153,13 +154,14 @@ public abstract class AbstractReferenceMetadataService {
         final NewReferenceMetadataEntity metadataEntity,
         final MetadataReferenceType referenceType,
         final String referenceId,
-        final boolean withDefaults
+        final boolean withDefaults,
+        final String environmentId
     ) {
         // if no format defined, we just set String format
         if (metadataEntity.getFormat() == null) {
             metadataEntity.setFormat(MetadataFormat.STRING);
         }
-        checkReferenceMetadataFormat(metadataEntity.getFormat(), metadataEntity.getValue(), referenceType, referenceId);
+        checkReferenceMetadataFormat(metadataEntity.getFormat(), metadataEntity.getValue(), referenceType, referenceId, environmentId);
         // First we prevent the duplicate metadata name
         final Optional<ReferenceMetadataEntity> optionalMetadata = findAllByReference(referenceType, referenceId, withDefaults)
             .stream()
@@ -191,7 +193,8 @@ public abstract class AbstractReferenceMetadataService {
         MetadataFormat format,
         String value,
         MetadataReferenceType referenceType,
-        String referenceId
+        String referenceId,
+        final String environmentId
     );
 
     private void createReferenceAuditLog(
@@ -226,6 +229,7 @@ public abstract class AbstractReferenceMetadataService {
                 break;
             case USER:
                 auditService.createOrganizationAuditLog(
+                    GraviteeContext.getCurrentOrganization(),
                     Maps.<Audit.AuditProperties, String>builder().put(USER, referenceId).put(METADATA, key).build(),
                     auditEvent,
                     updatedAt,
@@ -240,9 +244,10 @@ public abstract class AbstractReferenceMetadataService {
         final UpdateReferenceMetadataEntity metadataEntity,
         final MetadataReferenceType referenceType,
         final String referenceId,
-        final boolean withDefaults
+        final boolean withDefaults,
+        final String environmentId
     ) {
-        checkReferenceMetadataFormat(metadataEntity.getFormat(), metadataEntity.getValue(), referenceType, referenceId);
+        checkReferenceMetadataFormat(metadataEntity.getFormat(), metadataEntity.getValue(), referenceType, referenceId, environmentId);
         try {
             final Optional<Metadata> referenceMetadata = metadataRepository.findById(metadataEntity.getKey(), referenceId, referenceType);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AlertServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AlertServiceImpl.java
@@ -45,6 +45,7 @@ import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.service.*;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.*;
 import io.gravitee.rest.api.service.impl.alert.EmailNotifierConfiguration;
 import java.io.IOException;
@@ -779,7 +780,7 @@ public class AlertServiceImpl extends TransactionalService implements AlertServi
                     metadata.put(METADATA_NAME, METADATA_UNKNOWN_APPLICATION_NAME);
                     metadata.put(METADATA_UNKNOWN, Boolean.TRUE.toString());
                 } else {
-                    ApplicationEntity applicationEntity = applicationService.findById(application);
+                    ApplicationEntity applicationEntity = applicationService.findById(GraviteeContext.getCurrentEnvironment(), application);
                     metadata = mapper.convertValue(applicationEntity, Map.class);
                     metadata.remove("picture");
                 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
@@ -35,6 +35,7 @@ import io.gravitee.rest.api.model.api.UpdateApiEntity;
 import io.gravitee.rest.api.model.documentation.PageQuery;
 import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.service.*;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
@@ -106,7 +107,7 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
             final JsonNode jsonNode = objectMapper.readTree(apiDefinition);
             apiDefinition = preprocessApiDefinitionUpdatingIds(jsonNode, environmentId);
 
-            UpdateApiEntity importedApi = convertToEntity(apiDefinition, jsonNode);
+            UpdateApiEntity importedApi = convertToEntity(apiDefinition, jsonNode, environmentId);
             ApiEntity createdApiEntity = apiService.createWithApiDefinition(importedApi, userId, jsonNode);
             createPageAndMedia(createdApiEntity, jsonNode, environmentId);
             updateApiReferences(createdApiEntity, jsonNode, organizationId, environmentId, false);
@@ -168,6 +169,8 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
                         String roleId = membership.getRoleId();
                         if (!primaryOwnerRoleId.equals(roleId)) {
                             membershipService.addRoleToMemberOnReference(
+                                organizationId,
+                                environmentId,
                                 io.gravitee.rest.api.model.MembershipReferenceType.API,
                                 duplicatedApi.getId(),
                                 membership.getMemberType(),
@@ -235,7 +238,7 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
                 apiDefinition = preprocessApiDefinitionUpdatingIds(jsonNode, environmentId);
             }
 
-            UpdateApiEntity importedApi = convertToEntity(apiDefinition, jsonNode);
+            UpdateApiEntity importedApi = convertToEntity(apiDefinition, jsonNode, environmentId);
             ApiEntity updatedApiEntity = apiService.update(apiId, importedApi, false);
             updateApiReferences(updatedApiEntity, jsonNode, organizationId, environmentId, true);
             return updatedApiEntity;
@@ -245,7 +248,8 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
         }
     }
 
-    private UpdateApiEntity convertToEntity(String apiDefinition, JsonNode jsonNode) throws JsonProcessingException {
+    private UpdateApiEntity convertToEntity(String apiDefinition, JsonNode jsonNode, final String environmentId)
+        throws JsonProcessingException {
         final UpdateApiEntity importedApi = objectMapper
             // because definition could contains other values than the api itself (pages, members)
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
@@ -264,12 +268,12 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
             Set<String> groupNames = new HashSet<>(importedApi.getGroups());
             importedApi.getGroups().clear();
             for (String name : groupNames) {
-                List<GroupEntity> groupEntities = groupService.findByName(name);
+                List<GroupEntity> groupEntities = groupService.findByName(environmentId, name);
                 GroupEntity group;
                 if (groupEntities.isEmpty()) {
                     NewGroupEntity newGroupEntity = new NewGroupEntity();
                     newGroupEntity.setName(name);
-                    group = groupService.create(newGroupEntity);
+                    group = groupService.create(environmentId, newGroupEntity);
                 } else {
                     group = groupEntities.get(0);
                 }
@@ -474,6 +478,8 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
                             rolesToImport.forEach(
                                 role ->
                                     membershipService.addRoleToMemberOnReference(
+                                        organizationId,
+                                        environmentId,
                                         MembershipReferenceType.API,
                                         createdOrUpdatedApiEntity.getId(),
                                         MembershipMemberType.USER,
@@ -510,6 +516,8 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
                             roleEntity = roleUsedInTransfert.stream().map(roleService::findById).collect(Collectors.toList());
                         }
                         membershipService.transferApiOwnership(
+                            organizationId,
+                            environmentId,
                             createdOrUpdatedApiEntity.getId(),
                             new MembershipService.MembershipMember(userEntity.getId(), null, MembershipMemberType.USER),
                             roleEntity

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
@@ -26,6 +26,7 @@ import io.gravitee.repository.management.model.Audit;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.key.ApiKeyQuery;
 import io.gravitee.rest.api.service.*;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.*;
 import io.gravitee.rest.api.service.notification.ApiHook;
 import io.gravitee.rest.api.service.notification.NotificationParamsBuilder;
@@ -145,7 +146,10 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
             auditService.createApiAuditLog(plan.getApi(), properties, APIKEY_RENEWED, newApiKey.getCreatedAt(), null, newApiKey);
 
             // Notification
-            final ApplicationEntity application = applicationService.findById(newApiKey.getApplication());
+            final ApplicationEntity application = applicationService.findById(
+                GraviteeContext.getCurrentEnvironment(),
+                newApiKey.getApplication()
+            );
             final ApiModelEntity api = apiService.findByIdForTemplates(plan.getApi());
             final PrimaryOwnerEntity owner = application.getPrimaryOwner();
             final Map<String, Object> params = new NotificationParamsBuilder()
@@ -238,7 +242,10 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
 
             // notify
             if (notify) {
-                final ApplicationEntity application = applicationService.findById(key.getApplication());
+                final ApplicationEntity application = applicationService.findById(
+                    GraviteeContext.getCurrentEnvironment(),
+                    key.getApplication()
+                );
                 final ApiModelEntity api = apiService.findByIdForTemplates(plan.getApi());
                 final PrimaryOwnerEntity owner = application.getPrimaryOwner();
                 final Map<String, Object> params = new NotificationParamsBuilder()
@@ -474,7 +481,10 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
             apiKeyRepository.update(key);
 
             //notify
-            final ApplicationEntity application = applicationService.findById(key.getApplication());
+            final ApplicationEntity application = applicationService.findById(
+                GraviteeContext.getCurrentEnvironment(),
+                key.getApplication()
+            );
             final PlanEntity plan = planService.findById(key.getPlan());
             final ApiModelEntity api = apiService.findByIdForTemplates(plan.getApi());
             final PrimaryOwnerEntity owner = application.getPrimaryOwner();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiMetadataServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiMetadataServiceImpl.java
@@ -23,6 +23,7 @@ import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.service.ApiMetadataService;
 import io.gravitee.rest.api.service.ApiService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -65,13 +66,16 @@ public class ApiMetadataServiceImpl extends AbstractReferenceMetadataService imp
 
     @Override
     public ApiMetadataEntity create(final NewApiMetadataEntity metadataEntity) {
-        return convert(create(metadataEntity, API, metadataEntity.getApiId(), true), metadataEntity.getApiId());
+        return convert(
+            create(metadataEntity, API, metadataEntity.getApiId(), true, GraviteeContext.getCurrentEnvironment()),
+            metadataEntity.getApiId()
+        );
     }
 
     @Override
     public ApiMetadataEntity update(final UpdateApiMetadataEntity metadataEntity) {
         ApiMetadataEntity apiMetadataEntity = convert(
-            update(metadataEntity, API, metadataEntity.getApiId(), true),
+            update(metadataEntity, API, metadataEntity.getApiId(), true, GraviteeContext.getCurrentEnvironment()),
             metadataEntity.getApiId()
         );
         ApiEntity apiEntity = apiService.fetchMetadataForApi(apiService.findById(apiMetadataEntity.getApiId()));
@@ -84,7 +88,8 @@ public class ApiMetadataServiceImpl extends AbstractReferenceMetadataService imp
         MetadataFormat format,
         String value,
         MetadataReferenceType referenceType,
-        String referenceId
+        String referenceId,
+        final String environmentId
     ) {
         final ApiEntity apiEntity = apiService.findById(referenceId);
         metadataService.checkMetadataFormat(format, value, referenceType, apiEntity);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiQualityRuleServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiQualityRuleServiceImpl.java
@@ -25,6 +25,7 @@ import io.gravitee.repository.management.model.ApiQualityRule;
 import io.gravitee.rest.api.model.quality.*;
 import io.gravitee.rest.api.service.ApiQualityRuleService;
 import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.*;
 import java.util.Collections;
 import java.util.Date;
@@ -74,6 +75,7 @@ public class ApiQualityRuleServiceImpl extends AbstractService implements ApiQua
             }
             final ApiQualityRule apiQualityRule = convert(newEntity);
             auditService.createEnvironmentAuditLog(
+                GraviteeContext.getCurrentEnvironment(),
                 Collections.singletonMap(API_QUALITY_RULE, apiQualityRule.getApi()),
                 ApiQualityRule.AuditEvent.API_QUALITY_RULE_CREATED,
                 apiQualityRule.getCreatedAt(),
@@ -100,6 +102,7 @@ public class ApiQualityRuleServiceImpl extends AbstractService implements ApiQua
             }
             final ApiQualityRule apiQualityRule = apiQualityRuleRepository.update(convert(updateEntity));
             auditService.createEnvironmentAuditLog(
+                GraviteeContext.getCurrentEnvironment(),
                 singletonMap(API_QUALITY_RULE, apiQualityRule.getApi()),
                 ApiQualityRule.AuditEvent.API_QUALITY_RULE_UPDATED,
                 apiQualityRule.getUpdatedAt(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -292,7 +292,11 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         Stream<GroupEntity> groupEntityStream = groupService.findByIds(groups).stream();
 
         if (apiId != null) {
-            final MembershipEntity primaryOwner = membershipService.getPrimaryOwner(MembershipReferenceType.API, apiId);
+            final MembershipEntity primaryOwner = membershipService.getPrimaryOwner(
+                GraviteeContext.getCurrentOrganization(),
+                MembershipReferenceType.API,
+                apiId
+            );
             if (primaryOwner.getMemberType() == MembershipMemberType.GROUP) {
                 // don't remove the primary owner group of this API.
                 groupEntityStream =
@@ -430,7 +434,11 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             repoApi.setVisibility(api.getVisibility() == null ? Visibility.PRIVATE : Visibility.valueOf(api.getVisibility().toString()));
 
             // Add Default groups
-            Set<String> defaultGroups = groupService.findByEvent(GroupEvent.API_CREATE).stream().map(GroupEntity::getId).collect(toSet());
+            Set<String> defaultGroups = groupService
+                .findByEvent(GraviteeContext.getCurrentEnvironment(), GroupEvent.API_CREATE)
+                .stream()
+                .map(GroupEntity::getId)
+                .collect(toSet());
             if (repoApi.getGroups() == null) {
                 repoApi.setGroups(defaultGroups.isEmpty() ? null : defaultGroups);
             } else {
@@ -464,6 +472,8 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
             // Add the primary owner of the newly created API
             membershipService.addRoleToMemberOnReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
                 new MembershipService.MembershipReference(MembershipReferenceType.API, createdApi.getId()),
                 new MembershipService.MembershipMember(primaryOwner.getId(), null, MembershipMemberType.valueOf(primaryOwner.getType())),
                 new MembershipService.MembershipRole(RoleScope.API, SystemRole.PRIMARY_OWNER.name())
@@ -584,7 +594,9 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 }
                 if (ApiPrimaryOwnerMode.GROUP.name().equals(primaryOwnerFromDefinition.getType())) {
                     try {
-                        return new PrimaryOwnerEntity(groupService.findById(primaryOwnerFromDefinition.getId()));
+                        return new PrimaryOwnerEntity(
+                            groupService.findById(GraviteeContext.getCurrentEnvironment(), primaryOwnerFromDefinition.getId())
+                        );
                     } catch (GroupNotFoundException unfe) {
                         return getFirstPoGroupUserBelongsTo(userId);
                     }
@@ -614,7 +626,9 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 }
                 if (ApiPrimaryOwnerMode.GROUP.name().equals(primaryOwnerFromDefinition.getType())) {
                     try {
-                        return new PrimaryOwnerEntity(groupService.findById(primaryOwnerFromDefinition.getId()));
+                        return new PrimaryOwnerEntity(
+                            groupService.findById(GraviteeContext.getCurrentEnvironment(), primaryOwnerFromDefinition.getId())
+                        );
                     } catch (GroupNotFoundException unfe) {
                         try {
                             return getFirstPoGroupUserBelongsTo(userId);
@@ -827,6 +841,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     @Override
     public PrimaryOwnerEntity getPrimaryOwner(String apiId) throws TechnicalManagementException {
         MembershipEntity primaryOwnerMemberEntity = membershipService.getPrimaryOwner(
+            GraviteeContext.getCurrentOrganization(),
             io.gravitee.rest.api.model.MembershipReferenceType.API,
             apiId
         );
@@ -835,7 +850,9 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             throw new TechnicalManagementException("The API " + apiId + " doesn't have any primary owner.");
         }
         if (MembershipMemberType.GROUP == primaryOwnerMemberEntity.getMemberType()) {
-            return new PrimaryOwnerEntity(groupService.findById(primaryOwnerMemberEntity.getMemberId()));
+            return new PrimaryOwnerEntity(
+                groupService.findById(GraviteeContext.getCurrentEnvironment(), primaryOwnerMemberEntity.getMemberId())
+            );
         }
         return new PrimaryOwnerEntity(userService.findById(primaryOwnerMemberEntity.getMemberId()));
     }
@@ -1117,7 +1134,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             // get user subscribed apis, useful when an API becomes private and an app owner is not anymore in members.
             if (portal) {
                 final Set<String> applications = applicationService
-                    .findByUser(userId)
+                    .findByUser(GraviteeContext.getCurrentOrganization(), GraviteeContext.getCurrentEnvironment(), userId)
                     .stream()
                     .map(ApplicationListItem::getId)
                     .collect(toSet());
@@ -1768,7 +1785,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 if (getAuthenticatedUser() != null) {
                     properties.put(Event.EventProperties.USER.getValue(), getAuthenticatedUser().getUsername());
                 }
-                eventService.create(EventType.UNPUBLISH_API, null, properties);
+                eventService.create(singleton(GraviteeContext.getCurrentEnvironment()), EventType.UNPUBLISH_API, null, properties);
 
                 // Delete pages
                 pageService.deleteAllByApi(apiId, GraviteeContext.getCurrentEnvironment());
@@ -1778,7 +1795,12 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 // Delete API
                 apiRepository.delete(apiId);
                 // Delete memberships
-                membershipService.deleteReference(MembershipReferenceType.API, apiId);
+                membershipService.deleteReference(
+                    GraviteeContext.getCurrentOrganization(),
+                    GraviteeContext.getCurrentEnvironment(),
+                    MembershipReferenceType.API,
+                    apiId
+                );
                 // Delete notifications
                 genericNotificationConfigService.deleteReference(NotificationReferenceType.API, apiId);
                 portalNotificationConfigService.deleteReference(NotificationReferenceType.API, apiId);
@@ -1851,7 +1873,8 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 0,
                 0,
                 0,
-                1
+                1,
+                singletonList(GraviteeContext.getCurrentEnvironment())
             );
 
             if (!events.getContent().isEmpty()) {
@@ -1961,7 +1984,12 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             addDeploymentLabelToProperties(apiId, eventType, properties, apiDeploymentEntity);
 
             // And create event
-            eventService.create(eventType, objectMapper.writeValueAsString(apiValue), properties);
+            eventService.create(
+                singleton(GraviteeContext.getCurrentEnvironment()),
+                eventType,
+                objectMapper.writeValueAsString(apiValue),
+                properties
+            );
 
             return convert(singletonList(apiValue)).iterator().next();
         } else {
@@ -2024,7 +2052,12 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 lastPublishedAPI.setPicture(null);
 
                 // And create event
-                eventService.create(eventType, objectMapper.writeValueAsString(lastPublishedAPI), properties);
+                eventService.create(
+                    singleton(GraviteeContext.getCurrentEnvironment()),
+                    eventType,
+                    objectMapper.writeValueAsString(lastPublishedAPI),
+                    properties
+                );
                 return null;
             } else {
                 // this is the first time we start the api without previously deployed id.
@@ -2139,12 +2172,12 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             Set<String> groupNames = new HashSet<>(importedApi.getGroups());
             importedApi.getGroups().clear();
             for (String name : groupNames) {
-                List<GroupEntity> groupEntities = groupService.findByName(name);
+                List<GroupEntity> groupEntities = groupService.findByName(GraviteeContext.getCurrentEnvironment(), name);
                 GroupEntity group;
                 if (groupEntities.isEmpty()) {
                     NewGroupEntity newGroupEntity = new NewGroupEntity();
                     newGroupEntity.setName(name);
-                    group = groupService.create(newGroupEntity);
+                    group = groupService.create(GraviteeContext.getCurrentEnvironment(), newGroupEntity);
                 } else {
                     group = groupEntities.get(0);
                 }
@@ -2264,6 +2297,8 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                                 role -> {
                                     try {
                                         membershipService.addRoleToMemberOnReference(
+                                            GraviteeContext.getCurrentOrganization(),
+                                            GraviteeContext.getCurrentEnvironment(),
                                             MembershipReferenceType.API,
                                             createdOrUpdatedApiEntity.getId(),
                                             MembershipMemberType.USER,
@@ -2310,6 +2345,8 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                             roleEntity = roleUsedInTransfert.stream().map(roleService::findById).collect(Collectors.toList());
                         }
                         membershipService.transferApiOwnership(
+                            GraviteeContext.getCurrentOrganization(),
+                            GraviteeContext.getCurrentEnvironment(),
                             createdOrUpdatedApiEntity.getId(),
                             new MembershipService.MembershipMember(userEntity.getId(), null, MembershipMemberType.USER),
                             roleEntity
@@ -2813,7 +2850,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
     @Override
     public List<ApiHeaderEntity> getPortalHeaders(String apiId) {
-        List<ApiHeaderEntity> entities = apiHeaderService.findAll();
+        List<ApiHeaderEntity> entities = apiHeaderService.findAll(GraviteeContext.getCurrentEnvironment());
         ApiModelEntity apiEntity = this.findByIdForTemplates(apiId);
         Map<String, Object> model = new HashMap<>();
         model.put("api", apiEntity);
@@ -3107,7 +3144,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         builder.label(query.getLabel()).name(query.getName()).version(query.getVersion());
 
         if (!isBlank(query.getCategory())) {
-            builder.category(categoryService.findById(query.getCategory()).getId());
+            builder.category(categoryService.findById(query.getCategory(), GraviteeContext.getCurrentEnvironment()).getId());
         }
         if (query.getGroups() != null && !query.getGroups().isEmpty()) {
             builder.groups(query.getGroups().toArray(new String[0]));
@@ -3311,7 +3348,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 .forEach(groupEntity -> primaryOwnerIdToPrimaryOwnerEntity.put(groupEntity.getId(), new PrimaryOwnerEntity(groupEntity)));
         }
 
-        final List<CategoryEntity> categories = categoryService.findAll();
+        final List<CategoryEntity> categories = categoryService.findAll(GraviteeContext.getCurrentEnvironment());
         return streamApis
             .map(
                 publicApi -> this.convert(publicApi, primaryOwnerIdToPrimaryOwnerEntity.get(apiToMember.get(publicApi.getId())), categories)
@@ -3386,7 +3423,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         final Set<String> apiCategories = api.getCategories();
         if (apiCategories != null) {
             if (categories == null) {
-                categories = categoryService.findAll();
+                categories = categoryService.findAll(GraviteeContext.getCurrentEnvironment());
             }
             final Set<String> newApiCategories = new HashSet<>(apiCategories.size());
             for (final String apiView : apiCategories) {
@@ -3438,7 +3475,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
         final Set<String> apiCategories = updateApiEntity.getCategories();
         if (apiCategories != null) {
-            final List<CategoryEntity> categories = categoryService.findAll();
+            final List<CategoryEntity> categories = categoryService.findAll(GraviteeContext.getCurrentEnvironment());
             final Set<String> newApiCategories = new HashSet<>(apiCategories.size());
             for (final String apiCategory : apiCategories) {
                 final Optional<CategoryEntity> optionalCategory = categories

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationMetadataServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationMetadataServiceImpl.java
@@ -58,13 +58,19 @@ public class ApplicationMetadataServiceImpl extends AbstractReferenceMetadataSer
     }
 
     @Override
-    public ApplicationMetadataEntity create(final NewApplicationMetadataEntity metadataEntity) {
-        return convert(create(metadataEntity, APPLICATION, metadataEntity.getApplicationId(), false), metadataEntity.getApplicationId());
+    public ApplicationMetadataEntity create(final String environmentId, final NewApplicationMetadataEntity metadataEntity) {
+        return convert(
+            create(metadataEntity, APPLICATION, metadataEntity.getApplicationId(), false, environmentId),
+            metadataEntity.getApplicationId()
+        );
     }
 
     @Override
-    public ApplicationMetadataEntity update(final UpdateApplicationMetadataEntity metadataEntity) {
-        return convert(update(metadataEntity, APPLICATION, metadataEntity.getApplicationId(), false), metadataEntity.getApplicationId());
+    public ApplicationMetadataEntity update(final String environmentId, final UpdateApplicationMetadataEntity metadataEntity) {
+        return convert(
+            update(metadataEntity, APPLICATION, metadataEntity.getApplicationId(), false, environmentId),
+            metadataEntity.getApplicationId()
+        );
     }
 
     @Override
@@ -72,9 +78,10 @@ public class ApplicationMetadataServiceImpl extends AbstractReferenceMetadataSer
         MetadataFormat format,
         String value,
         MetadataReferenceType referenceType,
-        String referenceId
+        String referenceId,
+        final String environmentId
     ) {
-        final ApplicationEntity applicationEntity = applicationService.findById(referenceId);
+        final ApplicationEntity applicationEntity = applicationService.findById(environmentId, referenceId);
         metadataService.checkMetadataFormat(format, value, referenceType, applicationEntity);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -124,20 +124,20 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
     private final ObjectMapper mapper = new ObjectMapper();
 
     @Override
-    public ApplicationEntity findById(String applicationId) {
+    public ApplicationEntity findById(final String environmentId, String applicationId) {
         try {
             LOGGER.debug("Find application by ID: {}", applicationId);
 
             Optional<Application> applicationOptional = applicationRepository.findById(applicationId);
 
-            if (GraviteeContext.getCurrentEnvironment() != null) {
-                applicationOptional =
-                    applicationOptional.filter(result -> result.getEnvironmentId().equals(GraviteeContext.getCurrentEnvironment()));
+            if (environmentId != null) {
+                applicationOptional = applicationOptional.filter(result -> result.getEnvironmentId().equals(environmentId));
             }
 
             if (applicationOptional.isPresent()) {
                 Application application = applicationOptional.get();
                 MembershipEntity primaryOwnerMemberEntity = membershipService.getPrimaryOwner(
+                    GraviteeContext.getCurrentOrganization(),
                     MembershipReferenceType.APPLICATION,
                     application.getId()
                 );
@@ -159,7 +159,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
     }
 
     @Override
-    public Set<ApplicationListItem> findByIds(List<String> applicationIds) {
+    public Set<ApplicationListItem> findByIds(final String organizationId, final String environmentId, List<String> applicationIds) {
         try {
             LOGGER.debug("Find application by IDs: {}", applicationIds);
 
@@ -167,14 +167,14 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                 .findByIds(applicationIds)
                 .stream()
                 .filter(app -> ApplicationStatus.ACTIVE.equals(app.getStatus()))
-                .filter(app -> app.getEnvironmentId().equals(GraviteeContext.getCurrentEnvironment()))
+                .filter(app -> app.getEnvironmentId().equals(environmentId))
                 .collect(toSet());
 
             if (applications.isEmpty()) {
                 return emptySet();
             }
 
-            return this.convertToList(applications);
+            return this.convertToList(applications, organizationId);
         } catch (TechnicalException ex) {
             LOGGER.error("An error occurs while trying to find applications by ids {}", applicationIds, ex);
             throw new TechnicalManagementException("An error occurs while trying to find applications by ids {}" + applicationIds, ex);
@@ -182,24 +182,24 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
     }
 
     @Override
-    public Set<ApplicationListItem> findByUser(String username) {
+    public Set<ApplicationListItem> findByUser(final String organizationId, final String environmentId, String username) {
         try {
             LOGGER.debug("Find applications for user {}", username);
 
-            Set<String> userApplicationsIds = findUserApplicationsIds(username);
+            Set<String> userApplicationsIds = findUserApplicationsIds(username, organizationId);
 
             final Set<Application> applications = applicationRepository
                 .findByIds(new ArrayList<>(userApplicationsIds))
                 .stream()
                 .filter(app -> ApplicationStatus.ACTIVE.equals(app.getStatus()))
-                .filter(app -> app.getEnvironmentId().equals(GraviteeContext.getCurrentEnvironment()))
+                .filter(app -> app.getEnvironmentId().equals(environmentId))
                 .collect(toSet());
 
             if (applications.isEmpty()) {
                 return emptySet();
             }
 
-            return this.convertToList(applications);
+            return this.convertToList(applications, organizationId);
         } catch (TechnicalException ex) {
             LOGGER.error("An error occurs while trying to find applications for user {}", username, ex);
             throw new TechnicalManagementException("An error occurs while trying to find applications for user " + username, ex);
@@ -207,12 +207,14 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
     }
 
     @Override
-    public Set<ApplicationListItem> findByUserAndNameAndStatus(String userName, String name, String status) {
-        return findByUserAndNameAndStatus(userName, false, name, status);
-    }
-
-    @Override
-    public Set<ApplicationListItem> findByUserAndNameAndStatus(String userName, boolean isAdminUser, String name, String status) {
+    public Set<ApplicationListItem> findByUserAndNameAndStatus(
+        String userName,
+        boolean isAdminUser,
+        String name,
+        String status,
+        final String environmentId,
+        final String organizationId
+    ) {
         LOGGER.debug("Find applications by user {} and name {}, with isAdminUser {})", userName, name, isAdminUser);
         if (name == null || name.trim().isEmpty()) {
             return emptySet();
@@ -220,13 +222,19 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
 
         Set<String> userApplicationsIds = emptySet();
         if (!isAdminUser) {
-            userApplicationsIds = findUserApplicationsIds(userName);
+            userApplicationsIds = findUserApplicationsIds(userName, organizationId);
             if (userApplicationsIds.isEmpty()) {
                 return emptySet();
             }
         }
 
-        return searchApplicationsByNameAndStatusAndIds(name, status, userApplicationsIds.toArray(new String[0]));
+        return searchApplicationsByNameAndStatusAndIds(
+            name,
+            status,
+            userApplicationsIds.toArray(new String[0]),
+            environmentId,
+            organizationId
+        );
     }
 
     @Override
@@ -256,18 +264,20 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
     }
 
     @Override
-    public Set<ApplicationListItem> findByGroups(List<String> groupIds) {
-        return this.findByGroupsAndStatus(groupIds, ApplicationStatus.ACTIVE.name());
+    public Set<ApplicationListItem> findByGroups(final String organizationId, List<String> groupIds) {
+        return this.findByGroupsAndStatus(organizationId, groupIds, ApplicationStatus.ACTIVE.name());
     }
 
     @Override
-    public Set<ApplicationListItem> findByGroupsAndStatus(List<String> groupIds, String status) {
+    public Set<ApplicationListItem> findByGroupsAndStatus(final String organizationId, List<String> groupIds, String status) {
         LOGGER.debug("Find applications by groups {}", groupIds);
         try {
             ApplicationStatus requestedStatus = ApplicationStatus.valueOf(status.toUpperCase());
             Set<Application> applications = applicationRepository.findByGroups(groupIds, ApplicationStatus.valueOf(status.toUpperCase()));
 
-            return ApplicationStatus.ACTIVE.equals(requestedStatus) ? convertToList(applications) : convertToSimpleList(applications);
+            return ApplicationStatus.ACTIVE.equals(requestedStatus)
+                ? convertToList(applications, organizationId)
+                : convertToSimpleList(applications);
         } catch (TechnicalException ex) {
             LOGGER.error("An error occurs while trying to find applications for groups {}", groupIds, ex);
             throw new TechnicalManagementException("An error occurs while trying to find applications for groups " + groupIds, ex);
@@ -275,20 +285,17 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
     }
 
     @Override
-    public Set<ApplicationListItem> findAll() {
+    public Set<ApplicationListItem> findAll(final String organizationId, final String environmentId) {
         try {
             LOGGER.debug("Find all applications");
 
-            final Set<Application> applications = applicationRepository.findAllByEnvironment(
-                GraviteeContext.getCurrentEnvironment(),
-                ApplicationStatus.ACTIVE
-            );
+            final Set<Application> applications = applicationRepository.findAllByEnvironment(environmentId, ApplicationStatus.ACTIVE);
 
             if (applications == null || applications.isEmpty()) {
                 return emptySet();
             }
 
-            return this.convertToList(applications);
+            return this.convertToList(applications, organizationId);
         } catch (TechnicalException ex) {
             LOGGER.error("An error occurs while trying to find all applications", ex);
             throw new TechnicalManagementException("An error occurs while trying to find all applications", ex);
@@ -296,21 +303,20 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
     }
 
     @Override
-    public Set<ApplicationListItem> findByStatus(String status) {
+    public Set<ApplicationListItem> findByStatus(final String organizationId, final String environmentId, String status) {
         try {
             LOGGER.debug("Find all applications");
 
             ApplicationStatus requestedStatus = ApplicationStatus.valueOf(status.toUpperCase());
-            final Set<Application> applications = applicationRepository.findAllByEnvironment(
-                GraviteeContext.getCurrentEnvironment(),
-                requestedStatus
-            );
+            final Set<Application> applications = applicationRepository.findAllByEnvironment(environmentId, requestedStatus);
 
             if (applications == null || applications.isEmpty()) {
                 return emptySet();
             }
 
-            return ApplicationStatus.ACTIVE.equals(requestedStatus) ? convertToList(applications) : convertToSimpleList(applications);
+            return ApplicationStatus.ACTIVE.equals(requestedStatus)
+                ? convertToList(applications, organizationId)
+                : convertToSimpleList(applications);
         } catch (TechnicalException ex) {
             LOGGER.error("An error occurs while trying to find all applications", ex);
             throw new TechnicalManagementException("An error occurs while trying to find all applications", ex);
@@ -318,12 +324,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
     }
 
     @Override
-    public ApplicationEntity create(NewApplicationEntity newApplicationEntity, String userId) {
-        return this.create(newApplicationEntity, userId, GraviteeContext.getCurrentEnvironment());
-    }
-
-    @Override
-    public ApplicationEntity create(NewApplicationEntity newApplicationEntity, String userId, String environmentId) {
+    public ApplicationEntity create(String environmentId, NewApplicationEntity newApplicationEntity, String userId) {
         LOGGER.debug("Create {} for user {}", newApplicationEntity, userId);
 
         // Check that only one settings is defined
@@ -404,7 +405,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
 
         // Add Default groups
         Set<String> defaultGroups = groupService
-            .findByEvent(GroupEvent.APPLICATION_CREATE)
+            .findByEvent(GraviteeContext.getCurrentEnvironment(), GroupEvent.APPLICATION_CREATE)
             .stream()
             .map(GroupEntity::getId)
             .collect(toSet());
@@ -440,6 +441,8 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
 
             // Add the primary owner of the newly created Application
             membershipService.addRoleToMemberOnReference(
+                GraviteeContext.getCurrentOrganization(),
+                environmentId,
                 new MembershipService.MembershipReference(MembershipReferenceType.APPLICATION, createdApplication.getId()),
                 new MembershipService.MembershipMember(userId, null, MembershipMemberType.USER),
                 new MembershipService.MembershipRole(RoleScope.APPLICATION, SystemRole.PRIMARY_OWNER.name())
@@ -502,7 +505,12 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
     }
 
     @Override
-    public ApplicationEntity update(String applicationId, UpdateApplicationEntity updateApplicationEntity) {
+    public ApplicationEntity update(
+        final String organizationId,
+        final String environmentId,
+        String applicationId,
+        UpdateApplicationEntity updateApplicationEntity
+    ) {
         try {
             LOGGER.debug("Update application {}", applicationId);
             if (updateApplicationEntity.getGroups() != null && !updateApplicationEntity.getGroups().isEmpty()) {
@@ -542,7 +550,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                 if (clientId != null && !clientId.trim().isEmpty()) {
                     LOGGER.debug("Check that client_id is unique among all applications");
                     final Set<Application> applications = applicationRepository.findAllByEnvironment(
-                        GraviteeContext.getCurrentEnvironment(),
+                        environmentId,
                         ApplicationStatus.ACTIVE
                     );
                     final Optional<Application> byClientId = applications
@@ -556,7 +564,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                 }
             } else {
                 // Check that client registration is enabled
-                checkClientRegistrationEnabled();
+                checkClientRegistrationEnabled(environmentId);
                 checkClientSettings(updateApplicationEntity.getSettings().getoAuthClient());
 
                 // Update an OAuth client
@@ -618,7 +626,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                         }
                     }
                 );
-            return convert(Collections.singleton(updatedApplication)).iterator().next();
+            return convert(Collections.singleton(updatedApplication), organizationId).iterator().next();
         } catch (TechnicalException ex) {
             LOGGER.error("An error occurs while trying to update application {}", applicationId, ex);
             throw new TechnicalManagementException(
@@ -629,7 +637,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
     }
 
     @Override
-    public ApplicationEntity renewClientSecret(String applicationId) {
+    public ApplicationEntity renewClientSecret(final String organizationId, final String environmentId, String applicationId) {
         try {
             LOGGER.debug("Renew client secret for application {}", applicationId);
 
@@ -643,10 +651,10 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             }
 
             // Check that client registration is enabled
-            checkClientRegistrationEnabled();
+            checkClientRegistrationEnabled(environmentId);
 
             Application application = optApplicationToUpdate.get();
-            ApplicationEntity applicationEntity = findById(applicationId);
+            ApplicationEntity applicationEntity = findById(environmentId, applicationId);
 
             // Check that the application can be updated with a new client secret
             if (
@@ -683,7 +691,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                     updatedApplication
                 );
 
-                return convert(Collections.singleton(updatedApplication)).iterator().next();
+                return convert(Collections.singleton(updatedApplication), organizationId).iterator().next();
             }
 
             throw new ApplicationRenewClientSecretException(application.getName());
@@ -713,9 +721,16 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             application.setUpdatedAt(new Date());
 
             String userId = getAuthenticatedUsername();
-            membershipService.deleteReference(MembershipReferenceType.APPLICATION, applicationId);
+            membershipService.deleteReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
+                MembershipReferenceType.APPLICATION,
+                applicationId
+            );
             // Add the primary owner of the newly created Application
             membershipService.addRoleToMemberOnReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
                 new MembershipService.MembershipReference(MembershipReferenceType.APPLICATION, applicationId),
                 new MembershipService.MembershipMember(userId, null, MembershipMemberType.USER),
                 new MembershipService.MembershipRole(RoleScope.APPLICATION, SystemRole.PRIMARY_OWNER.name())
@@ -757,10 +772,6 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             LOGGER.error("An error occurs while trying to restore {}", applicationId, ex);
             throw new TechnicalManagementException(String.format("An error occurs while trying to restore %s", applicationId), ex);
         }
-    }
-
-    private void checkClientRegistrationEnabled() {
-        checkClientRegistrationEnabled(GraviteeContext.getCurrentEnvironment());
     }
 
     private void checkClientRegistrationEnabled(String environmentId) {
@@ -820,7 +831,12 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             // remove notifications
             genericNotificationConfigService.deleteReference(NotificationReferenceType.APPLICATION, applicationId);
             // delete memberships
-            membershipService.deleteReference(MembershipReferenceType.APPLICATION, applicationId);
+            membershipService.deleteReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
+                MembershipReferenceType.APPLICATION,
+                applicationId
+            );
             // delete alerts
             applicationAlertService.deleteAll(applicationId);
             // Audit
@@ -841,14 +857,11 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
         }
     }
 
-    private Set<ApplicationEntity> convert(Set<Application> applications) throws TechnicalException {
+    private Set<ApplicationEntity> convert(Set<Application> applications, final String organizationId) throws TechnicalException {
         if (applications == null || applications.isEmpty()) {
             return Collections.emptySet();
         }
-        RoleEntity primaryOwnerRole = roleService.findPrimaryOwnerRoleByOrganization(
-            GraviteeContext.getCurrentOrganization(),
-            RoleScope.APPLICATION
-        );
+        RoleEntity primaryOwnerRole = roleService.findPrimaryOwnerRoleByOrganization(organizationId, RoleScope.APPLICATION);
         if (primaryOwnerRole == null) {
             throw new RoleNotFoundException("APPLICATION_PRIMARY_OWNER");
         }
@@ -912,8 +925,8 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             .collect(toSet());
     }
 
-    private Set<ApplicationListItem> convertToList(Set<Application> applications) throws TechnicalException {
-        Set<ApplicationEntity> entities = convert(applications);
+    private Set<ApplicationListItem> convertToList(Set<Application> applications, final String organizationId) throws TechnicalException {
+        Set<ApplicationEntity> entities = convert(applications, organizationId);
 
         return entities
             .stream()
@@ -1075,8 +1088,8 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
     }
 
     @Override
-    public InlinePictureEntity getPicture(String applicationId) {
-        ApplicationEntity applicationEntity = findById(applicationId);
+    public InlinePictureEntity getPicture(final String environmentId, String applicationId) {
+        ApplicationEntity applicationEntity = findById(environmentId, applicationId);
         InlinePictureEntity imageEntity = new InlinePictureEntity();
         if (applicationEntity.getPicture() != null) {
             String[] parts = applicationEntity.getPicture().split(";", 2);
@@ -1088,8 +1101,8 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
     }
 
     @Override
-    public InlinePictureEntity getBackground(String applicationId) {
-        ApplicationEntity applicationEntity = findById(applicationId);
+    public InlinePictureEntity getBackground(final String environmentId, String applicationId) {
+        ApplicationEntity applicationEntity = findById(environmentId, applicationId);
         InlinePictureEntity imageEntity = new InlinePictureEntity();
         if (applicationEntity.getBackground() != null) {
             String[] parts = applicationEntity.getBackground().split(";", 2);
@@ -1100,7 +1113,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
         return imageEntity;
     }
 
-    private Set<String> findUserApplicationsIds(String username) {
+    private Set<String> findUserApplicationsIds(String username, final String organizationId) {
         //find applications where the user is a member
         Set<String> appIds = membershipService
             .getMembershipsByMemberAndReference(MembershipMemberType.USER, username, MembershipReferenceType.APPLICATION)
@@ -1115,21 +1128,27 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             .map(MembershipEntity::getReferenceId)
             .collect(toList());
 
-        appIds.addAll(this.findByGroups(groupIds).stream().map(ApplicationListItem::getId).collect(toSet()));
+        appIds.addAll(this.findByGroups(organizationId, groupIds).stream().map(ApplicationListItem::getId).collect(toSet()));
 
         return appIds;
     }
 
-    private Set<ApplicationListItem> searchApplicationsByNameAndStatusAndIds(String name, String status, String[] ids) {
+    private Set<ApplicationListItem> searchApplicationsByNameAndStatusAndIds(
+        String name,
+        String status,
+        String[] ids,
+        final String environmentId,
+        final String organizationId
+    ) {
         try {
             ApplicationCriteria criteria = new ApplicationCriteria.Builder()
                 .status(ApplicationStatus.valueOf(status))
                 .name(name.trim())
-                .environmentIds(singletonList(GraviteeContext.getCurrentEnvironment()))
+                .environmentIds(singletonList(environmentId))
                 .ids(ids)
                 .build();
             Page<Application> applications = applicationRepository.search(criteria, null);
-            return convertToList(new HashSet<>(applications.getContent()));
+            return convertToList(new HashSet<>(applications.getContent()), organizationId);
         } catch (TechnicalException ex) {
             String errorMessage = String.format("An error occurs while trying to find applications by name %s and id %s", name, ids);
             LOGGER.error(errorMessage, ex);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AuditServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AuditServiceImpl.java
@@ -89,8 +89,10 @@ public class AuditServiceImpl extends AbstractService implements AuditService {
         Builder criteria = new Builder().from(query.getFrom()).to(query.getTo());
 
         if (query.isCurrentEnvironmentLogsOnly()) {
+            // FIXME: Rework AuditQuery to remove call to GraviteeContext.getCurrentEnvironment() here
             criteria.references(Audit.AuditReferenceType.ENVIRONMENT, Collections.singletonList(GraviteeContext.getCurrentEnvironment()));
         } else if (query.isCurrentOrganizationLogsOnly()) {
+            // FIXME: Rework AuditQuery to remove call to GraviteeContext.getCurrentOrganization() here
             criteria.references(Audit.AuditReferenceType.ORGANIZATION, Collections.singletonList(GraviteeContext.getCurrentOrganization()));
         } else if (query.getApiIds() != null && !query.getApiIds().isEmpty()) {
             criteria.references(Audit.AuditReferenceType.API, query.getApiIds());
@@ -260,40 +262,26 @@ public class AuditServiceImpl extends AbstractService implements AuditService {
 
     @Override
     public void createEnvironmentAuditLog(
+        final String environmentId,
         Map<Audit.AuditProperties, String> properties,
         Audit.AuditEvent event,
         Date createdAt,
         Object oldValue,
         Object newValue
     ) {
-        createAuditLog(
-            Audit.AuditReferenceType.ENVIRONMENT,
-            GraviteeContext.getCurrentEnvironment(),
-            properties,
-            event,
-            createdAt,
-            oldValue,
-            newValue
-        );
+        createAuditLog(Audit.AuditReferenceType.ENVIRONMENT, environmentId, properties, event, createdAt, oldValue, newValue);
     }
 
     @Override
     public void createOrganizationAuditLog(
+        final String organizationId,
         Map<Audit.AuditProperties, String> properties,
         Audit.AuditEvent event,
         Date createdAt,
         Object oldValue,
         Object newValue
     ) {
-        createAuditLog(
-            Audit.AuditReferenceType.ORGANIZATION,
-            GraviteeContext.getCurrentOrganization(),
-            properties,
-            event,
-            createdAt,
-            oldValue,
-            newValue
-        );
+        createAuditLog(Audit.AuditReferenceType.ORGANIZATION, organizationId, properties, event, createdAt, oldValue, newValue);
     }
 
     @Async

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
@@ -30,7 +30,6 @@ import io.gravitee.rest.api.service.ConfigService;
 import io.gravitee.rest.api.service.NewsletterService;
 import io.gravitee.rest.api.service.ParameterService;
 import io.gravitee.rest.api.service.ReCaptchaService;
-import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -68,9 +67,9 @@ public class ConfigServiceImpl extends AbstractService implements ConfigService 
     private static final String SENSITIVE_VALUE = "********";
 
     @Override
-    public boolean portalLoginForced() {
+    public boolean portalLoginForced(final String environmentId) {
         boolean result = false;
-        final PortalAuthentication auth = getPortalSettings().getAuthentication();
+        final PortalAuthentication auth = getPortalSettings(environmentId).getAuthentication();
         if (auth.getForceLogin() != null) {
             result = auth.getForceLogin().isEnabled();
         }
@@ -78,13 +77,8 @@ public class ConfigServiceImpl extends AbstractService implements ConfigService 
     }
 
     @Override
-    public PortalConfigEntity getPortalConfig() {
-        return MAPPER.convertValue(getPortalSettings(), PortalConfigEntity.class);
-    }
-
-    @Override
-    public PortalSettingsEntity getPortalSettings() {
-        return this.getPortalSettings(GraviteeContext.getCurrentEnvironment());
+    public PortalConfigEntity getPortalConfig(final String environmentId) {
+        return MAPPER.convertValue(getPortalSettings(environmentId), PortalConfigEntity.class);
     }
 
     @Override
@@ -99,17 +93,12 @@ public class ConfigServiceImpl extends AbstractService implements ConfigService 
     }
 
     @Override
-    public ConsoleConfigEntity getConsoleConfig() {
-        return MAPPER.convertValue(getConsoleSettings(), ConsoleConfigEntity.class);
+    public ConsoleConfigEntity getConsoleConfig(final String organizationId) {
+        return MAPPER.convertValue(getConsoleSettings(organizationId), ConsoleConfigEntity.class);
     }
 
     @Override
-    public ConsoleSettingsEntity getConsoleSettings() {
-        return this.getConsoleSettings(GraviteeContext.getCurrentOrganization());
-    }
-
-    @Override
-    public ConsoleSettingsEntity getConsoleSettings(String organizationId) {
+    public ConsoleSettingsEntity getConsoleSettings(final String organizationId) {
         ConsoleSettingsEntity consoleConfigEntity = new ConsoleSettingsEntity();
         Object[] objects = getObjectArray(consoleConfigEntity);
 
@@ -269,15 +258,15 @@ public class ConfigServiceImpl extends AbstractService implements ConfigService 
     }
 
     @Override
-    public void save(PortalSettingsEntity portalSettingsEntity) {
+    public void save(final String environmentId, PortalSettingsEntity portalSettingsEntity) {
         Object[] objects = getObjectArray(portalSettingsEntity);
-        saveConfigByReference(objects, GraviteeContext.getCurrentEnvironment(), ParameterReferenceType.ENVIRONMENT);
+        saveConfigByReference(objects, environmentId, ParameterReferenceType.ENVIRONMENT);
     }
 
     @Override
-    public void save(ConsoleSettingsEntity consoleSettingsEntity) {
+    public void save(final String organizationId, ConsoleSettingsEntity consoleSettingsEntity) {
         Object[] objects = getObjectArray(consoleSettingsEntity);
-        saveConfigByReference(objects, GraviteeContext.getCurrentOrganization(), ParameterReferenceType.ORGANIZATION);
+        saveConfigByReference(objects, organizationId, ParameterReferenceType.ORGANIZATION);
     }
 
     private void saveConfigByReference(Object[] objects, String referenceId, ParameterReferenceType referenceType) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/CustomUserFieldsServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/CustomUserFieldsServiceImpl.java
@@ -171,9 +171,23 @@ public class CustomUserFieldsServiceImpl extends TransactionalService implements
         String key = oldValue != null ? oldValue.getKey() : newValue.getKey();
         CustomUserFieldReferenceType type = oldValue != null ? oldValue.getReferenceType() : newValue.getReferenceType();
         if (type == ORGANIZATION) {
-            auditService.createOrganizationAuditLog(Collections.singletonMap(USER_FIELD, key), event, createdAt, oldValue, newValue);
+            auditService.createOrganizationAuditLog(
+                GraviteeContext.getCurrentOrganization(),
+                Collections.singletonMap(USER_FIELD, key),
+                event,
+                createdAt,
+                oldValue,
+                newValue
+            );
         } else if (type == ENVIRONMENT) {
-            auditService.createEnvironmentAuditLog(Collections.singletonMap(USER_FIELD, key), event, createdAt, oldValue, newValue);
+            auditService.createEnvironmentAuditLog(
+                GraviteeContext.getCurrentEnvironment(),
+                Collections.singletonMap(USER_FIELD, key),
+                event,
+                createdAt,
+                oldValue,
+                newValue
+            );
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/DashboardServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/DashboardServiceImpl.java
@@ -33,6 +33,7 @@ import io.gravitee.rest.api.model.NewDashboardEntity;
 import io.gravitee.rest.api.model.UpdateDashboardEntity;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.DashboardService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.DashboardNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
@@ -127,6 +128,7 @@ public class DashboardServiceImpl extends AbstractService implements DashboardSe
             final List<Dashboard> dashboards = dashboardRepository.findByReferenceType(dashboardEntity.getReferenceType().name());
             Dashboard dashboard = dashboardRepository.create(convert(dashboardEntity, dashboards));
             auditService.createEnvironmentAuditLog(
+                GraviteeContext.getCurrentEnvironment(),
                 Collections.singletonMap(DASHBOARD, dashboard.getId()),
                 DASHBOARD_CREATED,
                 dashboard.getCreatedAt(),
@@ -154,6 +156,7 @@ public class DashboardServiceImpl extends AbstractService implements DashboardSe
                     savedDashboard = convert(dashboardRepository.update(dashboard));
                 }
                 auditService.createEnvironmentAuditLog(
+                    GraviteeContext.getCurrentEnvironment(),
                     Collections.singletonMap(DASHBOARD, dashboard.getId()),
                     DASHBOARD_UPDATED,
                     new Date(),
@@ -234,6 +237,7 @@ public class DashboardServiceImpl extends AbstractService implements DashboardSe
                 dashboardRepository.delete(dashboardId);
                 reorderAndSaveDashboards(dashboardOptional.get(), true);
                 auditService.createEnvironmentAuditLog(
+                    GraviteeContext.getCurrentEnvironment(),
                     Collections.singletonMap(DASHBOARD, dashboardId),
                     DASHBOARD_DELETED,
                     new Date(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EntrypointServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EntrypointServiceImpl.java
@@ -94,8 +94,8 @@ public class EntrypointServiceImpl extends TransactionalService implements Entry
         try {
             final Entrypoint entrypoint = convert(entrypointEntity, referenceId, referenceType);
             final EntrypointEntity savedEntryPoint = convert(entrypointRepository.create(entrypoint));
-            auditService.createEnvironmentAuditLog(
-                GraviteeContext.getCurrentEnvironment(),
+            auditService.createOrganizationAuditLog(
+                referenceId,
                 Collections.singletonMap(ENTRYPOINT, entrypoint.getId()),
                 ENTRYPOINT_CREATED,
                 new Date(),
@@ -127,8 +127,8 @@ public class EntrypointServiceImpl extends TransactionalService implements Entry
                 entrypoint.setReferenceId(existingEntrypoint.getReferenceId());
                 entrypoint.setReferenceType(existingEntrypoint.getReferenceType());
                 final EntrypointEntity savedEntryPoint = convert(entrypointRepository.update(entrypoint));
-                auditService.createEnvironmentAuditLog(
-                    GraviteeContext.getCurrentEnvironment(),
+                auditService.createOrganizationAuditLog(
+                    referenceId,
                     Collections.singletonMap(ENTRYPOINT, entrypoint.getId()),
                     ENTRYPOINT_UPDATED,
                     new Date(),
@@ -155,8 +155,8 @@ public class EntrypointServiceImpl extends TransactionalService implements Entry
             );
             if (entrypointOptional.isPresent()) {
                 entrypointRepository.delete(entrypointId);
-                auditService.createEnvironmentAuditLog(
-                    GraviteeContext.getCurrentEnvironment(),
+                auditService.createOrganizationAuditLog(
+                    referenceId,
                     Collections.singletonMap(ENTRYPOINT, entrypointId),
                     ENTRYPOINT_DELETED,
                     new Date(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EntrypointServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EntrypointServiceImpl.java
@@ -28,6 +28,7 @@ import io.gravitee.rest.api.model.NewEntryPointEntity;
 import io.gravitee.rest.api.model.UpdateEntryPointEntity;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.EntrypointService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.EntrypointNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
@@ -94,6 +95,7 @@ public class EntrypointServiceImpl extends TransactionalService implements Entry
             final Entrypoint entrypoint = convert(entrypointEntity, referenceId, referenceType);
             final EntrypointEntity savedEntryPoint = convert(entrypointRepository.create(entrypoint));
             auditService.createEnvironmentAuditLog(
+                GraviteeContext.getCurrentEnvironment(),
                 Collections.singletonMap(ENTRYPOINT, entrypoint.getId()),
                 ENTRYPOINT_CREATED,
                 new Date(),
@@ -126,6 +128,7 @@ public class EntrypointServiceImpl extends TransactionalService implements Entry
                 entrypoint.setReferenceType(existingEntrypoint.getReferenceType());
                 final EntrypointEntity savedEntryPoint = convert(entrypointRepository.update(entrypoint));
                 auditService.createEnvironmentAuditLog(
+                    GraviteeContext.getCurrentEnvironment(),
                     Collections.singletonMap(ENTRYPOINT, entrypoint.getId()),
                     ENTRYPOINT_UPDATED,
                     new Date(),
@@ -153,6 +156,7 @@ public class EntrypointServiceImpl extends TransactionalService implements Entry
             if (entrypointOptional.isPresent()) {
                 entrypointRepository.delete(entrypointId);
                 auditService.createEnvironmentAuditLog(
+                    GraviteeContext.getCurrentEnvironment(),
                     Collections.singletonMap(ENTRYPOINT, entrypointId),
                     ENTRYPOINT_DELETED,
                     new Date(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EnvironmentServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EnvironmentServiceImpl.java
@@ -76,16 +76,16 @@ public class EnvironmentServiceImpl extends TransactionalService implements Envi
     }
 
     @Override
-    public List<EnvironmentEntity> findByUser(String userId) {
-        return findByUserAndIdOrHrid(userId, null);
+    public List<EnvironmentEntity> findByUser(final String organizationId, String userId) {
+        return findByUserAndIdOrHrid(organizationId, userId, null);
     }
 
     @Override
-    public List<EnvironmentEntity> findByUserAndIdOrHrid(String userId, String idOrHrid) {
+    public List<EnvironmentEntity> findByUserAndIdOrHrid(final String organizationId, String userId, String idOrHrid) {
         try {
             LOGGER.debug("Find all environments by user");
 
-            Stream<Environment> envStream = environmentRepository.findByOrganization(GraviteeContext.getCurrentOrganization()).stream();
+            Stream<Environment> envStream = environmentRepository.findByOrganization(organizationId).stream();
 
             if (userId != null) {
                 final List<String> stringStream = membershipService

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
@@ -99,10 +99,10 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
     private EventManager eventManager;
 
     @Override
-    public List<GroupEntity> findAll() {
+    public List<GroupEntity> findAll(final String environmentId) {
         try {
             logger.debug("Find all groups");
-            Set<Group> all = groupRepository.findAllByEnvironment(GraviteeContext.getCurrentEnvironment());
+            Set<Group> all = groupRepository.findAllByEnvironment(environmentId);
             logger.debug("Find all groups - DONE");
             final List<GroupEntity> groups = all
                 .stream()
@@ -112,15 +112,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
 
             populateGroupFlags(groups);
 
-            if (
-                permissionService.hasPermission(
-                    RolePermission.ENVIRONMENT_GROUP,
-                    GraviteeContext.getCurrentEnvironment(),
-                    CREATE,
-                    UPDATE,
-                    DELETE
-                )
-            ) {
+            if (permissionService.hasPermission(RolePermission.ENVIRONMENT_GROUP, environmentId, CREATE, UPDATE, DELETE)) {
                 groups.forEach(groupEntity -> groupEntity.setManageable(true));
             } else {
                 Optional<RoleEntity> optGroupAdminSystemRole = roleService.findByScopeAndName(RoleScope.GROUP, SystemRole.ADMIN.name());
@@ -184,14 +176,14 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
     }
 
     @Override
-    public List<GroupEntity> findByName(String name) {
+    public List<GroupEntity> findByName(final String environmentId, String name) {
         try {
             logger.debug("findByUsername : {}", name);
             if (name == null) {
                 return Collections.emptyList();
             }
             List<GroupEntity> groupEntities = groupRepository
-                .findAllByEnvironment(GraviteeContext.getCurrentEnvironment())
+                .findAllByEnvironment(environmentId)
                 .stream()
                 .filter(group -> group.getName().equals(name))
                 .map(this::map)
@@ -206,20 +198,21 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
     }
 
     @Override
-    public GroupEntity create(NewGroupEntity group) {
+    public GroupEntity create(final String environmentId, NewGroupEntity group) {
         try {
             logger.debug("create {}", group);
-            if (!this.findByName(group.getName()).isEmpty()) {
+            if (!this.findByName(environmentId, group.getName()).isEmpty()) {
                 throw new GroupNameAlreadyExistsException(group.getName());
             }
             Group newGroup = this.map(group);
             newGroup.setId(UuidString.generateRandom());
-            newGroup.setEnvironmentId(GraviteeContext.getCurrentEnvironment());
+            newGroup.setEnvironmentId(environmentId);
             newGroup.setCreatedAt(new Date());
             newGroup.setUpdatedAt(newGroup.getCreatedAt());
             GroupEntity grp = this.map(groupRepository.create(newGroup));
             // Audit
             auditService.createEnvironmentAuditLog(
+                environmentId,
                 Collections.singletonMap(GROUP, newGroup.getId()),
                 GROUP_CREATED,
                 newGroup.getCreatedAt(),
@@ -235,11 +228,11 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
     }
 
     @Override
-    public GroupEntity update(String groupId, UpdateGroupEntity group) {
+    public GroupEntity update(final String environmentId, String groupId, UpdateGroupEntity group) {
         try {
             logger.debug("update {}", group);
-            GroupEntity updatedGroupEntity = this.findById(groupId);
-            Group previousGroup = this.map(updatedGroupEntity);
+            GroupEntity updatedGroupEntity = this.findById(environmentId, groupId);
+            Group previousGroup = this.map(updatedGroupEntity, environmentId);
             updatedGroupEntity.setName(group.getName());
             updatedGroupEntity.setUpdatedAt(new Date());
             updatedGroupEntity.setEventRules(group.getEventRules());
@@ -250,7 +243,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
             updatedGroupEntity.setEmailInvitation(group.isEmailInvitation());
             updatedGroupEntity.setDisableMembershipNotifications(group.isDisableMembershipNotifications());
 
-            Group updatedGroup = this.map(updatedGroupEntity);
+            Group updatedGroup = this.map(updatedGroupEntity, environmentId);
             GroupEntity grp = this.map(groupRepository.update(updatedGroup));
             logger.debug("update {} - DONE", grp);
 
@@ -258,13 +251,14 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
 
             // Audit
             auditService.createEnvironmentAuditLog(
+                updatedGroup.getEnvironmentId(),
                 Collections.singletonMap(GROUP, groupId),
                 GROUP_UPDATED,
                 updatedGroupEntity.getUpdatedAt(),
                 previousGroup,
                 updatedGroup
             );
-            return findById(groupId);
+            return findById(environmentId, groupId);
         } catch (TechnicalException ex) {
             final String error = "An error occurs while trying to update a group";
             logger.error(error, ex);
@@ -303,11 +297,20 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
     }
 
     private void removeOldDefaultRole(String groupId, MembershipReferenceType referenceType) {
-        membershipService.deleteReferenceMember(referenceType, null, MembershipMemberType.GROUP, groupId);
+        membershipService.deleteReferenceMember(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
+            referenceType,
+            null,
+            MembershipMemberType.GROUP,
+            groupId
+        );
     }
 
     private void addNewDefaultRole(String groupId, String newRole, RoleScope roleScope) {
         membershipService.addRoleToMemberOnReference(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
             new MembershipService.MembershipReference(MembershipReferenceType.valueOf(roleScope.name()), null),
             new MembershipService.MembershipMember(groupId, null, MembershipMemberType.GROUP),
             new MembershipService.MembershipRole(roleScope, newRole)
@@ -315,7 +318,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
     }
 
     @Override
-    public GroupEntity findById(String groupId) {
+    public GroupEntity findById(final String environmentId, String groupId) {
         try {
             logger.debug("findById {}", groupId);
             Optional<Group> group = groupRepository.findById(groupId);
@@ -325,15 +328,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
             logger.debug("findById {} - DONE", group.get());
             GroupEntity groupEntity = this.map(group.get());
 
-            if (
-                permissionService.hasPermission(
-                    RolePermission.ENVIRONMENT_GROUP,
-                    GraviteeContext.getCurrentEnvironment(),
-                    CREATE,
-                    UPDATE,
-                    DELETE
-                )
-            ) {
+            if (permissionService.hasPermission(RolePermission.ENVIRONMENT_GROUP, environmentId, CREATE, UPDATE, DELETE)) {
                 groupEntity.setManageable(true);
             } else {
                 Optional<RoleEntity> optGroupAdminSystemRole = roleService.findByScopeAndName(RoleScope.GROUP, SystemRole.ADMIN.name());
@@ -444,11 +439,11 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
     }
 
     @Override
-    public Set<GroupEntity> findByEvent(GroupEvent event) {
+    public Set<GroupEntity> findByEvent(final String environmentId, GroupEvent event) {
         try {
             logger.debug("findByEvent : {}", event);
             Set<GroupEntity> set = groupRepository
-                .findAllByEnvironment(GraviteeContext.getCurrentEnvironment())
+                .findAllByEnvironment(environmentId)
                 .stream()
                 .filter(
                     g ->
@@ -467,7 +462,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
     }
 
     @Override
-    public void delete(String groupId) {
+    public void delete(final String environmentId, String groupId) {
         try {
             logger.debug("delete {}", groupId);
             Optional<Group> group = groupRepository.findById(groupId);
@@ -493,12 +488,17 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
             }
 
             //remove all members
-            membershipService.deleteReference(MembershipReferenceType.GROUP, groupId);
+            membershipService.deleteReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
+                MembershipReferenceType.GROUP,
+                groupId
+            );
 
             //remove all applications or apis
             Date updatedDate = new Date();
             apiRepository
-                .search(new ApiCriteria.Builder().environmentId(GraviteeContext.getCurrentEnvironment()).groups(groupId).build())
+                .search(new ApiCriteria.Builder().environmentId(environmentId).groups(groupId).build())
                 .forEach(
                     api -> {
                         api.getGroups().remove(groupId);
@@ -549,7 +549,14 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
             groupRepository.delete(groupId);
 
             // Audit
-            auditService.createEnvironmentAuditLog(Collections.singletonMap(GROUP, groupId), GROUP_DELETED, new Date(), group.get(), null);
+            auditService.createEnvironmentAuditLog(
+                environmentId,
+                Collections.singletonMap(GROUP, groupId),
+                GROUP_DELETED,
+                new Date(),
+                group.get(),
+                null
+            );
 
             logger.debug("delete {} - DONE", groupId);
         } catch (TechnicalException ex) {
@@ -708,10 +715,10 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
     }
 
     @Override
-    public List<ApiEntity> getApis(String groupId) {
+    public List<ApiEntity> getApis(final String environmentId, String groupId) {
         return apiRepository
             .search(
-                new ApiCriteria.Builder().environmentId(GraviteeContext.getCurrentEnvironment()).groups(groupId).build(),
+                new ApiCriteria.Builder().environmentId(environmentId).groups(groupId).build(),
                 new ApiFieldExclusionFilter.Builder().excludeDefinition().excludePicture().build()
             )
             .stream()
@@ -750,7 +757,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         }
     }
 
-    private Group map(GroupEntity entity) {
+    private Group map(GroupEntity entity, final String environmentId) {
         if (entity == null) {
             return null;
         }
@@ -776,7 +783,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         group.setLockApplicationRole(entity.isLockApplicationRole());
         group.setSystemInvitation(entity.isSystemInvitation());
         group.setEmailInvitation(entity.isEmailInvitation());
-        group.setEnvironmentId(GraviteeContext.getCurrentEnvironment());
+        group.setEnvironmentId(environmentId);
         group.setDisableMembershipNotifications(entity.isDisableMembershipNotifications());
 
         return group;
@@ -863,7 +870,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
     }
 
     @Override
-    public void deleteUserFromGroup(String groupId, String username) {
+    public void deleteUserFromGroup(final String environmentId, String groupId, String username) {
         //check if user exist
         this.userService.findById(username);
 
@@ -871,9 +878,16 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
             ApplicationAlertEventType.APPLICATION_MEMBERSHIP_UPDATE,
             new ApplicationAlertMembershipEvent(Collections.emptySet(), Collections.singleton(groupId))
         );
-        membershipService.deleteReferenceMember(MembershipReferenceType.GROUP, groupId, MembershipMemberType.USER, username);
+        membershipService.deleteReferenceMember(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
+            MembershipReferenceType.GROUP,
+            groupId,
+            MembershipMemberType.USER,
+            username
+        );
 
-        GroupEntity existingGroup = this.findById(groupId);
+        GroupEntity existingGroup = this.findById(environmentId, groupId);
         if (existingGroup.getApiPrimaryOwner() != null && existingGroup.getApiPrimaryOwner().equals(username)) {
             updateApiPrimaryOwner(groupId, username);
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/InstanceServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/InstanceServiceImpl.java
@@ -23,6 +23,7 @@ import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.EventService;
 import io.gravitee.rest.api.service.InstanceService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.EventNotFoundException;
 import io.gravitee.rest.api.service.exceptions.InstanceNotFoundException;
 import java.io.IOException;
@@ -119,7 +120,8 @@ public class InstanceServiceImpl implements InstanceService {
                     return item;
                 }
             },
-            filter
+            filter,
+            Collections.singletonList(GraviteeContext.getCurrentEnvironment())
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/InvitationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/InvitationServiceImpl.java
@@ -93,7 +93,7 @@ public class InvitationServiceImpl extends TransactionalService implements Invit
                     .stream()
                     .map(MembershipEntity::getMemberId)
                     .collect(Collectors.toSet());
-                final GroupEntity group = groupService.findById(invitation.getReferenceId());
+                final GroupEntity group = groupService.findById(GraviteeContext.getCurrentEnvironment(), invitation.getReferenceId());
                 if (groupUsers.contains(user.getId())) {
                     throw new MemberEmailAlreadyExistsException(invitation.getEmail());
                 }
@@ -188,6 +188,8 @@ public class InvitationServiceImpl extends TransactionalService implements Invit
         }
         if (defaultRoleName != null) {
             membershipService.addRoleToMemberOnReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
                 new MembershipReference(MembershipReferenceType.valueOf(referenceType), referenceId),
                 new MembershipService.MembershipMember(userId, null, MembershipMemberType.USER),
                 new MembershipService.MembershipRole(roleScope, defaultRoleName)
@@ -198,7 +200,7 @@ public class InvitationServiceImpl extends TransactionalService implements Invit
     private void sendGroupInvitationEmail(NewInvitationEntity invitation) {
         final UserEntity userEntity = new UserEntity();
         userEntity.setEmail(invitation.getEmail());
-        final GroupEntity group = groupService.findById(invitation.getReferenceId());
+        final GroupEntity group = groupService.findById(GraviteeContext.getCurrentEnvironment(), invitation.getReferenceId());
         emailService.sendEmailNotification(
             new EmailNotificationBuilder()
                 .to(invitation.getEmail())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/LogsServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/LogsServiceImpl.java
@@ -36,6 +36,7 @@ import io.gravitee.rest.api.model.log.extended.Response;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.service.*;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.*;
 import io.netty.handler.codec.http.QueryStringDecoder;
 import java.util.*;
@@ -320,7 +321,7 @@ public class LogsServiceImpl implements LogsService {
                     metadata.put(METADATA_NAME, METADATA_UNKNOWN_APPLICATION_NAME);
                     metadata.put(METADATA_UNKNOWN, Boolean.TRUE.toString());
                 } else {
-                    ApplicationEntity applicationEntity = applicationService.findById(application);
+                    ApplicationEntity applicationEntity = applicationService.findById(GraviteeContext.getCurrentEnvironment(), application);
                     metadata.put(METADATA_NAME, applicationEntity.getName());
                     if (ApplicationStatus.ARCHIVED.toString().equals(applicationEntity.getStatus())) {
                         metadata.put(METADATA_DELETED, Boolean.TRUE.toString());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MediaServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MediaServiceImpl.java
@@ -157,8 +157,8 @@ public class MediaServiceImpl implements MediaService {
     }
 
     @Override
-    public Long getMediaMaxSize() {
-        return Long.valueOf(configService.getPortalSettings().getPortal().getUploadMedia().getMaxSizeInOctet());
+    public Long getMediaMaxSize(final String environmentId) {
+        return Long.valueOf(configService.getPortalSettings(environmentId).getPortal().getUploadMedia().getMaxSizeInOctet());
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MetadataServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MetadataServiceImpl.java
@@ -31,6 +31,7 @@ import io.gravitee.rest.api.model.NewMetadataEntity;
 import io.gravitee.rest.api.model.UpdateMetadataEntity;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.MetadataService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.DuplicateMetadataNameException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.notification.NotificationTemplateService;
@@ -112,7 +113,9 @@ public class MetadataServiceImpl extends TransactionalService implements Metadat
             metadata.setUpdatedAt(now);
             metadataRepository.create(metadata);
             // Audit
+            // FIXME: Use OrganizationAuditLog?
             auditService.createEnvironmentAuditLog(
+                GraviteeContext.getCurrentEnvironment(),
                 singletonMap(METADATA, metadata.getKey()),
                 METADATA_CREATED,
                 metadata.getCreatedAt(),
@@ -151,7 +154,9 @@ public class MetadataServiceImpl extends TransactionalService implements Metadat
             metadata.setUpdatedAt(now);
             metadataRepository.update(metadata);
             // Audit
+            // FIXME: Use OrganizationAuditLog?
             auditService.createEnvironmentAuditLog(
+                GraviteeContext.getCurrentEnvironment(),
                 singletonMap(METADATA, metadata.getKey()),
                 METADATA_UPDATED,
                 metadata.getCreatedAt(),
@@ -179,7 +184,15 @@ public class MetadataServiceImpl extends TransactionalService implements Metadat
             if (optMetadata.isPresent()) {
                 metadataRepository.delete(key, DEFAULT_REFERENCE_ID, MetadataReferenceType.DEFAULT);
                 // Audit
-                auditService.createEnvironmentAuditLog(singletonMap(METADATA, key), METADATA_DELETED, new Date(), optMetadata.get(), null);
+                // FIXME: Use OrganizationAuditLog?
+                auditService.createEnvironmentAuditLog(
+                    GraviteeContext.getCurrentEnvironment(),
+                    singletonMap(METADATA, key),
+                    METADATA_DELETED,
+                    new Date(),
+                    optMetadata.get(),
+                    null
+                );
                 // delete all overridden API metadata
                 final List<Metadata> apiMetadata = metadataRepository.findByKeyAndReferenceType(key, MetadataReferenceType.API);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/NotificationTemplateServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/NotificationTemplateServiceImpl.java
@@ -510,6 +510,7 @@ public class NotificationTemplateServiceImpl extends AbstractService implements 
     private void createAuditLog(Audit.AuditEvent event, Date createdAt, NotificationTemplate oldValue, NotificationTemplate newValue) {
         String notificationTemplateName = oldValue != null ? oldValue.getName() : newValue.getName();
         auditService.createOrganizationAuditLog(
+            GraviteeContext.getCurrentOrganization(),
             Collections.singletonMap(NOTIFICATION_TEMPLATE, notificationTemplateName),
             event,
             createdAt,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/OrganizationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/OrganizationServiceImpl.java
@@ -135,7 +135,12 @@ public class OrganizationServiceImpl extends TransactionalService implements Org
     private void createPublishOrganizationEvent(OrganizationEntity organizationEntity) throws JsonProcessingException {
         Map<String, String> properties = new HashMap<>();
         properties.put(Event.EventProperties.ORGANIZATION_ID.getValue(), organizationEntity.getId());
-        eventService.create(EventType.PUBLISH_ORGANIZATION, mapper.writeValueAsString(organizationEntity), properties);
+        eventService.create(
+            Collections.singleton(GraviteeContext.getCurrentEnvironment()),
+            EventType.PUBLISH_ORGANIZATION,
+            mapper.writeValueAsString(organizationEntity),
+            properties
+        );
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -45,6 +45,7 @@ import io.gravitee.rest.api.model.descriptor.GraviteeDescriptorEntity;
 import io.gravitee.rest.api.model.descriptor.GraviteeDescriptorPageEntity;
 import io.gravitee.rest.api.model.documentation.PageQuery;
 import io.gravitee.rest.api.service.*;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.*;
 import io.gravitee.rest.api.service.impl.swagger.parser.OAIParser;
@@ -2453,7 +2454,14 @@ public class PageServiceImpl extends AbstractService implements PageService, App
     private void createAuditLog(String apiId, Audit.AuditEvent event, Date createdAt, Page oldValue, Page newValue) {
         String pageId = oldValue != null ? oldValue.getId() : newValue.getId();
         if (apiId == null) {
-            auditService.createEnvironmentAuditLog(Collections.singletonMap(PAGE, pageId), event, createdAt, oldValue, newValue);
+            auditService.createEnvironmentAuditLog(
+                GraviteeContext.getCurrentEnvironment(),
+                Collections.singletonMap(PAGE, pageId),
+                event,
+                createdAt,
+                oldValue,
+                newValue
+            );
         } else {
             auditService.createApiAuditLog(apiId, Collections.singletonMap(PAGE, pageId), event, createdAt, oldValue, newValue);
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ParameterServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ParameterServiceImpl.java
@@ -409,6 +409,7 @@ public class ParameterServiceImpl extends TransactionalService implements Parame
                 } else if (!value.equals(optionalParameter.get().getValue())) {
                     final Parameter updatedParameter = parameterRepository.update(parameter);
                     auditService.createEnvironmentAuditLog(
+                        GraviteeContext.getCurrentEnvironment(),
                         singletonMap(PARAMETER, updatedParameter.getKey()),
                         PARAMETER_UPDATED,
                         new Date(),
@@ -426,6 +427,7 @@ public class ParameterServiceImpl extends TransactionalService implements Parame
                 }
                 final Parameter savedParameter = parameterRepository.create(parameter);
                 auditService.createEnvironmentAuditLog(
+                    GraviteeContext.getCurrentEnvironment(),
                     singletonMap(PARAMETER, savedParameter.getKey()),
                     PARAMETER_CREATED,
                     new Date(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PermissionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PermissionServiceImpl.java
@@ -70,6 +70,7 @@ public class PermissionServiceImpl extends AbstractService implements Permission
         }
 
         Map<String, char[]> permissions = membershipService.getUserMemberPermissions(
+            GraviteeContext.getCurrentEnvironment(),
             membershipReferenceType,
             referenceId,
             getAuthenticatedUsername()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/QualityMetricsServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/QualityMetricsServiceImpl.java
@@ -86,7 +86,7 @@ public class QualityMetricsServiceImpl extends AbstractService implements Qualit
     }
 
     @Override
-    public ApiQualityMetricsEntity getMetrics(ApiEntity apiEntity) {
+    public ApiQualityMetricsEntity getMetrics(ApiEntity apiEntity, final String environmentId) {
         if (!isApiMetricsEnabled()) {
             throw new ApiQualityMetricsDisableException();
         }
@@ -107,7 +107,7 @@ public class QualityMetricsServiceImpl extends AbstractService implements Qualit
         } else {
             Map<String, ApiQualityMetric> apiMetrics = getApiMetricsMap();
             for (Map.Entry<String, Integer> weight : weights.entrySet()) {
-                boolean passed = apiMetrics.get(weight.getKey()).isValid(apiEntity);
+                boolean passed = apiMetrics.get(weight.getKey()).isValid(apiEntity, environmentId);
                 result.getMetricsPassed().put(weight.getKey(), passed);
                 score += weight.getValue() * (passed ? 1 : 0);
                 maxScore += weight.getValue();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/QualityRuleServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/QualityRuleServiceImpl.java
@@ -29,6 +29,7 @@ import io.gravitee.rest.api.model.quality.QualityRuleEntity;
 import io.gravitee.rest.api.model.quality.UpdateQualityRuleEntity;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.QualityRuleService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.QualityRuleNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
@@ -92,6 +93,7 @@ public class QualityRuleServiceImpl extends AbstractService implements QualityRu
             final QualityRule qualityRule = convert(newEntity);
             final QualityRule createdQualityRule = qualityRuleRepository.create(qualityRule);
             auditService.createEnvironmentAuditLog(
+                GraviteeContext.getCurrentEnvironment(),
                 Collections.singletonMap(QUALITY_RULE, createdQualityRule.getId()),
                 QualityRule.AuditEvent.QUALITY_RULE_CREATED,
                 qualityRule.getCreatedAt(),
@@ -114,6 +116,7 @@ public class QualityRuleServiceImpl extends AbstractService implements QualityRu
             }
             final QualityRule qualityRule = qualityRuleRepository.update(convert(updateEntity, optionalQualityRule.get()));
             auditService.createEnvironmentAuditLog(
+                GraviteeContext.getCurrentEnvironment(),
                 singletonMap(QUALITY_RULE, qualityRule.getId()),
                 QUALITY_RULE_UPDATED,
                 qualityRule.getUpdatedAt(),
@@ -136,6 +139,7 @@ public class QualityRuleServiceImpl extends AbstractService implements QualityRu
                 // delete all reference on api quality rule
                 apiQualityRuleRepository.deleteByQualityRule(qualityRule);
                 auditService.createEnvironmentAuditLog(
+                    GraviteeContext.getCurrentEnvironment(),
                     Collections.singletonMap(QUALITY_RULE, qualityRule),
                     QualityRule.AuditEvent.QUALITY_RULE_DELETED,
                     new Date(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
@@ -139,6 +139,7 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
 
             RoleEntity entity = convert(roleRepository.create(role));
             auditService.createOrganizationAuditLog(
+                GraviteeContext.getCurrentOrganization(),
                 Collections.singletonMap(ROLE, role.getScope() + ":" + role.getName()),
                 ROLE_CREATED,
                 role.getCreatedAt(),
@@ -173,6 +174,7 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
             updatedRole.setReferenceType(role.getReferenceType());
             RoleEntity entity = convert(roleRepository.update(updatedRole));
             auditService.createOrganizationAuditLog(
+                GraviteeContext.getCurrentOrganization(),
                 Collections.singletonMap(ROLE, role.getScope() + ":" + role.getName()),
                 ROLE_UPDATED,
                 updatedRole.getUpdatedAt(),
@@ -211,6 +213,7 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
             roleRepository.delete(roleId);
 
             auditService.createOrganizationAuditLog(
+                GraviteeContext.getCurrentOrganization(),
                 Collections.singletonMap(ROLE, scope + ":" + role.getName()),
                 ROLE_DELETED,
                 role.getUpdatedAt(),
@@ -332,6 +335,7 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
                 role.setUpdatedAt(new Date());
                 roleRepository.update(role);
                 auditService.createOrganizationAuditLog(
+                    GraviteeContext.getCurrentOrganization(),
                     Collections.singletonMap(ROLE, role.getScope() + ":" + role.getName()),
                     ROLE_UPDATED,
                     role.getUpdatedAt(),
@@ -566,6 +570,7 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
             systemRole.setUpdatedAt(new Date());
             roleRepository.update(systemRole);
             auditService.createOrganizationAuditLog(
+                GraviteeContext.getCurrentOrganization(),
                 Collections.singletonMap(ROLE, systemRole.getScope() + ":" + systemRole.getName()),
                 ROLE_UPDATED,
                 systemRole.getCreatedAt(),
@@ -575,6 +580,7 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
         } else if (!existingRole.isPresent()) {
             roleRepository.create(systemRole);
             auditService.createOrganizationAuditLog(
+                GraviteeContext.getCurrentOrganization(),
                 Collections.singletonMap(ROLE, systemRole.getScope() + ":" + systemRole.getName()),
                 ROLE_CREATED,
                 systemRole.getCreatedAt(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
@@ -143,7 +143,11 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
         if (application != null && !application.trim().isEmpty()) {
             query.setApplication(application);
         } else if (isAuthenticated()) {
-            Set<ApplicationListItem> applications = applicationService.findByUser(getAuthenticatedUsername());
+            Set<ApplicationListItem> applications = applicationService.findByUser(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
+                getAuthenticatedUsername()
+            );
             query.setApplications(applications.stream().map(ApplicationListItem::getId).collect(toList()));
         }
 
@@ -227,7 +231,7 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                 }
             }
 
-            ApplicationEntity applicationEntity = applicationService.findById(application);
+            ApplicationEntity applicationEntity = applicationService.findById(GraviteeContext.getCurrentEnvironment(), application);
             if (ApplicationStatus.ARCHIVED.name().equals(applicationEntity.getStatus())) {
                 throw new ApplicationArchivedException(applicationEntity.getName());
             }
@@ -507,7 +511,10 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
 
             subscription = subscriptionRepository.update(subscription);
 
-            final ApplicationEntity application = applicationService.findById(subscription.getApplication());
+            final ApplicationEntity application = applicationService.findById(
+                GraviteeContext.getCurrentEnvironment(),
+                subscription.getApplication()
+            );
             final PlanEntity plan = planService.findById(subscription.getPlan());
             final String apiId = plan.getApi();
             final ApiModelEntity api = apiService.findByIdForTemplates(apiId);
@@ -624,7 +631,10 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                     subscription = subscriptionRepository.update(subscription);
 
                     // Send an email to subscriber
-                    final ApplicationEntity application = applicationService.findById(subscription.getApplication());
+                    final ApplicationEntity application = applicationService.findById(
+                        GraviteeContext.getCurrentEnvironment(),
+                        subscription.getApplication()
+                    );
                     final PlanEntity plan = planService.findById(subscription.getPlan());
                     String apiId = plan.getApi();
                     final ApiModelEntity api = apiService.findByIdForTemplates(apiId);
@@ -700,7 +710,10 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                 subscription = subscriptionRepository.update(subscription);
 
                 // Send an email to subscriber
-                final ApplicationEntity application = applicationService.findById(subscription.getApplication());
+                final ApplicationEntity application = applicationService.findById(
+                    GraviteeContext.getCurrentEnvironment(),
+                    subscription.getApplication()
+                );
                 final PlanEntity plan = planService.findById(subscription.getPlan());
                 String apiId = plan.getApi();
                 final ApiModelEntity api = apiService.findByIdForTemplates(apiId);
@@ -769,7 +782,10 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                 subscription = subscriptionRepository.update(subscription);
 
                 // Send an email to subscriber
-                final ApplicationEntity application = applicationService.findById(subscription.getApplication());
+                final ApplicationEntity application = applicationService.findById(
+                    GraviteeContext.getCurrentEnvironment(),
+                    subscription.getApplication()
+                );
                 final PlanEntity plan = planService.findById(subscription.getPlan());
                 String apiId = plan.getApi();
                 final ApiModelEntity api = apiService.findByIdForTemplates(apiId);
@@ -1037,7 +1053,10 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                 apiKeyService.update(apiKey);
             }
 
-            final ApplicationEntity application = applicationService.findById(subscription.getApplication());
+            final ApplicationEntity application = applicationService.findById(
+                GraviteeContext.getCurrentEnvironment(),
+                subscription.getApplication()
+            );
             final PlanEntity plan = planService.findById(subscription.getPlan());
             final String apiId = plan.getApi();
             final ApiModelEntity api = apiService.findByIdForTemplates(apiId);
@@ -1140,7 +1159,10 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
         subscriptions.forEach(
             subscription -> {
                 if (!metadata.containsKey(subscription.getApplication())) {
-                    ApplicationEntity applicationEntity = applicationService.findById(subscription.getApplication());
+                    ApplicationEntity applicationEntity = applicationService.findById(
+                        GraviteeContext.getCurrentEnvironment(),
+                        subscription.getApplication()
+                    );
                     metadata.put(subscription.getApplication(), "name", applicationEntity.getName());
                 }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TagServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TagServiceImpl.java
@@ -17,7 +17,6 @@ package io.gravitee.rest.api.service.impl;
 
 import static io.gravitee.repository.management.model.Audit.AuditProperties.TAG;
 import static io.gravitee.repository.management.model.Tag.AuditEvent.*;
-import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
@@ -35,6 +34,7 @@ import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.TagService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.DuplicateTagNameException;
 import io.gravitee.rest.api.service.exceptions.TagNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
@@ -127,7 +127,14 @@ public class TagServiceImpl extends AbstractService implements TagService {
                 try {
                     Tag tag = convert(tagEntity, referenceId, referenceType);
                     savedTags.add(convert(tagRepository.create(tag)));
-                    auditService.createOrganizationAuditLog(Collections.singletonMap(TAG, tag.getId()), TAG_CREATED, new Date(), null, tag);
+                    auditService.createOrganizationAuditLog(
+                        GraviteeContext.getCurrentOrganization(),
+                        Collections.singletonMap(TAG, tag.getId()),
+                        TAG_CREATED,
+                        new Date(),
+                        null,
+                        tag
+                    );
                 } catch (TechnicalException ex) {
                     LOGGER.error("An error occurs while trying to create tag {}", tagEntity.getName(), ex);
                     throw new TechnicalManagementException("An error occurs while trying to create tag " + tagEntity.getName(), ex);
@@ -155,6 +162,7 @@ public class TagServiceImpl extends AbstractService implements TagService {
                         tag.setReferenceType(existingTag.getReferenceType());
                         savedTags.add(convert(tagRepository.update(tag)));
                         auditService.createOrganizationAuditLog(
+                            GraviteeContext.getCurrentOrganization(),
                             Collections.singletonMap(TAG, tag.getId()),
                             TAG_UPDATED,
                             new Date(),
@@ -180,6 +188,7 @@ public class TagServiceImpl extends AbstractService implements TagService {
                 // delete all reference on APIs
                 apiService.deleteTagFromAPIs(tagId);
                 auditService.createOrganizationAuditLog(
+                    GraviteeContext.getCurrentOrganization(),
                     Collections.singletonMap(TAG, tagId),
                     TAG_DELETED,
                     new Date(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TaskServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TaskServiceImpl.java
@@ -21,7 +21,6 @@ import static io.gravitee.rest.api.model.permissions.ApiPermission.*;
 import static java.util.Collections.singleton;
 import static java.util.stream.Collectors.toList;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.search.UserCriteria;
@@ -227,7 +226,10 @@ public class TaskServiceImpl extends AbstractService implements TaskService {
                     final SubscriptionEntity subscription = (SubscriptionEntity) data;
 
                     if (!metadata.containsKey(subscription.getApplication())) {
-                        ApplicationEntity applicationEntity = applicationService.findById(subscription.getApplication());
+                        ApplicationEntity applicationEntity = applicationService.findById(
+                            GraviteeContext.getCurrentEnvironment(),
+                            subscription.getApplication()
+                        );
                         metadata.put(subscription.getApplication(), "name", applicationEntity.getName());
                     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TenantServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TenantServiceImpl.java
@@ -25,7 +25,6 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.TenantRepository;
 import io.gravitee.repository.management.model.Tenant;
 import io.gravitee.rest.api.model.NewTenantEntity;
-import io.gravitee.rest.api.model.TagReferenceType;
 import io.gravitee.rest.api.model.TenantEntity;
 import io.gravitee.rest.api.model.TenantReferenceType;
 import io.gravitee.rest.api.model.UpdateTenantEntity;
@@ -114,6 +113,7 @@ public class TenantServiceImpl extends TransactionalService implements TenantSer
                     Tenant tenant = convert(tenantEntity, referenceId, referenceType);
                     savedTenants.add(convert(tenantRepository.create(tenant)));
                     auditService.createEnvironmentAuditLog(
+                        GraviteeContext.getCurrentEnvironment(),
                         Collections.singletonMap(TENANT, tenant.getId()),
                         TENANT_CREATED,
                         new Date(),
@@ -147,6 +147,7 @@ public class TenantServiceImpl extends TransactionalService implements TenantSer
                         tenant.setReferenceType(existingTenant.getReferenceType());
                         savedTenants.add(convert(tenantRepository.update(tenant)));
                         auditService.createEnvironmentAuditLog(
+                            GraviteeContext.getCurrentEnvironment(),
                             Collections.singletonMap(TENANT, tenant.getId()),
                             TENANT_UPDATED,
                             new Date(),
@@ -174,6 +175,7 @@ public class TenantServiceImpl extends TransactionalService implements TenantSer
             if (tenantOptional.isPresent()) {
                 tenantRepository.delete(tenantId);
                 auditService.createEnvironmentAuditLog(
+                    GraviteeContext.getCurrentEnvironment(),
                     Collections.singletonMap(TENANT, tenantId),
                     TENANT_DELETED,
                     new Date(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ThemeServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ThemeServiceImpl.java
@@ -124,6 +124,7 @@ public class ThemeServiceImpl extends AbstractService implements ThemeService {
             Theme theme = themeRepository.create(convert(themeEntity));
 
             auditService.createEnvironmentAuditLog(
+                GraviteeContext.getCurrentEnvironment(),
                 Collections.singletonMap(THEME, theme.getId()),
                 THEME_CREATED,
                 theme.getCreatedAt(),
@@ -187,6 +188,7 @@ public class ThemeServiceImpl extends AbstractService implements ThemeService {
 
                 final ThemeEntity savedTheme = convert(themeRepository.update(theme));
                 auditService.createEnvironmentAuditLog(
+                    GraviteeContext.getCurrentEnvironment(),
                     Collections.singletonMap(THEME, theme.getId()),
                     THEME_UPDATED,
                     new Date(),
@@ -219,6 +221,7 @@ public class ThemeServiceImpl extends AbstractService implements ThemeService {
             if (themeOptional.isPresent()) {
                 themeRepository.delete(themeId);
                 auditService.createEnvironmentAuditLog(
+                    GraviteeContext.getCurrentEnvironment(),
                     Collections.singletonMap(THEME, themeId),
                     THEME_DELETED,
                     new Date(),
@@ -286,6 +289,7 @@ public class ThemeServiceImpl extends AbstractService implements ThemeService {
                                 theme.setUpdatedAt(new Date());
                                 this.themeRepository.update(themeUpdate);
                                 auditService.createEnvironmentAuditLog(
+                                    GraviteeContext.getCurrentEnvironment(),
                                     Collections.singletonMap(THEME, theme.getId()),
                                     THEME_UPDATED,
                                     new Date(),
@@ -375,7 +379,14 @@ public class ThemeServiceImpl extends AbstractService implements ThemeService {
             LOGGER.debug("Reset to default theme by ID: {}", themeId);
             final ThemeEntity previousTheme = findEnabled();
             themeRepository.delete(DEFAULT_THEME_ID);
-            auditService.createEnvironmentAuditLog(Collections.singletonMap(THEME, themeId), THEME_RESET, new Date(), previousTheme, null);
+            auditService.createEnvironmentAuditLog(
+                GraviteeContext.getCurrentEnvironment(),
+                Collections.singletonMap(THEME, themeId),
+                THEME_RESET,
+                new Date(),
+                previousTheme,
+                null
+            );
             return findEnabled();
         } catch (Exception ex) {
             final String error = "Error while trying to reset a default theme";

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TicketServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TicketServiceImpl.java
@@ -35,6 +35,7 @@ import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.builder.EmailNotificationBuilder;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.EmailRequiredException;
 import io.gravitee.rest.api.service.exceptions.SupportUnavailableException;
@@ -142,7 +143,7 @@ public class TicketServiceImpl extends TransactionalService implements TicketSer
             }
 
             if (ticketEntity.getApplication() != null && !ticketEntity.getApplication().isEmpty()) {
-                applicationEntity = applicationService.findById(ticketEntity.getApplication());
+                applicationEntity = applicationService.findById(GraviteeContext.getCurrentEnvironment(), ticketEntity.getApplication());
                 parameters.put("application", applicationEntity);
             } else {
                 applicationEntity = null;
@@ -277,7 +278,7 @@ public class TicketServiceImpl extends TransactionalService implements TicketSer
     private Ticket getApiNameAndApplicationName(Ticket ticket) {
         //Retrieve application name
         if (StringUtils.isNotEmpty(ticket.getApplication())) {
-            ApplicationEntity application = applicationService.findById(ticket.getApplication());
+            ApplicationEntity application = applicationService.findById(GraviteeContext.getCurrentEnvironment(), ticket.getApplication());
             ticket.setApplication(application.getName());
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TokenServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TokenServiceImpl.java
@@ -28,6 +28,7 @@ import io.gravitee.rest.api.model.TokenEntity;
 import io.gravitee.rest.api.model.TokenReferenceType;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.TokenService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.exceptions.TokenNameAlreadyExistsException;
 import java.util.*;
@@ -81,6 +82,7 @@ public class TokenServiceImpl extends AbstractService implements TokenService {
             final String decodedToken = UUID.toString(UUID.random());
             final Token token = convert(newToken, TokenReferenceType.USER, username, passwordEncoder.encode(decodedToken));
             auditService.createEnvironmentAuditLog(
+                GraviteeContext.getCurrentEnvironment(),
                 Collections.singletonMap(TOKEN, token.getId()),
                 TOKEN_CREATED,
                 token.getCreatedAt(),
@@ -108,6 +110,7 @@ public class TokenServiceImpl extends AbstractService implements TokenService {
             if (tokenOptional.isPresent()) {
                 tokenRepository.delete(tokenId);
                 auditService.createEnvironmentAuditLog(
+                    GraviteeContext.getCurrentEnvironment(),
                     Collections.singletonMap(TOKEN, tokenId),
                     TOKEN_DELETED,
                     new Date(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserMetadataServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserMetadataServiceImpl.java
@@ -66,12 +66,12 @@ public class UserMetadataServiceImpl extends AbstractReferenceMetadataService im
 
     @Override
     public UserMetadataEntity create(NewUserMetadataEntity metadata) {
-        return convert(create(metadata, USER, metadata.getUserId(), false), metadata.getUserId());
+        return convert(create(metadata, USER, metadata.getUserId(), false, GraviteeContext.getCurrentEnvironment()), metadata.getUserId());
     }
 
     @Override
     public UserMetadataEntity update(UpdateUserMetadataEntity metadata) {
-        return convert(update(metadata, USER, metadata.getUserId(), false), metadata.getUserId());
+        return convert(update(metadata, USER, metadata.getUserId(), false, GraviteeContext.getCurrentEnvironment()), metadata.getUserId());
     }
 
     @Override
@@ -132,7 +132,8 @@ public class UserMetadataServiceImpl extends AbstractReferenceMetadataService im
         MetadataFormat format,
         String value,
         MetadataReferenceType referenceType,
-        String referenceId
+        String referenceId,
+        final String environmentId
     ) {
         // do nothing for User, currently on String is used without templating
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/ApplicationTypeServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/ApplicationTypeServiceImpl.java
@@ -23,6 +23,7 @@ import io.gravitee.rest.api.model.configuration.application.ApplicationTypeEntit
 import io.gravitee.rest.api.model.configuration.application.ApplicationTypesEntity;
 import io.gravitee.rest.api.model.settings.Application;
 import io.gravitee.rest.api.service.ConfigService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.configuration.application.ApplicationTypeService;
 import io.gravitee.rest.api.service.exceptions.ApplicationTypeNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
@@ -89,7 +90,7 @@ public class ApplicationTypeServiceImpl implements ApplicationTypeService {
     }
 
     public JsonNode getApplicationTypesConfiguration() {
-        Application applicationConfig = configService.getPortalSettings().getApplication();
+        Application applicationConfig = configService.getPortalSettings(GraviteeContext.getCurrentEnvironment()).getApplication();
         Application.ApplicationTypes types = applicationConfig.getTypes();
         if (!applicationConfig.getRegistration().getEnabled()) {
             types.getBrowserType().setEnabled(false);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/ClientRegistrationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/ClientRegistrationServiceImpl.java
@@ -35,6 +35,7 @@ import io.gravitee.rest.api.model.configuration.application.registration.Initial
 import io.gravitee.rest.api.model.configuration.application.registration.NewClientRegistrationProviderEntity;
 import io.gravitee.rest.api.model.configuration.application.registration.UpdateClientRegistrationProviderEntity;
 import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.configuration.application.ClientRegistrationService;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
@@ -148,6 +149,7 @@ public class ClientRegistrationServiceImpl extends AbstractService implements Cl
             );
 
             auditService.createEnvironmentAuditLog(
+                GraviteeContext.getCurrentEnvironment(),
                 singletonMap(CLIENT_REGISTRATION_PROVIDER, createdClientRegistrationProvider.getId()),
                 ClientRegistrationProvider.AuditEvent.CLIENT_REGISTRATION_PROVIDER_CREATED,
                 createdClientRegistrationProvider.getUpdatedAt(),
@@ -208,6 +210,7 @@ public class ClientRegistrationServiceImpl extends AbstractService implements Cl
 
             // Audit
             auditService.createEnvironmentAuditLog(
+                GraviteeContext.getCurrentEnvironment(),
                 singletonMap(CLIENT_REGISTRATION_PROVIDER, id),
                 ClientRegistrationProvider.AuditEvent.CLIENT_REGISTRATION_PROVIDER_CREATED,
                 clientRegistrationProvider.getUpdatedAt(),
@@ -276,6 +279,7 @@ public class ClientRegistrationServiceImpl extends AbstractService implements Cl
             clientRegistrationProviderRepository.delete(id);
 
             auditService.createEnvironmentAuditLog(
+                GraviteeContext.getCurrentEnvironment(),
                 Collections.singletonMap(CLIENT_REGISTRATION_PROVIDER, id),
                 ClientRegistrationProvider.AuditEvent.CLIENT_REGISTRATION_PROVIDER_DELETED,
                 new Date(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl.java
@@ -97,7 +97,12 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
             properties.put(Event.EventProperties.DICTIONARY_ID.getValue(), id);
 
             // And create event
-            eventService.create(EventType.PUBLISH_DICTIONARY, mapper.writeValueAsString(dictionary), properties);
+            eventService.create(
+                Collections.singleton(GraviteeContext.getCurrentEnvironment()),
+                EventType.PUBLISH_DICTIONARY,
+                mapper.writeValueAsString(dictionary),
+                properties
+            );
             return convert(dictionary);
         } catch (Exception ex) {
             LOGGER.error("An error occurs while trying to deploy dictionary {}", id, ex);
@@ -125,7 +130,12 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
             properties.put(Event.EventProperties.DICTIONARY_ID.getValue(), id);
 
             // And create event
-            eventService.create(EventType.UNPUBLISH_DICTIONARY, mapper.writeValueAsString(dictionary), properties);
+            eventService.create(
+                Collections.singleton(GraviteeContext.getCurrentEnvironment()),
+                EventType.UNPUBLISH_DICTIONARY,
+                mapper.writeValueAsString(dictionary),
+                properties
+            );
             return convert(dictionary);
         } catch (Exception ex) {
             LOGGER.error("An error occurs while trying to undeploy dictionary {}", id, ex);
@@ -154,7 +164,12 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
             properties.put(Event.EventProperties.DICTIONARY_ID.getValue(), id);
 
             // And create event
-            eventService.create(EventType.START_DICTIONARY, null, properties);
+            eventService.create(
+                Collections.singleton(GraviteeContext.getCurrentEnvironment()),
+                EventType.START_DICTIONARY,
+                null,
+                properties
+            );
 
             // Audit
             createAuditLog(Dictionary.AuditEvent.DICTIONARY_UPDATED, dictionary.getCreatedAt(), optDictionary.get(), dictionary);
@@ -187,7 +202,12 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
             properties.put(Event.EventProperties.DICTIONARY_ID.getValue(), id);
 
             // And create event
-            eventService.create(EventType.STOP_DICTIONARY, null, properties);
+            eventService.create(
+                Collections.singleton(GraviteeContext.getCurrentEnvironment()),
+                EventType.STOP_DICTIONARY,
+                null,
+                properties
+            );
 
             // Audit
             createAuditLog(Dictionary.AuditEvent.DICTIONARY_UPDATED, dictionary.getCreatedAt(), optDictionary.get(), dictionary);
@@ -253,7 +273,12 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
             if (updatedDictionary.getState() == LifecycleState.STARTED) {
                 Map<String, String> properties = new HashMap<>();
                 properties.put(Event.EventProperties.DICTIONARY_ID.getValue(), id);
-                eventService.create(EventType.START_DICTIONARY, null, properties);
+                eventService.create(
+                    Collections.singleton(GraviteeContext.getCurrentEnvironment()),
+                    EventType.START_DICTIONARY,
+                    null,
+                    properties
+                );
             }
 
             // Audit
@@ -312,7 +337,14 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
     private void createAuditLog(Audit.AuditEvent event, Date createdAt, Dictionary oldValue, Dictionary newValue) {
         String dictionaryName = oldValue != null ? oldValue.getName() : newValue.getName();
 
-        auditService.createEnvironmentAuditLog(Collections.singletonMap(DICTIONARY, dictionaryName), event, createdAt, oldValue, newValue);
+        auditService.createEnvironmentAuditLog(
+            GraviteeContext.getCurrentEnvironment(),
+            Collections.singletonMap(DICTIONARY, dictionaryName),
+            event,
+            createdAt,
+            oldValue,
+            newValue
+        );
     }
 
     private DictionaryEntity convert(Dictionary dictionary) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/identity/IdentityProviderServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/identity/IdentityProviderServiceImpl.java
@@ -97,6 +97,7 @@ public class IdentityProviderServiceImpl extends AbstractService implements Iden
             );
 
             auditService.createOrganizationAuditLog(
+                GraviteeContext.getCurrentOrganization(),
                 singletonMap(IDENTITY_PROVIDER, createdIdentityProvider.getId()),
                 IdentityProvider.AuditEvent.IDENTITY_PROVIDER_CREATED,
                 createdIdentityProvider.getUpdatedAt(),
@@ -135,6 +136,7 @@ public class IdentityProviderServiceImpl extends AbstractService implements Iden
 
             // Audit
             auditService.createOrganizationAuditLog(
+                GraviteeContext.getCurrentOrganization(),
                 singletonMap(IDENTITY_PROVIDER, id),
                 IdentityProvider.AuditEvent.IDENTITY_PROVIDER_UPDATED,
                 identityProvider.getUpdatedAt(),
@@ -181,6 +183,7 @@ public class IdentityProviderServiceImpl extends AbstractService implements Iden
             identityProviderRepository.delete(id);
 
             auditService.createOrganizationAuditLog(
+                GraviteeContext.getCurrentOrganization(),
                 Collections.singletonMap(IDENTITY_PROVIDER, id),
                 IdentityProvider.AuditEvent.IDENTITY_PROVIDER_DELETED,
                 new Date(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/filtering/FilteringServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/filtering/FilteringServiceImpl.java
@@ -28,6 +28,7 @@ import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.RatingService;
 import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.TopApiService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.filtering.FilteringService;
 import io.gravitee.rest.api.service.impl.AbstractService;
 import java.util.*;
@@ -259,7 +260,11 @@ public class FilteringServiceImpl extends AbstractService implements FilteringSe
     private FilteredEntities<ApiEntity> getCurrentUserSubscribedApis(Collection<ApiEntity> apis, boolean excluded) {
         //get Current user applications
         List<String> currentUserApplicationsId = applicationService
-            .findByUser(getAuthenticatedUser().getUsername())
+            .findByUser(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
+                getAuthenticatedUser().getUsername()
+            )
             .stream()
             .map(ApplicationListItem::getId)
             .collect(Collectors.toList());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIConverter.java
@@ -203,7 +203,7 @@ public class OAIToAPIConverter implements SwaggerToApiConverter<OAIDescriptor>, 
                 Set<String> groupIdsToImport = xGraviteeIODefinition
                     .getGroups()
                     .stream()
-                    .flatMap(group -> groupService.findByName(group).stream())
+                    .flatMap(group -> groupService.findByName(GraviteeContext.getCurrentEnvironment(), group).stream())
                     .map(GroupEntity::getId)
                     .collect(Collectors.toSet());
                 apiEntity.setGroups(groupIdsToImport);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DefaultApiHeaderUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DefaultApiHeaderUpgrader.java
@@ -15,14 +15,9 @@
  */
 package io.gravitee.rest.api.service.impl.upgrade;
 
-import io.gravitee.rest.api.model.api.header.ApiHeaderEntity;
-import io.gravitee.rest.api.model.api.header.UpdateApiHeaderEntity;
 import io.gravitee.rest.api.service.ApiHeaderService;
 import io.gravitee.rest.api.service.Upgrader;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import java.util.List;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,7 +42,7 @@ public class DefaultApiHeaderUpgrader implements Upgrader, Ordered {
     @Override
     public boolean upgrade() {
         // Initialize default headers
-        if (apiHeaderService.findAll().size() == 0) {
+        if (apiHeaderService.findAll(GraviteeContext.getCurrentEnvironment()).size() == 0) {
             logger.info("Create default API Headers configuration for default environment");
             apiHeaderService.initialize(GraviteeContext.getDefaultEnvironment());
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/IdentityProviderUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/IdentityProviderUpgrader.java
@@ -22,6 +22,7 @@ import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.OrganizationService;
 import io.gravitee.rest.api.service.Upgrader;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.configuration.identity.IdentityProviderActivationService;
 import io.gravitee.rest.api.service.configuration.identity.IdentityProviderActivationService.ActivationTarget;
 import io.gravitee.rest.api.service.configuration.identity.IdentityProviderService;
@@ -256,7 +257,7 @@ public class IdentityProviderUpgrader implements Upgrader, Ordered {
                     List<String> groups = new ArrayList<>();
                     groupNames.forEach(
                         groupName -> {
-                            List<GroupEntity> groupsFound = groupService.findByName(groupName);
+                            List<GroupEntity> groupsFound = groupService.findByName(GraviteeContext.getCurrentEnvironment(), groupName);
 
                             if (groupsFound != null && groupsFound.size() == 1) {
                                 groups.add(groupsFound.get(0).getId());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/promotion/PromotionService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/promotion/PromotionService.java
@@ -38,11 +38,17 @@ public interface PromotionService {
      */
     List<PromotionTargetEntity> listPromotionTargets(String organizationId, String environmentId);
 
-    PromotionEntity promote(String api, PromotionRequestEntity promotionRequest, String userId);
+    PromotionEntity promote(final String sourceEnvironmentId, String api, PromotionRequestEntity promotionRequest, String userId);
 
     PromotionEntity createOrUpdate(PromotionEntity promotionEntity);
 
     Page<PromotionEntity> search(PromotionQuery query, Sortable sortable, Pageable pageable);
 
-    PromotionEntity processPromotion(String promotion, boolean accepted, String user);
+    PromotionEntity processPromotion(
+        final String organizationId,
+        final String environmentId,
+        String promotion,
+        boolean accepted,
+        String user
+    );
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/quality/ApiQualityMetric.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/quality/ApiQualityMetric.java
@@ -24,5 +24,5 @@ import io.gravitee.rest.api.model.parameters.Key;
  */
 public interface ApiQualityMetric {
     Key getWeightKey();
-    boolean isValid(ApiEntity api);
+    boolean isValid(ApiEntity api, final String environmentId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/quality/ApiQualityMetricCategories.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/quality/ApiQualityMetricCategories.java
@@ -30,7 +30,7 @@ public class ApiQualityMetricCategories implements ApiQualityMetric {
     }
 
     @Override
-    public boolean isValid(ApiEntity api) {
+    public boolean isValid(ApiEntity api, final String environmentId) {
         return api.getCategories() != null && !api.getCategories().isEmpty();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/quality/ApiQualityMetricDescription.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/quality/ApiQualityMetricDescription.java
@@ -37,7 +37,7 @@ public class ApiQualityMetricDescription implements ApiQualityMetric {
     }
 
     @Override
-    public boolean isValid(ApiEntity api) {
+    public boolean isValid(ApiEntity api, final String environmentId) {
         int minLength = Integer.parseInt(Key.API_QUALITY_METRICS_DESCRIPTION_MIN_LENGTH.defaultValue());
         List<String> minLengthParam = parameterService.findAll(
             Key.API_QUALITY_METRICS_DESCRIPTION_MIN_LENGTH,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/quality/ApiQualityMetricFunctionalDocumentation.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/quality/ApiQualityMetricFunctionalDocumentation.java
@@ -20,7 +20,6 @@ import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.documentation.PageQuery;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.service.PageService;
-import io.gravitee.rest.api.service.common.GraviteeContext;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -38,13 +37,10 @@ public class ApiQualityMetricFunctionalDocumentation implements ApiQualityMetric
     }
 
     @Override
-    public boolean isValid(ApiEntity api) {
+    public boolean isValid(ApiEntity api, final String environmentId) {
         return (
             pageService
-                .search(
-                    new PageQuery.Builder().api(api.getId()).published(true).type(PageType.MARKDOWN).build(),
-                    GraviteeContext.getCurrentEnvironment()
-                )
+                .search(new PageQuery.Builder().api(api.getId()).published(true).type(PageType.MARKDOWN).build(), environmentId)
                 .size() >
             0L
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/quality/ApiQualityMetricHealthcheck.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/quality/ApiQualityMetricHealthcheck.java
@@ -35,7 +35,7 @@ public class ApiQualityMetricHealthcheck implements ApiQualityMetric {
     }
 
     @Override
-    public boolean isValid(ApiEntity api) {
+    public boolean isValid(ApiEntity api, final String environmentId) {
         return this.apiService.hasHealthCheckEnabled(api, true);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/quality/ApiQualityMetricLabels.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/quality/ApiQualityMetricLabels.java
@@ -30,7 +30,7 @@ public class ApiQualityMetricLabels implements ApiQualityMetric {
     }
 
     @Override
-    public boolean isValid(ApiEntity api) {
+    public boolean isValid(ApiEntity api, final String environmentId) {
         return api.getLabels() != null && !api.getLabels().isEmpty();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/quality/ApiQualityMetricLogo.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/quality/ApiQualityMetricLogo.java
@@ -35,7 +35,7 @@ public class ApiQualityMetricLogo implements ApiQualityMetric {
     }
 
     @Override
-    public boolean isValid(ApiEntity api) {
+    public boolean isValid(ApiEntity api, final String environmentId) {
         return apiService.getPicture(api.getId()).getContent() != null;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/quality/ApiQualityMetricTechnicalDocumentation.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/quality/ApiQualityMetricTechnicalDocumentation.java
@@ -38,13 +38,10 @@ public class ApiQualityMetricTechnicalDocumentation implements ApiQualityMetric 
     }
 
     @Override
-    public boolean isValid(ApiEntity api) {
+    public boolean isValid(ApiEntity api, final String environmentId) {
         return (
             pageService
-                .search(
-                    new PageQuery.Builder().api(api.getId()).published(true).type(PageType.SWAGGER).build(),
-                    GraviteeContext.getCurrentEnvironment()
-                )
+                .search(new PageQuery.Builder().api(api.getId()).published(true).type(PageType.SWAGGER).build(), environmentId)
                 .size() >
             0L
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/AccessControlServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/AccessControlServiceTest.java
@@ -126,22 +126,32 @@ public class AccessControlServiceTest {
     @Test
     public void shouldNotAccessPrivateApiAsNotApiMember() {
         final ApiEntity apiEntityMock = mock(ApiEntity.class);
-        doReturn(null).when(membershipServiceMock).getUserMember(eq(MembershipReferenceType.API), any(), eq(USERNAME));
+        doReturn(null)
+            .when(membershipServiceMock)
+            .getUserMember(eq(GraviteeContext.getCurrentEnvironment()), eq(MembershipReferenceType.API), any(), eq(USERNAME));
         final PageEntity pageEntity = mock(PageEntity.class);
         connectUser();
 
-        boolean canAccess = accessControlService.canAccessPageFromConsole(apiEntityMock, pageEntity);
+        boolean canAccess = accessControlService.canAccessPageFromConsole(
+            GraviteeContext.getCurrentEnvironment(),
+            apiEntityMock,
+            pageEntity
+        );
 
         assertFalse(canAccess);
-        verify(membershipServiceMock, times(1)).getUserMember(eq(MembershipReferenceType.API), any(), eq(USERNAME));
-        verify(membershipServiceMock, never()).getUserMember(eq(MembershipReferenceType.GROUP), any(), any());
+        verify(membershipServiceMock, times(1))
+            .getUserMember(eq(GraviteeContext.getCurrentEnvironment()), eq(MembershipReferenceType.API), any(), eq(USERNAME));
+        verify(membershipServiceMock, never())
+            .getUserMember(eq(GraviteeContext.getCurrentEnvironment()), eq(MembershipReferenceType.GROUP), any(), any());
     }
 
     @Test
     public void shouldAccessPrivateApiAsApiMember() {
         final ApiEntity apiEntityMock = mock(ApiEntity.class);
         MemberEntity memberEntity = mock(MemberEntity.class);
-        doReturn(memberEntity).when(membershipServiceMock).getUserMember(eq(MembershipReferenceType.API), any(), eq(USERNAME));
+        doReturn(memberEntity)
+            .when(membershipServiceMock)
+            .getUserMember(eq(GraviteeContext.getCurrentEnvironment()), eq(MembershipReferenceType.API), any(), eq(USERNAME));
         final PageEntity pageEntity = mock(PageEntity.class);
         connectUser();
         when(
@@ -153,11 +163,17 @@ public class AccessControlServiceTest {
         )
             .thenReturn(true);
 
-        boolean canAccess = accessControlService.canAccessPageFromConsole(apiEntityMock, pageEntity);
+        boolean canAccess = accessControlService.canAccessPageFromConsole(
+            GraviteeContext.getCurrentEnvironment(),
+            apiEntityMock,
+            pageEntity
+        );
 
         assertTrue(canAccess);
-        verify(membershipServiceMock, times(1)).getUserMember(eq(MembershipReferenceType.API), any(), eq(USERNAME));
-        verify(membershipServiceMock, never()).getUserMember(eq(MembershipReferenceType.GROUP), any(), any());
+        verify(membershipServiceMock, times(1))
+            .getUserMember(eq(GraviteeContext.getCurrentEnvironment()), eq(MembershipReferenceType.API), any(), eq(USERNAME));
+        verify(membershipServiceMock, never())
+            .getUserMember(eq(GraviteeContext.getCurrentEnvironment()), eq(MembershipReferenceType.GROUP), any(), any());
     }
 
     @Test
@@ -165,8 +181,12 @@ public class AccessControlServiceTest {
         final ApiEntity apiEntityMock = mock(ApiEntity.class);
         MemberEntity memberEntity = mock(MemberEntity.class);
         when(apiEntityMock.getGroups()).thenReturn(Collections.singleton("groupid"));
-        doReturn(null).when(membershipServiceMock).getUserMember(eq(MembershipReferenceType.API), any(), eq(USERNAME));
-        doReturn(memberEntity).when(membershipServiceMock).getUserMember(eq(MembershipReferenceType.GROUP), any(), eq(USERNAME));
+        doReturn(null)
+            .when(membershipServiceMock)
+            .getUserMember(eq(GraviteeContext.getCurrentEnvironment()), eq(MembershipReferenceType.API), any(), eq(USERNAME));
+        doReturn(memberEntity)
+            .when(membershipServiceMock)
+            .getUserMember(eq(GraviteeContext.getCurrentEnvironment()), eq(MembershipReferenceType.GROUP), any(), eq(USERNAME));
 
         when(
             roleService.hasPermission(
@@ -180,11 +200,17 @@ public class AccessControlServiceTest {
         final PageEntity pageEntity = mock(PageEntity.class);
         connectUser();
 
-        boolean canAccess = accessControlService.canAccessPageFromConsole(apiEntityMock, pageEntity);
+        boolean canAccess = accessControlService.canAccessPageFromConsole(
+            GraviteeContext.getCurrentEnvironment(),
+            apiEntityMock,
+            pageEntity
+        );
 
         assertTrue(canAccess);
-        verify(membershipServiceMock, times(1)).getUserMember(eq(MembershipReferenceType.API), any(), eq(USERNAME));
-        verify(membershipServiceMock, times(1)).getUserMember(eq(MembershipReferenceType.GROUP), any(), eq(USERNAME));
+        verify(membershipServiceMock, times(1))
+            .getUserMember(eq(GraviteeContext.getCurrentEnvironment()), eq(MembershipReferenceType.API), any(), eq(USERNAME));
+        verify(membershipServiceMock, times(1))
+            .getUserMember(eq(GraviteeContext.getCurrentEnvironment()), eq(MembershipReferenceType.GROUP), any(), eq(USERNAME));
     }
 
     @Test
@@ -193,7 +219,11 @@ public class AccessControlServiceTest {
         PageEntity pageEntity = mock(PageEntity.class);
         when(pageEntity.isPublished()).thenReturn(false);
 
-        boolean canAccess = accessControlService.canAccessPageFromConsole(apiEntityMock, pageEntity);
+        boolean canAccess = accessControlService.canAccessPageFromConsole(
+            GraviteeContext.getCurrentEnvironment(),
+            apiEntityMock,
+            pageEntity
+        );
 
         assertFalse(canAccess);
     }
@@ -211,7 +241,7 @@ public class AccessControlServiceTest {
         when(pageEntity.getAccessControls()).thenReturn(accessControls);
         connectUser();
 
-        boolean canAccess = accessControlService.canAccessPageFromPortal(pageEntity);
+        boolean canAccess = accessControlService.canAccessPageFromPortal(GraviteeContext.getCurrentEnvironment(), pageEntity);
 
         assertFalse(canAccess);
     }
@@ -237,7 +267,7 @@ public class AccessControlServiceTest {
         )
             .thenReturn(new HashSet(Collections.singleton(roleEntity)));
 
-        boolean canAccess = accessControlService.canAccessPageFromPortal(pageEntity);
+        boolean canAccess = accessControlService.canAccessPageFromPortal(GraviteeContext.getCurrentEnvironment(), pageEntity);
 
         assertTrue(canAccess);
     }
@@ -264,7 +294,7 @@ public class AccessControlServiceTest {
         )
             .thenReturn(new HashSet(Collections.singleton(roleEntity)));
 
-        boolean canAccess = accessControlService.canAccessPageFromPortal(pageEntity);
+        boolean canAccess = accessControlService.canAccessPageFromPortal(GraviteeContext.getCurrentEnvironment(), pageEntity);
 
         assertTrue(canAccess);
     }
@@ -291,7 +321,7 @@ public class AccessControlServiceTest {
         )
             .thenReturn(new HashSet(Collections.singleton(roleEntity)));
 
-        boolean canAccess = accessControlService.canAccessPageFromPortal(pageEntity);
+        boolean canAccess = accessControlService.canAccessPageFromPortal(GraviteeContext.getCurrentEnvironment(), pageEntity);
 
         assertFalse(canAccess);
     }
@@ -309,7 +339,7 @@ public class AccessControlServiceTest {
         myGroup.setId(GROUP_ID);
         when(groupService.findByUser(USERNAME)).thenReturn(new HashSet<>(Collections.singleton(myGroup)));
 
-        boolean canAccess = accessControlService.canAccessPageFromPortal(pageEntity);
+        boolean canAccess = accessControlService.canAccessPageFromPortal(GraviteeContext.getCurrentEnvironment(), pageEntity);
 
         assertTrue(canAccess);
     }
@@ -328,7 +358,7 @@ public class AccessControlServiceTest {
         myGroup.setId(GROUP_ID);
         when(groupService.findByUser(USERNAME)).thenReturn(new HashSet<>(Collections.singleton(myGroup)));
 
-        boolean canAccess = accessControlService.canAccessPageFromPortal(pageEntity);
+        boolean canAccess = accessControlService.canAccessPageFromPortal(GraviteeContext.getCurrentEnvironment(), pageEntity);
 
         assertTrue(canAccess);
     }
@@ -347,7 +377,7 @@ public class AccessControlServiceTest {
         myGroup.setId(GROUP_ID);
         when(groupService.findByUser(USERNAME)).thenReturn(new HashSet<>(Collections.singleton(myGroup)));
 
-        boolean canAccess = accessControlService.canAccessPageFromPortal(pageEntity);
+        boolean canAccess = accessControlService.canAccessPageFromPortal(GraviteeContext.getCurrentEnvironment(), pageEntity);
 
         assertFalse(canAccess);
     }
@@ -370,9 +400,16 @@ public class AccessControlServiceTest {
         when(roleEntity.getId()).thenReturn(ROLE_ID);
         roles.add(roleEntity);
         when(memberEntity.getRoles()).thenReturn(roles);
-        when(membershipServiceMock.getUserMember(MembershipReferenceType.GROUP, GROUP_ID, USERNAME)).thenReturn(memberEntity);
+        when(
+            membershipServiceMock.getUserMember(GraviteeContext.getCurrentEnvironment(), MembershipReferenceType.GROUP, GROUP_ID, USERNAME)
+        )
+            .thenReturn(memberEntity);
 
-        boolean canAccess = accessControlService.canAccessPageFromConsole(apiEntityMock, pageEntity);
+        boolean canAccess = accessControlService.canAccessPageFromConsole(
+            GraviteeContext.getCurrentEnvironment(),
+            apiEntityMock,
+            pageEntity
+        );
 
         assertTrue(canAccess);
     }
@@ -397,7 +434,7 @@ public class AccessControlServiceTest {
         roles.add(roleEntity);
         when(membershipServiceMock.getRoles(MembershipReferenceType.API, API_ID, MembershipMemberType.USER, USERNAME)).thenReturn(roles);
 
-        boolean canAccess = accessControlService.canAccessPageFromPortal(API_ID, pageEntity);
+        boolean canAccess = accessControlService.canAccessPageFromPortal(GraviteeContext.getCurrentEnvironment(), API_ID, pageEntity);
 
         assertTrue(canAccess);
     }
@@ -407,7 +444,7 @@ public class AccessControlServiceTest {
         final PageEntity pageEntity = mock(PageEntity.class);
         when(pageEntity.getType()).thenReturn(PageType.MARKDOWN_TEMPLATE.name());
 
-        boolean canAccess = accessControlService.canAccessPageFromPortal(pageEntity);
+        boolean canAccess = accessControlService.canAccessPageFromPortal(GraviteeContext.getCurrentEnvironment(), pageEntity);
 
         assertFalse(canAccess);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_CreateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_CreateWithDefinitionTest.java
@@ -27,10 +27,7 @@ import io.gravitee.repository.management.model.Api;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.permissions.RoleScope;
-import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.exceptions.PlanNotFoundException;
-import io.gravitee.rest.api.service.exceptions.RoleNotFoundException;
 import io.gravitee.rest.api.service.impl.ApiDuplicatorServiceImpl;
 import io.gravitee.rest.api.service.spring.ImportConfiguration;
 import io.gravitee.rest.api.service.spring.ServiceConfiguration;
@@ -38,7 +35,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Optional;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
@@ -188,7 +184,15 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         verify(pageService, times(1))
             .duplicatePages(argThat(pagesList -> pagesList.size() == 2), eq(GraviteeContext.getCurrentEnvironment()), eq(API_ID));
         verify(membershipService, times(1))
-            .addRoleToMemberOnReference(MembershipReferenceType.API, API_ID, MembershipMemberType.USER, user.getId(), "API_OWNER");
+            .addRoleToMemberOnReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
+                MembershipReferenceType.API,
+                API_ID,
+                MembershipMemberType.USER,
+                user.getId(),
+                "API_OWNER"
+            );
     }
 
     @Test
@@ -244,8 +248,23 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         verify(apiService, times(1)).createWithApiDefinition(any(), eq("admin"), any());
         verify(pageService, times(1)).createPage(eq(API_ID), any(NewPageEntity.class), eq(GraviteeContext.getCurrentEnvironment()));
         verify(membershipService, times(1))
-            .addRoleToMemberOnReference(MembershipReferenceType.API, API_ID, MembershipMemberType.USER, user.getId(), "API_OWNER");
-        verify(membershipService, never()).transferApiOwnership(any(), any(), any());
+            .addRoleToMemberOnReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
+                MembershipReferenceType.API,
+                API_ID,
+                MembershipMemberType.USER,
+                user.getId(),
+                "API_OWNER"
+            );
+        verify(membershipService, never())
+            .transferApiOwnership(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
+                any(),
+                any(),
+                any()
+            );
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_UpdateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_UpdateWithDefinitionTest.java
@@ -178,7 +178,18 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         memberEntity.setId(admin.getId());
         memberEntity.setRoles(Collections.singletonList(poRoleEntity));
 
-        when(membershipService.addRoleToMemberOnReference(any(), any(), any(), any(), any())).thenReturn(memberEntity);
+        when(
+            membershipService.addRoleToMemberOnReference(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
+                any(),
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        )
+            .thenReturn(memberEntity);
         when(userService.findBySource(user.getSource(), user.getSourceId(), false)).thenReturn(user);
 
         apiDuplicatorService.updateWithImportedDefinition(
@@ -192,9 +203,25 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         verify(pageService, times(1))
             .createOrUpdatePages(argThat(pagesList -> pagesList.size() == 2), eq(GraviteeContext.getCurrentEnvironment()), eq(API_ID));
         verify(membershipService, never())
-            .addRoleToMemberOnReference(MembershipReferenceType.API, API_ID, MembershipMemberType.USER, user.getId(), "API_PRIMARY_OWNER");
+            .addRoleToMemberOnReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
+                MembershipReferenceType.API,
+                API_ID,
+                MembershipMemberType.USER,
+                user.getId(),
+                "API_PRIMARY_OWNER"
+            );
         verify(membershipService, times(1))
-            .addRoleToMemberOnReference(MembershipReferenceType.API, API_ID, MembershipMemberType.USER, user.getId(), "API_OWNER");
+            .addRoleToMemberOnReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
+                MembershipReferenceType.API,
+                API_ID,
+                MembershipMemberType.USER,
+                user.getId(),
+                "API_OWNER"
+            );
         verify(apiService, times(1)).update(eq(API_ID), any(), anyBoolean());
         verify(apiService, never()).create(any(), any());
     }
@@ -273,9 +300,25 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
 
         verify(pageService, never()).duplicatePages(anyList(), eq(GraviteeContext.getCurrentEnvironment()), eq(API_ID));
         verify(membershipService, never())
-            .addRoleToMemberOnReference(MembershipReferenceType.API, API_ID, MembershipMemberType.USER, user.getId(), "API_PRIMARY_OWNER");
+            .addRoleToMemberOnReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
+                MembershipReferenceType.API,
+                API_ID,
+                MembershipMemberType.USER,
+                user.getId(),
+                "API_PRIMARY_OWNER"
+            );
         verify(membershipService, times(1))
-            .addRoleToMemberOnReference(MembershipReferenceType.API, API_ID, MembershipMemberType.USER, user.getId(), "API_OWNER");
+            .addRoleToMemberOnReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
+                MembershipReferenceType.API,
+                API_ID,
+                MembershipMemberType.USER,
+                user.getId(),
+                "API_OWNER"
+            );
         verify(apiService, times(1)).update(eq(API_ID), any(), anyBoolean());
         verify(apiService, never()).create(any(), any());
     }
@@ -308,12 +351,16 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         verify(pageService, never()).createPage(eq(API_ID), any(NewPageEntity.class), eq(GraviteeContext.getCurrentEnvironment()));
         verify(membershipService, never())
             .addRoleToMemberOnReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
                 new MembershipService.MembershipReference(MembershipReferenceType.API, API_ID),
                 new MembershipService.MembershipMember(admin.getId(), null, MembershipMemberType.USER),
                 new MembershipService.MembershipRole(RoleScope.API, SystemRole.PRIMARY_OWNER.name())
             );
         verify(membershipService, never())
             .addRoleToMemberOnReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
                 new MembershipService.MembershipReference(MembershipReferenceType.API, API_ID),
                 new MembershipService.MembershipMember(user.getId(), null, MembershipMemberType.USER),
                 new MembershipService.MembershipRole(RoleScope.API, "OWNER")
@@ -349,12 +396,16 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         verify(pageService, never()).createPage(eq(API_ID), any(NewPageEntity.class), eq(GraviteeContext.getCurrentEnvironment()));
         verify(membershipService, never())
             .addRoleToMemberOnReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
                 new MembershipService.MembershipReference(MembershipReferenceType.API, API_ID),
                 new MembershipService.MembershipMember(admin.getId(), null, MembershipMemberType.USER),
                 new MembershipService.MembershipRole(RoleScope.API, SystemRole.PRIMARY_OWNER.name())
             );
         verify(membershipService, never())
             .addRoleToMemberOnReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
                 new MembershipService.MembershipReference(MembershipReferenceType.API, API_ID),
                 new MembershipService.MembershipMember(user.getId(), null, MembershipMemberType.USER),
                 new MembershipService.MembershipRole(RoleScope.API, "OWNER")
@@ -392,7 +443,14 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
 
         verify(pageService, times(1))
             .createOrUpdatePages(argThat(pagesList -> pagesList.size() == 2), eq(GraviteeContext.getCurrentEnvironment()), eq(API_ID));
-        verify(membershipService, never()).addRoleToMemberOnReference(any(), any(), any());
+        verify(membershipService, never())
+            .addRoleToMemberOnReference(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
+                any(),
+                any(),
+                any()
+            );
         verify(apiService, times(1)).update(eq(API_ID), any(), anyBoolean());
         verify(apiService, never()).create(any(), any());
     }
@@ -419,7 +477,14 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         );
 
         verify(pageService, never()).createPage(eq(API_ID), any(NewPageEntity.class), eq(GraviteeContext.getCurrentEnvironment()));
-        verify(membershipService, never()).addRoleToMemberOnReference(any(), any(), any());
+        verify(membershipService, never())
+            .addRoleToMemberOnReference(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
+                any(),
+                any(),
+                any()
+            );
         verify(apiService, times(1)).update(eq(API_ID), any(), anyBoolean());
         verify(apiService, never()).create(any(), any());
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiKeyServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiKeyServiceTest.java
@@ -24,6 +24,7 @@ import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.model.ApiKey;
 import io.gravitee.repository.management.model.Audit;
 import io.gravitee.rest.api.model.*;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.*;
 import io.gravitee.rest.api.service.impl.ApiKeyServiceImpl;
 import io.gravitee.rest.api.service.notification.ApiHook;
@@ -190,7 +191,7 @@ public class ApiKeyServiceTest {
 
         // Stub
         when(apiKeyRepository.findById(API_KEY)).thenReturn(Optional.of(apiKey));
-        when(applicationService.findById(subscription.getApplication())).thenReturn(application);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), subscription.getApplication())).thenReturn(application);
         when(planService.findById(subscription.getPlan())).thenReturn(plan);
         when(apiService.findByIdForTemplates(any())).thenReturn(api);
 
@@ -382,7 +383,7 @@ public class ApiKeyServiceTest {
         when(subscriptionService.findById(subscription.getId())).thenReturn(subscription);
         when(apiKeyRepository.create(any())).thenAnswer(returnsFirstArg());
         when(apiKeyRepository.findBySubscription(SUBSCRIPTION_ID)).thenReturn(Collections.singleton(apiKey));
-        when(applicationService.findById(subscription.getApplication())).thenReturn(application);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), subscription.getApplication())).thenReturn(application);
         when(planService.findById(subscription.getPlan())).thenReturn(plan);
         when(apiService.findByIdForTemplates(any())).thenReturn(api);
 
@@ -433,7 +434,7 @@ public class ApiKeyServiceTest {
         when(subscriptionService.findById(subscription.getId())).thenReturn(subscription);
         when(apiKeyRepository.create(any())).thenAnswer(returnsFirstArg());
         when(apiKeyRepository.findBySubscription(SUBSCRIPTION_ID)).thenReturn(Collections.singleton(apiKey));
-        when(applicationService.findById(subscription.getApplication())).thenReturn(application);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), subscription.getApplication())).thenReturn(application);
         when(planService.findById(subscription.getPlan())).thenReturn(plan);
         when(apiService.findByIdForTemplates(any())).thenReturn(api);
 
@@ -487,7 +488,7 @@ public class ApiKeyServiceTest {
         subscriptionEntity.setEndingAt(new Date());
         when(subscriptionService.findById(any())).thenReturn(subscriptionEntity);
         //notification mocks
-        when(applicationService.findById(any())).thenReturn(mock(ApplicationEntity.class));
+        when(applicationService.findById(eq(GraviteeContext.getCurrentEnvironment()), any())).thenReturn(mock(ApplicationEntity.class));
         PlanEntity mockedPlan = mock(PlanEntity.class);
         when(mockedPlan.getApi()).thenReturn("api");
         when(planService.findById(any())).thenReturn(mockedPlan);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiQualityMetricCategoriesTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiQualityMetricCategoriesTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.quality.ApiQualityMetricCategories;
 import java.util.Collections;
 import org.junit.Test;
@@ -43,7 +44,7 @@ public class ApiQualityMetricCategoriesTest {
         ApiEntity api = mock(ApiEntity.class);
         when(api.getCategories()).thenReturn(Collections.singleton("category"));
 
-        boolean valid = srv.isValid(api);
+        boolean valid = srv.isValid(api, GraviteeContext.getCurrentEnvironment());
 
         assertTrue(valid);
     }
@@ -53,7 +54,7 @@ public class ApiQualityMetricCategoriesTest {
         ApiEntity api = mock(ApiEntity.class);
         when(api.getCategories()).thenReturn(Collections.emptySet());
 
-        boolean valid = srv.isValid(api);
+        boolean valid = srv.isValid(api, GraviteeContext.getCurrentEnvironment());
 
         assertFalse(valid);
     }
@@ -63,7 +64,7 @@ public class ApiQualityMetricCategoriesTest {
         ApiEntity api = mock(ApiEntity.class);
         when(api.getCategories()).thenReturn(null);
 
-        boolean valid = srv.isValid(api);
+        boolean valid = srv.isValid(api, GraviteeContext.getCurrentEnvironment());
 
         assertFalse(valid);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiQualityMetricDescriptionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiQualityMetricDescriptionTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.quality.ApiQualityMetricDescription;
 import java.util.Arrays;
 import java.util.Collections;
@@ -52,7 +53,7 @@ public class ApiQualityMetricDescriptionTest {
         ApiEntity api = mock(ApiEntity.class);
         when(api.getDescription()).thenReturn(null);
 
-        boolean valid = srv.isValid(api);
+        boolean valid = srv.isValid(api, GraviteeContext.getCurrentEnvironment());
 
         assertFalse(valid);
     }
@@ -64,7 +65,7 @@ public class ApiQualityMetricDescriptionTest {
         ApiEntity api = mock(ApiEntity.class);
         when(api.getDescription()).thenReturn("1234567890");
 
-        boolean valid = srv.isValid(api);
+        boolean valid = srv.isValid(api, GraviteeContext.getCurrentEnvironment());
 
         assertFalse(valid);
     }
@@ -88,7 +89,7 @@ public class ApiQualityMetricDescriptionTest {
                 "1234567890"
             );
 
-        boolean valid = srv.isValid(api);
+        boolean valid = srv.isValid(api, GraviteeContext.getCurrentEnvironment());
 
         assertTrue(valid);
     }
@@ -100,7 +101,7 @@ public class ApiQualityMetricDescriptionTest {
         ApiEntity api = mock(ApiEntity.class);
         when(api.getDescription()).thenReturn("123");
 
-        boolean valid = srv.isValid(api);
+        boolean valid = srv.isValid(api, GraviteeContext.getCurrentEnvironment());
 
         assertTrue(valid);
     }
@@ -112,7 +113,7 @@ public class ApiQualityMetricDescriptionTest {
         ApiEntity api = mock(ApiEntity.class);
         when(api.getDescription()).thenReturn("12");
 
-        boolean valid = srv.isValid(api);
+        boolean valid = srv.isValid(api, GraviteeContext.getCurrentEnvironment());
 
         assertFalse(valid);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiQualityMetricFunctionalDocumentationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiQualityMetricFunctionalDocumentationTest.java
@@ -55,7 +55,7 @@ public class ApiQualityMetricFunctionalDocumentationTest {
         ApiEntity api = mock(ApiEntity.class);
         when(api.getId()).thenReturn(API_ID);
 
-        boolean valid = srv.isValid(api);
+        boolean valid = srv.isValid(api, GraviteeContext.getCurrentEnvironment());
 
         assertTrue(valid);
     }
@@ -66,7 +66,7 @@ public class ApiQualityMetricFunctionalDocumentationTest {
         ApiEntity api = mock(ApiEntity.class);
         when(api.getId()).thenReturn(API_ID);
 
-        boolean valid = srv.isValid(api);
+        boolean valid = srv.isValid(api, GraviteeContext.getCurrentEnvironment());
 
         assertFalse(valid);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiQualityMetricHealthcheckTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiQualityMetricHealthcheckTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.quality.ApiQualityMetricHealthcheck;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,7 +48,7 @@ public class ApiQualityMetricHealthcheckTest {
     @Test
     public void shouldBeValid() {
         when(apiService.hasHealthCheckEnabled(any(), eq(true))).thenReturn(true);
-        boolean valid = srv.isValid(mock(ApiEntity.class));
+        boolean valid = srv.isValid(mock(ApiEntity.class), GraviteeContext.getCurrentEnvironment());
 
         assertTrue(valid);
     }
@@ -55,7 +56,7 @@ public class ApiQualityMetricHealthcheckTest {
     @Test
     public void shouldNotBeValid() {
         when(apiService.hasHealthCheckEnabled(any(), eq(true))).thenReturn(false);
-        boolean valid = srv.isValid(mock(ApiEntity.class));
+        boolean valid = srv.isValid(mock(ApiEntity.class), GraviteeContext.getCurrentEnvironment());
 
         assertFalse(valid);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiQualityMetricLabelsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiQualityMetricLabelsTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.quality.ApiQualityMetricLabels;
 import java.util.Collections;
 import org.junit.Test;
@@ -43,7 +44,7 @@ public class ApiQualityMetricLabelsTest {
         ApiEntity api = mock(ApiEntity.class);
         when(api.getLabels()).thenReturn(Collections.singletonList("category"));
 
-        boolean valid = srv.isValid(api);
+        boolean valid = srv.isValid(api, GraviteeContext.getCurrentEnvironment());
 
         assertTrue(valid);
     }
@@ -53,7 +54,7 @@ public class ApiQualityMetricLabelsTest {
         ApiEntity api = mock(ApiEntity.class);
         when(api.getLabels()).thenReturn(Collections.emptyList());
 
-        boolean valid = srv.isValid(api);
+        boolean valid = srv.isValid(api, GraviteeContext.getCurrentEnvironment());
 
         assertFalse(valid);
     }
@@ -63,7 +64,7 @@ public class ApiQualityMetricLabelsTest {
         ApiEntity api = mock(ApiEntity.class);
         when(api.getLabels()).thenReturn(null);
 
-        boolean valid = srv.isValid(api);
+        boolean valid = srv.isValid(api, GraviteeContext.getCurrentEnvironment());
 
         assertFalse(valid);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiQualityMetricLogoTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiQualityMetricLogoTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.when;
 
 import io.gravitee.rest.api.model.InlinePictureEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
-import io.gravitee.rest.api.service.ApiService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.quality.ApiQualityMetricLogo;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -52,7 +52,7 @@ public class ApiQualityMetricLogoTest {
         ApiEntity api = mock(ApiEntity.class);
         when(api.getId()).thenReturn(API_ID);
 
-        boolean valid = srv.isValid(api);
+        boolean valid = srv.isValid(api, GraviteeContext.getCurrentEnvironment());
 
         assertFalse(valid);
     }
@@ -65,7 +65,7 @@ public class ApiQualityMetricLogoTest {
         ApiEntity api = mock(ApiEntity.class);
         when(api.getId()).thenReturn(API_ID);
 
-        boolean valid = srv.isValid(api);
+        boolean valid = srv.isValid(api, GraviteeContext.getCurrentEnvironment());
 
         assertTrue(valid);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiQualityMetricTechnicalDocumentationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiQualityMetricTechnicalDocumentationTest.java
@@ -55,7 +55,7 @@ public class ApiQualityMetricTechnicalDocumentationTest {
         ApiEntity api = mock(ApiEntity.class);
         when(api.getId()).thenReturn(API_ID);
 
-        boolean valid = srv.isValid(api);
+        boolean valid = srv.isValid(api, GraviteeContext.getCurrentEnvironment());
 
         assertTrue(valid);
     }
@@ -66,7 +66,7 @@ public class ApiQualityMetricTechnicalDocumentationTest {
         ApiEntity api = mock(ApiEntity.class);
         when(api.getId()).thenReturn(API_ID);
 
-        boolean valid = srv.isValid(api);
+        boolean valid = srv.isValid(api, GraviteeContext.getCurrentEnvironment());
 
         assertFalse(valid);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiQualityRuleServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiQualityRuleServiceTest.java
@@ -27,6 +27,7 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiQualityRuleRepository;
 import io.gravitee.repository.management.model.ApiQualityRule;
 import io.gravitee.rest.api.model.quality.*;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApiQualityRuleNotFoundException;
 import io.gravitee.rest.api.service.impl.ApiQualityRuleServiceImpl;
 import java.util.Date;
@@ -116,6 +117,7 @@ public class ApiQualityRuleServiceTest {
             );
         verify(auditService, times(1))
             .createEnvironmentAuditLog(
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(ImmutableMap.of(API_QUALITY_RULE, API_ID)),
                 eq(ApiQualityRule.AuditEvent.API_QUALITY_RULE_CREATED),
                 any(Date.class),
@@ -166,6 +168,7 @@ public class ApiQualityRuleServiceTest {
             );
         verify(auditService, times(1))
             .createEnvironmentAuditLog(
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(ImmutableMap.of(API_QUALITY_RULE, API_ID)),
                 eq(ApiQualityRule.AuditEvent.API_QUALITY_RULE_UPDATED),
                 any(Date.class),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_DeleteTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_DeleteTest.java
@@ -29,11 +29,7 @@ import io.gravitee.repository.management.model.LifecycleState;
 import io.gravitee.rest.api.model.MembershipReferenceType;
 import io.gravitee.rest.api.model.PlanEntity;
 import io.gravitee.rest.api.model.PlanStatus;
-import io.gravitee.rest.api.service.AuditService;
-import io.gravitee.rest.api.service.EventService;
-import io.gravitee.rest.api.service.PlanService;
-import io.gravitee.rest.api.service.SubscriptionService;
-import io.gravitee.rest.api.service.TopApiService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApiNotDeletableException;
 import io.gravitee.rest.api.service.exceptions.ApiRunningStateException;
 import io.gravitee.rest.api.service.impl.ApiServiceImpl;
@@ -145,7 +141,13 @@ public class ApiService_DeleteTest {
         when(planService.findByApi(API_ID)).thenReturn(Collections.emptySet());
 
         apiService.delete(API_ID);
-        verify(membershipService, times(1)).deleteReference(MembershipReferenceType.API, API_ID);
+        verify(membershipService, times(1))
+            .deleteReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
+                MembershipReferenceType.API,
+                API_ID
+            );
         verify(mediaService, times(1)).deleteAllByApi(API_ID);
         verify(apiMetadataService, times(1)).deleteAllByApi(API_ID);
     }
@@ -158,7 +160,13 @@ public class ApiService_DeleteTest {
         when(planService.findByApi(API_ID)).thenReturn(Collections.singleton(planEntity));
 
         apiService.delete(API_ID);
-        verify(membershipService, times(1)).deleteReference(MembershipReferenceType.API, API_ID);
+        verify(membershipService, times(1))
+            .deleteReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
+                MembershipReferenceType.API,
+                API_ID
+            );
     }
 
     @Test
@@ -172,7 +180,13 @@ public class ApiService_DeleteTest {
         apiService.delete(API_ID);
 
         verify(planService, times(1)).delete(PLAN_ID);
-        verify(membershipService, times(1)).deleteReference(MembershipReferenceType.API, API_ID);
+        verify(membershipService, times(1))
+            .deleteReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
+                MembershipReferenceType.API,
+                API_ID
+            );
     }
 
     @Test
@@ -187,7 +201,13 @@ public class ApiService_DeleteTest {
 
         verify(planService, times(1)).delete(PLAN_ID);
         verify(apiQualityRuleRepository, times(1)).deleteByApi(API_ID);
-        verify(membershipService, times(1)).deleteReference(MembershipReferenceType.API, API_ID);
+        verify(membershipService, times(1))
+            .deleteReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
+                MembershipReferenceType.API,
+                API_ID
+            );
         verify(mediaService, times(1)).deleteAllByApi(API_ID);
         verify(apiMetadataService, times(1)).deleteAllByApi(API_ID);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_FindByIdTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_FindByIdTest.java
@@ -105,7 +105,8 @@ public class ApiService_FindByIdTest {
         when(apiRepository.findById(API_ID)).thenReturn(Optional.of(api));
         MembershipEntity po = new MembershipEntity();
         po.setMemberId(USER_NAME);
-        when(membershipService.getPrimaryOwner(MembershipReferenceType.API, API_ID)).thenReturn(po);
+        when(membershipService.getPrimaryOwner(GraviteeContext.getCurrentOrganization(), MembershipReferenceType.API, API_ID))
+            .thenReturn(po);
         when(userService.findById(USER_NAME)).thenReturn(mock(UserEntity.class));
 
         final ApiEntity apiEntity = apiService.findById(API_ID);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_FindByUserTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_FindByUserTest.java
@@ -34,6 +34,7 @@ import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.model.common.SortableImpl;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.impl.ApiServiceImpl;
 import io.gravitee.rest.api.service.jackson.filter.ApiPermissionFilter;
 import java.util.*;
@@ -228,6 +229,7 @@ public class ApiService_FindByUserTest {
             .getMembershipsByMemberAndReference(MembershipMemberType.USER, null, MembershipReferenceType.API);
         verify(membershipService, times(0))
             .getMembershipsByMemberAndReference(MembershipMemberType.USER, null, MembershipReferenceType.GROUP);
-        verify(applicationService, times(0)).findByUser(null);
+        verify(applicationService, times(0))
+            .findByUser(GraviteeContext.getCurrentOrganization(), GraviteeContext.getCurrentEnvironment(), null);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_FindPrimaryOwnerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_FindPrimaryOwnerTest.java
@@ -26,6 +26,7 @@ import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.GroupNotFoundException;
 import io.gravitee.rest.api.service.exceptions.NoPrimaryOwnerGroupForUserException;
 import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
@@ -381,7 +382,7 @@ public class ApiService_FindPrimaryOwnerTest {
     private void defineGroup(String groupId) {
         GroupEntity groupEntity = new GroupEntity();
         groupEntity.setId(groupId);
-        when(groupService.findById(groupId)).thenReturn(groupEntity);
+        when(groupService.findById(GraviteeContext.getCurrentEnvironment(), groupId)).thenReturn(groupEntity);
     }
 
     private void setPoUserNonExisting() {
@@ -389,6 +390,7 @@ public class ApiService_FindPrimaryOwnerTest {
     }
 
     private void setPoGroupNonExisting() {
-        when(groupService.findById(PO_GROUP_ID)).thenThrow(new GroupNotFoundException(PO_GROUP_ID));
+        when(groupService.findById(GraviteeContext.getCurrentEnvironment(), PO_GROUP_ID))
+            .thenThrow(new GroupNotFoundException(PO_GROUP_ID));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_StartTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_StartTest.java
@@ -33,6 +33,7 @@ import io.gravitee.repository.management.model.Event;
 import io.gravitee.repository.management.model.LifecycleState;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.mixin.ApiMixin;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.impl.ApiServiceImpl;
@@ -101,7 +102,14 @@ public class ApiService_StartTest {
         when(u.getId()).thenReturn("uid");
         when(userService.findById(any())).thenReturn(u);
         MembershipEntity po = mock(MembershipEntity.class);
-        when(membershipService.getPrimaryOwner(eq(io.gravitee.rest.api.model.MembershipReferenceType.API), anyString())).thenReturn(po);
+        when(
+            membershipService.getPrimaryOwner(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(io.gravitee.rest.api.model.MembershipReferenceType.API),
+                anyString()
+            )
+        )
+            .thenReturn(po);
         when(api.getId()).thenReturn(API_ID);
     }
 
@@ -121,7 +129,8 @@ public class ApiService_StartTest {
         verify(api).setUpdatedAt(any());
         verify(api).setLifecycleState(LifecycleState.STARTED);
         verify(apiRepository).update(api);
-        verify(eventService).create(EventType.START_API, event.getPayload(), event.getProperties());
+        verify(eventService)
+            .create(singleton(GraviteeContext.getCurrentEnvironment()), EventType.START_API, event.getPayload(), event.getProperties());
         verify(notifierService, times(1)).trigger(eq(ApiHook.API_STARTED), eq(API_ID), any());
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_UpdateTest.java
@@ -25,7 +25,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.mockito.internal.util.collections.Sets.newSet;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.PropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
@@ -223,7 +222,8 @@ public class ApiService_UpdateTest {
             .thenReturn("toDecode=decoded-value");
         MembershipEntity primaryOwner = new MembershipEntity();
         primaryOwner.setMemberType(MembershipMemberType.USER);
-        when(membershipService.getPrimaryOwner(eq(MembershipReferenceType.API), any())).thenReturn(primaryOwner);
+        when(membershipService.getPrimaryOwner(eq(GraviteeContext.getCurrentOrganization()), eq(MembershipReferenceType.API), any()))
+            .thenReturn(primaryOwner);
         reset(searchEngineService);
     }
 
@@ -816,7 +816,8 @@ public class ApiService_UpdateTest {
 
         final MembershipEntity membership = new MembershipEntity();
         membership.setMemberId(USER_NAME);
-        when(membershipService.getPrimaryOwner(MembershipReferenceType.API, API_ID)).thenReturn(membership);
+        when(membershipService.getPrimaryOwner(GraviteeContext.getCurrentOrganization(), MembershipReferenceType.API, API_ID))
+            .thenReturn(membership);
 
         when(userService.findById(USER_NAME)).thenReturn(mock(UserEntity.class));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_Update_DefaultLoggingMaxDurationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_Update_DefaultLoggingMaxDurationTest.java
@@ -38,6 +38,7 @@ import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.model.permissions.SystemRole;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.impl.ApiServiceImpl;
 import io.gravitee.rest.api.service.jackson.filter.ApiPermissionFilter;
 import io.gravitee.rest.api.service.notification.NotificationTemplateService;
@@ -185,7 +186,8 @@ public class ApiService_Update_DefaultLoggingMaxDurationTest {
         when(parameterService.find(Key.API_PRIMARY_OWNER_MODE, ParameterReferenceType.ENVIRONMENT)).thenReturn("USER");
         MembershipEntity primaryOwner = new MembershipEntity();
         primaryOwner.setMemberType(MembershipMemberType.USER);
-        when(membershipService.getPrimaryOwner(eq(MembershipReferenceType.API), any())).thenReturn(primaryOwner);
+        when(membershipService.getPrimaryOwner(eq(GraviteeContext.getCurrentOrganization()), eq(MembershipReferenceType.API), any()))
+            .thenReturn(primaryOwner);
         reset(searchEngineService);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationAlertServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationAlertServiceTest.java
@@ -40,12 +40,12 @@ import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.model.alert.AlertReferenceType;
 import io.gravitee.rest.api.model.alert.AlertTriggerEntity;
 import io.gravitee.rest.api.model.alert.ApplicationAlertEventType;
-import io.gravitee.rest.api.model.alert.ApplicationAlertMembershipEvent;
 import io.gravitee.rest.api.model.alert.NewAlertTriggerEntity;
 import io.gravitee.rest.api.model.alert.UpdateAlertTriggerEntity;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.model.notification.NotificationTemplateEntity;
 import io.gravitee.rest.api.model.notification.NotificationTemplateEvent;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.impl.ApplicationAlertServiceImpl;
 import io.gravitee.rest.api.service.notification.AlertHook;
@@ -126,8 +126,8 @@ public class ApplicationAlertServiceTest {
         ApplicationEntity application = getApplication();
         prepareForCreation(newAlert);
 
-        when(applicationService.findById(APPLICATION_ID)).thenReturn(application);
-        cut.create(APPLICATION_ID, newAlert);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(application);
+        cut.create(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID, newAlert);
 
         verify(alertService, times(1)).create(newAlert);
         verify(notificationTemplateService, times(1))
@@ -143,8 +143,8 @@ public class ApplicationAlertServiceTest {
         ApplicationEntity application = getApplication();
         prepareForCreation(newAlert);
 
-        when(applicationService.findById(APPLICATION_ID)).thenReturn(application);
-        cut.create(APPLICATION_ID, newAlert);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(application);
+        cut.create(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID, newAlert);
 
         verify(alertService, times(1)).create(newAlert);
         verify(notificationTemplateService, times(1))
@@ -160,10 +160,10 @@ public class ApplicationAlertServiceTest {
         ApplicationEntity application = getApplication();
         prepareForCreation(newAlert);
 
-        when(applicationService.findById(APPLICATION_ID)).thenReturn(application);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(application);
         when(mapper.writeValueAsString(any())).thenThrow(JsonProcessingException.class);
 
-        cut.create(APPLICATION_ID, newAlert);
+        cut.create(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID, newAlert);
     }
 
     @Test
@@ -207,7 +207,7 @@ public class ApplicationAlertServiceTest {
         when(mapper.readTree(notification.getConfiguration())).thenReturn(emailNode);
         when(mapper.readTree(notification2.getConfiguration())).thenReturn(emailNode);
 
-        cut.addMemberToApplication(APPLICATION_ID, "add@mail.gio");
+        cut.addMemberToApplication(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID, "add@mail.gio");
 
         ArgumentCaptor<UpdateAlertTriggerEntity> updatingCaptor = ArgumentCaptor.forClass(UpdateAlertTriggerEntity.class);
 
@@ -226,9 +226,9 @@ public class ApplicationAlertServiceTest {
         triggers.add(trigger1);
 
         when(alertService.findByReference(AlertReferenceType.APPLICATION, APPLICATION_ID)).thenReturn(triggers);
-        when(applicationService.findById(APPLICATION_ID)).thenReturn(getApplication());
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(getApplication());
 
-        cut.addMemberToApplication(APPLICATION_ID, "add@mail.gio");
+        cut.addMemberToApplication(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID, "add@mail.gio");
 
         ArgumentCaptor<List<Notification>> notificationsCaptor = ArgumentCaptor.forClass(List.class);
 
@@ -242,7 +242,7 @@ public class ApplicationAlertServiceTest {
 
     @Test
     public void shouldNotAddMemberEmptyMail() throws Exception {
-        cut.addMemberToApplication(APPLICATION_ID, "");
+        cut.addMemberToApplication(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID, "");
         verify(alertService, never()).update(any());
     }
 
@@ -261,7 +261,7 @@ public class ApplicationAlertServiceTest {
 
         when(mapper.readTree(notification.getConfiguration())).thenThrow(JsonProcessingException.class);
 
-        cut.addMemberToApplication(APPLICATION_ID, "add@mail.gio");
+        cut.addMemberToApplication(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID, "add@mail.gio");
     }
 
     @Test
@@ -292,7 +292,7 @@ public class ApplicationAlertServiceTest {
         when(mapper.readTree(notification.getConfiguration())).thenReturn(emailNode);
         when(mapper.readTree(notification2.getConfiguration())).thenReturn(emailNode);
 
-        cut.deleteMemberFromApplication(APPLICATION_ID, "delete@mail.gio");
+        cut.deleteMemberFromApplication(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID, "delete@mail.gio");
 
         ArgumentCaptor<UpdateAlertTriggerEntity> updatingCaptor = ArgumentCaptor.forClass(UpdateAlertTriggerEntity.class);
 
@@ -305,7 +305,7 @@ public class ApplicationAlertServiceTest {
 
     @Test
     public void shouldNotDeleteMemberEmptyMail() throws Exception {
-        cut.deleteMemberFromApplication(APPLICATION_ID, "");
+        cut.deleteMemberFromApplication(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID, "");
         verify(alertService, never()).update(any());
     }
 
@@ -324,7 +324,7 @@ public class ApplicationAlertServiceTest {
 
         when(mapper.readTree(notification.getConfiguration())).thenThrow(JsonProcessingException.class);
 
-        cut.deleteMemberFromApplication(APPLICATION_ID, "delete@mail.gio");
+        cut.deleteMemberFromApplication(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID, "delete@mail.gio");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_ArchiveTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_ArchiveTest.java
@@ -25,9 +25,7 @@ import io.gravitee.repository.management.model.ApplicationStatus;
 import io.gravitee.rest.api.model.ApiKeyEntity;
 import io.gravitee.rest.api.model.MembershipReferenceType;
 import io.gravitee.rest.api.model.SubscriptionEntity;
-import io.gravitee.rest.api.service.ApiKeyService;
-import io.gravitee.rest.api.service.AuditService;
-import io.gravitee.rest.api.service.SubscriptionService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
 import io.gravitee.rest.api.service.impl.ApplicationServiceImpl;
 import java.util.Collections;
@@ -96,7 +94,13 @@ public class ApplicationService_ArchiveTest {
         applicationService.archive(APPLICATION_ID);
 
         verify(apiKeyService, times(1)).delete("key");
-        verify(membershipService, times(1)).deleteReference(MembershipReferenceType.APPLICATION, APPLICATION_ID);
+        verify(membershipService, times(1))
+            .deleteReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
+                MembershipReferenceType.APPLICATION,
+                APPLICATION_ID
+            );
         verify(subscriptionService, times(1)).close("sub");
         verify(application, times(1)).setStatus(ApplicationStatus.ARCHIVED);
         verify(applicationRepository, times(1)).update(application);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_CreateTest.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.service;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -111,10 +112,14 @@ public class ApplicationService_CreateTest {
         when(applicationRepository.create(any())).thenReturn(application);
         when(newApplication.getName()).thenReturn(APPLICATION_NAME);
         when(newApplication.getDescription()).thenReturn("My description");
-        when(groupService.findByEvent(any())).thenReturn(Collections.emptySet());
+        when(groupService.findByEvent(eq(GraviteeContext.getCurrentEnvironment()), any())).thenReturn(Collections.emptySet());
         when(userService.findById(any())).thenReturn(mock(UserEntity.class));
 
-        final ApplicationEntity applicationEntity = applicationService.create(newApplication, USER_NAME);
+        final ApplicationEntity applicationEntity = applicationService.create(
+            GraviteeContext.getCurrentEnvironment(),
+            newApplication,
+            USER_NAME
+        );
 
         assertNotNull(applicationEntity);
         assertEquals(APPLICATION_NAME, applicationEntity.getName());
@@ -131,7 +136,7 @@ public class ApplicationService_CreateTest {
         when(parameterService.findAsBoolean(Key.APPLICATION_REGISTRATION_ENABLED, "DEFAULT", ParameterReferenceType.ENVIRONMENT))
             .thenReturn(Boolean.FALSE);
 
-        applicationService.create(newApplication, USER_NAME);
+        applicationService.create(GraviteeContext.getCurrentEnvironment(), newApplication, USER_NAME);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -143,7 +148,7 @@ public class ApplicationService_CreateTest {
         when(newApplication.getSettings()).thenReturn(settings);
         when(parameterService.findAsBoolean(Key.APPLICATION_REGISTRATION_ENABLED, "DEFAULT", ParameterReferenceType.ENVIRONMENT))
             .thenReturn(Boolean.TRUE);
-        applicationService.create(newApplication, USER_NAME);
+        applicationService.create(GraviteeContext.getCurrentEnvironment(), newApplication, USER_NAME);
     }
 
     @Test(expected = ApplicationGrantTypesNotFoundException.class)
@@ -157,7 +162,7 @@ public class ApplicationService_CreateTest {
             .thenReturn(Boolean.TRUE);
         when(parameterService.findAsBoolean(Key.APPLICATION_TYPE_WEB_ENABLED, "DEFAULT", ParameterReferenceType.ENVIRONMENT))
             .thenReturn(Boolean.TRUE);
-        applicationService.create(newApplication, USER_NAME);
+        applicationService.create(GraviteeContext.getCurrentEnvironment(), newApplication, USER_NAME);
     }
 
     @Test(expected = ApplicationGrantTypesNotAllowedException.class)
@@ -174,7 +179,7 @@ public class ApplicationService_CreateTest {
             .thenReturn(Boolean.TRUE);
         when(parameterService.findAsBoolean(Key.APPLICATION_TYPE_WEB_ENABLED, "DEFAULT", ParameterReferenceType.ENVIRONMENT))
             .thenReturn(Boolean.TRUE);
-        applicationService.create(newApplication, USER_NAME);
+        applicationService.create(GraviteeContext.getCurrentEnvironment(), newApplication, USER_NAME);
     }
 
     @Test(expected = ApplicationRedirectUrisNotFound.class)
@@ -195,7 +200,7 @@ public class ApplicationService_CreateTest {
             .thenReturn(Boolean.TRUE);
         when(parameterService.findAsBoolean(Key.APPLICATION_TYPE_WEB_ENABLED, "DEFAULT", ParameterReferenceType.ENVIRONMENT))
             .thenReturn(Boolean.TRUE);
-        applicationService.create(newApplication, USER_NAME);
+        applicationService.create(GraviteeContext.getCurrentEnvironment(), newApplication, USER_NAME);
     }
 
     @Test(expected = ClientIdAlreadyExistsException.class)
@@ -213,7 +218,7 @@ public class ApplicationService_CreateTest {
         when(applicationRepository.findAllByEnvironment("DEFAULT", ApplicationStatus.ACTIVE))
             .thenReturn(Collections.singleton(application));
 
-        applicationService.create(newApplication, USER_NAME);
+        applicationService.create(GraviteeContext.getCurrentEnvironment(), newApplication, USER_NAME);
     }
 
     @Test(expected = TechnicalManagementException.class)
@@ -226,6 +231,6 @@ public class ApplicationService_CreateTest {
 
         when(applicationRepository.findAllByEnvironment("DEFAULT", ApplicationStatus.ACTIVE)).thenThrow(TechnicalException.class);
 
-        applicationService.create(newApplication, USER_NAME);
+        applicationService.create(GraviteeContext.getCurrentEnvironment(), newApplication, USER_NAME);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_FindAllTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_FindAllTest.java
@@ -28,6 +28,7 @@ import io.gravitee.repository.management.model.ApplicationType;
 import io.gravitee.rest.api.model.MembershipEntity;
 import io.gravitee.rest.api.model.RoleEntity;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.impl.ApplicationServiceImpl;
 import java.util.Collections;
@@ -73,14 +74,20 @@ public class ApplicationService_FindAllTest {
         when(membershipService.getMembershipsByReferencesAndRole(any(), any(), any()))
             .thenReturn(new HashSet<>(Collections.singletonList(new MembershipEntity())));
 
-        Set<ApplicationListItem> set = applicationService.findAll();
+        Set<ApplicationListItem> set = applicationService.findAll(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
         assertThat(set).hasSize(1);
         verify(applicationRepository, times(1)).findAllByEnvironment("DEFAULT", ApplicationStatus.ACTIVE);
     }
 
     @Test
     public void shouldTryFindAll_noResult() throws Exception {
-        Set<ApplicationListItem> set = applicationService.findAll();
+        Set<ApplicationListItem> set = applicationService.findAll(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
         assertThat(set).isEmpty();
         verify(applicationRepository, times(1)).findAllByEnvironment("DEFAULT", ApplicationStatus.ACTIVE);
     }
@@ -88,6 +95,9 @@ public class ApplicationService_FindAllTest {
     @Test(expected = TechnicalManagementException.class)
     public void shouldTryFindAll_exception() throws Exception {
         when(applicationRepository.findAllByEnvironment(eq("DEFAULT"), eq(ApplicationStatus.ACTIVE))).thenThrow(TechnicalException.class);
-        Set<ApplicationListItem> set = applicationService.findAll();
+        Set<ApplicationListItem> set = applicationService.findAll(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_FindByGroupTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_FindByGroupTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verify;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.repository.management.model.ApplicationStatus;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.impl.ApplicationServiceImpl;
 import java.util.Collections;
 import java.util.Set;
@@ -50,7 +51,10 @@ public class ApplicationService_FindByGroupTest {
 
     @Test
     public void shouldTryFindByGroup() throws Exception {
-        Set<ApplicationListItem> set = applicationService.findByGroups(Collections.singletonList(GROUP_ID));
+        Set<ApplicationListItem> set = applicationService.findByGroups(
+            GraviteeContext.getCurrentOrganization(),
+            Collections.singletonList(GROUP_ID)
+        );
         assertNotNull(set);
         assertTrue("result is empty", set.isEmpty());
         verify(applicationRepository, times(1)).findByGroups(Collections.singletonList(GROUP_ID), ApplicationStatus.ACTIVE);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_FindByIdTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_FindByIdTest.java
@@ -80,7 +80,7 @@ public class ApplicationService_FindByIdTest {
         when(application.getStatus()).thenReturn(ApplicationStatus.ACTIVE);
         when(application.getType()).thenReturn(ApplicationType.SIMPLE);
 
-        final ApplicationEntity applicationEntity = applicationService.findById(APPLICATION_ID);
+        final ApplicationEntity applicationEntity = applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID);
 
         assertNotNull(applicationEntity);
     }
@@ -88,13 +88,13 @@ public class ApplicationService_FindByIdTest {
     @Test(expected = ApplicationNotFoundException.class)
     public void shouldNotFindByIdBecauseNotExists() throws TechnicalException {
         when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.empty());
-        applicationService.findById(APPLICATION_ID);
+        applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID);
     }
 
     @Test(expected = TechnicalManagementException.class)
     public void shouldNotFindByIdBecauseTechnicalException() throws TechnicalException {
         when(applicationRepository.findById(APPLICATION_ID)).thenThrow(TechnicalException.class);
 
-        applicationService.findById(APPLICATION_ID);
+        applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_FindByUserAndNameTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_FindByUserAndNameTest.java
@@ -27,6 +27,7 @@ import io.gravitee.rest.api.model.MembershipEntity;
 import io.gravitee.rest.api.model.MembershipMemberType;
 import io.gravitee.rest.api.model.MembershipReferenceType;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.impl.ApplicationServiceImpl;
 import java.util.Collections;
 import java.util.HashSet;
@@ -58,7 +59,14 @@ public class ApplicationService_FindByUserAndNameTest {
 
     @Test
     public void shouldNotFindByNameWhenNull() throws Exception {
-        Set<ApplicationListItem> set = applicationService.findByUserAndNameAndStatus("myUser", null, "ACTIVE");
+        Set<ApplicationListItem> set = applicationService.findByUserAndNameAndStatus(
+            "myUser",
+            false,
+            null,
+            "ACTIVE",
+            GraviteeContext.getCurrentEnvironment(),
+            GraviteeContext.getCurrentOrganization()
+        );
         assertNotNull(set);
         assertEquals("result is empty", 0, set.size());
         verifyNoInteractions(applicationRepository);
@@ -66,7 +74,14 @@ public class ApplicationService_FindByUserAndNameTest {
 
     @Test
     public void shouldNotFindByNameWhenEmpty() throws Exception {
-        Set<ApplicationListItem> set = applicationService.findByUserAndNameAndStatus("myUser", "", "ACTIVE");
+        Set<ApplicationListItem> set = applicationService.findByUserAndNameAndStatus(
+            "myUser",
+            false,
+            "",
+            "ACTIVE",
+            GraviteeContext.getCurrentEnvironment(),
+            GraviteeContext.getCurrentOrganization()
+        );
         assertNotNull(set);
         assertEquals("result is empty", 0, set.size());
         verifyNoInteractions(applicationRepository);
@@ -75,7 +90,14 @@ public class ApplicationService_FindByUserAndNameTest {
     @Test
     public void shouldNotFindByName() throws Exception {
         when(applicationRepository.search(any(), any())).thenReturn(new Page<>(Collections.emptyList(), 0, 0, 0));
-        Set<ApplicationListItem> set = applicationService.findByUserAndNameAndStatus("myUser", true, "a", "ACTIVE");
+        Set<ApplicationListItem> set = applicationService.findByUserAndNameAndStatus(
+            "myUser",
+            true,
+            "a",
+            "ACTIVE",
+            GraviteeContext.getCurrentEnvironment(),
+            GraviteeContext.getCurrentOrganization()
+        );
         assertNotNull(set);
         assertEquals("result is empty", 0, set.size());
         ArgumentCaptor<ApplicationCriteria> queryCaptor = ArgumentCaptor.forClass(ApplicationCriteria.class);
@@ -91,7 +113,14 @@ public class ApplicationService_FindByUserAndNameTest {
             .thenReturn(new HashSet<>());
 
         // call
-        Set<ApplicationListItem> resultSet = applicationService.findByUserAndNameAndStatus("myUser", "random search", "ACTIVE");
+        Set<ApplicationListItem> resultSet = applicationService.findByUserAndNameAndStatus(
+            "myUser",
+            false,
+            "random search",
+            "ACTIVE",
+            GraviteeContext.getCurrentEnvironment(),
+            GraviteeContext.getCurrentOrganization()
+        );
 
         // check applicationRepository search has not been called, and so it returns empty
         assertTrue(resultSet.isEmpty());
@@ -103,7 +132,14 @@ public class ApplicationService_FindByUserAndNameTest {
         when(applicationRepository.search(any(), any())).thenReturn(new Page<>(Collections.emptyList(), 0, 0, 0));
 
         // call
-        applicationService.findByUserAndNameAndStatus("myUser", true, "random search", "ACTIVE");
+        applicationService.findByUserAndNameAndStatus(
+            "myUser",
+            true,
+            "random search",
+            "ACTIVE",
+            GraviteeContext.getCurrentEnvironment(),
+            GraviteeContext.getCurrentOrganization()
+        );
 
         // check membership hasn't been retrieved
         verify(membershipService, never()).getMembershipsByMemberAndReference(any(), any(), any());
@@ -132,7 +168,14 @@ public class ApplicationService_FindByUserAndNameTest {
             .thenReturn(memberships);
 
         // call
-        applicationService.findByUserAndNameAndStatus("myUser", "random search", "ACTIVE");
+        applicationService.findByUserAndNameAndStatus(
+            "myUser",
+            false,
+            "random search",
+            "ACTIVE",
+            GraviteeContext.getCurrentEnvironment(),
+            GraviteeContext.getCurrentOrganization()
+        );
 
         // check applicationRepository search has been called with applications
         ArgumentCaptor<ApplicationCriteria> queryCaptor = ArgumentCaptor.forClass(ApplicationCriteria.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_FindByUserTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_FindByUserTest.java
@@ -26,7 +26,6 @@ import io.gravitee.repository.management.model.ApplicationType;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.model.permissions.RoleScope;
-import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.impl.ApplicationServiceImpl;
 import java.util.*;
@@ -108,7 +107,11 @@ public class ApplicationService_FindByUserTest {
         po.setRoleId("APPLICATION_PRIMARY_OWNER");
         when(membershipService.getMembershipsByReferencesAndRole(any(), any(), any())).thenReturn(Collections.singleton(po));
 
-        Set<ApplicationListItem> apps = applicationService.findByUser(USERNAME);
+        Set<ApplicationListItem> apps = applicationService.findByUser(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
+            USERNAME
+        );
 
         Assert.assertNotNull(apps);
         Assert.assertFalse("should find app", apps.isEmpty());
@@ -123,7 +126,11 @@ public class ApplicationService_FindByUserTest {
             .thenReturn(Collections.singleton(appMembership));
         when(applicationRepository.findByIds(Collections.singletonList(APPLICATION_ID))).thenReturn(Collections.singleton(application));
 
-        Set<ApplicationListItem> apps = applicationService.findByUser(USERNAME);
+        Set<ApplicationListItem> apps = applicationService.findByUser(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
+            USERNAME
+        );
 
         Assert.assertNotNull(apps);
         Assert.assertTrue("should not find app", apps.isEmpty());
@@ -177,7 +184,11 @@ public class ApplicationService_FindByUserTest {
         memberships.add(poGroupApp);
         when(membershipService.getMembershipsByReferencesAndRole(any(), any(), any())).thenReturn(memberships);
 
-        Set<ApplicationListItem> apps = applicationService.findByUser(USERNAME);
+        Set<ApplicationListItem> apps = applicationService.findByUser(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
+            USERNAME
+        );
 
         Assert.assertNotNull(apps);
         Assert.assertFalse("should find apps", apps.isEmpty());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_RestoreTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_RestoreTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.service;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -28,6 +29,7 @@ import io.gravitee.repository.management.model.NotificationReferenceType;
 import io.gravitee.rest.api.model.ApplicationEntity;
 import io.gravitee.rest.api.model.MembershipReferenceType;
 import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApplicationActiveException;
 import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
 import io.gravitee.rest.api.service.impl.ApplicationServiceImpl;
@@ -102,8 +104,21 @@ public class ApplicationService_RestoreTest {
 
         ApplicationEntity result = applicationService.restore(APP);
 
-        verify(membershipService, times(1)).deleteReference(MembershipReferenceType.APPLICATION, APP);
-        verify(membershipService, times(1)).addRoleToMemberOnReference(any(), any(), any());
+        verify(membershipService, times(1))
+            .deleteReference(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
+                MembershipReferenceType.APPLICATION,
+                APP
+            );
+        verify(membershipService, times(1))
+            .addRoleToMemberOnReference(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
+                any(),
+                any(),
+                any()
+            );
         verify(genericNotificationConfigService, times(1)).deleteReference(NotificationReferenceType.APPLICATION, APP);
         verify(portalNotificationConfigService, times(1)).deleteReference(NotificationReferenceType.APPLICATION, APP);
         verify(auditService, times(1)).createApplicationAuditLog(any(), any(), any(), any(), any(), any());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_UpdateTest.java
@@ -31,10 +31,7 @@ import io.gravitee.rest.api.model.RoleEntity;
 import io.gravitee.rest.api.model.UpdateApplicationEntity;
 import io.gravitee.rest.api.model.application.ApplicationSettings;
 import io.gravitee.rest.api.model.application.SimpleApplicationSettings;
-import io.gravitee.rest.api.service.AuditService;
-import io.gravitee.rest.api.service.ParameterService;
-import io.gravitee.rest.api.service.SubscriptionService;
-import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.configuration.application.ClientRegistrationService;
 import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
 import io.gravitee.rest.api.service.exceptions.ClientIdAlreadyExistsException;
@@ -122,7 +119,12 @@ public class ApplicationService_UpdateTest {
         po.setRoleId("APPLICATION_PRIMARY_OWNER");
         when(membershipService.getMembershipsByReferencesAndRole(any(), any(), any())).thenReturn(Collections.singleton(po));
 
-        final ApplicationEntity applicationEntity = applicationService.update(APPLICATION_ID, existingApplication);
+        final ApplicationEntity applicationEntity = applicationService.update(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
+            APPLICATION_ID,
+            existingApplication
+        );
 
         verify(applicationRepository)
             .update(argThat(application -> APPLICATION_NAME.equals(application.getName()) && application.getUpdatedAt() != null));
@@ -135,7 +137,12 @@ public class ApplicationService_UpdateTest {
     public void shouldNotUpdateBecauseNotFound() throws TechnicalException {
         when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.empty());
 
-        applicationService.update(APPLICATION_ID, existingApplication);
+        applicationService.update(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
+            APPLICATION_ID,
+            existingApplication
+        );
     }
 
     @Test(expected = TechnicalManagementException.class)
@@ -152,7 +159,12 @@ public class ApplicationService_UpdateTest {
         when(existingApplication.getName()).thenReturn(APPLICATION_NAME);
         when(existingApplication.getDescription()).thenReturn("My description");
 
-        applicationService.update(APPLICATION_ID, existingApplication);
+        applicationService.update(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
+            APPLICATION_ID,
+            existingApplication
+        );
     }
 
     @Test
@@ -187,7 +199,12 @@ public class ApplicationService_UpdateTest {
         po.setRoleId("APPLICATION_PRIMARY_OWNER");
         when(membershipService.getMembershipsByReferencesAndRole(any(), any(), any())).thenReturn(Collections.singleton(po));
 
-        final ApplicationEntity applicationEntity = applicationService.update(APPLICATION_ID, existingApplication);
+        final ApplicationEntity applicationEntity = applicationService.update(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
+            APPLICATION_ID,
+            existingApplication
+        );
 
         verify(applicationRepository)
             .update(argThat(application -> APPLICATION_NAME.equals(application.getName()) && application.getUpdatedAt() != null));
@@ -218,6 +235,11 @@ public class ApplicationService_UpdateTest {
 
         when(existingApplication.getSettings()).thenReturn(settings);
 
-        applicationService.update(APPLICATION_ID, existingApplication);
+        applicationService.update(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
+            APPLICATION_ID,
+            existingApplication
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/CategoryService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/CategoryService_CreateTest.java
@@ -26,7 +26,7 @@ import io.gravitee.repository.management.model.Category;
 import io.gravitee.rest.api.model.CategoryEntity;
 import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.NewCategoryEntity;
-import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.DuplicateCategoryNameException;
 import io.gravitee.rest.api.service.exceptions.EnvironmentNotFoundException;
 import io.gravitee.rest.api.service.impl.CategoryServiceImpl;
@@ -64,10 +64,11 @@ public class CategoryService_CreateTest {
         v1.setName("v1");
         when(mockCategoryRepository.create(argThat(cat -> cat.getCreatedAt() != null))).thenReturn(new Category());
         when(mockEnvironmentService.findById("DEFAULT")).thenReturn(new EnvironmentEntity());
-        CategoryEntity category = categoryService.create(v1);
+        CategoryEntity category = categoryService.create(GraviteeContext.getCurrentEnvironment(), v1);
 
         assertNotNull("result is null", category);
-        verify(mockAuditService, times(1)).createEnvironmentAuditLog(any(), eq(CATEGORY_CREATED), any(), isNull(), any());
+        verify(mockAuditService, times(1))
+            .createEnvironmentAuditLog(eq(GraviteeContext.getCurrentEnvironment()), any(), eq(CATEGORY_CREATED), any(), isNull(), any());
         verify(mockCategoryRepository, times(1)).create(argThat(arg -> arg != null && arg.getName().equals("v1")));
     }
 
@@ -77,7 +78,7 @@ public class CategoryService_CreateTest {
 
         NewCategoryEntity nv1 = new NewCategoryEntity();
         nv1.setName("v1");
-        categoryService.create(nv1);
+        categoryService.create(GraviteeContext.getCurrentEnvironment(), nv1);
     }
 
     @Test(expected = DuplicateCategoryNameException.class)
@@ -89,7 +90,7 @@ public class CategoryService_CreateTest {
         when(mockCategoryRepository.findAllByEnvironment(any())).thenReturn(Collections.singleton(v1));
 
         try {
-            categoryService.create(nv1);
+            categoryService.create(GraviteeContext.getCurrentEnvironment(), nv1);
         } catch (DuplicateCategoryNameException e) {
             verify(mockCategoryRepository, never()).create(any());
             throw e;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/CategoryService_DeleteTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/CategoryService_DeleteTest.java
@@ -23,8 +23,7 @@ import static org.mockito.Mockito.*;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.CategoryRepository;
 import io.gravitee.repository.management.model.Category;
-import io.gravitee.rest.api.service.ApiService;
-import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.impl.CategoryServiceImpl;
 import java.util.Optional;
 import org.junit.Test;
@@ -60,19 +59,22 @@ public class CategoryService_DeleteTest {
 
         verify(mockCategoryRepository, times(1)).findById(any());
         verify(mockCategoryRepository, never()).delete(any());
-        verify(mockAuditService, never()).createEnvironmentAuditLog(any(), eq(CATEGORY_UPDATED), any(), any(), any());
+        verify(mockAuditService, never()).createEnvironmentAuditLog(any(), any(), eq(CATEGORY_UPDATED), any(), any(), any());
         verify(mockApiService, never()).deleteCategoryFromAPIs(eq("unknown"));
     }
 
     @Test
     public void shouldDeleteCategory() throws TechnicalException {
-        when(mockCategoryRepository.findById("known")).thenReturn(Optional.of(new Category()));
+        Category categoryToDelete = new Category();
+        categoryToDelete.setId("known");
+        categoryToDelete.setEnvironmentId("DEFAULT");
+        when(mockCategoryRepository.findById("known")).thenReturn(Optional.of(categoryToDelete));
 
         categoryService.delete("known");
 
         verify(mockCategoryRepository, times(1)).findById("known");
         verify(mockCategoryRepository, times(1)).delete("known");
-        verify(mockAuditService, times(1)).createEnvironmentAuditLog(any(), eq(CATEGORY_DELETED), any(), any(), any());
+        verify(mockAuditService, times(1)).createEnvironmentAuditLog(eq("DEFAULT"), any(), eq(CATEGORY_DELETED), any(), any(), any());
         verify(mockApiService, times(1)).deleteCategoryFromAPIs(eq("known"));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/CategoryService_FindTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/CategoryService_FindTest.java
@@ -24,6 +24,7 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.CategoryRepository;
 import io.gravitee.repository.management.model.Category;
 import io.gravitee.rest.api.model.CategoryEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.impl.CategoryServiceImpl;
 import java.util.Date;
 import java.util.List;
@@ -50,7 +51,7 @@ public class CategoryService_FindTest {
     public void shouldDoNothingWithEmptyResult() throws TechnicalException {
         when(mockCategoryRepository.findAllByEnvironment(any())).thenReturn(emptySet());
 
-        List<CategoryEntity> list = categoryService.findAll();
+        List<CategoryEntity> list = categoryService.findAll(GraviteeContext.getCurrentEnvironment());
 
         assertTrue(list.isEmpty());
         verify(mockCategoryRepository, times(1)).findAllByEnvironment(any());
@@ -68,7 +69,7 @@ public class CategoryService_FindTest {
         when(category.getCreatedAt()).thenReturn(new Date(9876543210L));
         when(mockCategoryRepository.findAllByEnvironment(any())).thenReturn(singleton(category));
 
-        List<CategoryEntity> list = categoryService.findAll();
+        List<CategoryEntity> list = categoryService.findAll(GraviteeContext.getCurrentEnvironment());
 
         assertFalse(list.isEmpty());
         assertEquals("one element", 1, list.size());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/CategoryService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/CategoryService_UpdateTest.java
@@ -26,7 +26,7 @@ import io.gravitee.repository.management.api.CategoryRepository;
 import io.gravitee.repository.management.model.Category;
 import io.gravitee.rest.api.model.CategoryEntity;
 import io.gravitee.rest.api.model.UpdateCategoryEntity;
-import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.CategoryNotFoundException;
 import io.gravitee.rest.api.service.impl.CategoryServiceImpl;
 import java.util.Date;
@@ -66,7 +66,8 @@ public class CategoryService_UpdateTest {
         assertTrue(list.isEmpty());
         verify(mockCategoryRepository, times(1)).findById(any());
         verify(mockCategoryRepository, never()).update(any());
-        verify(mockAuditService, never()).createEnvironmentAuditLog(any(), eq(CATEGORY_UPDATED), any(), any(), any());
+        verify(mockAuditService, never())
+            .createEnvironmentAuditLog(eq(GraviteeContext.getCurrentEnvironment()), any(), eq(CATEGORY_UPDATED), any(), any(), any());
     }
 
     @Test(expected = CategoryNotFoundException.class)
@@ -78,7 +79,8 @@ public class CategoryService_UpdateTest {
 
         verify(mockCategoryRepository, times(1)).findById(any());
         verify(mockCategoryRepository, never()).update(any());
-        verify(mockAuditService, never()).createEnvironmentAuditLog(any(), eq(CATEGORY_UPDATED), any(), any(), any());
+        verify(mockAuditService, never())
+            .createEnvironmentAuditLog(eq(GraviteeContext.getCurrentEnvironment()), any(), eq(CATEGORY_UPDATED), any(), any(), any());
     }
 
     @Test
@@ -86,7 +88,9 @@ public class CategoryService_UpdateTest {
         UpdateCategoryEntity mockCategory = mock(UpdateCategoryEntity.class);
         when(mockCategory.getId()).thenReturn("known");
         when(mockCategory.getName()).thenReturn("Known");
-        when(mockCategoryRepository.findById("known")).thenReturn(Optional.of(new Category()));
+        Category oldCategory = new Category();
+        oldCategory.setEnvironmentId("DEFAULT");
+        when(mockCategoryRepository.findById("known")).thenReturn(Optional.of(oldCategory));
         Category updatedCategory = mock(Category.class);
         when(updatedCategory.getId()).thenReturn("category-id");
         when(updatedCategory.getName()).thenReturn("category-name");
@@ -111,7 +115,8 @@ public class CategoryService_UpdateTest {
         assertEquals("CreatedAt", new Date(9876543210L), list.get(0).getCreatedAt());
         verify(mockCategoryRepository, times(1)).findById(any());
         verify(mockCategoryRepository, times(1)).update(any());
-        verify(mockAuditService, times(1)).createEnvironmentAuditLog(any(), eq(CATEGORY_UPDATED), any(), any(), any());
+        verify(mockAuditService, times(1))
+            .createEnvironmentAuditLog(eq(GraviteeContext.getCurrentEnvironment()), any(), eq(CATEGORY_UPDATED), any(), any(), any());
     }
 
     @Test
@@ -119,7 +124,9 @@ public class CategoryService_UpdateTest {
         UpdateCategoryEntity mockCategory = mock(UpdateCategoryEntity.class);
         when(mockCategory.getId()).thenReturn("category-id");
         when(mockCategory.getName()).thenReturn("Category ID");
-        when(mockCategoryRepository.findById("category-id")).thenReturn(Optional.of(new Category()));
+        Category oldCategory = new Category();
+        oldCategory.setEnvironmentId("DEFAULT");
+        when(mockCategoryRepository.findById("category-id")).thenReturn(Optional.of(oldCategory));
         Category updatedCategory = mock(Category.class);
         when(updatedCategory.getId()).thenReturn("category-id");
         when(updatedCategory.getName()).thenReturn("category-name");
@@ -143,6 +150,7 @@ public class CategoryService_UpdateTest {
         assertEquals("CreatedAt", new Date(9876543210L), category.getCreatedAt());
         verify(mockCategoryRepository, times(1)).findById(any());
         verify(mockCategoryRepository, times(1)).update(any());
-        verify(mockAuditService, times(1)).createEnvironmentAuditLog(any(), eq(CATEGORY_UPDATED), any(), any(), any());
+        verify(mockAuditService, times(1))
+            .createEnvironmentAuditLog(eq(GraviteeContext.getCurrentEnvironment()), any(), eq(CATEGORY_UPDATED), any(), any(), any());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ConfigServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ConfigServiceTest.java
@@ -28,6 +28,7 @@ import io.gravitee.rest.api.model.settings.ConsoleConfigEntity;
 import io.gravitee.rest.api.model.settings.ConsoleSettingsEntity;
 import io.gravitee.rest.api.model.settings.Logging;
 import io.gravitee.rest.api.model.settings.PortalSettingsEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.impl.ConfigServiceImpl;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -77,7 +78,7 @@ public class ConfigServiceTest {
         when(reCaptchaService.getSiteKey()).thenReturn("my-site-key");
         when(reCaptchaService.isEnabled()).thenReturn(true);
 
-        PortalSettingsEntity portalSettings = configService.getPortalSettings();
+        PortalSettingsEntity portalSettings = configService.getPortalSettings(GraviteeContext.getCurrentEnvironment());
 
         assertNotNull(portalSettings);
         assertEquals("force login", true, portalSettings.getAuthentication().getForceLogin().isEnabled());
@@ -115,7 +116,7 @@ public class ConfigServiceTest {
         when(environment.containsProperty(Key.PORTAL_ANALYTICS_ENABLED.key())).thenReturn(true);
         when(environment.containsProperty(Key.OPEN_API_DOC_TYPE_SWAGGER_ENABLED.key())).thenReturn(true);
 
-        PortalSettingsEntity portalSettings = configService.getPortalSettings();
+        PortalSettingsEntity portalSettings = configService.getPortalSettings(GraviteeContext.getCurrentEnvironment());
 
         assertNotNull(portalSettings);
         assertEquals("force login", true, portalSettings.getAuthentication().getForceLogin().isEnabled());
@@ -149,7 +150,7 @@ public class ConfigServiceTest {
         portalSettingsEntity.getPortal().setUrl("ACME");
         when(mockParameterService.save(PORTAL_URL, "ACME", "DEFAULT", ParameterReferenceType.ENVIRONMENT)).thenReturn(new Parameter());
 
-        configService.save(portalSettingsEntity);
+        configService.save(GraviteeContext.getCurrentEnvironment(), portalSettingsEntity);
 
         verify(mockParameterService, times(1)).save(PORTAL_URL, "ACME", "DEFAULT", ParameterReferenceType.ENVIRONMENT);
     }
@@ -166,7 +167,7 @@ public class ConfigServiceTest {
         when(reCaptchaService.getSiteKey()).thenReturn("my-site-key");
         when(reCaptchaService.isEnabled()).thenReturn(true);
 
-        ConsoleSettingsEntity consoleSettings = configService.getConsoleSettings();
+        ConsoleSettingsEntity consoleSettings = configService.getConsoleSettings(GraviteeContext.getCurrentOrganization());
 
         assertNotNull(consoleSettings);
         assertEquals("scheduler notifications", Integer.valueOf(11), consoleSettings.getScheduler().getNotificationsInSeconds());
@@ -188,7 +189,7 @@ public class ConfigServiceTest {
         when(reCaptchaService.getSiteKey()).thenReturn("my-site-key");
         when(reCaptchaService.isEnabled()).thenReturn(true);
 
-        ConsoleConfigEntity consoleConfig = configService.getConsoleConfig();
+        ConsoleConfigEntity consoleConfig = configService.getConsoleConfig(GraviteeContext.getCurrentOrganization());
 
         assertNotNull(consoleConfig);
         assertEquals("scheduler notifications", Integer.valueOf(11), consoleConfig.getScheduler().getNotificationsInSeconds());
@@ -213,7 +214,7 @@ public class ConfigServiceTest {
         when(environment.containsProperty(eq(Key.CONSOLE_AUTHENTICATION_LOCALLOGIN_ENABLED.key()))).thenReturn(true);
         when(environment.containsProperty(Key.CONSOLE_SCHEDULER_NOTIFICATIONS.key())).thenReturn(true);
 
-        ConsoleSettingsEntity consoleSettings = configService.getConsoleSettings();
+        ConsoleSettingsEntity consoleSettings = configService.getConsoleSettings(GraviteeContext.getCurrentOrganization());
 
         assertNotNull(consoleSettings);
         assertEquals("scheduler notifications", Integer.valueOf(11), consoleSettings.getScheduler().getNotificationsInSeconds());
@@ -256,7 +257,7 @@ public class ConfigServiceTest {
         when(mockParameterService.save(LOGGING_AUDIT_TRAIL_ENABLED, "true", "DEFAULT", ParameterReferenceType.ORGANIZATION))
             .thenReturn(new Parameter());
 
-        configService.save(consoleSettingsEntity);
+        configService.save(GraviteeContext.getCurrentOrganization(), consoleSettingsEntity);
 
         verify(mockParameterService, times(1)).save(ALERT_ENABLED, "true", "DEFAULT", ParameterReferenceType.ORGANIZATION);
         verify(mockParameterService, times(1)).save(LOGGING_DEFAULT_MAX_DURATION, "3000", "DEFAULT", ParameterReferenceType.ORGANIZATION);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/CustomUserFieldsServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/CustomUserFieldsServiceTest.java
@@ -25,6 +25,7 @@ import io.gravitee.repository.management.model.CustomUserField;
 import io.gravitee.repository.management.model.CustomUserFieldReferenceType;
 import io.gravitee.repository.management.model.MetadataFormat;
 import io.gravitee.rest.api.model.CustomUserFieldEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.CustomUserFieldAlreadyExistException;
 import io.gravitee.rest.api.service.exceptions.CustomUserFieldException;
 import io.gravitee.rest.api.service.exceptions.CustomUserFieldNotFoundException;
@@ -96,7 +97,7 @@ public class CustomUserFieldsServiceTest {
         CustomUserFieldEntity createdEntity = service.create(newFieldEntity);
 
         verify(customUserFieldsRepository).create(fieldCaptor.capture());
-        verify(auditService).createOrganizationAuditLog(anyMap(), any(), any(), any(), any());
+        verify(auditService).createOrganizationAuditLog(eq(GraviteeContext.getCurrentOrganization()), anyMap(), any(), any(), any(), any());
 
         assertEquals("CustomUserField.key", newFieldEntity.getKey().toLowerCase(), createdEntity.getKey());
         assertEquals("CustomUserField.label", newFieldEntity.getLabel(), createdEntity.getLabel());
@@ -192,7 +193,7 @@ public class CustomUserFieldsServiceTest {
         CustomUserFieldEntity updatedEntity = service.update(toUpdateFieldEntity);
 
         verify(customUserFieldsRepository).update(fieldCaptor.capture());
-        verify(auditService).createOrganizationAuditLog(anyMap(), any(), any(), any(), any());
+        verify(auditService).createOrganizationAuditLog(eq(GraviteeContext.getCurrentOrganization()), anyMap(), any(), any(), any(), any());
 
         assertEquals("updatedCustomField.key", toUpdateFieldEntity.getKey().toLowerCase(), updatedEntity.getKey());
         assertEquals("updatedCustomField.label", toUpdateFieldEntity.getLabel(), updatedEntity.getLabel());
@@ -219,7 +220,8 @@ public class CustomUserFieldsServiceTest {
         service.update(mock(CustomUserFieldEntity.class));
 
         verify(customUserFieldsRepository, never()).update(any());
-        verify(auditService, never()).createOrganizationAuditLog(anyMap(), any(), any(), any(), any());
+        verify(auditService, never())
+            .createOrganizationAuditLog(GraviteeContext.getCurrentOrganization(), anyMap(), any(), any(), any(), any());
     }
 
     @Test
@@ -227,7 +229,8 @@ public class CustomUserFieldsServiceTest {
         service.delete("unknown");
 
         verify(customUserFieldsRepository, never()).delete(anyString(), anyString(), any());
-        verify(auditService, never()).createOrganizationAuditLog(anyMap(), any(), any(), any(), any());
+        verify(auditService, never())
+            .createOrganizationAuditLog(eq(GraviteeContext.getCurrentOrganization()), anyMap(), any(), any(), any(), any());
     }
 
     @Test
@@ -241,7 +244,7 @@ public class CustomUserFieldsServiceTest {
         service.delete("validKEY"); // no issue with upper case here, we want to test the sanitizer on the key
 
         verify(customUserFieldsRepository).delete("validkey", ORG_ID, REF_TYPE);
-        verify(auditService).createOrganizationAuditLog(anyMap(), any(), any(), any(), any());
+        verify(auditService).createOrganizationAuditLog(eq(GraviteeContext.getCurrentOrganization()), anyMap(), any(), any(), any(), any());
         verify(ueUserMetadataService).deleteAllByCustomFieldId("validkey", ORG_ID, REF_TYPE);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/DashboardServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/DashboardServiceTest.java
@@ -34,6 +34,7 @@ import io.gravitee.repository.management.model.DashboardReferenceType;
 import io.gravitee.rest.api.model.DashboardEntity;
 import io.gravitee.rest.api.model.NewDashboardEntity;
 import io.gravitee.rest.api.model.UpdateDashboardEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.DashboardNotFoundException;
 import io.gravitee.rest.api.service.impl.DashboardServiceImpl;
 import java.util.Date;
@@ -210,6 +211,7 @@ public class DashboardServiceTest {
             );
         verify(auditService, times(1))
             .createEnvironmentAuditLog(
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(ImmutableMap.of(DASHBOARD, DASHBOARD_ID)),
                 eq(Dashboard.AuditEvent.DASHBOARD_CREATED),
                 any(Date.class),
@@ -279,6 +281,7 @@ public class DashboardServiceTest {
             );
         verify(auditService, times(1))
             .createEnvironmentAuditLog(
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(ImmutableMap.of(DASHBOARD, DASHBOARD_ID)),
                 eq(Dashboard.AuditEvent.DASHBOARD_UPDATED),
                 any(Date.class),
@@ -307,6 +310,7 @@ public class DashboardServiceTest {
         verify(dashboardRepository, times(1)).delete(DASHBOARD_ID);
         verify(auditService, times(1))
             .createEnvironmentAuditLog(
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(ImmutableMap.of(DASHBOARD, DASHBOARD_ID)),
                 eq(Dashboard.AuditEvent.DASHBOARD_DELETED),
                 any(Date.class),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/EnvironmentService_FindByUserAndIdOrHridTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/EnvironmentService_FindByUserAndIdOrHridTest.java
@@ -26,11 +26,9 @@ import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.impl.EnvironmentServiceImpl;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -69,7 +67,11 @@ public class EnvironmentService_FindByUserAndIdOrHridTest {
     public void shouldFindByUserFilteredByEnvId() throws TechnicalException {
         when(mockEnvironmentRepository.findByOrganization(any())).thenReturn(getEnvironments());
 
-        List<EnvironmentEntity> environments = environmentService.findByUserAndIdOrHrid(null, "envId");
+        List<EnvironmentEntity> environments = environmentService.findByUserAndIdOrHrid(
+            GraviteeContext.getCurrentOrganization(),
+            null,
+            "envId"
+        );
 
         assertThat(environments).hasSize(1);
     }
@@ -78,7 +80,11 @@ public class EnvironmentService_FindByUserAndIdOrHridTest {
     public void shouldFindByUserFilteredByEnvHrid() throws TechnicalException {
         when(mockEnvironmentRepository.findByOrganization(any())).thenReturn(getEnvironments());
 
-        List<EnvironmentEntity> environments = environmentService.findByUserAndIdOrHrid(null, "2env");
+        List<EnvironmentEntity> environments = environmentService.findByUserAndIdOrHrid(
+            GraviteeContext.getCurrentOrganization(),
+            null,
+            "2env"
+        );
 
         assertThat(environments).hasSize(1);
     }
@@ -87,7 +93,11 @@ public class EnvironmentService_FindByUserAndIdOrHridTest {
     public void shouldFindByUserFilteredByEnvHridAndId_noResult() throws TechnicalException {
         when(mockEnvironmentRepository.findByOrganization(any())).thenReturn(getEnvironments());
 
-        List<EnvironmentEntity> environments = environmentService.findByUserAndIdOrHrid(null, "fake-env");
+        List<EnvironmentEntity> environments = environmentService.findByUserAndIdOrHrid(
+            GraviteeContext.getCurrentOrganization(),
+            null,
+            "fake-env"
+        );
 
         assertThat(environments).isEmpty();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/EventServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/EventServiceTest.java
@@ -107,7 +107,7 @@ public class EventServiceTest {
         when(newEvent.getPayload()).thenReturn(EVENT_PAYLOAD);
         when(newEvent.getProperties()).thenReturn(EVENT_PROPERTIES);
 
-        final EventEntity eventEntity = eventService.create(newEvent);
+        final EventEntity eventEntity = eventService.create(Collections.singleton(GraviteeContext.getCurrentEnvironment()), newEvent);
 
         assertNotNull(eventEntity);
         assertEquals(EventType.PUBLISH_API.toString(), eventEntity.getType().toString());
@@ -173,7 +173,8 @@ public class EventServiceTest {
             1420070400000L,
             1422748800000L,
             0,
-            10
+            10,
+            Collections.singletonList(GraviteeContext.getCurrentEnvironment())
         );
         assertTrue(0L == eventPageEntity.getTotalElements());
     }
@@ -215,7 +216,8 @@ public class EventServiceTest {
             1420070400000L,
             1422748800000L,
             0,
-            10
+            10,
+            Collections.singletonList(GraviteeContext.getCurrentEnvironment())
         );
 
         assertTrue(2L == eventPageEntity.getTotalElements());
@@ -256,7 +258,8 @@ public class EventServiceTest {
             1420070400000L,
             1422748800000L,
             0,
-            10
+            10,
+            Collections.singletonList(GraviteeContext.getCurrentEnvironment())
         );
 
         assertTrue(2L == eventPageEntity.getTotalElements());
@@ -294,7 +297,15 @@ public class EventServiceTest {
         )
             .thenReturn(eventPage);
 
-        Page<EventEntity> eventPageEntity = eventService.search(null, values, 1420070400000L, 1422748800000L, 0, 10);
+        Page<EventEntity> eventPageEntity = eventService.search(
+            null,
+            values,
+            1420070400000L,
+            1422748800000L,
+            0,
+            10,
+            Collections.singletonList(GraviteeContext.getCurrentEnvironment())
+        );
 
         assertTrue(2L == eventPageEntity.getTotalElements());
         assertTrue("event1".equals(eventPageEntity.getContent().get(0).getId()));
@@ -338,7 +349,8 @@ public class EventServiceTest {
             1420070400000L,
             1422748800000L,
             0,
-            10
+            10,
+            Collections.singletonList(GraviteeContext.getCurrentEnvironment())
         );
 
         assertTrue(2L == eventPageEntity.getTotalElements());
@@ -376,7 +388,8 @@ public class EventServiceTest {
                 map.put("id", evt.getId());
                 map.put("state", evt.getType().name());
                 return map;
-            }
+            },
+            Collections.singletonList(GraviteeContext.getCurrentEnvironment())
         );
         assertNotNull(page);
         assertNotNull(page.getContent());
@@ -397,7 +410,8 @@ public class EventServiceTest {
                     map.put("state", evt.getType().name());
                     return map;
                 },
-                map -> !map.get("state").equals(io.gravitee.rest.api.model.EventType.GATEWAY_STOPPED.name())
+                map -> !map.get("state").equals(io.gravitee.rest.api.model.EventType.GATEWAY_STOPPED.name()),
+                Collections.singletonList(GraviteeContext.getCurrentEnvironment())
             );
         assertNotNull(page);
         assertNotNull(page.getContent());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/FilteringServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/FilteringServiceTest.java
@@ -30,6 +30,7 @@ import io.gravitee.rest.api.model.api.ApiLifecycleState;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.model.filtering.FilterableItem;
 import io.gravitee.rest.api.model.filtering.FilteredEntities;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.filtering.FilteringService;
 import io.gravitee.rest.api.service.impl.filtering.FilteringServiceImpl;
 import java.util.*;
@@ -145,7 +146,9 @@ public class FilteringServiceTest {
         appB.setId("B");
         ApplicationListItem appC = new ApplicationListItem();
         appC.setId("C");
-        doReturn(new HashSet<ApplicationListItem>(Arrays.asList(appC, appB, appA))).when(applicationService).findByUser(any());
+        doReturn(new HashSet<ApplicationListItem>(Arrays.asList(appC, appB, appA)))
+            .when(applicationService)
+            .findByUser(eq(GraviteeContext.getCurrentOrganization()), eq(GraviteeContext.getCurrentEnvironment()), any());
 
         SubscriptionEntity subA1 = new SubscriptionEntity();
         subA1.setApplication("A");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/GroupService_FindByEventTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/GroupService_FindByEventTest.java
@@ -25,7 +25,7 @@ import io.gravitee.repository.management.model.Group;
 import io.gravitee.repository.management.model.GroupEvent;
 import io.gravitee.repository.management.model.GroupEventRule;
 import io.gravitee.rest.api.model.GroupEntity;
-import io.gravitee.rest.api.service.GroupService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.impl.GroupServiceImpl;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -69,7 +69,7 @@ public class GroupService_FindByEventTest {
 
         when(membershipService.getRoles(any(), any(), any(), any())).thenReturn(Collections.emptySet());
 
-        Set<GroupEntity> groupEntities = groupService.findByEvent(API_CREATE);
+        Set<GroupEntity> groupEntities = groupService.findByEvent(GraviteeContext.getCurrentEnvironment(), API_CREATE);
 
         assertNotNull(groupEntities);
         assertFalse(groupEntities.isEmpty());
@@ -91,7 +91,7 @@ public class GroupService_FindByEventTest {
         findAll.add(grp2);
         when(groupRepository.findAllByEnvironment(any())).thenReturn(findAll);
 
-        Set<GroupEntity> groupEntities = groupService.findByEvent(API_CREATE);
+        Set<GroupEntity> groupEntities = groupService.findByEvent(GraviteeContext.getCurrentEnvironment(), API_CREATE);
 
         assertNotNull(groupEntities);
         assertTrue(groupEntities.isEmpty());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/GroupService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/GroupService_UpdateTest.java
@@ -28,6 +28,7 @@ import io.gravitee.rest.api.model.MembershipReferenceType;
 import io.gravitee.rest.api.model.UpdateGroupEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.impl.GroupServiceImpl;
 import java.util.Collections;
 import java.util.Optional;
@@ -79,7 +80,7 @@ public class GroupService_UpdateTest {
         when(permissionService.hasPermission(RolePermission.ENVIRONMENT_GROUP, "DEFAULT", CREATE, UPDATE, DELETE)).thenReturn(true);
         when(membershipService.getRoles(any(), any(), any(), any())).thenReturn(Collections.emptySet());
 
-        groupService.update(GROUP_ID, updatedGroupEntity);
+        groupService.update(GraviteeContext.getCurrentEnvironment(), GROUP_ID, updatedGroupEntity);
 
         verify(groupRepository)
             .update(
@@ -98,6 +99,8 @@ public class GroupService_UpdateTest {
 
         verify(membershipService)
             .addRoleToMemberOnReference(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
                 argThat(
                     membershipReference ->
                         membershipReference.getType() == MembershipReferenceType.API && membershipReference.getId() == null
@@ -123,9 +126,24 @@ public class GroupService_UpdateTest {
         when(permissionService.hasPermission(RolePermission.ENVIRONMENT_GROUP, "DEFAULT", CREATE, UPDATE, DELETE)).thenReturn(true);
         when(membershipService.getRoles(any(), any(), any(), any())).thenReturn(Collections.emptySet());
 
-        groupService.update(GROUP_ID, updatedGroupEntity);
+        groupService.update(GraviteeContext.getCurrentEnvironment(), GROUP_ID, updatedGroupEntity);
 
-        verify(membershipService, never()).deleteReferenceMember(any(), any(), any(), any());
-        verify(membershipService, never()).addRoleToMemberOnReference(any(), any(), any());
+        verify(membershipService, never())
+            .deleteReferenceMember(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
+                any(),
+                any(),
+                any(),
+                any()
+            );
+        verify(membershipService, never())
+            .addRoleToMemberOnReference(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
+                any(),
+                any(),
+                any()
+            );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/MembershipService_AddRoleToMemberOnReferenceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/MembershipService_AddRoleToMemberOnReferenceTest.java
@@ -21,6 +21,7 @@ import io.gravitee.repository.management.api.MembershipRepository;
 import io.gravitee.repository.management.model.Membership;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.NotAuthorizedMembershipException;
 import io.gravitee.rest.api.service.exceptions.RoleNotFoundException;
 import io.gravitee.rest.api.service.impl.MembershipServiceImpl;
@@ -91,7 +92,7 @@ public class MembershipService_AddRoleToMemberOnReferenceTest {
         newMembership.setReferenceId(API_ID);
         newMembership.setMemberId(GROUP_ID);
         newMembership.setMemberType(io.gravitee.repository.management.model.MembershipMemberType.GROUP);
-        when(groupService.findById(GROUP_ID)).thenReturn(mock(GroupEntity.class));
+        when(groupService.findById(GraviteeContext.getCurrentEnvironment(), GROUP_ID)).thenReturn(mock(GroupEntity.class));
         when(
             membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceId(
                 userEntity.getId(),
@@ -104,6 +105,8 @@ public class MembershipService_AddRoleToMemberOnReferenceTest {
         when(membershipRepository.create(any())).thenReturn(newMembership);
 
         membershipService.addRoleToMemberOnReference(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
             new MembershipService.MembershipReference(MembershipReferenceType.GROUP, GROUP_ID),
             new MembershipService.MembershipMember("my name", null, MembershipMemberType.USER),
             new MembershipService.MembershipRole(RoleScope.API, "OWNER")
@@ -141,7 +144,7 @@ public class MembershipService_AddRoleToMemberOnReferenceTest {
         newMembership.setReferenceId(API_ID);
         newMembership.setMemberId(GROUP_ID);
         newMembership.setMemberType(io.gravitee.repository.management.model.MembershipMemberType.GROUP);
-        when(groupService.findById(GROUP_ID)).thenReturn(mock(GroupEntity.class));
+        when(groupService.findById(GraviteeContext.getCurrentEnvironment(), GROUP_ID)).thenReturn(mock(GroupEntity.class));
         when(
             membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceId(
                 userEntity.getId(),
@@ -154,6 +157,8 @@ public class MembershipService_AddRoleToMemberOnReferenceTest {
         when(membershipRepository.create(any())).thenReturn(newMembership);
 
         membershipService.addRoleToMemberOnReference(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
             new MembershipService.MembershipReference(MembershipReferenceType.GROUP, GROUP_ID),
             new MembershipService.MembershipMember("my name", null, MembershipMemberType.USER),
             new MembershipService.MembershipRole(RoleScope.API, "PRIMARY_OWNER")
@@ -176,6 +181,8 @@ public class MembershipService_AddRoleToMemberOnReferenceTest {
     public void shouldDisallowAddUnknownRoleOnApi() throws Exception {
         when(roleService.findByScopeAndName(any(), any())).thenReturn(Optional.empty());
         membershipService.addRoleToMemberOnReference(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
             new MembershipService.MembershipReference(MembershipReferenceType.API, API_ID),
             new MembershipService.MembershipMember("xxxxx", null, MembershipMemberType.USER),
             new MembershipService.MembershipRole(RoleScope.ENVIRONMENT, "name")
@@ -186,6 +193,8 @@ public class MembershipService_AddRoleToMemberOnReferenceTest {
     public void shouldDisallowAddUnknownRoleOnApplication() throws Exception {
         when(roleService.findByScopeAndName(any(), any())).thenReturn(Optional.empty());
         membershipService.addRoleToMemberOnReference(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
             new MembershipService.MembershipReference(MembershipReferenceType.APPLICATION, APPLICATION_ID),
             new MembershipService.MembershipMember("xxxxx", null, MembershipMemberType.USER),
             new MembershipService.MembershipRole(RoleScope.ENVIRONMENT, "name")
@@ -198,6 +207,8 @@ public class MembershipService_AddRoleToMemberOnReferenceTest {
         when(role.getScope()).thenReturn(io.gravitee.rest.api.model.permissions.RoleScope.ENVIRONMENT);
         when(roleService.findByScopeAndName(any(), any())).thenReturn(Optional.of(role));
         membershipService.addRoleToMemberOnReference(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
             new MembershipService.MembershipReference(MembershipReferenceType.GROUP, GROUP_ID),
             new MembershipService.MembershipMember("xxxxx", null, MembershipMemberType.USER),
             new MembershipService.MembershipRole(RoleScope.ENVIRONMENT, "name")
@@ -220,6 +231,8 @@ public class MembershipService_AddRoleToMemberOnReferenceTest {
         )
             .thenReturn(Collections.singleton(mock(Membership.class)));
         membershipService.addRoleToMemberOnReference(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
             new MembershipService.MembershipReference(MembershipReferenceType.GROUP, GROUP_ID),
             new MembershipService.MembershipMember("xxxxx", null, MembershipMemberType.USER),
             new MembershipService.MembershipRole(RoleScope.API, "PRIMARY_OWNER")
@@ -233,6 +246,8 @@ public class MembershipService_AddRoleToMemberOnReferenceTest {
         when(role.getName()).thenReturn("PRIMARY_OWNER");
         when(roleService.findByScopeAndName(any(), any())).thenReturn(Optional.of(role));
         membershipService.addRoleToMemberOnReference(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
             new MembershipService.MembershipReference(MembershipReferenceType.GROUP, GROUP_ID),
             new MembershipService.MembershipMember("xxxxx", null, MembershipMemberType.USER),
             new MembershipService.MembershipRole(RoleScope.APPLICATION, "PRIMARY_OWNER")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/MembershipService_GetMemberPermissionsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/MembershipService_GetMemberPermissionsTest.java
@@ -29,6 +29,7 @@ import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.permissions.ApiPermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.impl.MembershipServiceImpl;
 import java.util.*;
 import org.junit.Test;
@@ -81,7 +82,11 @@ public class MembershipService_GetMemberPermissionsTest {
                 API_ID
             );
 
-        Map<String, char[]> permissions = membershipService.getUserMemberPermissions(api, USERNAME);
+        Map<String, char[]> permissions = membershipService.getUserMemberPermissions(
+            GraviteeContext.getCurrentEnvironment(),
+            api,
+            USERNAME
+        );
 
         assertNotNull(permissions);
         assertTrue(permissions.isEmpty());
@@ -125,7 +130,11 @@ public class MembershipService_GetMemberPermissionsTest {
         doReturn(rolePerms).when(roleEntity).getPermissions();
         doReturn(roleEntity).when(roleService).findById("API_" + ROLENAME);
 
-        Map<String, char[]> permissions = membershipService.getUserMemberPermissions(api, USERNAME);
+        Map<String, char[]> permissions = membershipService.getUserMemberPermissions(
+            GraviteeContext.getCurrentEnvironment(),
+            api,
+            USERNAME
+        );
 
         assertNotNull(permissions);
         assertPermissions(rolePerms, permissions);
@@ -188,7 +197,11 @@ public class MembershipService_GetMemberPermissionsTest {
         doReturn(RoleScope.API).when(roleEntity).getScope();
         doReturn(roleEntity).when(roleService).findById("API_" + ROLENAME);
 
-        Map<String, char[]> permissions = membershipService.getUserMemberPermissions(api, USERNAME);
+        Map<String, char[]> permissions = membershipService.getUserMemberPermissions(
+            GraviteeContext.getCurrentEnvironment(),
+            api,
+            USERNAME
+        );
 
         assertNotNull(permissions);
         assertPermissions(rolePerms, permissions);
@@ -263,7 +276,11 @@ public class MembershipService_GetMemberPermissionsTest {
         doReturn(RoleScope.API).when(roleEntity2).getScope();
         doReturn(roleEntity2).when(roleService).findById("API_" + ROLENAME2);
 
-        Map<String, char[]> permissions = membershipService.getUserMemberPermissions(api, USERNAME);
+        Map<String, char[]> permissions = membershipService.getUserMemberPermissions(
+            GraviteeContext.getCurrentEnvironment(),
+            api,
+            USERNAME
+        );
 
         assertNotNull(permissions);
         Map<String, char[]> expectedPermissions = new HashMap<>();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/MessageService_GetRecipientIdsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/MessageService_GetRecipientIdsTest.java
@@ -27,6 +27,7 @@ import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.Subscription;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.MessageRecipientFormatException;
 import io.gravitee.rest.api.service.impl.MessageServiceImpl;
 import java.util.*;
@@ -89,7 +90,7 @@ public class MessageService_GetRecipientIdsTest {
         try {
             Api api = new Api();
             api.setId(apiId);
-            messageService.getRecipientsId(api, message);
+            messageService.getRecipientsId(GraviteeContext.getCurrentEnvironment(), api, message);
             fail("should throw MessageRecipientFormatException");
         } catch (MessageRecipientFormatException ex) {
             // ok
@@ -113,7 +114,7 @@ public class MessageService_GetRecipientIdsTest {
 
         messageService.getRecipientsId(messageEntity);
 
-        verify(mockGroupService, never()).findById(any());
+        verify(mockGroupService, never()).findById(eq(GraviteeContext.getCurrentEnvironment()), any());
         verify(mockMembershipService, never()).getMembershipsByReferenceAndRole(any(), any(), any());
         verify(mockMembershipService, never()).getMembershipsByReferencesAndRole(any(), any(), any());
         verify(mockRoleService, never()).findByScopeAndName(any(), any());
@@ -142,7 +143,7 @@ public class MessageService_GetRecipientIdsTest {
         assertNotNull("not null", recipientIds);
         assertEquals("size=1", 1, recipientIds.size());
         assertTrue("user=user-id", recipientIds.contains("user-id"));
-        verify(mockGroupService, never()).findById(any());
+        verify(mockGroupService, never()).findById(eq(GraviteeContext.getCurrentEnvironment()), any());
         verify(mockMembershipService, times(1)).getMembershipsByReferenceAndRole(any(), any(), any());
         verify(mockMembershipService, never()).getMembershipsByReferencesAndRole(any(), any(), any());
         verify(mockRoleService, times(1)).findByScopeAndName(RoleScope.ENVIRONMENT, "API_PUBLISHER");
@@ -165,9 +166,9 @@ public class MessageService_GetRecipientIdsTest {
         messageRecipientEntity.setRoleValues(Collections.singletonList("API_PUBLISHER"));
         messageEntity.setRecipient(messageRecipientEntity);
 
-        messageService.getRecipientsId(api, messageEntity);
+        messageService.getRecipientsId(GraviteeContext.getCurrentEnvironment(), api, messageEntity);
 
-        verify(mockGroupService, never()).findById(any());
+        verify(mockGroupService, never()).findById(eq(GraviteeContext.getCurrentEnvironment()), any());
         verify(mockMembershipService, never()).getMembershipsByReferenceAndRole(any(), any(), any());
         verify(mockMembershipService, never()).getMembershipsByReferencesAndRole(any(), any(), any());
         verify(mockRoleService, never()).findByScopeAndName(any(), any());
@@ -206,13 +207,13 @@ public class MessageService_GetRecipientIdsTest {
         messageRecipientEntity.setRoleValues(Collections.singletonList("OWNER"));
         messageEntity.setRecipient(messageRecipientEntity);
 
-        Set<String> recipientIds = messageService.getRecipientsId(api, messageEntity);
+        Set<String> recipientIds = messageService.getRecipientsId(GraviteeContext.getCurrentEnvironment(), api, messageEntity);
 
         // then
         assertNotNull("not null", recipientIds);
         assertEquals("size=1", 1, recipientIds.size());
         assertTrue("user=user-id", recipientIds.contains("user-id"));
-        verify(mockGroupService, never()).findById(any());
+        verify(mockGroupService, never()).findById(eq(GraviteeContext.getCurrentEnvironment()), any());
         verify(mockMembershipService, never()).getMembershipsByReferenceAndRole(any(), any(), any());
         verify(mockMembershipService, times(1)).getMembershipsByReferencesAndRole(any(), any(), any());
         verify(mockRoleService, times(1)).findByScopeAndName(RoleScope.APPLICATION, "OWNER");
@@ -260,7 +261,7 @@ public class MessageService_GetRecipientIdsTest {
         messageRecipientEntity.setRoleValues(Collections.singletonList("OWNER"));
         messageEntity.setRecipient(messageRecipientEntity);
 
-        Set<String> recipientIds = messageService.getRecipientsId(api, messageEntity);
+        Set<String> recipientIds = messageService.getRecipientsId(GraviteeContext.getCurrentEnvironment(), api, messageEntity);
 
         // then
         assertNotNull("not null", recipientIds);
@@ -302,7 +303,7 @@ public class MessageService_GetRecipientIdsTest {
         messageRecipientEntity.setRoleValues(Collections.singletonList("API_SUBSCRIBERS"));
         messageEntity.setRecipient(messageRecipientEntity);
 
-        Set<String> recipientIds = messageService.getRecipientsId(api, messageEntity);
+        Set<String> recipientIds = messageService.getRecipientsId(GraviteeContext.getCurrentEnvironment(), api, messageEntity);
 
         // then
         assertNotNull("not null", recipientIds);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/NotificationTemplateServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/NotificationTemplateServiceTest.java
@@ -27,6 +27,7 @@ import io.gravitee.repository.management.model.NotificationTemplate;
 import io.gravitee.repository.management.model.NotificationTemplateReferenceType;
 import io.gravitee.repository.management.model.NotificationTemplateType;
 import io.gravitee.rest.api.model.notification.NotificationTemplateEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.NotificationTemplateNotFoundException;
 import io.gravitee.rest.api.service.impl.NotificationTemplateServiceImpl;
 import io.gravitee.rest.api.service.notification.HookScope;
@@ -176,7 +177,14 @@ public class NotificationTemplateServiceTest {
         notificationTemplateService.create(newNotificationTemplateEntity);
         verify(notificationTemplateRepository, times(1)).create(any());
         verify(auditService, times(1))
-            .createOrganizationAuditLog(any(), eq(NotificationTemplate.AuditEvent.NOTIFICATION_TEMPLATE_CREATED), any(), isNull(), any());
+            .createOrganizationAuditLog(
+                eq(GraviteeContext.getCurrentOrganization()),
+                any(),
+                eq(NotificationTemplate.AuditEvent.NOTIFICATION_TEMPLATE_CREATED),
+                any(),
+                isNull(),
+                any()
+            );
     }
 
     @Test
@@ -197,6 +205,7 @@ public class NotificationTemplateServiceTest {
         verify(notificationTemplateRepository, times(1)).update(any());
         verify(auditService, times(1))
             .createOrganizationAuditLog(
+                eq(GraviteeContext.getCurrentOrganization()),
                 any(),
                 eq(NotificationTemplate.AuditEvent.NOTIFICATION_TEMPLATE_UPDATED),
                 any(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ParameterServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ParameterServiceTest.java
@@ -306,6 +306,7 @@ public class ParameterServiceTest {
         verify(parameterRepository).create(parameter);
         verify(auditService)
             .createEnvironmentAuditLog(
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(singletonMap(PARAMETER, PORTAL_TOP_APIS.key())),
                 eq(PARAMETER_CREATED),
                 any(),
@@ -335,6 +336,7 @@ public class ParameterServiceTest {
         verify(parameterRepository).create(parameter);
         verify(auditService)
             .createEnvironmentAuditLog(
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(singletonMap(PARAMETER, PORTAL_TOP_APIS.key())),
                 eq(PARAMETER_CREATED),
                 any(),
@@ -363,7 +365,8 @@ public class ParameterServiceTest {
 
         assertEquals("api10", result.getValue());
         verify(parameterRepository, times(0)).create(any());
-        verify(auditService, times(0)).createEnvironmentAuditLog(any(), any(), any(), any(), any());
+        verify(auditService, times(0))
+            .createEnvironmentAuditLog(eq(GraviteeContext.getCurrentEnvironment()), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -386,7 +389,8 @@ public class ParameterServiceTest {
 
         assertEquals("api1", result.getValue());
         verify(parameterRepository, times(1)).create(any());
-        verify(auditService, times(1)).createEnvironmentAuditLog(any(), any(), any(), any(), any());
+        verify(auditService, times(1))
+            .createEnvironmentAuditLog(eq(GraviteeContext.getCurrentEnvironment()), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -409,7 +413,8 @@ public class ParameterServiceTest {
 
         assertEquals("api10;api11;api12", result.getValue());
         verify(parameterRepository, times(0)).create(any());
-        verify(auditService, times(0)).createEnvironmentAuditLog(any(), any(), any(), any(), any());
+        verify(auditService, times(0))
+            .createEnvironmentAuditLog(eq(GraviteeContext.getCurrentEnvironment()), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -432,7 +437,8 @@ public class ParameterServiceTest {
 
         assertEquals("api1", result.getValue());
         verify(parameterRepository, times(1)).create(any());
-        verify(auditService, times(1)).createEnvironmentAuditLog(any(), any(), any(), any(), any());
+        verify(auditService, times(1))
+            .createEnvironmentAuditLog(eq(GraviteeContext.getCurrentEnvironment()), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -455,6 +461,7 @@ public class ParameterServiceTest {
         verify(parameterRepository).update(newParameter);
         verify(auditService)
             .createEnvironmentAuditLog(
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(singletonMap(PARAMETER, PORTAL_TOP_APIS.key())),
                 eq(PARAMETER_UPDATED),
                 any(),
@@ -483,6 +490,7 @@ public class ParameterServiceTest {
         verify(parameterRepository).create(parameter);
         verify(auditService)
             .createEnvironmentAuditLog(
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(singletonMap(PARAMETER, PORTAL_TOP_APIS.key())),
                 eq(PARAMETER_CREATED),
                 any(),
@@ -513,7 +521,8 @@ public class ParameterServiceTest {
         );
 
         verify(parameterRepository, never()).update(newParameter);
-        verify(auditService, never()).createEnvironmentAuditLog(any(), any(), any(), any(), any());
+        verify(auditService, never())
+            .createEnvironmentAuditLog(eq(GraviteeContext.getCurrentEnvironment()), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -542,6 +551,7 @@ public class ParameterServiceTest {
         verify(parameterRepository).update(newParameter);
         verify(auditService)
             .createEnvironmentAuditLog(
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(singletonMap(PARAMETER, PORTAL_TOP_APIS.key())),
                 eq(PARAMETER_UPDATED),
                 any(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/QualityMetricsServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/QualityMetricsServiceTest.java
@@ -17,8 +17,7 @@ package io.gravitee.rest.api.service;
 
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -28,6 +27,7 @@ import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.model.quality.ApiQualityRuleEntity;
 import io.gravitee.rest.api.model.quality.QualityRuleEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApiQualityMetricsDisableException;
 import io.gravitee.rest.api.service.impl.QualityMetricsServiceImpl;
 import io.gravitee.rest.api.service.quality.ApiQualityMetricCategories;
@@ -82,7 +82,7 @@ public class QualityMetricsServiceTest {
         when(parameterService.findAsBoolean(Key.API_QUALITY_METRICS_ENABLED, ParameterReferenceType.ENVIRONMENT)).thenReturn(Boolean.FALSE);
         ApiEntity api = mock(ApiEntity.class);
 
-        srv.getMetrics(api);
+        srv.getMetrics(api, GraviteeContext.getCurrentEnvironment());
 
         fail();
     }
@@ -94,7 +94,7 @@ public class QualityMetricsServiceTest {
             .thenReturn(Collections.emptyMap());
         ApiEntity api = mock(ApiEntity.class);
 
-        ApiQualityMetricsEntity metrics = srv.getMetrics(api);
+        ApiQualityMetricsEntity metrics = srv.getMetrics(api, GraviteeContext.getCurrentEnvironment());
 
         assertEquals(1, metrics.getScore(), 0);
         assertTrue(metrics.getMetricsPassed().isEmpty());
@@ -108,10 +108,10 @@ public class QualityMetricsServiceTest {
         map.put(Key.API_QUALITY_METRICS_CATEGORIES_WEIGHT.key(), singletonList(1));
         when(parameterService.findAll(anyList(), any(Function.class), any(ParameterReferenceType.class))).thenReturn(map);
         ApiEntity api = mock(ApiEntity.class);
-        when(apiQualityMetricLogo.isValid(any())).thenReturn(Boolean.TRUE);
-        when(apiQualityMetricCategories.isValid(any())).thenReturn(Boolean.FALSE);
+        when(apiQualityMetricLogo.isValid(any(), eq(GraviteeContext.getCurrentEnvironment()))).thenReturn(Boolean.TRUE);
+        when(apiQualityMetricCategories.isValid(any(), eq(GraviteeContext.getCurrentEnvironment()))).thenReturn(Boolean.FALSE);
 
-        ApiQualityMetricsEntity metrics = srv.getMetrics(api);
+        ApiQualityMetricsEntity metrics = srv.getMetrics(api, GraviteeContext.getCurrentEnvironment());
 
         assertEquals(0.5, metrics.getScore(), 0);
         assertFalse(metrics.getMetricsPassed().isEmpty());
@@ -127,10 +127,10 @@ public class QualityMetricsServiceTest {
         map.put(Key.API_QUALITY_METRICS_CATEGORIES_WEIGHT.key(), singletonList(1));
         when(parameterService.findAll(anyList(), any(Function.class), any(ParameterReferenceType.class))).thenReturn(map);
         ApiEntity api = mock(ApiEntity.class);
-        when(apiQualityMetricLogo.isValid(any())).thenReturn(Boolean.TRUE);
-        when(apiQualityMetricCategories.isValid(any())).thenReturn(Boolean.TRUE);
+        when(apiQualityMetricLogo.isValid(any(), eq(GraviteeContext.getCurrentEnvironment()))).thenReturn(Boolean.TRUE);
+        when(apiQualityMetricCategories.isValid(any(), eq(GraviteeContext.getCurrentEnvironment()))).thenReturn(Boolean.TRUE);
 
-        ApiQualityMetricsEntity metrics = srv.getMetrics(api);
+        ApiQualityMetricsEntity metrics = srv.getMetrics(api, GraviteeContext.getCurrentEnvironment());
 
         assertEquals(1, metrics.getScore(), 0);
         assertFalse(metrics.getMetricsPassed().isEmpty());
@@ -146,10 +146,10 @@ public class QualityMetricsServiceTest {
         map.put(Key.API_QUALITY_METRICS_CATEGORIES_WEIGHT.key(), singletonList(2));
         when(parameterService.findAll(anyList(), any(Function.class), any(ParameterReferenceType.class))).thenReturn(map);
         ApiEntity api = mock(ApiEntity.class);
-        when(apiQualityMetricLogo.isValid(any())).thenReturn(Boolean.TRUE);
-        when(apiQualityMetricCategories.isValid(any())).thenReturn(Boolean.FALSE);
+        when(apiQualityMetricLogo.isValid(any(), eq(GraviteeContext.getCurrentEnvironment()))).thenReturn(Boolean.TRUE);
+        when(apiQualityMetricCategories.isValid(any(), eq(GraviteeContext.getCurrentEnvironment()))).thenReturn(Boolean.FALSE);
 
-        ApiQualityMetricsEntity metrics = srv.getMetrics(api);
+        ApiQualityMetricsEntity metrics = srv.getMetrics(api, GraviteeContext.getCurrentEnvironment());
 
         assertEquals(0.33, metrics.getScore(), 0);
         assertFalse(metrics.getMetricsPassed().isEmpty());
@@ -166,8 +166,8 @@ public class QualityMetricsServiceTest {
         when(parameterService.findAll(anyList(), any(Function.class), any(ParameterReferenceType.class))).thenReturn(map);
         ApiEntity api = mock(ApiEntity.class);
         when(api.getId()).thenReturn("apiID");
-        when(apiQualityMetricLogo.isValid(any())).thenReturn(Boolean.TRUE);
-        when(apiQualityMetricCategories.isValid(any())).thenReturn(Boolean.TRUE);
+        when(apiQualityMetricLogo.isValid(any(), eq(GraviteeContext.getCurrentEnvironment()))).thenReturn(Boolean.TRUE);
+        when(apiQualityMetricCategories.isValid(any(), eq(GraviteeContext.getCurrentEnvironment()))).thenReturn(Boolean.TRUE);
 
         final QualityRuleEntity qualityRule = mock(QualityRuleEntity.class);
         when(qualityRule.getId()).thenReturn("1");
@@ -180,7 +180,7 @@ public class QualityMetricsServiceTest {
         when(apiQualityRule.isChecked()).thenReturn(true);
         when(apiQualityRuleService.findByApi("apiID")).thenReturn(singletonList(apiQualityRule));
 
-        ApiQualityMetricsEntity metrics = srv.getMetrics(api);
+        ApiQualityMetricsEntity metrics = srv.getMetrics(api, GraviteeContext.getCurrentEnvironment());
 
         assertEquals(1, metrics.getScore(), 0);
         assertFalse(metrics.getMetricsPassed().isEmpty());
@@ -198,8 +198,8 @@ public class QualityMetricsServiceTest {
         when(parameterService.findAll(anyList(), any(Function.class), any(ParameterReferenceType.class))).thenReturn(map);
         ApiEntity api = mock(ApiEntity.class);
         when(api.getId()).thenReturn("apiID");
-        when(apiQualityMetricLogo.isValid(any())).thenReturn(Boolean.TRUE);
-        when(apiQualityMetricCategories.isValid(any())).thenReturn(Boolean.TRUE);
+        when(apiQualityMetricLogo.isValid(any(), eq(GraviteeContext.getCurrentEnvironment()))).thenReturn(Boolean.TRUE);
+        when(apiQualityMetricCategories.isValid(any(), eq(GraviteeContext.getCurrentEnvironment()))).thenReturn(Boolean.TRUE);
 
         final QualityRuleEntity qualityRule = mock(QualityRuleEntity.class);
         when(qualityRule.getId()).thenReturn("1");
@@ -212,7 +212,7 @@ public class QualityMetricsServiceTest {
         when(apiQualityRule.isChecked()).thenReturn(false);
         when(apiQualityRuleService.findByApi("apiID")).thenReturn(singletonList(apiQualityRule));
 
-        ApiQualityMetricsEntity metrics = srv.getMetrics(api);
+        ApiQualityMetricsEntity metrics = srv.getMetrics(api, GraviteeContext.getCurrentEnvironment());
 
         assertEquals(0.5, metrics.getScore(), 0);
         assertFalse(metrics.getMetricsPassed().isEmpty());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/QualityRuleServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/QualityRuleServiceTest.java
@@ -29,6 +29,7 @@ import io.gravitee.repository.management.api.ApiQualityRuleRepository;
 import io.gravitee.repository.management.api.QualityRuleRepository;
 import io.gravitee.repository.management.model.QualityRule;
 import io.gravitee.rest.api.model.quality.*;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.QualityRuleNotFoundException;
 import io.gravitee.rest.api.service.impl.QualityRuleServiceImpl;
 import java.util.Date;
@@ -153,6 +154,7 @@ public class QualityRuleServiceTest {
             );
         verify(auditService, times(1))
             .createEnvironmentAuditLog(
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(ImmutableMap.of(QUALITY_RULE, QUALITY_RULE_ID)),
                 eq(QualityRule.AuditEvent.QUALITY_RULE_CREATED),
                 any(Date.class),
@@ -207,6 +209,7 @@ public class QualityRuleServiceTest {
             );
         verify(auditService, times(1))
             .createEnvironmentAuditLog(
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(ImmutableMap.of(QUALITY_RULE, QUALITY_RULE_ID)),
                 eq(QualityRule.AuditEvent.QUALITY_RULE_UPDATED),
                 any(Date.class),
@@ -235,6 +238,7 @@ public class QualityRuleServiceTest {
         verify(qualityRuleRepository, times(1)).delete(QUALITY_RULE_ID);
         verify(auditService, times(1))
             .createEnvironmentAuditLog(
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(ImmutableMap.of(QUALITY_RULE, QUALITY_RULE_ID)),
                 eq(QualityRule.AuditEvent.QUALITY_RULE_DELETED),
                 any(Date.class),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/SubscriptionServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/SubscriptionServiceTest.java
@@ -19,7 +19,6 @@ import static io.gravitee.rest.api.service.impl.AbstractService.ENVIRONMENT_ADMI
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
@@ -35,6 +34,7 @@ import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.application.ApplicationSettings;
 import io.gravitee.rest.api.model.application.OAuthClientSettings;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.*;
 import io.gravitee.rest.api.service.impl.SubscriptionServiceImpl;
 import io.gravitee.rest.api.service.notification.ApiHook;
@@ -290,7 +290,7 @@ public class SubscriptionServiceTest {
 
         // Stub
         when(planService.findById(PLAN_ID)).thenReturn(plan);
-        when(applicationService.findById(APPLICATION_ID)).thenReturn(application);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(application);
         when(apiService.findByIdForTemplates(API_ID)).thenReturn(apiModelEntity);
         when(subscriptionRepository.create(any())).thenAnswer(returnsFirstArg());
 
@@ -318,7 +318,7 @@ public class SubscriptionServiceTest {
         when(generalConditionPage.getContentRevisionId()).thenReturn(pageRevisionId);
         // Stub
         when(planService.findById(PLAN_ID)).thenReturn(plan);
-        when(applicationService.findById(APPLICATION_ID)).thenReturn(application);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(application);
         when(apiService.findByIdForTemplates(API_ID)).thenReturn(apiModelEntity);
         when(subscriptionRepository.create(any())).thenAnswer(returnsFirstArg());
         when(pageService.findById(PAGE_ID)).thenReturn(generalConditionPage);
@@ -432,7 +432,7 @@ public class SubscriptionServiceTest {
 
         // Stub
         when(planService.findById(PLAN_ID)).thenReturn(plan);
-        when(applicationService.findById(APPLICATION_ID)).thenReturn(application);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(application);
         when(apiService.findByIdForTemplates(API_ID)).thenReturn(apiModelEntity);
         when(subscriptionRepository.update(any())).thenAnswer(returnsFirstArg());
         when(subscriptionRepository.create(any()))
@@ -499,7 +499,7 @@ public class SubscriptionServiceTest {
 
         // Stub
         when(planService.findById(PLAN_ID)).thenReturn(plan);
-        when(applicationService.findById(APPLICATION_ID)).thenReturn(application);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(application);
         when(apiService.findByIdForTemplates(API_ID)).thenReturn(apiModelEntity);
         when(subscriptionRepository.update(any())).thenAnswer(returnsFirstArg());
         when(subscriptionRepository.create(any()))
@@ -599,7 +599,7 @@ public class SubscriptionServiceTest {
 
         // Stub
         when(planService.findById(PLAN_ID)).thenReturn(plan);
-        when(applicationService.findById(APPLICATION_ID)).thenReturn(application);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(application);
 
         // Run
         subscriptionService.create(new NewSubscriptionEntity(PLAN_ID, APPLICATION_ID));
@@ -789,7 +789,7 @@ public class SubscriptionServiceTest {
         when(apiKeyService.findBySubscription(SUBSCRIPTION_ID)).thenReturn(singletonList(apiKey));
         when(apiService.findByIdForTemplates(API_ID)).thenReturn(apiModelEntity);
         when(planService.findById(PLAN_ID)).thenReturn(plan);
-        when(applicationService.findById(APPLICATION_ID)).thenReturn(application);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(application);
         when(application.getPrimaryOwner()).thenReturn(mock(PrimaryOwnerEntity.class));
 
         subscriptionService.close(SUBSCRIPTION_ID);
@@ -828,7 +828,7 @@ public class SubscriptionServiceTest {
         when(apiKeyService.findBySubscription(SUBSCRIPTION_ID)).thenReturn(singletonList(apiKey));
         when(apiService.findByIdForTemplates(API_ID)).thenReturn(apiModelEntity);
         when(planService.findById(PLAN_ID)).thenReturn(plan);
-        when(applicationService.findById(APPLICATION_ID)).thenReturn(application);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(application);
         when(application.getPrimaryOwner()).thenReturn(mock(PrimaryOwnerEntity.class));
 
         subscriptionService.pause(SUBSCRIPTION_ID);
@@ -861,7 +861,7 @@ public class SubscriptionServiceTest {
         when(notifierService.hasEmailNotificationFor(any(), any(), anyMap(), anyString())).thenReturn(false);
         when(subscriptionRepository.findById(SUBSCRIPTION_ID)).thenReturn(Optional.of(subscription));
         when(planService.findById(PLAN_ID)).thenReturn(plan);
-        when(applicationService.findById(APPLICATION_ID)).thenReturn(application);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(application);
         when(subscriptionRepository.update(any())).thenAnswer(returnsFirstArg());
 
         // Run
@@ -899,7 +899,7 @@ public class SubscriptionServiceTest {
         when(notifierService.hasEmailNotificationFor(any(), any(), anyMap(), anyString())).thenReturn(true);
         when(subscriptionRepository.findById(SUBSCRIPTION_ID)).thenReturn(Optional.of(subscription));
         when(planService.findById(PLAN_ID)).thenReturn(plan);
-        when(applicationService.findById(APPLICATION_ID)).thenReturn(application);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(application);
         when(subscriptionRepository.update(any())).thenAnswer(returnsFirstArg());
 
         // Run
@@ -939,7 +939,7 @@ public class SubscriptionServiceTest {
         // Stub
         when(subscriptionRepository.findById(SUBSCRIPTION_ID)).thenReturn(Optional.of(subscription));
         when(planService.findById(PLAN_ID)).thenReturn(plan);
-        when(applicationService.findById(APPLICATION_ID)).thenReturn(application);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(application);
         when(subscriptionRepository.update(any())).thenAnswer(returnsFirstArg());
         final UserEntity subscriberUser = new UserEntity();
         subscriberUser.setEmail(SUBSCRIBER_ID + "@acme.net");
@@ -979,7 +979,7 @@ public class SubscriptionServiceTest {
         // Stub
         when(subscriptionRepository.findById(SUBSCRIPTION_ID)).thenReturn(Optional.of(subscription));
         when(planService.findById(PLAN_ID)).thenReturn(plan);
-        when(applicationService.findById(APPLICATION_ID)).thenReturn(application);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(application);
         when(subscriptionRepository.update(any())).thenAnswer(returnsFirstArg());
         final UserEntity subscriberUser = new UserEntity();
         subscriberUser.setEmail(SUBSCRIBER_ID + "@acme.net");
@@ -1016,7 +1016,7 @@ public class SubscriptionServiceTest {
         // Stub
         when(plan.getSecurity()).thenReturn(PlanSecurityType.OAUTH2);
         when(planService.findById(PLAN_ID)).thenReturn(plan);
-        when(applicationService.findById(APPLICATION_ID)).thenReturn(application);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(application);
 
         // Run
         subscriptionService.create(new NewSubscriptionEntity(PLAN_ID, APPLICATION_ID));
@@ -1027,7 +1027,7 @@ public class SubscriptionServiceTest {
         // Stub
         when(plan.getSecurity()).thenReturn(PlanSecurityType.OAUTH2);
         when(planService.findById(PLAN_ID)).thenReturn(plan);
-        when(applicationService.findById(APPLICATION_ID)).thenReturn(application);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(application);
 
         // Run
         subscriptionService.create(new NewSubscriptionEntity(PLAN_ID, APPLICATION_ID));
@@ -1038,7 +1038,7 @@ public class SubscriptionServiceTest {
         when(plan.getSecurity()).thenReturn(PlanSecurityType.OAUTH2);
         when(plan.getStatus()).thenReturn(PlanStatus.PUBLISHED);
 
-        when(applicationService.findById(APPLICATION_ID)).thenReturn(application);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(application);
         when(planService.findById(PLAN_ID)).thenReturn(plan);
 
         // Run
@@ -1060,7 +1060,7 @@ public class SubscriptionServiceTest {
         when(plan.getStatus()).thenReturn(PlanStatus.PUBLISHED);
         when(plan.getApi()).thenReturn(API_ID);
         when(plan.getSecurity()).thenReturn(PlanSecurityType.API_KEY);
-        when(applicationService.findById(APPLICATION_ID)).thenReturn(application);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(application);
 
         subscriptionService.transfer(transferSubscription, USER_ID);
 
@@ -1123,7 +1123,7 @@ public class SubscriptionServiceTest {
 
         // Stub
         when(planService.findById(PLAN_ID)).thenReturn(plan);
-        when(applicationService.findById(APPLICATION_ID)).thenReturn(application);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(application);
         when(apiService.findByIdForTemplates("api1")).thenReturn(apiModelEntity);
 
         when(subscriptionRepository.create(any()))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/SwaggerService_CreateAPITest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/SwaggerService_CreateAPITest.java
@@ -33,6 +33,7 @@ import io.gravitee.policy.api.swagger.Policy;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.api.SwaggerApiEntity;
 import io.gravitee.rest.api.model.api.UpdateApiEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.impl.SwaggerServiceImpl;
 import io.gravitee.rest.api.service.impl.swagger.policy.PolicyOperationVisitor;
 import io.gravitee.rest.api.service.impl.swagger.policy.PolicyOperationVisitorManager;
@@ -47,7 +48,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -93,8 +93,8 @@ public class SwaggerService_CreateAPITest {
         grp1.setId("group1");
         GroupEntity grp2 = new GroupEntity();
         grp2.setId("group2");
-        when(groupService.findByName("group1")).thenReturn(Arrays.asList(grp1));
-        when(groupService.findByName("group2")).thenReturn(Arrays.asList(grp2));
+        when(groupService.findByName(GraviteeContext.getCurrentEnvironment(), "group1")).thenReturn(Arrays.asList(grp1));
+        when(groupService.findByName(GraviteeContext.getCurrentEnvironment(), "group2")).thenReturn(Arrays.asList(grp2));
 
         TagEntity tag1 = new TagEntity();
         tag1.setId("tagId1");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ThemeServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ThemeServiceTest.java
@@ -231,6 +231,7 @@ public class ThemeServiceTest {
             );
         verify(auditService, times(1))
             .createEnvironmentAuditLog(
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(ImmutableMap.of(THEME, THEME_ID)),
                 eq(Theme.AuditEvent.THEME_CREATED),
                 any(Date.class),
@@ -303,6 +304,7 @@ public class ThemeServiceTest {
 
         verify(auditService, times(1))
             .createEnvironmentAuditLog(
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(ImmutableMap.of(THEME, THEME_ID)),
                 eq(Theme.AuditEvent.THEME_UPDATED),
                 any(Date.class),
@@ -369,6 +371,7 @@ public class ThemeServiceTest {
 
         verify(auditService, times(1))
             .createEnvironmentAuditLog(
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(ImmutableMap.of(THEME, THEME_ID)),
                 eq(Theme.AuditEvent.THEME_RESET),
                 any(Date.class),
@@ -387,6 +390,7 @@ public class ThemeServiceTest {
         verify(themeRepository, times(1)).delete(THEME_ID);
         verify(auditService, times(1))
             .createEnvironmentAuditLog(
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(ImmutableMap.of(THEME, THEME_ID)),
                 eq(Theme.AuditEvent.THEME_DELETED),
                 any(Date.class),
@@ -526,6 +530,7 @@ public class ThemeServiceTest {
             );
         verify(auditService, times(1))
             .createEnvironmentAuditLog(
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(ImmutableMap.of(THEME, THEME_ID)),
                 eq(Theme.AuditEvent.THEME_CREATED),
                 any(Date.class),
@@ -583,6 +588,7 @@ public class ThemeServiceTest {
             );
         verify(auditService, times(1))
             .createEnvironmentAuditLog(
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(ImmutableMap.of(THEME, THEME_ID)),
                 eq(Theme.AuditEvent.THEME_UPDATED),
                 any(Date.class),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/TicketServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/TicketServiceTest.java
@@ -37,6 +37,7 @@ import io.gravitee.rest.api.model.common.SortableImpl;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.service.builder.EmailNotificationBuilder;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.EmailRequiredException;
 import io.gravitee.rest.api.service.exceptions.SupportUnavailableException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
@@ -178,7 +179,7 @@ public class TicketServiceTest {
         when(user.getFirstname()).thenReturn(USER_FIRSTNAME);
         when(user.getLastname()).thenReturn(USER_LASTNAME);
         when(apiService.findByIdForTemplates(API_ID, true)).thenReturn(api);
-        when(applicationService.findById(APPLICATION_ID)).thenReturn(application);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(application);
 
         when(ticketRepository.create(any())).thenThrow(new TechnicalException());
 
@@ -203,7 +204,7 @@ public class TicketServiceTest {
         when(user.getFirstname()).thenReturn(USER_FIRSTNAME);
         when(user.getLastname()).thenReturn(USER_LASTNAME);
         when(apiService.findByIdForTemplates(API_ID, true)).thenReturn(api);
-        when(applicationService.findById(APPLICATION_ID)).thenReturn(application);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(application);
 
         Ticket ticketToCreate = new Ticket();
         ticketToCreate.setId("generatedId");
@@ -280,7 +281,7 @@ public class TicketServiceTest {
         when(ticketRepository.search(any(TicketCriteria.class), any(Sortable.class), any(Pageable.class)))
             .thenReturn(new Page<>(ticketList, 0, 20, 20));
         when(apiService.findById(API_ID)).thenReturn(apiEntity);
-        when(applicationService.findById(APPLICATION_ID)).thenReturn(appEntity);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(appEntity);
 
         TicketQuery query = new TicketQuery();
         query.setFromUser("fromUser");
@@ -341,7 +342,7 @@ public class TicketServiceTest {
 
         when(ticketRepository.findById("ticket1")).thenReturn(Optional.of(ticket));
         when(apiService.findById(API_ID)).thenReturn(apiEntity);
-        when(applicationService.findById(APPLICATION_ID)).thenReturn(appEntity);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(appEntity);
 
         TicketEntity ticketEntity = ticketService.findById("ticket1");
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/TokenServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/TokenServiceTest.java
@@ -35,6 +35,7 @@ import io.gravitee.repository.management.model.Token;
 import io.gravitee.rest.api.idp.api.authentication.UserDetails;
 import io.gravitee.rest.api.model.NewTokenEntity;
 import io.gravitee.rest.api.model.TokenEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.TokenNameAlreadyExistsException;
 import io.gravitee.rest.api.service.impl.TokenServiceImpl;
 import java.util.Collection;
@@ -196,7 +197,15 @@ public class TokenServiceTest {
 
         tokenService.create(newToken);
 
-        verify(auditService).createEnvironmentAuditLog(anyMap(), eq(TOKEN_CREATED), any(Date.class), isNull(), any());
+        verify(auditService)
+            .createEnvironmentAuditLog(
+                eq(GraviteeContext.getCurrentEnvironment()),
+                anyMap(),
+                eq(TOKEN_CREATED),
+                any(Date.class),
+                isNull(),
+                any()
+            );
         verify(tokenRepository).create(any());
         verify(tokenRepository).findByReference(eq(USER.name()), eq(USER_ID));
     }
@@ -215,7 +224,15 @@ public class TokenServiceTest {
     public void shouldRevoke() throws TechnicalException {
         tokenService.revoke(TOKEN_ID);
 
-        verify(auditService).createEnvironmentAuditLog(anyMap(), eq(TOKEN_DELETED), any(Date.class), isNull(), eq(token));
+        verify(auditService)
+            .createEnvironmentAuditLog(
+                eq(GraviteeContext.getCurrentEnvironment()),
+                anyMap(),
+                eq(TOKEN_DELETED),
+                any(Date.class),
+                isNull(),
+                eq(token)
+            );
         verify(tokenRepository).delete(TOKEN_ID);
     }
 
@@ -225,7 +242,15 @@ public class TokenServiceTest {
 
         tokenService.revokeByUser(USER_ID);
 
-        verify(auditService).createEnvironmentAuditLog(anyMap(), eq(TOKEN_DELETED), any(Date.class), isNull(), eq(token));
+        verify(auditService)
+            .createEnvironmentAuditLog(
+                eq(GraviteeContext.getCurrentEnvironment()),
+                anyMap(),
+                eq(TOKEN_DELETED),
+                any(Date.class),
+                isNull(),
+                eq(token)
+            );
         verify(tokenRepository).delete(TOKEN_ID);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/UserMetadataServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/UserMetadataServiceTest.java
@@ -41,6 +41,7 @@ import io.gravitee.rest.api.model.MetadataFormat;
 import io.gravitee.rest.api.model.NewUserMetadataEntity;
 import io.gravitee.rest.api.model.UpdateUserMetadataEntity;
 import io.gravitee.rest.api.model.UserMetadataEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.impl.UserMetadataServiceImpl;
 import java.util.Arrays;
 import java.util.Collections;
@@ -132,7 +133,15 @@ public class UserMetadataServiceTest {
             .put(Audit.AuditProperties.USER, USER_ID)
             .put(METADATA, newUserMetadata.getKey())
             .build();
-        verify(auditService).createOrganizationAuditLog(eq(properties), eq(METADATA_CREATED), any(), eq(null), eq(newUserMetadata));
+        verify(auditService)
+            .createOrganizationAuditLog(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(properties),
+                eq(METADATA_CREATED),
+                any(),
+                eq(null),
+                eq(newUserMetadata)
+            );
     }
 
     @Test
@@ -167,7 +176,15 @@ public class UserMetadataServiceTest {
             .put(Audit.AuditProperties.USER, USER_ID)
             .put(METADATA, toUserMetadata.getKey())
             .build();
-        verify(auditService).createOrganizationAuditLog(eq(properties), eq(METADATA_UPDATED), any(), any(), any());
+        verify(auditService)
+            .createOrganizationAuditLog(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(properties),
+                eq(METADATA_UPDATED),
+                any(),
+                any(),
+                any()
+            );
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/UserServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/UserServiceTest.java
@@ -49,6 +49,7 @@ import io.gravitee.rest.api.model.configuration.identity.SocialIdentityProviderE
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.JWTHelper;
 import io.gravitee.rest.api.service.exceptions.*;
 import io.gravitee.rest.api.service.impl.UserServiceImpl;
@@ -520,7 +521,8 @@ public class UserServiceTest {
         environment2.setId("envId2");
         EnvironmentEntity environment3 = new EnvironmentEntity();
         environment3.setId("envId3");
-        when(environmentService.findByUser(any())).thenReturn(Arrays.asList(environment1, environment2, environment3));
+        when(environmentService.findByUser(eq(GraviteeContext.getCurrentOrganization()), any()))
+            .thenReturn(Arrays.asList(environment1, environment2, environment3));
 
         ApplicationListItem defaultApp = new ApplicationListItem();
         defaultApp.setName("Default application");
@@ -529,8 +531,8 @@ public class UserServiceTest {
 
         userService.connect(USER_NAME);
 
-        verify(applicationService, times(1)).create(any(), eq(USER_NAME), eq("envId2"));
-        verify(applicationService, times(1)).create(any(), eq(USER_NAME), eq("envId3"));
+        verify(applicationService, times(1)).create(eq("envId2"), any(), eq(USER_NAME));
+        verify(applicationService, times(1)).create(eq("envId3"), any(), eq(USER_NAME));
     }
 
     @Test
@@ -541,7 +543,7 @@ public class UserServiceTest {
 
         userService.connect(USER_NAME);
 
-        verify(applicationService, never()).create(any(), eq(USER_NAME));
+        verify(applicationService, never()).create(eq(GraviteeContext.getCurrentEnvironment()), any(), eq(USER_NAME));
     }
 
     @Test
@@ -551,7 +553,7 @@ public class UserServiceTest {
 
         userService.connect(USER_NAME);
 
-        verify(applicationService, never()).create(any(), eq(USER_NAME));
+        verify(applicationService, never()).create(eq(GraviteeContext.getCurrentEnvironment()), any(), eq(USER_NAME));
     }
 
     @Test(expected = UserRegistrationUnavailableException.class)
@@ -609,7 +611,14 @@ public class UserServiceTest {
         userService.finalizeResetPassword(userEntity);
 
         verify(auditService)
-            .createOrganizationAuditLog(anyMap(), argThat(evt -> evt.equals(User.AuditEvent.PASSWORD_CHANGED)), any(), any(), any());
+            .createOrganizationAuditLog(
+                eq(GraviteeContext.getCurrentOrganization()),
+                anyMap(),
+                argThat(evt -> evt.equals(User.AuditEvent.PASSWORD_CHANGED)),
+                any(),
+                any(),
+                any()
+            );
     }
 
     @Test(expected = PasswordFormatInvalidException.class)
@@ -916,7 +925,8 @@ public class UserServiceTest {
         PrimaryOwnerEntity primaryOwnerEntity = mock(PrimaryOwnerEntity.class);
         when(applicationListItem.getPrimaryOwner()).thenReturn(primaryOwnerEntity);
         when(primaryOwnerEntity.getId()).thenReturn(USER_NAME);
-        when(applicationService.findByUser(USER_NAME)).thenReturn(Collections.singleton(applicationListItem));
+        when(applicationService.findByUser(GraviteeContext.getCurrentOrganization(), GraviteeContext.getCurrentEnvironment(), USER_NAME))
+            .thenReturn(Collections.singleton(applicationListItem));
 
         try {
             userService.delete(USER_NAME);
@@ -936,7 +946,8 @@ public class UserServiceTest {
         String lastName = "last";
         String email = "email";
         when(apiService.findByUser(userId, null, false)).thenReturn(Collections.emptySet());
-        when(applicationService.findByUser(userId)).thenReturn(Collections.emptySet());
+        when(applicationService.findByUser(GraviteeContext.getCurrentOrganization(), GraviteeContext.getCurrentEnvironment(), userId))
+            .thenReturn(Collections.emptySet());
         User user = new User();
         user.setId(userId);
         user.setSourceId("sourceId");
@@ -950,7 +961,8 @@ public class UserServiceTest {
         userService.delete(userId);
 
         verify(apiService, times(1)).findByUser(userId, null, false);
-        verify(applicationService, times(1)).findByUser(userId);
+        verify(applicationService, times(1))
+            .findByUser(GraviteeContext.getCurrentOrganization(), GraviteeContext.getCurrentEnvironment(), userId);
         verify(membershipService, times(1)).removeMemberMemberships(MembershipMemberType.USER, userId);
         verify(userRepository, times(1))
             .update(
@@ -987,7 +999,8 @@ public class UserServiceTest {
         String lastName = "last";
         String email = "email";
         when(apiService.findByUser(userId, null, false)).thenReturn(Collections.emptySet());
-        when(applicationService.findByUser(userId)).thenReturn(Collections.emptySet());
+        when(applicationService.findByUser(GraviteeContext.getCurrentOrganization(), GraviteeContext.getCurrentEnvironment(), userId))
+            .thenReturn(Collections.emptySet());
         User user = new User();
         user.setId(userId);
         user.setSourceId("sourceId");
@@ -1002,7 +1015,8 @@ public class UserServiceTest {
         userService.delete(userId);
 
         verify(apiService, times(1)).findByUser(userId, null, false);
-        verify(applicationService, times(1)).findByUser(userId);
+        verify(applicationService, times(1))
+            .findByUser(GraviteeContext.getCurrentOrganization(), GraviteeContext.getCurrentEnvironment(), userId);
         verify(membershipService, times(1)).removeMemberMemberships(MembershipMemberType.USER, userId);
         verify(userRepository, times(1))
             .update(
@@ -1135,6 +1149,8 @@ public class UserServiceTest {
         //verify group creations
         verify(membershipService, never())
             .addRoleToMemberOnReference(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
                 any(MembershipService.MembershipReference.class),
                 any(MembershipService.MembershipMember.class),
                 any(MembershipService.MembershipRole.class)
@@ -1155,9 +1171,12 @@ public class UserServiceTest {
         when(userRepository.findBySource("oauth2", "janedoe@example.com", ORGANIZATION)).thenReturn(Optional.empty());
 
         //mock group search and association
-        when(groupService.findById("Example group")).thenReturn(mockGroupEntity("group_id_1", "Example group"));
-        when(groupService.findById("soft user")).thenReturn(mockGroupEntity("group_id_2", "soft user"));
-        when(groupService.findById("Api consumer")).thenReturn(mockGroupEntity("group_id_4", "Api consumer"));
+        when(groupService.findById(GraviteeContext.getCurrentEnvironment(), "Example group"))
+            .thenReturn(mockGroupEntity("group_id_1", "Example group"));
+        when(groupService.findById(GraviteeContext.getCurrentEnvironment(), "soft user"))
+            .thenReturn(mockGroupEntity("group_id_2", "soft user"));
+        when(groupService.findById(GraviteeContext.getCurrentEnvironment(), "Api consumer"))
+            .thenReturn(mockGroupEntity("group_id_4", "Api consumer"));
 
         // mock role search
         RoleEntity roleOrganizationAdmin = mockRoleEntity(RoleScope.ORGANIZATION, "ADMIN");
@@ -1173,6 +1192,8 @@ public class UserServiceTest {
 
         when(
             membershipService.updateRolesToMemberOnReferenceBySource(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(new MembershipService.MembershipReference(MembershipReferenceType.GROUP, "group_id_1")),
                 eq(new MembershipService.MembershipMember("janedoe@example.com", null, MembershipMemberType.USER)),
                 argThat(
@@ -1187,6 +1208,8 @@ public class UserServiceTest {
 
         when(
             membershipService.updateRolesToMemberOnReferenceBySource(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(new MembershipService.MembershipReference(MembershipReferenceType.GROUP, "group_id_2")),
                 eq(new MembershipService.MembershipMember("janedoe@example.com", null, MembershipMemberType.USER)),
                 argThat(
@@ -1201,6 +1224,8 @@ public class UserServiceTest {
 
         when(
             membershipService.updateRolesToMemberOnReferenceBySource(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(new MembershipService.MembershipReference(MembershipReferenceType.GROUP, "group_id_4")),
                 eq(new MembershipService.MembershipMember("janedoe@example.com", null, MembershipMemberType.USER)),
                 argThat(
@@ -1215,6 +1240,8 @@ public class UserServiceTest {
 
         when(
             membershipService.updateRolesToMemberOnReferenceBySource(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(new MembershipService.MembershipReference(MembershipReferenceType.ORGANIZATION, "DEFAULT")),
                 eq(new MembershipService.MembershipMember("janedoe@example.com", null, MembershipMemberType.USER)),
                 argThat(
@@ -1233,6 +1260,8 @@ public class UserServiceTest {
         //verify group creations
         verify(membershipService, times(1))
             .updateRolesToMemberOnReferenceBySource(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(new MembershipService.MembershipReference(MembershipReferenceType.GROUP, "group_id_1")),
                 eq(new MembershipService.MembershipMember("janedoe@example.com", null, MembershipMemberType.USER)),
                 argThat(
@@ -1245,6 +1274,8 @@ public class UserServiceTest {
 
         verify(membershipService, times(1))
             .updateRolesToMemberOnReferenceBySource(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(new MembershipService.MembershipReference(MembershipReferenceType.GROUP, "group_id_2")),
                 eq(new MembershipService.MembershipMember("janedoe@example.com", null, MembershipMemberType.USER)),
                 argThat(
@@ -1257,6 +1288,8 @@ public class UserServiceTest {
 
         verify(membershipService, times(0))
             .updateRolesToMemberOnReferenceBySource(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(new MembershipService.MembershipReference(MembershipReferenceType.GROUP, "group_id_3")),
                 eq(new MembershipService.MembershipMember("janedoe@example.com", null, MembershipMemberType.USER)),
                 argThat(
@@ -1269,6 +1302,8 @@ public class UserServiceTest {
 
         verify(membershipService, times(1))
             .updateRolesToMemberOnReferenceBySource(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(new MembershipService.MembershipReference(MembershipReferenceType.GROUP, "group_id_4")),
                 eq(new MembershipService.MembershipMember("janedoe@example.com", null, MembershipMemberType.USER)),
                 argThat(
@@ -1281,6 +1316,8 @@ public class UserServiceTest {
 
         verify(membershipService, times(1))
             .updateRolesToMemberOnReferenceBySource(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(new MembershipService.MembershipReference(MembershipReferenceType.ORGANIZATION, "DEFAULT")),
                 eq(new MembershipService.MembershipMember("janedoe@example.com", null, MembershipMemberType.USER)),
                 argThat(
@@ -1306,9 +1343,12 @@ public class UserServiceTest {
         when(userRepository.findBySource("oauth2", "janedoe@example.com", ORGANIZATION)).thenReturn(Optional.empty());
 
         //mock group search and association
-        when(groupService.findById("Example group")).thenReturn(mockGroupEntity("group_id_1", "Example group"));
-        when(groupService.findById("soft user")).thenReturn(mockGroupEntity("group_id_2", "soft user"));
-        when(groupService.findById("Api consumer")).thenReturn(mockGroupEntity("group_id_4", "Api consumer"));
+        when(groupService.findById(GraviteeContext.getCurrentEnvironment(), "Example group"))
+            .thenReturn(mockGroupEntity("group_id_1", "Example group"));
+        when(groupService.findById(GraviteeContext.getCurrentEnvironment(), "soft user"))
+            .thenReturn(mockGroupEntity("group_id_2", "soft user"));
+        when(groupService.findById(GraviteeContext.getCurrentEnvironment(), "Api consumer"))
+            .thenReturn(mockGroupEntity("group_id_4", "Api consumer"));
 
         // mock role search
         RoleEntity roleOrganizationAdmin = mockRoleEntity(RoleScope.ORGANIZATION, "ADMIN");
@@ -1339,6 +1379,8 @@ public class UserServiceTest {
 
         when(
             membershipService.updateRolesToMemberOnReferenceBySource(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(new MembershipService.MembershipReference(MembershipReferenceType.GROUP, "group_id_1")),
                 eq(new MembershipService.MembershipMember("janedoe@example.com", null, MembershipMemberType.USER)),
                 argThat(
@@ -1353,6 +1395,8 @@ public class UserServiceTest {
 
         when(
             membershipService.updateRolesToMemberOnReferenceBySource(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(new MembershipService.MembershipReference(MembershipReferenceType.GROUP, "group_id_2")),
                 eq(new MembershipService.MembershipMember("janedoe@example.com", null, MembershipMemberType.USER)),
                 argThat(
@@ -1367,6 +1411,8 @@ public class UserServiceTest {
 
         when(
             membershipService.updateRolesToMemberOnReferenceBySource(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(new MembershipService.MembershipReference(MembershipReferenceType.GROUP, "group_id_4")),
                 eq(new MembershipService.MembershipMember("janedoe@example.com", null, MembershipMemberType.USER)),
                 argThat(
@@ -1381,6 +1427,8 @@ public class UserServiceTest {
 
         when(
             membershipService.updateRolesToMemberOnReferenceBySource(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(new MembershipService.MembershipReference(MembershipReferenceType.ORGANIZATION, "DEFAULT")),
                 eq(new MembershipService.MembershipMember("janedoe@example.com", null, MembershipMemberType.USER)),
                 argThat(
@@ -1399,6 +1447,8 @@ public class UserServiceTest {
         //verify group creations
         verify(membershipService, times(1))
             .updateRolesToMemberOnReferenceBySource(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(new MembershipService.MembershipReference(MembershipReferenceType.GROUP, "group_id_1")),
                 eq(new MembershipService.MembershipMember("janedoe@example.com", null, MembershipMemberType.USER)),
                 argThat(
@@ -1411,6 +1461,8 @@ public class UserServiceTest {
 
         verify(membershipService, times(1))
             .updateRolesToMemberOnReferenceBySource(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(new MembershipService.MembershipReference(MembershipReferenceType.GROUP, "group_id_2")),
                 eq(new MembershipService.MembershipMember("janedoe@example.com", null, MembershipMemberType.USER)),
                 argThat(
@@ -1423,6 +1475,8 @@ public class UserServiceTest {
 
         verify(membershipService, times(0))
             .updateRolesToMemberOnReferenceBySource(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(new MembershipService.MembershipReference(MembershipReferenceType.GROUP, "group_id_3")),
                 eq(new MembershipService.MembershipMember("janedoe@example.com", null, MembershipMemberType.USER)),
                 argThat(
@@ -1435,6 +1489,8 @@ public class UserServiceTest {
 
         verify(membershipService, times(1))
             .updateRolesToMemberOnReferenceBySource(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(new MembershipService.MembershipReference(MembershipReferenceType.GROUP, "group_id_4")),
                 eq(new MembershipService.MembershipMember("janedoe@example.com", null, MembershipMemberType.USER)),
                 argThat(
@@ -1447,6 +1503,8 @@ public class UserServiceTest {
 
         verify(membershipService, times(1))
             .updateRolesToMemberOnReferenceBySource(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(new MembershipService.MembershipReference(MembershipReferenceType.ORGANIZATION, "DEFAULT")),
                 eq(new MembershipService.MembershipMember("janedoe@example.com", null, MembershipMemberType.USER)),
                 argThat(
@@ -1459,6 +1517,8 @@ public class UserServiceTest {
 
         verify(membershipService, times(1))
             .deleteReferenceMemberBySource(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
                 eq(MembershipReferenceType.GROUP),
                 eq("membershipId"),
                 eq(MembershipMemberType.USER),
@@ -1485,6 +1545,8 @@ public class UserServiceTest {
         //verify group creations
         verify(membershipService, never())
             .addRoleToMemberOnReference(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
                 any(MembershipService.MembershipReference.class),
                 any(MembershipService.MembershipMember.class),
                 any(MembershipService.MembershipRole.class)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/MembershipCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/MembershipCommandHandlerTest.java
@@ -34,6 +34,7 @@ import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
 import io.reactivex.observers.TestObserver;
 import java.util.List;
@@ -111,6 +112,8 @@ public class MembershipCommandHandlerTest {
 
         verify(membershipService)
             .updateRolesToMemberOnReference(
+                eq("orga#1"),
+                eq(GraviteeContext.getCurrentEnvironment()),
                 membershipReference.capture(),
                 membershipMember.capture(),
                 membershipRoles.capture(),
@@ -169,6 +172,8 @@ public class MembershipCommandHandlerTest {
 
         verify(membershipService)
             .updateRolesToMemberOnReference(
+                eq("orga#1"),
+                eq(GraviteeContext.getCurrentEnvironment()),
                 membershipReference.capture(),
                 membershipMember.capture(),
                 membershipRoles.capture(),
@@ -227,6 +232,8 @@ public class MembershipCommandHandlerTest {
 
         verify(membershipService)
             .updateRolesToMemberOnReference(
+                eq("orga#1"),
+                eq(GraviteeContext.getCurrentEnvironment()),
                 membershipReference.capture(),
                 membershipMember.capture(),
                 membershipRoles.capture(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/promotion/PromotionServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/promotion/PromotionServiceTest.java
@@ -214,7 +214,13 @@ public class PromotionServiceTest {
 
         when(promotionRepository.update(any())).thenReturn(getAPromotion());
 
-        promotionService.processPromotion(PROMOTION_ID, true, USER_ID);
+        promotionService.processPromotion(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
+            PROMOTION_ID,
+            true,
+            USER_ID
+        );
 
         verify(apiDuplicatorService, times(1)).createWithImportedDefinition(any(), eq(USER_ID), any(), any());
         verify(promotionRepository, times(1)).update(any());
@@ -241,7 +247,13 @@ public class PromotionServiceTest {
 
         when(promotionRepository.update(any())).thenReturn(getAPromotion());
 
-        promotionService.processPromotion(PROMOTION_ID, true, USER_ID);
+        promotionService.processPromotion(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
+            PROMOTION_ID,
+            true,
+            USER_ID
+        );
 
         verify(apiDuplicatorService, times(1)).updateWithImportedDefinition(any(), any(), eq(USER_ID), any(), any());
         verify(promotionRepository, times(1)).update(any());
@@ -260,7 +272,13 @@ public class PromotionServiceTest {
 
         when(promotionRepository.update(any())).thenReturn(getAPromotion());
 
-        promotionService.processPromotion(PROMOTION_ID, false, USER_ID);
+        promotionService.processPromotion(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
+            PROMOTION_ID,
+            false,
+            USER_ID
+        );
 
         verify(apiDuplicatorService, never()).createWithImportedDefinition(any(), eq(USER_ID), any(), any());
         verify(apiDuplicatorService, never()).updateWithImportedDefinition(any(), any(), eq(USER_ID), any(), any());
@@ -271,7 +289,13 @@ public class PromotionServiceTest {
     public void shouldNotProcessPromotionIfPromotionNotFound() throws Exception {
         when(promotionRepository.findById(any())).thenReturn(Optional.empty());
 
-        promotionService.processPromotion(PROMOTION_ID, true, USER_ID);
+        promotionService.processPromotion(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
+            PROMOTION_ID,
+            true,
+            USER_ID
+        );
     }
 
     @Test(expected = ForbiddenAccessException.class)
@@ -284,7 +308,13 @@ public class PromotionServiceTest {
 
         when(permissionService.hasPermission(any(), any(), any())).thenReturn(false);
 
-        promotionService.processPromotion(PROMOTION_ID, true, USER_ID);
+        promotionService.processPromotion(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
+            PROMOTION_ID,
+            true,
+            USER_ID
+        );
     }
 
     @Test(expected = BridgeOperationException.class)
@@ -306,7 +336,13 @@ public class PromotionServiceTest {
         CockpitReply<PromotionEntity> cockpitReply = new CockpitReply<>(null, CockpitReplyStatus.ERROR);
         when(cockpitService.processPromotion(any())).thenReturn(cockpitReply);
 
-        promotionService.processPromotion(PROMOTION_ID, true, USER_ID);
+        promotionService.processPromotion(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
+            PROMOTION_ID,
+            true,
+            USER_ID
+        );
 
         verify(apiDuplicatorService, times(1)).updateWithImportedDefinition(any(), any(), eq(USER_ID), any(), any());
         verify(promotionRepository, times(0)).update(any());
@@ -328,7 +364,12 @@ public class PromotionServiceTest {
 
         when(promotionRepository.update(any())).thenReturn(mock(Promotion.class));
 
-        final PromotionEntity promotionEntity = promotionService.promote("api#1", getAPromotionRequestEntity(), "user#1");
+        final PromotionEntity promotionEntity = promotionService.promote(
+            GraviteeContext.getCurrentEnvironment(),
+            "api#1",
+            getAPromotionRequestEntity(),
+            "user#1"
+        );
 
         assertThat(promotionEntity).isNotNull();
         verify(auditService).createApiAuditLog(eq("api#1"), any(), eq(PROMOTION_CREATED), any(), isNull(), any());
@@ -357,7 +398,7 @@ public class PromotionServiceTest {
 
         PromotionRequestEntity promotionRequestEntity = getAPromotionRequestEntity();
         promotionRequestEntity.setTargetEnvCockpitId(targetEnvCockpitId);
-        promotionService.promote("api#1", promotionRequestEntity, "user#1");
+        promotionService.promote(GraviteeContext.getCurrentEnvironment(), "api#1", promotionRequestEntity, "user#1");
     }
 
     private UserEntity getAUserEntity() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-subscription-pre-expiration-notif/src/main/java/io/gravitee/rest/api/services/subscriptionpreexpirationnotif/ScheduledSubscriptionPreExpirationNotificationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-subscription-pre-expiration-notif/src/main/java/io/gravitee/rest/api/services/subscriptionpreexpirationnotif/ScheduledSubscriptionPreExpirationNotificationService.java
@@ -143,7 +143,7 @@ public class ScheduledSubscriptionPreExpirationNotificationService extends Abstr
         SubscriptionEntity subscription = subscriptionService.findById(apiKey.getSubscription());
         ApiEntity api = apiService.findById(subscription.getApi());
         PlanEntity plan = planService.findById(subscription.getPlan());
-        ApplicationEntity application = applicationService.findById(subscription.getApplication());
+        ApplicationEntity application = applicationService.findById(GraviteeContext.getCurrentEnvironment(), subscription.getApplication());
 
         findEmailsToNotify(subscription, application)
             .forEach(email -> this.sendEmail(email, daysToExpiration, api, plan, application, apiKey));
@@ -155,7 +155,7 @@ public class ScheduledSubscriptionPreExpirationNotificationService extends Abstr
         ApiEntity api = apiService.findById(subscription.getApi());
         PlanEntity plan = planService.findById(subscription.getPlan());
 
-        ApplicationEntity application = applicationService.findById(subscription.getApplication());
+        ApplicationEntity application = applicationService.findById(GraviteeContext.getCurrentEnvironment(), subscription.getApplication());
 
         findEmailsToNotify(subscription, application)
             .forEach(email -> this.sendEmail(email, daysToExpiration, api, plan, application, null));


### PR DESCRIPTION
**Issue**

Related to:
 - https://github.com/gravitee-io/issues/issues/6071
 - https://github.com/gravitee-io/gravitee-api-management/pull/854

Fix: 
 - https://github.com/gravitee-io/issues/issues/6488
 - Create an OrganizationAuditLog instead of an Env one when dealing with Entrypoint https://github.com/gravitee-io/gravitee-api-management/pull/971/commits/7dd4d78ed29fdaafa3f5ef97343d6a127790daec

**Description**

During the implementation of the multi-env feature, a `GraviteeContext` based on a thread-local variable has been introduced. Everything works fine a service methods are executed after a call to the rest APIs directly as the Environment and Organization are properly set according to the Path Params. 

BUT when dealing with more complex processes with multiple services calls (like in the login) or asynchronous processes (like with Cockpit commands) the `GraviteeContext` variables aren't usable anymore as they always contain the same env/org. 

To fix that issue this PR starts to remove all calls to `GraviteeContext` from Services, to move them to the Resouce layer. Pretty much all the changes from this PR were done automatically by using IntelliJ refactoring capabilities, meaning it can't have introduced regression (as a drawback, there could have some duplications). Also, it has highlight multiple weird behaviors that will need extra investigation, I've annotated some of them with a `FIXME` and I will add comment on the PR.


**How to tests**

 - All the unit tests should be 🟢 
 - Postman tests should be 🟢 
 - You should not face login issues when the scenario from https://github.com/gravitee-io/issues/issues/6488#issuecomment-995973344: 
    - Linked your APIM installation to cockpit and create multiple env
    - Create an account but don’t log in right now
    - An admin update your user to set you a role to another environment
    - You then try to login 🚀 

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/remove-current-context-from-services-part-1/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
