### PR TITLE
Fix the dictionaries synchronization process in the gateway

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/ApiSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/ApiSynchronizer.java
@@ -95,8 +95,9 @@ public class ApiSynchronizer extends AbstractSynchronizer {
      * Run the initial synchronization which focus on api PUBLISH and START events only.
      */
     private long initialSynchronizeApis(long nextLastRefreshAt) {
-
-        final Long count = this.searchLatestEvents(bulkItems, null, nextLastRefreshAt, API_ID, EventType.PUBLISH_API, EventType.START_API)
+        // We look for all the latest events for APIs...
+        final Long count = this.searchLatestEvents(bulkItems, null, nextLastRefreshAt, API_ID, EventType.PUBLISH_API, EventType.START_API, EventType.UNPUBLISH_API, EventType.STOP_API)
+                .filter(e -> e.getType().equals(EventType.PUBLISH_API) || e.getType().equals(EventType.START_API))  // ... but if the latest event of an API is UNPUBLISH or STOP, it must not be registered
                 .compose(this::processApiRegisterEvents)
                 .count()
                 .blockingGet();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/DictionarySynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/DictionarySynchronizer.java
@@ -57,7 +57,7 @@ public class DictionarySynchronizer extends AbstractSynchronizer {
         if (lastRefreshAt == -1) {
             count = initialSynchronizeDictionaries(nextLastRefreshAt);
         } else {
-            count = this.searchLatestEvents(bulkItems, lastRefreshAt, nextLastRefreshAt, DICTIONARY_ID, EventType.PUBLISH_DICTIONARY, EventType.START_DICTIONARY, EventType.UNPUBLISH_DICTIONARY, EventType.STOP_DICTIONARY)
+            count = this.searchLatestEvents(bulkItems, lastRefreshAt, nextLastRefreshAt, DICTIONARY_ID, EventType.PUBLISH_DICTIONARY, EventType.UNPUBLISH_DICTIONARY)
                     .compose(this::processDictionaryEvents)
                     .count()
                     .blockingGet();
@@ -71,7 +71,9 @@ public class DictionarySynchronizer extends AbstractSynchronizer {
     }
 
     private long initialSynchronizeDictionaries(long nextLastRefreshAt) {
-        return this.searchLatestEvents(bulkItems, null, nextLastRefreshAt, DICTIONARY_ID, EventType.PUBLISH_DICTIONARY, EventType.START_DICTIONARY)
+        // We look only for the latest PUBLISH or UNPUBLISH events for dictionaries...
+        return this.searchLatestEvents(bulkItems, null, nextLastRefreshAt, DICTIONARY_ID, EventType.PUBLISH_DICTIONARY, EventType.UNPUBLISH_DICTIONARY)
+                .filter(e -> e.getType().equals(EventType.PUBLISH_DICTIONARY))  // ... but if the latest event of a dictionary is UNPUBLISH, it must not be loaded
                 .compose(this::processDictionaryDeployEvents)
                 .count()
                 .blockingGet();
@@ -81,9 +83,9 @@ public class DictionarySynchronizer extends AbstractSynchronizer {
     private Flowable<String> processDictionaryEvents(Flowable<Event> upstream) {
         return upstream.groupBy(Event::getType)
                 .flatMap(eventsByType -> {
-                    if (eventsByType.getKey() == EventType.PUBLISH_DICTIONARY || eventsByType.getKey() == EventType.START_DICTIONARY) {
+                    if (eventsByType.getKey() == EventType.PUBLISH_DICTIONARY) {
                         return eventsByType.compose(this::processDictionaryDeployEvents);
-                    } else if (eventsByType.getKey() == EventType.UNPUBLISH_DICTIONARY || eventsByType.getKey() == EventType.STOP_DICTIONARY) {
+                    } else if (eventsByType.getKey() == EventType.UNPUBLISH_DICTIONARY) {
                         return eventsByType.compose(this::processDictionaryUndeployEvents);
                     } else {
                         return Flowable.empty();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/DictionarySynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/DictionarySynchronizerTest.java
@@ -65,7 +65,7 @@ public class DictionarySynchronizerTest extends TestCase {
 
         final Event mockEvent = mockEvent(dictionary, EventType.PUBLISH_DICTIONARY);
         when(eventRepository.searchLatest(
-                argThat(criteria -> criteria != null && criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.START_DICTIONARY))),
+                argThat(criteria -> criteria != null && criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.UNPUBLISH_DICTIONARY))),
                 eq(Event.EventProperties.DICTIONARY_ID),
                 anyLong(),
                 anyLong()
@@ -84,7 +84,7 @@ public class DictionarySynchronizerTest extends TestCase {
 
         final Event mockEvent = mockEvent(dictionary, EventType.PUBLISH_DICTIONARY);
         when(eventRepository.searchLatest(
-                argThat(criteria -> criteria != null && criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.START_DICTIONARY, EventType.UNPUBLISH_DICTIONARY, EventType.STOP_DICTIONARY))),
+                argThat(criteria -> criteria != null && criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.UNPUBLISH_DICTIONARY))),
                 eq(Event.EventProperties.DICTIONARY_ID),
                 anyLong(),
                 anyLong()
@@ -110,14 +110,14 @@ public class DictionarySynchronizerTest extends TestCase {
         final Event mockEvent = mockEvent(dictionary, EventType.PUBLISH_DICTIONARY);
         final Event mockEvent2 = mockEvent(dictionary2, EventType.PUBLISH_DICTIONARY);
         when(eventRepository.searchLatest(
-                argThat(criteria -> criteria != null && criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.START_DICTIONARY, EventType.UNPUBLISH_DICTIONARY, EventType.STOP_DICTIONARY))),
+                argThat(criteria -> criteria != null && criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.UNPUBLISH_DICTIONARY))),
                 eq(Event.EventProperties.DICTIONARY_ID),
                 eq(0L),
                 eq(1L)
         )).thenReturn(singletonList(mockEvent));
 
         when(eventRepository.searchLatest(
-                argThat(criteria -> criteria != null && criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.START_DICTIONARY, EventType.UNPUBLISH_DICTIONARY, EventType.STOP_DICTIONARY))),
+                argThat(criteria -> criteria != null && criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.UNPUBLISH_DICTIONARY))),
                 eq(Event.EventProperties.DICTIONARY_ID),
                 eq(1L),
                 eq(1L)
@@ -137,7 +137,7 @@ public class DictionarySynchronizerTest extends TestCase {
 
         final Event mockEvent = mockEvent(dictionary, EventType.UNPUBLISH_DICTIONARY);
         when(eventRepository.searchLatest(
-                argThat(criteria -> criteria != null && criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.START_DICTIONARY, EventType.UNPUBLISH_DICTIONARY, EventType.STOP_DICTIONARY))),
+                argThat(criteria -> criteria != null && criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.UNPUBLISH_DICTIONARY))),
                 eq(Event.EventProperties.DICTIONARY_ID),
                 anyLong(),
                 anyLong()
@@ -163,14 +163,14 @@ public class DictionarySynchronizerTest extends TestCase {
         final Event mockEvent = mockEvent(dictionary, EventType.UNPUBLISH_DICTIONARY);
         final Event mockEvent2 = mockEvent(dictionary2, EventType.UNPUBLISH_DICTIONARY);
         when(eventRepository.searchLatest(
-                argThat(criteria -> criteria != null && criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.START_DICTIONARY, EventType.UNPUBLISH_DICTIONARY, EventType.STOP_DICTIONARY))),
+                argThat(criteria -> criteria != null && criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.UNPUBLISH_DICTIONARY))),
                 eq(Event.EventProperties.DICTIONARY_ID),
                 eq(0L),
                 eq(1L)
         )).thenReturn(singletonList(mockEvent));
 
         when(eventRepository.searchLatest(
-                argThat(criteria -> criteria != null && criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.START_DICTIONARY, EventType.UNPUBLISH_DICTIONARY, EventType.STOP_DICTIONARY))),
+                argThat(criteria -> criteria != null && criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.UNPUBLISH_DICTIONARY))),
                 eq(Event.EventProperties.DICTIONARY_ID),
                 eq(1L),
                 eq(1L)
