### PR TITLE
chore: bump versions of already released deps

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -47,49 +47,49 @@
         <!-- Versions of the plugins for the full distribution -->
         <!-- Management API & Gateway -->
         <gravitee-connector-http.version>1.1.0-SNAPSHOT</gravitee-connector-http.version>
-        <gravitee-policy-apikey.version>2.4.0-SNAPSHOT</gravitee-policy-apikey.version>
+        <gravitee-policy-apikey.version>2.4.0</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>1.5.0</gravitee-policy-assign-attributes.version>
-        <gravitee-policy-assign-content.version>1.7.0-SNAPSHOT</gravitee-policy-assign-content.version>
-        <gravitee-policy-cache.version>1.14.0-SNAPSHOT</gravitee-policy-cache.version>
-        <gravitee-policy-callout-http.version>1.15.0-SNAPSHOT</gravitee-policy-callout-http.version>
+        <gravitee-policy-assign-content.version>1.7.0</gravitee-policy-assign-content.version>
+        <gravitee-policy-cache.version>1.14.0</gravitee-policy-cache.version>
+        <gravitee-policy-callout-http.version>1.15.0</gravitee-policy-callout-http.version>
         <gravitee-policy-dynamic-routing.version>1.11.1</gravitee-policy-dynamic-routing.version>
-        <gravitee-policy-generate-http-signature.version>1.1.0-SNAPSHOT</gravitee-policy-generate-http-signature.version>
+        <gravitee-policy-generate-http-signature.version>1.1.0</gravitee-policy-generate-http-signature.version>
         <gravitee-policy-generate-jwt.version>1.5.0</gravitee-policy-generate-jwt.version>
-        <gravitee-policy-groovy.version>2.1.0-SNAPSHOT</gravitee-policy-groovy.version>
+        <gravitee-policy-groovy.version>2.1.0</gravitee-policy-groovy.version>
         <gravitee-policy-html-json.version>1.6.0</gravitee-policy-html-json.version>
-        <gravitee-policy-http-signature.version>1.5.0-SNAPSHOT</gravitee-policy-http-signature.version>
-        <gravitee-policy-ipfiltering.version>1.9.0-SNAPSHOT</gravitee-policy-ipfiltering.version>
-        <gravitee-policy-json-threat-protection.version>1.3.0-SNAPSHOT</gravitee-policy-json-threat-protection.version>
-        <gravitee-policy-json-to-json.version>1.7.0-SNAPSHOT</gravitee-policy-json-to-json.version>
+        <gravitee-policy-http-signature.version>1.5.0</gravitee-policy-http-signature.version>
+        <gravitee-policy-ipfiltering.version>1.9.0</gravitee-policy-ipfiltering.version>
+        <gravitee-policy-json-threat-protection.version>1.3.1</gravitee-policy-json-threat-protection.version>
+        <gravitee-policy-json-to-json.version>1.7.0</gravitee-policy-json-to-json.version>
         <gravitee-policy-json-validation.version>1.6.0</gravitee-policy-json-validation.version>
-        <gravitee-policy-json-xml.version>1.1.0-SNAPSHOT</gravitee-policy-json-xml.version>
-        <gravitee-policy-jws.version>1.3.0</gravitee-policy-jws.version>
-        <gravitee-policy-jwt.version>1.22.0-SNAPSHOT</gravitee-policy-jwt.version>
+        <gravitee-policy-json-xml.version>1.1.0</gravitee-policy-json-xml.version>
+        <gravitee-policy-jws.version>1.3.1</gravitee-policy-jws.version>
+        <gravitee-policy-jwt.version>1.22.0</gravitee-policy-jwt.version>
         <gravitee-policy-keyless.version>1.4.0</gravitee-policy-keyless.version>
         <gravitee-policy-latency.version>1.4.0</gravitee-policy-latency.version>
