### PR TITLE
refactor(gateway): use java configuration for ReactorHandlerFactory

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
@@ -20,6 +20,8 @@ import io.gravitee.gateway.core.classloader.DefaultClassLoader;
 import io.gravitee.gateway.core.component.ComponentProvider;
 import io.gravitee.gateway.core.component.spring.SpringComponentProvider;
 import io.gravitee.gateway.core.condition.ExpressionLanguageStringConditionEvaluator;
+import io.gravitee.gateway.handlers.api.ApiContextHandlerFactory;
+import io.gravitee.gateway.handlers.api.definition.Api;
 import io.gravitee.gateway.handlers.api.manager.ApiManager;
 import io.gravitee.gateway.handlers.api.manager.endpoint.ApiManagementEndpoint;
 import io.gravitee.gateway.handlers.api.manager.endpoint.ApisManagementEndpoint;
@@ -28,7 +30,9 @@ import io.gravitee.gateway.handlers.api.manager.impl.ApiManagerImpl;
 import io.gravitee.gateway.policy.PolicyPluginFactory;
 import io.gravitee.gateway.policy.impl.PolicyFactoryCreator;
 import io.gravitee.gateway.policy.impl.PolicyPluginFactoryImpl;
+import io.gravitee.gateway.reactor.handler.ReactorHandlerFactory;
 import io.gravitee.gateway.reactor.handler.context.ApiTemplateVariableProviderFactory;
+import io.gravitee.node.api.Node;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -47,6 +51,12 @@ public class ApiHandlerConfiguration {
 
     @Autowired
     private ApplicationContext applicationContext;
+
+    @Autowired
+    private Node node;
+
+    @Autowired
+    private io.gravitee.node.api.configuration.Configuration configuration;
 
     @Bean
     public ApiManager apiManager() {
@@ -96,5 +106,10 @@ public class ApiHandlerConfiguration {
     @Bean
     public ApiTemplateVariableProviderFactory apiTemplateVariableProviderFactory() {
         return new ApiTemplateVariableProviderFactory();
+    }
+
+    @Bean
+    public ReactorHandlerFactory<Api> reactorHandlerFactory() {
+        return new ApiContextHandlerFactory(applicationContext, configuration, node);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/resources/META-INF/spring.factories
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,0 @@
-io.gravitee.gateway.reactor.handler.ReactorHandlerFactory=\
-    io.gravitee.gateway.handlers.api.ApiContextHandlerFactory

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/ApiContextHandlerFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/ApiContextHandlerFactoryTest.java
@@ -39,7 +39,7 @@ public class ApiContextHandlerFactoryTest {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        apiContextHandlerFactory = new ApiContextHandlerFactory();
+        apiContextHandlerFactory = new ApiContextHandlerFactory(null, null, null);
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/ReactorHandlerFactoryManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/ReactorHandlerFactoryManager.java
@@ -15,31 +15,21 @@
  */
 package io.gravitee.gateway.reactor.handler;
 
-import io.gravitee.common.spring.factory.SpringFactoriesLoader;
 import io.gravitee.gateway.reactor.Reactable;
-import org.springframework.beans.factory.InitializingBean;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class ReactorHandlerFactoryManager extends SpringFactoriesLoader<ReactorHandlerFactory> implements InitializingBean {
+public class ReactorHandlerFactoryManager {
 
     private ReactorHandlerFactory<Reactable> reactorHandlerFactory;
 
+    public ReactorHandlerFactoryManager(ReactorHandlerFactory<Reactable> reactorHandlerFactory) {
+        this.reactorHandlerFactory = reactorHandlerFactory;
+    }
+
     public ReactorHandler create(Reactable reactable) {
         return reactorHandlerFactory.create(reactable);
-    }
-
-    @Override
-    protected Class<ReactorHandlerFactory> getObjectType() {
-        return ReactorHandlerFactory.class;
-    }
-
-    @Override
-    public void afterPropertiesSet() {
-        // For now, there is only a single reactorHandlerFactory.
-        // This must be updated as soon as we are looking to manage more reactable type
-        reactorHandlerFactory = getFactoriesInstances().iterator().next();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/spring/ReactorConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/spring/ReactorConfiguration.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.reactor.spring;
 import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.reactor.Reactor;
 import io.gravitee.gateway.reactor.handler.EntrypointResolver;
+import io.gravitee.gateway.reactor.handler.ReactorHandlerFactory;
 import io.gravitee.gateway.reactor.handler.ReactorHandlerFactoryManager;
 import io.gravitee.gateway.reactor.handler.ReactorHandlerRegistry;
 import io.gravitee.gateway.reactor.handler.context.provider.NodeTemplateVariableProvider;
@@ -56,8 +57,8 @@ public class ReactorConfiguration {
     }
 
     @Bean
-    public ReactorHandlerFactoryManager reactorHandlerFactoryManager() {
-        return new ReactorHandlerFactoryManager();
+    public ReactorHandlerFactoryManager reactorHandlerFactoryManager(ReactorHandlerFactory reactorHandlerFactory) {
+        return new ReactorHandlerFactoryManager(reactorHandlerFactory);
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/DebugConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/DebugConfiguration.java
@@ -16,21 +16,56 @@
 package io.gravitee.gateway.debug;
 
 import io.gravitee.gateway.debug.vertx.VertxDebugService;
+import io.gravitee.gateway.handlers.api.ApiContextHandlerFactory;
+import io.gravitee.gateway.handlers.api.definition.Api;
 import io.gravitee.gateway.reactor.handler.EntrypointResolver;
+import io.gravitee.gateway.reactor.handler.ReactorHandlerFactory;
 import io.gravitee.gateway.reactor.handler.ReactorHandlerFactoryManager;
 import io.gravitee.gateway.reactor.handler.ReactorHandlerRegistry;
 import io.gravitee.gateway.reactor.handler.impl.DefaultEntrypointResolver;
 import io.gravitee.gateway.reactor.handler.impl.DefaultReactorHandlerRegistry;
+import io.gravitee.node.api.Node;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class DebugConfiguration {
 
+    private final ApplicationContext applicationContext;
+
+    private final Node node;
+
+    private final io.gravitee.node.api.configuration.Configuration configuration;
+
+    public DebugConfiguration(
+        ApplicationContext applicationContext,
+        Node node,
+        io.gravitee.node.api.configuration.Configuration configuration
+    ) {
+        this.applicationContext = applicationContext;
+        this.node = node;
+        this.configuration = configuration;
+    }
+
     @Bean
     public VertxDebugService vertxDebugService() {
         return new VertxDebugService();
+    }
+
+    @Bean
+    @Qualifier("debugReactorHandlerFactory")
+    public ReactorHandlerFactory<Api> reactorHandlerFactory() {
+        return new ApiContextHandlerFactory(applicationContext.getParent(), configuration, node);
+    }
+
+    @Bean
+    @Qualifier("debugReactorHandlerFactoryManager")
+    public ReactorHandlerFactoryManager reactorHandlerFactoryManager(
+        @Qualifier("debugReactorHandlerFactory") ReactorHandlerFactory reactorHandlerFactory
+    ) {
+        return new ReactorHandlerFactoryManager(reactorHandlerFactory);
     }
 
     @Bean


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6944

**Description**

First step to debug mode:
Refactor ReactorHandlerFactory to instanriate it via Java Configuration instead of spring.factories.
It will allow us to instantiate it with dependencies of our choice.


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-adwvptnnsf.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-6944-debug-mode-step-1/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
