### PR TITLE
fix: fix update API with crossID

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/ApiConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/ApiConverter.java
@@ -26,14 +26,13 @@ import io.gravitee.rest.api.model.PropertiesEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.api.UpdateApiEntity;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashSet;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/ApiImportException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/ApiImportException.java
@@ -18,9 +18,9 @@ package io.gravitee.rest.api.service.exceptions;
 import io.gravitee.common.http.HttpStatusCode;
 import java.util.Map;
 
-public class PageImportException extends AbstractManagementException {
+public class ApiImportException extends AbstractManagementException {
 
-    public PageImportException(String message) {
+    public ApiImportException(String message) {
         super(message);
     }
 
@@ -31,7 +31,7 @@ public class PageImportException extends AbstractManagementException {
 
     @Override
     public String getTechnicalCode() {
-        return "page.invalid.import.definition";
+        return "invalid.import.definition";
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/imports/ImportApiJsonNode.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/imports/ImportApiJsonNode.java
@@ -42,10 +42,6 @@ public class ImportApiJsonNode extends ImportJsonNodeWithIds {
         return getChildNodesWithIdByName(PLANS);
     }
 
-    public ArrayNode getPlansArray() {
-        return getArray(PLANS);
-    }
-
     public boolean hasPages() {
         return hasArray(PAGES);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_UpdateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_UpdateWithDefinitionTest.java
@@ -32,6 +32,7 @@ import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.converter.PlanConverter;
+import io.gravitee.rest.api.service.exceptions.ApiImportException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.impl.ApiDuplicatorServiceImpl;
 import io.gravitee.rest.api.service.spring.ImportConfiguration;
@@ -42,6 +43,7 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -589,7 +591,7 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
             );
     }
 
-    @Test(expected = TechnicalManagementException.class)
+    @Test(expected = ApiImportException.class)
     public void shouldRaiseAnErrorWhenUpdatingAPlanBelongingToAnotherAPI() throws IOException {
         URL resource = Resources.getResource("io/gravitee/rest/api/management/service/import-api-update.definition+plans-missingData.json");
         String toBeImport = Resources.toString(resource, Charsets.UTF_8);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImplTest.java
@@ -82,7 +82,7 @@ public class ApiDuplicatorServiceImplTest {
                 .add(mapper.createObjectNode().put("id", "my-plan-id-2"))
         );
 
-        ImportApiJsonNode newApiDefinition = apiDuplicatorService.handleApiDefinitionIds(new ImportApiJsonNode(apiDefinition), "uat");
+        ImportApiJsonNode newApiDefinition = apiDuplicatorService.recalculateApiDefinitionIds(new ImportApiJsonNode(apiDefinition), "uat");
 
         assertEquals("e0a6482a-b8a7-3db4-a1b7-d36a462a9e38", newApiDefinition.getId());
         assertEquals("393ed51c-285d-3097-82eb-2bff2903dc62", newApiDefinition.getPlans().get(0).getId());
@@ -103,7 +103,7 @@ public class ApiDuplicatorServiceImplTest {
 
         when(apiService.findByEnvironmentIdAndCrossId("uat", "api-cross-id")).thenReturn(Optional.empty());
 
-        ImportApiJsonNode newApiDefinition = apiDuplicatorService.handleApiDefinitionIds(new ImportApiJsonNode(apiDefinition), "uat");
+        ImportApiJsonNode newApiDefinition = apiDuplicatorService.recalculateApiDefinitionIds(new ImportApiJsonNode(apiDefinition), "uat");
 
         assertEquals("6bcde800-d5ae-3215-8413-cae196f9edfc", newApiDefinition.getId());
         assertEquals("5025bd5d-b1a5-35f5-813b-65bb902aa4e7", newApiDefinition.getPlans().get(0).getId());
@@ -137,7 +137,7 @@ public class ApiDuplicatorServiceImplTest {
         when(apiService.findByEnvironmentIdAndCrossId("dev", "api-cross-id")).thenReturn(Optional.of(matchingApi));
         when(planService.findByApi("api-id-1")).thenReturn(Set.of(firstMatchingPlan, secondMatchingPlan));
 
-        ImportApiJsonNode newApiDefinition = apiDuplicatorService.handleApiDefinitionIds(new ImportApiJsonNode(apiDefinition), "dev");
+        ImportApiJsonNode newApiDefinition = apiDuplicatorService.recalculateApiDefinitionIds(new ImportApiJsonNode(apiDefinition), "dev");
 
         assertEquals("api-id-1", newApiDefinition.getId());
         assertEquals("plan-id-1", newApiDefinition.getPlans().get(0).getId());
@@ -182,7 +182,7 @@ public class ApiDuplicatorServiceImplTest {
         when(apiService.findByEnvironmentIdAndCrossId("dev", "api-cross-id")).thenReturn(Optional.of(matchingApi));
         when(pageService.findByApi("api-id-1")).thenReturn(List.of(rootFolder, nestedFolder, page));
 
-        ImportApiJsonNode newApiDefinition = apiDuplicatorService.handleApiDefinitionIds(new ImportApiJsonNode(apiDefinition), "dev");
+        ImportApiJsonNode newApiDefinition = apiDuplicatorService.recalculateApiDefinitionIds(new ImportApiJsonNode(apiDefinition), "dev");
 
         assertEquals("api-id-1", newApiDefinition.getId());
         assertEquals(3, newApiDefinition.getPages().size());
@@ -207,7 +207,7 @@ public class ApiDuplicatorServiceImplTest {
                 .add(mapper.createObjectNode().put("id", "page-id").put("parentId", "nested-folder-id"))
         );
 
-        ImportApiJsonNode newApiDefinition = apiDuplicatorService.handleApiDefinitionIds(new ImportApiJsonNode(apiDefinition), "uat");
+        ImportApiJsonNode newApiDefinition = apiDuplicatorService.recalculateApiDefinitionIds(new ImportApiJsonNode(apiDefinition), "uat");
 
         assertEquals("e0a6482a-b8a7-3db4-a1b7-d36a462a9e38", newApiDefinition.getId());
         assertEquals(3, newApiDefinition.getPages().size());
@@ -255,7 +255,7 @@ public class ApiDuplicatorServiceImplTest {
         when(pageService.findByApi("api-id-1")).thenReturn(List.of(matchingPage));
         when(planService.findByApi("api-id-1")).thenReturn(Set.of(matchingPlan));
 
-        ImportApiJsonNode newApiDefinition = apiDuplicatorService.handleApiDefinitionIds(new ImportApiJsonNode(apiDefinition), "dev");
+        ImportApiJsonNode newApiDefinition = apiDuplicatorService.recalculateApiDefinitionIds(new ImportApiJsonNode(apiDefinition), "dev");
 
         assertEquals("api-id-1", newApiDefinition.getId());
         assertEquals("plan-id-1", newApiDefinition.getPlans().get(0).getId());
@@ -283,7 +283,10 @@ public class ApiDuplicatorServiceImplTest {
                 .add(mapper.createObjectNode().put("name", "no-id"))
         );
 
-        ImportApiJsonNode newApiDefinition = apiDuplicatorService.handleApiDefinitionIds(new ImportApiJsonNode(apiDefinition), "default");
+        ImportApiJsonNode newApiDefinition = apiDuplicatorService.recalculateApiDefinitionIds(
+            new ImportApiJsonNode(apiDefinition),
+            "default"
+        );
 
         assertEquals("ed5fbfe2-9cab-3306-9e51-24721d5b6e82", newApiDefinition.getId());
         assertEquals("de653244-912e-384e-a60d-9f8625f18c81", newApiDefinition.getPlans().get(0).getId());


### PR DESCRIPTION
**Bug**
- create 2 Apis
- export ths first API
- go to the second API > import > import the previously generated file
==> CrossId search find the first API, so it updates it, but we are in the second one
==> Leads to a duplicate crossId : both API have the same crossId in API table

**Change**
Requesting an update of an API, with crossId belonging to another API is inconsistent.
So I added this error `"Can't update API [%s] cause crossId [%s] already belongs to another API in environment [%s]"`

Also renaming the exception dedicated to json API inconsistencies.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tmgrfcqibx.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-importrefactor-fixmarc2/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