-        <gravitee-policy-metrics-reporter.version>1.2.0-SNAPSHOT</gravitee-policy-metrics-reporter.version>
-        <gravitee-policy-mock.version>1.13.0-SNAPSHOT</gravitee-policy-mock.version>
-        <gravitee-policy-oauth2.version>1.19.0-SNAPSHOT</gravitee-policy-oauth2.version>
-        <gravitee-policy-openid-connect-userinfo.version>1.5.0-SNAPSHOT</gravitee-policy-openid-connect-userinfo.version>
+        <gravitee-policy-metrics-reporter.version>1.2.0</gravitee-policy-metrics-reporter.version>
+        <gravitee-policy-mock.version>1.13.0</gravitee-policy-mock.version>
+        <gravitee-policy-oauth2.version>1.19.0</gravitee-policy-oauth2.version>
+        <gravitee-policy-openid-connect-userinfo.version>1.5.0</gravitee-policy-openid-connect-userinfo.version>
         <gravitee-policy-override-http-method.version>1.3.0</gravitee-policy-override-http-method.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->
-        <!--    <gravitee-policy-quota.version>1.13.0</gravitee-policy-quota.version>    -->
-        <!--    <gravitee-policy-spikearrest.version>1.13.0</gravitee-policy-spikearrest.version>    -->
-        <gravitee-policy-ratelimit.version>1.15.0-SNAPSHOT</gravitee-policy-ratelimit.version>
-        <gravitee-policy-regex-threat-protection.version>1.3.0-SNAPSHOT</gravitee-policy-regex-threat-protection.version>
-        <gravitee-policy-request-content-limit.version>1.8.0-SNAPSHOT</gravitee-policy-request-content-limit.version>
-        <gravitee-policy-request-validation.version>1.13.0-SNAPSHOT</gravitee-policy-request-validation.version>
+        <!--    <gravitee-policy-quota.version>1.15.0</gravitee-policy-quota.version>    -->
+        <!--    <gravitee-policy-spikearrest.version>1.15.0</gravitee-policy-spikearrest.version>    -->
+        <gravitee-policy-ratelimit.version>1.15.0</gravitee-policy-ratelimit.version>
+        <gravitee-policy-regex-threat-protection.version>1.3.0</gravitee-policy-regex-threat-protection.version>
+        <gravitee-policy-request-content-limit.version>1.8.0</gravitee-policy-request-content-limit.version>
+        <gravitee-policy-request-validation.version>1.13.0</gravitee-policy-request-validation.version>
         <gravitee-policy-resource-filtering.version>1.8.0</gravitee-policy-resource-filtering.version>
         <gravitee-policy-rest-to-soap.version>1.12.0</gravitee-policy-rest-to-soap.version>
-        <gravitee-policy-retry.version>2.0.0.7327</gravitee-policy-retry.version>
+        <gravitee-policy-retry.version>2.1.0</gravitee-policy-retry.version>
         <gravitee-policy-role-based-access-control.version>1.1.0</gravitee-policy-role-based-access-control.version>
         <gravitee-policy-ssl-enforcement.version>1.2.0</gravitee-policy-ssl-enforcement.version>
         <gravitee-policy-traffic-shadowing.version>1.1.0</gravitee-policy-traffic-shadowing.version>
-        <gravitee-policy-transformheaders.version>1.9.0-SNAPSHOT</gravitee-policy-transformheaders.version>
+        <gravitee-policy-transformheaders.version>1.9.1</gravitee-policy-transformheaders.version>
         <gravitee-policy-transformqueryparams.version>1.6.0</gravitee-policy-transformqueryparams.version>
-        <gravitee-policy-url-rewriting.version>1.5.0-SNAPSHOT</gravitee-policy-url-rewriting.version>
-        <gravitee-policy-xml-json.version>1.8.0-SNAPSHOT</gravitee-policy-xml-json.version>
-        <gravitee-policy-xml-threat-protection.version>1.3.0-SNAPSHOT</gravitee-policy-xml-threat-protection.version>
+        <gravitee-policy-url-rewriting.version>1.5.0</gravitee-policy-url-rewriting.version>
+        <gravitee-policy-xml-json.version>1.8.0</gravitee-policy-xml-json.version>
+        <gravitee-policy-xml-threat-protection.version>1.3.0</gravitee-policy-xml-threat-protection.version>
         <gravitee-policy-xml-validation.version>1.1.0</gravitee-policy-xml-validation.version>
         <gravitee-policy-xslt.version>1.6.0</gravitee-policy-xslt.version>
         <gravitee-resource-cache.version>1.7.0-SNAPSHOT</gravitee-resource-cache.version>
