### PR TITLE
fix: handle condition for streamable policies

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/policy/impl/ConditionalExecutablePolicyTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/policy/impl/ConditionalExecutablePolicyTest.java
@@ -67,7 +67,7 @@ public class ConditionalExecutablePolicyTest extends TestCase {
     }
 
     @Test
-    public void shouldRunConditionalPolicyConditionOk() throws PolicyException {
+    public void shouldExecuteConditionalPolicyConditionOk() throws PolicyException {
         when(executionContext.getTemplateEngine()).thenReturn(templateEngine);
         when(templateEngine.getValue("condition", Boolean.class)).thenReturn(true);
 
@@ -77,7 +77,7 @@ public class ConditionalExecutablePolicyTest extends TestCase {
     }
 
     @Test
-    public void shouldNotRunConditionalPolicyConditionEvaluatedToFalse() throws PolicyException {
+    public void shouldNotExecuteConditionalPolicyConditionEvaluatedToFalse() throws PolicyException {
         when(executionContext.getTemplateEngine()).thenReturn(templateEngine);
         when(templateEngine.getValue("condition", Boolean.class)).thenReturn(false);
 
@@ -87,12 +87,31 @@ public class ConditionalExecutablePolicyTest extends TestCase {
     }
 
     @Test(expected = PolicyException.class)
-    public void shouldNotRunConditionalPolicyExpressionEvaluationException() throws PolicyException {
+    public void shouldNotExecuteConditionalPolicyExpressionEvaluationException() throws PolicyException {
         when(executionContext.getTemplateEngine()).thenReturn(templateEngine);
         when(templateEngine.getValue("condition", Boolean.class)).thenThrow(ExpressionEvaluationException.class);
 
         final ConditionalExecutablePolicy policy = new ConditionalExecutablePolicy("dummy", fakePolicy(), method, method, "condition");
         policy.execute(policyChain, executionContext);
+    }
+
+    @Test
+    public void shouldStreamConditionalPolicyConditionOk() throws PolicyException {
+        when(executionContext.getTemplateEngine()).thenReturn(templateEngine);
+        when(templateEngine.getValue("condition", Boolean.class)).thenReturn(true);
+
+        final ConditionalExecutablePolicy policy = new ConditionalExecutablePolicy("dummy", fakePolicy(), method, method, "condition");
+        policy.stream(policyChain, executionContext);
+        verify(policyChain, never()).doNext(any(), any());
+    }
+
+    @Test(expected = PolicyException.class)
+    public void shouldNotStreamConditionalPolicyExpressionEvaluationException() throws PolicyException {
+        when(executionContext.getTemplateEngine()).thenReturn(templateEngine);
+        when(templateEngine.getValue("condition", Boolean.class)).thenThrow(ExpressionEvaluationException.class);
+
+        final ConditionalExecutablePolicy policy = new ConditionalExecutablePolicy("dummy", fakePolicy(), method, method, "condition");
+        policy.stream(policyChain, executionContext);
     }
 
     private Object fakePolicy() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/flow/ConditionalPolicyTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/flow/ConditionalPolicyTest.java
@@ -30,8 +30,11 @@ import io.gravitee.gateway.standalone.flow.policy.Header1Policy;
 import io.gravitee.gateway.standalone.flow.policy.Header2Policy;
 import io.gravitee.gateway.standalone.flow.policy.MyPolicy;
 import io.gravitee.gateway.standalone.flow.policy.OnRequestPolicy;
+import io.gravitee.gateway.standalone.flow.policy.Stream1Policy;
+import io.gravitee.gateway.standalone.flow.policy.Stream2Policy;
 import io.gravitee.gateway.standalone.junit.annotation.ApiDescriptor;
 import io.gravitee.gateway.standalone.policy.PolicyBuilder;
+import io.gravitee.gateway.standalone.utils.StringUtils;
 import io.gravitee.plugin.core.api.ConfigurablePluginManager;
 import io.gravitee.plugin.policy.PolicyPlugin;
 import org.apache.http.HttpResponse;
@@ -57,6 +60,8 @@ public class ConditionalPolicyTest extends AbstractWiremockGatewayTest {
             .returnResponse();
         assertEquals(HttpStatusCode.OK_200, response.getStatusLine().getStatusCode());
         assertFalse(response.containsHeader("X-Gravitee-Policy"));
+        String responseContent = StringUtils.copy(response.getEntity().getContent());
+        assertEquals("OnResponseContent2Policy", responseContent);
         wireMockRule.verify(
             getRequestedFor(urlPathEqualTo("/team/my_team"))
                 .withHeader("X-Gravitee-Policy", equalTo("request-header1"))
@@ -74,6 +79,8 @@ public class ConditionalPolicyTest extends AbstractWiremockGatewayTest {
             .returnResponse();
         assertEquals(HttpStatusCode.OK_200, response.getStatusLine().getStatusCode());
         assertFalse(response.containsHeader("X-Gravitee-Policy"));
+        String responseContent = StringUtils.copy(response.getEntity().getContent());
+        assertEquals("", responseContent);
         wireMockRule.verify(
             getRequestedFor(urlPathEqualTo("/team/my_team"))
                 .withoutHeader("X-Gravitee-Policy")
@@ -87,7 +94,11 @@ public class ConditionalPolicyTest extends AbstractWiremockGatewayTest {
 
         PolicyPlugin myPolicyHeader1 = PolicyBuilder.build("header-policy1", Header1Policy.class);
         PolicyPlugin onRequestPolicy = PolicyBuilder.build("on-request-policy", OnRequestPolicy.class);
+        PolicyPlugin streamPolicy = PolicyBuilder.build("stream-policy", Stream1Policy.class);
+        PolicyPlugin streamPolicy2 = PolicyBuilder.build("stream-policy2", Stream2Policy.class);
         policyPluginManager.register(myPolicyHeader1);
         policyPluginManager.register(onRequestPolicy);
+        policyPluginManager.register(streamPolicy);
+        policyPluginManager.register(streamPolicy2);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/resources/io/gravitee/gateway/standalone/flow/conditional-policy-flow.json
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/resources/io/gravitee/gateway/standalone/flow/conditional-policy-flow.json
@@ -38,7 +38,22 @@
           "configuration": {}
         }
       ],
-      "post": [],
+      "post": [
+        {
+          "policy": "stream-policy",
+          "name": "My stream policy",
+          "description": "Step description",
+          "condition": "{#request.headers['conditionHeader'][0].equals(\"falsy-condition-to-verify-we-use-next-policy\")}",
+          "configuration": {}
+        },
+        {
+          "policy": "stream-policy2",
+          "name": "My stream policy",
+          "description": "Step description",
+          "condition": "{#request.headers['conditionHeader'][0].equals(\"condition-ok\")}",
+          "configuration": {}
+        }
+      ],
       "enabled": true
     }
   ]


### PR DESCRIPTION
**Issue**

gravitee-io/issues#6886

**Description**

Conditions do not work for Streamable Policies because of the lack of implementation for `stream()` method.
This PR resolves it

⚠️ Still a topic to discuss about the non-need of doNext() in case condition evaluates to false

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-oqfzeuhppx.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6886-conditional-onrequestcontent/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
