### PR TITLE
fix: undeploy dictionnaries when deleting

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl.java
@@ -295,15 +295,18 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
                 throw new DictionaryNotFoundException(id);
             }
 
-            // Force un-deployment
-            if (dictionary.get().getType() == DictionaryType.MANUAL) {
-                undeploy(id);
+            if (dictionary.get().getType() == DictionaryType.DYNAMIC) {
+                this.stop(id);
             }
 
-            this.stop(id);
-
             dictionaryRepository.delete(id);
-        } catch (TechnicalException ex) {
+
+            Map<String, String> properties = new HashMap<>();
+            properties.put(Event.EventProperties.DICTIONARY_ID.getValue(), id);
+
+            // And create event
+            eventService.create(EventType.UNPUBLISH_DICTIONARY, mapper.writeValueAsString(dictionary), properties);
+        } catch (Exception ex) {
             LOGGER.error("An error occurs while trying to delete a dictionary using its ID {}", id, ex);
             throw new TechnicalManagementException("An error occurs while trying to delete a dictionary using its ID " + id, ex);
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/src/main/java/io/gravitee/rest/api/services/dictionary/DictionaryRefresher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/src/main/java/io/gravitee/rest/api/services/dictionary/DictionaryRefresher.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.services.dictionary;
 import io.gravitee.definition.model.Property;
 import io.gravitee.rest.api.model.configuration.dictionary.DictionaryEntity;
 import io.gravitee.rest.api.model.configuration.dictionary.UpdateDictionaryEntity;
+import io.gravitee.rest.api.service.impl.configuration.dictionary.DictionaryNotFoundException;
 import io.gravitee.rest.api.services.dictionary.model.DynamicProperty;
 import io.gravitee.rest.api.services.dictionary.provider.Provider;
 import io.vertx.core.Handler;
@@ -83,6 +84,8 @@ public class DictionaryRefresher implements Handler<Long> {
                 dictionary.setProperties(properties);
                 dictionary = dictionaryService.update(dictionary.getId(), convert(dictionary));
                 dictionaryService.deploy(dictionary.getId());
+            } catch (DictionaryNotFoundException e) {
+                logger.info("Trying to update a deleted dictionary - nothing to do...");
             } catch (Exception ex) {
                 logger.error("Unexpected error while updating and deploying the dictionary", ex);
             }


### PR DESCRIPTION
gravitee-io/issues#6870

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/undeploy-dictionaries/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