@@ -194,14 +194,14 @@ public class DictionarySynchronizerTest extends TestCase {
             dictionary.setId("dictionary" + i + "-test");
 
             if (i % 2 == 0) {
-                eventAccumulator.add(mockEvent(dictionary, EventType.START_DICTIONARY));
+                eventAccumulator.add(mockEvent(dictionary, EventType.PUBLISH_DICTIONARY));
             } else {
-                eventAccumulator.add(mockEvent(dictionary, EventType.STOP_DICTIONARY));
+                eventAccumulator.add(mockEvent(dictionary, EventType.UNPUBLISH_DICTIONARY));
             }
 
             if (i % 100 == 0) {
                 when(eventRepository.searchLatest(
-                        argThat(criteria -> criteria != null && criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.START_DICTIONARY, EventType.UNPUBLISH_DICTIONARY, EventType.STOP_DICTIONARY))),
+                        argThat(criteria -> criteria != null && criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.UNPUBLISH_DICTIONARY))),
                         eq(Event.EventProperties.DICTIONARY_ID),
                         eq(page),
                         eq(100L)
@@ -226,7 +226,7 @@ public class DictionarySynchronizerTest extends TestCase {
         Event mockEvent = mockEvent(dictionary, EventType.PUBLISH_DICTIONARY);
         when(objectMapper.readValue(mockEvent.getPayload(), Dictionary.class)).thenThrow(new NullPointerException());
         when(eventRepository.searchLatest(
-                argThat(criteria -> criteria != null && criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.START_DICTIONARY))),
+                argThat(criteria -> criteria != null && criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY))),
                 eq(Event.EventProperties.DICTIONARY_ID),
                 anyLong(),
                 anyLong()

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/event/EventMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/event/EventMongoRepositoryImpl.java
@@ -43,16 +43,11 @@ public class EventMongoRepositoryImpl implements EventMongoRepositoryCustom {
         Aggregation aggregation;
         List<AggregationOperation> aggregationOperations = new ArrayList<>();
 
-        // Filter on group property.
-        if (criteria.getFrom() != 0) {
-            // When a 'from' date is specified we can optimize the pipeline by filtering event on 'updatedAt' field and avoid executing the grouping step on all events.
-            aggregationOperations.add(
-                Aggregation.match(
-                    Criteria.where("properties." + group.getValue()).exists(true).and("updatedAt").gte(new Date(criteria.getFrom()))
-                )
-            );
-        } else {
-            aggregationOperations.add(Aggregation.match(Criteria.where("properties." + group.getValue()).exists(true)));
+        aggregationOperations.add(Aggregation.match(Criteria.where("properties." + group.getValue()).exists(true)));
+        List<Criteria> criteriaList = buildDBCriteria(criteria);
+        // Match criteria.
+        if (!criteriaList.isEmpty()) {
+            aggregationOperations.add(Aggregation.match(new Criteria().andOperator(criteriaList.toArray(new Criteria[0]))));
         }
 
         // Sort.
@@ -63,13 +58,6 @@ public class EventMongoRepositoryImpl implements EventMongoRepositoryCustom {
 
         // Extract result.
         aggregationOperations.add(Aggregation.replaceRoot("doc"));
-
-        List<Criteria> criteriaList = buildDBCriteria(criteria);
-
-        // Match criteria.
-        if (!criteriaList.isEmpty()) {
-            aggregationOperations.add(Aggregation.match(new Criteria().andOperator(criteriaList.toArray(new Criteria[0]))));
-        }
 
         // Sort
         aggregationOperations.add(Aggregation.sort(Sort.Direction.DESC, "updatedAt", "_id"));
@@ -135,6 +123,8 @@ public class EventMongoRepositoryImpl implements EventMongoRepositoryCustom {
         // set range query
         if (criteria.getFrom() != 0 && criteria.getTo() != 0) {
             criteriaList.add(Criteria.where("updatedAt").gte(new Date(criteria.getFrom())).lt(new Date(criteria.getTo())));
+        } else if (criteria.getFrom() != 0) {
+            criteriaList.add(Criteria.where("updatedAt").gte(new Date(criteria.getFrom())));
         }
 
         // set environmentId

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/EventRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/EventRepositoryTest.java
@@ -236,7 +236,12 @@ public class EventRepositoryTest extends AbstractRepositoryTest {
 
     @Test
     public void searchLatestApiEventsWithoutPagingAndSize() {
-        List<Event> events = eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, null, null);
+        List<Event> events = eventRepository.searchLatest(
+            new EventCriteria.Builder().environmentId("DEFAULT").build(),
+            Event.EventProperties.API_ID,
+            null,
+            null
+        );
 
         assertEquals(5L, events.size());
         final Iterator<Event> iterator = events.iterator();
@@ -249,7 +254,12 @@ public class EventRepositoryTest extends AbstractRepositoryTest {
 
     @Test
     public void searchLatestApiEventsPage3Size1() {
-        List<Event> events = eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 3L, 1L);
+        List<Event> events = eventRepository.searchLatest(
+            new EventCriteria.Builder().environmentId("DEFAULT").build(),
+            Event.EventProperties.API_ID,
+            3L,
+            1L
+        );
 
         assertEquals(1L, events.size());
         final Iterator<Event> iterator = events.iterator();
@@ -261,65 +271,67 @@ public class EventRepositoryTest extends AbstractRepositoryTest {
         //The order of events should be always the same, whatever the page size is
 
         // Test 1 by 1
-        List<Event> events = eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 0L, 1L);
+        final EventCriteria eventCriteria = new EventCriteria.Builder().environmentId("DEFAULT").build();
+
+        List<Event> events = eventRepository.searchLatest(eventCriteria, Event.EventProperties.API_ID, 0L, 1L);
         Iterator<Event> iterator = events.iterator();
         assertEquals(1L, events.size());
         assertEquals("event11", iterator.next().getId());
 
-        events = eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 1L, 1L);
+        events = eventRepository.searchLatest(eventCriteria, Event.EventProperties.API_ID, 1L, 1L);
         iterator = events.iterator();
         assertEquals(1L, events.size());
         assertEquals("event10", iterator.next().getId());
 
-        events = eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 2L, 1L);
+        events = eventRepository.searchLatest(eventCriteria, Event.EventProperties.API_ID, 2L, 1L);
         iterator = events.iterator();
         assertEquals(1L, events.size());
         assertEquals("event06", iterator.next().getId());
 
-        events = eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 3L, 1L);
+        events = eventRepository.searchLatest(eventCriteria, Event.EventProperties.API_ID, 3L, 1L);
         iterator = events.iterator();
         assertEquals(1L, events.size());
         assertEquals("event04", iterator.next().getId());
 
-        events = eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 4L, 1L);
+        events = eventRepository.searchLatest(eventCriteria, Event.EventProperties.API_ID, 4L, 1L);
         iterator = events.iterator();
         assertEquals(1L, events.size());
         assertEquals("event02", iterator.next().getId());
 
         // Test 2 by 2
-        events = eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 0L, 2L);
+        events = eventRepository.searchLatest(eventCriteria, Event.EventProperties.API_ID, 0L, 2L);
         iterator = events.iterator();
         assertEquals(2L, events.size());
         assertEquals("event11", iterator.next().getId());
         assertEquals("event10", iterator.next().getId());
 
-        events = eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 1L, 2L);
+        events = eventRepository.searchLatest(eventCriteria, Event.EventProperties.API_ID, 1L, 2L);
         assertEquals(2L, events.size());
         iterator = events.iterator();
         assertEquals("event06", iterator.next().getId());
         assertEquals("event04", iterator.next().getId());
 
