### PR TITLE
fix: bring back import on API path based creation

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation/newApi.html
+++ b/gravitee-apim-console-webui/src/management/api/creation/newApi.html
@@ -49,14 +49,17 @@
         <div class="actions">
           <gv-button primary class="import-action" icon="code:left-circle" outlined ng-click="$ctrl.isImport = false">Cancel </gv-button>
           <gv-button primary icon="general:upload" outlined ng-click="$ctrl.isImport = true">Import</gv-button>
-          <gv-button primary icon-right="code:right-circle" ui-sref="management.apis.create({definitionVersion: $ctrl.definitionVersion})"
+          <gv-button primary icon-right="code:right-circle" ui-sref="management.apis.create({ definitionVersion: $ctrl.definitionVersion })"
             >Create
           </gv-button>
         </div>
       </div>
 
-      <div class="deprecated-action" ng-if="$ctrl.allowsPathBasedCreation">
-        <span>Or use <a ui-sref="management.apis.create({ definitionVersion: '1.0.0' })">Path Based Creation</a></span>
+      <div class="deprecated-action" ng-if="$ctrl.allowsPathBasedCreation && !$ctrl.isImport">
+        <span
+          >Or you can still use paths based | <a href="" ng-click="$ctrl.pathBasedImport()">Import</a> -
+          <a ui-sref="management.apis.create({ definitionVersion: '1.0.0' })">Create</a></span
+        >
       </div>
     </div>
   </div>

--- a/gravitee-apim-console-webui/src/management/api/creation/newApiPortal.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/newApiPortal.controller.ts
@@ -57,7 +57,13 @@ class NewApiController {
   }
 
   cancelImport() {
+    this.definitionVersion = '2.0.0';
     this.isImport = false;
+  }
+
+  pathBasedImport() {
+    this.definitionVersion = '1.0.0';
+    this.isImport = true;
   }
 
   getImportTitle() {


### PR DESCRIPTION
Add a Import anchor to be able to perform 1.0.0 imports from the UI

see https://github.com/gravitee-io/issues/issues/6377
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uvyygofwhi.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6377-api-path-based-with-import/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
