### PR TITLE
Test/cypress improvments

### DIFF
--- a/gravitee-apim-cypress/cypress/assertions/api.assertion.ts
+++ b/gravitee-apim-cypress/cypress/assertions/api.assertion.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Api, ApiLifecycleState, ApiQualityMetrics, ApiState, ApiVisibility, ApiWorkflowState, PortalApi } from '../model/apis';
+import { Api, ApiLifecycleState, ApiQualityMetrics, ApiState, ApiVisibility, ApiWorkflowState, PortalApi } from '@model/apis';
 
 export class ApiAssertions {
   private apiResponse: Cypress.Response<Api>;

--- a/gravitee-apim-cypress/cypress/assertions/environment-configuration.assertion.ts
+++ b/gravitee-apim-cypress/cypress/assertions/environment-configuration.assertion.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { QualityRule } from '../model/quality-rules';
-import { Group } from '../model/groups';
+import { QualityRule } from '@model/quality-rules';
+import { Group } from '@model/groups';
 
 export class EnvironmentQualityRuleAssertions {
   private response: Cypress.Response<QualityRule>;

--- a/gravitee-apim-cypress/cypress/assertions/error.assertion.ts
+++ b/gravitee-apim-cypress/cypress/assertions/error.assertion.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { PortalError, ManagementError } from '../model/technical';
+import { PortalError, ManagementError } from '@model/technical';
 
 export class ErrorAssertions {
   private response: Cypress.Response<PortalError>;

--- a/gravitee-apim-cypress/cypress/assertions/portal-settings.assertion.ts
+++ b/gravitee-apim-cypress/cypress/assertions/portal-settings.assertion.ts
@@ -13,9 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Api, ApiLifecycleState, ApiState, ApiVisibility, PortalApi } from '../model/apis';
-import { PortalSettings } from '../model/portal-settings';
-import { PortalApiAssertions } from './api.assertion';
+import { PortalSettings } from '@model/portal-settings';
 
 export class PortalSettingsAssertions {
   private settingsResponse: Cypress.Response<PortalSettings>;

--- a/gravitee-apim-cypress/cypress/commands/common/http.commands.ts
+++ b/gravitee-apim-cypress/cypress/commands/common/http.commands.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { RequestInfo, RequestInfoHolder } from '../../model/technical';
+import { RequestInfo, RequestInfoHolder } from '@model/technical';
 import Response = Cypress.Response;
 
 export type ParamMap = Record<string, string>;

--- a/gravitee-apim-cypress/cypress/commands/gravitee.commands.ts
+++ b/gravitee-apim-cypress/cypress/commands/gravitee.commands.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { BasicAuthentication } from '../model/users';
-import { RequestInfo } from '../model/technical';
+import { BasicAuthentication } from '@model/users';
+import { RequestInfo } from '@model/technical';
 import { ManagementCommands } from './management.commands';
 import { PortalCommands } from './portal.commands';
 

--- a/gravitee-apim-cypress/cypress/commands/management.commands.ts
+++ b/gravitee-apim-cypress/cypress/commands/management.commands.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { RequestInfo, RequestInfoHolder } from '../model/technical';
+import { RequestInfo, RequestInfoHolder } from '@model/technical';
 import { ApiManagementCommands } from './management/apis.management.commands';
 import { PortalSettingsManagementCommands } from './management/portal-settings.management.commands';
 import { EnvironmentConfigurationManagementCommands } from './management/environment-configuration.management.commands';

--- a/gravitee-apim-cypress/cypress/commands/management/api-management-commands.ts
+++ b/gravitee-apim-cypress/cypress/commands/management/api-management-commands.ts
@@ -13,10 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Api, ApiErrorCodes, ApiLifecycleState, ApiMember, PortalApi } from '@model/apis';
+import { Api, ApiLifecycleState, ApiMember } from '@model/apis';
 import { ApiImport } from '@model/api-imports';
-import { User, BasicAuthentication } from '@model/users';
-import { ErrorableManagement } from '@model/technical';
+import { BasicAuthentication } from '@model/users';
 
 export function createApi(auth: BasicAuthentication, body: Api, failOnStatusCode = false) {
   return cy.request({

--- a/gravitee-apim-cypress/cypress/commands/management/api-plan-management-commands.ts
+++ b/gravitee-apim-cypress/cypress/commands/management/api-plan-management-commands.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { NewPlanEntity } from 'model/plan';
-import { BasicAuthentication } from 'model/users';
+import { NewPlanEntity } from '@model/plan';
+import { BasicAuthentication } from '@model/users';
+
 export function createPlan(auth: BasicAuthentication, apiId: string, body: Partial<NewPlanEntity>, failOnStatusCode = false) {
   return cy.request({
     method: 'POST',

--- a/gravitee-apim-cypress/cypress/commands/management/api-plans-management-commands.ts
+++ b/gravitee-apim-cypress/cypress/commands/management/api-plans-management-commands.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 import { BasicAuthentication } from '@model/users';
-import { ApiPlanStatus } from '@model/apis';
+import { PlanStatus } from '@model/plan';
 
-export function getPlans(auth: BasicAuthentication, apiId: string, status: ApiPlanStatus) {
+export function getPlans(auth: BasicAuthentication, apiId: string, status: PlanStatus) {
   return cy.request({
     method: 'GET',
     url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}/plans`,

--- a/gravitee-apim-cypress/cypress/commands/management/apis-plans.management.commands.ts
+++ b/gravitee-apim-cypress/cypress/commands/management/apis-plans.management.commands.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 import { ErrorableManagement, RequestInfo } from '../../model/technical';
-import { Plan } from '../../model/apis';
 import Chainable = Cypress.Chainable;
 import Response = Cypress.Response;
 import { HttpConnector } from '../../model/technical.http';
+import { Plan } from '@model/plan';
 
 export class ApisPlansManagementCommands extends HttpConnector {
   constructor(requestInfo: RequestInfo) {

--- a/gravitee-apim-cypress/cypress/commands/management/apis-plans.management.commands.ts
+++ b/gravitee-apim-cypress/cypress/commands/management/apis-plans.management.commands.ts
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ErrorableManagement, RequestInfo } from '../../model/technical';
+import { ErrorableManagement, RequestInfo } from '@model/technical';
 import Chainable = Cypress.Chainable;
 import Response = Cypress.Response;
-import { HttpConnector } from '../../model/technical.http';
+import { HttpConnector } from '@model/technical.http';
 import { Plan } from '@model/plan';
 
 export class ApisPlansManagementCommands extends HttpConnector {

--- a/gravitee-apim-cypress/cypress/commands/management/apis-quality.management.commands.ts
+++ b/gravitee-apim-cypress/cypress/commands/management/apis-quality.management.commands.ts
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ErrorableManagement, RequestInfo } from '../../model/technical';
-import { ApiQualityMetrics, ApiQualityRule } from '../../model/apis';
+import { ErrorableManagement, RequestInfo } from '@model/technical';
+import { ApiQualityMetrics, ApiQualityRule } from '@model/apis';
 import Chainable = Cypress.Chainable;
 import Response = Cypress.Response;
-import { HttpConnector } from '../../model/technical.http';
-import { ParamMap } from '../common/http.commands';
+import { HttpConnector } from '@model/technical.http';
+import { ParamMap } from '@commands/common/http.commands';
 
 export class ApisQualityManagementCommands extends HttpConnector {
   constructor(requestInfo: RequestInfo) {

--- a/gravitee-apim-cypress/cypress/commands/management/apis-ratings.management.commands.ts
+++ b/gravitee-apim-cypress/cypress/commands/management/apis-ratings.management.commands.ts
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ErrorableManagement, RequestInfo } from '../../model/technical';
-import { ApiRating, ApiRatingResponse } from '../../model/apis';
+import { ErrorableManagement, RequestInfo } from '@model/technical';
+import { ApiRating, ApiRatingResponse } from '@model/apis';
 import Chainable = Cypress.Chainable;
 import Response = Cypress.Response;
-import { HttpConnector } from '../../model/technical.http';
+import { HttpConnector } from '@model/technical.http';
 
 export class ApisRatingsManagementCommands extends HttpConnector {
   constructor(requestInfo: RequestInfo) {

--- a/gravitee-apim-cypress/cypress/commands/management/apis-subscriptions.management.commands.ts
+++ b/gravitee-apim-cypress/cypress/commands/management/apis-subscriptions.management.commands.ts
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ErrorableManagement, RequestInfo } from '../../model/technical';
-import { Subscription } from '../../model/apis';
+import { ErrorableManagement, RequestInfo } from '@model/technical';
+import { Subscription } from '@model/apis';
 import Chainable = Cypress.Chainable;
 import Response = Cypress.Response;
-import { HttpConnector } from '../../model/technical.http';
+import { HttpConnector } from '@model/technical.http';
 
 export class ApisSubscriptionsManagementCommands extends HttpConnector {
   constructor(requestInfo: RequestInfo) {

--- a/gravitee-apim-cypress/cypress/commands/management/apis.management.commands.ts
+++ b/gravitee-apim-cypress/cypress/commands/management/apis.management.commands.ts
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ErrorableManagement, RequestInfo } from 'model/technical';
-import { Api, ApiDefinition, ApiDeployment, ApiMember } from 'model/apis';
+import { ErrorableManagement, RequestInfo } from '@model/technical';
+import { Api, ApiDefinition, ApiDeployment, ApiMember } from '@model/apis';
 import Chainable = Cypress.Chainable;
 import Response = Cypress.Response;
-import { HttpConnector } from 'model/technical.http';
+import { HttpConnector } from '@model/technical.http';
 
 export class ApiManagementCommands extends HttpConnector {
   constructor(requestInfo: RequestInfo) {

--- a/gravitee-apim-cypress/cypress/commands/management/application-management-commands.ts
+++ b/gravitee-apim-cypress/cypress/commands/management/application-management-commands.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Application } from 'model/applications';
-import { User, BasicAuthentication } from 'model/users';
+import { Application } from '@model/applications';
+import { BasicAuthentication } from '@model/users';
 
 export function createApplication(auth: BasicAuthentication, body: Application) {
   return cy.request({

--- a/gravitee-apim-cypress/cypress/commands/management/applications.management.commands.ts
+++ b/gravitee-apim-cypress/cypress/commands/management/applications.management.commands.ts
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ErrorableManagement, RequestInfo } from '../../model/technical';
+import { ErrorableManagement, RequestInfo } from '@model/technical';
 import Chainable = Cypress.Chainable;
 import Response = Cypress.Response;
-import { HttpConnector } from '../../model/technical.http';
-import { Application, ApplicationEntity } from '../../model/applications';
+import { HttpConnector } from '@model/technical.http';
+import { ApplicationEntity } from '@model/applications';
 
 export class ApplicationsManagementCommands extends HttpConnector {
   constructor(requestInfo: RequestInfo) {

--- a/gravitee-apim-cypress/cypress/commands/management/environment-configuration.management.commands.ts
+++ b/gravitee-apim-cypress/cypress/commands/management/environment-configuration.management.commands.ts
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ErrorableManagement, RequestInfo } from '../../model/technical';
+import { ErrorableManagement, RequestInfo } from '@model/technical';
 import Chainable = Cypress.Chainable;
 import Response = Cypress.Response;
-import { HttpConnector } from '../../model/technical.http';
-import { QualityRule } from '../../model/quality-rules';
-import { Group } from '../../model/groups';
-import { ParamMap } from '../common/http.commands';
-import { Member } from '../../model/members';
+import { HttpConnector } from '@model/technical.http';
+import { QualityRule } from '@model/quality-rules';
+import { Group } from '@model/groups';
+import { ParamMap } from '@commands/common/http.commands';
+import { Member } from '@model/members';
 
 export class EnvironmentConfigurationManagementCommands extends HttpConnector {
   constructor(requestInfo: RequestInfo) {

--- a/gravitee-apim-cypress/cypress/commands/management/organization-configuration-management-commands.ts
+++ b/gravitee-apim-cypress/cypress/commands/management/organization-configuration-management-commands.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { BasicAuthentication, ApiUser } from '@model/users';
+import { BasicAuthentication } from '@model/users';
 import { Role } from '@model/roles';
 
 export function createRole(auth: BasicAuthentication, body: Role) {

--- a/gravitee-apim-cypress/cypress/commands/management/portal-settings.management.commands.ts
+++ b/gravitee-apim-cypress/cypress/commands/management/portal-settings.management.commands.ts
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ErrorableManagement, RequestInfo } from '../../model/technical';
+import { ErrorableManagement, RequestInfo } from '@model/technical';
 import Chainable = Cypress.Chainable;
 import Response = Cypress.Response;
-import { HttpConnector } from '../../model/technical.http';
-import { PortalSettings } from '../../model/portal-settings';
+import { HttpConnector } from '@model/technical.http';
+import { PortalSettings } from '@model/portal-settings';
 
 export class PortalSettingsManagementCommands extends HttpConnector {
   constructor(requestInfo: RequestInfo) {

--- a/gravitee-apim-cypress/cypress/commands/management/user.management.commands.ts
+++ b/gravitee-apim-cypress/cypress/commands/management/user.management.commands.ts
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { CollectionResponse, ErrorableManagement, RequestInfo } from '../../model/technical';
-import { HttpConnector } from '../../model/technical.http';
-import { User, Task } from '../../model/users';
+import { CollectionResponse, ErrorableManagement, RequestInfo } from '@model/technical';
+import { HttpConnector } from '@model/technical.http';
+import { User, Task } from '@model/users';
 import Chainable = Cypress.Chainable;
 import Response = Cypress.Response;
 

--- a/gravitee-apim-cypress/cypress/commands/portal.commands.ts
+++ b/gravitee-apim-cypress/cypress/commands/portal.commands.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { RequestInfo, RequestInfoHolder } from '../model/technical';
+import { RequestInfo, RequestInfoHolder } from '@model/technical';
 import { ApiPortalCommands } from './portal/apis.portal.commands';
 
 export class PortalCommands extends RequestInfoHolder {

--- a/gravitee-apim-cypress/cypress/commands/portal/apis.portal.commands.ts
+++ b/gravitee-apim-cypress/cypress/commands/portal/apis.portal.commands.ts
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { CollectionResponse, ErrorablePortal, RequestInfo } from '../../model/technical';
-import { PortalApi } from '../../model/apis';
+import { CollectionResponse, ErrorablePortal, RequestInfo } from '@model/technical';
+import { PortalApi } from '@model/apis';
 import Chainable = Cypress.Chainable;
 import Response = Cypress.Response;
-import { HttpConnector } from '../../model/technical.http';
+import { HttpConnector } from '@model/technical.http';
 
 export class ApiPortalCommands extends HttpConnector {
   constructor(requestInfo: RequestInfo) {

--- a/gravitee-apim-cypress/cypress/fixtures/fakers/api-imports.ts
+++ b/gravitee-apim-cypress/cypress/fixtures/fakers/api-imports.ts
@@ -15,19 +15,11 @@
  */
 import * as faker from 'faker';
 import { ApiImport, ApiImportMember, ApiImportPage, ApiImportPlan, ApiImportProxyGroupLoadBalancerType } from '@model/api-imports';
-import {
-  ApiFlowMode,
-  ApiMember,
-  ApiPageType,
-  ApiPlanSecurityType,
-  ApiPlanStatus,
-  ApiPlanType,
-  ApiPlanValidationType,
-  ApiVisibility,
-} from '@model/apis';
+import { ApiFlowMode, ApiPageType, ApiVisibility } from '@model/apis';
 import { ApiFakers } from './apis';
 import { ApiUser } from '@model/users';
 import { Role } from '@model/roles';
+import { PlanSecurityType, PlanStatus, PlanType, PlanValidation } from '@model/plan';
 
 export class ApiImportFakers {
   static api(attributes?: Partial<ApiImport>): ApiImport {
@@ -119,10 +111,10 @@ export class ApiImportFakers {
     return {
       name,
       description,
-      validation: ApiPlanValidationType.AUTO,
-      security: ApiPlanSecurityType.KEY_LESS,
-      type: ApiPlanType.API,
-      status: ApiPlanStatus.STAGING,
+      validation: PlanValidation.AUTO,
+      security: PlanSecurityType.KEY_LESS,
+      type: PlanType.API,
+      status: PlanStatus.STAGING,
       order: 1,
       characteristics: [],
       paths: {},

--- a/gravitee-apim-cypress/cypress/fixtures/fakers/apis.ts
+++ b/gravitee-apim-cypress/cypress/fixtures/fakers/apis.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import * as faker from 'faker';
-import { Api, ApiDefinition } from 'model/apis';
+import { Api, ApiDefinition } from '@model/apis';
 import { Plan, PlanSecurityType, PlanStatus, PlanValidation } from '@model/plan';
 
 export class ApiFakers {

--- a/gravitee-apim-cypress/cypress/fixtures/fakers/apis.ts
+++ b/gravitee-apim-cypress/cypress/fixtures/fakers/apis.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 import * as faker from 'faker';
-import { Api, ApiDefinition, Plan, PlanSecurityType, PlanStatus, PlanValidation } from 'model/apis';
+import { Api, ApiDefinition } from 'model/apis';
+import { Plan, PlanSecurityType, PlanStatus, PlanValidation } from '@model/plan';
 
 export class ApiFakers {
   static version() {

--- a/gravitee-apim-cypress/cypress/fixtures/fakers/plans.ts
+++ b/gravitee-apim-cypress/cypress/fixtures/fakers/plans.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import * as faker from 'faker';
-import { NewPlanEntity } from 'model/plan';
+import { NewPlanEntity } from '@model/plan';
 
 export class PlanFakers {
   static plan(attributes?: Partial<NewPlanEntity>): NewPlanEntity {

--- a/gravitee-apim-cypress/cypress/fixtures/fakers/plans.ts
+++ b/gravitee-apim-cypress/cypress/fixtures/fakers/plans.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import * as faker from 'faker';
-import { NewPlanEntity, ValidationMode } from 'model/plan';
+import { NewPlanEntity } from 'model/plan';
 
 export class PlanFakers {
   static plan(attributes?: Partial<NewPlanEntity>): NewPlanEntity {

--- a/gravitee-apim-cypress/cypress/fixtures/fakers/users/users.ts
+++ b/gravitee-apim-cypress/cypress/fixtures/fakers/users/users.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { BasicAuthentication } from 'model/users';
+import { BasicAuthentication } from '@model/users';
 
 export const API_PUBLISHER_USER: BasicAuthentication = {
   username: Cypress.env('api_publisher_user_login'),

--- a/gravitee-apim-cypress/cypress/integration/bulk/apis-deploy-all.test.ts
+++ b/gravitee-apim-cypress/cypress/integration/bulk/apis-deploy-all.test.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { API_PUBLISHER_USER } from '../../fakers/users/users';
 import { gio } from '../../commands/gravitee.commands';
+import { API_PUBLISHER_USER } from '../../fixtures/fakers/users/users';
 
 describe('Deploy all apis', () => {
   it('Should deploy all apis', () => {

--- a/gravitee-apim-cypress/cypress/integration/bulk/apis-deploy-all.test.ts
+++ b/gravitee-apim-cypress/cypress/integration/bulk/apis-deploy-all.test.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { gio } from '../../commands/gravitee.commands';
-import { API_PUBLISHER_USER } from '../../fixtures/fakers/users/users';
+import { gio } from '@commands/gravitee.commands';
+import { API_PUBLISHER_USER } from '@fakers/users/users';
 
 describe('Deploy all apis', () => {
   it('Should deploy all apis', () => {

--- a/gravitee-apim-cypress/cypress/integration/bulk/plans.test.ts
+++ b/gravitee-apim-cypress/cypress/integration/bulk/plans.test.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { gio } from '../../commands/gravitee.commands';
-import { API_PUBLISHER_USER } from '../../fixtures/fakers/users/users';
-import { ApiFakers } from '../../fixtures/fakers/apis';
+import { gio } from '@commands/gravitee.commands';
+import { API_PUBLISHER_USER } from '@fakers/users/users';
+import { ApiFakers } from '@fakers/apis';
 
 describe('Bulk plans', () => {
   it('Should create and publish plans', () => {

--- a/gravitee-apim-cypress/cypress/integration/bulk/plans.test.ts
+++ b/gravitee-apim-cypress/cypress/integration/bulk/plans.test.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { API_PUBLISHER_USER } from '../../fakers/users/users';
 import { gio } from '../../commands/gravitee.commands';
-import { ApiFakers } from '../../fakers/apis';
+import { API_PUBLISHER_USER } from '../../fixtures/fakers/users/users';
+import { ApiFakers } from '../../fixtures/fakers/apis';
 
 describe('Bulk plans', () => {
   it('Should create and publish plans', () => {

--- a/gravitee-apim-cypress/cypress/integration/bulk/ratings.test.ts
+++ b/gravitee-apim-cypress/cypress/integration/bulk/ratings.test.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { gio } from '../../commands/gravitee.commands';
-import { PortalSettings } from '../../model/portal-settings';
-import { ManagementError } from '../../model/technical';
-import { ADMIN_USER, API_PUBLISHER_USER } from '../../fixtures/fakers/users/users';
-import { ApiFakers } from '../../fixtures/fakers/apis';
+import { gio } from '@commands/gravitee.commands';
+import { PortalSettings } from '@model/portal-settings';
+import { ManagementError } from '@model/technical';
+import { ADMIN_USER, API_PUBLISHER_USER } from '@fakers/users/users';
+import { ApiFakers } from '@fakers/apis';
 
 describe('Bulk Rate', () => {
   it('Should enable API rating', () => {

--- a/gravitee-apim-cypress/cypress/integration/bulk/subscriptions.test.ts
+++ b/gravitee-apim-cypress/cypress/integration/bulk/subscriptions.test.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { ADMIN_USER, API_PUBLISHER_USER, APPLICATION_USER } from '../../fakers/users/users';
+import { ADMIN_USER, API_PUBLISHER_USER } from '../../fakers/users/users';
 import { gio } from '../../commands/gravitee.commands';
-import { Plan, PlanSecurityType } from '../../model/apis';
 import { fail } from 'assert';
 import { BasicAuthentication } from '../../model/users';
+import { Plan, PlanSecurityType } from '@model/plan';
 
 describe('Create subscriptions', () => {
   it('Should create subscriptions', () => {

--- a/gravitee-apim-cypress/cypress/integration/bulk/subscriptions.test.ts
+++ b/gravitee-apim-cypress/cypress/integration/bulk/subscriptions.test.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { gio } from '../../commands/gravitee.commands';
+import { gio } from '@commands/gravitee.commands';
 import { fail } from 'assert';
-import { BasicAuthentication } from '../../model/users';
+import { BasicAuthentication } from '@model/users';
 import { Plan, PlanSecurityType } from '@model/plan';
-import { ADMIN_USER, API_PUBLISHER_USER } from 'fixtures/fakers/users/users';
+import { ADMIN_USER, API_PUBLISHER_USER } from '@fakers/users/users';
 
 describe('Create subscriptions', () => {
   it('Should create subscriptions', () => {

--- a/gravitee-apim-cypress/cypress/integration/bulk/subscriptions.test.ts
+++ b/gravitee-apim-cypress/cypress/integration/bulk/subscriptions.test.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { ADMIN_USER, API_PUBLISHER_USER } from '../../fakers/users/users';
 import { gio } from '../../commands/gravitee.commands';
 import { fail } from 'assert';
 import { BasicAuthentication } from '../../model/users';
 import { Plan, PlanSecurityType } from '@model/plan';
+import { ADMIN_USER, API_PUBLISHER_USER } from 'fixtures/fakers/users/users';
 
 describe('Create subscriptions', () => {
   it('Should create subscriptions', () => {

--- a/gravitee-apim-cypress/cypress/integration/rest-api/apis/api-flow.ts
+++ b/gravitee-apim-cypress/cypress/integration/rest-api/apis/api-flow.ts
@@ -109,7 +109,7 @@ context('Create an API flow', () => {
       },
       function () {
         cy.request({
-          url: `${Cypress.env('gatewayServer')}${api.context_path}?teststring=${api.id}`,
+          url: `${Cypress.env('gatewayServer')}${api.contextPath}?teststring=${api.id}`,
           retryOnStatusCodeFailure: true,
         }).should((response) => {
           expect(response.body.query_params.teststring).to.be.equal(api.id);

--- a/gravitee-apim-cypress/cypress/integration/rest-api/apis/api-flow.ts
+++ b/gravitee-apim-cypress/cypress/integration/rest-api/apis/api-flow.ts
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ADMIN_USER, API_PUBLISHER_USER, LOW_PERMISSION_USER } from 'fixtures/fakers/users/users';
+import { ADMIN_USER, LOW_PERMISSION_USER } from 'fixtures/fakers/users/users';
 import { ApiFakers } from 'fixtures/fakers/apis';
 import { PlanFakers } from 'fixtures/fakers/plans';
-import { createApi, deleteApi, deployApi, publishApi, startApi, stopApi } from 'commands/management/api-management-commands';
+import { createApi, deleteApi, publishApi, startApi, stopApi } from 'commands/management/api-management-commands';
 import { createPlan, publishPlan, deletePlan } from 'commands/management/api-plan-management-commands';
 import { Api } from 'model/apis';
-import { NewPlanEntity, SecurityType } from 'model/plan';
+import { NewPlanEntity, PlanSecurityType } from 'model/plan';
 
 context('Create an API flow', () => {
   let api: Api;
@@ -47,7 +47,7 @@ context('Create an API flow', () => {
 
   describe('Create a plan', () => {
     it('should create a keyless plan as admin user', function () {
-      const fakePlan = PlanFakers.plan({ security: SecurityType.KEY_LESS });
+      const fakePlan = PlanFakers.plan({ security: PlanSecurityType.KEY_LESS });
       createPlan(ADMIN_USER, api.id, fakePlan).should(function (response) {
         expect(response.status).to.equal(201);
         expect(response.body).to.have.all.keys(

--- a/gravitee-apim-cypress/cypress/integration/rest-api/apis/import-create-tests.ts
+++ b/gravitee-apim-cypress/cypress/integration/rest-api/apis/import-create-tests.ts
@@ -23,20 +23,13 @@ import {
 } from '../../../commands/management/api-management-commands';
 import { getPage, getPages } from '../../../commands/management/api-pages-management-commands';
 import { ApiImportFakers } from '../../../fixtures/fakers/api-imports';
-import {
-  ApiMetadataFormat,
-  ApiPageType,
-  ApiPlanSecurityType,
-  ApiPlanStatus,
-  ApiPlanType,
-  ApiPlanValidationType,
-  ApiPrimaryOwnerType,
-} from '@model/apis';
+import { ApiMetadataFormat, ApiPageType, ApiPrimaryOwnerType } from '@model/apis';
 import { getPlan } from '../../../commands/management/api-plans-management-commands';
 import { GroupFakers } from '../../../fixtures/fakers/groups';
 import { createGroup, deleteGroup, getGroup } from '../../../commands/management/environment-management-commands';
 import { createUser, deleteUser, getCurrentUser } from '../../../commands/management/user-management-commands';
 import { createRole, deleteRole } from 'commands/management/organization-configuration-management-commands';
+import { PlanValidation, PlanStatus, PlanType, PlanSecurityType } from '@model/plan';
 
 context('API - Imports', () => {
   describe('Create API from import', () => {
@@ -275,10 +268,10 @@ context('API - Imports', () => {
             expect(response.body.id).to.eq(planId1);
             expect(response.body.name).to.eq('test plan');
             expect(response.body.description).to.eq('this is a test plan');
-            expect(response.body.validation).to.eq(ApiPlanValidationType.AUTO);
-            expect(response.body.security).to.eq(ApiPlanSecurityType.KEY_LESS);
-            expect(response.body.type).to.eq(ApiPlanType.API);
-            expect(response.body.status).to.eq(ApiPlanStatus.STAGING);
+            expect(response.body.validation).to.eq(PlanValidation.AUTO);
+            expect(response.body.security).to.eq(PlanSecurityType.KEY_LESS);
+            expect(response.body.type).to.eq(PlanType.API);
+            expect(response.body.status).to.eq(PlanStatus.STAGING);
             expect(response.body.order).to.eq(0);
           });
       });
@@ -290,10 +283,10 @@ context('API - Imports', () => {
             expect(response.body.id).to.eq(planId2);
             expect(response.body.name).to.eq('test plan');
             expect(response.body.description).to.eq('this is a test plan');
-            expect(response.body.validation).to.eq(ApiPlanValidationType.AUTO);
-            expect(response.body.security).to.eq(ApiPlanSecurityType.KEY_LESS);
-            expect(response.body.type).to.eq(ApiPlanType.API);
-            expect(response.body.status).to.eq(ApiPlanStatus.STAGING);
+            expect(response.body.validation).to.eq(PlanValidation.AUTO);
+            expect(response.body.security).to.eq(PlanSecurityType.KEY_LESS);
+            expect(response.body.type).to.eq(PlanType.API);
+            expect(response.body.status).to.eq(PlanStatus.STAGING);
             expect(response.body.order).to.eq(0);
           });
       });

--- a/gravitee-apim-cypress/cypress/integration/rest-api/apis/import-create-tests.ts
+++ b/gravitee-apim-cypress/cypress/integration/rest-api/apis/import-create-tests.ts
@@ -13,23 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ADMIN_USER, LOW_PERMISSION_USER } from '../../../fixtures/fakers/users/users';
-import {
-  deleteApi,
-  getApiById,
-  getApiMembers,
-  getApiMetadata,
-  importCreateApi,
-} from '../../../commands/management/api-management-commands';
-import { getPage, getPages } from '../../../commands/management/api-pages-management-commands';
-import { ApiImportFakers } from '../../../fixtures/fakers/api-imports';
+
+import { PlanSecurityType, PlanStatus, PlanType, PlanValidation } from '@model/plan';
+import { ApiImportFakers } from '@fakers/api-imports';
+import { ADMIN_USER, LOW_PERMISSION_USER } from '@fakers/users/users';
+import { getApiById, importCreateApi, deleteApi, getApiMetadata, getApiMembers } from '@commands/management/api-management-commands';
+import { getPages, getPage } from '@commands/management/api-pages-management-commands';
+import { getPlan } from '@commands/management/api-plans-management-commands';
 import { ApiMetadataFormat, ApiPageType, ApiPrimaryOwnerType } from '@model/apis';
-import { getPlan } from '../../../commands/management/api-plans-management-commands';
-import { GroupFakers } from '../../../fixtures/fakers/groups';
-import { createGroup, deleteGroup, getGroup } from '../../../commands/management/environment-management-commands';
-import { createUser, deleteUser, getCurrentUser } from '../../../commands/management/user-management-commands';
-import { createRole, deleteRole } from 'commands/management/organization-configuration-management-commands';
-import { PlanValidation, PlanStatus, PlanType, PlanSecurityType } from '@model/plan';
+import { GroupFakers } from '@fakers/groups';
+import { createGroup, deleteGroup, getGroup } from '@commands/management/environment-management-commands';
+import { createUser, deleteUser, getCurrentUser } from '@commands/management/user-management-commands';
+import { createRole, deleteRole } from '@commands/management/organization-configuration-management-commands';
+import { ApiImport } from '@model/api-imports';
 
 context('API - Imports', () => {
   describe('Create API from import', () => {
@@ -337,7 +333,8 @@ context('API - Imports', () => {
     describe('Create API with metadata having key that does not yet exist', () => {
       const apiId = 'bc1287cb-b732-4ba1-b609-1e34d375b585';
 
-      const fakeApi = ApiImportFakers.api({
+      let fakeApi: ApiImport;
+      fakeApi = ApiImportFakers.api({
         id: apiId,
         metadata: [
           {

--- a/gravitee-apim-cypress/cypress/integration/rest-api/apis/import-update-tests.ts
+++ b/gravitee-apim-cypress/cypress/integration/rest-api/apis/import-update-tests.ts
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ADMIN_USER } from '../../../fixtures/fakers/users/users';
+
+import { PlanStatus, PlanValidation, PlanSecurityType, PlanType } from '@model/plan';
+import { ApiImportFakers } from '@fakers/api-imports';
 import {
   deleteApi,
   exportApi,
@@ -22,16 +24,15 @@ import {
   getApiMetadata,
   importCreateApi,
   importUpdateApi,
-} from '../../../commands/management/api-management-commands';
-import { getPage, getPages } from '../../../commands/management/api-pages-management-commands';
-import { ApiImportFakers } from '../../../fixtures/fakers/api-imports';
+} from '@commands/management/api-management-commands';
+import { ADMIN_USER } from '@fakers/users/users';
 import { ApiMetadataFormat, ApiPageType, ApiPrimaryOwnerType, ApiVisibility } from '@model/apis';
-import { getPlans } from '../../../commands/management/api-plans-management-commands';
-import { GroupFakers } from '../../../fixtures/fakers/groups';
-import { createGroup, deleteGroup, getGroup } from '../../../commands/management/environment-management-commands';
-import { createUser, deleteUser } from '../../../commands/management/user-management-commands';
-import { createRole, deleteRole } from '../../../commands/management/organization-configuration-management-commands';
-import { PlanStatus, PlanValidation, PlanSecurityType, PlanType } from '@model/plan';
+import { getPage, getPages } from '@commands/management/api-pages-management-commands';
+import { createUser, deleteUser } from '@commands/management/user-management-commands';
+import { createRole, deleteRole } from '@commands/management/organization-configuration-management-commands';
+import { getPlans } from '@commands/management/api-plans-management-commands';
+import { GroupFakers } from '@fakers/groups';
+import { createGroup, deleteGroup, getGroup } from '@commands/management/environment-management-commands';
 
 context('API - Imports - Update', () => {
   describe('Update API from import', () => {
@@ -477,7 +478,7 @@ context('API - Imports - Update', () => {
         cy.wrap(apiUpdate)
           .its('pages')
           .should('have.length', 2)
-          .should('satisfy',  pages => pages.some(({ type }) => type === ApiPageType.SYSTEM_FOLDER));
+          .should('satisfy', (pages) => pages.some(({ type }) => type === ApiPageType.SYSTEM_FOLDER));
       });
 
       it('should reject the import if trying to add a new system folder', () => {

--- a/gravitee-apim-cypress/cypress/integration/rest-api/apis/import-update-tests.ts
+++ b/gravitee-apim-cypress/cypress/integration/rest-api/apis/import-update-tests.ts
@@ -25,21 +25,13 @@ import {
 } from '../../../commands/management/api-management-commands';
 import { getPage, getPages } from '../../../commands/management/api-pages-management-commands';
 import { ApiImportFakers } from '../../../fixtures/fakers/api-imports';
-import {
-  ApiMetadataFormat,
-  ApiPageType,
-  ApiPlanSecurityType,
-  ApiPlanStatus,
-  ApiPlanType,
-  ApiPlanValidationType,
-  ApiPrimaryOwnerType,
-  ApiVisibility,
-} from '@model/apis';
+import { ApiMetadataFormat, ApiPageType, ApiPrimaryOwnerType, ApiVisibility } from '@model/apis';
 import { getPlans } from '../../../commands/management/api-plans-management-commands';
 import { GroupFakers } from '../../../fixtures/fakers/groups';
 import { createGroup, deleteGroup, getGroup } from '../../../commands/management/environment-management-commands';
 import { createUser, deleteUser } from '../../../commands/management/user-management-commands';
 import { createRole, deleteRole } from '../../../commands/management/organization-configuration-management-commands';
+import { PlanStatus, PlanValidation, PlanSecurityType, PlanType } from '@model/plan';
 
 context('API - Imports - Update', () => {
   describe('Update API from import', () => {
@@ -706,21 +698,21 @@ context('API - Imports - Update', () => {
       });
 
       it('should get 2 plans created on API', () => {
-        getPlans(ADMIN_USER, apiId, ApiPlanStatus.STAGING)
+        getPlans(ADMIN_USER, apiId, PlanStatus.STAGING)
           .ok()
           .should((response) => {
             expect(response.body).to.have.length(2);
             expect(response.body[0].description).to.eq('this is a test plan');
-            expect(response.body[0].validation).to.eq(ApiPlanValidationType.AUTO);
-            expect(response.body[0].security).to.eq(ApiPlanSecurityType.KEY_LESS);
-            expect(response.body[0].type).to.eq(ApiPlanType.API);
-            expect(response.body[0].status).to.eq(ApiPlanStatus.STAGING);
+            expect(response.body[0].validation).to.eq(PlanValidation.AUTO);
+            expect(response.body[0].security).to.eq(PlanSecurityType.KEY_LESS);
+            expect(response.body[0].type).to.eq(PlanType.API);
+            expect(response.body[0].status).to.eq(PlanStatus.STAGING);
             expect(response.body[0].order).to.eq(0);
             expect(response.body[1].description).to.eq('this is a test plan');
-            expect(response.body[1].validation).to.eq(ApiPlanValidationType.AUTO);
-            expect(response.body[1].security).to.eq(ApiPlanSecurityType.KEY_LESS);
-            expect(response.body[1].type).to.eq(ApiPlanType.API);
-            expect(response.body[1].status).to.eq(ApiPlanStatus.STAGING);
+            expect(response.body[1].validation).to.eq(PlanValidation.AUTO);
+            expect(response.body[1].security).to.eq(PlanSecurityType.KEY_LESS);
+            expect(response.body[1].type).to.eq(PlanType.API);
+            expect(response.body[1].status).to.eq(PlanStatus.STAGING);
             expect(response.body[1].order).to.eq(0);
           });
       });
@@ -736,13 +728,13 @@ context('API - Imports - Update', () => {
         id: '08a92f8c-e133-42ec-a92f-8ce139999999',
         name: 'test plan 1',
         description: 'this is a test plan',
-        status: ApiPlanStatus.CLOSED,
+        status: PlanStatus.CLOSED,
       });
       const fakePlan2 = ApiImportFakers.plan({
         id: '08a92f8c-e133-42ec-a92f-8ce138888888',
         name: 'test plan 2',
         description: 'this is a test plan',
-        status: ApiPlanStatus.CLOSED,
+        status: PlanStatus.CLOSED,
       });
       const fakeApi = ApiImportFakers.api({ id: apiId });
 
@@ -758,7 +750,7 @@ context('API - Imports - Update', () => {
       });
 
       it('should get 2 plans created on API, with specified status', () => {
-        getPlans(ADMIN_USER, apiId, ApiPlanStatus.CLOSED)
+        getPlans(ADMIN_USER, apiId, PlanStatus.CLOSED)
           .ok()
           .should((response) => {
             expect(response.body).to.have.length(2);
@@ -788,7 +780,7 @@ context('API - Imports - Update', () => {
       });
 
       it('should get the API plan, which has been updated', () => {
-        getPlans(ADMIN_USER, apiId, ApiPlanStatus.STAGING)
+        getPlans(ADMIN_USER, apiId, PlanStatus.STAGING)
           .ok()
           .should((response) => {
             expect(response.body).to.have.length(1);
@@ -821,7 +813,7 @@ context('API - Imports - Update', () => {
       });
 
       it('should get the API plan, containing only the plan that was in the update', () => {
-        getPlans(ADMIN_USER, apiId, ApiPlanStatus.STAGING)
+        getPlans(ADMIN_USER, apiId, PlanStatus.STAGING)
           .ok()
           .should((response) => {
             expect(response.body).to.have.length(1);

--- a/gravitee-apim-cypress/cypress/integration/rest-api/apis/plan-tests.ts
+++ b/gravitee-apim-cypress/cypress/integration/rest-api/apis/plan-tests.ts
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ADMIN_USER, API_PUBLISHER_USER, LOW_PERMISSION_USER } from 'fixtures/fakers/users/users';
+import { ADMIN_USER } from 'fixtures/fakers/users/users';
 import { ApiFakers } from 'fixtures/fakers/apis';
 import { PlanFakers } from 'fixtures/fakers/plans';
-import { createApi, deleteApi, stopApi } from 'commands/management/api-management-commands';
+import { createApi, deleteApi } from 'commands/management/api-management-commands';
 import { createPlan, deletePlan, publishPlan } from 'commands/management/api-plan-management-commands';
-import { SecurityType, NewPlanEntity } from '@model/plan';
+import { PlanSecurityType } from '@model/plan';
 
 context('Plan tests', () => {
   describe('Create a Plan', function () {
@@ -33,7 +33,7 @@ context('Plan tests', () => {
     });
 
     it('should create a keyless plan as admin user', function () {
-      const fakePlan = PlanFakers.plan({ security: SecurityType.KEY_LESS });
+      const fakePlan = PlanFakers.plan({ security: PlanSecurityType.KEY_LESS });
       createPlan(ADMIN_USER, this.apiId, fakePlan).should(function (response) {
         expect(response.status).to.equal(201);
         expect(response.body).to.have.all.keys(

--- a/gravitee-apim-cypress/cypress/model/api-imports.ts
+++ b/gravitee-apim-cypress/cypress/model/api-imports.ts
@@ -13,18 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  ApiFlowMode,
-  ApiVisibility,
-  ApiPageType,
-  ApiPlanValidationType,
-  ApiPlanSecurityType,
-  ApiPlanType,
-  ApiPlanStatus,
-  ApiFlowOperator,
-  ApiMetadataFormat,
-  ApiPrimaryOwnerType,
-} from '@model/apis';
+import { ApiFlowMode, ApiVisibility, ApiPageType, ApiFlowOperator, ApiMetadataFormat, ApiPrimaryOwnerType } from '@model/apis';
+import { PlanSecurityType, PlanStatus, PlanType, PlanValidation } from '@model/plan';
 
 export interface ApiImportMember {
   source: string;
@@ -51,10 +41,10 @@ export interface ApiImportPlan {
   id?: string;
   name: string;
   description: string;
-  validation: ApiPlanValidationType;
-  security: ApiPlanSecurityType;
-  type: ApiPlanType;
-  status: ApiPlanStatus;
+  validation: PlanValidation;
+  security: PlanSecurityType;
+  type: PlanType;
+  status: PlanStatus;
   order: number;
   characteristics: any[];
   created_at?: number;

--- a/gravitee-apim-cypress/cypress/model/apis.ts
+++ b/gravitee-apim-cypress/cypress/model/apis.ts
@@ -67,30 +67,6 @@ export interface PortalApi {
   categories: string[];
 }
 
-export enum ApiPlanType {
-  API = 'API',
-  CATALOG = 'CATALOG',
-}
-
-export enum ApiPlanSecurityType {
-  KEY_LESS = 'KEY_LESS',
-  API_KEY = 'API_KEY',
-  OAUTH2 = 'OAUTH2',
-  JWT = 'JWT',
-}
-
-export enum ApiPlanValidationType {
-  AUTO = 'AUTO',
-  MANUAL = 'MANUAL',
-}
-
-export enum ApiPlanStatus {
-  STAGING = 'STAGING',
-  PUBLISHED = 'PUBLISHED',
-  CLOSED = 'CLOSED',
-  DEPRECATED = 'DEPRECATED',
-}
-
 export enum ApiErrorCodes {
   API_NOT_FOUND = 'errors.api.notFound',
 }
@@ -182,36 +158,6 @@ export interface ApiRatingResponse {
 
 export interface ApiDeployment {
   deploymentLabel: string;
-}
-
-export interface Plan {
-  id?: string;
-  name: string;
-  description: string;
-  securityDefinition: PlanSecurityType;
-  validation?: PlanValidation;
-  created_at?: number;
-  updated_at?: number;
-  status?: PlanStatus;
-}
-
-export enum PlanValidation {
-  AUTO = 'AUTO',
-  MANUAL = 'MANUAL',
-}
-
-export enum PlanSecurityType {
-  KEY_LES = 'KEY_LESS',
-  API_KEY = 'API_KEY',
-  OAUTH2 = 'OAUTH2',
-  JWT = 'JWT',
-}
-
-export enum PlanStatus {
-  STAGING = 'STAGING',
-  PUBLISHED = 'PUBLISHED',
-  CLOSED = 'CLOSED',
-  DEPRECATED = 'DEPRECATED',
 }
 
 export interface Subscription {}

--- a/gravitee-apim-cypress/cypress/model/plan.ts
+++ b/gravitee-apim-cypress/cypress/model/plan.ts
@@ -28,28 +28,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export enum ValidationMode {
-  AUTO = 'AUTO',
-  MANUAL = 'MANUAL',
-}
-
-export enum SecurityType {
-  KEY_LESS = 'KEY_LESS',
-  API_KEY = 'API_KEY',
-  OAUTH2 = 'OAUTH2',
-  JWT = 'JWT',
-}
 
 export enum PlanType {
   API = 'API',
   CATALOG = 'CATALOG',
-}
-
-export enum StatusState {
-  STAGING = 'STAGING',
-  PUBLISHED = 'PUBLISHED',
-  CLOSED = 'CLOSED',
-  DEPRECATED = 'DEPRECATED',
 }
 
 export enum MethodType {
@@ -107,11 +89,11 @@ export interface NewPlanEntity {
   id: string;
   name: string;
   description: string;
-  validation: ValidationMode;
-  security: SecurityType;
+  validation: PlanValidation;
+  security: PlanSecurityType;
   securityDefinition: string;
   type: PlanType;
-  status: StatusState;
+  status: PlanStatus;
   api: string;
   characteristics: string[];
   tags: string[];
@@ -123,4 +105,34 @@ export interface NewPlanEntity {
   comment_message: string;
   selection_rule: string;
   general_conditions: string;
+}
+
+export interface Plan {
+  id?: string;
+  name: string;
+  description: string;
+  securityDefinition: PlanSecurityType;
+  validation?: PlanValidation;
+  created_at?: number;
+  updated_at?: number;
+  status?: PlanStatus;
+}
+
+export enum PlanValidation {
+  AUTO = 'AUTO',
+  MANUAL = 'MANUAL',
+}
+
+export enum PlanSecurityType {
+  KEY_LESS = 'KEY_LESS',
+  API_KEY = 'API_KEY',
+  OAUTH2 = 'OAUTH2',
+  JWT = 'JWT',
+}
+
+export enum PlanStatus {
+  STAGING = 'STAGING',
+  PUBLISHED = 'PUBLISHED',
+  CLOSED = 'CLOSED',
+  DEPRECATED = 'DEPRECATED',
 }

--- a/gravitee-apim-cypress/tsconfig.json
+++ b/gravitee-apim-cypress/tsconfig.json
@@ -5,8 +5,9 @@
     "types": ["cypress", "node"],
     "baseUrl": "./cypress",
     "paths": {
-      "@fakers/*": ["fakers/*"],
-      "@model/*": ["model/*"]
+      "@fakers/*": ["fixtures/fakers/*"],
+      "@model/*": ["model/*"],
+      "@commands/*": ["commands/*"]
     }
   },
   "include": ["**/*.ts"]


### PR DESCRIPTION
This PR concerns cypress tests and contains :
- a refactoring of plans models, avoiding duplicate models
- a fix of some import paths and variables
- a fix of typescript import paths, and rearrangement of imports
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-synwuuwtke.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/test-cypressimprovments/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
