### PR TITLE
refactor: avoid too many instantiations in conditional policies

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
@@ -19,6 +19,7 @@ import io.gravitee.common.util.DataEncryptor;
 import io.gravitee.gateway.core.classloader.DefaultClassLoader;
 import io.gravitee.gateway.core.component.ComponentProvider;
 import io.gravitee.gateway.core.component.spring.SpringComponentProvider;
+import io.gravitee.gateway.core.condition.ExpressionLanguageStringConditionEvaluator;
 import io.gravitee.gateway.handlers.api.manager.ApiManager;
 import io.gravitee.gateway.handlers.api.manager.endpoint.ApiManagementEndpoint;
 import io.gravitee.gateway.handlers.api.manager.endpoint.ApisManagementEndpoint;
@@ -79,7 +80,7 @@ public class ApiHandlerConfiguration {
 
     @Bean
     public PolicyFactoryCreator policyFactoryFactoryBean(final Environment environment, final PolicyPluginFactory policyPluginFactory) {
-        return new PolicyFactoryCreator(environment, policyPluginFactory);
+        return new PolicyFactoryCreator(environment, policyPluginFactory, new ExpressionLanguageStringConditionEvaluator());
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/PolicyFactoryCreator.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/PolicyFactoryCreator.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.policy.impl;
 
+import io.gravitee.gateway.core.condition.ConditionEvaluator;
 import io.gravitee.gateway.policy.PolicyFactory;
 import io.gravitee.gateway.policy.PolicyPluginFactory;
 import io.gravitee.gateway.policy.impl.tracing.TracingPolicyPluginFactory;
@@ -33,10 +34,16 @@ public class PolicyFactoryCreator implements FactoryBean<PolicyFactory> {
 
     private final Environment environment;
     private final PolicyPluginFactory policyPluginFactory;
+    private final ConditionEvaluator<String> conditionEvaluator;
 
-    public PolicyFactoryCreator(final Environment environment, final PolicyPluginFactory policyPluginFactory) {
+    public PolicyFactoryCreator(
+        final Environment environment,
+        final PolicyPluginFactory policyPluginFactory,
+        ConditionEvaluator<String> conditionEvaluator
+    ) {
         this.environment = environment;
         this.policyPluginFactory = policyPluginFactory;
+        this.conditionEvaluator = conditionEvaluator;
     }
 
     @Override
@@ -48,8 +55,8 @@ public class PolicyFactoryCreator implements FactoryBean<PolicyFactory> {
         }
 
         final PolicyFactory policyFactory = tracing
-            ? new TracingPolicyPluginFactory(policyPluginFactory)
-            : new PolicyFactoryImpl(policyPluginFactory);
+            ? new TracingPolicyPluginFactory(policyPluginFactory, conditionEvaluator)
+            : new PolicyFactoryImpl(policyPluginFactory, conditionEvaluator);
         return new CachedPolicyFactory(policyFactory);
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/PolicyFactoryImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/PolicyFactoryImpl.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.policy.impl;
 
+import io.gravitee.gateway.core.condition.ConditionEvaluator;
 import io.gravitee.gateway.policy.*;
 import io.gravitee.policy.api.PolicyConfiguration;
 import io.gravitee.policy.api.annotations.OnRequest;
@@ -30,9 +31,11 @@ import java.lang.reflect.Method;
 public class PolicyFactoryImpl implements PolicyFactory {
 
     private final PolicyPluginFactory policyPluginFactory;
+    private final ConditionEvaluator<String> conditionEvaluator;
 
-    public PolicyFactoryImpl(final PolicyPluginFactory policyPluginFactory) {
+    public PolicyFactoryImpl(final PolicyPluginFactory policyPluginFactory, final ConditionEvaluator<String> conditionEvaluator) {
         this.policyPluginFactory = policyPluginFactory;
+        this.conditionEvaluator = conditionEvaluator;
     }
 
     @Override
@@ -54,7 +57,7 @@ public class PolicyFactoryImpl implements PolicyFactory {
         }
 
         if (condition != null && !condition.isBlank()) {
-            return new ConditionalExecutablePolicy(policyMetadata.id(), policy, headMethod, streamMethod, condition);
+            return new ConditionalExecutablePolicy(policyMetadata.id(), policy, headMethod, streamMethod, condition, conditionEvaluator);
         }
         return new ExecutablePolicy(policyMetadata.id(), policy, headMethod, streamMethod);
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/tracing/TracingPolicyPluginFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/tracing/TracingPolicyPluginFactory.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.policy.impl.tracing;
 
+import io.gravitee.gateway.core.condition.ConditionEvaluator;
 import io.gravitee.gateway.policy.Policy;
 import io.gravitee.gateway.policy.PolicyMetadata;
 import io.gravitee.gateway.policy.PolicyPluginFactory;
@@ -28,8 +29,8 @@ import io.gravitee.policy.api.PolicyConfiguration;
  */
 public class TracingPolicyPluginFactory extends PolicyFactoryImpl {
 
-    public TracingPolicyPluginFactory(PolicyPluginFactory policyPluginFactory) {
-        super(policyPluginFactory);
+    public TracingPolicyPluginFactory(PolicyPluginFactory policyPluginFactory, ConditionEvaluator<String> conditionEvaluator) {
+        super(policyPluginFactory, conditionEvaluator);
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/policy/PolicyTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/policy/PolicyTest.java
@@ -22,6 +22,7 @@ import static org.reflections.ReflectionUtils.withModifier;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.core.condition.ExpressionLanguageStringConditionEvaluator;
 import io.gravitee.gateway.policy.impl.PolicyFactoryImpl;
 import io.gravitee.policy.api.PolicyChain;
 import io.gravitee.policy.api.annotations.OnRequest;
@@ -65,7 +66,7 @@ public class PolicyTest {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        policyFactory = spy(new PolicyFactoryImpl(policyPluginFactory));
+        policyFactory = spy(new PolicyFactoryImpl(policyPluginFactory, new ExpressionLanguageStringConditionEvaluator()));
 
         when(context.request()).thenReturn(request);
         when(context.response()).thenReturn(response);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/policy/impl/ConditionalExecutablePolicyTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/policy/impl/ConditionalExecutablePolicyTest.java
@@ -30,6 +30,8 @@ import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.api.stream.ReadWriteStream;
+import io.gravitee.gateway.core.condition.ConditionEvaluator;
+import io.gravitee.gateway.core.condition.ExpressionLanguageStringConditionEvaluator;
 import io.gravitee.gateway.policy.DummyPolicy;
 import io.gravitee.gateway.policy.DummyStreamablePolicy;
 import io.gravitee.gateway.policy.PolicyException;
@@ -62,12 +64,14 @@ public class ConditionalExecutablePolicyTest extends TestCase {
     private TemplateEngine templateEngine;
 
     private Method method;
+    private ConditionEvaluator<String> conditionEvaluator;
 
     @Before
     public void setUp() throws NoSuchMethodException {
         when(executionContext.request()).thenReturn(mock(Request.class));
         when(executionContext.response()).thenReturn(mock(Response.class));
         method = DummyPolicy.class.getMethod("onRequest", PolicyChain.class, Request.class, Response.class);
+        conditionEvaluator = new ExpressionLanguageStringConditionEvaluator();
     }
 
     @Test
@@ -80,7 +84,8 @@ public class ConditionalExecutablePolicyTest extends TestCase {
             fakeExecutePolicy(),
             method,
             method,
-            "condition"
+            "condition",
+            conditionEvaluator
         );
         policy.execute(policyChain, executionContext);
         verify(policyChain, never()).doNext(any(), any());
@@ -96,7 +101,8 @@ public class ConditionalExecutablePolicyTest extends TestCase {
             fakeExecutePolicy(),
             method,
             method,
-            "condition"
+            "condition",
+            conditionEvaluator
         );
         policy.execute(policyChain, executionContext);
         verify(policyChain, times(1)).doNext(any(), any());
@@ -112,7 +118,8 @@ public class ConditionalExecutablePolicyTest extends TestCase {
             fakeExecutePolicy(),
             method,
             method,
-            "condition"
+            "condition",
+            conditionEvaluator
         );
         policy.execute(policyChain, executionContext);
     }
@@ -128,7 +135,8 @@ public class ConditionalExecutablePolicyTest extends TestCase {
             fakeStreamPolicy(),
             method,
             method,
-            "condition"
+            "condition",
+            conditionEvaluator
         );
         final ReadWriteStream<Buffer> conditionedStream = policy.stream(policyChain, executionContext);
 
@@ -153,7 +161,8 @@ public class ConditionalExecutablePolicyTest extends TestCase {
             fakeStreamPolicy(),
             method,
             method,
-            "condition"
+            "condition",
+            conditionEvaluator
         );
         final ReadWriteStream<Buffer> conditionedStream = policy.stream(policyChain, executionContext);
         conditionedStream.write(Buffer.buffer("Test")).end();
@@ -171,7 +180,8 @@ public class ConditionalExecutablePolicyTest extends TestCase {
             fakeStreamPolicy(),
             method,
             method,
-            "condition"
+            "condition",
+            conditionEvaluator
         );
         final ReadWriteStream<Buffer> conditionedStream = policy.stream(policyChain, executionContext);
         conditionedStream.write(Buffer.buffer("Test")).end();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/policy/impl/PolicyFactoryImplTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/policy/impl/PolicyFactoryImplTest.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.policy.impl;
 
 import static org.mockito.Mockito.mock;
 
+import io.gravitee.gateway.core.condition.ExpressionLanguageStringConditionEvaluator;
 import io.gravitee.gateway.policy.DummyPolicy;
 import io.gravitee.gateway.policy.Policy;
 import io.gravitee.gateway.policy.PolicyFactory;
@@ -46,7 +47,7 @@ public class PolicyFactoryImplTest extends TestCase {
 
     @Before
     public void setUp() {
-        cut = new PolicyFactoryImpl(policyPluginFactory);
+        cut = new PolicyFactoryImpl(policyPluginFactory, new ExpressionLanguageStringConditionEvaluator());
     }
 
     @Test


### PR DESCRIPTION
**Issue**

gravitee-io/issues#6886

**Description**

According to review made after merge of https://github.com/gravitee-io/gravitee-api-management/pull/1139, we need some refactor:

- [x] Avoid to create a ConditionEvaluator for each new instance of ConditionalExecutablePolicies (move it at configuration level)
- [x] fix return type for `ConditionalExecutablePolicy#evaluateCondition(context)`
- [x] `resume()` and `pause()` should have the same behavior as `writeQueueFull`
- [x] Provide a unique way of evaluating condition, through a `Function` only instantiated once per `ConditionalExecutablePolicy`


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fzcpcatwvi.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6886-conditional-onrequestcontent-ter/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
