### PR TITLE
Revert "Enable Standalone Cache Manager"

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -93,7 +93,7 @@
         <gravitee-policy-xml-threat-protection.version>1.2.1</gravitee-policy-xml-threat-protection.version>
         <gravitee-policy-xml-validation.version>1.1.0</gravitee-policy-xml-validation.version>
         <gravitee-policy-xslt.version>1.6.0</gravitee-policy-xslt.version>
-        <gravitee-resource-cache.version>1.7.0-SNAPSHOT</gravitee-resource-cache.version>
+        <gravitee-resource-cache.version>1.6.2</gravitee-resource-cache.version>
         <gravitee-resource-oauth2-provider-am.version>1.14.1</gravitee-resource-oauth2-provider-am.version>
         <gravitee-resource-oauth2-provider-generic.version>1.16.1</gravitee-resource-oauth2-provider-generic.version>
         <gravitee-service-discovery-consul.version>1.3.0</gravitee-service-discovery-consul.version>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/pom.xml
@@ -114,22 +114,16 @@
             <artifactId>gravitee-node-management</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>io.gravitee.node</groupId>
-            <artifactId>gravitee-node-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.gravitee.node</groupId>
-            <artifactId>gravitee-node-cache</artifactId>
-        </dependency>
-
         <!-- Vert.x -->
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast</artifactId>
+        </dependency>
         <!-- JMH -->
         <dependency>
             <groupId>org.openjdk.jmh</groupId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/manager/ApiManagerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/manager/ApiManagerTest.java
@@ -29,8 +29,6 @@ import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.handlers.api.definition.Api;
 import io.gravitee.gateway.handlers.api.manager.impl.ApiManagerImpl;
 import io.gravitee.gateway.reactor.ReactorEvent;
-import io.gravitee.node.api.cache.CacheConfiguration;
-import io.gravitee.node.cache.standalone.StandaloneCache;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
@@ -67,7 +65,7 @@ public class ApiManagerTest {
         apiManager = spy(new ApiManagerImpl());
         MockitoAnnotations.initMocks(this);
 
-        ((ApiManagerImpl) apiManager).setApis(new StandaloneCache<>("api_manager_test", new CacheConfiguration()));
+        ((ApiManagerImpl) apiManager).setApis(new HashMap<>());
         when(gatewayConfiguration.shardingTags()).thenReturn(Optional.empty());
         when(gatewayConfiguration.hasMatchingTags(any())).thenCallRealMethod();
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-heartbeat/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-heartbeat/pom.xml
@@ -34,12 +34,6 @@
         <!-- Gravitee.io dependencies -->
         <dependency>
             <groupId>io.gravitee.node</groupId>
-            <artifactId>gravitee-node-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-cluster</artifactId>
             <scope>provided</scope>
         </dependency>
@@ -67,6 +61,13 @@
         <dependency>
             <groupId>io.gravitee.apim.repository</groupId>
             <artifactId>gravitee-apim-repository-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Hazelcast -->
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-heartbeat/src/main/java/io/gravitee/gateway/services/heartbeat/HeartbeatThread.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-heartbeat/src/main/java/io/gravitee/gateway/services/heartbeat/HeartbeatThread.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.gateway.services.heartbeat;
 
-import io.gravitee.node.api.message.Topic;
+import com.hazelcast.topic.ITopic;
 import io.gravitee.repository.management.model.Event;
 import java.util.Date;
 import org.slf4j.Logger;
@@ -29,10 +29,10 @@ public class HeartbeatThread implements Runnable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HeartbeatThread.class);
 
-    private final Topic<Event> topic;
+    private final ITopic<Event> topic;
     private final Event event;
 
