### PR TITLE
Org/env owners should be allowed to push models

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/services/CockpitApiPermissionCheckerImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/services/CockpitApiPermissionCheckerImpl.java
@@ -60,18 +60,33 @@ public class CockpitApiPermissionCheckerImpl implements CockpitApiPermissionChec
     }
 
     private boolean isNotAllowedToCreateApi(String userId, String environmentId) {
-        return !permissionService.hasPermission(userId, RolePermission.ENVIRONMENT_API, environmentId, RolePermissionAction.CREATE);
+        return (
+            !isAdmin(userId) &&
+            !permissionService.hasPermission(userId, RolePermission.ENVIRONMENT_API, environmentId, RolePermissionAction.CREATE)
+        );
     }
 
     private boolean isNotAllowedToUpdateApi(String userId, String environmentId) {
-        return !permissionService.hasPermission(userId, RolePermission.ENVIRONMENT_API, environmentId, RolePermissionAction.UPDATE);
+        return (
+            !isAdmin(userId) &&
+            !permissionService.hasPermission(userId, RolePermission.ENVIRONMENT_API, environmentId, RolePermissionAction.UPDATE)
+        );
     }
 
     private boolean isNotAllowedToUpdateDocumentation(String userId, String apiId) {
-        return !permissionService.hasPermission(userId, RolePermission.API_DOCUMENTATION, apiId, RolePermissionAction.UPDATE);
+        return (
+            !isAdmin(userId) &&
+            !permissionService.hasPermission(userId, RolePermission.API_DOCUMENTATION, apiId, RolePermissionAction.UPDATE)
+        );
     }
 
     private boolean isNotAllowedToUpdateApiDefinition(String userId, String apiId) {
-        return !permissionService.hasPermission(userId, RolePermission.API_DEFINITION, apiId, RolePermissionAction.UPDATE);
+        return (
+            !isAdmin(userId) && !permissionService.hasPermission(userId, RolePermission.API_DEFINITION, apiId, RolePermissionAction.UPDATE)
+        );
+    }
+
+    protected boolean isAdmin(String userId) {
+        return permissionService.hasManagementRights(userId);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/CockpitApiPermissionCheckerImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/CockpitApiPermissionCheckerImplTest.java
@@ -127,6 +127,14 @@ public class CockpitApiPermissionCheckerImplTest {
         assertThat(result).isEmpty();
     }
 
+    @Test
+    public void returns_empty_optional_when_user_is_admin() {
+        makeUserAdmin();
+
+        var result = permissionChecker.checkUpdatePermission(USER_ID, ENVIRONMENT_ID, API_ID, DeploymentMode.API_MOCKED);
+        assertThat(result).isEmpty();
+    }
+
     private void allowApiUpdate() {
         when(permissionService.hasPermission(USER_ID, RolePermission.ENVIRONMENT_API, ENVIRONMENT_ID, RolePermissionAction.UPDATE))
             .thenReturn(true);
@@ -139,5 +147,9 @@ public class CockpitApiPermissionCheckerImplTest {
 
     private void allowApiDefinitionUpdate() {
         when(permissionService.hasPermission(USER_ID, RolePermission.API_DEFINITION, API_ID, RolePermissionAction.UPDATE)).thenReturn(true);
+    }
+
+    private void makeUserAdmin() {
+        when(permissionService.hasManagementRights(USER_ID)).thenReturn(true);
     }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/gravitee-cockpit/issues/1400

**Description**

Organization or Environment owners should be able to push models even if they are not model owners anymore (i.e. after transfering ownership)


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nvtdxwmjae.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/1400-org-owner-allow-push-model/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
