### PR TITLE
fix: fix conditional policies onXXXXContent

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/ConditionalExecutablePolicy.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/ConditionalExecutablePolicy.java
@@ -15,8 +15,6 @@
  */
 package io.gravitee.gateway.policy.impl;
 
-import io.gravitee.common.http.HttpHeaders;
-import io.gravitee.el.exceptions.ExpressionEvaluationException;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.stream.ReadWriteStream;
@@ -57,13 +55,12 @@ public class ConditionalExecutablePolicy extends ExecutablePolicy {
 
     @Override
     public ReadWriteStream<Buffer> stream(PolicyChain chain, ExecutionContext context) throws PolicyException {
-        boolean isConditionTruthy = evaluateCondition(context);
+        ReadWriteStream<Buffer> stream = super.stream(chain, context);
 
-        ReadWriteStream<Buffer> stream = null;
-        if (isConditionTruthy) {
-            stream = super.stream(chain, context);
+        if (stream == null) {
+            return null;
         }
-        return stream;
+        return new ConditionalReadWriteStream(stream, chain, context, this.id(), condition, conditionEvaluator);
     }
 
     private boolean evaluateCondition(ExecutionContext context) throws PolicyException {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/ConditionalReadWriteStream.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/ConditionalReadWriteStream.java
@@ -1,0 +1,179 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.policy.impl;
+
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.gateway.api.stream.ReadStream;
+import io.gravitee.gateway.api.stream.ReadWriteStream;
+import io.gravitee.gateway.api.stream.SimpleReadWriteStream;
+import io.gravitee.gateway.api.stream.WriteStream;
+import io.gravitee.gateway.core.condition.ConditionEvaluator;
+import io.gravitee.policy.api.PolicyChain;
+import io.gravitee.policy.api.PolicyResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConditionalReadWriteStream extends SimpleReadWriteStream<Buffer> {
+
+    private static final String GATEWAY_POLICY_INTERNAL_ERROR_KEY = "GATEWAY_POLICY_INTERNAL_ERROR";
+    public static final Logger LOGGER = LoggerFactory.getLogger(ConditionalReadWriteStream.class);
+
+    private final String policyId;
+    private final ReadWriteStream<Buffer> delegate;
+    private final String condition;
+    private final ExecutionContext context;
+    private final ConditionEvaluator<String> conditionEvaluator;
+    private final PolicyChain chain;
+
+    private Boolean isConditionTruthy;
+
+    public ConditionalReadWriteStream(
+        ReadWriteStream<Buffer> delegate,
+        PolicyChain chain,
+        ExecutionContext context,
+        String policyId,
+        String condition,
+        ConditionEvaluator<String> conditionEvaluator
+    ) {
+        this.policyId = policyId;
+        this.delegate = delegate;
+        this.condition = condition;
+        this.context = context;
+        this.conditionEvaluator = conditionEvaluator;
+        this.chain = chain;
+    }
+
+    /**
+     * Set body handler for both delegate and this instance
+     * @param handler will handle the buffer
+     * @return this instance with the good body handler
+     */
+    @Override
+    public SimpleReadWriteStream<Buffer> bodyHandler(Handler<Buffer> handler) {
+        delegate.bodyHandler(handler);
+        return super.bodyHandler(handler);
+    }
+
+    /**
+     * Set end handler for both delegate and this instance
+     * @param handler that will be called at the end
+     * @return this instance with the good end handler
+     */
+    @Override
+    public SimpleReadWriteStream<Buffer> endHandler(Handler<Void> handler) {
+        delegate.endHandler(handler);
+        return super.endHandler(handler);
+    }
+
+    /**
+     * Pause both delegate and this instance in case of full queue
+     * @return this instance of ReadStream<Buffer>
+     */
+    @Override
+    public ReadStream<Buffer> pause() {
+        delegate.pause();
+        return super.pause();
+    }
+
+    /**
+     * Resume both delegate and this instance in case of full queue
+     * @return this instance of ReadStream<Buffer>
+     */
+    @Override
+    public ReadStream<Buffer> resume() {
+        delegate.resume();
+        return super.resume();
+    }
+
+    /**
+     * When condition evaluate to true, then we write on the delegate (targeted policy), else, on this instance
+     * @param buffer is the one to write
+     * @return this instance to be able to continue the chaining
+     */
+    @Override
+    public SimpleReadWriteStream<Buffer> write(Buffer buffer) {
+        if (evaluateCondition()) {
+            delegate.write(buffer);
+        } else {
+            super.write(buffer);
+        }
+        return this;
+    }
+
+    /**
+     * When condition evaluate to true, we end the delegate (targeted policy), else, we just end the current instance
+     */
+    @Override
+    public void end() {
+        if (evaluateCondition()) {
+            delegate.end();
+        } else {
+            super.end();
+        }
+    }
+
+    /**
+     * When condition evaluate to true, we end the delegate (targeted policy), else, we just end the current instance
+     */
+    @Override
+    public void end(Buffer buffer) {
+        if (evaluateCondition()) {
+            delegate.end(buffer);
+        } else {
+            super.end(buffer);
+        }
+    }
+
+    /**
+     * Drain handler for both delegate (targeted policy) and this instance.
+     * @param drainHandler to release the pressure on the stream
+     * @return this instance as a WriteStream<Buffer>
+     */
+    @Override
+    public WriteStream<Buffer> drainHandler(Handler<Void> drainHandler) {
+        delegate.drainHandler(drainHandler);
+        return super.drainHandler(drainHandler);
+    }
+
+    /**
+     * Depending on condition evaluation, get writeQueueFull()
+     * @return true if write queue is full
+     */
+    @Override
+    public boolean writeQueueFull() {
+        return evaluateCondition() ? delegate.writeQueueFull() : super.writeQueueFull();
+    }
+
+    /**
+     * Evaluate condition once and keep its value for this instance. This avoid evaluating multiple times the condition.
+     * In case of Exception during evaluation, policy chain will fail and exception rethrown
+     * @return the evaluation result of the condition.
+     */
+    private Boolean evaluateCondition() {
+        if (isConditionTruthy == null) {
+            try {
+                isConditionTruthy = conditionEvaluator.evaluate(context, condition);
+            } catch (RuntimeException e) {
+                LOGGER.error("Condition evaluation fails for policy {}", policyId, e);
+                chain.streamFailWith(PolicyResult.failure(GATEWAY_POLICY_INTERNAL_ERROR_KEY, "Request failed unintentionally"));
+                isConditionTruthy = false;
+            }
+        }
+        return isConditionTruthy;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/PolicyFactoryImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/PolicyFactoryImpl.java
@@ -53,7 +53,7 @@ public class PolicyFactoryImpl implements PolicyFactory {
             streamMethod = policyMetadata.method(OnResponseContent.class);
         }
 
-        if (condition != null) {
+        if (condition != null && !condition.isBlank()) {
             return new ConditionalExecutablePolicy(policyMetadata.id(), policy, headMethod, streamMethod, condition);
         }
         return new ExecutablePolicy(policyMetadata.id(), policy, headMethod, streamMethod);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/policy/DummyStreamablePolicy.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/policy/DummyStreamablePolicy.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.policy;
+
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.http.stream.TransformableRequestStreamBuilder;
+import io.gravitee.gateway.api.http.stream.TransformableResponseStreamBuilder;
+import io.gravitee.gateway.api.stream.ReadWriteStream;
+import io.gravitee.gateway.api.stream.exception.TransformationException;
+import io.gravitee.policy.api.PolicyChain;
+import io.gravitee.policy.api.annotations.OnRequestContent;
+import io.gravitee.policy.api.annotations.OnResponseContent;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class DummyStreamablePolicy {
+
+    @OnRequestContent
+    public ReadWriteStream<Buffer> onRequestContent(Request request, ExecutionContext executionContext, PolicyChain policyChain) {
+        return TransformableRequestStreamBuilder
+            .on(request)
+            .chain(policyChain)
+            .transform(
+                buffer -> {
+                    try {
+                        executionContext.setAttribute("stream", "On Request Content Dummy Streamable Policy");
+                        return Buffer.buffer("On Request Content Dummy Streamable Policy");
+                    } catch (Exception ioe) {
+                        throw new TransformationException("Unable to transform Dummy Streamable Policy Request: " + ioe.getMessage(), ioe);
+                    }
+                }
+            )
+            .build();
+    }
+
+    @OnResponseContent
+    public ReadWriteStream<Buffer> onResponseContent(Response response, ExecutionContext executionContext, PolicyChain policyChain) {
+        return TransformableResponseStreamBuilder
+            .on(response)
+            .chain(policyChain)
+            .transform(
+                buffer -> {
+                    try {
+                        executionContext.setAttribute("stream", "On Response Content Dummy Streamable Policy");
+                        return Buffer.buffer("On Response Content Dummy Streamable Policy");
+                    } catch (Exception ioe) {
+                        throw new TransformationException("Unable to transform Dummy Streamable Policy Response: " + ioe.getMessage(), ioe);
+                    }
+                }
+            )
+            .build();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/policy/impl/PolicyFactoryImplTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/policy/impl/PolicyFactoryImplTest.java
@@ -59,11 +59,29 @@ public class PolicyFactoryImplTest extends TestCase {
     }
 
     @Test
-    public void shouldCreateConditionalExecutablePolicyIfNoCondition() {
+    public void shouldCreateConditionalExecutablePolicyIfCondition() {
         final PolicyConfiguration policyConfiguration = mock(PolicyConfiguration.class);
         final Policy policy = cut.create(StreamType.ON_REQUEST, fakePolicyMetadata(), policyConfiguration, "execution-condition");
 
         assertTrue(policy instanceof ConditionalExecutablePolicy);
+    }
+
+    @Test
+    public void shouldNotCreateConditionalExecutablePolicyIfNullCondition() {
+        final PolicyConfiguration policyConfiguration = mock(PolicyConfiguration.class);
+        final Policy policy = cut.create(StreamType.ON_REQUEST, fakePolicyMetadata(), policyConfiguration, null);
+
+        assertTrue(policy instanceof ExecutablePolicy);
+        assertFalse(policy instanceof ConditionalExecutablePolicy);
+    }
+
+    @Test
+    public void shouldNotCreateConditionalExecutablePolicyIfEmptyCondition() {
+        final PolicyConfiguration policyConfiguration = mock(PolicyConfiguration.class);
+        final Policy policy = cut.create(StreamType.ON_REQUEST, fakePolicyMetadata(), policyConfiguration, "");
+
+        assertTrue(policy instanceof ExecutablePolicy);
+        assertFalse(policy instanceof ConditionalExecutablePolicy);
     }
 
     private PolicyMetadata fakePolicyMetadata() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/flow/InvalidConditionalStreamPolicyTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/flow/InvalidConditionalStreamPolicyTest.java
@@ -28,6 +28,7 @@ import io.gravitee.gateway.standalone.flow.policy.OnRequestPolicy;
 import io.gravitee.gateway.standalone.flow.policy.Stream2Policy;
 import io.gravitee.gateway.standalone.junit.annotation.ApiDescriptor;
 import io.gravitee.gateway.standalone.policy.PolicyBuilder;
+import io.gravitee.gateway.standalone.utils.StringUtils;
 import io.gravitee.plugin.core.api.ConfigurablePluginManager;
 import io.gravitee.plugin.policy.PolicyPlugin;
 import org.apache.http.HttpResponse;
@@ -40,30 +41,24 @@ import org.junit.Test;
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
-@ApiDescriptor("/io/gravitee/gateway/standalone/flow/invalid-conditional-policy-flow.json")
-public class InvalidConditionalPolicyTest extends AbstractWiremockGatewayTest {
+@ApiDescriptor("/io/gravitee/gateway/standalone/flow/invalid-conditional-stream-policy-flow.json")
+public class InvalidConditionalStreamPolicyTest extends AbstractWiremockGatewayTest {
 
     @Test
     public void shouldNotRunPoliciesIfConditionIsInvalid() throws Exception {
         wireMockRule.stubFor(get("/team/my_team").willReturn(ok()));
 
-        final HttpResponse response = execute(
-            Request.Get("http://localhost:8082/test/my_team").addHeader("conditionHeader", "condition-ok")
-        )
-            .returnResponse();
+        final HttpResponse response = execute(Request.Get("http://localhost:8082/test/my_team")).returnResponse();
         assertEquals(HttpStatusCode.INTERNAL_SERVER_ERROR_500, response.getStatusLine().getStatusCode());
-        wireMockRule.verify(0, anyRequestedFor(anyUrl()));
+        String responseContent = StringUtils.copy(response.getEntity().getContent());
+        wireMockRule.verify(1, anyRequestedFor(anyUrl()));
     }
 
     @Override
     public void registerPolicy(ConfigurablePluginManager<PolicyPlugin> policyPluginManager) {
         super.registerPolicy(policyPluginManager);
 
-        PolicyPlugin myPolicyHeader1 = PolicyBuilder.build("header-policy1", Header1Policy.class);
-        PolicyPlugin onRequestPolicy = PolicyBuilder.build("on-request-policy", OnRequestPolicy.class);
         PolicyPlugin streamPolicy2 = PolicyBuilder.build("stream-policy2", Stream2Policy.class);
-        policyPluginManager.register(myPolicyHeader1);
-        policyPluginManager.register(onRequestPolicy);
         policyPluginManager.register(streamPolicy2);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/resources/io/gravitee/gateway/standalone/flow/invalid-conditional-stream-policy-flow.json
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/resources/io/gravitee/gateway/standalone/flow/invalid-conditional-stream-policy-flow.json
@@ -1,0 +1,39 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/team",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "New flow",
+      "path-operator": {
+        "operator": "STARTS_WITH",
+        "path": "/"
+      },
+      "methods": [],
+      "pre": [],
+      "post": [
+        {
+        "policy": "stream-policy2",
+        "name": "My stream policy",
+        "description": "Step description",
+        "condition": "{#requestaders['condition___this_is_invalid)}",
+        "configuration": {}
+      }
+      ],
+      "enabled": true
+    }
+  ]
+}


### PR DESCRIPTION
**Issue**

gravitee-io/issues#6886

**Description**

Before this PR, condition were evaluated at the moment stream was built.
We fix that Implementing our own ConditionalReadWriteStream, which is responsible of evaluate the condition only once and :
- make the chain fail in case of exception
- execute the policy if condition is true
- do not execute it if condition is false


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ceqmmidzmh.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6886-conditional-onrequestcontent-bis/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
