### PR TITLE
fix: use appropriate logger name in resource manager

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/legacy/LegacyPolicyManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/legacy/LegacyPolicyManager.java
@@ -49,7 +49,7 @@ import org.springframework.util.ClassUtils;
  */
 public abstract class LegacyPolicyManager extends AbstractLifecycleComponent<PolicyManager> implements PolicyManager {
 
-    private final Logger logger = LoggerFactory.getLogger(DefaultPolicyManager.class);
+    protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     protected final PolicyFactory policyFactory;
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-resource/src/main/java/io/gravitee/gateway/resource/internal/ResourceManagerImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-resource/src/main/java/io/gravitee/gateway/resource/internal/ResourceManagerImpl.java
@@ -42,7 +42,6 @@ import org.springframework.util.ClassUtils;
  */
 public class ResourceManagerImpl extends LegacyResourceManagerImpl {
 
-    private final Logger logger = LoggerFactory.getLogger(ResourceManagerImpl.class);
     private final boolean legacyMode;
     private final DefaultClassLoader classLoader;
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-resource/src/main/java/io/gravitee/gateway/resource/internal/legacy/LegacyResourceManagerImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-resource/src/main/java/io/gravitee/gateway/resource/internal/legacy/LegacyResourceManagerImpl.java
@@ -41,7 +41,7 @@ import org.springframework.util.ClassUtils;
  */
 public class LegacyResourceManagerImpl extends AbstractLifecycleComponent<ResourceManager> implements ResourceLifecycleManager {
 
-    private final Logger logger = LoggerFactory.getLogger(LegacyResourceManagerImpl.class);
+    protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     protected final Map<String, io.gravitee.resource.api.Resource> resources = new HashMap<>();
     private final Map<String, PluginClassLoader> classloaders = new HashMap<>();


### PR DESCRIPTION


**Issue**

https://github.com/gravitee-io/issues/issues/6907

**Description**

Closes gravitee-io/issues#6907

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-spmqkvmtwr.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-6907-incorrect-logger-name/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
