### PR TITLE
Include all subfolders when building standalone zipfile

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/gravitee-apim-gateway-standalone-distribution-zip/src/main/assembly/plugin-assembly-standalone.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/gravitee-apim-gateway-standalone-distribution-zip/src/main/assembly/plugin-assembly-standalone.xml
@@ -34,8 +34,8 @@
             <directory>../target/distribution</directory>
             <outputDirectory>.</outputDirectory>
             <includes>
-                <include>bin/*</include>
-                <include>config/*</include>
+                <include>bin/**</include>
+                <include>config/**</include>
                 <include>lib/**</include>
                 <include>logs</include>
                 <include>metrics</include>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/gravitee-apim-rest-api-standalone-distribution-zip/src/main/assembly/plugin-assembly-standalone.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/gravitee-apim-rest-api-standalone-distribution-zip/src/main/assembly/plugin-assembly-standalone.xml
@@ -34,16 +34,16 @@
             <directory>../target/distribution</directory>
             <outputDirectory>.</outputDirectory>
             <includes>
-                <include>bin/*</include>
-                <include>config/*</include>
-                <include>dashboards/*</include>
+                <include>bin/**</include>
+                <include>config/**</include>
+                <include>dashboards/**</include>
                 <include>data</include>
                 <include>lib/**</include>
                 <include>logs</include>
                 <include>plugins/gravitee-apim-rest-api-*</include>
                 <include>plugins/ext/*</include>
-                <include>templates/*</include>
-                <include>themes/*</include>
+                <include>templates/**</include>
+                <include>themes/**</include>
             </includes>
         </fileSet>
     </fileSets>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7057

**Description**

Building APIM generates 2 distributions bundle:
 - the first one is a folder containing all the require files to run Management API or Gateway + all apim plugins + all others default plugins embedded (policies, connectors, ...)
 For instance `gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target/distribution`
 - the second one is a zip file, based on the folder generated first. We copy everything except default plugins (we only keep apim plugins)
 For instance `gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/gravitee-apim-gateway-standalone-distribution-zip/target/gravitee-apim-gateway-standalone-3.15.3-SNAPSHOT.zip`

This PR fixes a copy problem when generating the zip files. Files in nested folders were not copied.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tgvcdmucsu.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7057-image-not-found/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