-        events = eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 2L, 2L);
+        events = eventRepository.searchLatest(eventCriteria, Event.EventProperties.API_ID, 2L, 2L);
         iterator = events.iterator();
         assertEquals(1L, events.size());
         assertEquals("event02", iterator.next().getId());
 
         // Test 3 by 3
-        events = eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 0L, 3L);
+        events = eventRepository.searchLatest(eventCriteria, Event.EventProperties.API_ID, 0L, 3L);
         iterator = events.iterator();
         assertEquals(3L, events.size());
         assertEquals("event11", iterator.next().getId());
         assertEquals("event10", iterator.next().getId());
         assertEquals("event06", iterator.next().getId());
 
-        events = eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 1L, 3L);
+        events = eventRepository.searchLatest(eventCriteria, Event.EventProperties.API_ID, 1L, 3L);
         iterator = events.iterator();
         assertEquals(2L, events.size());
         assertEquals("event04", iterator.next().getId());
         assertEquals("event02", iterator.next().getId());
 
         // Test 4 by 4
-        events = eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 0L, 4L);
+        events = eventRepository.searchLatest(eventCriteria, Event.EventProperties.API_ID, 0L, 4L);
         iterator = events.iterator();
         assertEquals(4L, events.size());
         assertEquals("event11", iterator.next().getId());
