### PR TITLE
chore: bump "@gravitee/ui-components"

### DIFF
--- a/gravitee-apim-console-webui/package-lock.json
+++ b/gravitee-apim-console-webui/package-lock.json
@@ -8518,11 +8518,11 @@
       }
     },
     "@codemirror/history": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/history/-/history-0.19.0.tgz",
-      "integrity": "sha512-E0H+lncH66IMDhaND9jgkjE7s0dhYfjCPmS+Ig2Yes9I8+UIEecIdObj8c8HPCFGctGg3fxXqRAw2mdHl2Wouw==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/history/-/history-0.19.1.tgz",
+      "integrity": "sha512-mcm856QzHj2K6it7XPtKN1lcQ15tB+A5XRtRix9GHRQak4bbY0ljqYJFxD4wNEAAb4uC2axUyl4yEW57DHJmdQ==",
       "requires": {
-        "@codemirror/state": "^0.19.0",
+        "@codemirror/state": "^0.19.2",
         "@codemirror/view": "^0.19.0"
       }
     },
@@ -9170,9 +9170,9 @@
       "dev": true
     },
     "@gravitee/ui-components": {
-      "version": "3.25.3",
-      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.25.3.tgz",
-      "integrity": "sha512-fTk3q5T0XRDSgStlTuJ6QWRcggR2vhel1GN0U+O166wQOXWruOHGc/SlgSpNojZnhydNsg2BVkaBVjx/OjS39Q==",
+      "version": "3.25.4",
+      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.25.4.tgz",
+      "integrity": "sha512-9SzcxwejPbT0VBHhR2v6raSqBPN9DmkZQUEZKSHDsTmmYujqpEO+qD5wBWPJD/gzxYedbU9e3XZm5DrjuvgWrA==",
       "requires": {
         "@codemirror/basic-setup": "^0.19.1",
         "@codemirror/language-data": "^0.19.1",
@@ -18718,9 +18718,9 @@
       }
     },
     "date-fns": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.27.0.tgz",
-      "integrity": "sha512-sj+J0Mo2p2X1e306MHq282WS4/A8Pz/95GIFcsPNMPMZVI3EUrAdSv90al1k+p74WGLCruMXk23bfEDZa71X9Q=="
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
     },
     "debug": {
       "version": "2.6.9",

--- a/gravitee-apim-console-webui/package.json
+++ b/gravitee-apim-console-webui/package.json
@@ -15,7 +15,7 @@
     "@angular/upgrade": "12.2.3",
     "@asyncapi/web-component": "1.0.0-next.15",
     "@fontsource/libre-franklin": "4.4.5",
-    "@gravitee/ui-components": "3.25.3",
+    "@gravitee/ui-components": "3.25.4",
     "@gravitee/ui-particles-angular": "1.4.0",
     "@highcharts/map-collection": "1.1.3",
     "@toast-ui/editor": "2.5.2",

--- a/gravitee-apim-portal-webui/package-lock.json
+++ b/gravitee-apim-portal-webui/package-lock.json
@@ -3602,11 +3602,11 @@
       }
     },
     "@codemirror/history": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/history/-/history-0.19.0.tgz",
-      "integrity": "sha512-E0H+lncH66IMDhaND9jgkjE7s0dhYfjCPmS+Ig2Yes9I8+UIEecIdObj8c8HPCFGctGg3fxXqRAw2mdHl2Wouw==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/history/-/history-0.19.1.tgz",
+      "integrity": "sha512-mcm856QzHj2K6it7XPtKN1lcQ15tB+A5XRtRix9GHRQak4bbY0ljqYJFxD4wNEAAb4uC2axUyl4yEW57DHJmdQ==",
       "requires": {
-        "@codemirror/state": "^0.19.0",
+        "@codemirror/state": "^0.19.2",
         "@codemirror/view": "^0.19.0"
       }
     },
