### PR TITLE
fix: bump ui-components to 3.27.1 fix gv-http-client

### DIFF
--- a/gravitee-apim-console-webui/package-lock.json
+++ b/gravitee-apim-console-webui/package-lock.json
@@ -8420,9 +8420,9 @@
       }
     },
     "@codemirror/autocomplete": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.9.tgz",
-      "integrity": "sha512-Ph1LWHtFFqNUIqEVrws6I263ihe5TH+TRBPwxQ78j7st7Q67FDAmgKX6mNbUPh02dxfqQrc9qxlo5JIqKeiVdg==",
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.10.tgz",
+      "integrity": "sha512-8mgT+cSVxIoV/AbfJ36+r06xykxpACmXoD8bbTNwnkrttTwLkugxUP2oFAxL7I+TGMwxkX3ZquroyWX0HFO9nQ==",
       "requires": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/state": "^0.19.4",
@@ -8512,22 +8512,22 @@
       }
     },
     "@codemirror/highlight": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/highlight/-/highlight-0.19.6.tgz",
-      "integrity": "sha512-+eibu6on9quY8uN3xJ/n3rH+YIDLlpX7YulVmFvqAIz/ukRQ5tWaBmB7fMixHmnmRIRBRZgB8rNtonuMwZSAHQ==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/highlight/-/highlight-0.19.7.tgz",
+      "integrity": "sha512-3W32hBCY0pbbv/xidismw+RDMKuIag+fo4kZIbD7WoRj+Ttcaxjf+vP6RttRHXLaaqbWh031lTeON8kMlDhMYw==",
       "requires": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
+        "@codemirror/state": "^0.19.3",
         "@codemirror/view": "^0.19.0",
         "@lezer/common": "^0.15.0",
         "style-mod": "^4.0.0"
       }
     },
     "@codemirror/history": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/history/-/history-0.19.1.tgz",
-      "integrity": "sha512-mcm856QzHj2K6it7XPtKN1lcQ15tB+A5XRtRix9GHRQak4bbY0ljqYJFxD4wNEAAb4uC2axUyl4yEW57DHJmdQ==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/history/-/history-0.19.2.tgz",
+      "integrity": "sha512-unhP4t3N2smzmHoo/Yio6ueWi+il8gm9VKrvi6wlcdGH5fOfVDNkmjHQ495SiR+EdOG35+3iNebSPYww0vN7ow==",
       "requires": {
         "@codemirror/state": "^0.19.2",
         "@codemirror/view": "^0.19.0"
@@ -8581,12 +8581,12 @@
       }
     },
     "@codemirror/lang-javascript": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-0.19.3.tgz",
-      "integrity": "sha512-2NE5z98Nz9Rv4OS5UtgehCSnyQjac+P85+evzy1D/4wllp/EPaHIEEtSP1daBvrLy49SdI/9vES3ZJu6rSv4/w==",
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-0.19.4.tgz",
+      "integrity": "sha512-oRANfqQH5XNcfr0Y9pIzAxqXldLmCLpklknODtmEAZ8wQNBiVmgIeLb3JXdOJ43iZWnnmetkDOctFy/N8KuD4Q==",
       "requires": {
         "@codemirror/autocomplete": "^0.19.0",
-        "@codemirror/highlight": "^0.19.6",
+        "@codemirror/highlight": "^0.19.7",
         "@codemirror/language": "^0.19.0",
         "@codemirror/lint": "^0.19.0",
         "@codemirror/state": "^0.19.0",
@@ -8605,9 +8605,9 @@
       }
     },
     "@codemirror/lang-markdown": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-0.19.3.tgz",
-      "integrity": "sha512-kCLn5yKNOscCnCrJ03HiH3fHQE67E5cSG9+WhTOjIUMwxWTSo47AzorMAG/N5Ty37jP9Wd+fOSTCNU/A9Dq8yQ==",
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-0.19.4.tgz",
+      "integrity": "sha512-/MF/e1yRtiGOQOvHbXNv8AELITUT7tax1Zx3FCQTx8t28IdFOee6j0VPSghMcqskOQlNo8RXJBfP8bIyWPZBog==",
       "requires": {
         "@codemirror/highlight": "^0.19.0",
         "@codemirror/lang-html": "^0.19.0",
@@ -8764,9 +8764,9 @@
       }
     },
     "@codemirror/rangeset": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.5.tgz",
