### PR TITLE
fix: bump gravitee-definition version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <gravitee-alert-api.version>1.7.1</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>1.7.0</gravitee-cockpit-api.version>
         <gravitee-common.version>1.20.5</gravitee-common.version>
-        <gravitee-definition.version>1.28.1</gravitee-definition.version>
+        <gravitee-definition.version>1.28.2-SNAPSHOT</gravitee-definition.version>
         <gravitee-expression-language.version>1.6.3</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>1.27.3</gravitee-gateway-api.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6775

**Description**

Use the latest version of gravitee-definition, to fix the way the cron expression is computed from the old healthcheck rate configuration
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issue-6775-pb-in-cron-conversion/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
