### PR TITLE
Prevent from updating an API with an already used context path

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImpl.java
@@ -155,7 +155,9 @@ public class ApiServiceCockpitImpl implements ApiServiceCockpit {
         final SwaggerApiEntity api = swaggerService.createAPI(swaggerDescriptor, DefinitionVersion.V2);
         api.setPaths(null);
 
-        return ApiEntityResult.success(this.apiService.updateFromSwagger(apiId, api, swaggerDescriptor));
+        return checkContextPath(api)
+            .map(ApiEntityResult::failure)
+            .orElseGet(() -> ApiEntityResult.success(this.apiService.updateFromSwagger(apiId, api, swaggerDescriptor)));
     }
 
     private ApiEntityResult createApiEntity(String apiId, String userId, ImportSwaggerDescriptorEntity swaggerDescriptor) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImplTest.java
@@ -391,17 +391,20 @@ public class ApiServiceCockpitImplTest {
         expectedDescriptor.setWithPolicyPaths(true);
         expectedDescriptor.setWithPolicies(List.of("mock"));
 
-        SwaggerApiEntity swaggerApi = new SwaggerApiEntity();
-        swaggerApi.setMetadata(new ArrayList<>());
-
-        ApiEntity api = new ApiEntity();
-        api.setId(API_ID);
         Proxy proxy = new Proxy();
         VirtualHost virtualHost = new VirtualHost();
         proxy.setVirtualHosts(List.of(virtualHost));
+
+        SwaggerApiEntity swaggerApi = new SwaggerApiEntity();
+        swaggerApi.setMetadata(new ArrayList<>());
+        swaggerApi.setProxy(proxy);
+
+        ApiEntity api = new ApiEntity();
+        api.setId(API_ID);
         api.setProxy(proxy);
 
         when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
+        when(virtualHostService.sanitizeAndValidate(any(Collection.class))).thenReturn(List.of(virtualHost));
 
         ApiEntity updatedApiEntity = new ApiEntity();
         updatedApiEntity.setName("updated api");
@@ -434,6 +437,7 @@ public class ApiServiceCockpitImplTest {
         VirtualHost virtualHost = new VirtualHost();
         proxy.setVirtualHosts(List.of(virtualHost));
         api.setProxy(proxy);
+        swaggerApi.setProxy(proxy);
 
         when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
 
@@ -456,14 +460,16 @@ public class ApiServiceCockpitImplTest {
         expectedDescriptor.setWithPolicyPaths(true);
         expectedDescriptor.setWithPolicies(List.of("mock"));
 
-        SwaggerApiEntity swaggerApi = new SwaggerApiEntity();
-        swaggerApi.setMetadata(new ArrayList<>());
-
-        ApiEntity api = new ApiEntity();
-        api.setId(API_ID);
         Proxy proxy = new Proxy();
         VirtualHost virtualHost = new VirtualHost();
         proxy.setVirtualHosts(List.of(virtualHost));
+
+        SwaggerApiEntity swaggerApi = new SwaggerApiEntity();
+        swaggerApi.setMetadata(new ArrayList<>());
+        swaggerApi.setProxy(proxy);
+
+        ApiEntity api = new ApiEntity();
+        api.setId(API_ID);
         api.setProxy(proxy);
 
         when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
@@ -489,17 +495,20 @@ public class ApiServiceCockpitImplTest {
 
     @Test
     public void should_deploy_an_updated_published_api() {
-        SwaggerApiEntity swaggerApi = new SwaggerApiEntity();
-        swaggerApi.setMetadata(new ArrayList<>());
-
-        ApiEntity api = new ApiEntity();
-        api.setId(API_ID);
         Proxy proxy = new Proxy();
         VirtualHost virtualHost = new VirtualHost();
         proxy.setVirtualHosts(List.of(virtualHost));
+
+        SwaggerApiEntity swaggerApi = new SwaggerApiEntity();
+        swaggerApi.setMetadata(new ArrayList<>());
+        swaggerApi.setProxy(proxy);
+
+        ApiEntity api = new ApiEntity();
+        api.setId(API_ID);
         api.setProxy(proxy);
 
         when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
+        when(virtualHostService.sanitizeAndValidate(any(Collection.class))).thenReturn(List.of(virtualHost));
 
         ApiEntity updatedApiEntity = new ApiEntity();
         updatedApiEntity.setName("updated api");


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/gravitee-cockpit/issues/1938

**Description**

Before updating an API from Cockpit, check that the context path is unique. If not, send the relevant error message.

**Additional context**

Before this, update was failing but not proper response was sent to Cockpit
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lywjiuxpso.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/cockpit-1938-check-context-path-before-update-api/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
