### PR TITLE
fix: bump gravitee-policy-json-to-json

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -60,7 +60,7 @@
         <gravitee-policy-http-signature.version>1.5.0-SNAPSHOT</gravitee-policy-http-signature.version>
         <gravitee-policy-ipfiltering.version>1.9.0-SNAPSHOT</gravitee-policy-ipfiltering.version>
         <gravitee-policy-json-threat-protection.version>1.3.0-SNAPSHOT</gravitee-policy-json-threat-protection.version>
-        <gravitee-policy-json-to-json.version>1.6.0</gravitee-policy-json-to-json.version>
+        <gravitee-policy-json-to-json.version>1.7.0-SNAPSHOT</gravitee-policy-json-to-json.version>
         <gravitee-policy-json-validation.version>1.6.0</gravitee-policy-json-validation.version>
         <gravitee-policy-json-xml.version>1.1.0-SNAPSHOT</gravitee-policy-json-xml.version>
         <gravitee-policy-jws.version>1.3.0</gravitee-policy-jws.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6937

**Description**

use latest version of json-to-json policy

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mxsvjhdliz.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-6937-json-to-json-el/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
