### PR TITLE
fix(jdbc): fix invalid SQL syntax when finding plans by IDs or APIs

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAlertRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAlertRepository.java
@@ -15,8 +15,9 @@
  */
 package io.gravitee.repository.jdbc.management;
 
-import static io.gravitee.repository.jdbc.common.AbstractJdbcRepositoryConfiguration.escapeReservedWord;
 import static java.lang.String.format;
+import static java.util.Collections.emptyList;
+import static org.springframework.util.CollectionUtils.isEmpty;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
@@ -77,6 +78,9 @@ public class JdbcAlertRepository extends JdbcAbstractCrudRepository<AlertTrigger
     public List<AlertTrigger> findByReferenceAndReferenceIds(final String referenceType, final List<String> referenceIds)
         throws TechnicalException {
         LOGGER.debug("JdbcAlertRepository.findByReferenceAndReferenceIds({}, {})", referenceType, referenceIds);
+        if (isEmpty(referenceIds)) {
+            return emptyList();
+        }
         try {
             List<AlertTrigger> rows = jdbcTemplate.query(
                 getOrm().getSelectAllSql() +

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPlanRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPlanRepository.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.jdbc.management;
 
 import static java.lang.String.format;
+import static org.springframework.util.CollectionUtils.isEmpty;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
@@ -243,6 +244,9 @@ public class JdbcPlanRepository extends JdbcAbstractFindAllRepository<Plan> impl
     @Override
     public List<Plan> findByApis(List<String> apiIds) throws TechnicalException {
         LOGGER.debug("JdbcPlanRepository.findByApis({})", apiIds);
+        if (isEmpty(apiIds)) {
+            return Collections.emptyList();
+        }
         try {
             List<Plan> plans = jdbcTemplate.query(
                 getOrm().getSelectAllSql() + " where api in (" + getOrm().buildInClause(apiIds) + ")",
@@ -280,8 +284,11 @@ public class JdbcPlanRepository extends JdbcAbstractFindAllRepository<Plan> impl
 
     @Override
     public Set<Plan> findByIdIn(Collection<String> ids) throws TechnicalException {
+        LOGGER.debug("JdbcPlanRepository.findByIdIn({})", ids);
+        if (isEmpty(ids)) {
+            return Collections.emptySet();
+        }
         try {
-            LOGGER.debug("JdbcPlanRepository.findByIdIn({})", ids);
             List<Plan> plans = jdbcTemplate.query(
                 getOrm().getSelectAllSql() + " where id in (" + getOrm().buildInClause(ids) + ")",
                 ps -> getOrm().setArguments(ps, ids, 1),

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/AlertRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/AlertRepositoryTest.java
@@ -159,6 +159,13 @@ public class AlertRepositoryTest extends AbstractRepositoryTest {
         assertEquals(2, alerts.size());
     }
 
+    @Test
+    public void shouldFindByReferenceAndReferenceIds_andReturnEmptyListWhenInputListIsEmpty() throws Exception {
+        final List<AlertTrigger> alerts = alertRepository.findByReferenceAndReferenceIds("API", Collections.emptyList());
+        assertNotNull(alerts);
+        assertEquals(0, alerts.size());
+    }
+
     @Test(expected = IllegalStateException.class)
     public void shouldNotUpdateUnknownAlert() throws Exception {
         AlertTrigger unknownAlert = new AlertTrigger();

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/PlanRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/PlanRepositoryTest.java
@@ -93,6 +93,13 @@ public class PlanRepositoryTest extends AbstractRepositoryTest {
     }
 
     @Test
+    public void shouldFindByIdIn_andReturnEmptyListIfInputIsEmpty() throws TechnicalException {
+        Set<Plan> plans = planRepository.findByIdIn(List.of());
+        assertNotNull(plans);
+        assertEquals(0, plans.size());
+    }
+
+    @Test
     public void shouldFindOAuth2PlanById() throws TechnicalException {
         final Optional<Plan> planOAuth2 = planRepository.findById("plan-oauth2");
 
@@ -147,6 +154,13 @@ public class PlanRepositoryTest extends AbstractRepositoryTest {
         assertEquals(3, plans.size());
         assertEquals(2, plans.stream().filter(plan -> plan.getApi().equals("api1")).count());
         assertEquals(1, plans.stream().filter(plan -> plan.getApi().equals("4e0db366-f772-4489-8db3-66f772b48989")).count());
+    }
+
+    @Test
+    public void shouldFindByApis_andReturnEmptyListIfInputIsEmpty() throws Exception {
+        final List<Plan> plans = planRepository.findByApis(Arrays.asList());
+        assertNotNull(plans);
+        assertEquals(0, plans.size());
     }
 
     @Test


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7051

**Description**

fix(jdbc): fix invalid SQL syntax when finding plans by IDs or APIs

Calling PlanRepository findByApis or findByIds with empty list leads to an empty "IN ()" SQL syntax which is invalid

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-eqsikqbpzv.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-7051/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
