### PR TITLE
chore: exclude javax validation from swagger dependencies

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/pom.xml
@@ -33,10 +33,6 @@
 	<packaging>jar</packaging>
 	<name>Gravitee.io APIM - Management API - Management - Rest API</name>
 
-	<properties>
-		<swagger-jersey2-jaxrs.version>1.6.4</swagger-jersey2-jaxrs.version>
-	</properties>
-
 	<dependencies>
 
 		<!-- Gravitee Management dependencies-->
@@ -108,7 +104,6 @@
 		<dependency>
 			<groupId>io.swagger</groupId>
 			<artifactId>swagger-jersey2-jaxrs</artifactId>
-			<version>${swagger-jersey2-jaxrs.version}</version>
 		</dependency>
 
 		<dependency>
@@ -166,4 +161,5 @@
 			<artifactId>json-path</artifactId>
 		</dependency>
 	</dependencies>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,7 @@
         <powermock.version>2.0.9</powermock.version>
         <reactor-adapter.version>3.4.6</reactor-adapter.version>
         <snakeyaml.version>1.30</snakeyaml.version>
+        <swagger-jersey2-jaxrs.version>1.6.4</swagger-jersey2-jaxrs.version>
         <swagger-annotations.version>1.6.4</swagger-annotations.version>
         <swagger-core.version>2.1.11</swagger-core.version>
         <swagger-parser.version>2.0.29</swagger-parser.version>
@@ -485,8 +486,26 @@
 
             <dependency>
                 <groupId>io.swagger</groupId>
+                <artifactId>swagger-jersey2-jaxrs</artifactId>
+                <version>${swagger-jersey2-jaxrs.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.validation</groupId>
+                        <artifactId>validation-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>io.swagger</groupId>
                 <artifactId>swagger-annotations</artifactId>
                 <version>${swagger-annotations.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.validation</groupId>
+                        <artifactId>validation-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -498,6 +517,10 @@
                         <groupId>com.github.fge</groupId>
                         <artifactId>json-patch</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>javax.validation</groupId>
+                        <artifactId>validation-api</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -505,6 +528,12 @@
                 <groupId>io.swagger.core.v3</groupId>
                 <artifactId>swagger-core</artifactId>
                 <version>${swagger-core.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.validation</groupId>
+                        <artifactId>validation-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ooyrrdjhnf.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/chore-javax-validation-version/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
