### PR TITLE
Properly handle units on Stats widget in dashboard

### DIFF
--- a/gravitee-apim-console-webui/src/components/widget/stats/widget-data-stats-configuration.component.spec.ts
+++ b/gravitee-apim-console-webui/src/components/widget/stats/widget-data-stats-configuration.component.spec.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { IComponentControllerService } from 'angular';
+import { setupAngularJsTesting } from '../../../../jest.setup';
+
+setupAngularJsTesting();
+
+describe('WidgetDataStatsConfigurationComponent', () => {
+  let $componentController: IComponentControllerService;
+  let widgetDataStatsConfigurationComponent: any;
+
+  beforeEach(inject((_QualityRuleService_, _$componentController_) => {
+    $componentController = _$componentController_;
+    const bindings = {
+      chart: {},
+    };
+    widgetDataStatsConfigurationComponent = $componentController('gvWidgetDataStatsConfiguration', null, bindings);
+    widgetDataStatsConfigurationComponent.$onInit();
+  }));
+
+  it('init chart data', () => {
+    expect(widgetDataStatsConfigurationComponent.chart).toEqual({
+      request: {
+        type: 'stats',
+        field: 'response-time',
+      },
+      data: [
+        {
+          color: '#66bb6a',
+          key: 'min',
+          label: 'min',
+          unit: 'ms',
+        },
+        {
+          color: '#ef5350',
+          key: 'max',
+          label: 'max',
+          unit: 'ms',
+        },
+        {
+          color: '#42a5f5',
+          key: 'avg',
+          label: 'avg',
+          unit: 'ms',
+        },
+        {
+          color: '#ff8f2d',
+          fallback: [
+            {
+              key: 'rpm',
+              label: 'requests per minute',
+            },
+            {
+              key: 'rph',
+              label: 'requests per hour',
+            },
+          ],
+          key: 'rps',
+          label: 'requests per second',
+        },
+        {
+          color: 'black',
+          key: 'count',
+          label: 'total',
+        },
+      ],
+    });
+    expect(widgetDataStatsConfigurationComponent.selectedStats).toEqual(['min', 'max', 'avg', 'rps', 'count']);
+  });
+
+  it('set `chart` properly when selecting API latency', () => {
+    widgetDataStatsConfigurationComponent.chart.request.field = 'api-response-time';
+    widgetDataStatsConfigurationComponent.selectedStats = ['min', 'avg', 'rps', 'count'];
+    widgetDataStatsConfigurationComponent.onStatsChanged();
+
+    expect(widgetDataStatsConfigurationComponent.chart).toEqual({
+      request: {
+        type: 'stats',
+        field: 'api-response-time',
+      },
+      data: [
+        {
+          color: '#66bb6a',
+          key: 'min',
+          label: 'min',
+          unit: 'ms',
+        },
+        {
+          color: '#42a5f5',
+          key: 'avg',
+          label: 'avg',
+          unit: 'ms',
+        },
+        {
+          color: '#ff8f2d',
+          fallback: [
+            {
+              key: 'rpm',
+              label: 'requests per minute',
+            },
+            {
+              key: 'rph',
+              label: 'requests per hour',
+            },
+          ],
+          key: 'rps',
+          label: 'requests per second',
+        },
+        {
+          color: 'black',
+          key: 'count',
+          label: 'total',
+        },
+      ],
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/components/widget/stats/widget-data-stats-configuration.component.spec.ts
+++ b/gravitee-apim-console-webui/src/components/widget/stats/widget-data-stats-configuration.component.spec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { IComponentControllerService } from 'angular';
+
 import { setupAngularJsTesting } from '../../../../jest.setup';
 
 setupAngularJsTesting();
@@ -32,58 +33,102 @@ describe('WidgetDataStatsConfigurationComponent', () => {
   }));
 
   it('init chart data', () => {
+    const defaultSelectedStats = [
+      {
+        color: '#66bb6a',
+        key: 'min',
+        label: 'min',
+        unit: 'ms',
+      },
+      {
+        color: '#ef5350',
+        key: 'max',
+        label: 'max',
+        unit: 'ms',
+      },
+      {
+        color: '#42a5f5',
+        key: 'avg',
+        label: 'avg',
+        unit: 'ms',
+      },
+      {
+        color: '#ff8f2d',
+        fallback: [
+          {
+            key: 'rpm',
+            label: 'requests per minute',
+          },
+          {
+            key: 'rph',
+            label: 'requests per hour',
+          },
+        ],
+        key: 'rps',
+        label: 'requests per second',
+      },
+      {
+        color: 'black',
+        key: 'count',
+        label: 'total',
+      },
+    ];
+
     expect(widgetDataStatsConfigurationComponent.chart).toEqual({
       request: {
         type: 'stats',
         field: 'response-time',
       },
-      data: [
-        {
-          color: '#66bb6a',
-          key: 'min',
-          label: 'min',
-          unit: 'ms',
-        },
-        {
-          color: '#ef5350',
-          key: 'max',
-          label: 'max',
-          unit: 'ms',
-        },
-        {
-          color: '#42a5f5',
-          key: 'avg',
-          label: 'avg',
-          unit: 'ms',
-        },
-        {
-          color: '#ff8f2d',
-          fallback: [
-            {
-              key: 'rpm',
-              label: 'requests per minute',
-            },
-            {
-              key: 'rph',
-              label: 'requests per hour',
-            },
-          ],
-          key: 'rps',
-          label: 'requests per second',
-        },
-        {
-          color: 'black',
-          key: 'count',
-          label: 'total',
-        },
-      ],
+      data: defaultSelectedStats,
     });
-    expect(widgetDataStatsConfigurationComponent.selectedStats).toEqual(['min', 'max', 'avg', 'rps', 'count']);
+    expect(widgetDataStatsConfigurationComponent.selectedStatsKeys).toEqual(['min', 'max', 'avg', 'rps', 'count']);
   });
 
   it('set `chart` properly when selecting API latency', () => {
-    widgetDataStatsConfigurationComponent.chart.request.field = 'api-response-time';
-    widgetDataStatsConfigurationComponent.selectedStats = ['min', 'avg', 'rps', 'count'];
+    widgetDataStatsConfigurationComponent.selectedField = {
+      label: 'API latency (ms)',
+      value: 'api-response-time',
+      type: 'duration',
+    };
+    widgetDataStatsConfigurationComponent.onFieldChanged();
+
+    const selectedStats = [
+      {
+        color: '#66bb6a',
+        key: 'min',
+        label: 'min',
+        unit: 'ms',
+      },
+      {
+        color: '#42a5f5',
+        key: 'avg',
+        label: 'avg',
+        unit: 'ms',
+      },
+      {
+        color: '#ff8f2d',
+        fallback: [
+          {
+            key: 'rpm',
+            label: 'requests per minute',
+          },
+          {
+            key: 'rph',
+            label: 'requests per hour',
+          },
+        ],
+        key: 'rps',
+        label: 'requests per second',
+      },
+      {
+        color: 'black',
+        key: 'count',
+        label: 'total',
+      },
+    ];
+
+    widgetDataStatsConfigurationComponent.selectedStatsKeys = ['min', 'avg', 'rps', 'count'];
+
     widgetDataStatsConfigurationComponent.onStatsChanged();
 
     expect(widgetDataStatsConfigurationComponent.chart).toEqual({
@@ -91,40 +136,48 @@ describe('WidgetDataStatsConfigurationComponent', () => {
         type: 'stats',
         field: 'api-response-time',
       },
-      data: [
-        {
-          color: '#66bb6a',
-          key: 'min',
-          label: 'min',
-          unit: 'ms',
-        },
-        {
-          color: '#42a5f5',
-          key: 'avg',
-          label: 'avg',
-          unit: 'ms',
-        },
-        {
-          color: '#ff8f2d',
-          fallback: [
-            {
-              key: 'rpm',
-              label: 'requests per minute',
-            },
-            {
-              key: 'rph',
-              label: 'requests per hour',
-            },
-          ],
-          key: 'rps',
-          label: 'requests per second',
-        },
-        {
-          color: 'black',
-          key: 'count',
-          label: 'total',
-        },
-      ],
+      data: selectedStats,
+    });
+  });
+
+  it('set `chart` properly when selecting Request content length', () => {
+    widgetDataStatsConfigurationComponent.selectedField = {
+      label: 'Request content length (byte)',
+      value: 'request-content-length',
+      type: 'length',
+    };
+    widgetDataStatsConfigurationComponent.onFieldChanged();
+
+    const selectedStats = [
+      {
+        color: '#66bb6a',
+        key: 'min',
+        label: 'min',
+        unit: 'byte',
+      },
+      {
+        color: '#ef5350',
+        key: 'max',
+        label: 'max',
+        unit: 'byte',
+      },
+      {
+        color: '#42a5f5',
+        key: 'avg',
+        label: 'avg',
+        unit: 'byte',
+      },
+    ];
+
+    widgetDataStatsConfigurationComponent.selectedStatsKeys = ['min', 'max', 'avg'];
+    widgetDataStatsConfigurationComponent.onStatsChanged();
+
+    expect(widgetDataStatsConfigurationComponent.chart).toEqual({
+      request: {
+        type: 'stats',
+        field: 'request-content-length',
+      },
+      data: selectedStats,
     });
   });
 });

--- a/gravitee-apim-console-webui/src/components/widget/stats/widget-data-stats-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/components/widget/stats/widget-data-stats-configuration.component.ts
@@ -13,76 +13,87 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as _ from 'lodash';
+
+import { merge } from 'lodash';
+import { IOnInit } from 'angular';
 
 import DashboardService from '../../../services/dashboard.service';
+
+class WidgetDataStatsConfigurationController implements IOnInit {
+  public chart: any;
+
+  fields = this.DashboardService.getAverageableFields();
+  stats = [
+    {
+      key: 'min',
+      label: 'min',
+      unit: 'ms',
+      color: '#66bb6a',
+    },
+    {
+      key: 'max',
+      label: 'max',
+      unit: 'ms',
+      color: '#ef5350',
+    },
+    {
+      key: 'avg',
+      label: 'avg',
+      unit: 'ms',
+      color: '#42a5f5',
+    },
+    {
+      key: 'rps',
+      label: 'requests per second',
+      color: '#ff8f2d',
+      fallback: [
+        {
+          key: 'rpm',
+          label: 'requests per minute',
+        },
+        {
+          key: 'rph',
+          label: 'requests per hour',
+        },
+      ],
+    },
+    {
+      key: 'count',
+      label: 'total',
+      color: 'black',
+    },
+  ];
+  statKeys = this.stats.map((stat) => stat.key);
+  selectedStats: string[] = [];
+
+  constructor(private readonly DashboardService: DashboardService) {
+    'ngInject';
+  }
+
+  $onInit(): void {
+    if (!this.chart.data) {
+      merge(this.chart, {
+        request: {
+          type: 'stats',
+          field: this.fields[0].value,
+        },
+        data: this.stats,
+      });
+    }
+    this.selectedStats = this.chart.data.map((stat) => stat.key);
+  }
+
+  onStatsChanged() {
+    this.chart.data = this.stats.filter((stat) => this.selectedStats.includes(stat.key));
+  }
+}
+
 const WidgetDataStatsConfigurationComponent: ng.IComponentOptions = {
   template: require('./widget-data-stats-configuration.html'),
   bindings: {
     chart: '<',
   },
-  controller: function (DashboardService: DashboardService) {
-    'ngInject';
-    this.fields = DashboardService.getAverageableFields();
-    this.stats = [
-      {
-        key: 'min',
-        label: 'min',
-        unit: 'ms',
-        color: '#66bb6a',
-      },
-      {
-        key: 'max',
-        label: 'max',
-        unit: 'ms',
-        color: '#ef5350',
-      },
-      {
-        key: 'avg',
-        label: 'avg',
-        unit: 'ms',
-        color: '#42a5f5',
-      },
-      {
-        key: 'rps',
-        label: 'requests per second',
-        color: '#ff8f2d',
-        fallback: [
-          {
-            key: 'rpm',
-            label: 'requests per minute',
-          },
-          {
-            key: 'rph',
-            label: 'requests per hour',
-          },
-        ],
-      },
-      {
-        key: 'count',
-        label: 'total',
-        color: 'black',
-      },
-    ];
-    this.statKeys = _.map(this.stats, 'key');
-
-    this.$onInit = () => {
-      if (!this.chart.data) {
-        _.merge(this.chart, {
-          request: {
-            type: 'stats',
-            field: this.fields[0].value,
-          },
-          data: this.stats,
-        });
-      }
-      this.selectedStats = _.map(this.chart.data, 'key');
-    };
-
-    this.onStatsChanged = () => {
-      this.chart.data = _.filter(this.stats, (stat) => _.includes(this.selectedStats, stat.key));
-    };
-  },
+  controller: WidgetDataStatsConfigurationController,
 };
 
 export default WidgetDataStatsConfigurationComponent;

--- a/gravitee-apim-console-webui/src/components/widget/stats/widget-data-stats-configuration.html
+++ b/gravitee-apim-console-webui/src/components/widget/stats/widget-data-stats-configuration.html
@@ -18,15 +18,15 @@
 <div layout="column">
   <md-input-container>
     <label>Field</label>
-    <md-select ng-model="$ctrl.chart.request.field">
-      <md-option ng-repeat="field in $ctrl.fields" ng-value="field.value">{{field.label}}</md-option>
+    <md-select ng-model="$ctrl.selectedField" ng-change="$ctrl.onFieldChanged()">
+      <md-option ng-repeat="field in $ctrl.fields" ng-value="field">{{field.label}}</md-option>
     </md-select>
   </md-input-container>
 
   <md-input-container>
     <label>Stats</label>
-    <md-select ng-model="$ctrl.selectedStats" multiple="true" ng-change="$ctrl.onStatsChanged()" required>
-      <md-option ng-repeat="stat in $ctrl.statKeys" ng-value="stat">{{stat}}</md-option>
+    <md-select ng-model="$ctrl.selectedStatsKeys" multiple="true" ng-change="$ctrl.onStatsChanged()" required>
+      <md-option ng-repeat="stat in $ctrl.availableStats" ng-value="stat.key">{{stat.label}}</md-option>
     </md-select>
   </md-input-container>
 </div>

--- a/gravitee-apim-console-webui/src/components/widget/table/widget-data-table-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/components/widget/table/widget-data-table-configuration.component.ts
@@ -25,7 +25,14 @@ const WidgetDataTableConfigurationComponent: ng.IComponentOptions = {
   controller: function (DashboardService: DashboardService) {
     'ngInject';
     this.fields = DashboardService.getIndexedFields();
-    this.projections = _.concat({ label: 'Hits', value: '_count' }, DashboardService.getAverageableFields());
+    this.projections = _.concat(
+      {
+        label: 'Hits',
+        value: '_count',
+        type: 'count',
+      },
+      DashboardService.getAverageableFields(),
+    );
     this.projectionOrders = [
       { label: 'Desc', value: '-' },
       { label: 'Asc', value: '' },

--- a/gravitee-apim-console-webui/src/services/dashboard.service.ts
+++ b/gravitee-apim-console-webui/src/services/dashboard.service.ts
@@ -19,6 +19,12 @@ import AnalyticsService from './analytics.service';
 
 import { Dashboard } from '../entities/dashboard';
 
+export interface AverageableField {
+  label: string;
+  value: string;
+  type: 'duration' | 'length' | 'count';
+}
+
 class DashboardService {
   private AnalyticsService: AnalyticsService;
 
@@ -69,27 +75,32 @@ class DashboardService {
     };
   }
 
-  getAverageableFields() {
+  getAverageableFields(): AverageableField[] {
     return [
       {
         label: 'Global latency (ms)',
         value: 'response-time',
+        type: 'duration',
       },
       {
         label: 'API latency (ms)',
         value: 'api-response-time',
+        type: 'duration',
       },
       {
         label: 'Proxy latency (ms)',
         value: 'proxy-latency',
+        type: 'duration',
       },
       {
         label: 'Request content length (byte)',
         value: 'request-content-length',
+        type: 'length',
       },
       {
         label: 'Response content length (byte)',
         value: 'response-content-length',
+        type: 'length',
       },
     ];
   }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5706

**Description**

The implementation of Stats widget never took into account that units other than `ms` might be used, so whatever the selected field the available stats were always the same (and same of the units).


![image](https://user-images.githubusercontent.com/4112568/147932399-c7b7eeab-60a5-4503-87ad-6a0469058a2c.png)

This works well for duration-related metrics, but not with content length-related ones. To fix this issue I: 
 - Added some unit tests for this component
 - Refactored its controller to a class
 - Added a `type` attribute on analytic fields to be able to filter/compute the correct available stats for each type (currently `duration`, `length`, `count`)

This fix will be backported on `3.5.x` without the tests as nothing is setup properly for that on this branch: https://github.com/gravitee-io/gravitee-api-management/pull/1030

**Additional context**


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vcrssktbfe.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/5706-fix-stats-analytics-units/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
