### PR TITLE
chore: bump `@gravitee/ui-components` to 3.28.7

### DIFF
--- a/gravitee-apim-console-webui/package-lock.json
+++ b/gravitee-apim-console-webui/package-lock.json
@@ -8420,14 +8420,14 @@
       }
     },
     "@codemirror/autocomplete": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.10.tgz",
-      "integrity": "sha512-8mgT+cSVxIoV/AbfJ36+r06xykxpACmXoD8bbTNwnkrttTwLkugxUP2oFAxL7I+TGMwxkX3ZquroyWX0HFO9nQ==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.12.tgz",
+      "integrity": "sha512-zUQYo5gMdv7vhxlKoAY/vnNCGzlE9AU7+P649v3ovpQpoFdo3U1Nt01EJqFb4Sfaw6l1U/Elc9Iksd1lDy+MVw==",
       "requires": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/state": "^0.19.4",
         "@codemirror/text": "^0.19.2",
-        "@codemirror/tooltip": "^0.19.0",
+        "@codemirror/tooltip": "^0.19.12",
         "@codemirror/view": "^0.19.0",
         "@lezer/common": "^0.15.0"
       }
@@ -8467,9 +8467,9 @@
       }
     },
     "@codemirror/commands": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-0.19.6.tgz",
-      "integrity": "sha512-Mjc3ZfTifOn0h5499xI3MfCVIZvO2I0ochgzxfRtPOFwfXX/k7HTgnK0/KzuGDINyxUVeDaFCkf53TyyWjdxMQ==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-0.19.7.tgz",
+      "integrity": "sha512-Mwh064xnuDbFw+9KJAi2Hmg8Va+YqQzgn6e/94/bSJavY3uuIBPr4vJp6pFEa1qPp40qs5/XJ01ty/0G3uLewA==",
       "requires": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/matchbrackets": "^0.19.0",
@@ -8490,9 +8490,9 @@
       }
     },
     "@codemirror/fold": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/fold/-/fold-0.19.2.tgz",
-      "integrity": "sha512-FLi6RBhHPBnSbKZEu1S98z+VYSP5678cMdYVqhR58OWWTkEiLRVPeCTj8FhRKNL9B8Gx+lBQhGq3uwr3KtSs8w==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/fold/-/fold-0.19.3.tgz",
+      "integrity": "sha512-8hT+Eq2G68mL0yPRvSD2ewhnLQAX6sbUJmtGVKFcj8oAXtfpYCX8LIcfXsuI19Qs7gZkOSpqZvn+KKj8IhZoAw==",
       "requires": {
         "@codemirror/gutter": "^0.19.0",
         "@codemirror/language": "^0.19.0",
@@ -8581,9 +8581,9 @@
       }
     },
     "@codemirror/lang-javascript": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-0.19.4.tgz",
-      "integrity": "sha512-oRANfqQH5XNcfr0Y9pIzAxqXldLmCLpklknODtmEAZ8wQNBiVmgIeLb3JXdOJ43iZWnnmetkDOctFy/N8KuD4Q==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-0.19.6.tgz",
+      "integrity": "sha512-NgkoCIc3hdTNTBRIRuPqfUJ0WB798qEgwAgtjwYy6yoiK5CzbDS2z5CFW17h9RmaAx6t1m64iY2CZ3tC7r15Gw==",
       "requires": {
         "@codemirror/autocomplete": "^0.19.0",
         "@codemirror/highlight": "^0.19.7",
@@ -8632,11 +8632,11 @@
       }
     },
     "@codemirror/lang-python": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-0.19.2.tgz",
