### PR TITLE
Send angularJs `apiChangeSuccess` event on policy studio save

### DIFF
--- a/gravitee-apim-console-webui/src/ajs-upgraded-providers.ts
+++ b/gravitee-apim-console-webui/src/ajs-upgraded-providers.ts
@@ -18,6 +18,7 @@
  * Provider to temporarily ensure compatibility between AngularJs and Angular
  */
 import { InjectionToken } from '@angular/core';
+import { IScope } from 'angular';
 
 export const UIRouterState = new InjectionToken('UIRouterState');
 
@@ -49,5 +50,16 @@ function currentUserServiceFactory(i: any) {
 export const currentUserProvider = {
   provide: CurrentUserService,
   useFactory: currentUserServiceFactory,
+  deps: ['$injector'],
+};
+
+export const AjsRootScope = new InjectionToken<IScope>('AjsRootScope');
+
+function ajsRootScopeServiceFactory(i: any) {
+  return i.get('$rootScope');
+}
+export const ajsRootScopeProvider = {
+  provide: AjsRootScope,
+  useFactory: ajsRootScopeServiceFactory,
   deps: ['$injector'],
 };

--- a/gravitee-apim-console-webui/src/app.module.ts
+++ b/gravitee-apim-console-webui/src/app.module.ts
@@ -21,7 +21,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { UpgradeModule } from '@angular/upgrade/static';
 import { UIRouterUpgradeModule } from '@uirouter/angular-hybrid';
 
-import { uiRouterStateProvider, uiRouterStateParamsProvider, currentUserProvider } from './ajs-upgraded-providers';
+import { uiRouterStateProvider, uiRouterStateParamsProvider, currentUserProvider, ajsRootScopeProvider } from './ajs-upgraded-providers';
 import { ManagementModule } from './management/management.module';
 import { OrganizationSettingsModule } from './organization/configuration/organization-settings.module';
 import { httpInterceptorProviders } from './shared/interceptors/http-interceptors';
@@ -41,7 +41,7 @@ import { httpInterceptorProviders } from './shared/interceptors/http-interceptor
     OrganizationSettingsModule,
     ManagementModule,
   ],
