### PR TITLE
feat(gateway): use a dedicated policy chain factory for debug mode 

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
@@ -27,8 +27,9 @@ import io.gravitee.gateway.handlers.api.manager.endpoint.ApiManagementEndpoint;
 import io.gravitee.gateway.handlers.api.manager.endpoint.ApisManagementEndpoint;
 import io.gravitee.gateway.handlers.api.manager.endpoint.NodeApisEndpointInitializer;
 import io.gravitee.gateway.handlers.api.manager.impl.ApiManagerImpl;
+import io.gravitee.gateway.policy.PolicyFactoryCreator;
 import io.gravitee.gateway.policy.PolicyPluginFactory;
-import io.gravitee.gateway.policy.impl.PolicyFactoryCreator;
+import io.gravitee.gateway.policy.impl.PolicyFactoryCreatorImpl;
 import io.gravitee.gateway.policy.impl.PolicyPluginFactoryImpl;
 import io.gravitee.gateway.reactor.handler.ReactorHandlerFactory;
 import io.gravitee.gateway.reactor.handler.context.ApiTemplateVariableProviderFactory;
@@ -89,8 +90,8 @@ public class ApiHandlerConfiguration {
     }
 
     @Bean
-    public PolicyFactoryCreator policyFactoryFactoryBean(final Environment environment, final PolicyPluginFactory policyPluginFactory) {
-        return new PolicyFactoryCreator(environment, policyPluginFactory, new ExpressionLanguageStringConditionEvaluator());
+    public PolicyFactoryCreator policyFactoryCreator(final PolicyPluginFactory policyPluginFactory) {
+        return new PolicyFactoryCreatorImpl(configuration, policyPluginFactory, new ExpressionLanguageStringConditionEvaluator());
     }
 
     @Bean
@@ -109,7 +110,7 @@ public class ApiHandlerConfiguration {
     }
 
     @Bean
-    public ReactorHandlerFactory<Api> reactorHandlerFactory() {
-        return new ApiContextHandlerFactory(applicationContext, configuration, node);
+    public ReactorHandlerFactory<Api> reactorHandlerFactory(PolicyFactoryCreator policyFactoryCreator) {
+        return new ApiContextHandlerFactory(applicationContext, configuration, node, policyFactoryCreator);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/ApiContextHandlerFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/ApiContextHandlerFactoryTest.java
@@ -39,7 +39,7 @@ public class ApiContextHandlerFactoryTest {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        apiContextHandlerFactory = new ApiContextHandlerFactory(null, null, null);
+        apiContextHandlerFactory = new ApiContextHandlerFactory(null, null, null, null);
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-platform/src/main/java/io/gravitee/gateway/platform/spring/PlatformConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-platform/src/main/java/io/gravitee/gateway/platform/spring/PlatformConfiguration.java
@@ -24,7 +24,7 @@ import io.gravitee.gateway.platform.PlatformPolicyManager;
 import io.gravitee.gateway.platform.manager.OrganizationManager;
 import io.gravitee.gateway.platform.manager.impl.OrganizationManagerImpl;
 import io.gravitee.gateway.policy.PolicyConfigurationFactory;
-import io.gravitee.gateway.policy.PolicyFactory;
+import io.gravitee.gateway.policy.PolicyFactoryCreator;
 import io.gravitee.gateway.policy.impl.CachedPolicyConfigurationFactory;
 import io.gravitee.gateway.resource.ResourceConfigurationFactory;
 import io.gravitee.gateway.resource.ResourceLifecycleManager;
@@ -72,7 +72,7 @@ public class PlatformConfiguration {
 
     @Bean
     public PlatformPolicyManager platformPolicyManager(
-        PolicyFactory factory,
+        PolicyFactoryCreator factoryCreator,
         PolicyConfigurationFactory policyConfigurationFactory,
         PolicyClassLoaderFactory policyClassLoaderFactory,
         ResourceLifecycleManager resourceLifecycleManager,
@@ -89,7 +89,7 @@ public class PlatformConfiguration {
         return new PlatformPolicyManager(
             classLoaderLegacyMode,
             applicationContext.getBean(DefaultClassLoader.class),
-            factory,
+            factoryCreator.create(),
             policyConfigurationFactory,
             cpm,
             policyClassLoaderFactory,

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/PolicyFactoryCreator.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/PolicyFactoryCreator.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.policy;
+
+import org.springframework.beans.factory.FactoryBean;
+
+/**
+ * Factory of PolicyFactory. A PolicyFactory is created for each new API deployed.
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface PolicyFactoryCreator {
+    PolicyFactory create();
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/policy/DummyPolicy.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/policy/DummyPolicy.java
@@ -19,7 +19,9 @@ import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
 import io.gravitee.policy.api.PolicyChain;
 import io.gravitee.policy.api.annotations.OnRequest;
+import io.gravitee.policy.api.annotations.OnRequestContent;
 import io.gravitee.policy.api.annotations.OnResponse;
+import io.gravitee.policy.api.annotations.OnResponseContent;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -34,6 +36,16 @@ public class DummyPolicy {
 
     @OnResponse
     public void onResponse(Request chain, Response response, PolicyChain handler) {
+        // Do nothing
+    }
+
+    @OnRequestContent
+    public void onRequestContent(PolicyChain chain, Request request, Response response) {
+        // Do nothing
+    }
+
+    @OnResponseContent
+    public void onResponseContent(Request chain, Response response, PolicyChain handler) {
         // Do nothing
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/policy/impl/PolicyDebugDecorator.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/policy/impl/PolicyDebugDecorator.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.debug.policy.impl;
+
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.stream.ReadWriteStream;
+import io.gravitee.gateway.policy.Policy;
+import io.gravitee.gateway.policy.PolicyException;
+import io.gravitee.gateway.policy.StreamType;
+import io.gravitee.policy.api.PolicyChain;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class PolicyDebugDecorator implements Policy {
+
+    private final StreamType streamType;
+    private final Policy policy;
+
+    public PolicyDebugDecorator(StreamType streamType, Policy policy) {
+        this.streamType = streamType;
+        this.policy = policy;
+    }
+
+    @Override
+    public String id() {
+        return policy.id();
+    }
+
+    @Override
+    public void execute(PolicyChain chain, ExecutionContext context) throws PolicyException {
+        policy.execute(chain, context);
+    }
+
+    @Override
+    public ReadWriteStream<Buffer> stream(PolicyChain chain, ExecutionContext context) throws PolicyException {
+        return policy.stream(chain, context);
+    }
+
+    @Override
+    public boolean isStreamable() {
+        return policy.isStreamable();
+    }
+
+    @Override
+    public boolean isRunnable() {
+        return policy.isRunnable();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/policy/impl/PolicyDebugDecoratorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/policy/impl/PolicyDebugDecoratorFactory.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.debug.policy.impl;
+
+import io.gravitee.gateway.policy.Policy;
+import io.gravitee.gateway.policy.PolicyFactory;
+import io.gravitee.gateway.policy.PolicyMetadata;
+import io.gravitee.gateway.policy.StreamType;
+import io.gravitee.policy.api.PolicyConfiguration;
+import java.util.Objects;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class PolicyDebugDecoratorFactory implements PolicyFactory {
+
+    private final PolicyFactory delegate;
+
+    public PolicyDebugDecoratorFactory(PolicyFactory delegate) {
+        Objects.requireNonNull(delegate, "PolicyFactory delegate is mandatory");
+
+        this.delegate = delegate;
+    }
+
+    @Override
+    public Policy create(StreamType streamType, PolicyMetadata policyMetadata, PolicyConfiguration policyConfiguration) {
+        return new PolicyDebugDecorator(streamType, delegate.create(streamType, policyMetadata, policyConfiguration));
+    }
+
+    @Override
+    public Policy create(StreamType streamType, PolicyMetadata policyMetadata, PolicyConfiguration policyConfiguration, String condition) {
+        return new PolicyDebugDecorator(streamType, delegate.create(streamType, policyMetadata, policyConfiguration, condition));
+    }
+
+    @Override
+    public void cleanup(PolicyMetadata policyMetadata) {
+        delegate.cleanup(policyMetadata);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/policy/impl/PolicyDebugDecoratorFactoryCreator.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/policy/impl/PolicyDebugDecoratorFactoryCreator.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.debug.policy.impl;
+
+import io.gravitee.gateway.policy.PolicyFactory;
+import io.gravitee.gateway.policy.PolicyFactoryCreator;
+import java.util.Objects;
+
+public class PolicyDebugDecoratorFactoryCreator implements PolicyFactoryCreator {
+
+    private final PolicyFactoryCreator delegate;
+
+    public PolicyDebugDecoratorFactoryCreator(PolicyFactoryCreator delegate) {
+        Objects.requireNonNull(delegate, "PolicyFactoryCreator delegate is mandatory");
+        this.delegate = delegate;
+    }
+
+    @Override
+    public PolicyFactory create() {
+        return new PolicyDebugDecoratorFactory(delegate.create());
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/policy/DummyPolicy.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/policy/DummyPolicy.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.debug.policy;
+
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.policy.api.PolicyChain;
+import io.gravitee.policy.api.annotations.OnRequest;
+import io.gravitee.policy.api.annotations.OnRequestContent;
+import io.gravitee.policy.api.annotations.OnResponse;
+import io.gravitee.policy.api.annotations.OnResponseContent;
+
+public class DummyPolicy {
+
+    @OnRequest
+    public void onRequest(PolicyChain chain, Request request, Response response) {
+        // Do nothing
+    }
+
+    @OnResponse
+    public void onResponse(Request chain, Response response, PolicyChain handler) {
+        // Do nothing
+    }
+
+    @OnRequestContent
+    public void onRequestContent(PolicyChain chain, Request request, Response response) {
+        // Do nothing
+    }
+
+    @OnResponseContent
+    public void onResponseContent(Request chain, Response response, PolicyChain handler) {
+        // Do nothing
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/policy/impl/PolicyDebugDecoratorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/policy/impl/PolicyDebugDecoratorTest.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.debug.policy.impl;
+
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.reflections.ReflectionUtils.withAnnotation;
+import static org.reflections.ReflectionUtils.withModifier;
+
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.core.condition.ExpressionLanguageStringConditionEvaluator;
+import io.gravitee.gateway.debug.policy.DummyPolicy;
+import io.gravitee.gateway.policy.PolicyFactory;
+import io.gravitee.gateway.policy.PolicyMetadata;
+import io.gravitee.gateway.policy.PolicyPluginFactory;
+import io.gravitee.gateway.policy.StreamType;
+import io.gravitee.gateway.policy.impl.PolicyFactoryImpl;
+import io.gravitee.policy.api.PolicyChain;
+import io.gravitee.policy.api.annotations.OnRequest;
+import io.gravitee.policy.api.annotations.OnRequestContent;
+import io.gravitee.policy.api.annotations.OnResponse;
+import io.gravitee.policy.api.annotations.OnResponseContent;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Set;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.stubbing.Answer;
+import org.reflections.ReflectionUtils;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class PolicyDebugDecoratorTest {
+
+    @Mock
+    private PolicyPluginFactory policyPluginFactory;
+
+    private PolicyFactory policyFactory;
+
+    @Mock
+    private PolicyChain policyChain;
+
+    @Mock
+    private Request request;
+
+    @Mock
+    private Response response;
+
+    @Mock
+    private ExecutionContext context;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        policyFactory =
+            spy(
+                new PolicyDebugDecoratorFactory(
+                    new PolicyFactoryImpl(policyPluginFactory, new ExpressionLanguageStringConditionEvaluator())
+                )
+            );
+
+        when(context.request()).thenReturn(request);
+        when(context.response()).thenReturn(response);
+    }
+
+    @Test
+    public void onRequest() throws Exception {
+        PolicyMetadata policyMetadata = mock(PolicyMetadata.class);
+        when(policyMetadata.policy()).then((Answer<Class>) invocationOnMock -> DummyPolicy.class);
+        Method onRequestMethod = resolvePolicyMethod(DummyPolicy.class, OnRequest.class);
+        when(policyMetadata.method(OnRequest.class)).thenReturn(onRequestMethod);
+
+        DummyPolicy dummyPolicy = mock(DummyPolicy.class);
+        when(policyPluginFactory.create(DummyPolicy.class, null)).thenReturn(dummyPolicy);
+
+        io.gravitee.gateway.policy.Policy debugPolicy = Mockito.spy(policyFactory.create(StreamType.ON_REQUEST, policyMetadata, null));
+
+        debugPolicy.execute(policyChain, context);
+
+        Assert.assertTrue(debugPolicy.isRunnable());
+        Assert.assertFalse(debugPolicy.isStreamable());
+        verify(dummyPolicy, atLeastOnce()).onRequest(policyChain, request, response);
+        verify(dummyPolicy, never()).onRequestContent(policyChain, request, response);
+        verify(dummyPolicy, never()).onResponse(request, response, policyChain);
+        verify(dummyPolicy, never()).onResponseContent(request, response, policyChain);
+        verify(debugPolicy, atLeastOnce()).execute(policyChain, context);
+    }
+
+    @Test
+    public void onResponse() throws Exception {
+        PolicyMetadata policyMetadata = mock(PolicyMetadata.class);
+        when(policyMetadata.policy()).then((Answer<Class>) invocationOnMock -> DummyPolicy.class);
+        Method onResponseMethod = resolvePolicyMethod(DummyPolicy.class, OnResponse.class);
+        when(policyMetadata.method(OnResponse.class)).thenReturn(onResponseMethod);
+
+        DummyPolicy dummyPolicy = mock(DummyPolicy.class);
+        when(policyPluginFactory.create(DummyPolicy.class, null)).thenReturn(dummyPolicy);
+
+        io.gravitee.gateway.policy.Policy debugPolicy = Mockito.spy(policyFactory.create(StreamType.ON_RESPONSE, policyMetadata, null));
+
+        debugPolicy.execute(policyChain, context);
+
+        Assert.assertTrue(debugPolicy.isRunnable());
+        Assert.assertFalse(debugPolicy.isStreamable());
+        verify(dummyPolicy, never()).onRequest(policyChain, request, response);
+        verify(dummyPolicy, never()).onRequestContent(policyChain, request, response);
+        verify(dummyPolicy, atLeastOnce()).onResponse(request, response, policyChain);
+        verify(dummyPolicy, never()).onResponseContent(request, response, policyChain);
+        verify(debugPolicy, atLeastOnce()).execute(policyChain, context);
+    }
+
+    @Test
+    public void onRequestContent() throws Exception {
+        PolicyMetadata policyMetadata = mock(PolicyMetadata.class);
+        when(policyMetadata.policy()).then((Answer<Class>) invocationOnMock -> DummyPolicy.class);
+        Method onRequestContentMethod = resolvePolicyMethod(DummyPolicy.class, OnRequestContent.class);
+        when(policyMetadata.method(OnRequestContent.class)).thenReturn(onRequestContentMethod);
+
+        DummyPolicy dummyPolicy = mock(DummyPolicy.class);
+        when(policyPluginFactory.create(DummyPolicy.class, null)).thenReturn(dummyPolicy);
+
+        io.gravitee.gateway.policy.Policy debugPolicy = Mockito.spy(policyFactory.create(StreamType.ON_REQUEST, policyMetadata, null));
+
+        debugPolicy.stream(policyChain, context);
+
+        Assert.assertFalse(debugPolicy.isRunnable());
+        Assert.assertTrue(debugPolicy.isStreamable());
+        verify(dummyPolicy, never()).onRequest(policyChain, request, response);
+        verify(dummyPolicy, atLeastOnce()).onRequestContent(policyChain, request, response);
+        verify(dummyPolicy, never()).onResponse(request, response, policyChain);
+        verify(dummyPolicy, never()).onResponseContent(request, response, policyChain);
+        verify(debugPolicy, atLeastOnce()).stream(policyChain, context);
+    }
+
+    @Test
+    public void onResponseContent() throws Exception {
+        PolicyMetadata policyMetadata = mock(PolicyMetadata.class);
+        when(policyMetadata.policy()).then((Answer<Class>) invocationOnMock -> DummyPolicy.class);
+        Method onResponseContentMethod = resolvePolicyMethod(DummyPolicy.class, OnResponseContent.class);
+        when(policyMetadata.method(OnResponseContent.class)).thenReturn(onResponseContentMethod);
+
+        DummyPolicy dummyPolicy = mock(DummyPolicy.class);
+        when(policyPluginFactory.create(DummyPolicy.class, null)).thenReturn(dummyPolicy);
+
+        io.gravitee.gateway.policy.Policy debugPolicy = Mockito.spy(policyFactory.create(StreamType.ON_RESPONSE, policyMetadata, null));
+
+        debugPolicy.stream(policyChain, context);
+
+        Assert.assertFalse(debugPolicy.isRunnable());
+        Assert.assertTrue(debugPolicy.isStreamable());
+        verify(dummyPolicy, never()).onRequest(policyChain, request, response);
+        verify(dummyPolicy, never()).onRequestContent(policyChain, request, response);
+        verify(dummyPolicy, never()).onResponse(request, response, policyChain);
+        verify(dummyPolicy, atLeastOnce()).onResponseContent(request, response, policyChain);
+        verify(debugPolicy, atLeastOnce()).stream(policyChain, context);
+    }
+
+    private Method resolvePolicyMethod(Class<?> clazz, Class<? extends Annotation> annotationClass) {
+        Set<Method> methods = ReflectionUtils.getMethods(clazz, withModifier(Modifier.PUBLIC), withAnnotation(annotationClass));
+
+        if (methods.isEmpty()) {
+            return null;
+        }
+
+        return methods.iterator().next();
+    }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6945

**Description**

Use a dedicated PolicyChainFactory for debug mode. It will be responsible of wrapping policies created by PolicyManager into `DebugPolicy` object.

⚠️🛑  Rewrite and squash commits

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mxvcvqsslq.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-6945-debug-mode-step-2/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
