### PR TITLE
Use stable version of gravitee-gateway-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <gravitee-definition.version>1.31.0-SNAPSHOT</gravitee-definition.version>
         <gravitee-expression-language.version>1.7.2</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>1.31.0-SNAPSHOT</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.30.0</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>1.20.0-SNAPSHOT</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>


### PR DESCRIPTION
**Issue**

NA

**Description**

In order to avoid fetching a changing version of `1.31.0-SNAPSHOT`. 
The bump has been originally done in a revert a revert commit, meaning it shouldn't have been bump at that time. 
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kulrjhyfxs.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/use-stable-version/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