-      "integrity": "sha512-L3b+RIwIRKOJ3pJLOtpkxCUjGnxZKFyPb0CjYWKnVLuzEIaEExWWK7sp6rsejxOy8RjYzfCHlFhYB4UdQN7brw==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.6.tgz",
+      "integrity": "sha512-wYtgGnW2Jtrh2nj7vpcBoEZib+jfyilrLN6w7YMTzzSRN8xXhYRorOUg4VQIa1JwFcMQrjSCkIdqXsDqOX1cYg==",
       "requires": {
         "@codemirror/state": "^0.19.0"
       }
@@ -8830,9 +8830,9 @@
       }
     },
     "@codemirror/view": {
-      "version": "0.19.37",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.37.tgz",
-      "integrity": "sha512-SLuLx9p0O1ZHXLehvl5MwSvUrQRcsNGemzTgJ0zRajmc3BBsNigI1PXxdo7tvBhO5DcAzRRBXoke9DZFUR6Qqg==",
+      "version": "0.19.39",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.39.tgz",
+      "integrity": "sha512-ol4smHAwhWkW8p1diPZiZkLZVmKybKhQigwyrgdF7k1UFNY+/KDH4w2xic8JQXxX+v0ppMsoNf11C+afKJze5g==",
       "requires": {
         "@codemirror/rangeset": "^0.19.5",
         "@codemirror/state": "^0.19.3",
@@ -9091,11 +9091,11 @@
       "integrity": "sha512-svwnzu0KKVpMEuRU1G58xp1BNrho5qki/bxpF/y1tOjAOoM357Avw8Gc8xw40pbN5B1QNyT3wuZQ/nMwSbjh9w=="
     },
     "@formatjs/ecma402-abstract": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.0.tgz",
-      "integrity": "sha512-TOp5La9wmSh9G5bqFGN/ApmOXtJDzBGkYW+OTRd3ukY7J32RVGZPpN4O9BD651JUy66nj3g9CIENTNCgm4IRXQ==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.1.tgz",
+      "integrity": "sha512-tgtNODZUGuUI6PAcnvaLZpGrZLVkXnnAvgzOiueYMzFdOdcOw4iH1WKhCe3+r6VR8rHKToJ2HksUGNCB+zt/bg==",
       "requires": {
-        "@formatjs/intl-localematcher": "0.2.21",
+        "@formatjs/intl-localematcher": "0.2.22",
         "tslib": "^2.1.0"
       },
       "dependencies": {
@@ -9122,11 +9122,11 @@
       }
     },
     "@formatjs/intl-locale": {
-      "version": "2.4.41",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-locale/-/intl-locale-2.4.41.tgz",
-      "integrity": "sha512-FlPNzNpTColtOCcHg37a7P4WrDLCXIKtovRhA0mG7B/hCMn/FY+P2MwpQXVxgQXk6rje7a8Qv4IAcwnUcY+dIg==",
+      "version": "2.4.42",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-locale/-/intl-locale-2.4.42.tgz",
+      "integrity": "sha512-4OXUdigzsC+SRMYXRSLdA9sRbWRxubXn1x+eVHk02izoz6Bv/JNg+wyC3+3QcHyERe81XSCptLstRaLVirOBxA==",
       "requires": {
-        "@formatjs/ecma402-abstract": "1.11.0",
+        "@formatjs/ecma402-abstract": "1.11.1",
         "@formatjs/intl-getcanonicallocales": "1.8.0",
         "tslib": "^2.1.0"
       },
@@ -9139,9 +9139,9 @@
       }
     },
     "@formatjs/intl-localematcher": {
-      "version": "0.2.21",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.21.tgz",
-      "integrity": "sha512-JTJeLiNwexN4Gy0cMxoUPvJbKhXdnSuo5jPrDafEZpnDWlJ5VDYta8zUVVozO/pwzEmFVHEUpgiEDj+39L4oMg==",
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.22.tgz",
+      "integrity": "sha512-z+TvbHW8Q/g2l7/PnfUl0mV9gWxV4d0HT6GQyzkO5QI6QjCvCZGiztnmLX7zoyS16uSMvZ2PoMDfSK9xvZkRRA==",
       "requires": {
         "tslib": "^2.1.0"
       },
@@ -9154,12 +9154,12 @@
       }
     },
     "@formatjs/intl-relativetimeformat": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-9.4.0.tgz",
