### PR TITLE
Rework the CI workflow for kubernetes and docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -666,11 +666,6 @@ jobs:
                   at: .
             - get-apim-tag
             - run:
-                  name: Install Helm
-                  command: |
-                      curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
-                      helm version
-            - run:
                   name: Install Kubectl
                   command: |
                       curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
@@ -678,27 +673,12 @@ jobs:
                       mv ./kubectl /usr/local/bin/kubectl
                       kubectl version --client=true
             - run:
-                  name: Helm upgrade and 🚀 to APIM cluster
+                  name: 🚀 to APIM cluster
                   command: |
                       export K8S_NAMESPACE=apim-${CIRCLE_BRANCH//\./-}
 
                       az login --service-principal -u $AZURE_APPLICATION_ID --tenant $AZURE_TENANT -p $AZURE_APPLICATION_SECRET
                       az aks get-credentials --resource-group apim-hprod --name apim-hprod
-
-                      helm upgrade --repo https://helm.gravitee.io \
-                                   --install apim \
-                                   -n ${K8S_NAMESPACE} \
-                                   --reuse-values \
-                                   apim3 \
-                                   --set "api.image.repository=graviteeio.azurecr.io/apim-management-api" \
-                                   --set "api.image.tag=${TAG}" \
-                                   --set "portal.image.repository=graviteeio.azurecr.io/apim-portal-ui" \
-                                   --set "portal.image.tag=${TAG}" \
-                                   --set "ui.image.repository=graviteeio.azurecr.io/apim-management-ui" \
-                                   --set "ui.image.tag=${TAG}" \
-                                   --set "gateway.image.repository=graviteeio.azurecr.io/apim-gateway" \
-                                   --set "gateway.image.tag=${TAG}" \
-                                   --set "redis.repositoryVersion=3.12.1"
 
                       kubectl rollout restart deployment/apim-apim3-api -n ${K8S_NAMESPACE}
                       kubectl rollout restart deployment/apim-apim3-portal -n ${K8S_NAMESPACE}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -678,29 +678,6 @@ jobs:
                       mv ./kubectl /usr/local/bin/kubectl
                       kubectl version --client=true
             - run:
-                  name: Helm upgrade and 🚀 to Element Zero cluster
-                  command: |
-                      if [ "master" == "${CIRCLE_BRANCH}" ]
-                      then
-                          az login --service-principal -u $AZURE_APPLICATION_ID --tenant $AZURE_TENANT -p $AZURE_APPLICATION_SECRET
-                          az aks get-credentials --resource-group element-zero --name element-zero
-
-                          helm upgrade --repo https://helm.gravitee.io \
-                                      --install apim \
-                                      -n apim \
-                                      --reuse-values \
-                                      apim3 \
-                                       --set "api.image.repository=graviteeio.azurecr.io/apim-management-api" \
-                                       --set "api.image.tag=${TAG}" \
-                                       --set "portal.image.repository=graviteeio.azurecr.io/apim-portal-ui" \
-                                       --set "portal.image.tag=${TAG}" \
-                                       --set "ui.image.repository=graviteeio.azurecr.io/apim-management-ui" \
-                                       --set "ui.image.tag=${TAG}" \
-                                       --set "gateway.image.repository=graviteeio.azurecr.io/apim-gateway" \
-                                       --set "gateway.image.tag=${TAG}" \
-                                       --set "redis.repositoryVersion=3.12.1"
-                      fi
-            - run:
                   name: Helm upgrade and 🚀 to APIM cluster
                   command: |
                       export K8S_NAMESPACE=apim-${CIRCLE_BRANCH//\./-}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,30 +322,17 @@ jobs:
                   name: Build & Publish Management API and Gateway Docker Image to Azure Registry
                   command: |
                       export REST_API_PRIVATE_IMAGE_TAG=graviteeio.azurecr.io/apim-management-api:${TAG}
-                      export REST_API_PUBLIC_IMAGE_TAG=graviteeio/apim-management-api:${TAG}
-
                       export GATEWAY_PRIVATE_IMAGE_TAG=graviteeio.azurecr.io/apim-gateway:${TAG}
-                      export GATEWAY_PUBLIC_IMAGE_TAG=graviteeio/apim-gateway:${TAG}
 
                       docker build -f gravitee-apim-rest-api/docker/Dockerfile-dev \
                       --build-arg GRAVITEEIO_VERSION=${APIM_VERSION} \
                       -t ${REST_API_PRIVATE_IMAGE_TAG} \
-                      -t ${REST_API_PUBLIC_IMAGE_TAG} \
                       rest-api-docker-context
 
                       docker build -f gravitee-apim-gateway/docker/Dockerfile-dev \
                       --build-arg GRAVITEEIO_VERSION=${APIM_VERSION} \
                       -t ${GATEWAY_PRIVATE_IMAGE_TAG} \
-                      -t ${GATEWAY_PUBLIC_IMAGE_TAG} \
                       gateway-docker-context
-
-                      if [[ $CIRCLE_BRANCH =~ ^([0-9]+\.[0-9]+\.x|master)$ ]]
-                      then
-                        echo $DOCKERHUB_BOT_USER_TOKEN | docker login --username $DOCKERHUB_BOT_USER_NAME --password-stdin
-                        docker push ${REST_API_PUBLIC_IMAGE_TAG}
-                        docker push ${GATEWAY_PUBLIC_IMAGE_TAG}
-                        docker logout
-                      fi
 
                       echo $AZURE_DOCKER_REGISTRY_PASSWORD | docker login --username $AZURE_DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
                       docker push ${REST_API_PRIVATE_IMAGE_TAG}
@@ -524,16 +511,8 @@ jobs:
                       cp -fr docker/config .
                       cp -fr docker/run.sh .
 
-                      export PUBLIC_IMAGE_TAG=graviteeio/<< parameters.docker-image-name >>:${TAG}
                       export PRIVATE_IMAGE_TAG=graviteeio.azurecr.io/<< parameters.docker-image-name >>:${TAG}
-                      docker build -f docker/Dockerfile-dev -t ${PRIVATE_IMAGE_TAG} -t ${PUBLIC_IMAGE_TAG} .
-
-                      if [[ $CIRCLE_BRANCH =~ ^([0-9]+\.[0-9]+\.x|master)$ ]]
-                      then
-                        echo $DOCKERHUB_BOT_USER_TOKEN | docker login --username $DOCKERHUB_BOT_USER_NAME --password-stdin
-                        docker push ${PUBLIC_IMAGE_TAG}
-                        docker logout
-                      fi
+                      docker build -f docker/Dockerfile-dev -t ${PRIVATE_IMAGE_TAG} .
 
                       echo $AZURE_DOCKER_REGISTRY_PASSWORD | docker login --username $AZURE_DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
                       docker push ${PRIVATE_IMAGE_TAG}
@@ -987,12 +966,6 @@ workflows:
                       - secrethub/env-export:
                             secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/password
                             var-name: AZURE_DOCKER_REGISTRY_PASSWORD
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-name
-                            var-name: DOCKERHUB_BOT_USER_NAME
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-token
-                            var-name: DOCKERHUB_BOT_USER_TOKEN
                   filters:
                       branches:
                           only:
@@ -1058,12 +1031,6 @@ workflows:
                       - secrethub/env-export:
                             secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/password
                             var-name: AZURE_DOCKER_REGISTRY_PASSWORD
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-name
-                            var-name: DOCKERHUB_BOT_USER_NAME
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-token
-                            var-name: DOCKERHUB_BOT_USER_TOKEN
                   requires:
                       - Build APIM Console
                       - compute-apim-tag
@@ -1111,12 +1078,6 @@ workflows:
                       - secrethub/env-export:
                             secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/password
                             var-name: AZURE_DOCKER_REGISTRY_PASSWORD
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-name
-                            var-name: DOCKERHUB_BOT_USER_NAME
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-token
-                            var-name: DOCKERHUB_BOT_USER_TOKEN
                   requires:
                       - Build APIM Portal
                       - compute-apim-tag


### PR DESCRIPTION
**Description**

 - Stop publishing "dev" docker images on docker hub (master-latest, 3.10.x-latest, ...)
 - Stop deploying APIM on ElementZero Cluster
 - Remove all the Helm part since, for a given namespace, it's always the same helm chart that is used (with the same tag)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-flwrzhbvmk.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/rework-kube-deployment/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