@@ -327,13 +339,13 @@ public class EventRepositoryTest extends AbstractRepositoryTest {
         assertEquals("event06", iterator.next().getId());
         assertEquals("event04", iterator.next().getId());
 
-        events = eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 1L, 4L);
+        events = eventRepository.searchLatest(eventCriteria, Event.EventProperties.API_ID, 1L, 4L);
         iterator = events.iterator();
         assertEquals(1L, events.size());
         assertEquals("event02", iterator.next().getId());
 
         // Test 5 by 5
-        events = eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 0L, 5L);
+        events = eventRepository.searchLatest(eventCriteria, Event.EventProperties.API_ID, 0L, 5L);
         iterator = events.iterator();
         assertEquals(5L, events.size());
         assertEquals("event11", iterator.next().getId());
@@ -363,6 +375,20 @@ public class EventRepositoryTest extends AbstractRepositoryTest {
     }
 
     @Test
+    public void searchLatestDictionaryEventsByMixProperties() throws Exception {
+        List<Event> events = eventRepository.searchLatest(
+            new EventCriteria.Builder().from(1455800000000L).to(1455941000000L).types(EventType.PUBLISH_DICTIONARY).build(),
+            Event.EventProperties.DICTIONARY_ID,
+            0L,
+            10L
+        );
+
+        assertEquals(1L, events.size());
+        final Iterator<Event> iterator = events.iterator();
+        assertEquals("event09", iterator.next().getId());
+    }
+
+    @Test
     public void searchLatestDictionaryEventsWithoutPagingAndSize() {
         List<Event> events = eventRepository.searchLatest(
             new EventCriteria.Builder().build(),
@@ -373,7 +399,7 @@ public class EventRepositoryTest extends AbstractRepositoryTest {
 
         assertEquals(2L, events.size());
         final Iterator<Event> iterator = events.iterator();
-        assertEquals("event09", iterator.next().getId());
+        assertEquals("event12", iterator.next().getId());
         assertEquals("event08", iterator.next().getId());
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/EventRepositoryMock.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/EventRepositoryMock.java
@@ -55,6 +55,7 @@ public class EventRepositoryMock extends AbstractRepositoryMock<EventRepository>
         final Event event9 = mock(Event.class);
         final Event event10 = mock(Event.class);
         final Event event11 = mock(Event.class);
+        final Event event12 = mock(Event.class);
         final io.gravitee.common.data.domain.Page<Event> pageEvent = mock(io.gravitee.common.data.domain.Page.class);
         final io.gravitee.common.data.domain.Page<Event> pageEvent2 = mock(io.gravitee.common.data.domain.Page.class);
         final io.gravitee.common.data.domain.Page<Event> pageEvent3 = mock(io.gravitee.common.data.domain.Page.class);
@@ -124,7 +125,7 @@ public class EventRepositoryMock extends AbstractRepositoryMock<EventRepository>
         when(event8.getUpdatedAt()).thenReturn(parse("18/02/2016"));
 
         when(event9.getId()).thenReturn("event09");
-        when(event9.getEnvironmentId()).thenReturn("DEFAULT");
+        when(event9.getEnvironmentId()).thenReturn("OTHER");
         when(event9.getType()).thenReturn(EventType.PUBLISH_DICTIONARY);
         when(event9.getCreatedAt()).thenReturn(parse("19/02/2016"));
         when(event9.getUpdatedAt()).thenReturn(parse("19/02/2016"));
@@ -140,6 +141,12 @@ public class EventRepositoryMock extends AbstractRepositoryMock<EventRepository>
         when(event11.getType()).thenReturn(EventType.START_API);
         when(event11.getCreatedAt()).thenReturn(parse("16/02/2016"));
         when(event11.getUpdatedAt()).thenReturn(parse("16/02/2016"));
+
+        when(event12.getId()).thenReturn("event12");
+        when(event12.getEnvironmentId()).thenReturn("DEFAULT");
+        when(event12.getType()).thenReturn(EventType.STOP_DICTIONARY);
+        when(event12.getCreatedAt()).thenReturn(parse("20/02/2016"));
+        when(event12.getUpdatedAt()).thenReturn(parse("20/02/2016"));
 
         when(eventRepository.findById("event01")).thenReturn(of(event1));
 
@@ -287,41 +294,76 @@ public class EventRepositoryMock extends AbstractRepositoryMock<EventRepository>
 
         when(eventRepository.update(argThat(o -> o == null || o.getId().equals("unknown")))).thenThrow(new IllegalStateException());
 
-        when(eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, null, null))
+        when(
+            eventRepository.searchLatest(
+                new EventCriteria.Builder().environmentId("DEFAULT").build(),
+                Event.EventProperties.API_ID,
+                null,
+                null
+            )
+        )
             .thenReturn(Arrays.asList(event11, event10, event6, event4, event2));
 
-        when(eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 3L, 1L))
+        when(
+            eventRepository.searchLatest(new EventCriteria.Builder().environmentId("DEFAULT").build(), Event.EventProperties.API_ID, 3L, 1L)
+        )
             .thenReturn(singletonList(event4));
 
-        when(eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 0L, 1L))
+        when(
+            eventRepository.searchLatest(new EventCriteria.Builder().environmentId("DEFAULT").build(), Event.EventProperties.API_ID, 0L, 1L)
+        )
             .thenReturn(singletonList(event11));
