### PR TITLE
test(cypress): fix cypress configuration files

### DIFF
--- a/gravitee-apim-cypress/cypress/integration/bulk/cypress-config.json
+++ b/gravitee-apim-cypress/cypress/integration/bulk/cypress-config.json
@@ -1,4 +1,24 @@
 {
   "projectId": "gravitee-apim-cypress-bulk",
-  "integrationFolder": "cypress/integration/bulk"
+  "integrationFolder": "cypress/integration/bulk",
+  "baseUrl": "http://localhost:8083",
+  "video": false,
+  "screenshotOnRunFailure": false,
+  "testFiles": "**/*.ts",
+  "env": {
+    "failOnStatusCode": false,
+    "api_publisher_user_login": "api1",
+    "api_publisher_user_password": "api1",
+    "application_user_login": "application1",
+    "application_user_password": "application1",
+    "low_permission_user_login": "user",
+    "low_permission_user_password": "password",
+    "admin_user_login": "admin",
+    "admin_user_password": "admin",
+    "managementOrganizationApi": "/management/organizations/DEFAULT",
+    "managementApi": "/management/organizations/DEFAULT/environments/DEFAULT",
+    "managementUI": "http://localhost:8084",
+    "gatewayServer": "http://localhost:8082",
+    "portalApi": "/portal/environments/DEFAULT"
+  }
 }

--- a/gravitee-apim-cypress/cypress/integration/e2e/cypress-config.json
+++ b/gravitee-apim-cypress/cypress/integration/e2e/cypress-config.json
@@ -1,4 +1,24 @@
 {
   "projectId": "gravitee-apim-cypress-e2e",
-  "integrationFolder": "cypress/integration/e2e"
+  "integrationFolder": "cypress/integration/e2e",
+  "baseUrl": "http://localhost:8083",
+  "video": false,
+  "screenshotOnRunFailure": false,
+  "testFiles": "**/*.ts",
+  "env": {
+    "failOnStatusCode": false,
+    "api_publisher_user_login": "api1",
+    "api_publisher_user_password": "api1",
+    "application_user_login": "application1",
+    "application_user_password": "application1",
+    "low_permission_user_login": "user",
+    "low_permission_user_password": "password",
+    "admin_user_login": "admin",
+    "admin_user_password": "admin",
+    "managementOrganizationApi": "/management/organizations/DEFAULT",
+    "managementApi": "/management/organizations/DEFAULT/environments/DEFAULT",
+    "managementUI": "http://localhost:8084",
+    "gatewayServer": "http://localhost:8082",
+    "portalApi": "/portal/environments/DEFAULT"
+  }
 }

--- a/gravitee-apim-cypress/cypress/integration/rest-api/cypress-config.json
+++ b/gravitee-apim-cypress/cypress/integration/rest-api/cypress-config.json
@@ -1,4 +1,24 @@
 {
   "projectId": "gravitee-apim-cypress-rest-api",
-  "integrationFolder": "cypress/integration/rest-api"
+  "integrationFolder": "cypress/integration/rest-api",
+  "baseUrl": "http://localhost:8083",
+  "video": false,
+  "screenshotOnRunFailure": false,
+  "testFiles": "**/*.ts",
+  "env": {
+    "failOnStatusCode": false,
+    "api_publisher_user_login": "api1",
+    "api_publisher_user_password": "api1",
+    "application_user_login": "application1",
+    "application_user_password": "application1",
+    "low_permission_user_login": "user",
+    "low_permission_user_password": "password",
+    "admin_user_login": "admin",
+    "admin_user_password": "admin",
+    "managementOrganizationApi": "/management/organizations/DEFAULT",
+    "managementApi": "/management/organizations/DEFAULT/environments/DEFAULT",
+    "managementUI": "http://localhost:8084",
+    "gatewayServer": "http://localhost:8082",
+    "portalApi": "/portal/environments/DEFAULT"
+  }
 }

--- a/gravitee-apim-cypress/cypress/integration/ui/cypress-config.json
+++ b/gravitee-apim-cypress/cypress/integration/ui/cypress-config.json
@@ -4,5 +4,23 @@
   "video": true,
   "screenshotOnRunFailure": true,
   "viewportWidth": 1920,
-  "viewportHeight": 1080
+  "viewportHeight": 1080,
+  "baseUrl": "http://localhost:8083",
+  "testFiles": "**/*.ts",
+  "env": {
+    "failOnStatusCode": false,
+    "api_publisher_user_login": "api1",
+    "api_publisher_user_password": "api1",
+    "application_user_login": "application1",
+    "application_user_password": "application1",
+    "low_permission_user_login": "user",
+    "low_permission_user_password": "password",
+    "admin_user_login": "admin",
+    "admin_user_password": "admin",
+    "managementOrganizationApi": "/management/organizations/DEFAULT",
+    "managementApi": "/management/organizations/DEFAULT/environments/DEFAULT",
+    "managementUI": "http://localhost:8084",
+    "gatewayServer": "http://localhost:8082",
+    "portalApi": "/portal/environments/DEFAULT"
+  }
 }


### PR DESCRIPTION
test(cypress): fix cypress configuration files

Rollback cypress configuration files refactoring cause it broke npm scripts.
Cypress currently doesn't provide a simple way to extend base configuration files,
So go back to the old way, duplicating parameters in every configuration file.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ujngxjifrg.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/test-fix-cypress-config/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