-      "integrity": "sha512-qeDymHL97+pNxFiDrtaMFvd/dActt7sZjebPnrc8T2V1CcBkc2YkcaxEOD5dssM/rQ9dG9LqON/Nbk2fIxcapA==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-0.19.3.tgz",
+      "integrity": "sha512-WN0FnY0RZdmFJTHgHdXx7CgnfEpDJ96BROE2528mKPwJEbNaZecP92i27Nlnhy4oaSsSKnZ0zi4KlCOjvMmBoA==",
       "requires": {
-        "@codemirror/highlight": "^0.19.0",
+        "@codemirror/highlight": "^0.19.7",
         "@codemirror/language": "^0.19.0",
         "@lezer/python": "^0.15.0"
       }
@@ -8803,9 +8803,9 @@
       }
     },
     "@codemirror/stream-parser": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/stream-parser/-/stream-parser-0.19.3.tgz",
-      "integrity": "sha512-9fV6GgcZSLVvvPCd/SUt00G/Sqt91r0ojEQsgH7koWn4McTFvSujhOs0LHJlQGQRazuuWW1j3eqrv19+E9t40g==",
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/stream-parser/-/stream-parser-0.19.4.tgz",
+      "integrity": "sha512-rvZpn3Dnxxjc+Pbjo1o/sJCgVO/CSyWCr52zRLeYYT30y3a+ogHIEtsUFBnY6kUDlxoxO9uc318JGGNuX4wjjQ==",
       "requires": {
         "@codemirror/highlight": "^0.19.0",
         "@codemirror/language": "^0.19.0",
@@ -8816,23 +8816,23 @@
       }
     },
     "@codemirror/text": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.19.5.tgz",
-      "integrity": "sha512-Syu5Xc7tZzeUAM/y4fETkT0zgGr48rDG+w4U38bPwSIUr+L9S/7w2wDE1WGNzjaZPz12F6gb1gxWiSTg9ocLow=="
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.19.6.tgz",
+      "integrity": "sha512-T9jnREMIygx+TPC1bOuepz18maGq/92q2a+n4qTqObKwvNMg+8cMTslb8yxeEDEq7S3kpgGWxgO1UWbQRij0dA=="
     },
     "@codemirror/tooltip": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@codemirror/tooltip/-/tooltip-0.19.10.tgz",