-      "integrity": "sha512-nDKTZCqp3oDHrteY86H6MaoPO9r4MW0v7SwoGaqvAwbOpKrfOuceAiVIa65/i50DEHLrcXUKpOZnM/fNgCUBHg==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-9.4.1.tgz",
+      "integrity": "sha512-ktHwbJjjtF3rCrc21Qdl/jEzAZ4X8kf+XXHFF8eGmDxqG3+VTWwoqBySzaPStyFdQbRKC2n8rnSfPmtaWxckDw==",
       "requires": {
-        "@formatjs/ecma402-abstract": "1.11.0",
-        "@formatjs/intl-localematcher": "0.2.21",
+        "@formatjs/ecma402-abstract": "1.11.1",
+        "@formatjs/intl-localematcher": "0.2.22",
         "tslib": "^2.1.0"
       },
       "dependencies": {
@@ -9177,9 +9177,9 @@
       "dev": true
     },
     "@gravitee/ui-components": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.27.0.tgz",
-      "integrity": "sha512-DhOb3pvsgA9DUS2j4kH0hEJISgie8daChFwdkEZuo2Yxi6QATA9uoUjAuMlmwzFTpxY36Brj9MOI5C0ab+mLfw==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.27.1.tgz",
+      "integrity": "sha512-1Lbgcf34OQcZ/8yMy+gunD8VRo1wObuXqeXvY+rrAeG+n2zw/KmoYvaW2szB1HH1V4B8FNaz5Me9RSPrnGVf2w==",
       "requires": {
         "@codemirror/basic-setup": "^0.19.1",
         "@codemirror/language-data": "^0.19.1",
@@ -10761,9 +10761,9 @@
       }
     },
     "@lit/reactive-element": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.2.tgz",
-      "integrity": "sha512-oz3d3MKjQ2tXynQgyaQaMpGTDNyNDeBdo6dXf1AbjTwhA1IRINHmA7kSaVYv9ttKweNkEoNqp9DqteDdgWzPEg=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.1.1.tgz",
+      "integrity": "sha512-B2JdRMwCGv+VpIRj3CYVQBx3muPDeE8y+HPgWqzrAHsO5/40BpwDFZeplIV790BaTqDVUDvZOKMSbuFM9zWC0w=="
     },
     "@mdx-js/loader": {
       "version": "1.6.22",
@@ -27373,28 +27373,28 @@
       "dev": true
     },
     "lit": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.0.2.tgz",
-      "integrity": "sha512-hKA/1YaSB+P+DvKWuR2q1Xzy/iayhNrJ3aveD0OQ9CKn6wUjsdnF/7LavDOJsKP/K5jzW/kXsuduPgRvTFrFJw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.1.1.tgz",
+      "integrity": "sha512-yqDqf36IhXwOxIQSFqCMgpfvDCRdxLCLZl7m/+tO5C9W/OBHUj17qZpiMBT35v97QMVKcKEi1KZ3hZRyTwBNsQ==",
       "requires": {
-        "@lit/reactive-element": "^1.0.0",
-        "lit-element": "^3.0.0",
-        "lit-html": "^2.0.0"
+        "@lit/reactive-element": "^1.1.0",
+        "lit-element": "^3.1.0",
+        "lit-html": "^2.1.0"
       },
       "dependencies": {
         "lit-element": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.0.2.tgz",
-          "integrity": "sha512-9vTJ47D2DSE4Jwhle7aMzEwO2ZcOPRikqfT3CVG7Qol2c9/I4KZwinZNW5Xv8hNm+G/enSSfIwqQhIXi6ioAUg==",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.1.1.tgz",
+          "integrity": "sha512-14ClnMAU8EXnzC+M2/KDd3SFmNUn1QUw1+GxWkEMwGV3iaH8ObunMlO5svzvaWlkSV0WlxJCi40NGnDVJ2XZKQ==",
           "requires": {
-            "@lit/reactive-element": "^1.0.0",
-            "lit-html": "^2.0.0"
+            "@lit/reactive-element": "^1.1.0",
+            "lit-html": "^2.1.0"
           }
         },
         "lit-html": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.0.2.tgz",
