### PR TITLE
fix: add a search mode for search latest events

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/AbstractSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/AbstractSynchronizer.java
@@ -64,7 +64,7 @@ public abstract class AbstractSynchronizer extends AbstractService<AbstractSynch
      */
     public abstract void synchronize(long lastRefreshAt, long nextLastRefreshAt);
 
-    protected Flowable<Event> searchLatestEvents(int bulkSize, Long from, Long to, Event.EventProperties group, EventType... eventTypes) {
+    protected Flowable<Event> searchLatestEvents(int bulkSize, Long from, Long to, boolean strictMode, Event.EventProperties group, EventType... eventTypes) {
 
         return Flowable.create(emitter -> {
             try {
@@ -72,7 +72,9 @@ public abstract class AbstractSynchronizer extends AbstractService<AbstractSynch
                 EventCriteria criteria = new EventCriteria.Builder()
                         .types(eventTypes)
                         .from(from == null ? 0 : from - TIMEFRAME_BEFORE_DELAY)
-                        .to(to == null ? 0 : to + TIMEFRAME_AFTER_DELAY).build();
+                        .to(to == null ? 0 : to + TIMEFRAME_AFTER_DELAY)
+                        .strictMode(strictMode)
+                        .build();
 
                 List<Event> events;
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/ApiSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/ApiSynchronizer.java
@@ -77,7 +77,7 @@ public class ApiSynchronizer extends AbstractSynchronizer {
         if (lastRefreshAt == -1) {
             count = initialSynchronizeApis(nextLastRefreshAt);
         } else {
-            count = this.searchLatestEvents(bulkItems, lastRefreshAt, nextLastRefreshAt, API_ID, EventType.PUBLISH_API, EventType.START_API, EventType.UNPUBLISH_API, EventType.STOP_API)
+            count = this.searchLatestEvents(bulkItems, lastRefreshAt, nextLastRefreshAt, true, API_ID, EventType.PUBLISH_API, EventType.START_API, EventType.UNPUBLISH_API, EventType.STOP_API)
                     .compose(this::processApiEvents)
                     .count()
                     .blockingGet();
@@ -95,9 +95,8 @@ public class ApiSynchronizer extends AbstractSynchronizer {
      * Run the initial synchronization which focus on api PUBLISH and START events only.
      */
     private long initialSynchronizeApis(long nextLastRefreshAt) {
-        // We look for all the latest events for APIs...
-        final Long count = this.searchLatestEvents(bulkItems, null, nextLastRefreshAt, API_ID, EventType.PUBLISH_API, EventType.START_API, EventType.UNPUBLISH_API, EventType.STOP_API)
-                .filter(e -> e.getType().equals(EventType.PUBLISH_API) || e.getType().equals(EventType.START_API))  // ... but if the latest event of an API is UNPUBLISH or STOP, it must not be registered
+
+        final Long count = this.searchLatestEvents(bulkItems, null, nextLastRefreshAt, true, API_ID, EventType.PUBLISH_API, EventType.START_API)
                 .compose(this::processApiRegisterEvents)
                 .count()
                 .blockingGet();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/DictionarySynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/DictionarySynchronizer.java
@@ -57,7 +57,7 @@ public class DictionarySynchronizer extends AbstractSynchronizer {
         if (lastRefreshAt == -1) {
             count = initialSynchronizeDictionaries(nextLastRefreshAt);
         } else {
-            count = this.searchLatestEvents(bulkItems, lastRefreshAt, nextLastRefreshAt, DICTIONARY_ID, EventType.PUBLISH_DICTIONARY, EventType.UNPUBLISH_DICTIONARY)
+            count = this.searchLatestEvents(bulkItems, lastRefreshAt, nextLastRefreshAt, false, DICTIONARY_ID, EventType.PUBLISH_DICTIONARY, EventType.UNPUBLISH_DICTIONARY)
                     .compose(this::processDictionaryEvents)
                     .count()
                     .blockingGet();
@@ -72,7 +72,7 @@ public class DictionarySynchronizer extends AbstractSynchronizer {
 
     private long initialSynchronizeDictionaries(long nextLastRefreshAt) {
         // We look only for the latest PUBLISH or UNPUBLISH events for dictionaries...
-        return this.searchLatestEvents(bulkItems, null, nextLastRefreshAt, DICTIONARY_ID, EventType.PUBLISH_DICTIONARY, EventType.UNPUBLISH_DICTIONARY)
+        return this.searchLatestEvents(bulkItems, null, nextLastRefreshAt, false, DICTIONARY_ID, EventType.PUBLISH_DICTIONARY, EventType.UNPUBLISH_DICTIONARY)
                 .filter(e -> e.getType().equals(EventType.PUBLISH_DICTIONARY))  // ... but if the latest event of a dictionary is UNPUBLISH, it must not be loaded
                 .compose(this::processDictionaryDeployEvents)
                 .count()

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/EventRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/EventRepository.java
@@ -33,6 +33,13 @@ public interface EventRepository extends CrudRepository<Event, String> {
      * Search for latest {@link Event} matching the corresponding criteria for each event related to the specified group criteria (ex: 'api_id, 'dictionary_id').
      *
      * @param criteria the criteria to apply.
+     *                 When strictMode in criteria is enabled, the last event of the entity must be one of the types specified to be returned.
+     *                 Otherwise, when strictMode is disabled, events will be first filtered by type before finding the latest.
+     *                 Default strictMode is false.
+     *                 Example:
+     *                 Let assume we have an API with these events in this order: START, PUBLISH and UNPUBLISH.
+     *                 If strictMode == true and we search with types START & PUBLISH, then no event will be returned. Indeed, the current latest is UNPUBLISH and not in the search list.
+     *                 If strictMode == false and we search with types START & PUBLISH, then the PUBLISH event will be returned.
      * @param group the property to group on in order to retrieve the latest event. Can be {@link io.gravitee.repository.management.model.Event.EventProperties#API_ID} to retrieve latest event for each api
      *              or {@link io.gravitee.repository.management.model.Event.EventProperties#DICTIONARY_ID} to retrieve latest event for each dictionary.
      * @param page optional page number starting from 0, <code>null</code> means no paging.

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/EventCriteria.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/EventCriteria.java
@@ -32,12 +32,15 @@ public class EventCriteria {
 
     private String environmentId;
 
+    private boolean strictMode;
+
     EventCriteria(EventCriteria.Builder builder) {
         this.from = builder.from;
         this.to = builder.to;
         this.types = new HashSet<>(builder.types);
         this.properties = new HashMap<>(builder.properties);
         this.environmentId = builder.environmentId;
+        this.strictMode = builder.strictMode;
     }
 
     public Collection<EventType> getTypes() {
@@ -80,6 +83,14 @@ public class EventCriteria {
         this.environmentId = environmentId;
     }
 
+    public boolean isStrictMode() {
+        return strictMode;
+    }
+
+    public void setStrictMode(boolean strictMode) {
+        this.strictMode = strictMode;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -91,17 +102,13 @@ public class EventCriteria {
         if (to != that.to) return false;
         if (types != null ? !types.equals(that.types) : that.types != null) return false;
         if (environmentId != null ? !environmentId.equals(that.environmentId) : that.environmentId != null) return false;
+        if (strictMode != that.strictMode) return false;
         return properties != null ? properties.equals(that.properties) : that.properties == null;
     }
 
     @Override
     public int hashCode() {
-        int result = types != null ? types.hashCode() : 0;
-        result = 31 * result + (properties != null ? properties.hashCode() : 0);
-        result = 31 * result + (environmentId != null ? environmentId.hashCode() : 0);
-        result = 31 * result + (int) (from ^ (from >>> 32));
-        result = 31 * result + (int) (to ^ (to >>> 32));
-        return result;
+        return Objects.hash(types, properties, environmentId, from, to, strictMode);
     }
 
     public static class Builder {
@@ -115,6 +122,8 @@ public class EventCriteria {
         private long to;
 
         private String environmentId;
+
+        private boolean strictMode;
 
         public Builder from(long from) {
             this.from = from;
@@ -142,6 +151,12 @@ public class EventCriteria {
 
         public Builder environmentId(String environmentId) {
             this.environmentId = environmentId;
+
+            return this;
+        }
+
+        public Builder strictMode(boolean strictMode) {
+            this.strictMode = strictMode;
 
             return this;
         }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/utils/BodyCodecs.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/utils/BodyCodecs.java
@@ -15,8 +15,11 @@
  */
 package io.gravitee.repository.bridge.client.utils;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import io.gravitee.common.data.domain.Page;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.jackson.DatabindCodec;
 import io.vertx.ext.web.codec.BodyCodec;
 import io.vertx.ext.web.codec.impl.BodyCodecImpl;
 import java.util.List;
@@ -29,6 +32,9 @@ import java.util.stream.Collectors;
  * @author GraviteeSource Team
  */
 public class BodyCodecs {
+    static {
+        DatabindCodec.mapper().enable(JsonGenerator.Feature.IGNORE_UNKNOWN).disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+    }
 
     public static <T> BodyCodec<Optional<T>> optional(Class<T> clazz) {
         return new BodyCodecImpl<>(buffer -> Optional.of(buffer.toJsonObject().mapTo(clazz)));

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/BridgeService.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/BridgeService.java
@@ -15,12 +15,15 @@
  */
 package io.gravitee.repository.bridge.server;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.service.AbstractService;
 import io.gravitee.repository.bridge.server.handler.*;
 import io.gravitee.repository.bridge.server.http.configuration.HttpServerConfiguration;
 import io.gravitee.repository.bridge.server.version.VersionHandler;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.jackson.DatabindCodec;
 import io.vertx.ext.auth.AuthProvider;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.AuthHandler;
@@ -73,6 +76,8 @@ public class BridgeService extends AbstractService {
         if (enabled) {
             super.doStart();
             LOGGER.info("Start HTTP server for bridge");
+
+            configureMapper();
 
             // Start HTTP server
             Router mainRouter = Router.router(vertx).mountSubRouter(PATH, bridgeRouter);
@@ -151,6 +156,13 @@ public class BridgeService extends AbstractService {
             applicationContext.getAutowireCapableBeanFactory().autowireBean(dictionariesHandler);
             bridgeRouter.get("/dictionaries").handler(dictionariesHandler::findAll);
         }
+    }
+
+    private void configureMapper() {
+        DatabindCodec
+            .prettyMapper()
+            .enable(JsonGenerator.Feature.IGNORE_UNKNOWN)
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/EventsHandler.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/EventsHandler.java
@@ -197,6 +197,10 @@ public class EventsHandler extends AbstractHandler {
             propertiesObj.getMap().forEach(builder::property);
         }
 
+        String environmentId = payload.getString("environmentId");
+        if (environmentId != null) {
+            builder.environmentId(environmentId);
+        }
 
         Boolean strictMode = payload.getBoolean("strictMode");
         if (strictMode != null) {

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/EventsHandler.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/EventsHandler.java
@@ -197,6 +197,12 @@ public class EventsHandler extends AbstractHandler {
             propertiesObj.getMap().forEach(builder::property);
         }
 
+
+        Boolean strictMode = payload.getBoolean("strictMode");
+        if (strictMode != null) {
+            builder.strictMode(strictMode);
+        }
+
         return builder.build();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcEventRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcEventRepository.java
@@ -170,7 +170,16 @@ public class JdbcEventRepository extends JdbcAbstractPageableRepository<Event> i
         );
 
         builder.append(" inner join (select e.id from events e ");
-        builder.append(" where e.id in(").append(joinLatest(group, criteria, args)).append(")");
+        if (criteria.isStrictMode()) {
+            appendCriteria(builder, criteria, args, "e");
+            builder
+                .append(args.isEmpty() ? WHERE_CLAUSE : AND_CLAUSE)
+                .append("e.id in(")
+                .append(joinLatest(group, criteria, args))
+                .append(")");
+        } else {
+            builder.append(" where e.id in(").append(joinLatest(group, criteria, args)).append(")");
+        }
         builder.append("    order by e.updated_at desc, e.id desc ");
 
         if (page != null && size != null) {
@@ -316,8 +325,9 @@ public class JdbcEventRepository extends JdbcAbstractPageableRepository<Event> i
             .append("from events e1 ")
             .append("inner join event_properties ep1 on e1.id = ep1.event_id and ep1.property_key = ? and ep1.property_value is not null ");
 
-        appendCriteria(innerSelectLatestQuery, criteria, args, "e1");
-
+        if (!criteria.isStrictMode()) {
+            appendCriteria(innerSelectLatestQuery, criteria, args, "e1");
+        }
         return innerSelectLatestQuery.append(" group by ep1.property_value, ep1.event_id ");
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/event/EventMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/event/EventMongoRepositoryImpl.java
@@ -43,11 +43,25 @@ public class EventMongoRepositoryImpl implements EventMongoRepositoryCustom {
         Aggregation aggregation;
         List<AggregationOperation> aggregationOperations = new ArrayList<>();
 
-        aggregationOperations.add(Aggregation.match(Criteria.where("properties." + group.getValue()).exists(true)));
-        List<Criteria> criteriaList = buildDBCriteria(criteria);
-        // Match criteria.
-        if (!criteriaList.isEmpty()) {
-            aggregationOperations.add(Aggregation.match(new Criteria().andOperator(criteriaList.toArray(new Criteria[0]))));
+        if (criteria.isStrictMode()) {
+            // Filter on group property.
+            if (criteria.getFrom() != 0) {
+                // When a 'from' date is specified we can optimize the pipeline by filtering event on 'updatedAt' field and avoid executing the grouping step on all events.
+                aggregationOperations.add(
+                    Aggregation.match(
+                        Criteria.where("properties." + group.getValue()).exists(true).and("updatedAt").gte(new Date(criteria.getFrom()))
+                    )
+                );
+            } else {
+                aggregationOperations.add(Aggregation.match(Criteria.where("properties." + group.getValue()).exists(true)));
+            }
+        } else {
+            aggregationOperations.add(Aggregation.match(Criteria.where("properties." + group.getValue()).exists(true)));
+            List<Criteria> criteriaList = buildDBCriteria(criteria);
+            // Match criteria.
+            if (!criteriaList.isEmpty()) {
+                aggregationOperations.add(Aggregation.match(new Criteria().andOperator(criteriaList.toArray(new Criteria[0]))));
+            }
         }
 
         // Sort.
@@ -58,6 +72,15 @@ public class EventMongoRepositoryImpl implements EventMongoRepositoryCustom {
 
         // Extract result.
         aggregationOperations.add(Aggregation.replaceRoot("doc"));
+
+        if (criteria.isStrictMode()) {
+            List<Criteria> criteriaList = buildDBCriteria(criteria);
+
+            // Match criteria.
+            if (!criteriaList.isEmpty()) {
+                aggregationOperations.add(Aggregation.match(new Criteria().andOperator(criteriaList.toArray(new Criteria[0]))));
+            }
+        }
 
         // Sort
         aggregationOperations.add(Aggregation.sort(Sort.Direction.DESC, "updatedAt", "_id"));

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/EventRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/EventRepositoryTest.java
@@ -375,6 +375,40 @@ public class EventRepositoryTest extends AbstractRepositoryTest {
     }
 
     @Test
+    public void searchLatestApiEventsWithStrictModeEnabled() throws Exception {
+        List<Event> events = eventRepository.searchLatest(
+            new EventCriteria.Builder()
+                .property(Event.EventProperties.API_ID.getValue(), "api-1")
+                .types(EventType.START_API, EventType.PUBLISH_API)
+                .strictMode(true)
+                .build(),
+            Event.EventProperties.API_ID,
+            0L,
+            10L
+        );
+
+        assertEquals(0, events.size());
+    }
+
+    @Test
+    public void searchLatestApiEventsWithStrictModeDisabled() throws Exception {
+        List<Event> events = eventRepository.searchLatest(
+            new EventCriteria.Builder()
+                .property(Event.EventProperties.API_ID.getValue(), "api-1")
+                .types(EventType.START_API, EventType.PUBLISH_API)
+                .strictMode(false)
+                .build(),
+            Event.EventProperties.API_ID,
+            0L,
+            10L
+        );
+
+        assertEquals(1L, events.size());
+        final Iterator<Event> iterator = events.iterator();
+        assertEquals("event01", iterator.next().getId());
+    }
+
+    @Test
     public void searchLatestDictionaryEventsByMixProperties() throws Exception {
         List<Event> events = eventRepository.searchLatest(
             new EventCriteria.Builder().from(1455800000000L).to(1455941000000L).types(EventType.PUBLISH_DICTIONARY).build(),

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/EventRepositoryMock.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/EventRepositoryMock.java
@@ -17,6 +17,7 @@ package io.gravitee.repository.config.mock;
 
 import static io.gravitee.repository.utils.DateUtils.parse;
 import static java.util.Arrays.asList;
+import static java.util.Collections.EMPTY_LIST;
 import static java.util.Collections.singletonList;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
@@ -393,5 +394,33 @@ public class EventRepositoryMock extends AbstractRepositoryMock<EventRepository>
 
         when(eventRepository.searchLatest(new EventCriteria.Builder().build(), Event.EventProperties.DICTIONARY_ID, null, null))
             .thenReturn(Arrays.asList(event12, event8));
+
+        when(
+            eventRepository.searchLatest(
+                new EventCriteria.Builder()
+                    .property(Event.EventProperties.API_ID.getValue(), "api-1")
+                    .types(EventType.START_API, EventType.PUBLISH_API)
+                    .strictMode(true)
+                    .build(),
+                Event.EventProperties.API_ID,
+                0L,
+                10L
+            )
+        )
+            .thenReturn(EMPTY_LIST);
+
+        when(
+            eventRepository.searchLatest(
+                new EventCriteria.Builder()
+                    .property(Event.EventProperties.API_ID.getValue(), "api-1")
+                    .types(EventType.START_API, EventType.PUBLISH_API)
+                    .strictMode(false)
+                    .build(),
+                Event.EventProperties.API_ID,
+                0L,
+                10L
+            )
+        )
+            .thenReturn(singletonList(event1));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -709,7 +709,7 @@
                 <configuration>
                     <nodeVersion>12.13.0</nodeVersion>
                     <prettierJavaVersion>1.0.1</prettierJavaVersion>
-                    <skip>${skipTests}</skip>
+                    <skip>${skip.validation}</skip>
                 </configuration>
                 <executions>
                     <execution>
@@ -750,6 +750,7 @@
                         <ts>SLASHSTAR_STYLE</ts>
                         <js>SLASHSTAR_STYLE</js>
                     </mapping>
+                    <skip>${skip.validation}</skip>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6955
https://github.com/gravitee-io/issues/issues/6884

**Description**

Since gravitee-io/issues#6847, the gateway loads all latest events of all APIs, even if they are useless (like UNPUBLISH_API). It implies a very high start time.
By adding a search mode (strict or not), the gateway can find the latest event of an API in an efficient way and in the same time benefits from the fix of gravitee-io/issues#6847 for dictionaries events.

When adding new fields in objects that are sent through the http bridge, serialization issue can occurs if http bridge client and server are not in the same version. For example while upgrading the version of gravitee.
Options have been added in the mappers used by the http bridge to avoid these issues.

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6955-improve-latest-event-search/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
