### PR TITLE
Fix deletion of sharding tag no used in any entrypoint mapping

### DIFF
--- a/gravitee-apim-console-webui/src/organization/configuration/tags/org-settings-tags.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/tags/org-settings-tags.component.spec.ts
@@ -229,6 +229,26 @@ describe('OrgSettingsTagsComponent', () => {
     // no flush stop test here
   });
 
+  it('should delete a tag without entrypoint mapping', async () => {
+    fixture.detectChanges();
+    expectTagsListRequest([fakeTag({ id: 'tag-1' })]);
+    expectGroupListByOrganizationRequest([]);
+    expectPortalSettingsGetRequest(fakePortalSettings());
+    expectEntrypointsListRequest([]);
+    fixture.detectChanges();
+
+    const deleteButton = await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Button to delete a tag"]' }));
+    await deleteButton.click();
+
+    const confirmDialogButton = await rootLoader.getHarness(MatButtonHarness.with({ text: 'Delete' }));
+    await confirmDialogButton.click();
+
+    httpTestingController.expectOne({
+      method: 'DELETE',
+      url: `${CONSTANTS_TESTING.org.baseURL}/configuration/tags/tag-1`,
+    });
+  });
+
   it('should delete a mapping', async () => {
     fixture.detectChanges();
     expectTagsListRequest([fakeTag({ id: 'tag-1', restricted_groups: ['group-a'] }), fakeTag({ id: 'tag-2' })]);

--- a/gravitee-apim-console-webui/src/organization/configuration/tags/org-settings-tags.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/tags/org-settings-tags.component.ts
@@ -262,7 +262,8 @@ export class OrgSettingsTagsComponent implements OnInit, OnDestroy {
         // Remove tag in each entrypoints and update them all
         switchMap(() => {
           if (entrypointsToUpdate.length === 0) {
-            return of();
+            // Need to emit `undefined` to have a consistent return type and be sure next switchMap will be executed
+            return of<void[]>(undefined);
           }
           const entrypointsUpdated = entrypointsToUpdateWithManyTags.map((entrypoint) => ({
             ...entrypoint,


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6862

**Description**

Fix deletion of sharding tag not used in any entry-point mapping.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6862-fix-sharding-tag-deletion/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