-        when(eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 1L, 1L))
+        when(
+            eventRepository.searchLatest(new EventCriteria.Builder().environmentId("DEFAULT").build(), Event.EventProperties.API_ID, 1L, 1L)
+        )
             .thenReturn(singletonList(event10));
-        when(eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 2L, 1L))
+        when(
+            eventRepository.searchLatest(new EventCriteria.Builder().environmentId("DEFAULT").build(), Event.EventProperties.API_ID, 2L, 1L)
+        )
             .thenReturn(singletonList(event6));
-        when(eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 3L, 1L))
+        when(
+            eventRepository.searchLatest(new EventCriteria.Builder().environmentId("DEFAULT").build(), Event.EventProperties.API_ID, 3L, 1L)
+        )
             .thenReturn(singletonList(event4));
-        when(eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 4L, 1L))
+        when(
+            eventRepository.searchLatest(new EventCriteria.Builder().environmentId("DEFAULT").build(), Event.EventProperties.API_ID, 4L, 1L)
+        )
             .thenReturn(singletonList(event2));
 
-        when(eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 0L, 2L))
+        when(
+            eventRepository.searchLatest(new EventCriteria.Builder().environmentId("DEFAULT").build(), Event.EventProperties.API_ID, 0L, 2L)
+        )
             .thenReturn(Arrays.asList(event11, event10));
