### PR TITLE
chore: upgrade vertx to v4.2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,9 +55,9 @@
 
     <properties>
         <!-- Vert.X version is mandatory for vertx-grpc-protoc-plugin in gravitee-gateway-standalone-container -->
-        <vertx.version>4.2.3</vertx.version>
+        <vertx.version>4.2.4</vertx.version>
         <!-- Gravitee dependencies version -->
-        <gravitee-bom.version>2.0</gravitee-bom.version>
+        <gravitee-bom.version>2.1</gravitee-bom.version>
         <gravitee-alert-api.version>1.8.0</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>1.9.0</gravitee-cockpit-api.version>
         <gravitee-common.version>1.25.0</gravitee-common.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7008

**Description**

Upgrade vertx to 4.2.4 to fix some critical issues

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qqdnpqbkap.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7008-upgrade-vertx-4-2-4/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