-      "integrity": "sha512-xqIhCHr+IYoamdNLvBnU/oDh92zPnsbT1zLaFtKTFi9GI9SxOfBhWY3jfMENlK0j1C9rk8+AvwpXblPGvY/O6w==",
+      "version": "0.19.13",
+      "resolved": "https://registry.npmjs.org/@codemirror/tooltip/-/tooltip-0.19.13.tgz",
+      "integrity": "sha512-7vgvjQjwFQ9hPejw2s+w3UR1XAYjQ5M0F9HRwutXkZHP1tBFV7LnNJ3xBD7F9SR9kAh8WgdL3BpUsEwX1aqoQg==",
       "requires": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/view": "^0.19.0"
       }
     },
     "@codemirror/view": {
-      "version": "0.19.39",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.39.tgz",
-      "integrity": "sha512-ol4smHAwhWkW8p1diPZiZkLZVmKybKhQigwyrgdF7k1UFNY+/KDH4w2xic8JQXxX+v0ppMsoNf11C+afKJze5g==",
+      "version": "0.19.40",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.40.tgz",
+      "integrity": "sha512-0CQV99+/nIKTVVbDs0XjW4Rkp8TobzJBXRaUHF6mOroVjuIBBcolE1eAGVEU5LrCS44C798jiP4r/HhLDNS+rw==",
       "requires": {
         "@codemirror/rangeset": "^0.19.5",
         "@codemirror/state": "^0.19.3",
@@ -9091,11 +9091,11 @@
       "integrity": "sha512-svwnzu0KKVpMEuRU1G58xp1BNrho5qki/bxpF/y1tOjAOoM357Avw8Gc8xw40pbN5B1QNyT3wuZQ/nMwSbjh9w=="
     },
     "@formatjs/ecma402-abstract": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.1.tgz",
-      "integrity": "sha512-tgtNODZUGuUI6PAcnvaLZpGrZLVkXnnAvgzOiueYMzFdOdcOw4iH1WKhCe3+r6VR8rHKToJ2HksUGNCB+zt/bg==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.2.tgz",
+      "integrity": "sha512-qDgOL0vtfJ51cc0pRbFB/oXc4qDbamG22Z6h/QWy6FBxaQgppiy8JF0iYbmNO35cC8r88bQGsgfd/eM6/eTEQQ==",
       "requires": {
-        "@formatjs/intl-localematcher": "0.2.22",
+        "@formatjs/intl-localematcher": "0.2.23",
         "tslib": "^2.1.0"
       },
       "dependencies": {
@@ -9122,11 +9122,11 @@
       }
     },
     "@formatjs/intl-locale": {
-      "version": "2.4.43",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-locale/-/intl-locale-2.4.43.tgz",
-      "integrity": "sha512-3Q0U1GbNR63vD21Y+0VsNvNDYpUA9wmpKenH5c0oaHKGw5mtGuiuD53H83w/u3ZqIfy2vqOjJGYDR8wHjb8/iA==",
+      "version": "2.4.44",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-locale/-/intl-locale-2.4.44.tgz",
+      "integrity": "sha512-k8Jhl7mJHzPVDrb5b/wR0sO8vG/aG8IA97171hGk4eZKpwNwQ0HBk6u22eaObcDRJ1yfzBT9oeT4AZfrnbl0Pw==",
       "requires": {
-        "@formatjs/ecma402-abstract": "1.11.1",
+        "@formatjs/ecma402-abstract": "1.11.2",
         "@formatjs/intl-getcanonicallocales": "1.9.0",
         "tslib": "^2.1.0"
       },
@@ -9139,9 +9139,9 @@
       }
     },
     "@formatjs/intl-localematcher": {
-      "version": "0.2.22",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.22.tgz",
-      "integrity": "sha512-z+TvbHW8Q/g2l7/PnfUl0mV9gWxV4d0HT6GQyzkO5QI6QjCvCZGiztnmLX7zoyS16uSMvZ2PoMDfSK9xvZkRRA==",
+      "version": "0.2.23",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.23.tgz",
+      "integrity": "sha512-oCe2TOciTtB1bEbJ85EvYrXQxD0epusmVJfJ7AduO0tlbXP42CmDIYIH2CZ+kP2GE+PTLQD1Hbt9kpOpl939MQ==",
       "requires": {
         "tslib": "^2.1.0"
       },
@@ -9154,12 +9154,12 @@
       }
     },
     "@formatjs/intl-relativetimeformat": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-9.5.0.tgz",
-      "integrity": "sha512-wbfWPgh2m/gsYQVZlE1HQ5g/usPhpKMqL5ffZvj+l7SUPVwuaTsg+k7AjWS4il6Kb92hD+FdKPYdRY+IpCyqxg==",
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-9.5.1.tgz",
+      "integrity": "sha512-A4kL6tTjcvVgyKH33BREBWBW2nPgTJSkhjKcTGfNHdmvWN8WAbDovRVOUZ6UmufRW7ZZfoDA8QT7sEOKuxKqyg==",
       "requires": {
-        "@formatjs/ecma402-abstract": "1.11.1",
-        "@formatjs/intl-localematcher": "0.2.22",
+        "@formatjs/ecma402-abstract": "1.11.2",
+        "@formatjs/intl-localematcher": "0.2.23",
         "tslib": "^2.1.0"
       },
       "dependencies": {
@@ -9177,9 +9177,9 @@
       "dev": true
     },
     "@gravitee/ui-components": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.28.0.tgz",