-        when(eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 1L, 2L))
+        when(
+            eventRepository.searchLatest(new EventCriteria.Builder().environmentId("DEFAULT").build(), Event.EventProperties.API_ID, 1L, 2L)
+        )
             .thenReturn(Arrays.asList(event6, event4));
-        when(eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 2L, 2L))
+        when(
+            eventRepository.searchLatest(new EventCriteria.Builder().environmentId("DEFAULT").build(), Event.EventProperties.API_ID, 2L, 2L)
+        )
             .thenReturn(singletonList(event2));
 
-        when(eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 0L, 3L))
+        when(
+            eventRepository.searchLatest(new EventCriteria.Builder().environmentId("DEFAULT").build(), Event.EventProperties.API_ID, 0L, 3L)
+        )
             .thenReturn(Arrays.asList(event11, event10, event6));
-        when(eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 1L, 3L))
+        when(
+            eventRepository.searchLatest(new EventCriteria.Builder().environmentId("DEFAULT").build(), Event.EventProperties.API_ID, 1L, 3L)
+        )
             .thenReturn(Arrays.asList(event4, event2));
 
-        when(eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 0L, 4L))
+        when(
+            eventRepository.searchLatest(new EventCriteria.Builder().environmentId("DEFAULT").build(), Event.EventProperties.API_ID, 0L, 4L)
+        )
             .thenReturn(Arrays.asList(event11, event10, event6, event4));
