### PR TITLE
fix(rest-api): scans the import path even if the PolicyPaths is not selected

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/pathMappings.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/pathMappings.controller.ts
@@ -103,7 +103,7 @@ class ApiPathMappingsController {
       .then(
         (selectedDoc) => {
           if (selectedDoc) {
-            this.ApiService.importPathMappings(this.api.id, selectedDoc).then((updatedApi) => {
+            this.ApiService.importPathMappings(this.api.id, selectedDoc, this.api.gravitee).then((updatedApi) => {
               this.onSave(updatedApi);
             });
           }

--- a/gravitee-apim-console-webui/src/services/api.service.ts
+++ b/gravitee-apim-console-webui/src/services/api.service.ts
@@ -268,8 +268,14 @@ export class ApiService {
     return this.$http.post(`${this.Constants.env.baseURL}/apis/verify`, criteria, config);
   }
 
-  importPathMappings(apiId: any, page: any): IHttpPromise<any> {
-    return this.$http.post(`${this.Constants.env.baseURL}/apis/${apiId}/import-path-mappings?page=${page}`, {});
+  importPathMappings(apiId: any, page: any, definitionVersion?: string): IHttpPromise<any> {
+    let params = `?page=${page}`;
+
+    if (definitionVersion) {
+      params += `&definitionVersion=${definitionVersion}`;
+    }
+
+    return this.$http.post(`${this.Constants.env.baseURL}/apis/${apiId}/import-path-mappings${params}`, {});
   }
 
   duplicate(apiId: any, config: { context_path: any; version: any; filtered_fields: any[] }): IHttpPromise<any> {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
@@ -556,9 +556,12 @@ public class ApiResource extends AbstractResource {
         }
     )
     @Permissions({ @Permission(value = RolePermission.API_DEFINITION, acls = RolePermissionAction.UPDATE) })
-    public Response importApiPathMappingsFromPage(@QueryParam("page") @NotNull String page) {
+    public Response importApiPathMappingsFromPage(
+        @QueryParam("page") @NotNull String page,
+        @QueryParam("definitionVersion") @DefaultValue("1.0.0") String definitionVersion
+    ) {
         final ApiEntity apiEntity = (ApiEntity) getApi().getEntity();
-        ApiEntity updatedApi = apiService.importPathMappingsFromPage(apiEntity, page);
+        ApiEntity updatedApi = apiService.importPathMappingsFromPage(apiEntity, page, DefinitionVersion.valueOfLabel(definitionVersion));
         return Response
             .ok(updatedApi)
             .tag(Long.toString(updatedApi.getUpdatedAt().getTime()))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiResourceTest.java
@@ -25,12 +25,11 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
 import io.gravitee.common.component.Lifecycle;
+import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.Proxy;
 import io.gravitee.definition.model.VirtualHost;
 import io.gravitee.rest.api.management.rest.resource.param.LifecycleActionParam;
-import io.gravitee.rest.api.model.ApiStateEntity;
-import io.gravitee.rest.api.model.EventType;
-import io.gravitee.rest.api.model.Visibility;
+import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.api.ApiDeploymentEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.api.ApiLifecycleState;
@@ -361,5 +360,25 @@ public class ApiResourceTest extends AbstractResourceTest {
         assertEquals(BAD_REQUEST_400, response.getStatus());
         final String message = response.readEntity(String.class);
         assertTrue(message, message.contains("Invalid image format"));
+    }
+
+    @Test
+    public void shouldImportApiPathMappingsFromPage() {
+        when(apiService.importPathMappingsFromPage(any(), eq("Foo"), eq(DefinitionVersion.valueOfLabel("1.0.0")))).thenReturn(mockApi);
+
+        final Response response = envTarget(API + "/import-path-mappings").queryParam("page", "Foo").request().post(null);
+        assertEquals(OK_200, response.getStatus());
+    }
+
+    @Test
+    public void shouldImportApiPathMappingsFromPageWithDefinitionVersion() {
+        when(apiService.importPathMappingsFromPage(any(), eq("Foo"), eq(DefinitionVersion.valueOfLabel("2.0.0")))).thenReturn(mockApi);
+
+        final Response response = envTarget(API + "/import-path-mappings")
+            .queryParam("page", "Foo")
+            .queryParam("definitionVersion", "2.0.0")
+            .request()
+            .post(null);
+        assertEquals(OK_200, response.getStatus());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.common.data.domain.Page;
+import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.Plan;
 import io.gravitee.definition.model.Rule;
 import io.gravitee.definition.model.flow.Flow;
@@ -120,7 +121,7 @@ public interface ApiService {
 
     boolean exists(String apiId);
 
-    ApiEntity importPathMappingsFromPage(ApiEntity apiEntity, String page);
+    ApiEntity importPathMappingsFromPage(ApiEntity apiEntity, String page, DefinitionVersion definitionVersion);
 
     Set<CategoryEntity> listCategories(Collection<String> apis, String environment);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -2192,12 +2192,13 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     }
 
     @Override
-    public ApiEntity importPathMappingsFromPage(final ApiEntity apiEntity, final String page) {
+    public ApiEntity importPathMappingsFromPage(final ApiEntity apiEntity, final String page, DefinitionVersion definitionVersion) {
         final PageEntity pageEntity = pageService.findById(page);
         if (SWAGGER.name().equals(pageEntity.getType())) {
             final ImportSwaggerDescriptorEntity importSwaggerDescriptorEntity = new ImportSwaggerDescriptorEntity();
             importSwaggerDescriptorEntity.setPayload(pageEntity.getContent());
-            final SwaggerApiEntity swaggerApiEntity = swaggerService.createAPI(importSwaggerDescriptorEntity);
+            importSwaggerDescriptorEntity.setWithPathMapping(true);
+            final SwaggerApiEntity swaggerApiEntity = swaggerService.createAPI(importSwaggerDescriptorEntity, definitionVersion);
             apiEntity.getPathMappings().addAll(swaggerApiEntity.getPathMappings());
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIConverter.java
@@ -60,6 +60,8 @@ public class OAIToAPIConverter implements SwaggerToApiConverter<OAIDescriptor>, 
 
     private static final String PICTURE_REGEX = "^data:image/[\\w]+;base64,.*$";
 
+    protected static final Pattern PATH_PARAMS_PATTERN = Pattern.compile("\\{(.[^/\\}]*)\\}");
+
     private Collection<? extends OAIOperationVisitor> visitors;
     protected final ImportSwaggerDescriptorEntity swaggerDescriptor;
     private final PolicyOperationVisitorManager policyOperationVisitorManager;
@@ -291,7 +293,7 @@ public class OAIToAPIConverter implements SwaggerToApiConverter<OAIDescriptor>, 
                 .entrySet()
                 .forEach(
                     entry -> {
-                        String path = entry.getKey().replaceAll("\\{(.[^/\\}]*)\\}", ":$1");
+                        String path = PATH_PARAMS_PATTERN.matcher(entry.getKey()).replaceAll(":$1");
                         if (swaggerDescriptor.isWithPathMapping()) {
                             pathMappings.add(path);
                         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIConverter.java
@@ -282,75 +282,75 @@ public class OAIToAPIConverter implements SwaggerToApiConverter<OAIDescriptor>, 
     protected SwaggerApiEntity fill(final SwaggerApiEntity apiEntity, OpenAPI oai) {
         apiEntity.setGraviteeDefinitionVersion(DefinitionVersion.V1.getLabel());
 
-        if (swaggerDescriptor.isWithPolicyPaths()) {
-            // Paths
-            Map<String, List<Rule>> paths = new HashMap<>();
+        Map<String, List<Rule>> paths = new HashMap<>();
+        Set<String> pathMappings = new HashSet();
 
+        if (swaggerDescriptor.isWithPolicyPaths() || swaggerDescriptor.isWithPathMapping()) {
             oai
                 .getPaths()
                 .entrySet()
                 .forEach(
                     entry -> {
                         String path = entry.getKey().replaceAll("\\{(.[^/\\}]*)\\}", ":$1");
+                        if (swaggerDescriptor.isWithPathMapping()) {
+                            pathMappings.add(path);
+                        }
 
-                        Map<PathItem.HttpMethod, Operation> operations = entry.getValue().readOperationsMap();
-                        List<Rule> rules = new ArrayList<>();
+                        if (swaggerDescriptor.isWithPolicyPaths()) {
+                            Map<PathItem.HttpMethod, Operation> operations = entry.getValue().readOperationsMap();
+                            List<Rule> rules = new ArrayList<>();
 
-                        operations.forEach(
-                            (httpMethod, operation) ->
-                                getVisitors()
-                                    .forEach(
-                                        (Consumer<OAIOperationVisitor>) oaiOperationVisitor -> {
-                                            // Consider only policy visitor for now
-                                            Optional<Policy> policy = (Optional<Policy>) oaiOperationVisitor.visit(oai, operation);
+                            operations.forEach(
+                                (httpMethod, operation) ->
+                                    getVisitors()
+                                        .forEach(
+                                            (Consumer<OAIOperationVisitor>) oaiOperationVisitor -> {
+                                                // Consider only policy visitor for now
+                                                Optional<Policy> policy = (Optional<Policy>) oaiOperationVisitor.visit(oai, operation);
 
-                                            if (policy.isPresent()) {
-                                                final Rule rule = new Rule();
-                                                rule.setEnabled(true);
-                                                rule.setDescription(
-                                                    operation.getSummary() == null
-                                                        ? (
-                                                            operation.getOperationId() == null
-                                                                ? operation.getDescription()
-                                                                : operation.getOperationId()
-                                                        )
-                                                        : operation.getSummary()
-                                                );
-                                                rule.setMethods(singleton(HttpMethod.valueOf(httpMethod.name())));
+                                                if (policy.isPresent()) {
+                                                    final Rule rule = new Rule();
+                                                    rule.setEnabled(true);
+                                                    rule.setDescription(
+                                                        operation.getSummary() == null
+                                                            ? (
+                                                                operation.getOperationId() == null
+                                                                    ? operation.getDescription()
+                                                                    : operation.getOperationId()
+                                                            )
+                                                            : operation.getSummary()
+                                                    );
+                                                    rule.setMethods(singleton(HttpMethod.valueOf(httpMethod.name())));
 
-                                                io.gravitee.definition.model.Policy defPolicy = new io.gravitee.definition.model.Policy();
-                                                defPolicy.setName(policy.get().getName());
-                                                defPolicy.setConfiguration(clearNullValues(policy.get().getConfiguration()));
-                                                rule.setPolicy(defPolicy);
-                                                rules.add(rule);
+                                                    io.gravitee.definition.model.Policy defPolicy = new io.gravitee.definition.model.Policy();
+                                                    defPolicy.setName(policy.get().getName());
+                                                    defPolicy.setConfiguration(clearNullValues(policy.get().getConfiguration()));
+                                                    rule.setPolicy(defPolicy);
+                                                    rules.add(rule);
+                                                }
                                             }
-                                        }
-                                    )
-                        );
-                        paths.put(path, rules);
+                                        )
+                            );
+                            paths.put(path, rules);
+                        }
                     }
                 );
-
-            apiEntity.setPaths(paths);
-        }
-
-        // Path Mappings
-        if (apiEntity.getPaths() != null) {
-            apiEntity.setPathMappings(apiEntity.getPaths().keySet());
         }
 
         final String defaultDeclaredPath = "/";
-        Map<String, List<Rule>> paths = new HashMap<>();
 
-        paths.put(defaultDeclaredPath, new ArrayList<>());
-
-        if (!swaggerDescriptor.isWithPolicyPaths()) {
-            apiEntity.setPaths(paths);
+        // Path
+        if (paths.isEmpty()) {
+            paths.put(defaultDeclaredPath, new ArrayList<>());
         }
 
-        if (!swaggerDescriptor.isWithPathMapping()) {
-            apiEntity.setPathMappings(singleton(defaultDeclaredPath));
+        // Path Mappings
+        if (pathMappings.isEmpty()) {
+            pathMappings.add(defaultDeclaredPath);
         }
+
+        apiEntity.setPaths(paths);
+        apiEntity.setPathMappings(pathMappings);
 
         return apiEntity;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIV2Converter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIV2Converter.java
@@ -56,68 +56,74 @@ public class OAIToAPIV2Converter extends OAIToAPIConverter {
 
     @Override
     protected SwaggerApiEntity fill(SwaggerApiEntity apiEntity, OpenAPI oai) {
-        // flows
         apiEntity.setGraviteeDefinitionVersion(DefinitionVersion.V2.getLabel());
 
-        if (swaggerDescriptor.isWithPolicyPaths()) {
-            List<Flow> allFlows = new ArrayList();
+        List<Flow> allFlows = new ArrayList();
+        Set<String> pathMappings = new HashSet();
+
+        if (swaggerDescriptor.isWithPolicyPaths() || swaggerDescriptor.isWithPathMapping()) {
             oai
                 .getPaths()
                 .forEach(
                     (key, pathItem) -> {
                         String path = key.replaceAll("\\{(.[^/\\}]*)\\}", ":$1");
+                        if (swaggerDescriptor.isWithPathMapping()) {
+                            pathMappings.add(path);
+                        }
 
-                        Map<PathItem.HttpMethod, Operation> operations = pathItem.readOperationsMap();
-                        operations.forEach(
-                            (httpMethod, operation) -> {
-                                final Flow flow = createFlow(path, Collections.singleton(HttpMethod.valueOf(httpMethod.name())));
+                        if (swaggerDescriptor.isWithPolicyPaths()) {
+                            Map<PathItem.HttpMethod, Operation> operations = pathItem.readOperationsMap();
+                            operations.forEach(
+                                (httpMethod, operation) -> {
+                                    final Flow flow = createFlow(path, Collections.singleton(HttpMethod.valueOf(httpMethod.name())));
 
-                                getVisitors()
-                                    .forEach(
-                                        (Consumer<OAIOperationVisitor>) oaiOperationVisitor -> {
-                                            Optional<Policy> policy = (Optional<Policy>) oaiOperationVisitor.visit(oai, operation);
-                                            if (policy.isPresent()) {
-                                                final Step step = new Step();
-                                                step.setName(policy.get().getName());
-                                                step.setEnabled(true);
-                                                step.setDescription(
-                                                    operation.getSummary() == null
-                                                        ? (
-                                                            operation.getOperationId() == null
-                                                                ? operation.getDescription()
-                                                                : operation.getOperationId()
-                                                        )
-                                                        : operation.getSummary()
-                                                );
+                                    getVisitors()
+                                        .forEach(
+                                            (Consumer<OAIOperationVisitor>) oaiOperationVisitor -> {
+                                                Optional<Policy> policy = (Optional<Policy>) oaiOperationVisitor.visit(oai, operation);
+                                                if (policy.isPresent()) {
+                                                    final Step step = new Step();
+                                                    step.setName(policy.get().getName());
+                                                    step.setEnabled(true);
+                                                    step.setDescription(
+                                                        operation.getSummary() == null
+                                                            ? (
+                                                                operation.getOperationId() == null
+                                                                    ? operation.getDescription()
+                                                                    : operation.getOperationId()
+                                                            )
+                                                            : operation.getSummary()
+                                                    );
 
-                                                step.setPolicy(policy.get().getName());
-                                                String configuration = clearNullValues(policy.get().getConfiguration());
-                                                step.setConfiguration(configuration);
+                                                    step.setPolicy(policy.get().getName());
+                                                    String configuration = clearNullValues(policy.get().getConfiguration());
+                                                    step.setConfiguration(configuration);
 
-                                                String scope = getScope(configuration);
-                                                if (scope != null && scope.toLowerCase().equals("response")) {
-                                                    flow.getPost().add(step);
-                                                } else {
-                                                    flow.getPre().add(step);
+                                                    String scope = getScope(configuration);
+                                                    if (scope != null && scope.toLowerCase().equals("response")) {
+                                                        flow.getPost().add(step);
+                                                    } else {
+                                                        flow.getPre().add(step);
+                                                    }
                                                 }
                                             }
-                                        }
-                                    );
-                                allFlows.add(flow);
-                            }
-                        );
+                                        );
+                                    allFlows.add(flow);
+                                }
+                            );
+                        }
                     }
                 );
-            apiEntity.setFlows(allFlows);
-            if (swaggerDescriptor.isWithPathMapping() && allFlows.size() > 0) {
-                apiEntity.setPathMappings(allFlows.stream().map(flow -> flow.getPath()).collect(Collectors.toSet()));
-            }
         }
 
-        final String defaultDeclaredPath = "/";
-        if (!swaggerDescriptor.isWithPathMapping()) {
-            apiEntity.setPathMappings(singleton(defaultDeclaredPath));
+        // Path Mappings
+        if (pathMappings.isEmpty()) {
+            final String defaultDeclaredPath = "/";
+            pathMappings.add(defaultDeclaredPath);
         }
+
+        apiEntity.setFlows(allFlows);
+        apiEntity.setPathMappings(pathMappings);
 
         return apiEntity;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIV2Converter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIV2Converter.java
@@ -66,7 +66,7 @@ public class OAIToAPIV2Converter extends OAIToAPIConverter {
                 .getPaths()
                 .forEach(
                     (key, pathItem) -> {
-                        String path = key.replaceAll("\\{(.[^/\\}]*)\\}", ":$1");
+                        String path = PATH_PARAMS_PATTERN.matcher(key).replaceAll(":$1");
                         if (swaggerDescriptor.isWithPathMapping()) {
                             pathMappings.add(path);
                         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/SwaggerService_CreateAPITest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/SwaggerService_CreateAPITest.java
@@ -60,8 +60,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class SwaggerService_CreateAPITest {
 
-    protected DefinitionVersion definitionVersion = DefinitionVersion.V2;
-
     @Mock
     private PolicyOperationVisitorManager policyOperationVisitorManager;
 
@@ -73,6 +71,10 @@ public class SwaggerService_CreateAPITest {
 
     @InjectMocks
     protected SwaggerServiceImpl swaggerService;
+
+    protected DefinitionVersion getDefinitionVersion() {
+        return DefinitionVersion.V1;
+    }
 
     @Before
     public void setup() {
@@ -552,7 +554,7 @@ public class SwaggerService_CreateAPITest {
         assertTrue(swaggerApiEntity.getPathMappings().containsAll(asList("/pets", "/pets/:petId")));
         validatePathMappings(swaggerApiEntity, asList("/pets", "/pets/:petId"));
 
-        validatePolicies(swaggerApiEntity, 1, 0, this.definitionVersion.equals(DefinitionVersion.V1) ? asList("/") : asList());
+        validatePolicies(swaggerApiEntity, 1, 0, this.getDefinitionVersion().equals(DefinitionVersion.V1) ? asList("/") : asList());
     }
 
     protected void validatePathMappings(SwaggerApiEntity api, List<String> expectedPaths) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/SwaggerService_CreateAPITest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/SwaggerService_CreateAPITest.java
@@ -26,6 +26,7 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.io.Resources;
 import io.gravitee.common.http.HttpMethod;
+import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.Endpoint;
 import io.gravitee.definition.model.Rule;
 import io.gravitee.definition.model.VirtualHost;
@@ -58,6 +59,8 @@ import org.mockito.junit.MockitoJUnitRunner;
  */
 @RunWith(MockitoJUnitRunner.class)
 public class SwaggerService_CreateAPITest {
+
+    protected DefinitionVersion definitionVersion = DefinitionVersion.V2;
 
     @Mock
     private PolicyOperationVisitorManager policyOperationVisitorManager;
@@ -108,7 +111,7 @@ public class SwaggerService_CreateAPITest {
     // Swagger v1
     @Test
     public void shouldPrepareAPIFromSwaggerV1_URL_json() throws IOException {
-        validate(prepareUrl("io/gravitee/rest/api/management/service/swagger-v1.json"));
+        validate(prepareUrl("io/gravitee/rest/api/management/service/swagger-v1.json", true, true));
     }
 
     @Test
@@ -119,7 +122,7 @@ public class SwaggerService_CreateAPITest {
     // Swagger v2
     @Test
     public void shouldPrepareAPIFromSwaggerV2_URL_json() throws IOException {
-        validate(prepareUrl("io/gravitee/rest/api/management/service/swagger-v2.json"));
+        validate(prepareUrl("io/gravitee/rest/api/management/service/swagger-v2.json", true, true));
     }
 
     @Test
@@ -129,14 +132,18 @@ public class SwaggerService_CreateAPITest {
 
     @Test
     public void shouldPrepareAPIFromSwaggerV2_URL_json_extensions() throws IOException {
-        final SwaggerApiEntity swaggerApiEntity = prepareUrl("io/gravitee/rest/api/management/service/swagger-withExtensions-v2.json");
+        final SwaggerApiEntity swaggerApiEntity = prepareUrl(
+            "io/gravitee/rest/api/management/service/swagger-withExtensions-v2.json",
+            true,
+            true
+        );
         validate(swaggerApiEntity);
         validateExtensions(swaggerApiEntity);
     }
 
     @Test
     public void shouldPrepareAPIFromSwaggerV2_URL_yaml() throws IOException {
-        validate(prepareUrl("io/gravitee/rest/api/management/service/swagger-v2.yaml"));
+        validate(prepareUrl("io/gravitee/rest/api/management/service/swagger-v2.yaml", true, true));
     }
 
     @Test
@@ -146,7 +153,11 @@ public class SwaggerService_CreateAPITest {
 
     @Test
     public void shouldPrepareAPIFromSwaggerV2_URL_yaml_extensions() throws IOException {
-        final SwaggerApiEntity swaggerApiEntity = prepareUrl("io/gravitee/rest/api/management/service/swagger-withExtensions-v2.yaml");
+        final SwaggerApiEntity swaggerApiEntity = prepareUrl(
+            "io/gravitee/rest/api/management/service/swagger-withExtensions-v2.yaml",
+            true,
+            true
+        );
         validate(swaggerApiEntity);
         validateExtensions(swaggerApiEntity);
     }
@@ -154,7 +165,7 @@ public class SwaggerService_CreateAPITest {
     // OpenAPI
     @Test
     public void shouldPrepareAPIFromSwaggerV3_URL_json() throws IOException {
-        validate(prepareUrl("io/gravitee/rest/api/management/service/openapi.json"));
+        validate(prepareUrl("io/gravitee/rest/api/management/service/openapi.json", true, true));
     }
 
     @Test
@@ -164,14 +175,18 @@ public class SwaggerService_CreateAPITest {
 
     @Test
     public void shouldPrepareAPIFromSwaggerV3_URL_json_extensions() throws IOException {
-        final SwaggerApiEntity swaggerApiEntity = prepareUrl("io/gravitee/rest/api/management/service/openapi-withExtensions.json");
+        final SwaggerApiEntity swaggerApiEntity = prepareUrl(
+            "io/gravitee/rest/api/management/service/openapi-withExtensions.json",
+            true,
+            true
+        );
         validate(swaggerApiEntity);
         validateExtensions(swaggerApiEntity);
     }
 
     @Test
     public void shouldPrepareAPIFromSwaggerV3_URL_yaml() throws IOException {
-        validate(prepareUrl("io/gravitee/rest/api/management/service/openapi.yaml"));
+        validate(prepareUrl("io/gravitee/rest/api/management/service/openapi.yaml", true, true));
     }
 
     @Test
@@ -181,7 +196,11 @@ public class SwaggerService_CreateAPITest {
 
     @Test
     public void shouldPrepareAPIFromSwaggerV3_URL_yaml_extensions() throws IOException {
-        final SwaggerApiEntity swaggerApiEntity = prepareUrl("io/gravitee/rest/api/management/service/openapi-withExtensions.yaml");
+        final SwaggerApiEntity swaggerApiEntity = prepareUrl(
+            "io/gravitee/rest/api/management/service/openapi-withExtensions.yaml",
+            true,
+            true
+        );
         validate(swaggerApiEntity);
         validateExtensions(swaggerApiEntity);
     }
@@ -294,12 +313,12 @@ public class SwaggerService_CreateAPITest {
         return this.createAPI(swaggerDescriptor);
     }
 
-    private SwaggerApiEntity prepareUrl(String file) {
+    private SwaggerApiEntity prepareUrl(String file, boolean withPolicyPaths, boolean withPathMapping) {
         URL url = Resources.getResource(file);
         ImportSwaggerDescriptorEntity swaggerDescriptor = new ImportSwaggerDescriptorEntity();
         swaggerDescriptor.setType(ImportSwaggerDescriptorEntity.Type.URL);
-        swaggerDescriptor.setWithPolicyPaths(true);
-        swaggerDescriptor.setWithPathMapping(true);
+        swaggerDescriptor.setWithPolicyPaths(withPolicyPaths);
+        swaggerDescriptor.setWithPathMapping(withPathMapping);
         //        swaggerDescriptor.setWithPolicies(asList("mock"));
         try {
             swaggerDescriptor.setPayload(url.toURI().getPath());
@@ -524,5 +543,19 @@ public class SwaggerService_CreateAPITest {
     public void shouldPrepareAPIFromSwaggerV3WithComplexReferences() throws IOException {
         final SwaggerApiEntity api = prepareInline("io/gravitee/rest/api/management/service/mock/json-api.yml", true, true);
         validatePolicies(api, 2, 5, asList("/drives"));
+    }
+
+    @Test
+    public void shouldPrepareAPIFromSwaggerV3WithURLAndPathMappingOnly() throws IOException {
+        final SwaggerApiEntity swaggerApiEntity = prepareUrl("io/gravitee/rest/api/management/service/openapi.yaml", false, true);
+
+        assertTrue(swaggerApiEntity.getPathMappings().containsAll(asList("/pets", "/pets/:petId")));
+        validatePathMappings(swaggerApiEntity, asList("/pets", "/pets/:petId"));
+
+        validatePolicies(swaggerApiEntity, 1, 0, this.definitionVersion.equals(DefinitionVersion.V1) ? asList("/") : asList());
+    }
+
+    protected void validatePathMappings(SwaggerApiEntity api, List<String> expectedPaths) {
+        assertTrue(api.getPathMappings().containsAll(expectedPaths));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/SwaggerService_CreateAPIV2Test.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/SwaggerService_CreateAPIV2Test.java
@@ -38,10 +38,12 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class SwaggerService_CreateAPIV2Test extends SwaggerService_CreateAPITest {
 
-    protected DefinitionVersion definitionVersion = DefinitionVersion.V2;
+    protected DefinitionVersion getDefinitionVersion() {
+        return DefinitionVersion.V2;
+    }
 
     protected SwaggerApiEntity createAPI(ImportSwaggerDescriptorEntity swaggerDescriptor) {
-        return swaggerService.createAPI(swaggerDescriptor, this.definitionVersion);
+        return swaggerService.createAPI(swaggerDescriptor, this.getDefinitionVersion());
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/SwaggerService_CreateAPIV2Test.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/SwaggerService_CreateAPIV2Test.java
@@ -38,8 +38,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class SwaggerService_CreateAPIV2Test extends SwaggerService_CreateAPITest {
 
+    protected DefinitionVersion definitionVersion = DefinitionVersion.V2;
+
     protected SwaggerApiEntity createAPI(ImportSwaggerDescriptorEntity swaggerDescriptor) {
-        return swaggerService.createAPI(swaggerDescriptor, DefinitionVersion.V2);
+        return swaggerService.createAPI(swaggerDescriptor, this.definitionVersion);
     }
 
     @Override


### PR DESCRIPTION
**Issue**
https://github.com/gravitee-io/issues/issues/6723

**Description**

Adding path mapping works even if the isWithPolicyPaths option is not true

backport for 3.5.x : https://github.com/gravitee-io/gravitee-api-management/pull/1041

**Additional context**




---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fnfdopqviu.chromatic.com)
<!-- Storybook placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ghgvxstuuu.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6723-fix-import-path-mapping/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
