### PR TITLE
Properly handle units on Stats widget in dashboard - 3.5.x

### DIFF
--- a/gravitee-apim-console-webui/src/components/widget/stats/widget-data-stats-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/components/widget/stats/widget-data-stats-configuration.component.ts
@@ -13,75 +13,87 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import { merge } from 'lodash';
+import { IOnInit } from 'angular';
+
 import DashboardService from '../../../services/dashboard.service';
-import * as _ from 'lodash';
+
+class WidgetDataStatsConfigurationController implements IOnInit {
+  public chart: any;
+
+  fields = this.DashboardService.getAverageableFields();
+  stats = [
+    {
+      key: 'min',
+      label: 'min',
+      unit: 'ms',
+      color: '#66bb6a',
+    },
+    {
+      key: 'max',
+      label: 'max',
+      unit: 'ms',
+      color: '#ef5350',
+    },
+    {
+      key: 'avg',
+      label: 'avg',
+      unit: 'ms',
+      color: '#42a5f5',
+    },
+    {
+      key: 'rps',
+      label: 'requests per second',
+      color: '#ff8f2d',
+      fallback: [
+        {
+          key: 'rpm',
+          label: 'requests per minute',
+        },
+        {
+          key: 'rph',
+          label: 'requests per hour',
+        },
+      ],
+    },
+    {
+      key: 'count',
+      label: 'total',
+      color: 'black',
+    },
+  ];
+  statKeys = this.stats.map((stat) => stat.key);
+  selectedStats: string[] = [];
+
+  constructor(private readonly DashboardService: DashboardService) {
+    'ngInject';
+  }
+
+  $onInit(): void {
+    if (!this.chart.data) {
+      merge(this.chart, {
+        request: {
+          type: 'stats',
+          field: this.fields[0].value,
+        },
+        data: this.stats,
+      });
+    }
+    this.selectedStats = this.chart.data.map((stat) => stat.key);
+  }
+
+  onStatsChanged() {
+    this.chart.data = this.stats.filter((stat) => this.selectedStats.includes(stat.key));
+  }
+}
+
 const WidgetDataStatsConfigurationComponent: ng.IComponentOptions = {
   template: require('./widget-data-stats-configuration.html'),
   bindings: {
     chart: '<',
   },
-  controller: function (DashboardService: DashboardService) {
-    'ngInject';
-    this.fields = DashboardService.getAverageableFields();
-    this.stats = [
-      {
-        key: 'min',
-        label: 'min',
-        unit: 'ms',
-        color: '#66bb6a',
-      },
-      {
-        key: 'max',
-        label: 'max',
-        unit: 'ms',
-        color: '#ef5350',
-      },
-      {
-        key: 'avg',
-        label: 'avg',
-        unit: 'ms',
-        color: '#42a5f5',
-      },
-      {
-        key: 'rps',
-        label: 'requests per second',
-        color: '#ff8f2d',
-        fallback: [
-          {
-            key: 'rpm',
-            label: 'requests per minute',
-          },
-          {
-            key: 'rph',
-            label: 'requests per hour',
-          },
-        ],
-      },
-      {
-        key: 'count',
-        label: 'total',
-        color: 'black',
-      },
-    ];
-    this.statKeys = _.map(this.stats, 'key');
-
-    this.$onInit = () => {
-      if (!this.chart.data) {
-        _.merge(this.chart, {
-          request: {
-            type: 'stats',
-            field: this.fields[0].value,
-          },
-          data: this.stats,
-        });
-      }
-      this.selectedStats = _.map(this.chart.data, 'key');
-    };
-
-    this.onStatsChanged = () => {
-      this.chart.data = _.filter(this.stats, (stat) => _.includes(this.selectedStats, stat.key));
-    };
-  },
+  controller: WidgetDataStatsConfigurationController,
 };
 
 export default WidgetDataStatsConfigurationComponent;

--- a/gravitee-apim-console-webui/src/components/widget/stats/widget-data-stats-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/components/widget/stats/widget-data-stats-configuration.component.ts
@@ -17,54 +17,28 @@
 import { merge } from 'lodash';
 import { IOnInit } from 'angular';
 
