### PR TITLE
Downgrade `jakarta.mail` to 1.6.7 to fix email features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <jakarta.validation-api.version>2.0.2</jakarta.validation-api.version>
         <jakarta.annotation-api.version>1.3.5</jakarta.annotation-api.version>
         <javax.inject.version>1</javax.inject.version>
-        <jakarta.mail.version>2.0.1</jakarta.mail.version>
+        <jakarta.mail.version>1.6.7</jakarta.mail.version>
         <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
         <jakarta.transaction-api.version>1.3.3</jakarta.transaction-api.version>
         <jakarta.activation-api.version>1.2.2</jakarta.activation-api.version>


### PR DESCRIPTION
**Issue**

Email service isn't working anymore, doing any action resulting in an email will lead to the following error:
```
Caused by: org.springframework.mail.MailSendException: Mail server connection failed; nested exception is javax.mail.NoSuchProviderException: smtp. Failed messages: javax.mail.NoSuchProviderException: smtp
	at org.springframework.mail.javamail.JavaMailSenderImpl.doSend(JavaMailSenderImpl.java:448)
	at org.springframework.mail.javamail.JavaMailSenderImpl.send(JavaMailSenderImpl.java:361)
	at org.springframework.mail.javamail.JavaMailSenderImpl.send(JavaMailSenderImpl.java:356)
	at io.gravitee.rest.api.service.impl.EmailServiceImpl.sendEmailNotification(EmailServiceImpl.java:157)
	... 18 common frames omitted
Caused by: javax.mail.NoSuchProviderException: smtp
	at javax.mail.Session.getService(Session.java:874)
	at javax.mail.Session.getTransport(Session.java:804)
	at javax.mail.Session.getTransport(Session.java:745)
	at javax.mail.Session.getTransport(Session.java:725)
	at org.springframework.mail.javamail.JavaMailSenderImpl.getTransport(JavaMailSenderImpl.java:538)
	at org.springframework.mail.javamail.JavaMailSenderImpl.connectTransport(JavaMailSenderImpl.java:517)
	at org.springframework.mail.javamail.JavaMailSenderImpl.doSend(JavaMailSenderImpl.java:437)
	... 21 common frames omitted
```
**Description**

JakartaMail 2.x switched to the new `jakarta.mail` namespace.
So libraries using earlier versions of JakartaMail/JavaMail will not work with it as they need the `javax.mail` namespace.

Spring 5.x is importing stuff from `javax.mail` namespace and so cannot be used with JakartaMail 2.x for now.

According to Support for Jakarta EE 9 (annotations and interfaces in jakarta.* namespace), Spring will switch to using the jakarta.* namespace in Spring Framework 6 / Spring Boot 3. For details see: https://github.com/spring-projects/spring-framework/issues/25354
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mxhiiweflk.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-email/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