-          "integrity": "sha512-dON7Zg8btb14/fWohQLQBdSgkoiQA4mIUy87evmyJHtxRq7zS6LlC32bT5EPWiof5PUQaDpF45v2OlrxHA5Clg==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.1.1.tgz",
+          "integrity": "sha512-E4BImK6lopAYanJpvcGaAG8kQFF1ccIulPu2BRNZI7acFB6i4ujjjsnaPVFT1j/4lD9r8GKih0Y8d7/LH8SeyQ==",
           "requires": {
             "@types/trusted-types": "^2.0.2"
           }

--- a/gravitee-apim-console-webui/package.json
+++ b/gravitee-apim-console-webui/package.json
@@ -15,7 +15,7 @@
     "@angular/upgrade": "12.2.3",
     "@asyncapi/web-component": "1.0.0-next.15",
     "@fontsource/libre-franklin": "4.4.5",
-    "@gravitee/ui-components": "3.27.0",
+    "@gravitee/ui-components": "3.27.1",
     "@gravitee/ui-particles-angular": "1.4.0",
     "@highcharts/map-collection": "1.1.3",
     "@toast-ui/editor": "2.5.2",

--- a/gravitee-apim-portal-webui/package-lock.json
+++ b/gravitee-apim-portal-webui/package-lock.json
@@ -3531,9 +3531,9 @@
       }
     },
     "@codemirror/autocomplete": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.9.tgz",
-      "integrity": "sha512-Ph1LWHtFFqNUIqEVrws6I263ihe5TH+TRBPwxQ78j7st7Q67FDAmgKX6mNbUPh02dxfqQrc9qxlo5JIqKeiVdg==",
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.10.tgz",
+      "integrity": "sha512-8mgT+cSVxIoV/AbfJ36+r06xykxpACmXoD8bbTNwnkrttTwLkugxUP2oFAxL7I+TGMwxkX3ZquroyWX0HFO9nQ==",
       "requires": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/state": "^0.19.4",
@@ -3623,22 +3623,22 @@
       }
     },
     "@codemirror/highlight": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/highlight/-/highlight-0.19.6.tgz",
-      "integrity": "sha512-+eibu6on9quY8uN3xJ/n3rH+YIDLlpX7YulVmFvqAIz/ukRQ5tWaBmB7fMixHmnmRIRBRZgB8rNtonuMwZSAHQ==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/highlight/-/highlight-0.19.7.tgz",
+      "integrity": "sha512-3W32hBCY0pbbv/xidismw+RDMKuIag+fo4kZIbD7WoRj+Ttcaxjf+vP6RttRHXLaaqbWh031lTeON8kMlDhMYw==",
       "requires": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
+        "@codemirror/state": "^0.19.3",
         "@codemirror/view": "^0.19.0",
         "@lezer/common": "^0.15.0",
         "style-mod": "^4.0.0"
       }
     },
     "@codemirror/history": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/history/-/history-0.19.1.tgz",
-      "integrity": "sha512-mcm856QzHj2K6it7XPtKN1lcQ15tB+A5XRtRix9GHRQak4bbY0ljqYJFxD4wNEAAb4uC2axUyl4yEW57DHJmdQ==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/history/-/history-0.19.2.tgz",
+      "integrity": "sha512-unhP4t3N2smzmHoo/Yio6ueWi+il8gm9VKrvi6wlcdGH5fOfVDNkmjHQ495SiR+EdOG35+3iNebSPYww0vN7ow==",
       "requires": {
         "@codemirror/state": "^0.19.2",
         "@codemirror/view": "^0.19.0"
@@ -3692,12 +3692,12 @@
       }
     },
     "@codemirror/lang-javascript": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-0.19.3.tgz",
