### PR TITLE
fix: restore API Primary Owner privileges

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/apiAdmin.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/apiAdmin.controller.ts
@@ -32,6 +32,7 @@ class ApiAdminController {
 
   constructor(
     private resolvedApi: any,
+    private resolvedApiGroups: any,
     private $state: StateService,
     private $scope: IScope,
     private $rootScope: IScope,
@@ -55,6 +56,8 @@ class ApiAdminController {
 
     this.api = resolvedApi.data;
     this.api.etag = resolvedApi.headers('etag');
+
+    this.resolvedApiGroups = resolvedApiGroups;
 
     SidenavService.setCurrentResource(this.api.name);
 
@@ -224,6 +227,10 @@ class ApiAdminController {
 
   canReview(): boolean {
     return this.Constants.env.settings.apiReview.enabled && this.api.workflow_state === 'IN_REVIEW';
+  }
+
+  canTransferOwnership(): boolean {
+    return this.UserService.currentUser.isAdmin() || this.UserService.isApiPrimaryOwner(this.api, this.resolvedApiGroups);
   }
 
   isRequestForChanges(): boolean {

--- a/gravitee-apim-console-webui/src/management/api/apis.route.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis.route.ts
@@ -68,6 +68,13 @@ function apisRouterConfig($stateProvider: StateProvider) {
             return response.data;
           });
         },
+        resolvedApiGroups: ($stateParams: StateParams, ApiService: ApiService, UserService: UserService) => {
+          if (UserService.isUserHasPermissions(['api-member-r'])) {
+            return ApiService.getGroupsWithMembers($stateParams.apiId).then((response) => {
+              return response.data;
+            });
+          }
+        },
         resolvedTags: (TagService: TagService) => {
           return TagService.list().then((response) => {
             return response.data;

--- a/gravitee-apim-console-webui/src/management/api/portal/apis.portal.route.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/apis.portal.route.html
@@ -123,7 +123,7 @@
         <li
           class="iterable-item"
           ui-sref-active="aui-nav-selected"
-          ng-if="apiCtrl.menu.members.perm"
+          ng-if="apiCtrl.canTransferOwnership()"
           ui-sref="management.apis.detail.portal.transferownership"
         >
           <a class="execute">Transfer ownership</a>

--- a/gravitee-apim-console-webui/src/management/api/portal/userGroupAccess/members/members.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/userGroupAccess/members/members.controller.ts
@@ -33,6 +33,7 @@ class ApiMembersController {
     private ApiService: ApiService,
     private resolvedMembers,
     private resolvedGroups,
+    private resolvedApiGroups,
     private $mdDialog: ng.material.IDialogService,
     private NotificationService,
     private $scope,
@@ -52,18 +53,11 @@ class ApiMembersController {
     });
     this.groupMembers = {};
     this.groupIdsWithMembers = [];
-    if (this.api.groups) {
-      _.forEach(this.api.groups, (grp) => {
-        GroupService.getMembers(grp).then((members) => {
-          const filteredMembers = _.filter(members.data, (m: any) => {
-            return m.roles.API;
-          });
 
-          if (filteredMembers.length > 0) {
-            this.groupMembers[grp] = filteredMembers;
-            this.groupIdsWithMembers.push(grp);
-          }
-        });
+    if (this.api.groups && this.UserService.isUserHasPermissions(['api-member-r'])) {
+      ApiService.getGroupsWithMembers(this.api.id).then(({ data: groupsWithMembers }) => {
+        this.groupMembers = groupsWithMembers;
+        this.groupIdsWithMembers = Object.keys(groupsWithMembers);
       });
     }
 

--- a/gravitee-apim-console-webui/src/management/api/portal/userGroupAccess/transferOwnership/transferOwnership.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/userGroupAccess/transferOwnership/transferOwnership.html
@@ -106,10 +106,13 @@
           layout-align="center center"
           layout-padding="5px"
           flex
-          ng-if="apiTransferOwnershipCtrl.ApiPrimaryOwnerModeService.isGroupOnly() && !(apiTransferOwnershipCtrl.poGroups && apiTransferOwnershipCtrl.poGroups.length > 0)"
+          ng-if="!apiTransferOwnershipCtrl.canUseGroupAsPrimaryOwner()"
         >
           <md-input-container flex>
-            <div>You must belong to at least one group with an API primary owner member (which is not the current primary owner).</div>
+            <div>
+              To set a group as a primary owner, you must belong to at least one group with an API primary owner member (which is not the
+              current primary owner).
+            </div>
           </md-input-container>
         </div>
 
@@ -123,7 +126,7 @@
       </div>
       <div class="md-actions gravitee-api-save-button" layout="row" flex>
         <md-button
-          ng-disabled="!(apiTransferOwnershipCtrl.usersSelected && apiTransferOwnershipCtrl.usersSelected[0]) && !apiTransferOwnershipCtrl.newPrimaryOwnerGroup"
+          ng-disabled="!apiTransferOwnershipCtrl.newPORole && apiTransferOwnershipCtrl.api.owner.type.toUpperCase() === 'USER'"
           class="md-primary md-raised"
           ng-click="apiTransferOwnershipCtrl.showTransferOwnershipConfirm($event)"
           >Transfer</md-button

--- a/gravitee-apim-console-webui/src/management/configuration/groups/group/addMemberDialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/groups/group/addMemberDialog.controller.ts
@@ -42,7 +42,7 @@ function DialogAddGroupMemberController(
   this.defaultApiRole = defaultApiRole;
   this.defaultApplicationRole = defaultApplicationRole;
   this.usersSelected = [];
-  this.defaultApiRole = defaultApiRole ? defaultApiRole : _.find(apiRoles, { default: true }).name;
+  this.defaultApiRole = defaultApiRole ? defaultApiRole : _.find(apiRoles, { default: true })?.name;
   this.defaultApplicationRole = defaultApplicationRole ? defaultApplicationRole : _.find(applicationRoles, { default: true }).name;
 
   this.canChangeDefaultApiRole = canChangeDefaultApiRole;

--- a/gravitee-apim-console-webui/src/services/api.service.ts
+++ b/gravitee-apim-console-webui/src/services/api.service.ts
@@ -345,6 +345,13 @@ class ApiService {
   }
 
   /*
+   * Groups
+   */
+  getGroupsWithMembers(api: string): ng.IHttpPromise<any> {
+    return this.$http.get(`${this.Constants.env.baseURL}/apis/${api}/groups`);
+  }
+
+  /*
    * API events
    */
   getApiEvents(api, eventTypes): ng.IPromise<any> {

--- a/gravitee-apim-console-webui/src/services/apiPrimaryOwnerMode.service.ts
+++ b/gravitee-apim-console-webui/src/services/apiPrimaryOwnerMode.service.ts
@@ -20,6 +20,11 @@ export enum ApiPrimaryOwnerMode {
   GROUP = 'GROUP',
 }
 
+export enum ApiPrimaryOwnerType {
+  USER = 'USER',
+  GROUP = 'GROUP',
+}
+
 class ApiPrimaryOwnerModeService {
   constructor(private Constants) {
     'ngInject';

--- a/gravitee-apim-console-webui/src/services/user.service.ts
+++ b/gravitee-apim-console-webui/src/services/user.service.ts
@@ -24,6 +24,8 @@ import Base64Service from './base64.service';
 import EnvironmentService from './environment.service';
 import { IHttpResponse, IScope } from 'angular';
 import _ = require('lodash');
+import { ApiPrimaryOwnerType } from './apiPrimaryOwnerMode.service';
+import { RoleName, RoleScope } from '../management/configuration/groups/group/membershipState';
 
 class UserService {
   /**
@@ -356,6 +358,22 @@ class UserService {
     });
 
     return permissions;
+  }
+
+  public isApiPrimaryOwner(api, groups = {}): boolean {
+    return this.isDirectApiPrimaryOwner(api) || this.isApiPrimaryOwnerFromGroup(api, groups);
+  }
+
+  private isDirectApiPrimaryOwner(api): boolean {
+    return api.owner.type === ApiPrimaryOwnerType.USER && this.currentUser?.id === api.owner.id;
+  }
+
+  private isApiPrimaryOwnerFromGroup(api, groups): boolean {
+    return (
+      api.owner.type === ApiPrimaryOwnerType.GROUP &&
+      groups[api.owner.id] &&
+      groups[api.owner.id].some((member) => member.roles[RoleScope.API] === RoleName.PRIMARY_OWNER && member.id === this.currentUser?.id)
+    );
   }
 }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/MembershipRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/MembershipRepository.java
@@ -17,6 +17,7 @@ package io.gravitee.repository.management.api;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.*;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -146,6 +147,22 @@ public interface MembershipRepository extends FindAllRepository<Membership> {
         MembershipMemberType memberType,
         MembershipReferenceType referenceType,
         String roleId
+    ) throws TechnicalException;
+
+    /**
+     * find all memberships for a member, a referenceType and a list of roles
+     * @param memberId the member
+     * @param memberType the member type. Can be USER or GROUP.
+     * @param referenceType the referenceType
+     * @param roleIds the role id list
+     * @return the list of memberships, or an empty set
+     * @throws TechnicalException if something goes wrong, should never happen.
+     */
+    Set<Membership> findByMemberIdAndMemberTypeAndReferenceTypeAndRoleIdIn(
+        String memberId,
+        MembershipMemberType memberType,
+        MembershipReferenceType referenceType,
+        Collection<String> roleIds
     ) throws TechnicalException;
 
     /**

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpMembershipRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpMembershipRepository.java
@@ -20,6 +20,7 @@ import io.gravitee.repository.management.api.MembershipRepository;
 import io.gravitee.repository.management.model.Membership;
 import io.gravitee.repository.management.model.MembershipMemberType;
 import io.gravitee.repository.management.model.MembershipReferenceType;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -114,6 +115,16 @@ public class HttpMembershipRepository extends AbstractRepository implements Memb
         MembershipReferenceType referenceType,
         String referenceId,
         String roleId
+    ) throws TechnicalException {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Set<Membership> findByMemberIdAndMemberTypeAndReferenceTypeAndRoleIdIn(
+        String memberId,
+        MembershipMemberType memberType,
+        MembershipReferenceType referenceType,
+        Collection<String> roleIds
     ) throws TechnicalException {
         throw new IllegalStateException();
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoMembershipRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoMembershipRepository.java
@@ -22,6 +22,7 @@ import io.gravitee.repository.management.model.MembershipMemberType;
 import io.gravitee.repository.management.model.MembershipReferenceType;
 import io.gravitee.repository.mongodb.management.internal.membership.MembershipMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.MembershipMongo;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -278,6 +279,36 @@ public class MongoMembershipRepository implements MembershipRepository {
             referenceType,
             referenceId,
             roleId,
+            memberships
+        );
+        return memberships;
+    }
+
+    @Override
+    public Set<Membership> findByMemberIdAndMemberTypeAndReferenceTypeAndRoleIdIn(
+        String memberId,
+        MembershipMemberType memberType,
+        MembershipReferenceType referenceType,
+        Collection<String> roleIds
+    ) throws TechnicalException {
+        logger.debug(
+            "Find membership by user and referenceType and referenceId and roleId in [{}, {}, {}, {}, {}]",
+            memberId,
+            memberType,
+            referenceType,
+            roleIds
+        );
+        Set<Membership> memberships = internalMembershipRepo
+            .findByMemberIdAndMemberTypeAndReferenceTypeAndRoleIdIn(memberId, memberType.name(), referenceType.name(), roleIds)
+            .stream()
+            .map(this::map)
+            .collect(Collectors.toSet());
+        logger.debug(
+            "Find membership by user and referenceType and referenceId, roleId in [{}, {}, {}, {}, {}] = {}",
+            memberId,
+            memberType,
+            referenceType,
+            roleIds,
             memberships
         );
         return memberships;

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoRoleRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoRoleRepository.java
@@ -97,8 +97,8 @@ public class MongoRoleRepository implements RoleRepository {
         try {
             internalRoleRepo.deleteById(roleId);
         } catch (Exception e) {
-            LOGGER.error("An error occured when deleting role [{}]", roleId, e);
-            throw new TechnicalException("An error occured when deleting role");
+            LOGGER.error("An error occurred when deleting role [{}]", roleId, e);
+            throw new TechnicalException("An error occurred when deleting role");
         }
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/membership/MembershipMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/membership/MembershipMongoRepository.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.mongodb.management.internal.membership;
 
 import io.gravitee.repository.mongodb.management.internal.model.MembershipMongo;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import org.springframework.data.mongodb.repository.MongoRepository;
@@ -58,6 +59,14 @@ public interface MembershipMongoRepository extends MongoRepository<MembershipMon
         String memberType,
         String referenceType,
         String roleId
+    );
+
+    @Query("{ 'memberId' : ?0, 'memberType' : ?1, 'referenceType' : ?2, 'roleId' : { $in: ?3 } }")
+    Set<MembershipMongo> findByMemberIdAndMemberTypeAndReferenceTypeAndRoleIdIn(
+        String memberId,
+        String memberType,
+        String referenceType,
+        Collection<String> roleIds
     );
 
     @Query("{ 'memberId' : ?0, 'memberType' : ?1, 'referenceType' : ?2, 'source' : ?3 }")

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/MembershipRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/MembershipRepositoryTest.java
@@ -197,6 +197,22 @@ public class MembershipRepositoryTest extends AbstractRepositoryTest {
     }
 
     @Test
+    public void shouldFindByMemberIdAndMemberTypeAndReferenceTypeAndRoleIdIn() throws TechnicalException {
+        Set<Membership> memberships = membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndRoleIdIn(
+            "user1",
+            MembershipMemberType.USER,
+            MembershipReferenceType.API,
+            Set.of("API_OWNER", "UNKNOWN_ROLE")
+        );
+        assertNotNull("result must not be null", memberships);
+        assertTrue(!memberships.isEmpty());
+        Membership membership = memberships.iterator().next();
+        assertEquals("API_OWNER", membership.getRoleId());
+        assertEquals("api1", membership.getReferenceId());
+        assertEquals("user1", membership.getMemberId());
+    }
+
+    @Test
     public void shouldFindByMemberIdAndMemberTypeAndReferenceTypeAndReferenceId() throws TechnicalException {
         Set<Membership> memberships = membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceId(
             "user1",

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/MembershipRepositoryMock.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/MembershipRepositoryMock.java
@@ -114,6 +114,17 @@ public class MembershipRepositoryMock extends AbstractRepositoryMock<MembershipR
             )
         )
             .thenReturn(singleton(m1));
+
+        when(
+            membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndRoleIdIn(
+                eq("user1"),
+                eq(MembershipMemberType.USER),
+                eq(MembershipReferenceType.API),
+                argThat(roleIds -> roleIds.contains(API_OWNER_ROLE))
+            )
+        )
+            .thenReturn(singleton(m1));
+
         when(
             membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceId(
                 "user1",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/TransferOwnership.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/TransferOwnership.java
@@ -40,7 +40,6 @@ public class TransferOwnership {
      */
     private MembershipMemberType type;
 
-    @NotNull
     @JsonProperty("role")
     private String poRole;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiGroupsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiGroupsResource.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource;
+
+import io.gravitee.common.http.MediaType;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.rest.api.management.rest.security.Permission;
+import io.gravitee.rest.api.management.rest.security.Permissions;
+import io.gravitee.rest.api.model.GroupMemberEntity;
+import io.gravitee.rest.api.model.MemberEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.GET;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+
+public class ApiGroupsResource extends AbstractResource {
+
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("api")
+    @ApiParam(name = "api", hidden = true)
+    private String apiId;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Get API groups mapped to members", notes = "User must have the MANAGE_MEMBERS permission to use this service")
+    @ApiResponses(
+        {
+            @ApiResponse(code = 200, message = "API groups with members", response = MemberEntity.class, responseContainer = "Map"),
+            @ApiResponse(code = 403, message = "Forbidden"),
+            @ApiResponse(code = 500, message = "Internal Server Error"),
+        }
+    )
+    @Permissions({ @Permission(value = RolePermission.API_MEMBER, acls = RolePermissionAction.READ) })
+    public Map<String, List<GroupMemberEntity>> getApiGroupsWithMembers() {
+        return apiService.getGroupsWithMembers(GraviteeContext.getCurrentEnvironment(), apiId);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiMembersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiMembersResource.java
@@ -186,14 +186,12 @@ public class ApiMembersResource extends AbstractResource {
     public Response transferApiMemberOwnership(@Valid @NotNull TransferOwnership transferOwnership) {
         List<RoleEntity> newRoles = new ArrayList<>();
 
-        Optional<RoleEntity> optNewRole = roleService.findByScopeAndName(RoleScope.API, transferOwnership.getPoRole());
-        if (optNewRole.isPresent()) {
-            newRoles.add(optNewRole.get());
-        } else {
-            //it doesn't matter
+        if (transferOwnership.getPoRole() != null) {
+            roleService.findByScopeAndName(RoleScope.API, transferOwnership.getPoRole()).ifPresent(newRoles::add);
         }
 
         apiService.findById(api);
+
         membershipService.transferApiOwnership(
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
@@ -738,6 +738,11 @@ public class ApiResource extends AbstractResource {
         return resourceContext.getResource(ApiMembersResource.class);
     }
 
+    @Path("groups")
+    public ApiGroupsResource getApiGroupsResource() {
+        return resourceContext.getResource(ApiGroupsResource.class);
+    }
+
     @Path("analytics")
     public ApiAnalyticsResource getApiAnalyticsResource() {
         return resourceContext.getResource(ApiAnalyticsResource.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResource.java
@@ -137,19 +137,7 @@ public class GroupMembersResource extends AbstractResource {
         List<GroupMemberEntity> groupMemberEntities = members
             .keySet()
             .stream()
-            .map(
-                id -> {
-                    Map<String, String> roles = members
-                        .get(id)
-                        .stream()
-                        .flatMap(m -> m.getRoles().stream())
-                        .collect(Collectors.toMap(role -> role.getScope().name(), RoleEntity::getName));
-
-                    GroupMemberEntity groupMemberEntity = new GroupMemberEntity(members.get(id).get(0));
-                    groupMemberEntity.setRoles(roles);
-                    return groupMemberEntity;
-                }
-            )
+            .map(id -> new GroupMemberEntity(members.get(id).get(0)))
             .sorted(Comparator.comparing(GroupMemberEntity::getId))
             .collect(toList());
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiGroupsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiGroupsResourceTest.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.model.GroupMemberEntity;
+import io.gravitee.rest.api.model.MemberEntity;
+import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.model.permissions.ApiPermission;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.common.UuidString;
+import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.io.IOException;
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Priority;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class ApiGroupsResourceTest extends AbstractResourceTest {
+
+    private static final String API_ID = "8b8a03a1-429e-4cd2-a860-b258300c2b80";
+    private static final String ENVIRONMENT = "DEFAULT";
+
+    @Override
+    protected String contextPath() {
+        return "apis/";
+    }
+
+    @Override
+    protected void decorate(ResourceConfig resourceConfig) {
+        resourceConfig.register(ApiResourceNotAdminTest.AuthenticationFilter.class);
+    }
+
+    @Priority(50)
+    public static class AuthenticationFilter implements ContainerRequestFilter {
+
+        @Override
+        public void filter(final ContainerRequestContext requestContext) throws IOException {
+            requestContext.setSecurityContext(
+                new SecurityContext() {
+                    @Override
+                    public Principal getUserPrincipal() {
+                        return () -> USER_NAME;
+                    }
+
+                    @Override
+                    public boolean isUserInRole(String string) {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean isSecure() {
+                        return true;
+                    }
+
+                    @Override
+                    public String getAuthenticationScheme() {
+                        return "BASIC";
+                    }
+                }
+            );
+        }
+    }
+
+    @Before
+    public void init() {
+        Mockito.reset(apiService);
+        Mockito.reset(roleService);
+    }
+
+    @Test
+    public void shouldReturn500IfTechnicalException() {
+        ApiEntity api = Mockito.mock(ApiEntity.class);
+
+        when(apiService.findById(API_ID)).thenReturn(api);
+
+        when(roleService.hasPermission(any(), eq(ApiPermission.MEMBER), eq(new RolePermissionAction[] { RolePermissionAction.READ })))
+            .thenReturn(true);
+
+        when(apiService.getGroupsWithMembers(ENVIRONMENT, API_ID)).thenThrow(new TechnicalManagementException());
+
+        Response response = envTarget(API_ID).path("groups").request().get();
+
+        assertEquals(HttpStatusCode.INTERNAL_SERVER_ERROR_500, response.getStatus());
+    }
+
+    @Test
+    public void shouldReturn403IfNotGranted() {
+        Response response = envTarget(API_ID).path("groups").request().get();
+        assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
+    }
+
+    @Test
+    public void shouldReturnGroupsIfGranted() {
+        ApiEntity api = Mockito.mock(ApiEntity.class);
+
+        when(apiService.findById(API_ID)).thenReturn(api);
+
+        Map<String, char[]> userPermissions = Map.of(ApiPermission.MEMBER.name(), "R".toCharArray());
+
+        when(membershipService.getUserMemberPermissions(ENVIRONMENT, api, USER_NAME)).thenReturn(userPermissions);
+
+        when(roleService.hasPermission(eq(userPermissions), any(), any())).thenReturn(true);
+
+        when(apiService.getGroupsWithMembers(ENVIRONMENT, API_ID))
+            .thenReturn(Map.of(UuidString.generateRandom(), List.of(new GroupMemberEntity())));
+
+        Response response = envTarget(API_ID).path("groups").request().get();
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+
+        Map<String, List<MemberEntity>> responseBody = response.readEntity(new GenericType<>() {});
+
+        assertEquals(1, responseBody.size());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/GroupMemberEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/GroupMemberEntity.java
@@ -17,7 +17,10 @@ package io.gravitee.rest.api.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
@@ -32,6 +35,10 @@ public class GroupMemberEntity {
         this.displayName = memberEntity.getDisplayName();
         this.createdAt = memberEntity.getCreatedAt();
         this.updatedAt = memberEntity.getUpdatedAt();
+        this.roles = new HashMap<>();
+        for (RoleEntity role : memberEntity.getRoles()) {
+            this.roles.put(role.getScope().name(), role.getName());
+        }
     }
 
     private String id;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/RoleEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/RoleEntity.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.model.permissions.SystemRole;
 import java.util.Map;
 import java.util.Objects;
 
@@ -91,6 +92,10 @@ public class RoleEntity {
 
     public void setSystem(boolean system) {
         this.system = system;
+    }
+
+    public boolean isApiPrimaryOwner() {
+        return scope == RoleScope.API && SystemRole.PRIMARY_OWNER.name().equals(name);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/MembershipRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/MembershipRepositoryProxy.java
@@ -20,6 +20,7 @@ import io.gravitee.repository.management.api.MembershipRepository;
 import io.gravitee.repository.management.model.Membership;
 import io.gravitee.repository.management.model.MembershipMemberType;
 import io.gravitee.repository.management.model.MembershipReferenceType;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -95,6 +96,16 @@ public class MembershipRepositoryProxy extends AbstractProxy<MembershipRepositor
         String roleId
     ) throws TechnicalException {
         return target.findByMemberIdAndMemberTypeAndReferenceTypeAndRoleId(memberId, memberType, referenceType, roleId);
+    }
+
+    @Override
+    public Set<Membership> findByMemberIdAndMemberTypeAndReferenceTypeAndRoleIdIn(
+        String memberId,
+        MembershipMemberType memberType,
+        MembershipReferenceType referenceType,
+        Collection<String> roleIds
+    ) throws TechnicalException {
+        return target.findByMemberIdAndMemberTypeAndReferenceTypeAndRoleIdIn(memberId, memberType, referenceType, roleIds);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
@@ -171,5 +171,7 @@ public interface ApiService {
     void addGroup(String api, String group);
     void removeGroup(String api, String group);
 
+    Map<String, List<GroupMemberEntity>> getGroupsWithMembers(String environmentId, String apiId) throws TechnicalManagementException;
+
     boolean canManageApi(RoleEntity role);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/MembershipService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/MembershipService.java
@@ -114,6 +114,12 @@ public interface MembershipService {
         MembershipReferenceType referenceType,
         String role
     );
+    Set<MembershipEntity> getMembershipsByMemberAndReferenceAndRoleIn(
+        MembershipMemberType memberType,
+        String memberId,
+        MembershipReferenceType referenceType,
+        Collection<String> roleIds
+    );
     Set<MembershipEntity> getMembershipsByMembersAndReference(
         MembershipMemberType memberType,
         List<String> membersId,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/RoleService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/RoleService.java
@@ -22,9 +22,7 @@ import io.gravitee.rest.api.model.UpdateRoleEntity;
 import io.gravitee.rest.api.model.permissions.Permission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.permissions.RoleScope;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/DefaultRoleEntityDefinition.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/DefaultRoleEntityDefinition.java
@@ -96,8 +96,8 @@ public interface DefaultRoleEntityDefinition {
         false,
         Maps
             .<String, char[]>builder()
-            .put(ApiPermission.DEFINITION.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })
-            .put(ApiPermission.GATEWAY_DEFINITION.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })
+            .put(ApiPermission.DEFINITION.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId() })
+            .put(ApiPermission.GATEWAY_DEFINITION.getName(), new char[] { CREATE.getId(), READ.getId() })
             .put(ApiPermission.PLAN.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })
             .put(ApiPermission.SUBSCRIPTION.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })
             .put(ApiPermission.MEMBER.getName(), new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() })

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_FindByUserTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_FindByUserTest.java
@@ -36,6 +36,7 @@ import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.model.common.SortableImpl;
 import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.impl.ApiServiceImpl;
 import io.gravitee.rest.api.service.jackson.filter.ApiPermissionFilter;
@@ -109,6 +110,7 @@ public class ApiService_FindByUserTest {
     @Test
     public void shouldFindByUser() throws TechnicalException {
         final String userRoleId = "API_USER";
+        final String poRoleId = "API_PRIMARY_OWNER";
 
         Map<String, char[]> userPermissions = ImmutableMap.of("MEMBER", "CRUD".toCharArray());
         RoleEntity userRole = new RoleEntity();
@@ -133,8 +135,13 @@ public class ApiService_FindByUserTest {
             .thenReturn(Collections.singleton(membership));
 
         RoleEntity poRole = new RoleEntity();
-        poRole.setId("API_PRIMARY_OWNER");
+        poRole.setId(poRoleId);
+        poRole.setScope(RoleScope.API);
+        poRole.setName(SystemRole.PRIMARY_OWNER.name());
+
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), any())).thenReturn(poRole);
+
+        when(roleService.findByScope(RoleScope.API)).thenReturn(List.of(poRole, userRole));
 
         MemberEntity poMember = new MemberEntity();
         poMember.setId("admin");
@@ -160,6 +167,7 @@ public class ApiService_FindByUserTest {
     @Test
     public void shouldFindByUserPaginated() throws TechnicalException {
         final String userRoleId = "API_USER";
+        final String poRoleId = "API_PRIMARY_OWNER";
 
         Map<String, char[]> userPermissions = ImmutableMap.of("MEMBER", "CRUD".toCharArray());
         RoleEntity userRole = new RoleEntity();
@@ -198,8 +206,13 @@ public class ApiService_FindByUserTest {
             .thenReturn(Arrays.asList(api1, api2));
 
         RoleEntity poRole = new RoleEntity();
-        poRole.setId("API_PRIMARY_OWNER");
+        poRole.setId(poRoleId);
+        poRole.setScope(RoleScope.API);
+        poRole.setName(SystemRole.PRIMARY_OWNER.name());
+
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), any())).thenReturn(poRole);
+
+        when(roleService.findByScope(RoleScope.API)).thenReturn(List.of(userRole, poRole));
 
         MemberEntity poMember = new MemberEntity();
         poMember.setId("admin");
@@ -231,6 +244,15 @@ public class ApiService_FindByUserTest {
 
     @Test
     public void shouldNotFindByUserBecauseNotExists() throws TechnicalException {
+        final String poRoleId = "API_PRIMARY_OWNER";
+
+        RoleEntity poRole = new RoleEntity();
+        poRole.setId(poRoleId);
+        poRole.setScope(RoleScope.API);
+        poRole.setName(SystemRole.PRIMARY_OWNER.name());
+
+        when(roleService.findByScope(RoleScope.API)).thenReturn(List.of(poRole));
+
         when(membershipService.getMembershipsByMemberAndReference(MembershipMemberType.USER, USER_NAME, MembershipReferenceType.API))
             .thenReturn(Collections.emptySet());
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_GetGroupsWithMembersTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_GetGroupsWithMembersTest.java
@@ -1,0 +1,327 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.rest.api.model.*;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.model.permissions.SystemRole;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.common.UuidString;
+import io.gravitee.rest.api.service.impl.ApiServiceImpl;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ApiService_GetGroupsWithMembersTest {
+
+    @Mock
+    private ApiRepository apiRepository;
+
+    @Mock
+    private MembershipService membershipService;
+
+    @Mock
+    private GroupService groupService;
+
+    @Mock
+    private RoleService roleService;
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private final ApiServiceImpl apiService = new ApiServiceImpl();
+
+    private static final String ENVIRONMENT = "DEFAULT";
+
+    @Test
+    public void shouldGetApiGroupsWithMembers_WithPrimaryOwnerPrivilege_ifGroupIsTheApiPrimaryOwner() throws TechnicalException {
+        final String expectedUserRole = "PRIMARY_OWNER";
+
+        String apiId = UuidString.generateRandom();
+        String groupId = UuidString.generateRandom();
+
+        Api api = mock(Api.class);
+        when(api.getId()).thenReturn(apiId);
+        when(api.getGroups()).thenReturn(Set.of(groupId));
+        when(apiRepository.findById(apiId)).thenReturn(Optional.of(api));
+
+        GroupEntity group = Mockito.mock(GroupEntity.class);
+        when(group.getId()).thenReturn(groupId);
+        when(groupService.findById(eq(ENVIRONMENT), eq(groupId))).thenReturn(group);
+
+        RoleEntity groupMemberApiRole = new RoleEntity();
+        groupMemberApiRole.setName(SystemRole.PRIMARY_OWNER.name());
+        groupMemberApiRole.setScope(RoleScope.API);
+
+        MemberEntity groupMember = Mockito.mock(MemberEntity.class);
+        when(groupMember.getReferenceId()).thenReturn(groupId);
+        when(groupMember.getRoles()).thenReturn(List.of(groupMemberApiRole));
+        when(membershipService.getMembersByReferencesAndRole(MembershipReferenceType.GROUP, List.of(groupId), null))
+            .thenReturn(Set.of(groupMember));
+
+        MembershipEntity apiPrimaryOwnerMembership = Mockito.mock(MembershipEntity.class);
+        when(apiPrimaryOwnerMembership.getMemberType()).thenReturn(MembershipMemberType.GROUP);
+        when(apiPrimaryOwnerMembership.getMemberId()).thenReturn(groupId);
+        when(membershipService.getPrimaryOwner(any(), eq(MembershipReferenceType.API), eq(apiId))).thenReturn(apiPrimaryOwnerMembership);
+
+        Map<String, List<GroupMemberEntity>> groupsWithMembers = apiService.getGroupsWithMembers(ENVIRONMENT, apiId);
+        assertEquals(1, groupsWithMembers.size());
+
+        List<GroupMemberEntity> groupMembers = groupsWithMembers.get(groupId);
+        assertNotNull(groupMembers);
+        assertEquals(1, groupMembers.size());
+
+        GroupMemberEntity updatedGroupMember = groupMembers.get(0);
+        assertNotNull(updatedGroupMember.getRoles());
+        assertEquals(1, updatedGroupMember.getRoles().size());
+
+        String userRole = updatedGroupMember.getRoles().get("API");
+        assertEquals(expectedUserRole, userRole);
+    }
+
+    @Test
+    public void shouldGetApiGroupsWithMembers_RevokingPrimaryOwnerPrivilege_ifApiPrimaryOwnerIsOfTypeUser() throws TechnicalException {
+        final String expectedUserRole = "OWNER";
+
+        String apiId = UuidString.generateRandom();
+        String groupId = UuidString.generateRandom();
+        String apiPrimaryOwnerUserId = UuidString.generateRandom();
+
+        UserEntity apiPrimaryOwner = Mockito.mock(UserEntity.class);
+        when(apiPrimaryOwner.getId()).thenReturn(apiPrimaryOwnerUserId);
+        when(userService.findById(apiPrimaryOwnerUserId)).thenReturn(apiPrimaryOwner);
+
+        Api api = mock(Api.class);
+        when(api.getId()).thenReturn(apiId);
+        when(api.getGroups()).thenReturn(Set.of(groupId));
+        when(apiRepository.findById(apiId)).thenReturn(Optional.of(api));
+
+        GroupEntity group = Mockito.mock(GroupEntity.class);
+        when(group.getId()).thenReturn(groupId);
+        when(group.getRoles()).thenReturn(Map.of(RoleScope.API, expectedUserRole));
+        when(groupService.findById(eq(ENVIRONMENT), eq(groupId))).thenReturn(group);
+
+        RoleEntity groupMemberApiRole = new RoleEntity();
+        groupMemberApiRole.setName(SystemRole.PRIMARY_OWNER.name());
+        groupMemberApiRole.setScope(RoleScope.API);
+
+        MemberEntity groupMember = Mockito.mock(MemberEntity.class);
+        when(groupMember.getReferenceId()).thenReturn(groupId);
+        when(groupMember.getRoles()).thenReturn(List.of(groupMemberApiRole));
+        when(membershipService.getMembersByReferencesAndRole(MembershipReferenceType.GROUP, List.of(groupId), null))
+            .thenReturn(Set.of(groupMember));
+
+        MembershipEntity apiPrimaryOwnerMembership = Mockito.mock(MembershipEntity.class);
+        when(apiPrimaryOwnerMembership.getMemberType()).thenReturn(MembershipMemberType.USER);
+        when(apiPrimaryOwnerMembership.getMemberId()).thenReturn(apiPrimaryOwnerUserId);
+        when(membershipService.getPrimaryOwner(any(), eq(MembershipReferenceType.API), eq(apiId))).thenReturn(apiPrimaryOwnerMembership);
+
+        RoleEntity groupDefaultApiRole = Mockito.mock(RoleEntity.class);
+        when(groupDefaultApiRole.getName()).thenReturn(expectedUserRole);
+        when(roleService.findByScopeAndName(eq(RoleScope.API), eq(expectedUserRole))).thenReturn(Optional.of(groupDefaultApiRole));
+
+        Map<String, List<GroupMemberEntity>> groupsWithMembers = apiService.getGroupsWithMembers(ENVIRONMENT, apiId);
+        assertEquals(1, groupsWithMembers.size());
+
+        List<GroupMemberEntity> groupMembers = groupsWithMembers.get(groupId);
+        assertNotNull(groupMembers);
+        assertEquals(1, groupMembers.size());
+
+        GroupMemberEntity updatedGroupMember = groupMembers.get(0);
+        assertNotNull(updatedGroupMember.getRoles());
+        assertEquals(1, updatedGroupMember.getRoles().size());
+
+        String userRole = updatedGroupMember.getRoles().get(RoleScope.API.name());
+        assertEquals(expectedUserRole, userRole);
+    }
+
+    @Test
+    public void shouldGetApiGroupsWithMembers_RevokingPrimaryOwnerPrivilege_ifGroupIsNotTheApiPrimaryOwner() throws TechnicalException {
+        final String expectedUserRole = "REVIEWER";
+
+        String apiId = UuidString.generateRandom();
+        String groupId = UuidString.generateRandom();
+        String apiPrimaryOwnerGroupId = UuidString.generateRandom();
+
+        GroupEntity apiPrimaryOwner = Mockito.mock(GroupEntity.class);
+        when(apiPrimaryOwner.getId()).thenReturn(apiPrimaryOwnerGroupId);
+        when(groupService.findById(anyString(), eq(apiPrimaryOwnerGroupId))).thenReturn(apiPrimaryOwner);
+
+        Api api = mock(Api.class);
+        when(api.getId()).thenReturn(apiId);
+        when(api.getGroups()).thenReturn(Set.of(groupId));
+        when(apiRepository.findById(apiId)).thenReturn(Optional.of(api));
+
+        GroupEntity group = Mockito.mock(GroupEntity.class);
+        when(group.getId()).thenReturn(groupId);
+        when(group.getRoles()).thenReturn(Map.of(RoleScope.API, expectedUserRole));
+        when(groupService.findById(eq(ENVIRONMENT), eq(groupId))).thenReturn(group);
+
+        RoleEntity groupMemberApiRole = new RoleEntity();
+        groupMemberApiRole.setName(SystemRole.PRIMARY_OWNER.name());
+        groupMemberApiRole.setScope(RoleScope.API);
+
+        MemberEntity groupMember = Mockito.mock(MemberEntity.class);
+        when(groupMember.getReferenceId()).thenReturn(groupId);
+        when(groupMember.getRoles()).thenReturn(List.of(groupMemberApiRole));
+        when(membershipService.getMembersByReferencesAndRole(MembershipReferenceType.GROUP, List.of(groupId), null))
+            .thenReturn(Set.of(groupMember));
+
+        MembershipEntity apiPrimaryOwnerMembership = Mockito.mock(MembershipEntity.class);
+        when(apiPrimaryOwnerMembership.getMemberType()).thenReturn(MembershipMemberType.GROUP);
+        when(apiPrimaryOwnerMembership.getMemberId()).thenReturn(apiPrimaryOwnerGroupId);
+        when(membershipService.getPrimaryOwner(any(), eq(MembershipReferenceType.API), eq(apiId))).thenReturn(apiPrimaryOwnerMembership);
+
+        RoleEntity groupDefaultApiRole = Mockito.mock(RoleEntity.class);
+        when(groupDefaultApiRole.getName()).thenReturn(expectedUserRole);
+        when(roleService.findByScopeAndName(eq(RoleScope.API), eq(expectedUserRole))).thenReturn(Optional.of(groupDefaultApiRole));
+
+        Map<String, List<GroupMemberEntity>> groupsWithMembers = apiService.getGroupsWithMembers(ENVIRONMENT, apiId);
+        assertEquals(1, groupsWithMembers.size());
+
+        List<GroupMemberEntity> groupMembers = groupsWithMembers.get(groupId);
+        assertNotNull(groupMembers);
+        assertEquals(1, groupMembers.size());
+
+        GroupMemberEntity updatedGroupMember = groupMembers.get(0);
+        assertNotNull(updatedGroupMember.getRoles());
+        assertEquals(1, updatedGroupMember.getRoles().size());
+
+        String updatedMemberRole = updatedGroupMember.getRoles().get(RoleScope.API.name());
+        assertEquals(expectedUserRole, updatedMemberRole);
+    }
+
+    @Test
+    public void shouldGetApiGroupsWithMembers_RemovingPrimaryOwnerPrivilege_ifGroupIsNotTheApiPrimaryOwner_andNoDefaultRole()
+        throws TechnicalException {
+        String apiId = UuidString.generateRandom();
+        String groupId = UuidString.generateRandom();
+        String apiPrimaryOwnerGroupId = UuidString.generateRandom();
+
+        GroupEntity apiPrimaryOwner = Mockito.mock(GroupEntity.class);
+        when(apiPrimaryOwner.getId()).thenReturn(apiPrimaryOwnerGroupId);
+        when(groupService.findById(eq(ENVIRONMENT), eq(apiPrimaryOwnerGroupId))).thenReturn(apiPrimaryOwner);
+
+        Api api = mock(Api.class);
+        when(api.getId()).thenReturn(apiId);
+        when(api.getGroups()).thenReturn(Set.of(groupId));
+        when(apiRepository.findById(apiId)).thenReturn(Optional.of(api));
+
+        GroupEntity group = Mockito.mock(GroupEntity.class);
+        when(group.getId()).thenReturn(groupId);
+        when(group.getRoles()).thenReturn(Map.of());
+        when(groupService.findById(anyString(), eq(groupId))).thenReturn(group);
+
+        RoleEntity groupMemberApiRole = new RoleEntity();
+        groupMemberApiRole.setName(SystemRole.PRIMARY_OWNER.name());
+        groupMemberApiRole.setScope(RoleScope.API);
+
+        MemberEntity groupMember = Mockito.mock(MemberEntity.class);
+        when(groupMember.getReferenceId()).thenReturn(groupId);
+        when(groupMember.getRoles()).thenReturn(List.of(groupMemberApiRole));
+        when(membershipService.getMembersByReferencesAndRole(MembershipReferenceType.GROUP, List.of(groupId), null))
+            .thenReturn(Set.of(groupMember));
+
+        MembershipEntity apiPrimaryOwnerMembership = Mockito.mock(MembershipEntity.class);
+        when(apiPrimaryOwnerMembership.getMemberType()).thenReturn(MembershipMemberType.GROUP);
+        when(apiPrimaryOwnerMembership.getMemberId()).thenReturn(apiPrimaryOwnerGroupId);
+        when(membershipService.getPrimaryOwner(any(), eq(MembershipReferenceType.API), eq(apiId))).thenReturn(apiPrimaryOwnerMembership);
+
+        Map<String, List<GroupMemberEntity>> groupsWithMembers = apiService.getGroupsWithMembers(ENVIRONMENT, apiId);
+        assertEquals(1, groupsWithMembers.size());
+
+        List<GroupMemberEntity> groupMembers = groupsWithMembers.get(groupId);
+        assertNotNull(groupMembers);
+        assertEquals(1, groupMembers.size());
+
+        GroupMemberEntity updatedGroupMember = groupMembers.get(0);
+        assertNotNull(updatedGroupMember.getRoles());
+        assertEquals(1, updatedGroupMember.getRoles().size());
+
+        String userRole = updatedGroupMember.getRoles().get(RoleScope.API.name());
+        assertNull(userRole);
+    }
+
+    @Test
+    public void shouldGetApiGroupsWithMembers_RemovingPrimaryOwnerPrivilege_ifGroupIsNotTheApiPrimaryOwner_andDefaultRoleHasBeenDeleted()
+        throws TechnicalException {
+        final String deletedRole = "USER";
+
+        String apiId = UuidString.generateRandom();
+        String groupId = UuidString.generateRandom();
+        String apiPrimaryOwnerUserId = UuidString.generateRandom();
+
+        UserEntity apiPrimaryOwner = Mockito.mock(UserEntity.class);
+        when(apiPrimaryOwner.getId()).thenReturn(apiPrimaryOwnerUserId);
+        when(userService.findById(apiPrimaryOwnerUserId)).thenReturn(apiPrimaryOwner);
+
+        Api api = mock(Api.class);
+        when(api.getId()).thenReturn(apiId);
+        when(api.getGroups()).thenReturn(Set.of(groupId));
+        when(apiRepository.findById(apiId)).thenReturn(Optional.of(api));
+
+        GroupEntity group = Mockito.mock(GroupEntity.class);
+        when(group.getId()).thenReturn(groupId);
+        when(group.getRoles()).thenReturn(Map.of(RoleScope.API, deletedRole));
+        when(groupService.findById(eq(ENVIRONMENT), eq(groupId))).thenReturn(group);
+
+        RoleEntity groupMemberApiRole = new RoleEntity();
+        groupMemberApiRole.setName(SystemRole.PRIMARY_OWNER.name());
+        groupMemberApiRole.setScope(RoleScope.API);
+
+        MemberEntity groupMember = Mockito.mock(MemberEntity.class);
+        when(groupMember.getReferenceId()).thenReturn(groupId);
+        when(groupMember.getRoles()).thenReturn(List.of(groupMemberApiRole));
+        when(membershipService.getMembersByReferencesAndRole(MembershipReferenceType.GROUP, List.of(groupId), null))
+            .thenReturn(Set.of(groupMember));
+
+        MembershipEntity apiPrimaryOwnerMembership = Mockito.mock(MembershipEntity.class);
+        when(apiPrimaryOwnerMembership.getMemberType()).thenReturn(MembershipMemberType.USER);
+        when(apiPrimaryOwnerMembership.getMemberId()).thenReturn(apiPrimaryOwnerUserId);
+        when(membershipService.getPrimaryOwner(any(), eq(MembershipReferenceType.API), eq(apiId))).thenReturn(apiPrimaryOwnerMembership);
+
+        when(roleService.findByScopeAndName(eq(RoleScope.API), eq(deletedRole))).thenReturn(Optional.empty());
+
+        Map<String, List<GroupMemberEntity>> groupsWithMembers = apiService.getGroupsWithMembers(ENVIRONMENT, apiId);
+        assertEquals(1, groupsWithMembers.size());
+
+        List<GroupMemberEntity> groupMembers = groupsWithMembers.get(groupId);
+        assertNotNull(groupMembers);
+        assertEquals(1, groupMembers.size());
+
+        GroupMemberEntity updatedGroupMember = groupMembers.get(0);
+        assertNotNull(updatedGroupMember.getRoles());
+        assertEquals(1, updatedGroupMember.getRoles().size());
+
+        String userRole = updatedGroupMember.getRoles().get(RoleScope.API.name());
+        assertNull(userRole);
+    }
+}


### PR DESCRIPTION
API primary owners appointed from a group now keep this privilege on an API only if the group has been explicitly appointed as a primary owner for this API. Otherwise their privilege is demoted to the default API role set in the group configuration. If no default API role has been defined on the group, the user ends up with no role at all.

According to the [documentation](https://docs.gravitee.io/apim/3.x/apim_publisherguide_manage_members.html#roles), API primary owner is by default the only user to be able to delete an API or update its context path. The default permissions for the `OWNER` role have been updated accordingly.

The `Transfer Ownership` link is not displayed anymore if the user is not a Primary Owner in a inherited or direct way (The link was displayed but led to an empty page before the revision)

see https://github.com/gravitee-io/issues/issues/6360

🗒️  Regarding the nature of the rules in place another issue has been created to cover them in our integrations tests

see https://github.com/gravitee-io/issues/issues/7033


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6360-fix-primary-owner-role-check/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
