### PR TITLE
fix: allow publishers to access API creation

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation/newApiPortal.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/newApiPortal.controller.ts
@@ -51,7 +51,7 @@ class NewApiController {
   }
 
   $onInit() {
-    this.ConsoleSettingsService.get().then(({ data }) => {
+    this.ConsoleSettingsService.getConsole().then(({ data }) => {
       this.consoleSettings = data;
     });
   }

--- a/gravitee-apim-console-webui/src/management/management.run.ts
+++ b/gravitee-apim-console-webui/src/management/management.run.ts
@@ -51,7 +51,7 @@ function runBlock(
         return;
       }
 
-      const settings = await ConsoleSettingsService.get();
+      const settings = await ConsoleSettingsService.getConsole();
       const hasPathBasedApiCreation = settings?.data?.management?.pathBasedApiCreation?.enabled;
       if (!hasPathBasedApiCreation) {
         return trans.router.stateService.target('management.apis.new');

--- a/gravitee-apim-console-webui/src/services/consoleSettings.service.ts
+++ b/gravitee-apim-console-webui/src/services/consoleSettings.service.ts
@@ -27,6 +27,10 @@ class ConsoleSettingsService {
     return this.$http.get(`${this.Constants.org.baseURL}/settings/`);
   }
 
+  getConsole() {
+    return this.$http.get(`${this.Constants.org.baseURL}/console`);
+  }
+
   isReadonly(settings: any, property: string): boolean {
     if (settings && settings.metadata && settings.metadata.readonly) {
       return settings.metadata.readonly.some((key) => key === property);


### PR DESCRIPTION
Because they cannot read organisation settings and this resource is
needed to check if Path based creation is enabled or not, API publisher
could not create an API from the UI anymore.

see https://github.com/gravitee-io/issues/issues/6902



<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hvqyccmfbr.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6902-fix-api-creation/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