-      "integrity": "sha512-2NE5z98Nz9Rv4OS5UtgehCSnyQjac+P85+evzy1D/4wllp/EPaHIEEtSP1daBvrLy49SdI/9vES3ZJu6rSv4/w==",
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-0.19.4.tgz",
+      "integrity": "sha512-oRANfqQH5XNcfr0Y9pIzAxqXldLmCLpklknODtmEAZ8wQNBiVmgIeLb3JXdOJ43iZWnnmetkDOctFy/N8KuD4Q==",
       "requires": {
         "@codemirror/autocomplete": "^0.19.0",
-        "@codemirror/highlight": "^0.19.6",
+        "@codemirror/highlight": "^0.19.7",
         "@codemirror/language": "^0.19.0",
         "@codemirror/lint": "^0.19.0",
         "@codemirror/state": "^0.19.0",
@@ -3716,9 +3716,9 @@
       }
     },
     "@codemirror/lang-markdown": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-0.19.3.tgz",
-      "integrity": "sha512-kCLn5yKNOscCnCrJ03HiH3fHQE67E5cSG9+WhTOjIUMwxWTSo47AzorMAG/N5Ty37jP9Wd+fOSTCNU/A9Dq8yQ==",
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-0.19.4.tgz",
+      "integrity": "sha512-/MF/e1yRtiGOQOvHbXNv8AELITUT7tax1Zx3FCQTx8t28IdFOee6j0VPSghMcqskOQlNo8RXJBfP8bIyWPZBog==",
       "requires": {
         "@codemirror/highlight": "^0.19.0",
         "@codemirror/lang-html": "^0.19.0",
@@ -3875,9 +3875,9 @@
       }
     },
     "@codemirror/rangeset": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.5.tgz",
-      "integrity": "sha512-L3b+RIwIRKOJ3pJLOtpkxCUjGnxZKFyPb0CjYWKnVLuzEIaEExWWK7sp6rsejxOy8RjYzfCHlFhYB4UdQN7brw==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.6.tgz",
+      "integrity": "sha512-wYtgGnW2Jtrh2nj7vpcBoEZib+jfyilrLN6w7YMTzzSRN8xXhYRorOUg4VQIa1JwFcMQrjSCkIdqXsDqOX1cYg==",
       "requires": {
         "@codemirror/state": "^0.19.0"
       }