-      "integrity": "sha512-AXFGU17bvV2pQbeYEeE/KWwCHt5acR+3DRwgUpyLo6YwFhhqHro8IFoYD5V5i4lJPEhZj/OfbJbYxreMxz3l5w==",
+      "version": "3.28.7",
+      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.28.7.tgz",
+      "integrity": "sha512-TbSven69IEsdbJyxxboujvnQaj1tB4JU3wNf8OQT5JW3CBnv9uUC6DRvw/6+RXMn0O3kkRNijCq7i+d/7P7oBg==",
       "requires": {
         "@codemirror/basic-setup": "^0.19.1",
         "@codemirror/language-data": "^0.19.1",
@@ -10665,9 +10665,9 @@
       "integrity": "sha512-vv0nSdIaVCRcJ8rPuDdsrNVfBOYe/4Szr/LhF929XyDmBndLDuWiCCHooGlGlJfzELyO608AyDhVsuX/ZG36NA=="
     },
     "@lezer/cpp": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lezer/cpp/-/cpp-0.15.0.tgz",
-      "integrity": "sha512-IXX79VTsV/kxDyxzr2XogSobaj4hVXm8cp24oOoB3DzcGu+6X3VVVNOWo/I8Mg1U42OCPGGHrjZU1hmDjrl6BA==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@lezer/cpp/-/cpp-0.15.2.tgz",
+      "integrity": "sha512-4Ve5LIRCE+VF+XE/cfSSOg6VuTOfh1pU2oxLKJu3XbyYzmSp9IjSZcW/UNcSRtMxM05MQ4/3AR5tUwp9PL4ExA==",
       "requires": {
         "@lezer/lr": "^0.15.0"
       }
@@ -10713,9 +10713,9 @@
       }
     },
     "@lezer/lr": {
-      "version": "0.15.5",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.5.tgz",
-      "integrity": "sha512-DEcLyhdmBxD1foQe7RegLrSlfS/XaTMGLkO5evkzHWAQKh/JnFWp7j7iNB7s2EpxzRrBCh0U+W7JDCeFhv2mng==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.7.tgz",
+      "integrity": "sha512-rmUukgyKSm6xzXO4cK5hkpX3+ZTHF+bHDkEuhofAVUTS3J23YytUxGWsrDwBVvGbhvxW87kheb2mRYHRwKacDQ==",
       "requires": {
         "@lezer/common": "^0.15.0"
       }
@@ -10761,9 +10761,9 @@
       }
     },
     "@lit/reactive-element": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.1.1.tgz",
-      "integrity": "sha512-B2JdRMwCGv+VpIRj3CYVQBx3muPDeE8y+HPgWqzrAHsO5/40BpwDFZeplIV790BaTqDVUDvZOKMSbuFM9zWC0w=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.2.0.tgz",
+      "integrity": "sha512-7i/Fz8enAQ2AN5DyJ2i2AFERufjP6x1NjuHoNgDyJkjjHxEoo8kVyyHxu1A9YyeShlksjt5FvpvENBDuivQHLA=="
     },
     "@mdx-js/loader": {
       "version": "1.6.22",

--- a/gravitee-apim-console-webui/package.json
+++ b/gravitee-apim-console-webui/package.json
@@ -15,7 +15,7 @@
     "@angular/upgrade": "12.2.3",
     "@asyncapi/web-component": "1.0.0-next.15",
     "@fontsource/libre-franklin": "4.4.5",
-    "@gravitee/ui-components": "3.28.0",
+    "@gravitee/ui-components": "3.28.7",
     "@gravitee/ui-particles-angular": "1.4.0",
     "@highcharts/map-collection": "1.1.3",
     "@toast-ui/editor": "2.5.2",

--- a/gravitee-apim-portal-webui/package-lock.json
+++ b/gravitee-apim-portal-webui/package-lock.json
@@ -3531,14 +3531,14 @@
       }
     },
     "@codemirror/autocomplete": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.10.tgz",
-      "integrity": "sha512-8mgT+cSVxIoV/AbfJ36+r06xykxpACmXoD8bbTNwnkrttTwLkugxUP2oFAxL7I+TGMwxkX3ZquroyWX0HFO9nQ==",
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.12.tgz",
+      "integrity": "sha512-zUQYo5gMdv7vhxlKoAY/vnNCGzlE9AU7+P649v3ovpQpoFdo3U1Nt01EJqFb4Sfaw6l1U/Elc9Iksd1lDy+MVw==",
       "requires": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/state": "^0.19.4",
         "@codemirror/text": "^0.19.2",
