### PR TITLE
Fix user info display 

### DIFF
--- a/gravitee-apim-console-webui/src/user/_user.scss
+++ b/gravitee-apim-console-webui/src/user/_user.scss
@@ -2,29 +2,34 @@ $userImageSize: 160px;
 
 .gravitee-user-container {
   ng-md-icon {
-    top: -5px;
+    // Needed to override some weird global styles
+    top: 0;
   }
 
-  md-input-container {
-    width: 80%;
-    margin: 0 !important;
-    padding: 0 !important;
+  &__info-row,
+  &__editable-info-row {
+    display: flex;
+    flex-direction: row;
+
+    &__icon {
+      margin-right: 12px;
+    }
+
+    &__label {
+      flex: 1 1 auto;
+    }
+  }
+
+  &__editable-info-row {
+    align-items: baseline;
+  }
+
+  &__info-row {
+    align-items: center;
   }
 }
 
 .gravitee-user-token {
   font-style: italic;
   padding: 10px;
-}
-
-.field-label {
-  padding-top: 2em;
-}
-
-.field-input-container {
-  display: inline-block;
-  position: relative;
-  padding: 2px;
-  margin: 10px 0;
-  vertical-align: middle;
 }

--- a/gravitee-apim-console-webui/src/user/user.html
+++ b/gravitee-apim-console-webui/src/user/user.html
@@ -23,9 +23,9 @@
       <form name="formUser" ng-submit="$ctrl.save()">
         <div layout="row">
           <div flex="80">
-            <div layout="row" layout-align="start center">
-              <ng-md-icon flex="10" icon="person"></ng-md-icon>
-              <md-input-container>
+            <div class="gravitee-user-container__info-row">
+              <ng-md-icon class="gravitee-user-container__editable-info-row__icon" icon="person"></ng-md-icon>
+              <md-input-container class="gravitee-user-container__editable-info-row__label">
                 <label>Firstname</label>
                 <input
                   ng-model="$ctrl.user.firstname"
@@ -34,10 +34,7 @@
                   ng-disabled="!$ctrl.isInternalUser()"
                 />
               </md-input-container>
-            </div>
-            <div layout="row" layout-align="start center">
-              <ng-md-icon flex="10" icon="person"></ng-md-icon>
-              <md-input-container>
+              <md-input-container class="gravitee-user-container__editable-info-row__label">
                 <label>Lastname</label>
                 <input
                   ng-model="$ctrl.user.lastname"
@@ -47,15 +44,16 @@
                 />
               </md-input-container>
             </div>
-            <div layout="row" layout-align="start center">
-              <ng-md-icon flex="10" icon="contact_mail"></ng-md-icon>
-              <md-input-container>
+            <div class="gravitee-user-container__editable-info-row">
+              <ng-md-icon class="gravitee-user-container__editable-info-row__icon" icon="contact_mail"></ng-md-icon>
+              <md-input-container class="gravitee-user-container__editable-info-row__label">
                 <label>Email</label>
                 <input ng-model="$ctrl.user.email" type="text" ng-required="$ctrl.isInternalUser()" ng-disabled="!$ctrl.isInternalUser()" />
               </md-input-container>
             </div>
-            <div layout="row" layout-align="start center">
-              <ng-md-icon flex="10" icon="lock">
+
+            <div class="gravitee-user-container__info-row">
+              <ng-md-icon class="gravitee-user-container__info-row__icon" icon="lock">
                 <md-tooltip>
                   <span ng-repeat="auth in $ctrl.user.authorities">{{auth.authority}}{{$last ? '' : ',&nbsp'}}</span>
                 </md-tooltip>
@@ -64,13 +62,17 @@
                 >{{"[" + role.scope + "]&nbsp;" + role.name}}{{$last ? '' : '&nbsp;-&nbsp;'}}</label
               >
             </div>
-            <div layout="row" layout-align="start center">
-              <ng-md-icon flex="10" icon="group"></ng-md-icon>
+            <div class="gravitee-user-container__info-row">
+              <ng-md-icon class="gravitee-user-container__info-row__icon" icon="group"></ng-md-icon>
               <label>{{$ctrl.groups}}</label>
             </div>
-            <div layout="row" ng-if="$ctrl.fields && $ctrl.fields.length > 0" ng-repeat="field in $ctrl.fields">
-              <label flex="10" class="field-label">{{field.label}}</label>
-              <md-input-container class="field-input-container">
+            <div
+              class="gravitee-user-container__info-row"
+              ng-if="$ctrl.fields && $ctrl.fields.length > 0"
+              ng-repeat="field in $ctrl.fields"
+            >
+              <label class="gravitee-user-container__info-row__icon">{{field.label}}</label>
+              <md-input-container class="gravitee-user-container__editable-info-row__label">
                 <input
                   ng-if="!field.values || field.values.length == 0"
                   ng-model="$ctrl.user.customFields[field.key]"


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5625

**Description**

Update HTML and SCSS to avoid any override of input fields

Before:

<img width="1165" alt="Capture d’écran 2022-01-19 à 14 45 03" src="https://user-images.githubusercontent.com/4112568/150143598-1713fb21-3935-49d1-b483-3d91c724ece6.png">

After:
<img width="1172" alt="Capture d’écran 2022-01-19 à 14 44 10" src="https://user-images.githubusercontent.com/4112568/150143628-b1e33721-7a24-44e7-8ce8-97d0d371348a.png">

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/5625-fix-user-info/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
