### PR TITLE
fix: bump rest-to-soap from 1.12.0 to 1.13.0 

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -80,7 +80,7 @@
         <gravitee-policy-request-content-limit.version>1.8.0</gravitee-policy-request-content-limit.version>
         <gravitee-policy-request-validation.version>1.13.0</gravitee-policy-request-validation.version>
         <gravitee-policy-resource-filtering.version>1.8.0</gravitee-policy-resource-filtering.version>
-        <gravitee-policy-rest-to-soap.version>1.12.0</gravitee-policy-rest-to-soap.version>
+        <gravitee-policy-rest-to-soap.version>1.13.0</gravitee-policy-rest-to-soap.version>
         <gravitee-policy-retry.version>2.1.0</gravitee-policy-retry.version>
         <gravitee-policy-role-based-access-control.version>1.1.0</gravitee-policy-role-based-access-control.version>
         <gravitee-policy-ssl-enforcement.version>1.2.0</gravitee-policy-ssl-enforcement.version>

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -47,49 +47,49 @@
         <!-- Versions of the plugins for the full distribution -->
         <!-- Management API & Gateway -->
         <gravitee-connector-http.version>1.1.0</gravitee-connector-http.version>
-        <gravitee-policy-apikey.version>2.4.0-upgrade-project-config</gravitee-policy-apikey.version>
-        <gravitee-policy-assign-attributes.version>1.5.0-upgrade-project-config</gravitee-policy-assign-attributes.version>
-        <gravitee-policy-assign-content.version>1.7.0-upgrade-project-config</gravitee-policy-assign-content.version>
-        <gravitee-policy-cache.version>1.14.0-upgrade-project-config</gravitee-policy-cache.version>
-        <gravitee-policy-callout-http.version>1.15.0-upgrade-project-config</gravitee-policy-callout-http.version>
+        <gravitee-policy-apikey.version>2.4.0</gravitee-policy-apikey.version>
+        <gravitee-policy-assign-attributes.version>1.5.0</gravitee-policy-assign-attributes.version>
+        <gravitee-policy-assign-content.version>1.7.0</gravitee-policy-assign-content.version>
+        <gravitee-policy-cache.version>1.14.0</gravitee-policy-cache.version>
+        <gravitee-policy-callout-http.version>1.15.0</gravitee-policy-callout-http.version>
         <gravitee-policy-dynamic-routing.version>1.11.1</gravitee-policy-dynamic-routing.version>
         <gravitee-policy-generate-http-signature.version>1.1.0</gravitee-policy-generate-http-signature.version>
         <gravitee-policy-generate-jwt.version>1.5.0</gravitee-policy-generate-jwt.version>
-        <gravitee-policy-groovy.version>2.1.0-upgrade-project-config</gravitee-policy-groovy.version>
+        <gravitee-policy-groovy.version>2.1.0</gravitee-policy-groovy.version>
         <gravitee-policy-html-json.version>1.6.0</gravitee-policy-html-json.version>
         <gravitee-policy-http-signature.version>1.5.0</gravitee-policy-http-signature.version>
-        <gravitee-policy-ipfiltering.version>1.9.0-upgrade-project-config</gravitee-policy-ipfiltering.version>
+        <gravitee-policy-ipfiltering.version>1.9.0</gravitee-policy-ipfiltering.version>
         <gravitee-policy-json-threat-protection.version>1.3.1</gravitee-policy-json-threat-protection.version>
-        <gravitee-policy-json-to-json.version>1.7.0-upgrade-project-config</gravitee-policy-json-to-json.version>
+        <gravitee-policy-json-to-json.version>1.7.0</gravitee-policy-json-to-json.version>
         <gravitee-policy-json-validation.version>1.6.0</gravitee-policy-json-validation.version>
-        <gravitee-policy-json-xml.version>1.1.0-upgrade-project-config</gravitee-policy-json-xml.version>
-        <gravitee-policy-jws.version>1.3.1-upgrade-project-config</gravitee-policy-jws.version>
-        <gravitee-policy-jwt.version>1.22.0-upgrade-project-config</gravitee-policy-jwt.version>
+        <gravitee-policy-json-xml.version>1.1.0</gravitee-policy-json-xml.version>
+        <gravitee-policy-jws.version>1.3.1</gravitee-policy-jws.version>
+        <gravitee-policy-jwt.version>1.22.0</gravitee-policy-jwt.version>
         <gravitee-policy-keyless.version>1.4.0</gravitee-policy-keyless.version>
         <gravitee-policy-latency.version>1.4.0</gravitee-policy-latency.version>
