### PR TITLE
fix: allow users with read only permission to read APIs

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -1033,17 +1033,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     public boolean canManageApi(RoleEntity role) {
         return (
             role.getScope().equals(RoleScope.API) &&
-            role
-                .getPermissions()
-                .entrySet()
-                .stream()
-                .filter(entry -> isManagementPermission(entry.getKey()))
-                .anyMatch(
-                    entry -> {
-                        String stringPerm = new String(entry.getValue());
-                        return stringPerm.contains("C") || stringPerm.contains("U") || stringPerm.contains("D");
-                    }
-                )
+            role.getPermissions().entrySet().stream().anyMatch(entry -> isManagementPermission(entry.getKey()))
         );
     }
 


### PR DESCRIPTION
The required permissions to access APIs from the console were set
to Create, Update or Delete, making user with the Read permission
attached to their role unable to access APIs, be it from a group
or a direct membership.

see https://github.com/gravitee-io/issues/issues/6475

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6475-fix-read-only-premissions/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