-        "@codemirror/tooltip": "^0.19.0",
+        "@codemirror/tooltip": "^0.19.12",
         "@codemirror/view": "^0.19.0",
         "@lezer/common": "^0.15.0"
       }
@@ -3578,9 +3578,9 @@
       }
     },
     "@codemirror/commands": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-0.19.6.tgz",
-      "integrity": "sha512-Mjc3ZfTifOn0h5499xI3MfCVIZvO2I0ochgzxfRtPOFwfXX/k7HTgnK0/KzuGDINyxUVeDaFCkf53TyyWjdxMQ==",
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-0.19.7.tgz",
+      "integrity": "sha512-Mwh064xnuDbFw+9KJAi2Hmg8Va+YqQzgn6e/94/bSJavY3uuIBPr4vJp6pFEa1qPp40qs5/XJ01ty/0G3uLewA==",
       "requires": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/matchbrackets": "^0.19.0",
@@ -3601,9 +3601,9 @@
       }
     },
     "@codemirror/fold": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/fold/-/fold-0.19.2.tgz",
-      "integrity": "sha512-FLi6RBhHPBnSbKZEu1S98z+VYSP5678cMdYVqhR58OWWTkEiLRVPeCTj8FhRKNL9B8Gx+lBQhGq3uwr3KtSs8w==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/fold/-/fold-0.19.3.tgz",
+      "integrity": "sha512-8hT+Eq2G68mL0yPRvSD2ewhnLQAX6sbUJmtGVKFcj8oAXtfpYCX8LIcfXsuI19Qs7gZkOSpqZvn+KKj8IhZoAw==",
       "requires": {
         "@codemirror/gutter": "^0.19.0",
         "@codemirror/language": "^0.19.0",
@@ -3692,9 +3692,9 @@
       }
     },
     "@codemirror/lang-javascript": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-0.19.4.tgz",
-      "integrity": "sha512-oRANfqQH5XNcfr0Y9pIzAxqXldLmCLpklknODtmEAZ8wQNBiVmgIeLb3JXdOJ43iZWnnmetkDOctFy/N8KuD4Q==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-0.19.6.tgz",
+      "integrity": "sha512-NgkoCIc3hdTNTBRIRuPqfUJ0WB798qEgwAgtjwYy6yoiK5CzbDS2z5CFW17h9RmaAx6t1m64iY2CZ3tC7r15Gw==",
       "requires": {
         "@codemirror/autocomplete": "^0.19.0",
         "@codemirror/highlight": "^0.19.7",
@@ -3743,11 +3743,11 @@
       }
     },
     "@codemirror/lang-python": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-0.19.2.tgz",
-      "integrity": "sha512-qeDymHL97+pNxFiDrtaMFvd/dActt7sZjebPnrc8T2V1CcBkc2YkcaxEOD5dssM/rQ9dG9LqON/Nbk2fIxcapA==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-0.19.3.tgz",
+      "integrity": "sha512-WN0FnY0RZdmFJTHgHdXx7CgnfEpDJ96BROE2528mKPwJEbNaZecP92i27Nlnhy4oaSsSKnZ0zi4KlCOjvMmBoA==",
       "requires": {
-        "@codemirror/highlight": "^0.19.0",
+        "@codemirror/highlight": "^0.19.7",
         "@codemirror/language": "^0.19.0",
         "@lezer/python": "^0.15.0"
       }
@@ -3914,9 +3914,9 @@
       }
     },
     "@codemirror/stream-parser": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/stream-parser/-/stream-parser-0.19.3.tgz",
