### PR TITLE
test: remove useless 'root' parameter from some cypress requests query strings

### DIFF
--- a/gravitee-apim-cypress/cypress/commands/management/api-management-commands.ts
+++ b/gravitee-apim-cypress/cypress/commands/management/api-management-commands.ts
@@ -119,9 +119,6 @@ export function getApiById(auth: BasicAuthentication, apiId: string) {
     url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}`,
     auth,
     failOnStatusCode: false,
-    qs: {
-      root: true,
-    },
   });
 }
 
@@ -131,9 +128,6 @@ export function getApiMetadata(auth: BasicAuthentication, apiId: string) {
     url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}/metadata`,
     auth,
     failOnStatusCode: false,
-    qs: {
-      root: true,
-    },
   });
 }
 

--- a/gravitee-apim-cypress/cypress/commands/management/api-plans-management-commands.ts
+++ b/gravitee-apim-cypress/cypress/commands/management/api-plans-management-commands.ts
@@ -19,11 +19,11 @@ import { ApiPlanStatus } from '@model/apis';
 export function getPlans(auth: BasicAuthentication, apiId: string, status: ApiPlanStatus) {
   return cy.request({
     method: 'GET',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}/plans?status=${status}`,
+    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}/plans`,
     auth,
     failOnStatusCode: false,
     qs: {
-      root: true,
+      status: status,
     },
   });
 }


### PR DESCRIPTION
test: remove useless 'root' parameter from some cypress requests query strings
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-yxarmdmkmn.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/test-import-tests-fixes/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
