### PR TITLE
 fix(portal): use metadata to read subscription details

### DIFF
--- a/gravitee-apim-portal-webui/src/app/pages/api/api-subscribe/api-subscribe.component.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/api/api-subscribe/api-subscribe.component.ts
@@ -38,6 +38,7 @@ import { ItemResourceTypeEnum } from 'src/app/model/itemResourceType.enum';
 import { FeatureEnum } from 'src/app/model/feature.enum';
 import { getPicture, getPictureDisplayName } from '@gravitee/ui-components/src/lib/item';
 import StatusEnum = Subscription.StatusEnum;
+import { formatCurlCommandLine } from '../../../utils/utils';
 
 @Component({
   selector: 'app-api-subscribe',
@@ -113,7 +114,7 @@ export class ApiSubscribeComponent implements OnInit {
 
     this.apiId = this.route.snapshot.params.apiId;
     this.api = this.route.snapshot.data.api;
-    this.apiSample = `curl "${this.api.entrypoints[0]}"`;
+    this.apiSample = formatCurlCommandLine(this.api.entrypoints[0]);
     this.apiName = this.api.name;
 
     Promise.all([
@@ -353,12 +354,12 @@ export class ApiSubscribeComponent implements OnInit {
           const currentPlan = this.getCurrentPlan();
           if (currentPlan.security.toUpperCase() === Plan.SecurityEnum.APIKEY) {
             const apikeyHeader = this.configurationService.get('portal.apikeyHeader');
-            this.apiSample += ` -H "${apikeyHeader}:${subscription.keys[0].key}"`;
+            this.apiSample = formatCurlCommandLine(this.api.entrypoints[0], { name: apikeyHeader, value: subscription.keys[0].key });
           } else if (
             currentPlan.security.toUpperCase() === Plan.SecurityEnum.OAUTH2 ||
             currentPlan.security.toUpperCase() === Plan.SecurityEnum.JWT
           ) {
-            this.apiSample += ` -H "Authorization: Bearer xxxx-xxxx-xxxx-xxxx"`;
+            this.apiSample = formatCurlCommandLine(this.api.entrypoints[0], { name: 'Authorization', value: 'Bearer xxxx-xxxx-xxxx-xxxx' });
           } else {
             this.apiSample = null;
           }

--- a/gravitee-apim-portal-webui/src/app/pages/subscriptions/subscriptions.component.css
+++ b/gravitee-apim-portal-webui/src/app/pages/subscriptions/subscriptions.component.css
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 section {
-  background-color: white;
   display: flex;
 }
 
 .table-container {
+  background-color: white;
   width: 100%;
 }
 

--- a/gravitee-apim-portal-webui/src/app/pages/subscriptions/subscriptions.component.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/subscriptions/subscriptions.component.ts
@@ -35,6 +35,7 @@ import { switchMap, takeUntil } from 'rxjs/operators';
 import { Pagination } from '@gravitee/ui-components/wc/gv-pagination';
 import { Subject } from 'rxjs';
 import StatusEnum = Subscription.StatusEnum;
+import { formatCurlCommandLine } from '../../utils/utils';
 
 @Component({
   selector: 'app-subscriptions',
@@ -215,9 +216,7 @@ export class SubscriptionsComponent implements OnInit, OnDestroy {
     const entrypoints = this.subscriptionsMetadata[sub.subscription.api].entrypoints;
     const entrypoint = entrypoints && entrypoints[0] && entrypoints[0].target;
     if (entrypoint && keys[0]) {
-      // keep the line break
-      this.curlExample = `curl --header "${this.apikeyHeader}:${keys[0].key}" \\
-    ${entrypoint}`;
+      this.curlExample = formatCurlCommandLine(entrypoint, { name: this.apikeyHeader, value: keys[0].key });
     }
   }
 

--- a/gravitee-apim-portal-webui/src/app/pages/subscriptions/subscriptions.component.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/subscriptions/subscriptions.component.ts
@@ -256,14 +256,6 @@ export class SubscriptionsComponent implements OnInit, OnDestroy {
     return this.curlExample ? '25vh' : '45vh';
   }
 
-  async loadApi(apiId: string) {
-    if (!this.apis.has(apiId)) {
-      const api = await this.apiService.getApiByApiId({ apiId }).toPromise();
-      this.apis.set(apiId, api);
-    }
-    return this.apis.get(apiId);
-  }
-
   async selectSubscriptions(application) {
     this.selectedApplicationId = application?.id;
     this.curlExample = null;
@@ -275,10 +267,9 @@ export class SubscriptionsComponent implements OnInit, OnDestroy {
         this.subscriptionsMetadata = { ...this.subscriptionsMetadata, ...metadata };
         const subscription = await Promise.all(
           data.map(async (applicationSubscription) => {
-            const api = await this.loadApi(applicationSubscription.api);
             return {
               subscription: applicationSubscription,
-              api,
+              api: this.subscriptionsMetadata[applicationSubscription.api],
               plan: this.subscriptionsMetadata[applicationSubscription.plan],
             };
           }),

--- a/gravitee-apim-portal-webui/src/app/utils/utils.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/utils/utils.spec.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { formatCurlCommandLine } from './utils';
+
+describe('Utils', () => {
+  it('should format curl as command line', () => {
+    const curl = formatCurlCommandLine('http://localhost');
+    expect(curl).toEqual(`curl http://localhost`);
+  });
+
+  it('should format curl as command line with header', () => {
+    const curl = formatCurlCommandLine('http://localhost', { name: 'Content-Type', value: 'application/json' });
+    expect(curl).toEqual(`curl --header "Content-Type: application/json" \\
+     http://localhost`);
+  });
+
+  it('should format curl as command line with headers', () => {
+    const curl = formatCurlCommandLine(
+      'http://localhost',
+      { name: 'Content-Type', value: 'application/json' },
+      { name: 'Authorization', value: 'Bearer xxxx-xxxx-xxxx-xxxx' },
+    );
+    expect(curl).toEqual(`curl --header "Content-Type: application/json" \\
+     --header "Authorization: Bearer xxxx-xxxx-xxxx-xxxx" \\
+     http://localhost`);
+  });
+});

--- a/gravitee-apim-portal-webui/src/app/utils/utils.ts
+++ b/gravitee-apim-portal-webui/src/app/utils/utils.ts
@@ -14,8 +14,27 @@
  * limitations under the License.
  */
 
+export interface Header {
+  name: string;
+  value: string;
+}
+
 export function createPromiseList(size) {
   const deferredList = [];
   const list = new Array(size).fill(null).map(() => new Promise((resolve, reject) => deferredList.push({ resolve, reject })));
   return { list, deferredList };
+}
+
+export function formatCurlCommandLine(url: string, ...headers: Header[]): string {
+  const headersFormatted = headers
+    // keep the line break
+    .reduce(
+      (acc, header) =>
+        acc +
+        `--header "${header.name}: ${header.value}" \\
+     `,
+      ' ',
+    );
+
+  return `curl${headersFormatted}${url}`;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApplicationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApplicationRepository.java
@@ -22,6 +22,7 @@ import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.model.Application;
 import io.gravitee.repository.management.model.ApplicationStatus;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -51,7 +52,7 @@ public interface ApplicationRepository extends CrudRepository<Application, Strin
      * @param ids a list of applications id
      * @return List Applications
      */
-    Set<Application> findByIds(List<String> ids) throws TechnicalException;
+    Set<Application> findByIds(Collection<String> ids) throws TechnicalException;
 
     /**
      * find a list of Applications via their ids.
@@ -59,7 +60,7 @@ public interface ApplicationRepository extends CrudRepository<Application, Strin
      * @param sortable a sortable
      * @return List Applications sort with sortable parameter.
      */
-    Set<Application> findByIds(List<String> ids, Sortable sortable) throws TechnicalException;
+    Set<Application> findByIds(Collection<String> ids, Sortable sortable) throws TechnicalException;
 
     /**
      * find applications by their groups

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApplicationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApplicationRepository.java
@@ -23,6 +23,7 @@ import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.model.Application;
 import io.gravitee.repository.management.model.ApplicationStatus;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -61,12 +62,12 @@ public class HttpApplicationRepository extends AbstractRepository implements App
     }
 
     @Override
-    public Set<Application> findByIds(List<String> ids) {
+    public Set<Application> findByIds(Collection<String> ids) {
         throw new IllegalStateException();
     }
 
     @Override
-    public Set<Application> findByIds(List<String> ids, Sortable sortable) {
+    public Set<Application> findByIds(Collection<String> ids, Sortable sortable) {
         throw new IllegalStateException();
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApplicationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApplicationRepository.java
@@ -221,12 +221,12 @@ public class JdbcApplicationRepository extends JdbcAbstractCrudRepository<Applic
     }
 
     @Override
-    public Set<Application> findByIds(List<String> ids) throws TechnicalException {
+    public Set<Application> findByIds(Collection<String> ids) throws TechnicalException {
         return this.findByIds(ids, null);
     }
 
     @Override
-    public Set<Application> findByIds(List<String> ids, Sortable sortable) throws TechnicalException {
+    public Set<Application> findByIds(Collection<String> ids, Sortable sortable) throws TechnicalException {
         LOGGER.debug("JdbcApplicationRepository.findByIds({}, {})", ids, sortable);
         try {
             if (isEmpty(ids)) {

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApplicationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApplicationRepository.java
@@ -99,12 +99,12 @@ public class MongoApplicationRepository implements ApplicationRepository {
     }
 
     @Override
-    public Set<Application> findByIds(List<String> ids) {
+    public Set<Application> findByIds(Collection<String> ids) {
         return mapApplications(internalApplicationRepo.findByIds(ids));
     }
 
     @Override
-    public Set<Application> findByIds(List<String> ids, Sortable sortable) {
+    public Set<Application> findByIds(Collection<String> ids, Sortable sortable) {
         return mapApplications(internalApplicationRepo.findByIds(ids, sortable));
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/application/ApplicationMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/application/ApplicationMongoRepository.java
@@ -17,6 +17,7 @@ package io.gravitee.repository.mongodb.management.internal.application;
 
 import io.gravitee.repository.management.model.ApplicationStatus;
 import io.gravitee.repository.mongodb.management.internal.model.ApplicationMongo;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import org.springframework.data.mongodb.repository.MongoRepository;
@@ -30,7 +31,7 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface ApplicationMongoRepository extends MongoRepository<ApplicationMongo, String>, ApplicationMongoRepositoryCustom {
-    default Set<ApplicationMongo> findByIds(List<String> ids) {
+    default Set<ApplicationMongo> findByIds(Collection<String> ids) {
         return this.findByIds(ids, null);
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/application/ApplicationMongoRepositoryCustom.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/application/ApplicationMongoRepositoryCustom.java
@@ -20,6 +20,7 @@ import io.gravitee.repository.management.api.search.ApplicationCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.mongodb.management.internal.model.ApplicationMongo;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -30,5 +31,5 @@ import java.util.Set;
 public interface ApplicationMongoRepositoryCustom {
     Page<ApplicationMongo> search(ApplicationCriteria applicationCriteria, final Pageable pageable);
 
-    Set<ApplicationMongo> findByIds(List<String> ids, Sortable sortable);
+    Set<ApplicationMongo> findByIds(Collection<String> ids, Sortable sortable);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/application/ApplicationMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/application/ApplicationMongoRepositoryImpl.java
@@ -25,6 +25,7 @@ import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.mongodb.management.internal.model.ApplicationMongo;
 import io.gravitee.repository.mongodb.utils.FieldUtils;
+import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -81,7 +82,7 @@ public class ApplicationMongoRepositoryImpl implements ApplicationMongoRepositor
     }
 
     @Override
-    public Set<ApplicationMongo> findByIds(List<String> ids, Sortable sortable) {
+    public Set<ApplicationMongo> findByIds(Collection<String> ids, Sortable sortable) {
         Query query = new Query();
         query.addCriteria(Criteria.where("id").in(ids));
         if (sortable != null && StringUtils.isNotEmpty(sortable.field())) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionsResource.java
@@ -31,6 +31,7 @@ import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.model.subscription.SubscriptionMetadataQuery;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.common.GraviteeContext;
@@ -131,7 +132,15 @@ public class ApiSubscriptionsResource extends AbstractResource {
         }
 
         PagedResult<SubscriptionEntity> result = new PagedResult<>(subscriptions, pageable.getSize());
-        result.setMetadata(subscriptionService.getMetadata(subscriptions.getContent()).getMetadata());
+        SubscriptionMetadataQuery subscriptionMetadataQuery = new SubscriptionMetadataQuery(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
+            subscriptions.getContent()
+        )
+            .withApis(true)
+            .withApplications(true)
+            .withPlans(true);
+        result.setMetadata(subscriptionService.getMetadata(subscriptionMetadataQuery).toMap());
         return result;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionsResource.java
@@ -31,8 +31,10 @@ import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.model.subscription.SubscriptionMetadataQuery;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.service.*;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.swagger.annotations.*;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -161,7 +163,15 @@ public class ApplicationSubscriptionsResource extends AbstractResource {
         }
 
         PagedResult<SubscriptionEntity> result = new PagedResult<>(subscriptions, pageable.getSize());
-        result.setMetadata(subscriptionService.getMetadata(subscriptions.getContent()).getMetadata());
+        SubscriptionMetadataQuery subscriptionMetadataQuery = new SubscriptionMetadataQuery(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
+            subscriptions.getContent()
+        )
+            .withApis(true)
+            .withApplications(true)
+            .withPlans(true);
+        result.setMetadata(subscriptionService.getMetadata(subscriptionMetadataQuery).toMap());
         return result;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/CurrentUserResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/CurrentUserResource.java
@@ -430,7 +430,7 @@ public class CurrentUserResource extends AbstractResource {
     )
     public PagedResult getUserTasks() {
         List<TaskEntity> tasks = taskService.findAll(getAuthenticatedUserOrNull());
-        Map<String, Map<String, Object>> metadata = taskService.getMetadata(tasks).getMetadata();
+        Map<String, Map<String, Object>> metadata = taskService.getMetadata(tasks).toMap();
         PagedResult<TaskEntity> pagedResult = new PagedResult<>(tasks);
         pagedResult.setMetadata(metadata);
         return pagedResult;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/UserResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/UserResource.java
@@ -166,7 +166,7 @@ public class UserResource extends AbstractResource {
         Metadata metadata = membershipService.findUserMembershipMetadata(userMemberships, type);
         UserMembershipList userMembershipList = new UserMembershipList();
         userMembershipList.setMemberships(userMemberships);
-        userMembershipList.setMetadata(metadata.getMetadata());
+        userMembershipList.setMetadata(metadata.toMap());
         return userMembershipList;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/pagedresult/Metadata.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/pagedresult/Metadata.java
@@ -26,7 +26,7 @@ public class Metadata {
 
     private Map<String, Map<String, Object>> metadata = new HashMap<>();
 
-    public Map<String, Map<String, Object>> getMetadata() {
+    public Map<String, Map<String, Object>> toMap() {
         return metadata;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/subscription/SubscriptionMetadataQuery.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/subscription/SubscriptionMetadataQuery.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.subscription;
+
+import io.gravitee.rest.api.model.SubscriptionEntity;
+import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.model.pagedresult.Metadata;
+import java.util.*;
+import java.util.function.BiFunction;
+
+/**
+ * @author Guillaume Cusnieux (guillaume.cusnieux at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class SubscriptionMetadataQuery {
+
+    private String organization;
+
+    private String environment;
+
+    private Collection<SubscriptionEntity> subscriptions;
+
+    private boolean withApplications = false;
+
+    private boolean withPlans = false;
+
+    private boolean withApis = false;
+
+    private boolean withSubscribers = false;
+
+    private boolean details = false;
+
+    private Map<DelegateType, List<BiFunction>> delegates = new HashMap<>();
+
+    public SubscriptionMetadataQuery(String organization, String environment, Collection<SubscriptionEntity> subscriptions) {
+        this.organization = organization;
+        this.environment = environment;
+        this.subscriptions = subscriptions;
+    }
+
+    public String getOrganization() {
+        return organization;
+    }
+
+    public void setOrganization(String organization) {
+        this.organization = organization;
+    }
+
+    public String getEnvironment() {
+        return environment;
+    }
+
+    public void setEnvironment(String environment) {
+        this.environment = environment;
+    }
+
+    public Collection<SubscriptionEntity> getSubscriptions() {
+        return subscriptions;
+    }
+
+    public void setSubscriptions(Collection<SubscriptionEntity> subscriptions) {
+        this.subscriptions = subscriptions;
+    }
+
+    public Optional<Boolean> ifApplications() {
+        return ifTrue(withApplications);
+    }
+
+    private Optional<Boolean> ifTrue(boolean feature) {
+        if (feature) {
+            return Optional.of(true);
+        }
+        return Optional.empty();
+    }
+
+    public SubscriptionMetadataQuery withApplications(boolean withApplications) {
+        this.withApplications = withApplications;
+        return this;
+    }
+
+    public Optional<Boolean> ifPlans() {
+        return ifTrue(withPlans);
+    }
+
+    public SubscriptionMetadataQuery withPlans(boolean withPlans) {
+        this.withPlans = withPlans;
+        return this;
+    }
+
+    public Optional<Boolean> ifApis() {
+        return ifTrue(withApis);
+    }
+
+    public SubscriptionMetadataQuery withApis(boolean withApis) {
+        this.withApis = withApis;
+        return this;
+    }
+
+    public Optional<Boolean> ifSubscribers() {
+        return ifTrue(withSubscribers);
+    }
+
+    public SubscriptionMetadataQuery withSubscribers(boolean withSubscribers) {
+        this.withSubscribers = withSubscribers;
+        return this;
+    }
+
+    public boolean hasDetails() {
+        return details;
+    }
+
+    public SubscriptionMetadataQuery excludeDetails() {
+        this.details = false;
+        return this;
+    }
+
+    public SubscriptionMetadataQuery includeDetails() {
+        this.details = true;
+        return this;
+    }
+
+    public SubscriptionMetadataQuery fillMetadata(DelegateType type, BiFunction<Metadata, ?, ?>... delegate) {
+        this.delegates.put(type, Arrays.asList(delegate));
+        return this;
+    }
+
+    public SubscriptionMetadataQuery fillApiMetadata(BiFunction<Metadata, ApiEntity, ApiEntity>... delegate) {
+        return this.fillMetadata(DelegateType.API, delegate);
+    }
+
+    public List<BiFunction> getApiDelegate() {
+        if (this.delegates.containsKey(DelegateType.API)) {
+            return this.delegates.get(DelegateType.API);
+        }
+        return Collections.emptyList();
+    }
+
+    public enum DelegateType {
+        API,
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/param/PaginationParam.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/param/PaginationParam.java
@@ -49,4 +49,8 @@ public class PaginationParam {
     public void setSize(Integer size) {
         this.size = size;
     }
+
+    public boolean hasPagination() {
+        return this.getSize() != null && this.getSize().equals(-1);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResourceTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.internal.util.collections.Sets.newSet;
 
 import io.gravitee.common.data.domain.Page;
@@ -32,6 +33,7 @@ import io.gravitee.rest.api.model.NewSubscriptionEntity;
 import io.gravitee.rest.api.model.PlanEntity;
 import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
+import io.gravitee.rest.api.model.pagedresult.Metadata;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.portal.rest.model.*;
@@ -95,9 +97,14 @@ public class SubscriptionsResourceTest extends AbstractResourceTest {
     public void shouldGetSubscriptionsForApi() {
         final ApplicationListItem application = new ApplicationListItem();
         application.setId(APPLICATION);
+
         doReturn(newSet(application))
             .when(applicationService)
             .findByUser(eq(GraviteeContext.getCurrentOrganization()), eq(GraviteeContext.getCurrentEnvironment()), any());
+
+        Metadata metadata = new Metadata();
+        metadata.put("api-id", "name", "My api");
+        doReturn(metadata).when(subscriptionService).getMetadata(any());
 
         final Response response = target().queryParam("apiId", API).request().get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
@@ -200,6 +207,10 @@ public class SubscriptionsResourceTest extends AbstractResourceTest {
         doReturn(true)
             .when(permissionService)
             .hasPermission(RolePermission.APPLICATION_SUBSCRIPTION, APPLICATION, RolePermissionAction.READ);
+
+        Metadata metadata = new Metadata();
+        metadata.put("api-id", "name", "My api");
+        doReturn(metadata).when(subscriptionService).getMetadata(any());
 
         assertEquals(OK_200, target().queryParam("applicationId", APPLICATION).request().get().getStatus());
         assertEquals(OK_200, target().queryParam("apiId", API).request().get().getStatus());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApplicationRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApplicationRepositoryProxy.java
@@ -23,6 +23,7 @@ import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.model.Application;
 import io.gravitee.repository.management.model.ApplicationStatus;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -62,12 +63,12 @@ public class ApplicationRepositoryProxy extends AbstractProxy<ApplicationReposit
     }
 
     @Override
-    public Set<Application> findByIds(List<String> ids) throws TechnicalException {
+    public Set<Application> findByIds(Collection<String> ids) throws TechnicalException {
         return target.findByIds(ids);
     }
 
     @Override
-    public Set<Application> findByIds(List<String> ids, Sortable sortable) throws TechnicalException {
+    public Set<Application> findByIds(Collection<String> ids, Sortable sortable) throws TechnicalException {
         return target.findByIds(ids, sortable);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
@@ -43,6 +43,8 @@ public interface ApiService {
 
     Set<ApiEntity> findAllByEnvironment(String environment);
 
+    Set<ApiEntity> findByEnvironmentAndIdIn(String environment, Set<String> ids);
+
     default Set<ApiEntity> findAllLightByEnvironment(String environmentId) {
         return findAllLightByEnvironment(environmentId, true);
     }
@@ -191,4 +193,6 @@ public interface ApiService {
     void checkPolicyConfigurations(Map<String, List<Rule>> paths, List<Flow> flows, List<Plan> plans);
 
     Map<String, Long> countPublishedByUserGroupedByCategories(String userId);
+
+    void calculateEntrypoints(String environment, ApiEntity api);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApplicationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApplicationService.java
@@ -21,6 +21,7 @@ import io.gravitee.rest.api.model.NewApplicationEntity;
 import io.gravitee.rest.api.model.UpdateApplicationEntity;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.model.common.Sortable;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -32,7 +33,7 @@ import java.util.Set;
 public interface ApplicationService {
     ApplicationEntity findById(final String environment, String applicationId);
 
-    Set<ApplicationListItem> findByIds(final String organizationId, final String environmentId, List<String> applicationIds);
+    Set<ApplicationListItem> findByIds(final String organizationId, final String environmentId, Collection<String> applicationIds);
 
     default Set<ApplicationListItem> findByUser(final String organizationId, final String environmentId, String username) {
         return findByUser(organizationId, environmentId, username, null);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/PlanService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/PlanService.java
@@ -31,6 +31,8 @@ import java.util.Set;
 public interface PlanService {
     PlanEntity findById(String plan);
 
+    Set<PlanEntity> findByIdIn(Set<String> ids);
+
     Set<PlanEntity> findByApi(String api);
 
     List<PlanEntity> search(PlanQuery query);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/SubscriptionService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/SubscriptionService.java
@@ -20,6 +20,7 @@ import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.pagedresult.Metadata;
+import io.gravitee.rest.api.model.subscription.SubscriptionMetadataQuery;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import java.util.Collection;
 import java.util.List;
@@ -70,7 +71,7 @@ public interface SubscriptionService {
 
     Page<SubscriptionEntity> search(SubscriptionQuery query, Pageable pageable);
 
-    Metadata getMetadata(List<SubscriptionEntity> subscriptions);
+    Metadata getMetadata(SubscriptionMetadataQuery query);
 
     SubscriptionEntity transfer(TransferSubscriptionEntity transferSubscription, String userId);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -157,7 +157,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
     }
 
     @Override
-    public Set<ApplicationListItem> findByIds(final String organizationId, final String environmentId, List<String> applicationIds) {
+    public Set<ApplicationListItem> findByIds(final String organizationId, final String environmentId, Collection<String> applicationIds) {
         try {
             LOGGER.debug("Find application by IDs: {}", applicationIds);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PlanServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PlanServiceImpl.java
@@ -110,6 +110,15 @@ public class PlanServiceImpl extends TransactionalService implements PlanService
     }
 
     @Override
+    public Set<PlanEntity> findByIdIn(Set<String> ids) {
+        try {
+            return planRepository.findByIdIn(ids).stream().map(this::convert).collect(Collectors.toSet());
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("An error has occurred retrieving plans by ids", e);
+        }
+    }
+
+    @Override
     public Set<PlanEntity> findByApi(String api) {
         try {
             logger.debug("Find plan by api : {}", api);


### PR DESCRIPTION
When rolling on an application to view its subscription, the request
was failing if the subscription was referring to a deleted API.

see https://github.com/gravitee-io/issues/issues/6953
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-draqldfrhw.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6953-fix-app-hover/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
