### PR TITLE
fix: clean docker file dev

### DIFF
--- a/gravitee-apim-rest-api/docker/Dockerfile-dev
+++ b/gravitee-apim-rest-api/docker/Dockerfile-dev
@@ -58,31 +58,3 @@ ENTRYPOINT ["./bin/gravitee"]
 VOLUME ${GRAVITEEIO_HOME}/logs
 HEALTHCHECK --interval=5s --timeout=3s --retries=6 --start-period=30s \
             CMD curl --user admin:adminadmin --fail http://localhost:18083/_node/health || exit 1
-
-
-
-
-FROM eclipse-temurin:11-jre-focal
-LABEL maintainer="contact@graviteesource.com"
-
-ARG GRAVITEEIO_VERSION=0
-ENV GRAVITEEIO_HOME /opt/graviteeio-management-api
-
-ADD ./gravitee-apim-rest-api-distribution-${GRAVITEEIO_VERSION}.tar.gz /tmp/
-
-RUN apt-get update \
-    && apt-get --yes upgrade \
-    && apt-get --yes install htop \
-    && mv /tmp/gravitee-apim-rest-api-distribution-${GRAVITEEIO_VERSION} ${GRAVITEEIO_HOME} \
-    && rm -rf /tmp/* \
-    && rm -rf /var/lib/apt/lists/* \
-	&& chgrp -R 0 ${GRAVITEEIO_HOME} \
-    && chmod -R g=u ${GRAVITEEIO_HOME}
-
-WORKDIR ${GRAVITEEIO_HOME}
-EXPOSE 8083
-ENTRYPOINT ["./bin/gravitee"]
-VOLUME ${GRAVITEEIO_HOME}/logs
-CMD ["./bin/gravitee"]
-HEALTHCHECK --interval=5s --timeout=3s --retries=6 --start-period=30s \
-            CMD curl --user admin:adminadmin --fail http://localhost:18083/_node/health || exit 1


### PR DESCRIPTION
**Description**

When the performance branch has been merged, a bad modification on the rest-api dockerfile-dev file was added. Actually, the former definition of the dockerfile remained at the end of the file. Copy/paste issue I guess
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-roouspdyvu.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/clean-dockerfile-dev/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
