### PR TITLE
fix(sync): fix API synchronization when environment has no HrID

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/ApiSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/ApiSynchronizer.java
@@ -264,13 +264,13 @@ public class ApiSynchronizer extends AbstractSynchronizer {
 
         if (apiEnv != null) {
             definition.setEnvironmentId(apiEnv.getId());
-            definition.setEnvironmentHrid(apiEnv.getHrids() != null ? apiEnv.getHrids().stream().findFirst().get() : null);
+            definition.setEnvironmentHrid(apiEnv.getHrids() != null ? apiEnv.getHrids().stream().findFirst().orElse(null) : null);
 
             final io.gravitee.repository.management.model.Organization apiOrg = organizationMap.get(apiEnv.getOrganizationId());
 
             if (apiOrg != null) {
                 definition.setOrganizationId(apiOrg.getId());
-                definition.setOrganizationHrid(apiOrg.getHrids() != null ? apiOrg.getHrids().stream().findFirst().get() : null);
+                definition.setOrganizationHrid(apiOrg.getHrids() != null ? apiOrg.getHrids().stream().findFirst().orElse(null) : null);
             }
         }
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/ApiSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/ApiSynchronizer.java
@@ -176,7 +176,7 @@ public class ApiSynchronizer extends AbstractSynchronizer {
                     try {
                         apiManager.register(api);
                     } catch (Exception e) {
-                        logger.error("An error occurred when trying to synchronize api {} [{}].", api.getName(), api.getId());
+                        logger.error("An error occurred when trying to synchronize api {} [{}].", api.getName(), api.getId(), e);
                     }
                 }
             )
@@ -194,7 +194,7 @@ public class ApiSynchronizer extends AbstractSynchronizer {
                     try {
                         apiManager.unregister(apiId);
                     } catch (Exception e) {
-                        logger.error("An error occurred when trying to unregister api [{}].", apiId);
+                        logger.error("An error occurred when trying to unregister api [{}].", apiId, e);
                     }
                 }
             )
@@ -226,7 +226,7 @@ public class ApiSynchronizer extends AbstractSynchronizer {
             return Maybe.just(apiDefinition);
         } catch (Exception e) {
             // Log the error and ignore this event.
-            logger.error("Unable to extract api definition from event [{}].", apiEvent.getId());
+            logger.error("Unable to extract api definition from event [{}].", apiEvent.getId(), e);
             return Maybe.empty();
         }
     }
@@ -255,7 +255,7 @@ public class ApiSynchronizer extends AbstractSynchronizer {
 
                             return environment;
                         } catch (Exception e) {
-                            logger.warn("An error occurred fetching the environment {} and its organization.", envId);
+                            logger.warn("An error occurred fetching the environment {} and its organization.", envId, e);
                             return null;
                         }
                     }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_15_3/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_15_3/schema.yml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - changeSet:
+      id: 3.15.3
+      author: GraviteeSource Team
+      preConditions:
+        - onFail: MARK_RAN
+        - sqlCheck:
+            expectedResult: 1
+            sql: select count(*) from ${gravitee_prefix}environments where id = 'DEFAULT'
+        - sqlCheck:
+            expectedResult: 0
+            sql: select count(*) from ${gravitee_prefix}environment_hrids where environment_id = 'DEFAULT' and pos = 0
+      changes:
+        - sql:
+            sql: insert into ${gravitee_prefix}environment_hrids (environment_id, hrid, pos) values ('DEFAULT', 'default', 0)

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -117,3 +117,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v3_14_0/schema.yml
   - include:
       - file: liquibase/changelogs/v3_15_0/schema.yml
+  - include:
+      - file: liquibase/changelogs/v3_15_3/schema.yml


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7053

**Description**

fix(sync): fix API synchronization when environment has no HrID

An environment may have no HrId.
For example, running APIM on JDBC, the environment_hrids table is empty.

When enhancing API definition with org and env HR ids, we take the first HR id of the list, whithout checking if its empty.
In case of an empty list, it leads to a NoSuchElementException.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qghbbhgckf.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-7053/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
