### PR TITLE
Improve swagger-ui in our UIs

### DIFF
--- a/gravitee-apim-console-webui/package-lock.json
+++ b/gravitee-apim-console-webui/package-lock.json
@@ -14520,9 +14520,9 @@
       }
     },
     "swagger-ui-dist": {
-      "version": "3.48.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.48.0.tgz",
-      "integrity": "sha512-UgpKIQW5RAb4nYRG8B615blmQzct0DNuvtX4904Fe2aMWAVfWeKHKl4kwzFXuBJgr2WYWTwM1PnhZ+qqkLrpPg=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.3.0.tgz",
+      "integrity": "sha512-RY1c3y6uuHBTu4nZPXcvrv9cnKj6MbaNMZK1NDyGHrUbQOO5WmkuMo6wi93WFzSURJk0SboD1X9nM5CtQAu2Og=="
     },
     "symbol-tree": {
       "version": "3.2.4",

--- a/gravitee-apim-console-webui/package.json
+++ b/gravitee-apim-console-webui/package.json
@@ -60,7 +60,7 @@
     "showdown": "^1.9.1",
     "showdown-highlightjs-extension": "^0.1.2",
     "showdown-prettify": "^1.3.0",
-    "swagger-ui-dist": "^3.48.0",
+    "swagger-ui-dist": "^4.3.0",
     "tinycolor2": "^1.4.2",
     "traverse": "^0.6.6",
     "unicode": "^11.0.1",

--- a/gravitee-apim-console-webui/src/components/documentation/page/page-swagger.component.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/page/page-swagger.component.ts
@@ -107,9 +107,9 @@ class PageSwaggerComponentController implements IController {
     if (this.pageConfiguration?.showURL === 'true') {
       let url = '';
       if (this.$state.params.apiId) {
-        url = `${this.Constants.env.baseURL}/apis/${this.$state.params.apiId}/pages/${this.$state.params.pageId}/content'`;
+        url = `${this.Constants.env.baseURL}/apis/${this.$state.params.apiId}/pages/${this.$state.params.pageId}/content`;
       } else {
-        url = `${this.Constants.env.baseURL}/portal/pages/${this.$state.params.pageId}/content'`;
+        url = `${this.Constants.env.baseURL}/portal/pages/${this.$state.params.pageId}/content`;
       }
       if (url.includes('{:envId}')) {
         url = url.replace('{:envId}', this.Constants.org.currentEnv.id);

--- a/gravitee-apim-portal-webui/package-lock.json
+++ b/gravitee-apim-portal-webui/package-lock.json
@@ -17559,9 +17559,9 @@
       }
     },
     "swagger-ui-dist": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.25.0.tgz",
-      "integrity": "sha512-vwvJPPbdooTvDwLGzjIXinOXizDJJ6U1hxnJL3y6U3aL1d2MSXDmKg2139XaLBhsVZdnQJV2bOkX4reB+RXamg=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.3.0.tgz",
+      "integrity": "sha512-RY1c3y6uuHBTu4nZPXcvrv9cnKj6MbaNMZK1NDyGHrUbQOO5WmkuMo6wi93WFzSURJk0SboD1X9nM5CtQAu2Og=="
     },
     "swagger2openapi": {
       "version": "6.2.3",

--- a/gravitee-apim-portal-webui/package.json
+++ b/gravitee-apim-portal-webui/package.json
@@ -55,7 +55,7 @@
     "redoc": "^2.0.0-rc.53",
     "resize-observer-polyfill": "^1.5.1",
     "rxjs": "6.5.5",
-    "swagger-ui-dist": "^3.25.0",
+    "swagger-ui-dist": "^4.3.0",
     "tslib": "^1.11.1",
     "zone.js": "~0.10.2"
   },

--- a/gravitee-apim-portal-webui/projects/portal-webclient-sdk/src/lib/model/pageConfiguration.ts
+++ b/gravitee-apim-portal-webui/projects/portal-webclient-sdk/src/lib/model/pageConfiguration.ts
@@ -30,7 +30,7 @@ export interface PageConfiguration {
     /**
      * Show the URL to download the content.
      */
-    show_url?: string;
+    show_url?: boolean;
     /**
      * Display the operationId in the operations list.
      */

--- a/gravitee-apim-portal-webui/scripts/update-sdk.sh
+++ b/gravitee-apim-portal-webui/scripts/update-sdk.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 npx @openapitools/openapi-generator-cli@1.0.18-4.3.1 generate \
--i ../gravitee-management-rest-api/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/main/resources/openapi.yaml \
+-i ../gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/openapi.yaml \
 -g typescript-angular \
 -o projects/portal-webclient-sdk/src/lib/ \
 -puseSingleRequestParameter=true \

--- a/gravitee-apim-portal-webui/src/styles.scss
+++ b/gravitee-apim-portal-webui/src/styles.scss
@@ -188,6 +188,13 @@ h2.title {
   opacity: 0.5;
 }
 
+/* Hack for swagger, because the previous h2.title is also applied in the swagger-ui component */
+.swagger-ui .info .title {
+  font-size: initial;
+  line-height: initial;
+  opacity: initial;
+}
+
 h3.title {
   font-size: var(--gv-theme-font-size-l);
   line-height: var(--gv-theme-font-size-l);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PageMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/PageMapper.java
@@ -128,7 +128,7 @@ public class PageMapper {
             pageConfiguration.setShowExtensions(Boolean.parseBoolean(showExtensions));
         }
         if (showUrl != null) {
-            pageConfiguration.setShowUrl(showUrl);
+            pageConfiguration.setShowUrl(Boolean.parseBoolean(showUrl));
         }
         if (tryIt != null) {
             pageConfiguration.setTryIt(Boolean.parseBoolean(tryIt));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/openapi.yaml
@@ -4739,7 +4739,7 @@ components:
           type: string
           description: Base URL used to try the API.
         show_url:
-          type: string
+          type: boolean
           description: Show the URL to download the content.
         display_operation_id:
           type: boolean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/PageMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/PageMapperTest.java
@@ -128,7 +128,7 @@ public class PageMapperTest {
         assertEquals(42, pageConfiguration.getMaxDisplayedTags());
         assertFalse(pageConfiguration.getShowCommonExtensions());
         assertTrue(pageConfiguration.getShowExtensions());
-        assertEquals(PAGE_CONFIGURATION_SHOW_URL, pageConfiguration.getShowUrl());
+        assertFalse(pageConfiguration.getShowUrl());
         assertTrue(pageConfiguration.getTryIt());
         assertFalse(pageConfiguration.getTryItAnonymous());
         assertEquals(PAGE_CONFIGURATION_TRY_IT_URL, pageConfiguration.getTryItUrl());


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6713

**Description**

* bump swagger-ui-dist version to 4.3.0
* fix a wrong type for a parameter that cause the downloadURL to be always displayed in portal
* fix the pb of the issue
* add a CSS hack to display well swaggerUI in portal
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6713-error-with-swagger-ui/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
