### PR TITLE
fix: template is not enabled by default

### DIFF
--- a/gravitee-apim-console-webui/src/organization/configuration/notification-templates/org-settings-notification-template.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/notification-templates/org-settings-notification-template.component.ts
@@ -87,7 +87,7 @@ export class OrgSettingsNotificationTemplateComponent implements OnInit, OnDestr
     this.notificationTemplatesForm = new FormGroup({});
 
     this.notificationTemplates.forEach((notificationTemplate) => {
-      const useCustomTemplateFormControl = new FormControl(notificationTemplate.enabled);
+      const useCustomTemplateFormControl = new FormControl(!!notificationTemplate.enabled);
       const titleFormControl = new FormControl({ value: notificationTemplate.title, disabled: !notificationTemplate.enabled }, [
         Validators.required,
       ]);


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6864

The first time the console loads a template that is not overridden, the 'enabled' boolean is not defined.Must initialized with false.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-aejulxlvei.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6864-fix-notification-templates-override/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