@@ -4021,9 +4021,9 @@
       }
     },
     "@gravitee/ui-components": {
-      "version": "3.25.3",
-      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.25.3.tgz",
-      "integrity": "sha512-fTk3q5T0XRDSgStlTuJ6QWRcggR2vhel1GN0U+O166wQOXWruOHGc/SlgSpNojZnhydNsg2BVkaBVjx/OjS39Q==",
+      "version": "3.25.4",
+      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.25.4.tgz",
+      "integrity": "sha512-9SzcxwejPbT0VBHhR2v6raSqBPN9DmkZQUEZKSHDsTmmYujqpEO+qD5wBWPJD/gzxYedbU9e3XZm5DrjuvgWrA==",
       "requires": {
         "@codemirror/basic-setup": "^0.19.1",
         "@codemirror/language-data": "^0.19.1",
@@ -8666,9 +8666,9 @@
       }
     },
     "date-fns": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.27.0.tgz",
-      "integrity": "sha512-sj+J0Mo2p2X1e306MHq282WS4/A8Pz/95GIFcsPNMPMZVI3EUrAdSv90al1k+p74WGLCruMXk23bfEDZa71X9Q=="
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
     },
     "debug": {
       "version": "4.1.1",

--- a/gravitee-apim-portal-webui/package.json
+++ b/gravitee-apim-portal-webui/package.json
@@ -36,7 +36,7 @@
     "@angular/router": "9.1.1",
     "@asyncapi/web-component": "1.0.0-next.15",
     "@formatjs/intl-relativetimeformat": "9.3.1",
-    "@gravitee/ui-components": "3.25.3",
+    "@gravitee/ui-components": "3.25.4",
     "@highcharts/map-collection": "1.1.3",
     "@ibm/plex": "5.1.3",
     "@ngx-translate/core": "12.1.2",

--- a/gravitee-apim-portal-webui/src/app/components/gv-page-redoc/gv-page-redoc.component.ts
+++ b/gravitee-apim-portal-webui/src/app/components/gv-page-redoc/gv-page-redoc.component.ts
@@ -75,14 +75,14 @@ export class GvPageRedocComponent implements OnInit, OnDestroy {
     if (page) {
       // @ts-ignore
       // https://github.com/Redocly/redoc/blob/master/src/theme.ts
-      const color = getCssVar(document.body, '--gv-theme-color-dark');
-      const successColor = getCssVar(document.body, '--gv-theme-color');
-      const dangerColor = getCssVar(document.body, '--gv-theme-color-danger');
-      const textColor = getCssVar(document.body, '--gv-theme-font-color-dark');
-      const textColorLight = getCssVar(document.body, '--gv-theme-font-color-light');
-      const fontFamily = getCssVar(document.body, '--gv-theme-font-family');
-      const fontSize = getCssVar(document.body, '--gv-theme-font-size-m');
-      const sidebarColor = getCssVar(document.body, '--gv-theme-neutral-color-lightest');
+      const color = getCssVar(document.body, '--gv-theme-color-dark', undefined);
+      const successColor = getCssVar(document.body, '--gv-theme-color', undefined);
+      const dangerColor = getCssVar(document.body, '--gv-theme-color-danger', undefined);
+      const textColor = getCssVar(document.body, '--gv-theme-font-color-dark', undefined);
+      const textColorLight = getCssVar(document.body, '--gv-theme-font-color-light', undefined);
+      const fontFamily = getCssVar(document.body, '--gv-theme-font-family', undefined);
+      const fontSize = getCssVar(document.body, '--gv-theme-font-size-m', undefined);
+      const sidebarColor = getCssVar(document.body, '--gv-theme-neutral-color-lightest', undefined);
 
       const options = {
         expandResponses: '',

--- a/gravitee-apim-portal-webui/src/app/services/translation.service.ts
+++ b/gravitee-apim-portal-webui/src/app/services/translation.service.ts
@@ -34,7 +34,7 @@ export class TranslationService {
       const browserLang = this.translateService.getBrowserLang();
       this.translateService.use(environment.locales.includes(browserLang) ? browserLang : defaultLang).subscribe((translations) => {
         setLanguage(this.translateService.currentLang);
-        addTranslations(this.translateService.currentLang, translations);
+        addTranslations(this.translateService.currentLang, translations, this.translateService.currentLang);
         this.translateService.get(i18n('site.title')).subscribe((title) => this.titleService.setTitle(title));
         resolve(true);
       });


### PR DESCRIPTION
**Issue**
na

**Description**


Bump `@gravitee/ui-components` now using Typescript

**Additional context**

☑️ By @ThibaudAV on local serve :
- [x] Test portal
- [x] Test Console AngularJs PS
- [x] Test Console Angular PS

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lfowtvwyov.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/bump-ui-compo/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