-        <gravitee-policy-metrics-reporter.version>1.2.0-upgrade-project-config</gravitee-policy-metrics-reporter.version>
-        <gravitee-policy-mock.version>1.13.0-upgrade-project-config</gravitee-policy-mock.version>
-        <gravitee-policy-oauth2.version>1.19.0-upgrade-project-config</gravitee-policy-oauth2.version>
-        <gravitee-policy-openid-connect-userinfo.version>1.5.0-upgrade-project-config</gravitee-policy-openid-connect-userinfo.version>
+        <gravitee-policy-metrics-reporter.version>1.2.0</gravitee-policy-metrics-reporter.version>
+        <gravitee-policy-mock.version>1.13.0</gravitee-policy-mock.version>
+        <gravitee-policy-oauth2.version>1.19.0</gravitee-policy-oauth2.version>
+        <gravitee-policy-openid-connect-userinfo.version>1.5.0</gravitee-policy-openid-connect-userinfo.version>
         <gravitee-policy-override-http-method.version>1.3.0</gravitee-policy-override-http-method.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->
         <!--    <gravitee-policy-quota.version>1.15.0</gravitee-policy-quota.version>    -->
         <!--    <gravitee-policy-spikearrest.version>1.15.0</gravitee-policy-spikearrest.version>    -->
-        <gravitee-policy-ratelimit.version>1.15.0-upgrade-project-configuration</gravitee-policy-ratelimit.version>
-        <gravitee-policy-regex-threat-protection.version>1.3.0-upgrade-project-config</gravitee-policy-regex-threat-protection.version>
-        <gravitee-policy-request-content-limit.version>1.8.0-upgrade-project-config</gravitee-policy-request-content-limit.version>
-        <gravitee-policy-request-validation.version>1.13.0-upgrade-project-config</gravitee-policy-request-validation.version>
+        <gravitee-policy-ratelimit.version>1.15.0</gravitee-policy-ratelimit.version>
+        <gravitee-policy-regex-threat-protection.version>1.3.0</gravitee-policy-regex-threat-protection.version>
+        <gravitee-policy-request-content-limit.version>1.8.0</gravitee-policy-request-content-limit.version>
+        <gravitee-policy-request-validation.version>1.13.0</gravitee-policy-request-validation.version>
         <gravitee-policy-resource-filtering.version>1.8.0</gravitee-policy-resource-filtering.version>
         <gravitee-policy-rest-to-soap.version>1.12.0</gravitee-policy-rest-to-soap.version>
-        <gravitee-policy-retry.version>2.1.1-renovate-major-gravitee-bom-version</gravitee-policy-retry.version>
+        <gravitee-policy-retry.version>2.1.0</gravitee-policy-retry.version>
         <gravitee-policy-role-based-access-control.version>1.1.0</gravitee-policy-role-based-access-control.version>
         <gravitee-policy-ssl-enforcement.version>1.2.0</gravitee-policy-ssl-enforcement.version>
         <gravitee-policy-traffic-shadowing.version>1.1.0</gravitee-policy-traffic-shadowing.version>
         <gravitee-policy-transformheaders.version>1.9.1</gravitee-policy-transformheaders.version>
         <gravitee-policy-transformqueryparams.version>1.6.0</gravitee-policy-transformqueryparams.version>
-        <gravitee-policy-url-rewriting.version>1.5.0-upgrade-project-config</gravitee-policy-url-rewriting.version>
-        <gravitee-policy-xml-json.version>1.8.0-upgrade-project-config</gravitee-policy-xml-json.version>
-        <gravitee-policy-xml-threat-protection.version>1.3.0-upgrade-project-config</gravitee-policy-xml-threat-protection.version>
+        <gravitee-policy-url-rewriting.version>1.5.0</gravitee-policy-url-rewriting.version>
+        <gravitee-policy-xml-json.version>1.8.0</gravitee-policy-xml-json.version>
+        <gravitee-policy-xml-threat-protection.version>1.3.0</gravitee-policy-xml-threat-protection.version>
         <gravitee-policy-xml-validation.version>1.1.0</gravitee-policy-xml-validation.version>
         <gravitee-policy-xslt.version>1.6.0</gravitee-policy-xslt.version>
         <gravitee-resource-cache.version>1.7.0</gravitee-resource-cache.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7025

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fhocsoymrc.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-7025-resttosoap-headers/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
