### PR TITLE
fix: set organization context before retrieving the cockpit user

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeployModelCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeployModelCommandHandler.java
@@ -81,8 +81,10 @@ public class DeployModelCommandHandler implements CommandHandler<DeployModelComm
         DeploymentMode mode = DeploymentMode.fromDeployModelPayload(payload);
 
         try {
-            final UserEntity user = userService.findBySource("cockpit", userId, false);
             final EnvironmentEntity environment = environmentService.findByCockpitId(environmentId);
+            GraviteeContext.setCurrentEnvironment(environment.getId());
+            GraviteeContext.setCurrentOrganization(environment.getOrganizationId());
+            final UserEntity user = userService.findBySource("cockpit", userId, false);
 
             ApiEntityResult result;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImpl.java
@@ -71,8 +71,6 @@ public class ApiServiceCockpitImpl implements ApiServiceCockpit {
 
     @Override
     public ApiEntityResult createApi(String apiId, String userId, String swaggerDefinition, String environmentId, DeploymentMode mode) {
-        GraviteeContext.setCurrentEnvironment(environmentId);
-
         if (mode == DeploymentMode.API_MOCKED) {
             logger.debug("Create Mocked Api [{}].", apiId);
             return createMockedApi(apiId, userId, swaggerDefinition, environmentId);
@@ -89,8 +87,6 @@ public class ApiServiceCockpitImpl implements ApiServiceCockpit {
 
     @Override
     public ApiEntityResult updateApi(String apiId, String userId, String swaggerDefinition, String environmentId, DeploymentMode mode) {
-        GraviteeContext.setCurrentEnvironment(environmentId);
-
         if (mode == DeploymentMode.API_DOCUMENTED) {
             logger.debug("Update Documented Api [{}].", apiId);
             return updateDocumentedApi(apiId, swaggerDefinition);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeployModelCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeployModelCommandHandlerTest.java
@@ -54,6 +54,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @PrepareForTest(GraviteeContext.class)
 public class DeployModelCommandHandlerTest {
 
+    public static final String ENVIRONMENT_ID = "environment#id";
+    public static final String ORGANIZATION_ID = "organization#id";
+
     @Mock
     private UserService userService;
 
@@ -100,7 +103,8 @@ public class DeployModelCommandHandlerTest {
         when(userService.findBySource("cockpit", payload.getUserId(), false)).thenReturn(user);
 
         EnvironmentEntity environment = new EnvironmentEntity();
-        environment.setId("environment#id");
+        environment.setId(ENVIRONMENT_ID);
+        environment.setOrganizationId(ORGANIZATION_ID);
         when(environmentService.findByCockpitId(payload.getEnvironmentId())).thenReturn(environment);
 
         when(permissionChecker.checkCreatePermission(user.getId(), environment.getId(), DeploymentMode.API_DOCUMENTED))
@@ -127,6 +131,10 @@ public class DeployModelCommandHandlerTest {
 
         obs.awaitTerminalEvent();
         obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
+
+        PowerMockito.verifyStatic(GraviteeContext.class);
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
     }
 
     @Test
@@ -147,7 +155,7 @@ public class DeployModelCommandHandlerTest {
         when(userService.findBySource("cockpit", payload.getUserId(), false)).thenReturn(user);
 
         EnvironmentEntity environment = new EnvironmentEntity();
-        environment.setId("environment#id");
+        environment.setId(ENVIRONMENT_ID);
         when(environmentService.findByCockpitId(payload.getEnvironmentId())).thenReturn(environment);
 
         when(permissionChecker.checkCreatePermission(user.getId(), environment.getId(), DeploymentMode.API_MOCKED))
@@ -194,7 +202,7 @@ public class DeployModelCommandHandlerTest {
         when(userService.findBySource("cockpit", payload.getUserId(), false)).thenReturn(user);
 
         EnvironmentEntity environment = new EnvironmentEntity();
-        environment.setId("environment#id");
+        environment.setId(ENVIRONMENT_ID);
         when(environmentService.findByCockpitId(payload.getEnvironmentId())).thenReturn(environment);
 
         when(permissionChecker.checkCreatePermission(user.getId(), environment.getId(), DeploymentMode.API_PUBLISHED))
@@ -241,7 +249,7 @@ public class DeployModelCommandHandlerTest {
         when(userService.findBySource("cockpit", payload.getUserId(), false)).thenReturn(user);
 
         EnvironmentEntity environment = new EnvironmentEntity();
-        environment.setId("environment#id");
+        environment.setId(ENVIRONMENT_ID);
         when(environmentService.findByCockpitId(payload.getEnvironmentId())).thenReturn(environment);
 
         when(
@@ -290,7 +298,7 @@ public class DeployModelCommandHandlerTest {
         when(userService.findBySource("cockpit", payload.getUserId(), false)).thenReturn(user);
 
         EnvironmentEntity environment = new EnvironmentEntity();
-        environment.setId("environment#id");
+        environment.setId(ENVIRONMENT_ID);
         when(environmentService.findByCockpitId(payload.getEnvironmentId())).thenReturn(environment);
 
         when(permissionChecker.checkUpdatePermission(user.getId(), environment.getId(), payload.getModelId(), DeploymentMode.API_MOCKED))
@@ -337,7 +345,7 @@ public class DeployModelCommandHandlerTest {
         when(userService.findBySource("cockpit", payload.getUserId(), false)).thenReturn(user);
 
         EnvironmentEntity environment = new EnvironmentEntity();
-        environment.setId("environment#id");
+        environment.setId(ENVIRONMENT_ID);
         when(environmentService.findByCockpitId(payload.getEnvironmentId())).thenReturn(environment);
 
         when(permissionChecker.checkUpdatePermission(user.getId(), environment.getId(), payload.getModelId(), DeploymentMode.API_PUBLISHED))
@@ -384,7 +392,7 @@ public class DeployModelCommandHandlerTest {
         when(userService.findBySource("cockpit", payload.getUserId(), false)).thenReturn(user);
 
         EnvironmentEntity environment = new EnvironmentEntity();
-        environment.setId("environment#id");
+        environment.setId(ENVIRONMENT_ID);
         when(environmentService.findByCockpitId(payload.getEnvironmentId())).thenReturn(environment);
 
         when(permissionChecker.checkCreatePermission(user.getId(), environment.getId(), DeploymentMode.API_DOCUMENTED))
@@ -431,7 +439,7 @@ public class DeployModelCommandHandlerTest {
         when(userService.findBySource("cockpit", payload.getUserId(), false)).thenReturn(user);
 
         EnvironmentEntity environment = new EnvironmentEntity();
-        environment.setId("environment#id");
+        environment.setId(ENVIRONMENT_ID);
         when(environmentService.findByCockpitId(payload.getEnvironmentId())).thenReturn(environment);
 
         when(permissionChecker.checkCreatePermission(user.getId(), environment.getId(), DeploymentMode.API_DOCUMENTED))
@@ -473,7 +481,7 @@ public class DeployModelCommandHandlerTest {
         when(userService.findBySource("cockpit", payload.getUserId(), false)).thenReturn(user);
 
         EnvironmentEntity environment = new EnvironmentEntity();
-        environment.setId("environment#id");
+        environment.setId(ENVIRONMENT_ID);
         when(environmentService.findByCockpitId(payload.getEnvironmentId())).thenReturn(environment);
 
         when(permissionChecker.checkCreatePermission(user.getId(), environment.getId(), DeploymentMode.API_DOCUMENTED))
@@ -512,7 +520,7 @@ public class DeployModelCommandHandlerTest {
         when(userService.findBySource("cockpit", payload.getUserId(), false)).thenReturn(user);
 
         EnvironmentEntity environment = new EnvironmentEntity();
-        environment.setId("environment#id");
+        environment.setId(ENVIRONMENT_ID);
         when(environmentService.findByCockpitId(payload.getEnvironmentId())).thenReturn(environment);
 
         when(
@@ -553,7 +561,7 @@ public class DeployModelCommandHandlerTest {
         when(userService.findBySource("cockpit", payload.getUserId(), false)).thenReturn(user);
 
         EnvironmentEntity environment = new EnvironmentEntity();
-        environment.setId("environment#id");
+        environment.setId(ENVIRONMENT_ID);
         when(environmentService.findByCockpitId(payload.getEnvironmentId())).thenReturn(environment);
 
         when(permissionChecker.checkCreatePermission(user.getId(), environment.getId(), DeploymentMode.API_DOCUMENTED))
@@ -602,7 +610,7 @@ public class DeployModelCommandHandlerTest {
         when(userService.findBySource("cockpit", payload.getUserId(), false)).thenReturn(user);
 
         EnvironmentEntity environment = new EnvironmentEntity();
-        environment.setId("environment#id");
+        environment.setId(ENVIRONMENT_ID);
         when(environmentService.findByCockpitId(payload.getEnvironmentId())).thenReturn(environment);
 
         when(permissionChecker.checkCreatePermission(user.getId(), environment.getId(), DeploymentMode.API_DOCUMENTED))
@@ -635,7 +643,7 @@ public class DeployModelCommandHandlerTest {
         when(userService.findBySource("cockpit", payload.getUserId(), false)).thenReturn(user);
 
         EnvironmentEntity environment = new EnvironmentEntity();
-        environment.setId("environment#id");
+        environment.setId(ENVIRONMENT_ID);
         when(environmentService.findByCockpitId(payload.getEnvironmentId())).thenReturn(environment);
 
         when(permissionChecker.checkCreatePermission(user.getId(), environment.getId(), DeploymentMode.API_DOCUMENTED))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImplTest.java
@@ -42,14 +42,13 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 /**
  * @author GraviteeSource Team
  */
-@RunWith(PowerMockRunner.class)
+@RunWith(MockitoJUnitRunner.class)
 @PrepareForTest(GraviteeContext.class)
 public class ApiServiceCockpitImplTest {
 
@@ -109,7 +108,6 @@ public class ApiServiceCockpitImplTest {
                 planService,
                 virtualHostService
             );
-        PowerMockito.spy(GraviteeContext.class);
     }
 
     @Test
@@ -131,6 +129,8 @@ public class ApiServiceCockpitImplTest {
 
         when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
         when(apiService.createWithApiDefinition(eq(swaggerApi), eq(USER_ID), any(ObjectNode.class))).thenReturn(api);
+
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
 
         service.createApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_DOCUMENTED);
 
@@ -187,10 +187,9 @@ public class ApiServiceCockpitImplTest {
         when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
         when(apiService.createWithApiDefinition(eq(swaggerApi), eq(USER_ID), any(ObjectNode.class))).thenReturn(api);
 
-        service.createApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_MOCKED);
-
-        PowerMockito.verifyStatic(GraviteeContext.class);
         GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
+
+        service.createApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_MOCKED);
 
         verify(swaggerService).createAPI(descriptorCaptor.capture(), eq(DefinitionVersion.V2));
         assertThat(descriptorCaptor.getValue()).usingRecursiveComparison().isEqualTo(expectedDescriptor);
@@ -229,7 +228,7 @@ public class ApiServiceCockpitImplTest {
     }
 
     @Test
-    public void should_create_an_published_api() {
+    public void should_create_a_published_api() {
         ImportSwaggerDescriptorEntity expectedDescriptor = new ImportSwaggerDescriptorEntity();
         expectedDescriptor.setPayload(SWAGGER_DEFINITION);
         expectedDescriptor.setWithDocumentation(true);
@@ -252,10 +251,9 @@ public class ApiServiceCockpitImplTest {
 
         preparePageServiceMock();
 
-        service.createApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED);
-
-        PowerMockito.verifyStatic(GraviteeContext.class);
         GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
+
+        service.createApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED);
 
         verify(swaggerService).createAPI(descriptorCaptor.capture(), eq(DefinitionVersion.V2));
         assertThat(descriptorCaptor.getValue()).usingRecursiveComparison().isEqualTo(expectedDescriptor);
@@ -340,6 +338,8 @@ public class ApiServiceCockpitImplTest {
 
         preparePageServiceMock();
 
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
+
         service.createApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED);
 
         verify(pageService).update(eq(PAGE_ID), updatePageCaptor.capture());
@@ -365,18 +365,15 @@ public class ApiServiceCockpitImplTest {
 
         when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
 
-        when(apiService.exists(API_ID)).thenReturn(true);
-
         ApiEntity updatedApiEntity = new ApiEntity();
         updatedApiEntity.setName("updated api");
         updatedApiEntity.setProxy(proxy);
         when(apiService.updateFromSwagger(eq(API_ID), eq(swaggerApi), any(ImportSwaggerDescriptorEntity.class)))
             .thenReturn(updatedApiEntity);
 
-        final var result = service.updateApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_DOCUMENTED);
-
-        PowerMockito.verifyStatic(GraviteeContext.class);
         GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
+
+        final var result = service.updateApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_DOCUMENTED);
 
         verify(swaggerService).createAPI(descriptorCaptor.capture(), eq(DefinitionVersion.V2));
         assertThat(descriptorCaptor.getValue()).usingRecursiveComparison().isEqualTo(expectedDescriptor);
@@ -406,8 +403,6 @@ public class ApiServiceCockpitImplTest {
 
         when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
 
-        when(apiService.exists(API_ID)).thenReturn(true);
-
         ApiEntity updatedApiEntity = new ApiEntity();
         updatedApiEntity.setName("updated api");
         updatedApiEntity.setProxy(proxy);
@@ -417,11 +412,10 @@ public class ApiServiceCockpitImplTest {
         when(apiService.deploy(anyString(), anyString(), any(EventType.class), any(ApiDeploymentEntity.class)))
             .thenReturn(updatedApiEntity);
 
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
+
         final var result = service.updateApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_MOCKED);
         assertThat(result.getApi()).isEqualTo(updatedApiEntity);
-
-        PowerMockito.verifyStatic(GraviteeContext.class);
-        GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
 
         verify(swaggerService).createAPI(descriptorCaptor.capture(), eq(DefinitionVersion.V2));
         assertThat(descriptorCaptor.getValue()).usingRecursiveComparison().isEqualTo(expectedDescriptor);
@@ -442,8 +436,6 @@ public class ApiServiceCockpitImplTest {
         api.setProxy(proxy);
 
         when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
-
-        when(apiService.exists(API_ID)).thenReturn(true);
 
         ApiEntity updatedApiEntity = new ApiEntity();
         updatedApiEntity.setName("updated api");
@@ -476,8 +468,6 @@ public class ApiServiceCockpitImplTest {
 
         when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
 
-        when(apiService.exists(API_ID)).thenReturn(true);
-
         ApiEntity updatedApiEntity = new ApiEntity();
         updatedApiEntity.setName("updated api");
         updatedApiEntity.setProxy(proxy);
@@ -486,11 +476,10 @@ public class ApiServiceCockpitImplTest {
         when(apiService.deploy(anyString(), anyString(), any(EventType.class), any(ApiDeploymentEntity.class)))
             .thenReturn(updatedApiEntity);
 
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
+
         final var result = service.updateApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED);
         assertThat(result.getApi()).isEqualTo(updatedApiEntity);
-
-        PowerMockito.verifyStatic(GraviteeContext.class);
-        GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
 
         verify(swaggerService).createAPI(descriptorCaptor.capture(), eq(DefinitionVersion.V2));
         assertThat(descriptorCaptor.getValue()).usingRecursiveComparison().isEqualTo(expectedDescriptor);
@@ -511,8 +500,6 @@ public class ApiServiceCockpitImplTest {
         api.setProxy(proxy);
 
         when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
-
-        when(apiService.exists(API_ID)).thenReturn(true);
 
         ApiEntity updatedApiEntity = new ApiEntity();
         updatedApiEntity.setName("updated api");


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/gravitee-cockpit/issues/1398

**Description**

An error occurs when a user trie to deploy an API, using the designer on cockpit, on a different organization than the default one.
It happens because we fetch the wrong user if the organization is not set in the gravitee context.

**Screenshot**

***Before***
<img width="1790" alt="Screenshot 2021-12-22 at 15 58 02" src="https://user-images.githubusercontent.com/25704259/147112049-5f8f774f-0401-4003-8ec5-06cc8c060127.png">


***After***
<img width="1788" alt="Screenshot 2021-12-22 at 15 56 05" src="https://user-images.githubusercontent.com/25704259/147111951-04779e9c-ab9e-4db6-8351-b23f14c3d076.png">

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-likailfriy.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-1398-deploy-cockpit-model/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
