### PR TITLE
Update schedules in Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,7 @@
 {
-    "extends": ["config:js-app", "schedule:daily"],
+    "extends": ["config:js-app", "schedule:earlyMondays"],
     "prConcurrentLimit": 5,
     "rebaseWhen": "conflicted",
-    "dependencyDashboard": true,
     "commitMessageTopic": "{{depName}}",
     "packageRules": [
         {
@@ -55,6 +54,10 @@
             "excludePackagePatterns": ["typescript", "@angular*"],
             "groupName": "devDependencies (non-major)",
             "groupSlug": "devdependencies-non-major"
+        },
+        {
+            "matchPackageNames": ["@gravitee/ui-components"],
+            "schedule": ["at any time"]
         }
     ]
 }


### PR DESCRIPTION
**Issue**

NA

**Description**

Update schedules in Renovate config:
 - Set the global schedule to `earlyMondays`
 - Set the `@gravitee/ui-components` schedule to `at any time` in order to have a live update of our own package

Also, remove `dependencyDashboard` as Issues are not activated on this repo
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wxlzqqhvkf.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/update-renovate-config/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
