### PR TITLE
fix(webhook): trim webhook url when creating an application alert

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/AlertMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/AlertMapper.java
@@ -191,7 +191,7 @@ public class AlertMapper {
             try {
                 WebhookNotifierConfiguration webhookConfig = new WebhookNotifierConfiguration(
                     alertInput.getWebhook().getHttpMethod().getValue(),
-                    alertInput.getWebhook().getUrl()
+                    alertInput.getWebhook().getUrl().strip()
                 );
                 if (
                     alertInput.getWebhook().getHttpMethod() == HttpMethod.PUT ||

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/AlertMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/AlertMapperTest.java
@@ -293,6 +293,24 @@ public class AlertMapperTest {
     }
 
     @Test
+    public void convertAlertWebhookWithSpaceInURL() {
+        AlertInput alertInput = new AlertInput();
+        AlertWebhook alertWebhook = new AlertWebhook();
+        alertWebhook.setHttpMethod(HttpMethod.HEAD);
+        alertWebhook.setUrl("http://my.url/with/final/space ");
+        alertInput.setWebhook(alertWebhook);
+        alertInput.setStatusCode("200");
+        alertInput.setStatusPercent(20);
+        alertInput.setDuration(10);
+
+        final NewAlertTriggerEntity newAlert = alertMapper.convert(alertInput);
+        assertEquals(
+            "{\"method\":\"HEAD\",\"url\":\"http://my.url/with/final/space\",\"headers\":[],\"body\":null}",
+            newAlert.getNotifications().get(0).getConfiguration()
+        );
+    }
+
+    @Test
     public void convertAlertTriggerEntityToAlertResponseTime() {
         AlertTriggerEntity alertTriggerEntity = mock(AlertTriggerEntity.class);
         when(alertTriggerEntity.getType()).thenReturn(AlertMapper.RESPONSE_TIME_ALERT);


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6979

**Description**

trim webhook url when creating an application alert
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uiulzjtzge.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6979-trim-webhook-url/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
