### PR TITLE
fix(portal): set  doc TOC max-height according to the page content

### DIFF
--- a/gravitee-apim-portal-webui/src/app/components/gv-documentation/gv-documentation.component.ts
+++ b/gravitee-apim-portal-webui/src/app/components/gv-documentation/gv-documentation.component.ts
@@ -80,7 +80,6 @@ export class GvDocumentationComponent implements AfterViewInit {
 
   @ViewChild('treeMenu', { static: false }) treeMenu;
   private loadingTimer: any;
-  private lastTop: number;
 
   @Input() fragment: string;
 
@@ -93,24 +92,17 @@ export class GvDocumentationComponent implements AfterViewInit {
     }
   }
 
-  static updateMenuPosition(menuElement, lastTop) {
+  static updateMenuPosition(menuElement) {
     if (menuElement) {
       const scrollTop = document.scrollingElement.scrollTop;
       if (document.querySelector(this.PAGE_COMPONENT)) {
-        const { height } = menuElement.getBoundingClientRect();
         const contentHeight = document.querySelector(this.PAGE_COMPONENT).getBoundingClientRect().height;
-        if (contentHeight - scrollTop <= height) {
-          menuElement.style.top = `${lastTop}px`;
-          menuElement.style.bottom = `${contentHeight - scrollTop}px`;
-          menuElement.style.position = `absolute`;
-          return null;
-        } else {
-          this.reset(menuElement);
-          return scrollTop + ScrollService.getHeaderHeight();
-        }
+
+        menuElement.style['max-height'] = `${contentHeight - scrollTop}px`;
+
+        this.reset(menuElement);
       } else {
         this.reset(menuElement);
-        return scrollTop + ScrollService.getHeaderHeight();
       }
     }
   }
@@ -200,7 +192,7 @@ export class GvDocumentationComponent implements AfterViewInit {
   onScroll() {
     if (this.treeMenu) {
       window.requestAnimationFrame(() => {
-        this.lastTop = GvDocumentationComponent.updateMenuPosition(this.treeMenu.nativeElement, this.lastTop);
+        GvDocumentationComponent.updateMenuPosition(this.treeMenu.nativeElement);
       });
     }
   }
@@ -208,7 +200,6 @@ export class GvDocumentationComponent implements AfterViewInit {
   @HostListener(':gv-tree:select', ['$event.detail.value'])
   onPageChange(page) {
     this.router.navigate([], { queryParams: { page: page.id } }).then(() => {
-      this.lastTop = null;
       GvDocumentationComponent.reset(this.treeMenu.nativeElement);
     });
     this.currentPage = page;

--- a/gravitee-apim-portal-webui/src/app/components/gv-markdown-toc/gv-markdown-toc.component.css
+++ b/gravitee-apim-portal-webui/src/app/components/gv-markdown-toc/gv-markdown-toc.component.css
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 .page__box {
+  height: 100%;
   max-width: 250px;
 }
 

--- a/gravitee-apim-portal-webui/src/app/components/gv-markdown-toc/gv-markdown-toc.component.ts
+++ b/gravitee-apim-portal-webui/src/app/components/gv-markdown-toc/gv-markdown-toc.component.ts
@@ -37,7 +37,6 @@ export class GvMarkdownTocComponent implements OnInit, OnDestroy, AfterViewInit 
   textRenderer = new marked.TextRenderer();
   /* ****************** */
   private scrollInProgress: boolean;
-  private lastTop: number;
 
   constructor(
     private route: ActivatedRoute,
@@ -74,7 +73,7 @@ export class GvMarkdownTocComponent implements OnInit, OnDestroy, AfterViewInit 
   @HostListener('window:scroll')
   onScroll() {
     window.requestAnimationFrame(() => {
-      this.lastTop = GvDocumentationComponent.updateMenuPosition(this.element.nativeElement, this.lastTop);
+      GvDocumentationComponent.updateMenuPosition(this.element.nativeElement);
     });
   }
 

--- a/gravitee-apim-portal-webui/src/app/components/gv-page-redoc/gv-page-redoc.component.ts
+++ b/gravitee-apim-portal-webui/src/app/components/gv-page-redoc/gv-page-redoc.component.ts
@@ -35,7 +35,6 @@ export class GvPageRedocComponent implements OnInit, OnDestroy {
   @ViewChild('redoc', { static: true }) redocContainer;
 
   @Input() fragment: string;
-  private lastTop: number;
 
   constructor(private notificationService: NotificationService, private pageService: PageService) {}
 
@@ -48,10 +47,7 @@ export class GvPageRedocComponent implements OnInit, OnDestroy {
   @HostListener('window:scroll')
   onScroll() {
     window.requestAnimationFrame(() => {
-      this.lastTop = GvDocumentationComponent.updateMenuPosition(this.redocMenu, this.lastTop);
-      if (this.lastTop) {
-        this.lastTop -= 108;
-      }
+      GvDocumentationComponent.updateMenuPosition(this.redocMenu);
     });
   }
 


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6618

**Description**

The toc menu cannot be higher than the height of the page content without what is already scrolled

**Additional context**

To test it faster you can use this PR (🍒 cherry-pick commit into master) : https://github.com/gravitee-io/gravitee-api-management/pull/1004 and run `npm run serve:apim-master` into portal project


before : 
![image](https://user-images.githubusercontent.com/4974420/147475038-39a80a03-50ae-48b8-9d25-7fdb87960538.png)

after :

![image](https://user-images.githubusercontent.com/4974420/147475008-fe7122ee-1049-4cb9-a86c-648eb55df27b.png)



<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6618-fix-portal-toc/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