-      "integrity": "sha512-9fV6GgcZSLVvvPCd/SUt00G/Sqt91r0ojEQsgH7koWn4McTFvSujhOs0LHJlQGQRazuuWW1j3eqrv19+E9t40g==",
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/stream-parser/-/stream-parser-0.19.4.tgz",
+      "integrity": "sha512-rvZpn3Dnxxjc+Pbjo1o/sJCgVO/CSyWCr52zRLeYYT30y3a+ogHIEtsUFBnY6kUDlxoxO9uc318JGGNuX4wjjQ==",
       "requires": {
         "@codemirror/highlight": "^0.19.0",
         "@codemirror/language": "^0.19.0",
@@ -3927,23 +3927,23 @@
       }
     },
     "@codemirror/text": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.19.5.tgz",
-      "integrity": "sha512-Syu5Xc7tZzeUAM/y4fETkT0zgGr48rDG+w4U38bPwSIUr+L9S/7w2wDE1WGNzjaZPz12F6gb1gxWiSTg9ocLow=="
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.19.6.tgz",
+      "integrity": "sha512-T9jnREMIygx+TPC1bOuepz18maGq/92q2a+n4qTqObKwvNMg+8cMTslb8yxeEDEq7S3kpgGWxgO1UWbQRij0dA=="
     },
     "@codemirror/tooltip": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@codemirror/tooltip/-/tooltip-0.19.10.tgz",
-      "integrity": "sha512-xqIhCHr+IYoamdNLvBnU/oDh92zPnsbT1zLaFtKTFi9GI9SxOfBhWY3jfMENlK0j1C9rk8+AvwpXblPGvY/O6w==",
+      "version": "0.19.13",
+      "resolved": "https://registry.npmjs.org/@codemirror/tooltip/-/tooltip-0.19.13.tgz",
+      "integrity": "sha512-7vgvjQjwFQ9hPejw2s+w3UR1XAYjQ5M0F9HRwutXkZHP1tBFV7LnNJ3xBD7F9SR9kAh8WgdL3BpUsEwX1aqoQg==",
       "requires": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/view": "^0.19.0"
       }
     },
     "@codemirror/view": {
-      "version": "0.19.39",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.39.tgz",
-      "integrity": "sha512-ol4smHAwhWkW8p1diPZiZkLZVmKybKhQigwyrgdF7k1UFNY+/KDH4w2xic8JQXxX+v0ppMsoNf11C+afKJze5g==",
+      "version": "0.19.40",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.40.tgz",
+      "integrity": "sha512-0CQV99+/nIKTVVbDs0XjW4Rkp8TobzJBXRaUHF6mOroVjuIBBcolE1eAGVEU5LrCS44C798jiP4r/HhLDNS+rw==",
       "requires": {
         "@codemirror/rangeset": "^0.19.5",
         "@codemirror/state": "^0.19.3",
@@ -3997,28 +3997,28 @@
       }
     },
     "@formatjs/intl-locale": {
-      "version": "2.4.43",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-locale/-/intl-locale-2.4.43.tgz",
-      "integrity": "sha512-3Q0U1GbNR63vD21Y+0VsNvNDYpUA9wmpKenH5c0oaHKGw5mtGuiuD53H83w/u3ZqIfy2vqOjJGYDR8wHjb8/iA==",
+      "version": "2.4.44",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-locale/-/intl-locale-2.4.44.tgz",
+      "integrity": "sha512-k8Jhl7mJHzPVDrb5b/wR0sO8vG/aG8IA97171hGk4eZKpwNwQ0HBk6u22eaObcDRJ1yfzBT9oeT4AZfrnbl0Pw==",
       "requires": {
-        "@formatjs/ecma402-abstract": "1.11.1",
+        "@formatjs/ecma402-abstract": "1.11.2",
         "@formatjs/intl-getcanonicallocales": "1.9.0",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "@formatjs/ecma402-abstract": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.1.tgz",
-          "integrity": "sha512-tgtNODZUGuUI6PAcnvaLZpGrZLVkXnnAvgzOiueYMzFdOdcOw4iH1WKhCe3+r6VR8rHKToJ2HksUGNCB+zt/bg==",
+          "version": "1.11.2",
+          "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.2.tgz",
+          "integrity": "sha512-qDgOL0vtfJ51cc0pRbFB/oXc4qDbamG22Z6h/QWy6FBxaQgppiy8JF0iYbmNO35cC8r88bQGsgfd/eM6/eTEQQ==",
           "requires": {
-            "@formatjs/intl-localematcher": "0.2.22",
+            "@formatjs/intl-localematcher": "0.2.23",
             "tslib": "^2.1.0"
           }
         },
         "@formatjs/intl-localematcher": {
-          "version": "0.2.22",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.22.tgz",
-          "integrity": "sha512-z+TvbHW8Q/g2l7/PnfUl0mV9gWxV4d0HT6GQyzkO5QI6QjCvCZGiztnmLX7zoyS16uSMvZ2PoMDfSK9xvZkRRA==",
+          "version": "0.2.23",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.23.tgz",
+          "integrity": "sha512-oCe2TOciTtB1bEbJ85EvYrXQxD0epusmVJfJ7AduO0tlbXP42CmDIYIH2CZ+kP2GE+PTLQD1Hbt9kpOpl939MQ==",
           "requires": {
             "tslib": "^2.1.0"
           }
@@ -4063,9 +4063,9 @@
       }
     },
     "@gravitee/ui-components": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.28.0.tgz",