-        when(eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 1L, 4L))
+        when(
+            eventRepository.searchLatest(new EventCriteria.Builder().environmentId("DEFAULT").build(), Event.EventProperties.API_ID, 1L, 4L)
+        )
             .thenReturn(singletonList(event2));
 
-        when(eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.API_ID, 0L, 5L))
+        when(
+            eventRepository.searchLatest(new EventCriteria.Builder().environmentId("DEFAULT").build(), Event.EventProperties.API_ID, 0L, 5L)
+        )
             .thenReturn(Arrays.asList(event11, event10, event6, event4, event2));
 
         when(
@@ -339,7 +381,17 @@ public class EventRepositoryMock extends AbstractRepositoryMock<EventRepository>
         )
             .thenReturn(singletonList(event4));
 
+        when(
+            eventRepository.searchLatest(
+                new EventCriteria.Builder().from(1455800000000L).to(1455941000000L).types(EventType.PUBLISH_DICTIONARY).build(),
+                Event.EventProperties.DICTIONARY_ID,
+                0L,
+                10L
+            )
+        )
+            .thenReturn(singletonList(event9));
+
         when(eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.DICTIONARY_ID, null, null))
-            .thenReturn(Arrays.asList(event9, event8));
+            .thenReturn(Arrays.asList(event12, event8));
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/event-tests/events.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/event-tests/events.json
@@ -127,5 +127,17 @@
     },
     "createdAt": 1464739200000,
     "updatedAt": 1464739200000
+  },
+  {
+    "id": "event12",
+    "environmentId": "OTHER",
+    "type": "STOP_DICTIONARY",
+    "payload": "{}",
+    "parentId": null,
+    "properties": {
+      "dictionary_id": "dictionary-2"
+    },
+    "createdAt": 1455940000000,
+    "updatedAt": 1455940000000
   }
 ]


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6044
https://github.com/gravitee-io/issues/issues/6847

**Description**

Before this fix, the `searchLatest` method filtered the last event of each object (Dictionary or API) against a list of criteria.
Now, the `searchLatest` method finds the latest event that matches the criteria, for each object (Dictionary or API)

As a consequence, now the gateway only retrieves PUBLISH and UNPUBLISH events of a dictionary.
STOP and START events should only be considered in the Management API

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-dictionaries-sync/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
