### PR TITLE
Display documentation menu properly when content isn't standard

### DIFF
--- a/gravitee-apim-portal-webui/src/app/components/gv-documentation/gv-documentation.component.ts
+++ b/gravitee-apim-portal-webui/src/app/components/gv-documentation/gv-documentation.component.ts
@@ -97,13 +97,11 @@ export class GvDocumentationComponent implements AfterViewInit {
       const scrollTop = document.scrollingElement.scrollTop;
       if (document.querySelector(this.PAGE_COMPONENT)) {
         const contentHeight = document.querySelector(this.PAGE_COMPONENT).getBoundingClientRect().height;
-
-        menuElement.style['max-height'] = `${contentHeight - scrollTop}px`;
-
-        this.reset(menuElement);
-      } else {
-        this.reset(menuElement);
+        // Both contentHeight and scrollTop can be 0 if page content isn't loaded yet, in that case just set max height to 100%
+        const menuMaxHeight = contentHeight - scrollTop;
+        menuElement.style['max-height'] = menuMaxHeight === 0 ? `100%` : `${menuMaxHeight}px`;
       }
+      this.reset(menuElement);
     }
   }
 

--- a/gravitee-apim-portal-webui/src/app/components/gv-documentation/gv-documentation.component.ts
+++ b/gravitee-apim-portal-webui/src/app/components/gv-documentation/gv-documentation.component.ts
@@ -97,11 +97,16 @@ export class GvDocumentationComponent implements AfterViewInit {
       const scrollTop = document.scrollingElement.scrollTop;
       if (document.querySelector(this.PAGE_COMPONENT)) {
         const contentHeight = document.querySelector(this.PAGE_COMPONENT).getBoundingClientRect().height;
+        const viewportHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
+        const maxAvailableHeight =
+          viewportHeight - (ScrollService.getHeaderHeight() + 2 * GvDocumentationComponent.PAGE_PADDING_TOP_BOTTOM);
+
+        const menuMaxHeight = Math.max(contentHeight, maxAvailableHeight) - scrollTop;
+
         // Both contentHeight and scrollTop can be 0 if page content isn't loaded yet, in that case just set max height to 100%
-        const menuMaxHeight = contentHeight - scrollTop;
         menuElement.style['max-height'] = menuMaxHeight === 0 ? `100%` : `${menuMaxHeight}px`;
       }
-      this.reset(menuElement);
+      GvDocumentationComponent.reset(menuElement);
     }
   }
 


### PR DESCRIPTION
**Issue**

Might be related to:
 - https://github.com/gravitee-io/issues/issues/6905
 - https://github.com/gravitee-io/issues/issues/6952

**Description**

Fix documentation menu:
 - when content isn't loaded yet 
 - when content is smaller than the viewport

Both these fixes are related to the computation of the menu height
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-smbwyigncp.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6905-fix-anchors/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