-import DashboardService from '../../../services/dashboard.service';
+import DashboardService, { AverageableField } from '../../../services/dashboard.service';
+
+// tslint:disable-next-line:interface-name
+interface Stat {
+  key: string;
+  label: string;
+  unit?: string;
+  color: string;
+  fallback?: any;
+}
 
 class WidgetDataStatsConfigurationController implements IOnInit {
-  public chart: any;
+  public chart: {
+    request: { type: string; field: any };
+    data: Stat[];
+  };
 
   fields = this.DashboardService.getAverageableFields();
-  stats = [
-    {
-      key: 'min',
-      label: 'min',
-      unit: 'ms',
-      color: '#66bb6a',
-    },
-    {
-      key: 'max',
-      label: 'max',
-      unit: 'ms',
-      color: '#ef5350',
-    },
-    {
-      key: 'avg',
-      label: 'avg',
-      unit: 'ms',
-      color: '#42a5f5',
-    },
-    {
-      key: 'rps',
-      label: 'requests per second',
-      color: '#ff8f2d',
-      fallback: [
-        {
-          key: 'rpm',
-          label: 'requests per minute',
-        },
-        {
-          key: 'rph',
-          label: 'requests per hour',
-        },
-      ],
-    },
-    {
-      key: 'count',
-      label: 'total',
-      color: 'black',
-    },
-  ];
-  statKeys = this.stats.map((stat) => stat.key);
-  selectedStats: string[] = [];
+
+  selectedField: AverageableField;
+  selectedStatsKeys: string[] = [];
+  availableStats: Stat[];
 
   constructor(private readonly DashboardService: DashboardService) {
     'ngInject';
@@ -72,19 +46,99 @@ class WidgetDataStatsConfigurationController implements IOnInit {
 
   $onInit(): void {
     if (!this.chart.data) {
+      const defaultField = this.fields[0];
       merge(this.chart, {
         request: {
           type: 'stats',
-          field: this.fields[0].value,
+          field: defaultField.value,
         },
-        data: this.stats,
+        data: WidgetDataStatsConfigurationController.getStatsAccordingToFieldType(defaultField.type),
       });
     }
-    this.selectedStats = this.chart.data.map((stat) => stat.key);
+
+    this.selectedField = this.fields.find((field) => field.value === this.chart.request.field);
+    this.availableStats = WidgetDataStatsConfigurationController.getStatsAccordingToFieldType(this.selectedField.type);
+    this.selectedStatsKeys = this.chart.data.map((stat) => stat.key);
+  }
+
+  onFieldChanged() {
+    this.chart.request.field = this.selectedField.value;
+    this.availableStats = WidgetDataStatsConfigurationController.getStatsAccordingToFieldType(this.selectedField.type);
+    this.selectedStatsKeys = this.availableStats.map((stat) => stat.key);
+    this.onStatsChanged();
   }
 
   onStatsChanged() {
-    this.chart.data = this.stats.filter((stat) => this.selectedStats.includes(stat.key));
+    this.chart.data = this.availableStats.filter((stat) => (this.selectedStatsKeys ?? []).includes(stat.key));
+  }
+
+  // tslint:disable-next-line:member-ordering
+  private static getStatsAccordingToFieldType(fieldType: AverageableField['type']) {
+    if (fieldType === 'duration') {
+      return [
+        {
+          key: 'min',
+          label: 'min',
+          unit: 'ms',
+          color: '#66bb6a',
+        },
+        {
+          key: 'max',
+          label: 'max',
+          unit: 'ms',
+          color: '#ef5350',
+        },
+        {
+          key: 'avg',
+          label: 'avg',
+          unit: 'ms',
+          color: '#42a5f5',
+        },
+        {
+          key: 'rps',
+          label: 'requests per second',
+          color: '#ff8f2d',
+          fallback: [
+            {
+              key: 'rpm',
+              label: 'requests per minute',
+            },
+            {
+              key: 'rph',
+              label: 'requests per hour',
+            },
+          ],
+        },
+        {
+          key: 'count',
+          label: 'total',
+          color: 'black',
+        },
+      ];
+    } else if (fieldType === 'length') {
+      return [
+        {
+          key: 'min',
+          label: 'min',
+          unit: 'byte',
+          color: '#66bb6a',
+        },
+        {
+          key: 'max',
+          label: 'max',
+          unit: 'byte',
+          color: '#ef5350',
+        },
+        {
+          key: 'avg',
+          label: 'avg',
+          unit: 'byte',
+          color: '#42a5f5',
+        },
+      ];
+    } else {
+      return [];
+    }
   }
 }
 

--- a/gravitee-apim-console-webui/src/components/widget/stats/widget-data-stats-configuration.html
+++ b/gravitee-apim-console-webui/src/components/widget/stats/widget-data-stats-configuration.html
@@ -18,15 +18,15 @@
 <div layout="column">
   <md-input-container>
     <label>Field</label>
-    <md-select ng-model="$ctrl.chart.request.field">
-      <md-option ng-repeat="field in $ctrl.fields" ng-value="field.value">{{field.label}}</md-option>
+    <md-select ng-model="$ctrl.selectedField" ng-change="$ctrl.onFieldChanged()">
+      <md-option ng-repeat="field in $ctrl.fields" ng-value="field">{{field.label}}</md-option>
     </md-select>
   </md-input-container>
 
   <md-input-container>
     <label>Stats</label>
-    <md-select ng-model="$ctrl.selectedStats" multiple="true" ng-change="$ctrl.onStatsChanged()" required>
-      <md-option ng-repeat="stat in $ctrl.statKeys" ng-value="stat">{{stat}}</md-option>
+    <md-select ng-model="$ctrl.selectedStatsKeys" multiple="true" ng-change="$ctrl.onStatsChanged()" required>
+      <md-option ng-repeat="stat in $ctrl.availableStats" ng-value="stat.key">{{stat.label}}</md-option>
     </md-select>
   </md-input-container>
 </div>

--- a/gravitee-apim-console-webui/src/components/widget/table/widget-data-table-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/components/widget/table/widget-data-table-configuration.component.ts
@@ -24,7 +24,14 @@ const WidgetDataTableConfigurationComponent: ng.IComponentOptions = {
   controller: function (DashboardService: DashboardService) {
     'ngInject';
     this.fields = DashboardService.getIndexedFields();
-    this.projections = _.concat({ label: 'Hits', value: '_count' }, DashboardService.getAverageableFields());
+    this.projections = _.concat(
+      {
+        label: 'Hits',
+        value: '_count',
+        type: 'count',
+      },
+      DashboardService.getAverageableFields(),
+    );
     this.projectionOrders = [
       { label: 'Desc', value: '-' },
       { label: 'Asc', value: '' },

--- a/gravitee-apim-console-webui/src/services/dashboard.service.ts
+++ b/gravitee-apim-console-webui/src/services/dashboard.service.ts
@@ -17,6 +17,13 @@ import AnalyticsService from './analytics.service';
 import * as _ from 'lodash';
 import { Dashboard } from '../entities/dashboard';
 
+// tslint:disable-next-line:interface-name
+export interface AverageableField {
+  label: string;
+  value: string;
+  type: 'duration' | 'length' | 'count';
+}
+
 class DashboardService {
   private dashboardsURL: string;
   private AnalyticsService: AnalyticsService;
@@ -69,27 +76,32 @@ class DashboardService {
     };
   }
 
-  getAverageableFields() {
+  getAverageableFields(): AverageableField[] {
     return [
       {
         label: 'Global latency (ms)',
         value: 'response-time',
+        type: 'duration',
       },
       {
         label: 'API latency (ms)',
         value: 'api-response-time',
+        type: 'duration',
       },
       {
         label: 'Proxy latency (ms)',
         value: 'proxy-latency',
+        type: 'duration',
       },
       {
         label: 'Request content length (byte)',
         value: 'request-content-length',
+        type: 'length',
       },
       {
         label: 'Response content length (byte)',
         value: 'response-content-length',
+        type: 'length',
       },
     ];
   }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5706

**Description**

Backport of https://github.com/gravitee-io/gravitee-api-management/pull/1028 on `3.5.x`. 

I cherry-picked the commits from the PR targeting `master` except unit test-related changes as nothing is set up.

Original description: 
> The implementation of Stats widget never took into account that units other than `ms` might be used, so whatever the selected field the available stats were always the same (and same of the units).

> This works well for duration-related metrics, but not with content length-related ones. To fix this issue I: 
> - Added some unit tests for this component
> - Refactored its controller to a class
>  - Added a `type` attribute on analytic fields to be able to filter/compute the correct available stats for each type (currently `duration`, `length`, `count`)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/5706-fix-stats-analytics-units-3-5-x/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
