### PR TITLE
test(cypress): improve gateway request retries

### DIFF
--- a/gravitee-apim-cypress/cypress/integration/rest-api/apis/mock-policy-tests.ts
+++ b/gravitee-apim-cypress/cypress/integration/rest-api/apis/mock-policy-tests.ts
@@ -31,6 +31,7 @@ import { Api, ResponseTemplate } from 'model/apis';
 import { NewPlanEntity, PlanSecurityType } from 'model/plan';
 import { ApiImportFakers } from 'fixtures/fakers/api-imports';
 import { ApiImport } from '@model/api-imports';
+import { requestGateway } from 'support/common/http.commands';
 
 context('Create a mock policy on a API v1 (path based)', () => {
   let createdApi: Api;
@@ -70,16 +71,13 @@ context('Create a mock policy on a API v1 (path based)', () => {
     });
   });
 
-  it('should successfully call the mocked API endpoint (v1 API)', function () {
-    cy.retryRequest(`${Cypress.env('gatewayServer')}${createdApi.context_path}`, {
-      retries: 15,
-      function: function (response) {
-        if (response.status !== 200) {
-          throw new Error(`still wrong status`);
-        }
+  it('should successfully call the mocked API endpoint', function () {
+    requestGateway(
+      {
+        method: 'GET',
+        url: `${Cypress.env('gatewayServer')}${createdApi.context_path}`,
       },
-      timeout: 1000,
-    }).should((response: Cypress.Response<any>) => {
+    ).should((response: Cypress.Response<any>) => {
       expect(response.headers['test-value']).to.equal('value123');
       expect(response.body.message).to.equal('This is a mocked response');
     });
@@ -117,19 +115,14 @@ context('Create a mock policy (API v2)', () => {
   });
 
   it('should successfully call the mocked API endpoint', () => {
-    cy.retryRequest(`${Cypress.env('gatewayServer')}${createdApi.context_path}`, {
-      retries: 15,
-      function: function (response) {
-        if (response.status !== 200) {
-          throw new Error(`still wrong status`);
-        }
+    requestGateway(
+      {
+        method: 'GET',
+        url: `${Cypress.env('gatewayServer')}${createdApi.context_path}`,
       },
-      timeout: 1000,
-    })
-      .ok()
-      .should((response: Cypress.Response<any>) => {
-        expect(response.body.message).to.equal('this is a mock response');
-      });
+    ).should((response: Cypress.Response<any>) => {
+      expect(response.body.message).to.equal('this is a mock response');
+    });
   });
 
   after(() => {

--- a/gravitee-apim-cypress/cypress/model/plan.ts
+++ b/gravitee-apim-cypress/cypress/model/plan.ts
@@ -1,12 +1,12 @@
 /*
  * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *         http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
This simplifies the way of requesting gateway from cypress tests.

The `requestGateway` retries calls to gateway with delay, until the "validWhen" condition is met.
By default, this condition is the HTTP 200 OK gateway response, as in most cases, consumer wants to ensure his API has been deployed.
But it can be override by caller if needed.

Delays and maximum wait time can also be override by caller if needed.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lzkkjoqkev.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/test-improvegatewayrequestsretry/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
