### PR TITLE
fix(gateway): instantiate propertly AlertProcessor in ResponseProcessorChainFactory

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/ResponseProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/ResponseProcessorChainFactory.java
@@ -24,6 +24,7 @@ import io.gravitee.gateway.reactor.processor.responsetime.ResponseTimeProcessor;
 import io.gravitee.gateway.report.ReporterService;
 import io.gravitee.node.api.Node;
 import io.gravitee.plugin.alert.AlertEventProducer;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,7 +49,9 @@ public class ResponseProcessorChainFactory {
     private String port;
 
     public Processor<ExecutionContext> create() {
-        List<Processor<ExecutionContext>> processors = Arrays.asList(new ResponseTimeProcessor(), new ReporterProcessor(reporterService));
+        List<Processor<ExecutionContext>> processors = new ArrayList<>(
+            Arrays.asList(new ResponseTimeProcessor(), new ReporterProcessor(reporterService))
+        );
 
         if (!eventProducer.isEmpty()) {
             processors.add(new AlertProcessor(eventProducer, node, port));


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6969

**Description**

Do not use Arrays.asList() (immutable) to instanciate the processors list: it instantiate a Arrays$ArrayList which is not java.util.ArrayList


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xqpikyqqyk.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-6969-alert-processor/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