-  providers: [httpInterceptorProviders, uiRouterStateProvider, uiRouterStateParamsProvider, currentUserProvider],
+  providers: [httpInterceptorProviders, uiRouterStateProvider, uiRouterStateParamsProvider, currentUserProvider, ajsRootScopeProvider],
 })
 export class AppModule {
   constructor(private upgrade: UpgradeModule) {}

--- a/gravitee-apim-console-webui/src/management/api/design/design/management-api-design.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/design/design/management-api-design.component.spec.ts
@@ -26,7 +26,7 @@ import { ManagementModule } from '../../../management.module';
 import { fakeApiFlowSchema } from '../../../../entities/flow/apiFlowSchema.fixture';
 import { fakeApi } from '../../../../entities/api/Api.fixture';
 import { fakeResourceListItem } from '../../../../entities/resource/resourceListItem.fixture';
-import { CurrentUserService, UIRouterStateParams } from '../../../../ajs-upgraded-providers';
+import { AjsRootScope, CurrentUserService, UIRouterStateParams } from '../../../../ajs-upgraded-providers';
 import { User } from '../../../../entities/user';
 import { fakeUpdateApi } from '../../../../entities/api/UpdateApi.fixture';
 
@@ -42,6 +42,7 @@ describe('ManagementApiDesignComponent', () => {
   const policies = [fakePolicyListItem()];
   const api = fakeApi();
   const resources = [fakeResourceListItem()];
+  const ajsRootScopeBroadcastMock = jest.fn();
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -52,6 +53,7 @@ describe('ManagementApiDesignComponent', () => {
           provide: CurrentUserService,
           useValue: { currentUser },
         },
+        { provide: AjsRootScope, useValue: { $broadcast: ajsRootScopeBroadcastMock } },
       ],
     })
       .overrideProvider(InteractivityChecker, {
@@ -158,6 +160,8 @@ describe('ManagementApiDesignComponent', () => {
         }),
       );
       req.flush(api);
+
+      expect(ajsRootScopeBroadcastMock).toHaveBeenCalledWith('apiChangeSuccess', { api });
 
       // call new ngOnInit
       httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/apis/schema`).flush(apiFlowSchema);

--- a/gravitee-apim-console-webui/src/management/api/design/design/management-api-design.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/design/design/management-api-design.component.ts
@@ -25,7 +25,7 @@ import { PolicyListItem } from '../../../../entities/policy';
 import { Flow } from '../../../../entities/flow/flow';
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 import { ApiService } from '../../../../services-ngx/api.service';
-import { UIRouterStateParams } from '../../../../ajs-upgraded-providers';
+import { AjsRootScope, UIRouterStateParams } from '../../../../ajs-upgraded-providers';
 import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
 import { ResourceService } from '../../../../services-ngx/resource.service';
 import { ResourceListItem } from '../../../../entities/resource/resourceListItem';
@@ -220,6 +220,7 @@ export class ManagementApiDesignComponent implements OnInit, OnDestroy {
     private readonly snackBarService: SnackBarService,
     private readonly permissionService: GioPermissionService,
     @Inject(UIRouterStateParams) private readonly ajsStateParams,
+    @Inject(AjsRootScope) private readonly ajsRootScope,
   ) {}
 
   ngOnInit(): void {
@@ -275,6 +276,7 @@ export class ManagementApiDesignComponent implements OnInit, OnDestroy {
       .pipe(
         tap(() => {
           this.snackBarService.success('Design of api successfully updated!');
+          this.ajsRootScope.$broadcast('apiChangeSuccess', { api: this.api });
         }),
       )
       .subscribe(() => {

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/design/policy-studio-design.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/design/policy-studio-design.component.spec.ts
@@ -26,7 +26,7 @@ import { ManagementModule } from '../../../management.module';
 import { fakeApiFlowSchema } from '../../../../entities/flow/apiFlowSchema.fixture';
 import { fakeApi } from '../../../../entities/api/Api.fixture';
 import { fakeResourceListItem } from '../../../../entities/resource/resourceListItem.fixture';
-import { CurrentUserService, UIRouterStateParams } from '../../../../ajs-upgraded-providers';
+import { AjsRootScope, CurrentUserService, UIRouterStateParams } from '../../../../ajs-upgraded-providers';
 import { User } from '../../../../entities/user';
 import { fakeUpdateApi } from '../../../../entities/api/UpdateApi.fixture';
 
@@ -42,6 +42,7 @@ describe('PolicyStudioDesignComponent', () => {
   const policies = [fakePolicyListItem()];
   const api = fakeApi();
   const resources = [fakeResourceListItem()];
+  const ajsRootScopeBroadcastMock = jest.fn();
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -52,6 +53,7 @@ describe('PolicyStudioDesignComponent', () => {
           provide: CurrentUserService,
           useValue: { currentUser },
         },
+        { provide: AjsRootScope, useValue: { $broadcast: ajsRootScopeBroadcastMock } },
       ],
     })
       .overrideProvider(InteractivityChecker, {
@@ -158,6 +160,8 @@ describe('PolicyStudioDesignComponent', () => {
         }),
       );
       req.flush(api);
+
+      expect(ajsRootScopeBroadcastMock).toHaveBeenCalledWith('apiChangeSuccess', { api });
 
       // call new ngOnInit
       httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/apis/schema`).flush(apiFlowSchema);

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/design/policy-studio-design.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/design/policy-studio-design.component.ts
@@ -19,6 +19,7 @@ import { combineLatest, EMPTY, interval, Subject, timer } from 'rxjs';
 import { catchError, filter, switchMap, take, takeUntil, tap } from 'rxjs/operators';
 import { cloneDeep } from 'lodash';
 import { StateParams } from '@uirouter/angularjs';
+import { IScope } from 'angular';
 
 import { PolicyService } from '../../../../services-ngx/policy.service';
 import { Organization } from '../../../../entities/organization/organization';
@@ -26,7 +27,7 @@ import { PolicyListItem } from '../../../../entities/policy';
 import { Flow } from '../../../../entities/flow/flow';
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 import { ApiService } from '../../../../services-ngx/api.service';
-import { UIRouterStateParams } from '../../../../ajs-upgraded-providers';
+import { AjsRootScope, UIRouterStateParams } from '../../../../ajs-upgraded-providers';
 import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
 import { ResourceService } from '../../../../services-ngx/resource.service';
 import { ResourceListItem } from '../../../../entities/resource/resourceListItem';
@@ -222,6 +223,7 @@ export class PolicyStudioDesignComponent implements OnInit, OnDestroy {
     private readonly snackBarService: SnackBarService,
     private readonly permissionService: GioPermissionService,
     @Inject(UIRouterStateParams) private readonly ajsStateParams: StateParams,
+    @Inject(AjsRootScope) private readonly ajsRootScope: IScope,
   ) {}
 
   ngOnInit(): void {
@@ -278,6 +280,7 @@ export class PolicyStudioDesignComponent implements OnInit, OnDestroy {
       .update(this.api)
       .pipe(
         tap(() => {
+          this.ajsRootScope.$broadcast('apiChangeSuccess', { api: this.api });
           this.snackBarService.success('Design of api successfully updated!');
         }),
       )


### PR DESCRIPTION
**Issue**
https://github.com/gravitee-io/issues/issues/6893
https://github.com/gravitee-io/issues/issues/6934

**Description**

Send event to display "deploy bar" like : 
![image](https://user-images.githubusercontent.com/4974420/152753579-892d20b7-bf50-4a4c-8d53-460abc8df71d.png)


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mfeboeeumz.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/debug-mode-fix-deploy-bar/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