@@ -3941,9 +3941,9 @@
       }
     },
     "@codemirror/view": {
-      "version": "0.19.37",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.37.tgz",
-      "integrity": "sha512-SLuLx9p0O1ZHXLehvl5MwSvUrQRcsNGemzTgJ0zRajmc3BBsNigI1PXxdo7tvBhO5DcAzRRBXoke9DZFUR6Qqg==",
+      "version": "0.19.39",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.39.tgz",
+      "integrity": "sha512-ol4smHAwhWkW8p1diPZiZkLZVmKybKhQigwyrgdF7k1UFNY+/KDH4w2xic8JQXxX+v0ppMsoNf11C+afKJze5g==",
       "requires": {
         "@codemirror/rangeset": "^0.19.5",
         "@codemirror/state": "^0.19.3",
@@ -3997,21 +3997,29 @@
       }
     },
     "@formatjs/intl-locale": {
-      "version": "2.4.41",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-locale/-/intl-locale-2.4.41.tgz",
-      "integrity": "sha512-FlPNzNpTColtOCcHg37a7P4WrDLCXIKtovRhA0mG7B/hCMn/FY+P2MwpQXVxgQXk6rje7a8Qv4IAcwnUcY+dIg==",
+      "version": "2.4.42",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-locale/-/intl-locale-2.4.42.tgz",
+      "integrity": "sha512-4OXUdigzsC+SRMYXRSLdA9sRbWRxubXn1x+eVHk02izoz6Bv/JNg+wyC3+3QcHyERe81XSCptLstRaLVirOBxA==",
       "requires": {
-        "@formatjs/ecma402-abstract": "1.11.0",
+        "@formatjs/ecma402-abstract": "1.11.1",
         "@formatjs/intl-getcanonicallocales": "1.8.0",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "@formatjs/ecma402-abstract": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.0.tgz",
-          "integrity": "sha512-TOp5La9wmSh9G5bqFGN/ApmOXtJDzBGkYW+OTRd3ukY7J32RVGZPpN4O9BD651JUy66nj3g9CIENTNCgm4IRXQ==",
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.1.tgz",
+          "integrity": "sha512-tgtNODZUGuUI6PAcnvaLZpGrZLVkXnnAvgzOiueYMzFdOdcOw4iH1WKhCe3+r6VR8rHKToJ2HksUGNCB+zt/bg==",
           "requires": {
-            "@formatjs/intl-localematcher": "0.2.21",
+            "@formatjs/intl-localematcher": "0.2.22",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@formatjs/intl-localematcher": {
+          "version": "0.2.22",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.22.tgz",
+          "integrity": "sha512-z+TvbHW8Q/g2l7/PnfUl0mV9gWxV4d0HT6GQyzkO5QI6QjCvCZGiztnmLX7zoyS16uSMvZ2PoMDfSK9xvZkRRA==",
+          "requires": {
             "tslib": "^2.1.0"
           }
         },
@@ -4055,9 +4063,9 @@
       }
     },
     "@gravitee/ui-components": {
-      "version": "3.25.4",
-      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.25.4.tgz",
-      "integrity": "sha512-9SzcxwejPbT0VBHhR2v6raSqBPN9DmkZQUEZKSHDsTmmYujqpEO+qD5wBWPJD/gzxYedbU9e3XZm5DrjuvgWrA==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.27.1.tgz",
+      "integrity": "sha512-1Lbgcf34OQcZ/8yMy+gunD8VRo1wObuXqeXvY+rrAeG+n2zw/KmoYvaW2szB1HH1V4B8FNaz5Me9RSPrnGVf2w==",
       "requires": {
         "@codemirror/basic-setup": "^0.19.1",
         "@codemirror/language-data": "^0.19.1",
@@ -4077,28 +4085,31 @@
       },
       "dependencies": {
         "@formatjs/ecma402-abstract": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.0.tgz",
-          "integrity": "sha512-TOp5La9wmSh9G5bqFGN/ApmOXtJDzBGkYW+OTRd3ukY7J32RVGZPpN4O9BD651JUy66nj3g9CIENTNCgm4IRXQ==",
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.1.tgz",
+          "integrity": "sha512-tgtNODZUGuUI6PAcnvaLZpGrZLVkXnnAvgzOiueYMzFdOdcOw4iH1WKhCe3+r6VR8rHKToJ2HksUGNCB+zt/bg==",
           "requires": {
-            "@formatjs/intl-localematcher": "0.2.21",
+            "@formatjs/intl-localematcher": "0.2.22",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@formatjs/intl-localematcher": {
+          "version": "0.2.22",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.22.tgz",
+          "integrity": "sha512-z+TvbHW8Q/g2l7/PnfUl0mV9gWxV4d0HT6GQyzkO5QI6QjCvCZGiztnmLX7zoyS16uSMvZ2PoMDfSK9xvZkRRA==",
+          "requires": {
             "tslib": "^2.1.0"
           }
         },
         "@formatjs/intl-relativetimeformat": {
-          "version": "9.4.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-9.4.0.tgz",
-          "integrity": "sha512-nDKTZCqp3oDHrteY86H6MaoPO9r4MW0v7SwoGaqvAwbOpKrfOuceAiVIa65/i50DEHLrcXUKpOZnM/fNgCUBHg==",
+          "version": "9.4.1",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-9.4.1.tgz",
+          "integrity": "sha512-ktHwbJjjtF3rCrc21Qdl/jEzAZ4X8kf+XXHFF8eGmDxqG3+VTWwoqBySzaPStyFdQbRKC2n8rnSfPmtaWxckDw==",
           "requires": {
-            "@formatjs/ecma402-abstract": "1.11.0",
-            "@formatjs/intl-localematcher": "0.2.21",
+            "@formatjs/ecma402-abstract": "1.11.1",
+            "@formatjs/intl-localematcher": "0.2.22",
             "tslib": "^2.1.0"
           }
-        },
-        "codemirror-asciidoc": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/codemirror-asciidoc/-/codemirror-asciidoc-2.0.0.tgz",
-          "integrity": "sha512-FX+3ube2WySVuEbpBE2iObTDYYCu1HVBFgcwEsTNDGZdlk7pSLZdRCg05Un2LrzwHWN/iAowmjvQ6rXfUej36w=="
         },
         "tslib": {
           "version": "2.3.1",
@@ -4949,9 +4960,9 @@
       }
     },
     "@lit/reactive-element": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.0.2.tgz",
