### PR TITLE
chore: disable old classloader to use the new one by default

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiContextHandlerFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiContextHandlerFactory.java
@@ -90,7 +90,7 @@ public class ApiContextHandlerFactory implements ReactorHandlerFactory<Api> {
     @Value("${handlers.request.headers.x-forwarded-prefix:false}")
     private boolean overrideXForwardedPrefix;
 
-    @Value("${classloader.legacy.enabled:true}")
+    @Value("${classloader.legacy.enabled:false}")
     private boolean classLoaderLegacyMode;
 
     @Autowired

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -416,7 +416,7 @@ api:
 #  unit: MILLISECONDS
 
 # Since v3.15.0, a new internal classloader used to load api policies is in place.
-# Setting it to true or removing this setting will switch back to the legacy mode used prior the v3.15.0.
+# Setting it to true will switch back to the legacy mode used prior the v3.15.0.
 classloader:
   legacy:
     enabled: false


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6988

**Description**

The new classloader system used on the gateway side wasn't activated by default in the code.