### PR TITLE
fix: check plans ownership before updating an API from import

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PlanRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PlanRepository.java
@@ -17,6 +17,7 @@ package io.gravitee.repository.management.api;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.Plan;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -45,4 +46,14 @@ public interface PlanRepository extends CrudRepository<Plan, String> {
      * @throws TechnicalException
      */
     Set<Plan> findByApi(String apiId) throws TechnicalException;
+
+    /**
+     * Returns the list of plans matching the list of plan IDs.
+     *
+     * @param ids A set of plan ids.
+     *
+     * @return The set of plans matching the given IDs.
+     * @throws TechnicalException
+     */
+    Set<Plan> findByIdIn(Collection<String> ids) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpPlanRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpPlanRepository.java
@@ -19,6 +19,7 @@ import io.gravitee.repository.bridge.client.utils.BodyCodecs;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.model.Plan;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -63,6 +64,11 @@ public class HttpPlanRepository extends AbstractRepository implements PlanReposi
 
     @Override
     public Set<Plan> findAll() throws TechnicalException {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<Plan> findByIdIn(Collection<String> ids) throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPlanRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPlanRepository.java
@@ -277,4 +277,20 @@ public class JdbcPlanRepository extends JdbcAbstractFindAllRepository<Plan> impl
             throw new TechnicalException("Failed to find plans by api", ex);
         }
     }
+
+    @Override
+    public Set<Plan> findByIdIn(Collection<String> ids) throws TechnicalException {
+        try {
+            LOGGER.debug("JdbcPlanRepository.findByIdIn({})", ids);
+            List<Plan> plans = jdbcTemplate.query(
+                getOrm().getSelectAllSql() + " where id in (" + getOrm().buildInClause(ids) + ")",
+                ps -> getOrm().setArguments(ps, ids, 1),
+                getOrm().getRowMapper()
+            );
+            return new HashSet<>(plans);
+        } catch (final Exception ex) {
+            LOGGER.error("Failed to find plans by id list", ex);
+            throw new TechnicalException("Failed to find plans by id list", ex);
+        }
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPlanRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPlanRepository.java
@@ -21,10 +21,12 @@ import io.gravitee.repository.management.model.Plan;
 import io.gravitee.repository.mongodb.management.internal.model.PlanMongo;
 import io.gravitee.repository.mongodb.management.internal.plan.PlanMongoRepository;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -97,5 +99,15 @@ public class MongoPlanRepository implements PlanRepository {
     @Override
     public Set<Plan> findAll() throws TechnicalException {
         return internalPlanRepository.findAll().stream().map(this::map).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Plan> findByIdIn(Collection<String> ids) throws TechnicalException {
+        try {
+            Iterable<PlanMongo> plans = internalPlanRepository.findAllById(ids);
+            return StreamSupport.stream(plans.spliterator(), false).map(this::map).collect(Collectors.toSet());
+        } catch (Exception ex) {
+            throw new TechnicalException("Failed to find plans by id list", ex);
+        }
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/PlanRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/PlanRepositoryTest.java
@@ -68,6 +68,31 @@ public class PlanRepositoryTest extends AbstractRepositoryTest {
     }
 
     @Test
+    public void shouldFindByIdIn() throws TechnicalException {
+        Set<Plan> plans = planRepository.findByIdIn(List.of("my-plan", "unknown-id"));
+        assertNotNull(plans);
+        assertEquals(1, plans.size());
+
+        Plan plan = new ArrayList<>(plans).get(0);
+
+        assertEquals("my-plan", plan.getId());
+        assertEquals("GCU-my-plan", plan.getGeneralConditions());
+        assertEquals("Free plan", plan.getName());
+        assertEquals("Description of the free plan", plan.getDescription());
+        assertEquals("api1", plan.getApi());
+        assertEquals(Plan.PlanSecurityType.API_KEY, plan.getSecurity());
+        assertEquals(Plan.PlanValidationType.AUTO, plan.getValidation());
+        assertEquals(Plan.PlanType.API, plan.getType());
+        assertEquals(Plan.Status.PUBLISHED, plan.getStatus());
+        assertEquals(2, plan.getOrder());
+        assertTrue(compareDate(new Date(1506964899000L), plan.getCreatedAt()));
+        assertTrue(compareDate(new Date(1507032062000L), plan.getUpdatedAt()));
+        assertTrue(compareDate(new Date(1506878460000L), plan.getPublishedAt()));
+        assertTrue(compareDate(new Date(1507611600000L), plan.getClosedAt()));
+        assertTrue(compareDate(new Date(1507611670000L), plan.getNeedRedeployAt()));
+    }
+
+    @Test
     public void shouldFindOAuth2PlanById() throws TechnicalException {
         final Optional<Plan> planOAuth2 = planRepository.findById("plan-oauth2");
 

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/PlanRepositoryMock.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/PlanRepositoryMock.java
@@ -28,10 +28,7 @@ import static org.mockito.Mockito.when;
 
 import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.model.Plan;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.Optional;
+import java.util.*;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -150,5 +147,7 @@ public class PlanRepositoryMock extends AbstractRepositoryMock<PlanRepository> {
         when(planRepository.findById("unknown")).thenReturn(empty());
 
         when(planRepository.update(argThat(o -> o == null || o.getId().equals("unknown")))).thenThrow(new IllegalStateException());
+
+        when(planRepository.findByIdIn(List.of("my-plan", "unknown-id"))).thenReturn(Set.of(plan2));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/PlanRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/PlanRepositoryProxy.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.repository.proxy;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.model.Plan;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -63,5 +64,10 @@ public class PlanRepositoryProxy extends AbstractProxy<PlanRepository> implement
     @Override
     public Set<Plan> findAll() throws TechnicalException {
         return target.findAll();
+    }
+
+    @Override
+    public Set<Plan> findByIdIn(Collection<String> ids) throws TechnicalException {
+        return target.findByIdIn(ids);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/PlanService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/PlanService.java
@@ -53,4 +53,6 @@ public interface PlanService {
     PlansConfigurationEntity getConfiguration();
 
     PlanEntity createOrUpdatePlan(PlanEntity planEntity, final String environmentId);
+
+    boolean anyPlanMismatchWithApi(List<String> planIds, String apiId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PlanServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PlanServiceImpl.java
@@ -810,4 +810,13 @@ public class PlanServiceImpl extends TransactionalService implements PlanService
             throw new UnauthorizedPlanSecurityTypeException(securityType);
         }
     }
+
+    @Override
+    public boolean anyPlanMismatchWithApi(List<String> planIds, String apiId) {
+        try {
+            return planRepository.findByIdIn(planIds).stream().map(Plan::getApi).filter(Objects::nonNull).anyMatch(id -> !id.equals(apiId));
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("An error has occurred checking plans ownership", e);
+        }
+    }
 }


### PR DESCRIPTION
Before performing an update import, the plans provided in the import
definition are now checked to verify that none of their ID is already
associated to another plan belonging to another API.

The check is performed before any further update to avoid inconsistency
in API data.

see https://github.com/gravitee-io/issues/issues/6693
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hbgeplnowc.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6693-fix-plans-unicity/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
