### PR TITLE
test: fix data for UT in repositories - 3.5.x

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/command-tests/commands.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/command-tests/commands.json
@@ -50,7 +50,7 @@
     "to": "MANAGEMENT_API",
     "tags": ["DATA_TO_INDEX", "INSERT"],
     "acknowledgments": ["node1", "node2"],
-    "expiredAt": 1640983982000,
+    "expiredAt": 4796668799000,
     "createdAt": 1546305346000,
     "updatedAt": 1548983746000
   },


### PR DESCRIPTION
an expiration date was set to 2021/12/31 -> change it to 2121/12/31
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-2022-bug-3-5-x/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