-      "integrity": "sha512-AXFGU17bvV2pQbeYEeE/KWwCHt5acR+3DRwgUpyLo6YwFhhqHro8IFoYD5V5i4lJPEhZj/OfbJbYxreMxz3l5w==",
+      "version": "3.28.7",
+      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.28.7.tgz",
+      "integrity": "sha512-TbSven69IEsdbJyxxboujvnQaj1tB4JU3wNf8OQT5JW3CBnv9uUC6DRvw/6+RXMn0O3kkRNijCq7i+d/7P7oBg==",
       "requires": {
         "@codemirror/basic-setup": "^0.19.1",
         "@codemirror/language-data": "^0.19.1",
@@ -4085,29 +4085,29 @@
       },
       "dependencies": {
         "@formatjs/ecma402-abstract": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.1.tgz",
-          "integrity": "sha512-tgtNODZUGuUI6PAcnvaLZpGrZLVkXnnAvgzOiueYMzFdOdcOw4iH1WKhCe3+r6VR8rHKToJ2HksUGNCB+zt/bg==",
+          "version": "1.11.2",
+          "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.2.tgz",
+          "integrity": "sha512-qDgOL0vtfJ51cc0pRbFB/oXc4qDbamG22Z6h/QWy6FBxaQgppiy8JF0iYbmNO35cC8r88bQGsgfd/eM6/eTEQQ==",
           "requires": {
-            "@formatjs/intl-localematcher": "0.2.22",
+            "@formatjs/intl-localematcher": "0.2.23",
             "tslib": "^2.1.0"
           }
         },
         "@formatjs/intl-localematcher": {
-          "version": "0.2.22",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.22.tgz",
-          "integrity": "sha512-z+TvbHW8Q/g2l7/PnfUl0mV9gWxV4d0HT6GQyzkO5QI6QjCvCZGiztnmLX7zoyS16uSMvZ2PoMDfSK9xvZkRRA==",
+          "version": "0.2.23",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.23.tgz",
+          "integrity": "sha512-oCe2TOciTtB1bEbJ85EvYrXQxD0epusmVJfJ7AduO0tlbXP42CmDIYIH2CZ+kP2GE+PTLQD1Hbt9kpOpl939MQ==",
           "requires": {
             "tslib": "^2.1.0"
           }
         },
         "@formatjs/intl-relativetimeformat": {
-          "version": "9.5.0",
-          "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-9.5.0.tgz",
-          "integrity": "sha512-wbfWPgh2m/gsYQVZlE1HQ5g/usPhpKMqL5ffZvj+l7SUPVwuaTsg+k7AjWS4il6Kb92hD+FdKPYdRY+IpCyqxg==",
+          "version": "9.5.1",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-9.5.1.tgz",
+          "integrity": "sha512-A4kL6tTjcvVgyKH33BREBWBW2nPgTJSkhjKcTGfNHdmvWN8WAbDovRVOUZ6UmufRW7ZZfoDA8QT7sEOKuxKqyg==",
           "requires": {
-            "@formatjs/ecma402-abstract": "1.11.1",
-            "@formatjs/intl-localematcher": "0.2.22",
+            "@formatjs/ecma402-abstract": "1.11.2",
+            "@formatjs/intl-localematcher": "0.2.23",
             "tslib": "^2.1.0"
           }
         },
