### PR TITLE
fix(console): fix redirection after role creation in organization set…

### DIFF
--- a/gravitee-apim-console-webui/src/organization/configuration/roles/role/org-settings-role.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/roles/role/org-settings-role.component.spec.ts
@@ -317,10 +317,15 @@ describe('OrgSettingsRoleComponent', () => {
         },
         system: false,
       });
-      req.flush(null);
+      req.flush({
+        name: 'CREATED_ROLE_NAME',
+      });
       fixture.detectChanges();
 
-      expect(fakeAjsState.go).toHaveBeenCalledWith('organization.settings.ng-roleedit', { role: 'NEW NAME', roleScope: 'ORGANIZATION' });
+      expect(fakeAjsState.go).toHaveBeenCalledWith('organization.settings.ng-roleedit', {
+        role: 'CREATED_ROLE_NAME',
+        roleScope: 'ORGANIZATION',
+      });
     });
   });
 

--- a/gravitee-apim-console-webui/src/organization/configuration/roles/role/org-settings-role.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/roles/role/org-settings-role.component.ts
@@ -173,9 +173,9 @@ export class OrgSettingsRoleComponent implements OnInit, OnDestroy {
           return EMPTY;
         }),
       )
-      .subscribe(() => {
+      .subscribe((resultingRole) => {
         if (!this.isEditMode) {
-          this.ajsState.go('organization.settings.ng-roleedit', { roleScope: this.roleScope, role: roleFormValue.name.toUpperCase() });
+          this.ajsState.go('organization.settings.ng-roleedit', { roleScope: this.roleScope, role: resultingRole.name });
         } else {
           this.ngOnInit();
         }

--- a/gravitee-apim-console-webui/src/services-ngx/role.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/role.service.ts
@@ -60,12 +60,12 @@ export class RoleService {
       .pipe(map((role) => ({ ...role, scope: role.scope.toUpperCase() as RoleScope })));
   }
 
-  create(role: Role): Observable<void> {
-    return this.http.post<void>(`${this.constants.org.baseURL}/configuration/rolescopes/${role.scope}/roles`, role);
+  create(role: Role): Observable<Role> {
+    return this.http.post<Role>(`${this.constants.org.baseURL}/configuration/rolescopes/${role.scope}/roles`, role);
   }
 
-  update(role: Role): Observable<void> {
-    return this.http.put<void>(`${this.constants.org.baseURL}/configuration/rolescopes/${role.scope}/roles/${role.name}`, role);
+  update(role: Role): Observable<Role> {
+    return this.http.put<Role>(`${this.constants.org.baseURL}/configuration/rolescopes/${role.scope}/roles/${role.name}`, role);
   }
 
   delete(scope: string, roleName: string): Observable<void> {


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6810

**Description**

fix(console): fix redirection after role creation in organization settings

Use resulting role name returned by backend instead of input role name, cause backend may have altered it (for example by replacing spaces by underscores)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uumumouqke.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-6810-create-role-with-space/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
