### PR TITLE
feat: bump elasticsearch version to 3.8.3 adds openSearch support

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -101,9 +101,9 @@
         <gravitee-fetcher-github.version>1.6.0</gravitee-fetcher-github.version>
         <gravitee-fetcher-gitlab.version>1.11.0</gravitee-fetcher-gitlab.version>
         <gravitee-fetcher-http.version>1.12.0</gravitee-fetcher-http.version>
-        <gravitee-repository-elasticsearch.version>3.8.2</gravitee-repository-elasticsearch.version>
+        <gravitee-repository-elasticsearch.version>3.8.3-SNAPSHOT</gravitee-repository-elasticsearch.version>
         <!-- Gateway Only -->
-        <gravitee-reporter-elasticsearch.version>3.8.2</gravitee-reporter-elasticsearch.version>
+        <gravitee-reporter-elasticsearch.version>3.8.3-SNAPSHOT</gravitee-reporter-elasticsearch.version>
         <gravitee-reporter-file.version>2.4.3</gravitee-reporter-file.version>
         <gravitee-reporter-tcp.version>1.3.3</gravitee-reporter-tcp.version>
         <!--	Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit	-->


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6890

This backports https://github.com/gravitee-io/issues/issues/6423 to 3.10
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/feat-opensearchsupport-on-3-10/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
