### PR TITLE
feat(headers): Rework HTTP headers to re-use internal structure

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -46,51 +46,51 @@
     <properties>
         <!-- Versions of the plugins for the full distribution -->
         <!-- Management API & Gateway -->
-        <gravitee-connector-http.version>1.0.0</gravitee-connector-http.version>
-        <gravitee-connector-kafka.version>1.0.1</gravitee-connector-kafka.version>
-        <gravitee-policy-apikey.version>2.3.0</gravitee-policy-apikey.version>
+        <gravitee-connector-http.version>1.1.0-SNAPSHOT</gravitee-connector-http.version>
+        <gravitee-connector-kafka.version>1.1.0-SNAPSHOT</gravitee-connector-kafka.version>
+        <gravitee-policy-apikey.version>2.4.0-SNAPSHOT</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>1.5.0</gravitee-policy-assign-attributes.version>
-        <gravitee-policy-assign-content.version>1.6.0</gravitee-policy-assign-content.version>
-        <gravitee-policy-cache.version>1.13.0</gravitee-policy-cache.version>
-        <gravitee-policy-callout-http.version>1.14.0</gravitee-policy-callout-http.version>
+        <gravitee-policy-assign-content.version>1.7.0-SNAPSHOT</gravitee-policy-assign-content.version>
+        <gravitee-policy-cache.version>1.14.0-SNAPSHOT</gravitee-policy-cache.version>
+        <gravitee-policy-callout-http.version>1.15.0-SNAPSHOT</gravitee-policy-callout-http.version>
         <gravitee-policy-dynamic-routing.version>1.11.1</gravitee-policy-dynamic-routing.version>
-        <gravitee-policy-generate-http-signature.version>1.0.0</gravitee-policy-generate-http-signature.version>
+        <gravitee-policy-generate-http-signature.version>1.1.0-SNAPSHOT</gravitee-policy-generate-http-signature.version>
         <gravitee-policy-generate-jwt.version>1.5.0</gravitee-policy-generate-jwt.version>
-        <gravitee-policy-groovy.version>1.16.0</gravitee-policy-groovy.version>
+        <gravitee-policy-groovy.version>2.1.0-SNAPSHOT</gravitee-policy-groovy.version>
         <gravitee-policy-html-json.version>1.6.0</gravitee-policy-html-json.version>
-        <gravitee-policy-http-signature.version>1.4.0</gravitee-policy-http-signature.version>
-        <gravitee-policy-ipfiltering.version>1.8.0</gravitee-policy-ipfiltering.version>
-        <gravitee-policy-json-threat-protection.version>1.2.2</gravitee-policy-json-threat-protection.version>
+        <gravitee-policy-http-signature.version>1.5.0-SNAPSHOT</gravitee-policy-http-signature.version>
+        <gravitee-policy-ipfiltering.version>1.9.0-SNAPSHOT</gravitee-policy-ipfiltering.version>
+        <gravitee-policy-json-threat-protection.version>1.3.0-SNAPSHOT</gravitee-policy-json-threat-protection.version>
         <gravitee-policy-json-to-json.version>1.6.0</gravitee-policy-json-to-json.version>
         <gravitee-policy-json-validation.version>1.6.0</gravitee-policy-json-validation.version>
-        <gravitee-policy-json-xml.version>1.0.0</gravitee-policy-json-xml.version>
+        <gravitee-policy-json-xml.version>1.1.0-SNAPSHOT</gravitee-policy-json-xml.version>
         <gravitee-policy-jws.version>1.3.0</gravitee-policy-jws.version>
-        <gravitee-policy-jwt.version>1.21.0</gravitee-policy-jwt.version>
+        <gravitee-policy-jwt.version>1.22.0-SNAPSHOT</gravitee-policy-jwt.version>
         <gravitee-policy-keyless.version>1.4.0</gravitee-policy-keyless.version>
         <gravitee-policy-latency.version>1.4.0</gravitee-policy-latency.version>
-        <gravitee-policy-metrics-reporter.version>1.1.0</gravitee-policy-metrics-reporter.version>
-        <gravitee-policy-mock.version>1.12.0</gravitee-policy-mock.version>
-        <gravitee-policy-oauth2.version>1.18.0</gravitee-policy-oauth2.version>
-        <gravitee-policy-openid-connect-userinfo.version>1.4.0</gravitee-policy-openid-connect-userinfo.version>
+        <gravitee-policy-metrics-reporter.version>1.2.0-SNAPSHOT</gravitee-policy-metrics-reporter.version>
+        <gravitee-policy-mock.version>1.13.0-SNAPSHOT</gravitee-policy-mock.version>
+        <gravitee-policy-oauth2.version>1.19.0-SNAPSHOT</gravitee-policy-oauth2.version>
+        <gravitee-policy-openid-connect-userinfo.version>1.5.0-SNAPSHOT</gravitee-policy-openid-connect-userinfo.version>
         <gravitee-policy-override-http-method.version>1.3.0</gravitee-policy-override-http-method.version>
         <!--	Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit	-->
         <!--	<gravitee-policy-quota.version>1.13.0</gravitee-policy-quota.version>	-->
         <!--	<gravitee-policy-spikearrest.version>1.13.0</gravitee-policy-spikearrest.version>	-->
-        <gravitee-policy-ratelimit.version>1.14.0</gravitee-policy-ratelimit.version>
-        <gravitee-policy-regex-threat-protection.version>1.2.0</gravitee-policy-regex-threat-protection.version>
-        <gravitee-policy-request-content-limit.version>1.7.0</gravitee-policy-request-content-limit.version>
-        <gravitee-policy-request-validation.version>1.12.0</gravitee-policy-request-validation.version>
+        <gravitee-policy-ratelimit.version>1.15.0-SNAPSHOT</gravitee-policy-ratelimit.version>
+        <gravitee-policy-regex-threat-protection.version>1.3.0-SNAPSHOT</gravitee-policy-regex-threat-protection.version>
+        <gravitee-policy-request-content-limit.version>1.8.0-SNAPSHOT</gravitee-policy-request-content-limit.version>
+        <gravitee-policy-request-validation.version>1.13.0-SNAPSHOT</gravitee-policy-request-validation.version>
         <gravitee-policy-resource-filtering.version>1.8.0</gravitee-policy-resource-filtering.version>
         <gravitee-policy-rest-to-soap.version>1.12.0</gravitee-policy-rest-to-soap.version>
-        <gravitee-policy-retry.version>2.0.0</gravitee-policy-retry.version>
+        <gravitee-policy-retry.version>2.1.0-SNAPSHOT</gravitee-policy-retry.version>
         <gravitee-policy-role-based-access-control.version>1.1.0</gravitee-policy-role-based-access-control.version>
         <gravitee-policy-ssl-enforcement.version>1.2.0</gravitee-policy-ssl-enforcement.version>
         <gravitee-policy-traffic-shadowing.version>1.1.0</gravitee-policy-traffic-shadowing.version>
-        <gravitee-policy-transformheaders.version>1.8.2</gravitee-policy-transformheaders.version>
+        <gravitee-policy-transformheaders.version>1.9.0-SNAPSHOT</gravitee-policy-transformheaders.version>
         <gravitee-policy-transformqueryparams.version>1.6.0</gravitee-policy-transformqueryparams.version>
-        <gravitee-policy-url-rewriting.version>1.4.0</gravitee-policy-url-rewriting.version>
-        <gravitee-policy-xml-json.version>1.7.0</gravitee-policy-xml-json.version>
-        <gravitee-policy-xml-threat-protection.version>1.2.1</gravitee-policy-xml-threat-protection.version>
+        <gravitee-policy-url-rewriting.version>1.5.0-SNAPSHOT</gravitee-policy-url-rewriting.version>
+        <gravitee-policy-xml-json.version>1.8.0-SNAPSHOT</gravitee-policy-xml-json.version>
+        <gravitee-policy-xml-threat-protection.version>1.3.0-SNAPSHOT</gravitee-policy-xml-threat-protection.version>
         <gravitee-policy-xml-validation.version>1.1.0</gravitee-policy-xml-validation.version>
         <gravitee-policy-xslt.version>1.6.0</gravitee-policy-xslt.version>
         <gravitee-resource-cache.version>1.7.0-SNAPSHOT</gravitee-resource-cache.version>
@@ -107,8 +107,8 @@
         <gravitee-repository-elasticsearch.version>3.10.0-SNAPSHOT</gravitee-repository-elasticsearch.version>
         <!-- Gateway Only -->
         <gravitee-reporter-elasticsearch.version>3.10.0-SNAPSHOT</gravitee-reporter-elasticsearch.version>
-        <gravitee-reporter-file.version>2.4.3</gravitee-reporter-file.version>
-        <gravitee-reporter-tcp.version>1.3.3</gravitee-reporter-tcp.version>
+        <gravitee-reporter-file.version>2.5.0-SNAPSHOT</gravitee-reporter-file.version>
+        <gravitee-reporter-tcp.version>1.4.0-SNAPSHOT</gravitee-reporter-tcp.version>
         <!--	Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit	-->
         <!--	<gravitee-gateway-services-ratelimit.version>1.13.0</gravitee-gateway-services-ratelimit.version>	-->
         <gravitee-tracer-jaeger.version>1.0.1</gravitee-tracer-jaeger.version>

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -82,7 +82,7 @@
         <gravitee-policy-request-validation.version>1.13.0-SNAPSHOT</gravitee-policy-request-validation.version>
         <gravitee-policy-resource-filtering.version>1.8.0</gravitee-policy-resource-filtering.version>
         <gravitee-policy-rest-to-soap.version>1.12.0</gravitee-policy-rest-to-soap.version>
-        <gravitee-policy-retry.version>2.1.0-SNAPSHOT</gravitee-policy-retry.version>
+        <gravitee-policy-retry.version>2.0.0.7327</gravitee-policy-retry.version>
         <gravitee-policy-role-based-access-control.version>1.1.0</gravitee-policy-role-based-access-control.version>
         <gravitee-policy-ssl-enforcement.version>1.2.0</gravitee-policy-ssl-enforcement.version>
         <gravitee-policy-traffic-shadowing.version>1.1.0</gravitee-policy-traffic-shadowing.version>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/endpoint/factory/impl/EndpointFactoryImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/endpoint/factory/impl/EndpointFactoryImpl.java
