### PR TITLE
chore: license directory content is git ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,12 +12,6 @@ gravitee-**/target/
 .classpath
 /bin/
 
-# TODO
-# gravitee-apim-rest-api-standalone/gravitee-rest-api-standalone-distribution/src/main/resources/license/*
-# gravitee-apim-rest-api-standalone/gravitee-rest-api-standalone-distribution/src/main/resources/logs/*
-# gravitee-apim-rest-api-standalone/gravitee-rest-api-standalone-distribution/src/main/resources/data/*
-# gravitee-apim-rest-api-standalone/gravitee-rest-api-standalone-distribution/src/main/resources/plugins/*
-
 # Related to UI Console and Portal
 **/.tmp/
 **/coverage/

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/license/.gitignore
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/license/.gitignore
@@ -1,0 +1,4 @@
+# Disregard this entire folder
+*
+# Except this .gitignore file
+!.gitignore

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/license/.gitignore
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/license/.gitignore
@@ -1,0 +1,4 @@
+# Disregard this entire folder
+*
+# Except this .gitignore file
+!.gitignore


### PR DESCRIPTION
Adding the license directory, containing .gitignore to ignore his content.
Works the same as plugins and logs directories.
Removing the associated TODO comment in main gitignore file.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-opxrzlhotx.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/chore-improvegitignore/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
