### PR TITLE
fix: try to split tests of apim

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,9 +279,37 @@ jobs:
                       - ./gateway-docker-context
 
     test:
+        docker:
+            - image: cimg/openjdk:11.0
+        resource_class: medium
+        steps:
+            - checkout
+            - attach_workspace:
+                  at: .
+            - restore-maven-cache
+            - run:
+                  name: Run tests
+                  command: |
+                      mvn -pl 'gravitee-apim-definition, gravitee-apim-rest-api, gravitee-apim-gateway' -amd --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dskip.validation=true -T 2C
+            - run:
+                  name: Save test results
+                  command: |
+                      mkdir -p ~/test-results/junit/
+                      find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
+                  when: always
+            - notify-on-failure
+            - store_test_results:
+                  path: ~/test-results
+            - persist_to_workspace:
+                  root: .
+                  paths:
+                      - gravitee-apim-gateway/gravitee-apim-gateway-coverage/target/site/jacoco-aggregate/
+                      - gravitee-apim-rest-api/gravitee-apim-rest-api-coverage/target/site/jacoco-aggregate/
+
+    test-repository:
         machine:
-            image: ubuntu-2004:202107-02
-        resource_class: xlarge
+            image: ubuntu-2004:current
+        resource_class: large
         steps:
             - checkout
             - attach_workspace:
@@ -292,7 +320,8 @@ jobs:
                   command: |
                       # Need to use `verify` phase to get repo-test's jar build and shared to mongodb and jdbc repos 
                       # and then collect and merge all coverage reports
-                      mvn -s .gravitee.settings.xml verify --no-transfer-progress -Dskip.validation=true -T 2C
+                      cd gravitee-apim-repository
+                      mvn -s ../.gravitee.settings.xml verify --no-transfer-progress -Dskip.validation=true -T 2C
             - run:
                   name: Save test results
                   command: |
@@ -300,15 +329,12 @@ jobs:
                       find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
                   when: always
             - notify-on-failure
-            - save-maven-cache
             - store_test_results:
                   path: ~/test-results
             - persist_to_workspace:
                   root: .
                   paths:
-                      - gravitee-apim-gateway/gravitee-apim-gateway-coverage/target/site/jacoco-aggregate/
                       - gravitee-apim-repository/gravitee-apim-repository-coverage/target/site/jacoco-aggregate/
-                      - gravitee-apim-rest-api/gravitee-apim-rest-api-coverage/target/site/jacoco-aggregate/
 
     publish-on-artifactory:
         docker:
@@ -1161,6 +1187,9 @@ workflows:
             - test:
                   requires:
                       - build
+            - test-repository:
+                  requires:
+                      - build
             - run_postman_tests:
                   requires:
                       - build
@@ -1180,28 +1209,30 @@ workflows:
                   context: cicd-orchestrator
                   requires:
                       - test
+                      - test-repository
             - publish-on-artifactory:
                   filters:
                       branches:
                           only:
                               - master
                               - /^\d+\.\d+\.x$/
-                              - fix-nexus-pb
                   requires:
                       - test
+                      - test-repository
             - publish-on-nexus:
                   filters:
                       branches:
                           only:
                               - master
                               - /^\d+\.\d+\.x$/
-                              - fix-nexus-pb
                   requires:
                       - test
+                      - test-repository
             - publish-images-azure-registry:
                   context: cicd-orchestrator
                   requires:
                       - test
+                      - test-repository
                   filters:
                       branches:
                           only:

--- a/gravitee-apim-gateway/gravitee-apim-gateway-coverage/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-coverage/pom.xml
@@ -209,7 +209,7 @@
                 <executions>
                     <execution>
                         <id>report-aggregate</id>
-                        <phase>verify</phase>
+                        <phase>test</phase>
                         <goals>
                             <goal>report-aggregate</goal>
                         </goals>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http/ClientConnectionResponseTemplateTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http/ClientConnectionResponseTemplateTest.java
@@ -34,7 +34,7 @@ public class ClientConnectionResponseTemplateTest extends AbstractWiremockGatewa
 
     @Test
     public void call_unreachable_api_with_response_template() throws Exception {
-        HttpResponse response = Request.Post("http://localhost:8082/unreachable").execute().returnResponse();
+        HttpResponse response = execute(Request.Post("http://localhost:8082/unreachable")).returnResponse();
 
         assertEquals(HttpStatus.SC_BAD_GATEWAY, response.getStatusLine().getStatusCode());
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
@@ -53,13 +53,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>io.gravitee.apim.definition</groupId>
-            <artifactId>gravitee-apim-definition-jackson</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Runtime scope -->
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/pom.xml
@@ -48,13 +48,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>io.gravitee.apim.definition</groupId>
-            <artifactId>gravitee-apim-definition-jackson</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Runtime scope -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-coverage/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-coverage/pom.xml
@@ -197,7 +197,7 @@
                 <executions>
                     <execution>
                         <id>report-aggregate</id>
-                        <phase>verify</phase>
+                        <phase>test</phase>
                         <goals>
                             <goal>report-aggregate</goal>
                         </goals>


### PR DESCRIPTION
**Description**

This PR splits the test job in two:
* one for the repository part, on a VM executor
* one for all the rest (Rest API & GW), on a docker executor.

The idea is to downsize the VM executor because it costs a lot. And if flaky tests appear, restarting the test job will cost even less credits.

**Additional information**

Some figures for comparison:
 * before this PR, 1 job:
   * the `test` job  could take an average of 12min, on a X-Large VM executor => 1200 credits
 * after this PR, 2 jobs in //:
   * the `test repository` job takes an average of 7min30, on a Large VM executor => 150 credits
   * the `test` job takes an average of 7min, on a medium docker executor => 70 credits


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mxkpuxhgta.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/split-repository-tests/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