@@ -4864,9 +4864,9 @@
       "integrity": "sha512-vv0nSdIaVCRcJ8rPuDdsrNVfBOYe/4Szr/LhF929XyDmBndLDuWiCCHooGlGlJfzELyO608AyDhVsuX/ZG36NA=="
     },
     "@lezer/cpp": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lezer/cpp/-/cpp-0.15.0.tgz",
-      "integrity": "sha512-IXX79VTsV/kxDyxzr2XogSobaj4hVXm8cp24oOoB3DzcGu+6X3VVVNOWo/I8Mg1U42OCPGGHrjZU1hmDjrl6BA==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@lezer/cpp/-/cpp-0.15.2.tgz",
+      "integrity": "sha512-4Ve5LIRCE+VF+XE/cfSSOg6VuTOfh1pU2oxLKJu3XbyYzmSp9IjSZcW/UNcSRtMxM05MQ4/3AR5tUwp9PL4ExA==",
       "requires": {
         "@lezer/lr": "^0.15.0"
       }
@@ -4912,9 +4912,9 @@
       }
     },
     "@lezer/lr": {
-      "version": "0.15.5",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.5.tgz",
-      "integrity": "sha512-DEcLyhdmBxD1foQe7RegLrSlfS/XaTMGLkO5evkzHWAQKh/JnFWp7j7iNB7s2EpxzRrBCh0U+W7JDCeFhv2mng==",
+      "version": "0.15.7",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.7.tgz",
+      "integrity": "sha512-rmUukgyKSm6xzXO4cK5hkpX3+ZTHF+bHDkEuhofAVUTS3J23YytUxGWsrDwBVvGbhvxW87kheb2mRYHRwKacDQ==",
       "requires": {
         "@lezer/common": "^0.15.0"
       }
@@ -4960,9 +4960,9 @@
       }
     },
     "@lit/reactive-element": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.1.1.tgz",
-      "integrity": "sha512-B2JdRMwCGv+VpIRj3CYVQBx3muPDeE8y+HPgWqzrAHsO5/40BpwDFZeplIV790BaTqDVUDvZOKMSbuFM9zWC0w=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.2.0.tgz",
+      "integrity": "sha512-7i/Fz8enAQ2AN5DyJ2i2AFERufjP6x1NjuHoNgDyJkjjHxEoo8kVyyHxu1A9YyeShlksjt5FvpvENBDuivQHLA=="
     },
     "@ngneat/spectator": {
       "version": "5.13.4",

--- a/gravitee-apim-portal-webui/package.json
+++ b/gravitee-apim-portal-webui/package.json
@@ -36,7 +36,7 @@
     "@angular/router": "9.1.1",
     "@asyncapi/web-component": "1.0.0-next.15",
     "@formatjs/intl-relativetimeformat": "9.3.1",
-    "@gravitee/ui-components": "3.28.0",
+    "@gravitee/ui-components": "3.28.7",
     "@highcharts/map-collection": "1.1.3",
     "@ibm/plex": "5.1.3",
     "@ngx-translate/core": "12.1.2",


### PR DESCRIPTION
**Issue**

NA

**Description**

Bump `@gravitee/ui-components` to 3.28.7
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gazvygygvc.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/bump-ui-components/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
