### PR TITLE
Fix release process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,9 +91,9 @@ commands:
                       rm -fr gravitee-apim-console-webui/node_modules/
                       rm -fr gravitee-apim-portal-webui/node_modules/
 
-                      tar -cjf ${CIRCLE_PROJECT_REPONAME}.tar.bz2 .
+                      tar -cjf /tmp/${CIRCLE_PROJECT_REPONAME}.tar.bz2 .
             - persist_to_workspace:
-                  root: .
+                  root: /tmp
                   paths:
                       - ./*.tar.bz2
 
@@ -876,7 +876,7 @@ jobs:
                       - aws-cli/setup
                       - run:
                             command: |
-                                aws s3 cp .${CIRCLE_PROJECT_REPONAME}.tar.bz2 s3://${S3_BUCKET_NAME}/${CIRCLE_PROJECT_REPONAME}/project/ \
+                                aws s3 cp ${CIRCLE_PROJECT_REPONAME}.tar.bz2 s3://${S3_BUCKET_NAME}/${CIRCLE_PROJECT_REPONAME}/project/ \
                                 --endpoint-url https://cellar-c2.services.clever-cloud.com \
                                 --acl public-read
                             name: S3 Copy ${CIRCLE_PROJECT_REPONAME}.tar.bz2 -> s3://${S3_BUCKET_NAME}/${CIRCLE_PROJECT_REPONAME}/project/


### PR DESCRIPTION
**Issue**

NA

**Description**

Create bz2 archive in `tmp` folder instead of inside itself (which leads to errors).
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pzejslqmfw.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-release/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
