### PR TITLE
feat: bump elasticsearch version to 3.5.6 adds openSearch support

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -97,9 +97,9 @@
         <gravitee-fetcher-github.version>1.5.0</gravitee-fetcher-github.version>
         <gravitee-fetcher-gitlab.version>1.10.0</gravitee-fetcher-gitlab.version>
         <gravitee-fetcher-http.version>1.11.0</gravitee-fetcher-http.version>
-        <gravitee-repository-elasticsearch.version>3.5.5</gravitee-repository-elasticsearch.version>
+        <gravitee-repository-elasticsearch.version>3.5.6-SNAPSHOT</gravitee-repository-elasticsearch.version>
         <!-- Gateway Only -->
-        <gravitee-reporter-elasticsearch.version>3.5.5</gravitee-reporter-elasticsearch.version>
+        <gravitee-reporter-elasticsearch.version>3.5.6-SNAPSHOT</gravitee-reporter-elasticsearch.version>
         <gravitee-reporter-file.version>2.0.5</gravitee-reporter-file.version>
         <gravitee-reporter-tcp.version>1.1.3</gravitee-reporter-tcp.version>
         <!--	Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit	-->


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6889

This backports https://github.com/gravitee-io/issues/issues/6423 to 3.5