-      "integrity": "sha512-oz3d3MKjQ2tXynQgyaQaMpGTDNyNDeBdo6dXf1AbjTwhA1IRINHmA7kSaVYv9ttKweNkEoNqp9DqteDdgWzPEg=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.1.1.tgz",
+      "integrity": "sha512-B2JdRMwCGv+VpIRj3CYVQBx3muPDeE8y+HPgWqzrAHsO5/40BpwDFZeplIV790BaTqDVUDvZOKMSbuFM9zWC0w=="
     },
     "@ngneat/spectator": {
       "version": "5.13.4",
@@ -7928,6 +7939,11 @@
           "dev": true
         }
       }
+    },
+    "codemirror-asciidoc": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/codemirror-asciidoc/-/codemirror-asciidoc-2.0.0.tgz",
+      "integrity": "sha512-FX+3ube2WySVuEbpBE2iObTDYYCu1HVBFgcwEsTNDGZdlk7pSLZdRCg05Un2LrzwHWN/iAowmjvQ6rXfUej36w=="
     },
     "collect-v8-coverage": {
       "version": "1.0.1",
@@ -13908,28 +13924,28 @@
       "dev": true
     },
     "lit": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.0.2.tgz",
-      "integrity": "sha512-hKA/1YaSB+P+DvKWuR2q1Xzy/iayhNrJ3aveD0OQ9CKn6wUjsdnF/7LavDOJsKP/K5jzW/kXsuduPgRvTFrFJw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.1.1.tgz",
+      "integrity": "sha512-yqDqf36IhXwOxIQSFqCMgpfvDCRdxLCLZl7m/+tO5C9W/OBHUj17qZpiMBT35v97QMVKcKEi1KZ3hZRyTwBNsQ==",
       "requires": {
-        "@lit/reactive-element": "^1.0.0",
-        "lit-element": "^3.0.0",
-        "lit-html": "^2.0.0"
+        "@lit/reactive-element": "^1.1.0",
+        "lit-element": "^3.1.0",
+        "lit-html": "^2.1.0"
       }
     },
     "lit-element": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.0.2.tgz",
-      "integrity": "sha512-9vTJ47D2DSE4Jwhle7aMzEwO2ZcOPRikqfT3CVG7Qol2c9/I4KZwinZNW5Xv8hNm+G/enSSfIwqQhIXi6ioAUg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.1.1.tgz",
+      "integrity": "sha512-14ClnMAU8EXnzC+M2/KDd3SFmNUn1QUw1+GxWkEMwGV3iaH8ObunMlO5svzvaWlkSV0WlxJCi40NGnDVJ2XZKQ==",
       "requires": {
-        "@lit/reactive-element": "^1.0.0",
-        "lit-html": "^2.0.0"
+        "@lit/reactive-element": "^1.1.0",
+        "lit-html": "^2.1.0"
       }
     },
     "lit-html": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.0.2.tgz",
-      "integrity": "sha512-dON7Zg8btb14/fWohQLQBdSgkoiQA4mIUy87evmyJHtxRq7zS6LlC32bT5EPWiof5PUQaDpF45v2OlrxHA5Clg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.1.1.tgz",
+      "integrity": "sha512-E4BImK6lopAYanJpvcGaAG8kQFF1ccIulPu2BRNZI7acFB6i4ujjjsnaPVFT1j/4lD9r8GKih0Y8d7/LH8SeyQ==",
       "requires": {
         "@types/trusted-types": "^2.0.2"
       }

--- a/gravitee-apim-portal-webui/package.json
+++ b/gravitee-apim-portal-webui/package.json
@@ -36,7 +36,7 @@
     "@angular/router": "9.1.1",
     "@asyncapi/web-component": "1.0.0-next.15",
     "@formatjs/intl-relativetimeformat": "9.3.1",
-    "@gravitee/ui-components": "3.25.4",
+    "@gravitee/ui-components": "3.27.1",
     "@highcharts/map-collection": "1.1.3",
     "@ibm/plex": "5.1.3",
     "@ngx-translate/core": "12.1.2",


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/gravitee-ui-components/issues/539

**Description**

Bump ui-component to 3.27.1 to fix the display of headers in Try It mode

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pzgjgugdbl.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-gv-http-client-repeat/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