-    HeartbeatThread(Topic<Event> topic, Event event) {
+    HeartbeatThread(ITopic<Event> topic, Event event) {
         this.topic = topic;
         this.event = event;
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-heartbeat/src/test/java/io/gravitee/gateway/services/heartbeat/HeartbeatServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-heartbeat/src/test/java/io/gravitee/gateway/services/heartbeat/HeartbeatServiceTest.java
@@ -20,10 +20,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
+import com.hazelcast.topic.ITopic;
+import com.hazelcast.topic.Message;
 import io.gravitee.common.utils.UUID;
 import io.gravitee.node.api.cluster.ClusterManager;
-import io.gravitee.node.api.message.Message;
-import io.gravitee.node.api.message.Topic;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.EventRepository;
 import io.gravitee.repository.management.model.Event;
@@ -49,7 +49,7 @@ public class HeartbeatServiceTest {
     private EventRepository eventRepository;
 
     @Mock
-    private Topic<Event> topic;
+    private ITopic<Event> topic;
 
     @Mock
     private Message<Event> message;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/pom.xml
@@ -98,6 +98,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Hazelcast -->
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Vert.x -->
         <dependency>
             <groupId>io.vertx</groupId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/ApiKeysCache.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/ApiKeysCache.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.gateway.services.sync.cache;
 
-import io.gravitee.node.api.cache.Cache;
 import io.gravitee.repository.management.model.ApiKey;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -30,9 +29,9 @@ public class ApiKeysCache {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ApiKeysCache.class);
 
-    protected Cache<String, ApiKey> cache;
+    protected Map<String, ApiKey> cache;
 
-    public ApiKeysCache(Cache<String, ApiKey> cache) {
+    public ApiKeysCache(Map<String, ApiKey> cache) {
         this.cache = cache;
     }
 
@@ -43,7 +42,7 @@ public class ApiKeysCache {
             apiKey.getPlan(),
             apiKey.getApplication()
         );
-        cache.evict(buildCacheKey(apiKey));
+        cache.remove(buildCacheKey(apiKey));
     }
 
     public void put(ApiKey apiKey) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/ApiKeysCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/ApiKeysCacheService.java
@@ -29,7 +29,6 @@ import io.gravitee.gateway.services.sync.cache.repository.ApiKeyRepositoryWrappe
 import io.gravitee.gateway.services.sync.cache.task.FullApiKeyRefresher;
 import io.gravitee.gateway.services.sync.cache.task.IncrementalApiKeyRefresher;
 import io.gravitee.gateway.services.sync.cache.task.Result;
-import io.gravitee.node.api.cache.CacheManager;
 import io.gravitee.node.api.cluster.ClusterManager;
 import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.vertx.ext.web.Router;
@@ -117,7 +116,7 @@ public class ApiKeysCacheService extends AbstractService implements EventListene
         LOGGER.debug("Register API key repository implementation {}", ApiKeyRepositoryWrapper.class.getName());
         beanFactory.registerSingleton(
             ApiKeyRepository.class.getName(),
-            new ApiKeyRepositoryWrapper(this.apiKeyRepository, new ApiKeysCache(cacheManager.getOrCreateCache(API_KEY_CACHE_NAME)))
+            new ApiKeyRepositoryWrapper(this.apiKeyRepository, new ApiKeysCache(cacheManager.getCache(API_KEY_CACHE_NAME)))
         );
 
         LOGGER.info("Associate a new HTTP handler on {}", PATH);
@@ -165,7 +164,7 @@ public class ApiKeysCacheService extends AbstractService implements EventListene
                                     chunk
                                 );
                                 refresher.setApiKeyRepository(apiKeyRepository);
-                                refresher.setCache(new ApiKeysCache(cacheManager.getOrCreateCache(API_KEY_CACHE_NAME)));
+                                refresher.setCache(new ApiKeysCache(cacheManager.getCache(API_KEY_CACHE_NAME)));
 
                                 return refresher;
                             }
@@ -280,7 +279,7 @@ public class ApiKeysCacheService extends AbstractService implements EventListene
             if (clusterManager.isMasterNode() || (!clusterManager.isMasterNode() && !distributed)) {
                 final FullApiKeyRefresher refresher = new FullApiKeyRefresher(planIds);
                 refresher.setApiKeyRepository(apiKeyRepository);
-                refresher.setCache(new ApiKeysCache(cacheManager.getOrCreateCache(API_KEY_CACHE_NAME)));
+                refresher.setCache(new ApiKeysCache(cacheManager.getCache(API_KEY_CACHE_NAME)));
 
                 CompletableFuture
                     .supplyAsync(refresher::call, executorService)

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/CacheManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/CacheManager.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.cache;
+
+import com.hazelcast.core.HazelcastInstance;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public final class CacheManager {
+
+    @Autowired
+    private HazelcastInstance hzInstance;
+
+    public <K, V> Map<K, V> getCache(String name) {
+        return hzInstance.getMap(name);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/SubscriptionsCacheService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/SubscriptionsCacheService.java
@@ -29,7 +29,6 @@ import io.gravitee.gateway.services.sync.cache.repository.SubscriptionRepository
 import io.gravitee.gateway.services.sync.cache.task.FullSubscriptionRefresher;
 import io.gravitee.gateway.services.sync.cache.task.IncrementalSubscriptionRefresher;
 import io.gravitee.gateway.services.sync.cache.task.Result;
-import io.gravitee.node.api.cache.CacheManager;
 import io.gravitee.node.api.cluster.ClusterManager;
 import io.gravitee.repository.management.api.SubscriptionRepository;
 import io.vertx.ext.web.Router;
@@ -118,7 +117,7 @@ public class SubscriptionsCacheService extends AbstractService implements EventL
         LOGGER.debug("Register subscription repository implementation {}", SubscriptionRepositoryWrapper.class.getName());
         beanFactory.registerSingleton(
             SubscriptionRepository.class.getName(),
-            new SubscriptionRepositoryWrapper(subscriptionRepository, cacheManager.getOrCreateCache(CACHE_NAME))
+            new SubscriptionRepositoryWrapper(subscriptionRepository, cacheManager.getCache(CACHE_NAME))
         );
 
         LOGGER.info("Associate a new HTTP handler on {}", PATH);
@@ -169,7 +168,7 @@ public class SubscriptionsCacheService extends AbstractService implements EventL
                                         chunks
                                     );
                                     refresher.setSubscriptionRepository(subscriptionRepository);
-                                    refresher.setCache(cacheManager.getOrCreateCache(CACHE_NAME));
+                                    refresher.setCache(cacheManager.getCache(CACHE_NAME));
 
                                     return refresher;
                                 }
@@ -288,7 +287,7 @@ public class SubscriptionsCacheService extends AbstractService implements EventL
             if (clusterManager.isMasterNode() || (!clusterManager.isMasterNode() && !distributed)) {
                 final FullSubscriptionRefresher refresher = new FullSubscriptionRefresher(planIds);
                 refresher.setSubscriptionRepository(subscriptionRepository);
-                refresher.setCache(cacheManager.getOrCreateCache(CACHE_NAME));
+                refresher.setCache(cacheManager.getCache(CACHE_NAME));
 
                 CompletableFuture
                     .supplyAsync(refresher::call, executorService)

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/repository/SubscriptionRepositoryWrapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/repository/SubscriptionRepositoryWrapper.java
@@ -16,7 +16,6 @@
 package io.gravitee.gateway.services.sync.cache.repository;
 
 import io.gravitee.common.data.domain.Page;
-import io.gravitee.node.api.cache.Cache;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.SubscriptionRepository;
 import io.gravitee.repository.management.api.search.Pageable;
@@ -31,9 +30,9 @@ import java.util.*;
 public class SubscriptionRepositoryWrapper implements SubscriptionRepository {
 
     private final SubscriptionRepository wrapped;
-    private final Cache<String, Subscription> cache;
+    private final Map<String, Subscription> cache;
 
-    public SubscriptionRepositoryWrapper(final SubscriptionRepository wrapped, final Cache<String, Subscription> cache) {
+    public SubscriptionRepositoryWrapper(final SubscriptionRepository wrapped, final Map<String, Subscription> cache) {
         this.wrapped = wrapped;
         this.cache = cache;
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/task/SubscriptionRefresher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/task/SubscriptionRefresher.java
@@ -17,7 +17,6 @@ package io.gravitee.gateway.services.sync.cache.task;
 
 import static io.gravitee.repository.management.model.Subscription.Status.*;
 
-import io.gravitee.node.api.cache.Cache;
 import io.gravitee.repository.management.api.SubscriptionRepository;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
 import io.gravitee.repository.management.model.Subscription;
@@ -36,7 +35,7 @@ public abstract class SubscriptionRefresher implements Callable<Result<Boolean>>
 
     private SubscriptionRepository subscriptionRepository;
 
-    private Cache<String, Object> cache;
+    private Map<String, Object> cache;
 
     protected Result<Boolean> doRefresh(SubscriptionCriteria criteria) {
         logger.debug("Refresh api-keys");
@@ -56,11 +55,11 @@ public abstract class SubscriptionRefresher implements Callable<Result<Boolean>>
         Object element = cache.get(subscription.getId());
 
         if ((CLOSED.equals(subscription.getStatus()) || PAUSED.equals(subscription.getStatus())) && element != null) {
-            cache.evict(subscription.getId());
+            cache.remove(subscription.getId());
             String oldKey = (String) element;
             Subscription eltSubscription = (Subscription) cache.get(oldKey);
             if (eltSubscription != null && eltSubscription.getId().equals(subscription.getId())) {
-                cache.evict(oldKey);
+                cache.remove(oldKey);
             }
         } else if (ACCEPTED.equals(subscription.getStatus())) {
             logger.debug(
@@ -83,7 +82,7 @@ public abstract class SubscriptionRefresher implements Callable<Result<Boolean>>
             if (element != null) {
                 final String oldKey = (String) element;
                 if (!oldKey.equals(key)) {
-                    cache.evict(oldKey);
+                    cache.remove(oldKey);
                 }
             }
         }
@@ -93,7 +92,7 @@ public abstract class SubscriptionRefresher implements Callable<Result<Boolean>>
         this.subscriptionRepository = subscriptionRepository;
     }
 
-    public void setCache(Cache<String, Object> cache) {
+    public void setCache(Map<String, Object> cache) {
         this.cache = cache;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/spring/SyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/spring/SyncConfiguration.java
@@ -16,10 +16,11 @@
 package io.gravitee.gateway.services.sync.spring;
 
 import io.gravitee.gateway.services.sync.SyncManager;
+import io.gravitee.gateway.services.sync.cache.CacheManager;
 import io.gravitee.gateway.services.sync.cache.configuration.LocalCacheConfiguration;
 import io.gravitee.gateway.services.sync.healthcheck.ApiSyncProbe;
 import io.gravitee.gateway.services.sync.synchronizer.*;
-import io.gravitee.node.api.cache.CacheManager;
+import io.gravitee.repository.management.model.Plan;
 import io.reactivex.annotations.NonNull;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
@@ -66,6 +67,11 @@ public class SyncConfiguration {
         threadPoolExecutor.allowCoreThreadTimeOut(true);
 
         return threadPoolExecutor;
+    }
+
+    @Bean
+    public CacheManager cacheManager() {
+        return new CacheManager();
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/cache/ApiKeysCacheTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/cache/ApiKeysCacheTest.java
@@ -17,8 +17,6 @@ package io.gravitee.gateway.services.sync.cache;
 
 import static org.junit.Assert.*;
 
-import io.gravitee.node.api.cache.CacheConfiguration;
-import io.gravitee.node.cache.standalone.StandaloneCache;
 import io.gravitee.repository.management.model.ApiKey;
 import java.util.HashMap;
 import org.junit.Before;
@@ -30,7 +28,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class ApiKeysCacheTest {
 
-    private final ApiKeysCache apiKeysCache = new ApiKeysCache(new StandaloneCache<>("ApiKeysCacheTest", new CacheConfiguration()));
+    private final ApiKeysCache apiKeysCache = new ApiKeysCache(new HashMap<>());
 
     @Mock
     private ApiKey cachedApiKey1;
@@ -82,6 +80,6 @@ public class ApiKeysCacheTest {
         apiKeysCache.remove(apiKey);
 
         assertEquals(2, apiKeysCache.cache.size());
-        assertNull(apiKeysCache.cache.get("api-id.key-id"));
+        assertFalse(apiKeysCache.cache.containsKey("api-id.key-id"));
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/spring/StandaloneConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/spring/StandaloneConfiguration.java
@@ -70,7 +70,7 @@ import org.springframework.context.annotation.Import;
         PolicyConfiguration.class,
         PlatformConfiguration.class,
         ConnectorConfiguration.class,
-        ClusterConfiguration.class,
+        ClusterConfiguration.class
     }
 )
 public class StandaloneConfiguration {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/spring/StandaloneConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/spring/StandaloneConfiguration.java
@@ -54,6 +54,7 @@ import org.springframework.context.annotation.Import;
 @Configuration
 @Import(
     {
+        ClusterConfiguration.class,
         VertxConfiguration.class,
         ReactorConfiguration.class,
         NodeCertificatesConfiguration.class,
@@ -70,7 +71,6 @@ import org.springframework.context.annotation.Import;
         PolicyConfiguration.class,
         PlatformConfiguration.class,
         ConnectorConfiguration.class,
-        ClusterConfiguration.class
     }
 )
 public class StandaloneConfiguration {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/hazelcast.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/hazelcast.xml
@@ -3,7 +3,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.0.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
 
     <network>
         <join>

--- a/pom.xml
+++ b/pom.xml
@@ -60,12 +60,12 @@
         <gravitee-bom.version>1.4</gravitee-bom.version>
         <gravitee-alert-api.version>1.8.0</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>1.9.0</gravitee-cockpit-api.version>
-        <gravitee-common.version>1.25.0-SNAPSHOT</gravitee-common.version>
+        <gravitee-common.version>1.24.0</gravitee-common.version>
         <gravitee-connector-api.version>1.0.0</gravitee-connector-api.version>
         <gravitee-definition.version>1.30.1</gravitee-definition.version>
         <gravitee-expression-language.version>1.7.2</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>1.31.0-SNAPSHOT</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.30.0-SNAPSHOT</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>1.19.0-SNAPSHOT</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -233,12 +233,6 @@
 
             <dependency>
                 <groupId>io.gravitee.node</groupId>
-                <artifactId>gravitee-node-cache</artifactId>
-                <version>${gravitee-node.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>io.gravitee.node</groupId>
                 <artifactId>gravitee-node-vertx</artifactId>
                 <version>${gravitee-node.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>1.31.0-SNAPSHOT</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
-        <gravitee-node.version>1.20.0-SNAPSHOT</gravitee-node.version>
+        <gravitee-node.version>1.19.0-SNAPSHOT</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>
         <gravitee-plugin.version>1.20.0</gravitee-plugin.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -65,9 +65,9 @@
         <gravitee-definition.version>1.30.1</gravitee-definition.version>
         <gravitee-expression-language.version>1.7.2</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>1.30.0-SNAPSHOT</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.30.0</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
-        <gravitee-node.version>1.19.0-SNAPSHOT</gravitee-node.version>
+        <gravitee-node.version>1.19.0</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>
         <gravitee-plugin.version>1.20.0</gravitee-plugin.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>


### PR DESCRIPTION
**Issue**

Somehow related to:
 - https://graviteedevops.atlassian.net/browse/ARCH-63

 
**Description**

It looks like there are some CI issues since https://github.com/gravitee-io/gravitee-api-management/pull/897 has been merged on `master`. 
When running package phase in `gravitee-apim-gateway-standalone-container` the machine executor is stuck forever after having logged:
```shell
09:49:43.302 [vert.x-eventloop-thread-2] ERROR io.vertx.core.impl.DeploymentManager - Undeploy failed
java.lang.IllegalStateException: Unknown deployment
	at io.vertx.core.impl.DeploymentManager.undeployVerticle(DeploymentManager.java:80)
	at io.vertx.core.impl.DeploymentManager.undeployAll(DeploymentManager.java:109)
	at io.vertx.core.impl.VertxImpl.lambda$close$14(VertxImpl.java:581)
	at io.vertx.core.impl.future.FutureImpl$3.onSuccess(FutureImpl.java:141)
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:60)
	at io.vertx.core.impl.future.FutureImpl.addListener(FutureImpl.java:196)
	at io.vertx.core.impl.future.PromiseImpl.addListener(PromiseImpl.java:23)
	at io.vertx.core.impl.future.FutureImpl.onComplete(FutureImpl.java:164)
	at io.vertx.core.impl.future.PromiseImpl.onComplete(PromiseImpl.java:23)
	at io.vertx.core.impl.VertxImpl.close(VertxImpl.java:580)
	at io.vertx.reactivex.core.Vertx.close(Vertx.java:433)
	at io.vertx.reactivex.core.Vertx.close(Vertx.java:440)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.beans.factory.support.DisposableBeanAdapter.invokeCustomDestroyMethod(DisposableBeanAdapter.java:281)
	at org.springframework.beans.factory.support.DisposableBeanAdapter.destroy(DisposableBeanAdapter.java:215)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.destroyBean(DefaultSingletonBeanRegistry.java:587)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.destroySingleton(DefaultSingletonBeanRegistry.java:559)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.destroySingleton(DefaultListableBeanFactory.java:1152)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.destroySingletons(DefaultSingletonBeanRegistry.java:520)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.destroySingletons(DefaultListableBeanFactory.java:1145)
	at org.springframework.context.support.AbstractApplicationContext.destroyBeans(AbstractApplicationContext.java:1106)
	at org.springframework.context.support.AbstractApplicationContext.doClose(AbstractApplicationContext.java:1075)
	at org.springframework.context.support.AbstractApplicationContext.close(AbstractApplicationContext.java:1021)
	at io.gravitee.node.container.spring.SpringBasedContainer.doStop(SpringBasedContainer.java:98)
	at io.gravitee.common.component.AbstractLifecycleComponent.stop(AbstractLifecycleComponent.java:41)
	at io.gravitee.gateway.standalone.junit.stmt.ApiDeployerStatement.lambda$stopServer$1(ApiDeployerStatement.java:144)
	at java.base/java.lang.Thread.run(Thread.java:829)
09:49:43.301 [vert.x-eventloop-thread-15] INFO  i.g.g.s.vertx.ReactorVerticle - Stopping HTTP Server...
09:49:43.301 [vert.x-eventloop-thread-7] INFO  i.g.g.s.vertx.ReactorVerticle - HTTP Server has been correctly stopped
09:49:43.302 [vert.x-eventloop-thread-11] INFO  i.g.g.s.vertx.ReactorVerticle - HTTP Server has been correctly stopped
09:49:43.303 [vert.x-eventloop-thread-15] INFO  i.g.g.s.vertx.ReactorVerticle - HTTP Server has been correctly stopped
09:49:43.302 [vert.x-eventloop-thread-12] INFO  i.g.g.s.vertx.ReactorVerticle - HTTP Server has been correctly stopped
09:49:43.302 [vert.x-eventloop-thread-13] INFO  i.g.g.s.vertx.ReactorVerticle - HTTP Server has been correctly stopped
09:49:43.311 [vert.x-eventloop-thread-5] INFO  i.g.g.s.vertx.ReactorVerticle - Stopping HTTP Server...
09:49:43.311 [vert.x-eventloop-thread-5] INFO  i.g.g.s.vertx.ReactorVerticle - HTTP Server has been correctly stopped
09:49:43.311 [vert.x-eventloop-thread-5] ERROR io.vertx.core.impl.ContextImpl - Unhandled exception
java.util.concurrent.RejectedExecutionException: event executor terminated
	at io.netty.util.concurrent.SingleThreadEventExecutor.reject(SingleThreadEventExecutor.java:923)
	at io.netty.util.concurrent.SingleThreadEventExecutor.offerTask(SingleThreadEventExecutor.java:350)
	at io.netty.util.concurrent.SingleThreadEventExecutor.addTask(SingleThreadEventExecutor.java:343)
	at io.netty.util.concurrent.SingleThreadEventExecutor.execute(SingleThreadEventExecutor.java:825)
	at io.netty.util.concurrent.SingleThreadEventExecutor.execute(SingleThreadEventExecutor.java:815)
	at io.vertx.core.impl.EventLoopContext.execute(EventLoopContext.java:83)
	at io.vertx.core.impl.ContextImpl.execute(ContextImpl.java:260)
	at io.vertx.core.impl.EventLoopContext.execute(EventLoopContext.java:22)
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:51)
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:211)
	at io.vertx.core.impl.future.PromiseImpl.tryComplete(PromiseImpl.java:23)
	at io.vertx.core.Promise.tryComplete(Promise.java:121)
	at io.vertx.core.Promise.complete(Promise.java:77)
	at io.vertx.core.AbstractVerticle.stop(AbstractVerticle.java:121)
	at io.vertx.core.impl.DeploymentManager$DeploymentImpl.lambda$doUndeploy$6(DeploymentManager.java:355)
	at io.vertx.core.impl.AbstractContext.dispatch(AbstractContext.java:100)
	at io.vertx.core.impl.AbstractContext.dispatch(AbstractContext.java:63)
	at io.vertx.core.impl.EventLoopContext.lambda$runOnContext$0(EventLoopContext.java:38)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469)
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:384)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:829)
09:49:43.319 [vert.x-eventloop-thread-14] INFO  i.g.g.s.vertx.ReactorVerticle - Stopping HTTP Server...
09:49:43.319 [vert.x-eventloop-thread-14] ERROR i.n.u.c.D.rejectedExecution - Failed to submit a listener notification task. Event loop shut down?
java.util.concurrent.RejectedExecutionException: event executor terminated
	at io.netty.util.concurrent.SingleThreadEventExecutor.reject(SingleThreadEventExecutor.java:923)
	at io.netty.util.concurrent.SingleThreadEventExecutor.offerTask(SingleThreadEventExecutor.java:350)
	at io.netty.util.concurrent.SingleThreadEventExecutor.addTask(SingleThreadEventExecutor.java:343)
	at io.netty.util.concurrent.SingleThreadEventExecutor.execute(SingleThreadEventExecutor.java:825)
	at io.netty.util.concurrent.SingleThreadEventExecutor.execute(SingleThreadEventExecutor.java:815)
	at io.netty.util.concurrent.DefaultPromise.safeExecute(DefaultPromise.java:841)
	at io.netty.util.concurrent.DefaultPromise.notifyListeners(DefaultPromise.java:499)
	at io.netty.util.concurrent.DefaultPromise.addListener(DefaultPromise.java:184)
	at io.netty.util.concurrent.DefaultPromise.addListener(DefaultPromise.java:35)
	at io.vertx.core.net.impl.TCPServerBase.actualClose(TCPServerBase.java:228)
	at io.vertx.core.net.impl.TCPServerBase.close(TCPServerBase.java:221)
	at io.vertx.core.http.impl.HttpServerImpl.close(HttpServerImpl.java:280)
	at io.vertx.core.http.impl.HttpServerImpl.close(HttpServerImpl.java:259)
	at io.gravitee.gateway.standalone.vertx.ReactorVerticle.stop(ReactorVerticle.java:106)
	at io.vertx.core.AbstractVerticle.stop(AbstractVerticle.java:120)
	at io.vertx.core.impl.DeploymentManager$DeploymentImpl.lambda$doUndeploy$6(DeploymentManager.java:355)
	at io.vertx.core.impl.AbstractContext.dispatch(AbstractContext.java:100)
	at io.vertx.core.impl.AbstractContext.dispatch(AbstractContext.java:63)
	at io.vertx.core.impl.EventLoopContext.lambda$runOnContext$0(EventLoopContext.java:38)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469)
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:384)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:829)
09:49:43.319 [vert.x-eventloop-thread-14] ERROR io.vertx.core.impl.ContextImpl - Unhandled exception
java.util.concurrent.RejectedExecutionException: event executor terminated
	at io.netty.util.concurrent.SingleThreadEventExecutor.reject(SingleThreadEventExecutor.java:923)
	at io.netty.util.concurrent.SingleThreadEventExecutor.offerTask(SingleThreadEventExecutor.java:350)
	at io.netty.util.concurrent.SingleThreadEventExecutor.addTask(SingleThreadEventExecutor.java:343)
	at io.netty.util.concurrent.SingleThreadEventExecutor.execute(SingleThreadEventExecutor.java:825)
	at io.netty.util.concurrent.SingleThreadEventExecutor.execute(SingleThreadEventExecutor.java:815)
	at io.vertx.core.impl.EventLoopContext.execute(EventLoopContext.java:83)
	at io.vertx.core.impl.ContextImpl.execute(ContextImpl.java:260)
	at io.vertx.core.impl.EventLoopContext.execute(EventLoopContext.java:22)
	at io.vertx.core.impl.future.FutureBase.emitSuccess(FutureBase.java:51)
	at io.vertx.core.impl.future.FutureImpl.tryComplete(FutureImpl.java:211)
	at io.vertx.core.impl.future.PromiseImpl.tryComplete(PromiseImpl.java:23)
	at io.vertx.core.Promise.tryComplete(Promise.java:121)
	at io.vertx.core.Promise.complete(Promise.java:77)
	at io.vertx.core.AbstractVerticle.stop(AbstractVerticle.java:121)
	at io.vertx.core.impl.DeploymentManager$DeploymentImpl.lambda$doUndeploy$6(DeploymentManager.java:355)
	at io.vertx.core.impl.AbstractContext.dispatch(AbstractContext.java:100)
	at io.vertx.core.impl.AbstractContext.dispatch(AbstractContext.java:63)
	at io.vertx.core.impl.EventLoopContext.lambda$runOnContext$0(EventLoopContext.java:38)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:469)
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:384)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:829)
```

The APIM team investigated a bit to find out what could be the root cause, however, it doesn't feel obvious for people who didn't work directly on this Hazelcast replacement.

As it is currently blocking all the PRs against `master` of this monorepo, this PR reverts multiple commits to get back to a stable situation. Reverted commits are related to Hazelcast replacement directly or to dependencies updates looking related to that.

--- 

🔍  @gravitee-io/archi we will let you do deeper investigation on that topic


