### PR TITLE
ci: bump gravitee-elasticsearch version

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -103,9 +103,9 @@
         <gravitee-fetcher-github.version>1.6.0</gravitee-fetcher-github.version>
         <gravitee-fetcher-gitlab.version>1.11.0</gravitee-fetcher-gitlab.version>
         <gravitee-fetcher-http.version>1.12.0</gravitee-fetcher-http.version>
-        <gravitee-repository-elasticsearch.version>3.10.0-SNAPSHOT</gravitee-repository-elasticsearch.version>
+        <gravitee-repository-elasticsearch.version>3.11.0-SNAPSHOT</gravitee-repository-elasticsearch.version>
         <!-- Gateway Only -->
-        <gravitee-reporter-elasticsearch.version>3.10.0-SNAPSHOT</gravitee-reporter-elasticsearch.version>
+        <gravitee-reporter-elasticsearch.version>3.11.0-SNAPSHOT</gravitee-reporter-elasticsearch.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->
         <!--    <gravitee-gateway-services-ratelimit.version>1.13.0</gravitee-gateway-services-ratelimit.version>    -->
         <gravitee-reporter-file.version>2.5.0-SNAPSHOT</gravitee-reporter-file.version>


### PR DESCRIPTION
**Issue**

Gravitee-elasticsearch plugin is not the correct version in the docker images we build for azure environment

**Description**

bump gravitee-elasticsearch to 3.11.0-SNAPSHOT
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uadtnxjbix.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/bump-elastic-plugin-in-distribution/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
