### PR TITLE
fix: set failure status message according to status code

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/error/SimpleFailureProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/error/SimpleFailureProcessor.java
@@ -26,6 +26,7 @@ import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.core.processor.AbstractProcessor;
 import io.gravitee.gateway.core.processor.ProcessorFailure;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import java.util.List;
 
 /**
@@ -63,6 +64,7 @@ public class SimpleFailureProcessor extends AbstractProcessor<ExecutionContext> 
         context.request().metrics().setErrorKey(failure.key());
 
         response.status(failure.statusCode());
+        response.reason(HttpResponseStatus.valueOf(response.status()).reasonPhrase());
         response.headers().set(HttpHeaders.CONNECTION, HttpHeadersValues.CONNECTION_CLOSE);
 
         if (failure.message() != null) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http/StreamFailOnResponseGatewayTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http/StreamFailOnResponseGatewayTest.java
@@ -24,6 +24,7 @@ import io.gravitee.gateway.standalone.policy.PolicyBuilder;
 import io.gravitee.gateway.standalone.policy.TransformResponseStreamFailPolicy;
 import io.gravitee.plugin.core.api.ConfigurablePluginManager;
 import io.gravitee.plugin.policy.PolicyPlugin;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.entity.ContentType;
@@ -48,6 +49,7 @@ public class StreamFailOnResponseGatewayTest extends AbstractWiremockGatewayTest
         HttpResponse response = execute(request).returnResponse();
 
         assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatusLine().getStatusCode());
+        assertEquals(HttpResponseStatus.INTERNAL_SERVER_ERROR.reasonPhrase(), response.getStatusLine().getReasonPhrase());
         wireMockRule.verify(1, postRequestedFor(urlPathEqualTo("/api")));
     }
 


### PR DESCRIPTION
The failure processor was forwarding the upstream status message
while modifying the status code, leading to oddities such as
500 OK responses on the caller site.

see https://github.com/gravitee-io/issues/issues/6831

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6831-fix-proxy-failure-status-message/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