@@ -16,7 +16,6 @@
 package io.gravitee.gateway.core.endpoint.factory.impl;
 
 import io.gravitee.common.component.Lifecycle;
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.connector.api.Connection;
 import io.gravitee.connector.api.Connector;
 import io.gravitee.connector.api.Response;
@@ -24,6 +23,7 @@ import io.gravitee.definition.model.Endpoint;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.api.http2.HttpFrame;
 import io.gravitee.gateway.api.processor.ProcessorFailure;
 import io.gravitee.gateway.api.proxy.ProxyConnection;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/failover/FailoverInvoker.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/failover/FailoverInvoker.java
@@ -15,13 +15,13 @@
  */
 package io.gravitee.gateway.core.failover;
 
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.context.MutableExecutionContext;
 import io.gravitee.gateway.api.endpoint.resolver.EndpointResolver;
 import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.api.proxy.ProxyConnection;
 import io.gravitee.gateway.api.proxy.ProxyResponse;
 import io.gravitee.gateway.api.stream.ReadStream;
@@ -192,7 +192,7 @@ public class FailoverInvoker extends EndpointInvoker {
 
         @Override
         public HttpHeaders headers() {
-            return new HttpHeaders();
+            return HttpHeaders.create();
         }
 
         @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/logging/LoggableClientRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/logging/LoggableClientRequest.java
@@ -17,12 +17,13 @@ package io.gravitee.gateway.core.logging;
 
 import static io.gravitee.gateway.core.logging.utils.LoggingUtils.isContentTypeLoggable;
 
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.RequestWrapper;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.api.stream.ReadStream;
 import io.gravitee.gateway.core.logging.utils.LoggingUtils;
 import io.gravitee.reporter.api.log.Log;
@@ -53,7 +54,7 @@ public class LoggableClientRequest extends RequestWrapper {
         log.getClientRequest().setUri(this.uri());
 
         if (LoggingUtils.isRequestHeadersLoggable(context)) {
-            log.getClientRequest().setHeaders(new HttpHeaders(this.headers()));
+            log.getClientRequest().setHeaders(HttpHeaders.create(this.headers()));
         }
     }
 
@@ -63,7 +64,7 @@ public class LoggableClientRequest extends RequestWrapper {
             chunk -> {
                 if (buffer == null) {
                     buffer = Buffer.buffer();
-                    isContentTypeLoggable = isContentTypeLoggable(request.headers().contentType(), context);
+                    isContentTypeLoggable = isContentTypeLoggable(request.headers().get(HttpHeaderNames.CONTENT_TYPE), context);
                 }
                 bodyHandler.handle(chunk);
                 if (isContentTypeLoggable && LoggingUtils.isRequestPayloadsLoggable(context)) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/logging/LoggableClientResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/logging/LoggableClientResponse.java
@@ -17,12 +17,13 @@ package io.gravitee.gateway.core.logging;
 
 import static io.gravitee.gateway.core.logging.utils.LoggingUtils.isContentTypeLoggable;
 
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.api.http2.HttpFrame;
 import io.gravitee.gateway.api.stream.WriteStream;
 import io.gravitee.gateway.core.logging.utils.LoggingUtils;
@@ -52,7 +53,7 @@ public class LoggableClientResponse implements Response {
     public WriteStream<Buffer> write(Buffer chunk) {
         if (buffer == null) {
             buffer = Buffer.buffer();
-            isContentTypeLoggable = isContentTypeLoggable(response.headers().contentType(), context);
+            isContentTypeLoggable = isContentTypeLoggable(response.headers().get(HttpHeaderNames.CONTENT_TYPE), context);
         }
 
         if (isContentTypeLoggable && LoggingUtils.isResponsePayloadsLoggable(context)) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/logging/LoggableProxyConnection.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/logging/LoggableProxyConnection.java
@@ -17,10 +17,11 @@ package io.gravitee.gateway.core.logging;
 
 import static io.gravitee.gateway.core.logging.utils.LoggingUtils.*;
 
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.api.proxy.ProxyConnection;
 import io.gravitee.gateway.api.proxy.ProxyRequest;
 import io.gravitee.gateway.api.proxy.ProxyResponse;
@@ -97,7 +98,7 @@ public class LoggableProxyConnection implements ProxyConnection {
     public WriteStream<Buffer> write(Buffer chunk) {
         if (buffer == null) {
             buffer = Buffer.buffer();
-            isContentTypeLoggable = isContentTypeLoggable(proxyRequest.headers().contentType(), context);
+            isContentTypeLoggable = isContentTypeLoggable(proxyRequest.headers().get(HttpHeaderNames.CONTENT_TYPE), context);
         }
 
         proxyConnection.write(chunk);
@@ -164,7 +165,7 @@ public class LoggableProxyConnection implements ProxyConnection {
                 chunk -> {
                     if (buffer == null) {
                         buffer = Buffer.buffer();
-                        isContentTypeLoggable = isContentTypeLoggable(proxyResponse.headers().contentType(), context);
+                        isContentTypeLoggable = isContentTypeLoggable(proxyResponse.headers().get(HttpHeaderNames.CONTENT_TYPE), context);
                     }
 
                     if (isContentTypeLoggable && LoggingUtils.isProxyResponsePayloadsLoggable(context)) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/proxy/EmptyProxyResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/proxy/EmptyProxyResponse.java
@@ -15,10 +15,11 @@
  */
 package io.gravitee.gateway.core.proxy;
 
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpHeadersValues;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.api.proxy.ProxyResponse;
 import io.gravitee.gateway.api.stream.ReadStream;
 
@@ -31,14 +32,14 @@ public class EmptyProxyResponse implements ProxyResponse {
     private Handler<Buffer> bodyHandler;
     private Handler<Void> endHandler;
 
-    private final HttpHeaders httpHeaders = new HttpHeaders();
+    private final HttpHeaders httpHeaders = HttpHeaders.create();
 
     private final int statusCode;
 
     public EmptyProxyResponse(int statusCode) {
         this.statusCode = statusCode;
 
-        httpHeaders.set(HttpHeaders.CONNECTION, HttpHeadersValues.CONNECTION_CLOSE);
+        httpHeaders.set(HttpHeaderNames.CONNECTION, HttpHeadersValues.CONNECTION_CLOSE);
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/proxy/ws/SwitchProtocolProxyResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/proxy/ws/SwitchProtocolProxyResponse.java
@@ -15,10 +15,10 @@
  */
 package io.gravitee.gateway.core.proxy.ws;
 
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.api.proxy.ProxyResponse;
 import io.gravitee.gateway.api.stream.ReadStream;
 
@@ -27,7 +27,7 @@ public class SwitchProtocolProxyResponse implements ProxyResponse {
     private Handler<Buffer> bodyHandler;
     private Handler<Void> endHandler;
 
-    private final HttpHeaders httpHeaders = new HttpHeaders();
+    private final HttpHeaders httpHeaders = HttpHeaders.create();
 
     @Override
     public int status() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiContextHandlerFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiContextHandlerFactory.java
@@ -63,8 +63,6 @@ import io.gravitee.plugin.resource.ResourceClassLoaderFactory;
 import io.gravitee.plugin.resource.ResourcePlugin;
 import io.gravitee.resource.api.ResourceManager;
 import io.vertx.core.Vertx;
-import java.net.URL;
-import java.net.URLClassLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -102,11 +100,7 @@ public class ApiContextHandlerFactory implements ReactorHandlerFactory<Api> {
     public ReactorHandler create(Api api) {
         try {
             if (api.isEnabled()) {
-                ReactorHandlerClassLoader parentClassLoader = new ReactorHandlerClassLoader(
-                    ApiContextHandlerFactory.class.getClassLoader()
-                );
-
-                Class<?> handlerClass = parentClassLoader.loadClass(ApiReactorHandler.class.getName());
+                Class<?> handlerClass = this.getClass().getClassLoader().loadClass(ApiReactorHandler.class.getName());
 
                 final ApiReactorHandler handler = (ApiReactorHandler) handlerClass.getConstructor(Api.class).newInstance(api);
                 final ComponentProvider globalComponentProvider = applicationContext.getBean(ComponentProvider.class);
@@ -363,12 +357,5 @@ public class ApiContextHandlerFactory implements ReactorHandlerFactory<Api> {
 
     public void setApplicationContext(ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
-    }
-
-    private static class ReactorHandlerClassLoader extends URLClassLoader {
-
-        public ReactorHandlerClassLoader(ClassLoader parent) {
-            super(new URL[] {}, parent);
-        }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/cors/CorsPreflightInvoker.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/cors/CorsPreflightInvoker.java
@@ -15,12 +15,12 @@
  */
 package io.gravitee.gateway.handlers.api.processor.cors;
 
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Invoker;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.api.proxy.ProxyConnection;
 import io.gravitee.gateway.api.proxy.ProxyResponse;
 import io.gravitee.gateway.api.stream.ReadStream;
@@ -65,7 +65,7 @@ public class CorsPreflightInvoker implements Invoker {
 
     private static class CorsPreflightProxyResponse implements ProxyResponse {
 
-        private final HttpHeaders headers = new HttpHeaders();
+        private final HttpHeaders headers = HttpHeaders.create();
         private Handler<Void> endHandler;
 
         @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/error/SimpleFailureProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/error/SimpleFailureProcessor.java
@@ -18,12 +18,12 @@ package io.gravitee.gateway.handlers.api.processor.error;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpHeadersValues;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.processor.ProcessorFailure;
 import io.gravitee.gateway.core.processor.AbstractProcessor;
 import java.util.List;
@@ -63,10 +63,10 @@ public class SimpleFailureProcessor extends AbstractProcessor<ExecutionContext> 
         context.request().metrics().setErrorKey(failure.key());
 
         response.status(failure.statusCode());
-        response.headers().set(HttpHeaders.CONNECTION, HttpHeadersValues.CONNECTION_CLOSE);
+        response.headers().set(HttpHeaderNames.CONNECTION, HttpHeadersValues.CONNECTION_CLOSE);
 
         if (failure.message() != null) {
-            List<String> accepts = context.request().headers().get(HttpHeaders.ACCEPT);
+            List<String> accepts = context.request().headers().getAll(HttpHeaderNames.ACCEPT);
 
             Buffer payload;
             String contentType;
@@ -94,8 +94,8 @@ public class SimpleFailureProcessor extends AbstractProcessor<ExecutionContext> 
                 payload = Buffer.buffer(failure.message());
             }
 
-            response.headers().set(HttpHeaders.CONTENT_LENGTH, Integer.toString(payload.length()));
-            response.headers().set(HttpHeaders.CONTENT_TYPE, contentType);
+            response.headers().set(HttpHeaderNames.CONTENT_LENGTH, Integer.toString(payload.length()));
+            response.headers().set(HttpHeaderNames.CONTENT_TYPE, contentType);
             response.write(payload);
         }
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/shutdown/ShutdownProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/shutdown/ShutdownProcessor.java
@@ -16,14 +16,12 @@
 package io.gravitee.gateway.handlers.api.processor.shutdown;
 
 import io.gravitee.common.component.Lifecycle;
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpHeadersValues;
 import io.gravitee.common.http.HttpVersion;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.core.processor.AbstractProcessor;
 import io.gravitee.node.api.Node;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.vertx.core.http.HttpHeaders;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/error/templates/ResponseTemplateBasedFailureProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/error/templates/ResponseTemplateBasedFailureProcessorTest.java
@@ -17,7 +17,6 @@ package io.gravitee.gateway.handlers.api.processor.error.templates;
 
 import static org.mockito.Mockito.*;
 
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.definition.model.ResponseTemplate;
@@ -25,6 +24,8 @@ import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.api.processor.ProcessorFailure;
 import io.gravitee.reporter.api.http.Metrics;
 import java.util.Collections;
@@ -166,7 +167,7 @@ public class ResponseTemplateBasedFailureProcessorTest {
         failure.setKey("POLICY_ERROR_KEY");
         failure.setStatusCode(HttpStatusCode.INTERNAL_SERVER_ERROR_500);
 
-        when(requestHeaders.getAccept()).thenReturn(Collections.singletonList(MediaType.MEDIA_APPLICATION_XML));
+        when(requestHeaders.getAll(HttpHeaderNames.ACCEPT)).thenReturn(Collections.singletonList(MediaType.APPLICATION_XML));
         when(context.getAttribute(ExecutionContext.ATTR_PREFIX + "failure")).thenReturn(failure);
 
         processor.handle(context);
@@ -197,7 +198,7 @@ public class ResponseTemplateBasedFailureProcessorTest {
         failure.setKey("POLICY_ERROR_KEY");
         failure.setStatusCode(HttpStatusCode.INTERNAL_SERVER_ERROR_500);
 
-        when(requestHeaders.getAccept()).thenReturn(Collections.singletonList(MediaType.MEDIA_APPLICATION_XML));
+        when(requestHeaders.getAll(HttpHeaderNames.ACCEPT)).thenReturn(Collections.singletonList(MediaType.APPLICATION_XML));
         when(context.getAttribute(ExecutionContext.ATTR_PREFIX + "failure")).thenReturn(failure);
 
         processor.handle(context);
@@ -224,7 +225,7 @@ public class ResponseTemplateBasedFailureProcessorTest {
         failure.setKey("POLICY_ERROR_KEY");
         failure.setStatusCode(HttpStatusCode.INTERNAL_SERVER_ERROR_500);
 
-        when(requestHeaders.getAccept()).thenReturn(Collections.singletonList(MediaType.MEDIA_APPLICATION_JSON));
+        when(requestHeaders.getAll(HttpHeaderNames.ACCEPT)).thenReturn(Collections.singletonList(MediaType.APPLICATION_JSON));
         when(context.getAttribute(ExecutionContext.ATTR_PREFIX + "failure")).thenReturn(failure);
 
         processor.handle(context);
@@ -251,8 +252,8 @@ public class ResponseTemplateBasedFailureProcessorTest {
         failure.setKey("POLICY_ERROR_KEY");
         failure.setStatusCode(HttpStatusCode.INTERNAL_SERVER_ERROR_500);
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.set(HttpHeaders.ACCEPT, "text/html, application/json, */*;q=0.8, application/xml;q=0.9");
+        HttpHeaders headers = HttpHeaders.create();
+        headers.set(HttpHeaderNames.ACCEPT, "text/html, application/json, */*;q=0.8, application/xml;q=0.9");
         when(request.headers()).thenReturn(headers);
         when(context.getAttribute(ExecutionContext.ATTR_PREFIX + "failure")).thenReturn(failure);
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/forward/XForwardedPrefixProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/forward/XForwardedPrefixProcessorTest.java
@@ -18,11 +18,12 @@ package io.gravitee.gateway.handlers.api.processor.forward;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
 
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.api.context.MutableExecutionContext;
 import io.gravitee.gateway.api.context.SimpleExecutionContext;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,7 +51,7 @@ public class XForwardedPrefixProcessorTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         context = new SimpleExecutionContext(request, response);
-        HttpHeaders headers = new HttpHeaders();
+        HttpHeaders headers = HttpHeaders.create();
         Mockito.when(request.headers()).thenReturn(headers);
     }
 
@@ -61,7 +62,7 @@ public class XForwardedPrefixProcessorTest {
         new XForwardedPrefixProcessor()
             .handler(
                 context -> {
-                    List<String> xForwardedPrefixList = context.request().headers().get(HttpHeaders.X_FORWARDED_PREFIX);
+                    List<String> xForwardedPrefixList = context.request().headers().getAll(HttpHeaderNames.X_FORWARDED_PREFIX);
                     assertEquals(xForwardedPrefixList.size(), 1);
                     assertEquals(xForwardedPrefixList.get(0), CONTEXT_PATH);
                 }
@@ -73,14 +74,14 @@ public class XForwardedPrefixProcessorTest {
     public void testXForwardedPrefixInHeader() {
         when(request.contextPath()).thenReturn(CONTEXT_PATH);
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.add(HttpHeaders.X_FORWARDED_PREFIX, "randomPrefix");
+        HttpHeaders headers = HttpHeaders.create();
+        headers.add(HttpHeaderNames.X_FORWARDED_PREFIX, "randomPrefix");
         when(request.headers()).thenReturn(headers);
 
         new XForwardedPrefixProcessor()
             .handler(
                 context -> {
-                    List<String> xForwardedPrefixList = context.request().headers().get(HttpHeaders.X_FORWARDED_PREFIX);
+                    List<String> xForwardedPrefixList = context.request().headers().getAll(HttpHeaderNames.X_FORWARDED_PREFIX);
                     assertEquals(xForwardedPrefixList.size(), 1);
                     assertEquals(xForwardedPrefixList.get(0), CONTEXT_PATH);
                 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParametersProcessorBenchmark.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParametersProcessorBenchmark.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.gateway.handlers.api.processor.pathparameters;
 
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.common.http.HttpVersion;
 import io.gravitee.common.util.LinkedMultiValueMap;
@@ -25,6 +24,7 @@ import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.context.SimpleExecutionContext;
 import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.api.http2.HttpFrame;
 import io.gravitee.gateway.api.stream.ReadStream;
 import io.gravitee.gateway.api.ws.WebSocket;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/shutdown/ShutdownProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/shutdown/ShutdownProcessorTest.java
@@ -18,12 +18,12 @@ package io.gravitee.gateway.handlers.api.processor.shutdown;
 import static org.mockito.Mockito.*;
 
 import io.gravitee.common.component.Lifecycle;
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpHeadersValues;
 import io.gravitee.common.http.HttpVersion;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.node.api.Node;
 import org.junit.Before;
 import org.junit.Test;
@@ -83,7 +83,7 @@ public class ShutdownProcessorTest {
         when(node.lifecycleState()).thenReturn(Lifecycle.State.STOPPING);
         when(request.version()).thenReturn(HttpVersion.HTTP_1_0);
 
-        cut.handler(context -> verify(headers).set(HttpHeaders.CONNECTION, HttpHeadersValues.CONNECTION_CLOSE));
+        cut.handler(context -> verify(headers).set(io.vertx.core.http.HttpHeaders.CONNECTION, HttpHeadersValues.CONNECTION_CLOSE));
         cut.handle(context);
     }
 
@@ -92,7 +92,7 @@ public class ShutdownProcessorTest {
         when(node.lifecycleState()).thenReturn(Lifecycle.State.STOPPING);
         when(request.version()).thenReturn(HttpVersion.HTTP_1_1);
 
-        cut.handler(context -> verify(headers).set(HttpHeaders.CONNECTION, HttpHeadersValues.CONNECTION_CLOSE));
+        cut.handler(context -> verify(headers).set(io.vertx.core.http.HttpHeaders.CONNECTION, HttpHeadersValues.CONNECTION_CLOSE));
         cut.handle(context);
     }
 
@@ -101,7 +101,7 @@ public class ShutdownProcessorTest {
         when(node.lifecycleState()).thenReturn(Lifecycle.State.STOPPING);
         when(request.version()).thenReturn(HttpVersion.HTTP_2);
 
-        cut.handler(context -> verify(headers).set(HttpHeaders.CONNECTION, HttpHeadersValues.CONNECTION_GO_AWAY));
+        cut.handler(context -> verify(headers).set(io.vertx.core.http.HttpHeaders.CONNECTION, HttpHeadersValues.CONNECTION_GO_AWAY));
         cut.handle(context);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpHeaders.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpHeaders.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.http.vertx;
+
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.vertx.core.MultiMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class VertxHttpHeaders implements HttpHeaders {
+
+    private final MultiMap headers;
+
+    public VertxHttpHeaders(final MultiMap headers) {
+        this.headers = headers;
+    }
+
+    @Override
+    public String get(CharSequence name) {
+        return headers.get(name);
+    }
+
+    @Override
+    public List<String> getAll(CharSequence name) {
+        return headers.getAll(name);
+    }
+
+    @Override
+    public boolean contains(CharSequence name) {
+        return headers.contains(name);
+    }
+
+    @Override
+    public Set<String> names() {
+        return headers.names();
+    }
+
+    @Override
+    public HttpHeaders add(CharSequence name, CharSequence value) {
+        headers.add(name, value);
+        return this;
+    }
+
+    @Override
+    public HttpHeaders add(CharSequence name, Iterable<CharSequence> values) {
+        headers.add(name, values);
+        return this;
+    }
+
+    @Override
+    public HttpHeaders set(CharSequence name, CharSequence value) {
+        headers.set(name, value);
+        return this;
+    }
+
+    @Override
+    public HttpHeaders set(CharSequence name, Iterable<CharSequence> values) {
+        headers.set(name, values);
+        return this;
+    }
+
+    @Override
+    public HttpHeaders remove(CharSequence name) {
+        headers.remove(name);
+        return this;
+    }
+
+    @Override
+    public void clear() {
+        headers.clear();
+    }
+
+    @Override
+    public int size() {
+        return headers.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return headers.isEmpty();
+    }
+
+    @Override
+    public Iterator<Map.Entry<String, String>> iterator() {
+        return headers.iterator();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpServerResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpServerResponse.java
@@ -15,16 +15,15 @@
  */
 package io.gravitee.gateway.http.vertx;
 
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpHeadersValues;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.api.stream.WriteStream;
 import io.netty.buffer.ByteBuf;
 import io.vertx.core.http.HttpConnection;
-import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 
 /**
@@ -35,13 +34,15 @@ public class VertxHttpServerResponse implements Response {
 
     protected final HttpServerResponse serverResponse;
     private final Request serverRequest;
-    protected final HttpHeaders headers = new HttpHeaders();
+    protected final HttpHeaders headers;
 
-    protected HttpHeaders trailers;
+    protected final HttpHeaders trailers;
 
     public VertxHttpServerResponse(final VertxHttpServerRequest serverRequest) {
         this.serverRequest = serverRequest;
         this.serverResponse = serverRequest.getNativeServerRequest().response();
+        this.headers = new VertxHttpHeaders(this.serverResponse.headers());
+        this.trailers = new VertxHttpHeaders(this.serverResponse.trailers());
     }
 
     @Override
@@ -80,9 +81,6 @@ public class VertxHttpServerResponse implements Response {
 
     @Override
     public HttpHeaders trailers() {
-        if (trailers == null) {
-            trailers = new HttpHeaders();
-        }
         return trailers;
     }
 
@@ -93,12 +91,11 @@ public class VertxHttpServerResponse implements Response {
                 writeHeaders();
 
                 // Vertx requires to set the chunked flag if transfer_encoding header as the "chunked" value
-                String transferEncodingHeader = headers().getFirst(HttpHeaders.TRANSFER_ENCODING);
+                String transferEncodingHeader = headers().getFirst(io.vertx.core.http.HttpHeaders.TRANSFER_ENCODING);
                 if (HttpHeadersValues.TRANSFER_ENCODING_CHUNKED.equalsIgnoreCase(transferEncodingHeader)) {
                     serverResponse.setChunked(true);
                 } else if (transferEncodingHeader == null) {
-                    String connectionHeader = headers().getFirst(HttpHeaders.CONNECTION);
-                    String contentLengthHeader = headers().getFirst(HttpHeaders.CONTENT_LENGTH);
+                    String contentLengthHeader = headers().getFirst(io.vertx.core.http.HttpHeaders.CONTENT_LENGTH);
                     if (contentLengthHeader == null) {
                         serverResponse.setChunked(true);
                     }
@@ -129,8 +126,6 @@ public class VertxHttpServerResponse implements Response {
                 writeHeaders();
             }
 
-            writeTrailers();
-
             serverResponse
                 .end()
                 .onComplete(
@@ -151,19 +146,11 @@ public class VertxHttpServerResponse implements Response {
         return this;
     }
 
-    protected void writeTrailers() {
-        if (trailers != null) {
-            trailers.forEach(serverResponse::putTrailer);
-        }
-    }
-
     private boolean valid() {
         return !serverResponse.closed() && !serverResponse.ended();
     }
 
-    protected void writeHeaders() {
-        headers.forEach(serverResponse::putHeader);
-    }
+    protected void writeHeaders() {}
 
     public HttpConnection getNativeConnection() {
         return ((VertxHttpServerRequest) serverRequest).getNativeServerRequest().connection();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/policy/impl/SimpleRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/policy/impl/SimpleRequest.java
@@ -15,13 +15,13 @@
  */
 package io.gravitee.gateway.policy.impl;
 
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.common.http.HttpVersion;
 import io.gravitee.common.util.MultiValueMap;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.api.http2.HttpFrame;
 import io.gravitee.gateway.api.stream.ReadStream;
 import io.gravitee.gateway.api.ws.WebSocket;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/policy/impl/SimpleResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/policy/impl/SimpleResponse.java
@@ -15,20 +15,10 @@
  */
 package io.gravitee.gateway.policy.impl;
 
-import io.gravitee.common.http.HttpHeaders;
-import io.gravitee.common.http.HttpMethod;
-import io.gravitee.common.http.HttpVersion;
-import io.gravitee.common.util.MultiValueMap;
-import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.api.buffer.Buffer;
-import io.gravitee.gateway.api.handler.Handler;
-import io.gravitee.gateway.api.http2.HttpFrame;
-import io.gravitee.gateway.api.stream.ReadStream;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.api.stream.WriteStream;
-import io.gravitee.gateway.api.ws.WebSocket;
-import io.gravitee.reporter.api.http.Metrics;
-import javax.net.ssl.SSLSession;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/ResponseProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/ResponseProcessorChainFactory.java
@@ -48,10 +48,7 @@ public class ResponseProcessorChainFactory {
     private String port;
 
     public Processor<ExecutionContext> create() {
-        final List<Processor<ExecutionContext>> processors = Arrays.asList(
-            new ResponseTimeProcessor(),
-            new ReporterProcessor(reporterService)
-        );
+        List<Processor<ExecutionContext>> processors = Arrays.asList(new ResponseTimeProcessor(), new ReporterProcessor(reporterService));
 
         if (!eventProducer.isEmpty()) {
             processors.add(new AlertProcessor(eventProducer, node, port));

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/notfound/NotFoundReporter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/notfound/NotFoundReporter.java
@@ -15,10 +15,8 @@
  */
 package io.gravitee.gateway.reactor.processor.notfound;
 
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.buffer.Buffer;
-import io.gravitee.gateway.api.handler.Handler;
 import io.gravitee.gateway.core.processor.AbstractProcessor;
 import io.gravitee.gateway.report.ReporterService;
 import io.gravitee.reporter.api.http.Metrics;
@@ -56,7 +54,7 @@ public class NotFoundReporter extends AbstractProcessor<ExecutionContext> {
                         log.setClientRequest(new io.gravitee.reporter.api.common.Request());
                         log.getClientRequest().setMethod(context.request().method());
                         log.getClientRequest().setUri(context.request().uri());
-                        log.getClientRequest().setHeaders(new HttpHeaders(context.request().headers()));
+                        log.getClientRequest().setHeaders(context.request().headers());
                         log.getClientRequest().setBody(payload.toString());
 
                         metrics.setLog(log);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/DummyReactorHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/DummyReactorHandler.java
@@ -18,10 +18,10 @@ package io.gravitee.gateway.reactor.handler;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.reactor.Reactable;
 import java.util.List;
 import java.util.Set;
@@ -60,7 +60,7 @@ public class DummyReactorHandler extends AbstractReactorHandler<Reactable> {
     @Override
     protected void doHandle(ExecutionContext executionContext) {
         Response proxyResponse = mock(Response.class);
-        when(proxyResponse.headers()).thenReturn(new HttpHeaders());
+        when(proxyResponse.headers()).thenReturn(HttpHeaders.create());
         when(proxyResponse.status()).thenReturn(HttpStatusCode.OK_200);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/EntrypointResolverTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/EntrypointResolverTest.java
@@ -19,9 +19,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.*;
 
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.reactor.handler.impl.DefaultEntrypointResolver;
 import io.gravitee.gateway.reactor.handler.impl.HandlerEntryPointComparator;
 import java.util.ArrayList;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/processor/forward/XForwardForProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/processor/forward/XForwardForProcessorTest.java
@@ -17,11 +17,12 @@ package io.gravitee.gateway.reactor.processor.forward;
 
 import static org.mockito.Mockito.when;
 
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.api.context.MutableExecutionContext;
 import io.gravitee.gateway.api.context.SimpleExecutionContext;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.reporter.api.http.Metrics;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -58,7 +59,7 @@ public class XForwardForProcessorTest {
     public void test_not_X_Forward_for_in_Header() throws InterruptedException {
         final CountDownLatch lock = new CountDownLatch(1);
 
-        when(headers.getFirst(HttpHeaders.X_FORWARDED_FOR)).thenReturn(null);
+        when(headers.getFirst(HttpHeaderNames.X_FORWARDED_FOR)).thenReturn(null);
         when(request.remoteAddress()).thenReturn("192.168.0.1");
 
         new XForwardForProcessor()
@@ -79,7 +80,7 @@ public class XForwardForProcessorTest {
     public void test_with_one_X_Forward_for_in_Header() throws InterruptedException {
         final CountDownLatch lock = new CountDownLatch(1);
 
-        when(headers.getFirst(HttpHeaders.X_FORWARDED_FOR)).thenReturn("197.225.30.74");
+        when(headers.getFirst(HttpHeaderNames.X_FORWARDED_FOR)).thenReturn("197.225.30.74");
         when(request.remoteAddress()).thenReturn("192.168.0.1");
 
         new XForwardForProcessor()
@@ -100,7 +101,7 @@ public class XForwardForProcessorTest {
     public void test_with_one_X_Forward_for_in_Header_withPort() throws InterruptedException {
         final CountDownLatch lock = new CountDownLatch(1);
 
-        when(headers.getFirst(HttpHeaders.X_FORWARDED_FOR)).thenReturn("197.225.30.74:5000");
+        when(headers.getFirst(HttpHeaderNames.X_FORWARDED_FOR)).thenReturn("197.225.30.74:5000");
         when(request.remoteAddress()).thenReturn("192.168.0.1");
 
         new XForwardForProcessor()
@@ -121,7 +122,7 @@ public class XForwardForProcessorTest {
     public void test_with_many_X_Forward_for_in_Header() throws InterruptedException {
         final CountDownLatch lock = new CountDownLatch(1);
 
-        when(headers.getFirst(HttpHeaders.X_FORWARDED_FOR)).thenReturn("197.225.30.74, 10.0.0.1, 10.0.0.2");
+        when(headers.getFirst(HttpHeaderNames.X_FORWARDED_FOR)).thenReturn("197.225.30.74, 10.0.0.1, 10.0.0.2");
         when(request.remoteAddress()).thenReturn("192.168.0.1");
 
         new XForwardForProcessor()
@@ -142,7 +143,7 @@ public class XForwardForProcessorTest {
     public void test_with_many_X_Forward_for_in_Header_withPorts() throws InterruptedException {
         final CountDownLatch lock = new CountDownLatch(1);
 
-        when(headers.getFirst(HttpHeaders.X_FORWARDED_FOR)).thenReturn("197.225.30.74:5000, 10.0.0.1, 10.0.0.2");
+        when(headers.getFirst(HttpHeaderNames.X_FORWARDED_FOR)).thenReturn("197.225.30.74:5000, 10.0.0.1, 10.0.0.2");
         when(request.remoteAddress()).thenReturn("192.168.0.1");
 
         new XForwardForProcessor()
@@ -163,7 +164,7 @@ public class XForwardForProcessorTest {
     public void test_with_one_X_Forward_for_in_Header_withIPv6() throws InterruptedException {
         final CountDownLatch lock = new CountDownLatch(1);
 
-        when(headers.getFirst(HttpHeaders.X_FORWARDED_FOR)).thenReturn("2001:0db8:85a3:0000:0000:8a2e:0370:7334");
+        when(headers.getFirst(HttpHeaderNames.X_FORWARDED_FOR)).thenReturn("2001:0db8:85a3:0000:0000:8a2e:0370:7334");
         when(request.remoteAddress()).thenReturn("192.168.0.1");
 
         new XForwardForProcessor()
@@ -184,7 +185,7 @@ public class XForwardForProcessorTest {
     public void test_with_one_X_Forward_for_in_Header_withIPv6_hexadecimalFormat() throws InterruptedException {
         final CountDownLatch lock = new CountDownLatch(1);
 
-        when(headers.getFirst(HttpHeaders.X_FORWARDED_FOR)).thenReturn("2001:db8:85a3:0:0:8a2e:370:7334");
+        when(headers.getFirst(HttpHeaderNames.X_FORWARDED_FOR)).thenReturn("2001:db8:85a3:0:0:8a2e:370:7334");
         when(request.remoteAddress()).thenReturn("192.168.0.1");
 
         new XForwardForProcessor()
@@ -205,7 +206,7 @@ public class XForwardForProcessorTest {
     public void test_with_one_X_Forward_for_in_Header_withIPv6_hexadecimalFormat_consecutiveColons() throws InterruptedException {
         final CountDownLatch lock = new CountDownLatch(1);
 
-        when(headers.getFirst(HttpHeaders.X_FORWARDED_FOR)).thenReturn("2001:db8:85a3::8a2e:370:7334");
+        when(headers.getFirst(HttpHeaderNames.X_FORWARDED_FOR)).thenReturn("2001:db8:85a3::8a2e:370:7334");
         when(request.remoteAddress()).thenReturn("192.168.0.1");
 
         new XForwardForProcessor()

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/processor/transaction/TraceContextProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/processor/transaction/TraceContextProcessorTest.java
@@ -18,12 +18,12 @@ package io.gravitee.gateway.reactor.processor.transaction;
 import static io.gravitee.gateway.reactor.processor.transaction.TraceContextProcessor.HEADER_TRACE_PARENT;
 import static io.gravitee.gateway.reactor.processor.transaction.TraceContextProcessor.HEADER_TRACE_STATE;
 
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.utils.UUID;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.api.context.MutableExecutionContext;
 import io.gravitee.gateway.api.context.SimpleExecutionContext;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.reporter.api.http.Metrics;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -52,8 +52,8 @@ public class TraceContextProcessorTest {
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
         context = new SimpleExecutionContext(request, response);
-        Mockito.when(request.headers()).thenReturn(new HttpHeaders());
-        Mockito.when(response.headers()).thenReturn(new HttpHeaders());
+        Mockito.when(request.headers()).thenReturn(HttpHeaders.create());
+        Mockito.when(response.headers()).thenReturn(HttpHeaders.create());
         Mockito.when(request.metrics()).thenReturn(Metrics.on(System.currentTimeMillis()).build());
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/processor/transaction/TransactionProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/processor/transaction/TransactionProcessorTest.java
@@ -15,12 +15,12 @@
  */
 package io.gravitee.gateway.reactor.processor.transaction;
 
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.utils.UUID;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.api.context.MutableExecutionContext;
 import io.gravitee.gateway.api.context.SimpleExecutionContext;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.reporter.api.http.Metrics;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -52,8 +52,8 @@ public class TransactionProcessorTest {
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
         context = new SimpleExecutionContext(request, response);
-        Mockito.when(request.headers()).thenReturn(new HttpHeaders());
-        Mockito.when(response.headers()).thenReturn(new HttpHeaders());
+        Mockito.when(request.headers()).thenReturn(HttpHeaders.create());
+        Mockito.when(response.headers()).thenReturn(HttpHeaders.create());
         Mockito.when(request.metrics()).thenReturn(Metrics.on(System.currentTimeMillis()).build());
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-apikey/src/test/java/io/gravitee/gateway/security/apikey/ApiKeyAuthenticationHandlerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-apikey/src/test/java/io/gravitee/gateway/security/apikey/ApiKeyAuthenticationHandlerTest.java
@@ -20,12 +20,12 @@ import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import io.gravitee.common.http.GraviteeHttpHeader;
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.util.LinkedMultiValueMap;
 import io.gravitee.common.util.MultiValueMap;
 import io.gravitee.definition.model.Api;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.core.component.ComponentProvider;
 import io.gravitee.gateway.security.core.AuthenticationContext;
 import io.gravitee.gateway.security.core.AuthenticationPolicy;
@@ -94,7 +94,7 @@ public class ApiKeyAuthenticationHandlerTest {
     @Test
     public void shouldNotHandleRequest() {
         when(authenticationContext.request()).thenReturn(request);
-        when(request.headers()).thenReturn(new HttpHeaders());
+        when(request.headers()).thenReturn(HttpHeaders.create());
         when(api.getId()).thenReturn("api-id");
 
         MultiValueMap<String, String> parameters = mock(MultiValueMap.class);
@@ -109,7 +109,7 @@ public class ApiKeyAuthenticationHandlerTest {
         when(authenticationContext.request()).thenReturn(request);
         when(request.metrics()).thenReturn(metrics);
         when(api.getId()).thenReturn("api-id");
-        HttpHeaders headers = new HttpHeaders();
+        HttpHeaders headers = HttpHeaders.create();
         headers.set("X-Gravitee-Api-Key", "xxxxx-xxxx-xxxxx");
         when(request.headers()).thenReturn(headers);
         when(apiKeyRepository.findByKeyAndApi("xxxxx-xxxx-xxxxx", "api-id")).thenReturn(of(new ApiKey()));
@@ -130,7 +130,7 @@ public class ApiKeyAuthenticationHandlerTest {
         when(request.parameters()).thenReturn(parameters);
         when(apiKeyRepository.findByKeyAndApi("xxxxx-xxxx-xxxxx", "api-id")).thenReturn(of(new ApiKey()));
 
-        HttpHeaders headers = new HttpHeaders();
+        HttpHeaders headers = HttpHeaders.create();
         when(request.headers()).thenReturn(headers);
 
         boolean handle = authenticationHandler.canHandle(authenticationContext);
@@ -146,7 +146,7 @@ public class ApiKeyAuthenticationHandlerTest {
         parameters.put("api-key", Collections.singletonList(""));
         when(request.parameters()).thenReturn(parameters);
 
-        HttpHeaders headers = new HttpHeaders();
+        HttpHeaders headers = HttpHeaders.create();
         when(request.headers()).thenReturn(headers);
 
         boolean handle = authenticationHandler.canHandle(authenticationContext);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/main/java/io/gravitee/gateway/security/core/TokenExtractor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/main/java/io/gravitee/gateway/security/core/TokenExtractor.java
@@ -15,10 +15,8 @@
  */
 package io.gravitee.gateway.security.core;
 
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.gateway.api.Request;
-import java.util.List;
-import java.util.Optional;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
 import org.springframework.util.StringUtils;
 
 /**
@@ -38,18 +36,12 @@ public class TokenExtractor {
      * @return String Json Web Token.
      */
     public static String extract(Request request) {
-        List<String> authorizationHeaders = request.headers() != null ? request.headers().get(HttpHeaders.AUTHORIZATION) : null;
+        String authorization = request.headers().getFirst(HttpHeaderNames.AUTHORIZATION);
 
-        if (authorizationHeaders != null && !authorizationHeaders.isEmpty()) {
-            Optional<String> authorizationBearerHeader = authorizationHeaders
-                .stream()
-                .filter(h -> StringUtils.startsWithIgnoreCase(h, BEARER))
-                .findFirst();
-            if (authorizationBearerHeader.isPresent()) {
-                String authToken = authorizationBearerHeader.get().substring(BEARER.length()).trim();
-                if (!authToken.isEmpty()) {
-                    return authToken;
-                }
+        if (authorization != null && !authorization.isEmpty() && StringUtils.startsWithIgnoreCase(authorization, BEARER)) {
+            final String authToken = authorization.substring(BEARER.length()).trim();
+            if (!authToken.isEmpty()) {
+                return authToken;
             }
         }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/test/java/io/gravitee/gateway/security/core/TokenExtractorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/src/test/java/io/gravitee/gateway/security/core/TokenExtractorTest.java
@@ -17,9 +17,10 @@ package io.gravitee.gateway.security.core;
 
 import static org.mockito.Mockito.when;
 
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.util.LinkedMultiValueMap;
 import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,7 +43,7 @@ public class TokenExtractorTest {
 
     @Test
     public void shouldNotExtract_noAuthorizationHeader() {
-        HttpHeaders headers = new HttpHeaders();
+        HttpHeaders headers = HttpHeaders.create();
         when(request.headers()).thenReturn(headers);
         when(request.parameters()).thenReturn(new LinkedMultiValueMap<>());
 
@@ -55,8 +56,8 @@ public class TokenExtractorTest {
     public void shouldNotExtract_unknownAuthorizationHeader() {
         String jwt = "dummy-token";
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", "Basic " + jwt);
+        HttpHeaders headers = HttpHeaders.create();
+        headers.add(HttpHeaderNames.AUTHORIZATION, "Basic " + jwt);
         when(request.headers()).thenReturn(headers);
 
         String token = TokenExtractor.extract(request);
@@ -66,10 +67,8 @@ public class TokenExtractorTest {
 
     @Test
     public void shouldNotExtract_bearerAuthorizationHeader_noValue() {
-        String jwt = "dummy-token";
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", TokenExtractor.BEARER);
+        HttpHeaders headers = HttpHeaders.create();
+        headers.add(HttpHeaderNames.AUTHORIZATION, TokenExtractor.BEARER);
         when(request.headers()).thenReturn(headers);
 
         String token = TokenExtractor.extract(request);
@@ -81,8 +80,8 @@ public class TokenExtractorTest {
     public void shouldExtract_fromHeader() {
         String jwt = "dummy-token";
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Authorization", TokenExtractor.BEARER + ' ' + jwt);
+        HttpHeaders headers = HttpHeaders.create();
+        headers.add(HttpHeaderNames.AUTHORIZATION, TokenExtractor.BEARER + ' ' + jwt);
         when(request.headers()).thenReturn(headers);
 
         String token = TokenExtractor.extract(request);
@@ -95,7 +94,7 @@ public class TokenExtractorTest {
     public void shouldExtract_fromQueryParameter() {
         String jwt = "dummy-token";
 
-        HttpHeaders headers = new HttpHeaders();
+        HttpHeaders headers = HttpHeaders.create();
         when(request.headers()).thenReturn(headers);
 
         LinkedMultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-jwt/src/test/java/io/gravitee/gateway/security/jwt/JWTAuthenticationHandlerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-jwt/src/test/java/io/gravitee/gateway/security/jwt/JWTAuthenticationHandlerTest.java
@@ -18,10 +18,11 @@ package io.gravitee.gateway.security.jwt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.util.LinkedMultiValueMap;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.security.core.*;
 import io.gravitee.gateway.security.jwt.policy.CheckSubscriptionPolicy;
 import java.util.Iterator;
@@ -56,7 +57,7 @@ public class JWTAuthenticationHandlerTest {
 
     @Test
     public void shouldNotHandleRequest_noAuthorizationHeader() {
-        when(request.headers()).thenReturn(new HttpHeaders());
+        when(request.headers()).thenReturn(HttpHeaders.create());
 
         boolean handle = authenticationHandler.canHandle(authenticationContext);
         Assert.assertFalse(handle);
@@ -64,10 +65,10 @@ public class JWTAuthenticationHandlerTest {
 
     @Test
     public void shouldNotHandleRequest_invalidAuthorizationHeader() {
-        HttpHeaders headers = new HttpHeaders();
+        HttpHeaders headers = HttpHeaders.create();
         when(request.headers()).thenReturn(headers);
 
-        headers.add(HttpHeaders.AUTHORIZATION, "");
+        headers.add(HttpHeaderNames.AUTHORIZATION, "");
 
         boolean handle = authenticationHandler.canHandle(authenticationContext);
         Assert.assertFalse(handle);
@@ -75,10 +76,10 @@ public class JWTAuthenticationHandlerTest {
 
     @Test
     public void shouldNotHandleRequest_noBearerAuthorizationHeader() {
-        HttpHeaders headers = new HttpHeaders();
+        HttpHeaders headers = HttpHeaders.create();
         when(request.headers()).thenReturn(headers);
 
-        headers.add(HttpHeaders.AUTHORIZATION, "Basic xxx-xx-xxx-xx-xx");
+        headers.add(HttpHeaderNames.AUTHORIZATION, "Basic xxx-xx-xxx-xx-xx");
 
         boolean handle = authenticationHandler.canHandle(authenticationContext);
         Assert.assertFalse(handle);
@@ -87,10 +88,10 @@ public class JWTAuthenticationHandlerTest {
 
     @Test
     public void shouldHandleRequest_validAuthorizationHeader() {
-        HttpHeaders headers = new HttpHeaders();
+        HttpHeaders headers = HttpHeaders.create();
         when(request.headers()).thenReturn(headers);
 
-        headers.add(HttpHeaders.AUTHORIZATION, JWTAuthenticationHandler.BEARER_AUTHORIZATION_TYPE + " xxx-xx-xxx-xx-xx");
+        headers.add(HttpHeaderNames.AUTHORIZATION, JWTAuthenticationHandler.BEARER_AUTHORIZATION_TYPE + " xxx-xx-xxx-xx-xx");
 
         boolean handle = authenticationHandler.canHandle(authenticationContext);
         Assert.assertTrue(handle);
@@ -99,10 +100,10 @@ public class JWTAuthenticationHandlerTest {
 
     @Test
     public void shouldHandleRequest_ignoreCaseAuthorizationHeader() {
-        HttpHeaders headers = new HttpHeaders();
+        HttpHeaders headers = HttpHeaders.create();
         when(request.headers()).thenReturn(headers);
 
-        headers.add(HttpHeaders.AUTHORIZATION, "BeaRer xxx-xx-xxx-xx-xx");
+        headers.add(HttpHeaderNames.AUTHORIZATION, "BeaRer xxx-xx-xxx-xx-xx");
 
         boolean handle = authenticationHandler.canHandle(authenticationContext);
         Assert.assertTrue(handle);
@@ -111,7 +112,10 @@ public class JWTAuthenticationHandlerTest {
 
     @Test
     public void shouldHandleRequest_validQueryParameter() {
-        LinkedMultiValueMap parameters = new LinkedMultiValueMap();
+        HttpHeaders headers = HttpHeaders.create();
+        when(request.headers()).thenReturn(headers);
+
+        LinkedMultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
         when(request.parameters()).thenReturn(parameters);
         parameters.add("access_token", "xxx-xx-xxx-xx-xx");
 
@@ -122,10 +126,10 @@ public class JWTAuthenticationHandlerTest {
 
     @Test
     public void shouldNotHandleRequest_noBearerValue() {
-        HttpHeaders headers = new HttpHeaders();
+        HttpHeaders headers = HttpHeaders.create();
         when(request.headers()).thenReturn(headers);
 
-        headers.add(HttpHeaders.AUTHORIZATION, JWTAuthenticationHandler.BEARER_AUTHORIZATION_TYPE + " ");
+        headers.add(HttpHeaderNames.AUTHORIZATION, JWTAuthenticationHandler.BEARER_AUTHORIZATION_TYPE + " ");
 
         boolean handle = authenticationHandler.canHandle(authenticationContext);
         Assert.assertFalse(handle);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-oauth2/src/test/java/io/gravitee/gateway/security/oauth2/OAuth2AuthenticationHandlerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-oauth2/src/test/java/io/gravitee/gateway/security/oauth2/OAuth2AuthenticationHandlerTest.java
@@ -18,10 +18,11 @@ package io.gravitee.gateway.security.oauth2;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.util.LinkedMultiValueMap;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.security.core.AuthenticationContext;
 import io.gravitee.gateway.security.core.AuthenticationPolicy;
 import io.gravitee.gateway.security.core.HookAuthenticationPolicy;
@@ -60,7 +61,7 @@ public class OAuth2AuthenticationHandlerTest {
 
     @Test
     public void shouldNotHandleRequest_noAuthorizationHeader() {
-        when(request.headers()).thenReturn(new HttpHeaders());
+        when(request.headers()).thenReturn(HttpHeaders.create());
 
         boolean handle = authenticationHandler.canHandle(authenticationContext);
         Assert.assertFalse(handle);
@@ -68,10 +69,10 @@ public class OAuth2AuthenticationHandlerTest {
 
     @Test
     public void shouldNotHandleRequest_invalidAuthorizationHeader() {
-        HttpHeaders headers = new HttpHeaders();
+        HttpHeaders headers = HttpHeaders.create();
         when(request.headers()).thenReturn(headers);
 
-        headers.add(HttpHeaders.AUTHORIZATION, "");
+        headers.add(HttpHeaderNames.AUTHORIZATION, "");
 
         boolean handle = authenticationHandler.canHandle(authenticationContext);
         Assert.assertFalse(handle);
@@ -79,10 +80,10 @@ public class OAuth2AuthenticationHandlerTest {
 
     @Test
     public void shouldNotHandleRequest_noBearerAuthorizationHeader() {
-        HttpHeaders headers = new HttpHeaders();
+        HttpHeaders headers = HttpHeaders.create();
         when(request.headers()).thenReturn(headers);
 
-        headers.add(HttpHeaders.AUTHORIZATION, "Basic xxx-xx-xxx-xx-xx");
+        headers.add(HttpHeaderNames.AUTHORIZATION, "Basic xxx-xx-xxx-xx-xx");
 
         boolean handle = authenticationHandler.canHandle(authenticationContext);
         Assert.assertFalse(handle);
@@ -90,10 +91,10 @@ public class OAuth2AuthenticationHandlerTest {
 
     @Test
     public void shouldHandleRequest_validAuthorizationHeader() {
-        HttpHeaders headers = new HttpHeaders();
+        HttpHeaders headers = HttpHeaders.create();
         when(request.headers()).thenReturn(headers);
 
-        headers.add(HttpHeaders.AUTHORIZATION, OAuth2AuthenticationHandler.BEARER_AUTHORIZATION_TYPE + " xxx-xx-xxx-xx-xx");
+        headers.add(HttpHeaderNames.AUTHORIZATION, OAuth2AuthenticationHandler.BEARER_AUTHORIZATION_TYPE + " xxx-xx-xxx-xx-xx");
 
         boolean handle = authenticationHandler.canHandle(authenticationContext);
         Assert.assertTrue(handle);
@@ -101,10 +102,10 @@ public class OAuth2AuthenticationHandlerTest {
 
     @Test
     public void shouldHandleRequest_ignoreCaseAuthorizationHeader() {
-        HttpHeaders headers = new HttpHeaders();
+        HttpHeaders headers = HttpHeaders.create();
         when(request.headers()).thenReturn(headers);
 
-        headers.add(HttpHeaders.AUTHORIZATION, "BeaRer xxx-xx-xxx-xx-xx");
+        headers.add(HttpHeaderNames.AUTHORIZATION, "BeaRer xxx-xx-xxx-xx-xx");
 
         boolean handle = authenticationHandler.canHandle(authenticationContext);
         Assert.assertTrue(handle);
@@ -112,7 +113,9 @@ public class OAuth2AuthenticationHandlerTest {
 
     @Test
     public void shouldHandleRequest_validQueryParameter() {
-        LinkedMultiValueMap parameters = new LinkedMultiValueMap();
+        HttpHeaders headers = HttpHeaders.create();
+        when(request.headers()).thenReturn(headers);
+        LinkedMultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
         when(request.parameters()).thenReturn(parameters);
         parameters.add("access_token", "xxx-xx-xxx-xx-xx");
 
@@ -122,10 +125,10 @@ public class OAuth2AuthenticationHandlerTest {
 
     @Test
     public void shouldNotHandleRequest_noBearerValue() {
-        HttpHeaders headers = new HttpHeaders();
+        HttpHeaders headers = HttpHeaders.create();
         when(request.headers()).thenReturn(headers);
 
-        headers.add(HttpHeaders.AUTHORIZATION, OAuth2AuthenticationHandler.BEARER_AUTHORIZATION_TYPE + " ");
+        headers.add(HttpHeaderNames.AUTHORIZATION, OAuth2AuthenticationHandler.BEARER_AUTHORIZATION_TYPE + " ");
 
         boolean handle = authenticationHandler.canHandle(authenticationContext);
         Assert.assertFalse(handle);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-oauth2/src/test/java/io/gravitee/gateway/security/oauth2/policy/CheckSubscriptionPolicyTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-oauth2/src/test/java/io/gravitee/gateway/security/oauth2/policy/CheckSubscriptionPolicyTest.java
@@ -19,15 +19,14 @@ import static io.gravitee.reporter.api.http.Metrics.on;
 import static java.lang.System.currentTimeMillis;
 import static org.mockito.Mockito.*;
 
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.policy.PolicyException;
 import io.gravitee.policy.api.PolicyChain;
 import io.gravitee.policy.api.PolicyResult;
-import io.gravitee.reporter.api.http.Metrics;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.SubscriptionRepository;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/vertx/VertxDebugConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/vertx/VertxDebugConfiguration.java
@@ -83,7 +83,6 @@ public class VertxDebugConfiguration {
     }
 
     @Bean("gatewayDebugHttpServer")
-    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
     public VertxHttpServerFactory vertxHttpServerFactory(
         Vertx vertx,
         @Qualifier("debugHttpServerConfiguration") HttpServerConfiguration httpServerConfiguration,

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/http/el/EvaluableHttpResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/http/el/EvaluableHttpResponse.java
@@ -15,7 +15,8 @@
  */
 package io.gravitee.gateway.services.healthcheck.http.el;
 
-import io.gravitee.common.http.HttpHeaders;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.http.vertx.VertxHttpHeaders;
 import io.vertx.core.http.HttpClientResponse;
 
 /**
@@ -26,14 +27,13 @@ public final class EvaluableHttpResponse {
 
     private final int statusCode;
     private final String content;
-    private final HttpHeaders httpHeaders = new HttpHeaders();
+    private final HttpHeaders httpHeaders;
 
     public EvaluableHttpResponse(final HttpClientResponse response, final String content) {
         this.statusCode = response.statusCode();
         this.content = content;
 
-        // Copy HTTP headers
-        response.headers().names().forEach(headerName -> httpHeaders.put(headerName, response.headers().getAll(headerName)));
+        httpHeaders = new VertxHttpHeaders(response.headers());
     }
 
     public int getStatus() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <jetty94.wiremock.version>9.4.44.v20210927</jetty94.wiremock.version>
-        <gravitee-connector-http.version>1.0.0</gravitee-connector-http.version>
+        <gravitee-connector-http.version>1.1.0-SNAPSHOT</gravitee-connector-http.version>
     </properties>
 
     <dependencyManagement>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/TimeoutServerResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/TimeoutServerResponse.java
@@ -15,10 +15,10 @@
  */
 package io.gravitee.gateway.standalone.vertx;
 
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.api.http2.HttpFrame;
 import io.gravitee.gateway.api.stream.WriteStream;
 import io.vertx.core.Vertx;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxReactorConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxReactorConfiguration.java
@@ -39,7 +39,7 @@ public class VertxReactorConfiguration {
     }
 
     @Bean("gatewayHttpServer")
-    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    //    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
     public VertxHttpServerFactory vertxHttpServerFactory(
         Vertx vertx,
         @Qualifier("httpServerConfiguration") HttpServerConfiguration httpServerConfiguration,

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/AbstractSecuredGatewayTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/AbstractSecuredGatewayTest.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.standalone;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public abstract class AbstractSecuredGatewayTest extends AbstractGatewayTest {
+    // Disabled for now because there are some race condition between https and http tests when running all tests."
+    //    static {
+    //        System.setProperty("http.secured", "true");
+    //        System.setProperty("http.alpn", "true");
+    //        System.setProperty("http.ssl.keystore.type", "self-signed");
+    //    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/AbstractWiremockGatewayTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/AbstractWiremockGatewayTest.java
@@ -46,7 +46,7 @@ public abstract class AbstractWiremockGatewayTest extends AbstractGatewayTest {
     protected final WireMockRule wireMockRule = getWiremockRule();
 
     @Before
-    public void initExecutor() {
+    public void initExecutor() throws Exception {
         // Create a dedicated HttpClient for each test with no pooling to avoid side effects.
         final CloseableHttpClient client = HttpClients.custom().build();
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/grpc/GrpcSecuredServerStreamingTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/grpc/GrpcSecuredServerStreamingTest.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.standalone.grpc;
+
+import io.gravitee.gateway.grpc.manualflowcontrol.HelloReply;
+import io.gravitee.gateway.grpc.manualflowcontrol.HelloRequest;
+import io.gravitee.gateway.grpc.manualflowcontrol.StreamingGreeterGrpc;
+import io.gravitee.gateway.standalone.AbstractGatewayTest;
+import io.gravitee.gateway.standalone.AbstractSecuredGatewayTest;
+import io.gravitee.gateway.standalone.junit.annotation.ApiDescriptor;
+import io.gravitee.gateway.standalone.junit.rules.ApiDeployer;
+import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.net.ClientOptionsBase;
+import io.vertx.grpc.VertxChannelBuilder;
+import io.vertx.grpc.VertxServer;
+import io.vertx.grpc.VertxServerBuilder;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+/**
+ *
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Ignore("Disabled for now because there are some race condition between https and http tests when running all tests.")
+@ApiDescriptor("/io/gravitee/gateway/standalone/grpc/streaming-greeter.json")
+public class GrpcSecuredServerStreamingTest extends AbstractSecuredGatewayTest {
+
+    @Rule
+    public final TestRule chain = RuleChain.outerRule(new ApiDeployer(this));
+
+    private static final int STREAM_MESSAGE_NUMBER = 3;
+    private static final long STREAM_SLEEP_MILLIS = 10;
+
+    @Test
+    public void simple_grpc_request() throws InterruptedException {
+        Vertx vertx = Vertx.vertx();
+
+        // Prepare gRPC Server
+        StreamingGreeterGrpc.StreamingGreeterImplBase service = new StreamingGreeterGrpc.StreamingGreeterImplBase() {
+            @Override
+            public StreamObserver<HelloRequest> sayHelloStreaming(StreamObserver<HelloReply> responseObserver) {
+                return new StreamObserver<>() {
+                    @Override
+                    public void onNext(HelloRequest helloRequest) {
+                        for (int i = 0; i < STREAM_MESSAGE_NUMBER; i++) {
+                            HelloReply helloReply = HelloReply
+                                .newBuilder()
+                                .setMessage("Hello " + helloRequest.getName() + " part " + i)
+                                .build();
+                            responseObserver.onNext(helloReply);
+
+                            try {
+                                Thread.sleep(STREAM_SLEEP_MILLIS);
+                            } catch (InterruptedException e) {
+                                responseObserver.onError(Status.ABORTED.asException());
+                            }
+                        }
+                        responseObserver.onCompleted();
+                    }
+
+                    @Override
+                    public void onError(Throwable throwable) {}
+
+                    @Override
+                    public void onCompleted() {}
+                };
+            }
+        };
+
+        VertxServer rpcServer = VertxServerBuilder.forAddress(vertx, "localhost", 50051).addService(service).build();
+
+        // Wait for result
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // Prepare gRPC Client
+        ManagedChannel channel = VertxChannelBuilder
+            .forAddress(vertx, "localhost", 8082)
+            .useSsl(
+                new Handler<ClientOptionsBase>() {
+                    @Override
+                    public void handle(ClientOptionsBase event) {
+                        event.setUseAlpn(true).setSsl(true).setTrustAll(true);
+                    }
+                }
+            )
+            .build();
+
+        // Start is asynchronous
+        rpcServer.start(
+            new Handler<>() {
+                @Override
+                public void handle(AsyncResult<Void> event) {
+                    // Get a stub to use for interacting with the remote service
+                    StreamingGreeterGrpc.StreamingGreeterStub stub = StreamingGreeterGrpc.newStub(channel);
+
+                    // Call the remote service
+                    StreamObserver<HelloRequest> requestStreamObserver = stub.sayHelloStreaming(
+                        new StreamObserver<>() {
+                            @Override
+                            public void onNext(HelloReply helloReply) {}
+
+                            @Override
+                            public void onError(Throwable throwable) {
+                                Assert.fail();
+                            }
+
+                            @Override
+                            public void onCompleted() {
+                                latch.countDown();
+                            }
+                        }
+                    );
+
+                    requestStreamObserver.onNext(HelloRequest.newBuilder().setName("David").build());
+                }
+            }
+        );
+
+        Assert.assertTrue(latch.await(10, TimeUnit.SECONDS));
+        rpcServer.shutdown(event -> channel.shutdownNow());
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/grpc/GrpcUnknownEndpointTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/grpc/GrpcUnknownEndpointTest.java
@@ -48,7 +48,6 @@ public class GrpcUnknownEndpointTest extends AbstractGatewayTest {
     public final TestRule chain = RuleChain.outerRule(new ApiDeployer(this));
 
     @Test
-    @Ignore("Vertx-grpc doesn't work with vertx 3.9.7, to re-enable with vertx 4 (see https://github.com/vert-x3/vertx-grpc/issues/90)")
     public void simple_grpc_request() throws InterruptedException {
         Vertx vertx = Vertx.vertx();
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http/SimpleGatewayTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http/SimpleGatewayTest.java
@@ -38,7 +38,14 @@ public class SimpleGatewayTest extends AbstractWiremockGatewayTest {
     public void call_get_started_api_noBody() throws Exception {
         wireMockRule.stubFor(get("/team/my_team").willReturn(ok()));
 
-        final HttpResponse response = execute(Request.Get("http://localhost:8082/test/my_team")).returnResponse();
+        final HttpResponse response = execute(
+            Request
+                .Get("http://localhost:8082/test/my_team")
+                .addHeader("test", "test01")
+                .addHeader("test", "test02")
+                .addHeader("single", "single")
+        )
+            .returnResponse();
 
         assertEquals(HttpStatusCode.OK_200, response.getStatusLine().getStatusCode());
         wireMockRule.verify(getRequestedFor(urlPathEqualTo("/team/my_team")));

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http2/Http2UnexpectedHttpHeadersGatewayTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http2/Http2UnexpectedHttpHeadersGatewayTest.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.standalone.http2;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import io.gravitee.common.http.HttpHeadersValues;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.standalone.junit.annotation.ApiDescriptor;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.*;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Ignore("Disabled for now because there are some race condition between https and http tests when running all tests.")
+@ApiDescriptor("/io/gravitee/gateway/standalone/http/teams.json")
+public class Http2UnexpectedHttpHeadersGatewayTest extends Http2WiremockGatewayTest {
+
+    @Test
+    public void shouldNotReceiveConnectionHeader() throws Exception {
+        wireMockRule.stubFor(
+            get("/team/my_team").willReturn(ok().withHeader(HttpHeaderNames.CONNECTION, HttpHeadersValues.CONNECTION_CLOSE))
+        );
+
+        io.vertx.core.http.HttpClient httpClient = Vertx
+            .vertx()
+            .createHttpClient(
+                new HttpClientOptions().setSsl(true).setTrustAll(true).setUseAlpn(true).setProtocolVersion(HttpVersion.HTTP_2)
+            );
+
+        httpClient
+            .request(HttpMethod.GET, "https://localhost:8082/test/my_team")
+            .onComplete(
+                new Handler<AsyncResult<HttpClientRequest>>() {
+                    @Override
+                    public void handle(AsyncResult<HttpClientRequest> event) {
+                        Assert.assertTrue(event.succeeded());
+
+                        event
+                            .result()
+                            .send()
+                            .onComplete(
+                                new Handler<AsyncResult<HttpClientResponse>>() {
+                                    @Override
+                                    public void handle(AsyncResult<HttpClientResponse> event) {
+                                        Assert.assertTrue(event.succeeded());
+
+                                        HttpClientResponse httpClientResponse = event.result();
+
+                                        assertEquals(HttpStatusCode.OK_200, httpClientResponse.statusCode());
+                                        assertNull(httpClientResponse.getHeader(HttpHeaderNames.CONNECTION));
+                                        wireMockRule.verify(getRequestedFor(urlPathEqualTo("/team/my_team")));
+                                    }
+                                }
+                            );
+                    }
+                }
+            );
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http2/Http2WiremockGatewayTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http2/Http2WiremockGatewayTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.standalone.http2;
+
+import io.gravitee.gateway.standalone.AbstractWiremockGatewayTest;
+import org.apache.http.client.fluent.Executor;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.junit.Before;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public abstract class Http2WiremockGatewayTest extends AbstractWiremockGatewayTest {
+    static {
+        System.setProperty("http.secured", "true");
+        System.setProperty("http.alpn", "true");
+        System.setProperty("http.ssl.keystore.type", "self-signed");
+    }
+
+    @Before
+    public void initExecutor() throws Exception {
+        // Create a dedicated HttpClient for each test with no pooling to avoid side effects.
+        final SSLContextBuilder builder = new SSLContextBuilder();
+        builder.loadTrustMaterial(null, new TrustSelfSignedStrategy());
+        final SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(builder.build());
+        final CloseableHttpClient client = HttpClients.custom().setSSLSocketFactory(sslsf).build();
+
+        this.executor = Executor.newInstance(client);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketAcceptTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketAcceptTest.java
@@ -69,9 +69,10 @@ public class WebsocketAcceptTest extends AbstractWebSocketGatewayTest {
                     final WebSocket webSocket = event.result();
                     webSocket.frameHandler(
                         frame -> {
-                            Assert.assertTrue(frame.isText());
-                            Assert.assertEquals("PING", frame.textData());
-                            latch.countDown();
+                            if (frame.isText()) {
+                                Assert.assertEquals("PING", frame.textData());
+                                latch.countDown();
+                            }
                         }
                     );
                 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketBidirectionalTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketBidirectionalTest.java
@@ -54,10 +54,10 @@ public class WebsocketBidirectionalTest extends AbstractWebSocketGatewayTest {
                     event.accept();
                     event.frameHandler(
                         frame -> {
-                            Assert.assertTrue(frame.isText());
-                            Assert.assertEquals("PONG", frame.textData());
-
-                            latch.countDown();
+                            if (frame.isText()) {
+                                Assert.assertEquals("PONG", frame.textData());
+                                latch.countDown();
+                            }
                         }
                     );
                     event.writeTextMessage("PING");
@@ -77,10 +77,10 @@ public class WebsocketBidirectionalTest extends AbstractWebSocketGatewayTest {
                     final WebSocket webSocket = event.result();
                     webSocket.frameHandler(
                         frame -> {
-                            Assert.assertTrue(frame.isText());
-                            Assert.assertEquals("PING", frame.textData());
-
-                            webSocket.writeTextMessage("PONG");
+                            if (frame.isText()) {
+                                Assert.assertEquals("PING", frame.textData());
+                                webSocket.writeTextMessage("PONG");
+                            }
                         }
                     );
                 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketPingFrameTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketPingFrameTest.java
@@ -55,9 +55,10 @@ public class WebsocketPingFrameTest extends AbstractWebSocketGatewayTest {
                     event.accept();
                     event.frameHandler(
                         frame -> {
-                            Assert.assertTrue(frame.isPing());
-                            Assert.assertEquals("PING", frame.textData());
-                            latch.countDown();
+                            if (frame.isPing()) {
+                                Assert.assertEquals("PING", frame.textData());
+                                latch.countDown();
+                            }
                         }
                     );
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -61,17 +61,17 @@
         <gravitee-alert-api.version>1.8.0</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>1.9.0</gravitee-cockpit-api.version>
         <gravitee-common.version>1.25.0-SNAPSHOT</gravitee-common.version>
-        <gravitee-connector-api.version>1.0.0</gravitee-connector-api.version>
+        <gravitee-connector-api.version>1.1.0-SNAPSHOT</gravitee-connector-api.version>
         <gravitee-definition.version>1.31.0-SNAPSHOT</gravitee-definition.version>
-        <gravitee-expression-language.version>1.7.2</gravitee-expression-language.version>
+        <gravitee-expression-language.version>1.8.0-SNAPSHOT</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>1.30.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.31.0-SNAPSHOT</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>1.20.0-SNAPSHOT</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>
         <gravitee-plugin.version>1.22.0-SNAPSHOT</gravitee-plugin.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-reporter-api.version>1.21.0</gravitee-reporter-api.version>
+        <gravitee-reporter-api.version>1.22.0-SNAPSHOT</gravitee-reporter-api.version>
         <gravitee-resource-cache-provider-api.version>1.1.0</gravitee-resource-cache-provider-api.version>
         <gravitee-resource-oauth2-provider-api.version>1.3.0</gravitee-resource-oauth2-provider-api.version>
         <gravitee-service-discovery-api.version>1.1.1</gravitee-service-discovery-api.version>


### PR DESCRIPTION
Closes gravitee-io/issues#6772
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qxvlxmmyrc.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-6772-http-headers-rework/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
