### PR TITLE
change wording of the banner management

### DIFF
--- a/gravitee-apim-console-webui/docs/management-configuration-apiportalheader.md
+++ b/gravitee-apim-console-webui/docs/management-configuration-apiportalheader.md
@@ -18,6 +18,6 @@ My hard coded name | `My hard coded value`
 
 You are able to combine API attributes, metadata and strings.
 
-Additionally, the `API List Page` section allows you to decide
+Additionally, the `API Page list options` section allows you to decide
 whether the top ranked API for the given environment should be emphasised
 at the top of the list.

--- a/gravitee-apim-console-webui/src/management/configuration/api-portal-header/api-portal-header.html
+++ b/gravitee-apim-console-webui/src/management/configuration/api-portal-header/api-portal-header.html
@@ -79,15 +79,15 @@
         </table>
       </md-table-container>
 
-      <h3>API List Page</h3>
+      <h3>API Page list options</h3>
       <md-input-container class="gv-input-container-dense">
         <md-checkbox
           ng-model="$ctrl.settings.portal.apis.promotedApiMode.enabled"
-          aria-label="Show Promoted API"
+          aria-label="Display promotion banner"
           ng-disabled="$ctrl.isReadonlySetting('portal.apis.promotedApiMode.enabled')"
           ng-change="$ctrl.savePromotedApiMode()"
         >
-          Show promoted API banner
+          Display promotion banner
           <md-tooltip ng-if="$ctrl.isReadonlySetting('portal.apis.promotedApiMode.enabled')"
             >{{$ctrl.providedConfigurationMessage}}</md-tooltip
           >


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6897

**Description**

Change wording of the banner management:

Before:
![Capture d’écran 2022-01-11 à 22 07 49](https://user-images.githubusercontent.com/13161768/149021714-9aef1405-6ba9-484c-abe2-70c1e6a0cac3.png)

After:
![Capture d’écran 2022-01-11 à 22 09 39](https://user-images.githubusercontent.com/13161768/149021880-06211c3e-4bc4-43ea-8e60-5e3f26777cc1.png)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fnnpyvelqp.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6897-console-wording/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