@@ -107,10 +107,10 @@
         <!-- Gateway Only -->
         <gravitee-reporter-elasticsearch.version>3.11.0-SNAPSHOT</gravitee-reporter-elasticsearch.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->
-        <!--    <gravitee-gateway-services-ratelimit.version>1.13.0</gravitee-gateway-services-ratelimit.version>    -->
+        <!--    <gravitee-gateway-services-ratelimit.version>1.15.0</gravitee-gateway-services-ratelimit.version>    -->
         <gravitee-reporter-file.version>2.5.0-SNAPSHOT</gravitee-reporter-file.version>
         <gravitee-reporter-tcp.version>1.4.0-SNAPSHOT</gravitee-reporter-tcp.version>
-        <gravitee-tracer-jaeger.version>1.0.1</gravitee-tracer-jaeger.version>
+        <gravitee-tracer-jaeger.version>1.1.0-SNAPSHOT</gravitee-tracer-jaeger.version>
     </properties>
 
     <dependencies>
@@ -622,8 +622,8 @@
                 <gravitee-ae-connectors-ws.version>1.5.4</gravitee-ae-connectors-ws.version>
                 <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
                 <!-- Management API Only -->
-                <gravitee-notifier-email.version>1.3.0</gravitee-notifier-email.version>
-                <gravitee-notifier-slack.version>1.2.0</gravitee-notifier-slack.version>
+                <gravitee-notifier-email.version>1.3.1</gravitee-notifier-email.version>
+                <gravitee-notifier-slack.version>1.2.1</gravitee-notifier-slack.version>
                 <gravitee-notifier-webhook.version>1.1.0</gravitee-notifier-webhook.version>
                 <!-- Gateway Only -->
             </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -57,21 +57,21 @@
         <!-- Vert.X version is mandatory for vertx-grpc-protoc-plugin in gravitee-gateway-standalone-container -->
         <vertx.version>4.2.3</vertx.version>
         <!-- Gravitee dependencies version -->
-        <gravitee-bom.version>2.0-SNAPSHOT</gravitee-bom.version>
+        <gravitee-bom.version>2.0</gravitee-bom.version>
         <gravitee-alert-api.version>1.8.0</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>1.9.0</gravitee-cockpit-api.version>
-        <gravitee-common.version>1.25.0-SNAPSHOT</gravitee-common.version>
+        <gravitee-common.version>1.25.0</gravitee-common.version>
         <gravitee-connector-api.version>1.1.0-SNAPSHOT</gravitee-connector-api.version>
         <gravitee-definition.version>1.31.0-SNAPSHOT</gravitee-definition.version>
-        <gravitee-expression-language.version>1.8.0-SNAPSHOT</gravitee-expression-language.version>
+        <gravitee-expression-language.version>1.8.0</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>1.31.0-SNAPSHOT</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>1.20.0-SNAPSHOT</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>
         <gravitee-plugin.version>1.22.0-SNAPSHOT</gravitee-plugin.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-reporter-api.version>1.22.0-SNAPSHOT</gravitee-reporter-api.version>
+        <gravitee-reporter-api.version>1.22.0</gravitee-reporter-api.version>
         <gravitee-resource-cache-provider-api.version>1.1.0</gravitee-resource-cache-provider-api.version>
         <gravitee-resource-oauth2-provider-api.version>1.3.0</gravitee-resource-oauth2-provider-api.version>
         <gravitee-service-discovery-api.version>1.1.1</gravitee-service-discovery-api.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6995

**Description**

Every policies are now configured to use semantic release. For the 3.15.0 version of APIM, every modified policy has already been released. So we need to change the pom.xml of apim-distribution module.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dcrsqixndp.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6995-prepare-3-15-release/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
