### PR TITLE
CI/CD : add PUT endpoint to import API definition without specifying ID

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
@@ -412,7 +412,6 @@ public class ApiResource extends AbstractResource {
     public Response updateApiWithDefinition(@ApiParam(name = "definition", required = true) String apiDefinition) {
         ApiEntity updatedApi = apiDuplicatorService.createWithImportedDefinition(
             apiDefinition,
-            getAuthenticatedUser(),
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment()
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
@@ -365,6 +365,30 @@ public class ApisResource extends AbstractResource {
         );
     }
 
+    @PUT
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("import")
+    @ApiOperation(value = "Update the API from the API definition")
+    @ApiResponses(
+        {
+            @ApiResponse(code = 200, message = "API successfully updated from API definition", response = ApiEntity.class),
+            @ApiResponse(code = 403, message = "Forbidden"),
+            @ApiResponse(code = 500, message = "Internal server error"),
+        }
+    )
+    public Response updateWithDefinition(@ApiParam(name = "definition", required = true) String apiDefinition) {
+        ApiEntity updatedApi = apiDuplicatorService.updateWithImportedDefinition(
+            apiDefinition,
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
+        return Response
+            .ok(updatedApi)
+            .tag(Long.toString(updatedApi.getUpdatedAt().getTime()))
+            .lastModified(updatedApi.getUpdatedAt())
+            .build();
+    }
+
     @Path("{api}")
     public ApiResource getApiResource() {
         return resourceContext.getResource(ApiResource.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
@@ -237,7 +237,6 @@ public class ApisResource extends AbstractResource {
     ) {
         ApiEntity imported = apiDuplicatorService.createWithImportedDefinition(
             apiDefinition,
-            getAuthenticatedUser(),
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment()
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PromotionResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PromotionResource.java
@@ -64,8 +64,7 @@ public class PromotionResource extends AbstractResource {
                     GraviteeContext.getCurrentOrganization(),
                     GraviteeContext.getCurrentEnvironment(),
                     promotion,
-                    accepted,
-                    getAuthenticatedUser()
+                    accepted
                 )
             )
             .build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApisResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApisResourceTest.java
@@ -126,12 +126,7 @@ public class ApisResourceTest extends AbstractResourceTest {
         createdApi.setId("my-beautiful-api");
         doReturn(createdApi)
             .when(apiDuplicatorService)
-            .createWithImportedDefinition(
-                any(),
-                any(),
-                eq(GraviteeContext.getCurrentOrganization()),
-                eq(GraviteeContext.getCurrentEnvironment())
-            );
+            .createWithImportedDefinition(any(), eq(GraviteeContext.getCurrentOrganization()), eq(GraviteeContext.getCurrentEnvironment()));
 
         final Response response = envTarget().path("import").request().post(Entity.json(apiDefinition));
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
@@ -149,12 +144,7 @@ public class ApisResourceTest extends AbstractResourceTest {
         createdApi.setId("my-beautiful-api");
         doReturn(createdApi)
             .when(apiDuplicatorService)
-            .createWithImportedDefinition(
-                any(),
-                any(),
-                eq(GraviteeContext.getCurrentOrganization()),
-                eq(GraviteeContext.getCurrentEnvironment())
-            );
+            .createWithImportedDefinition(any(), eq(GraviteeContext.getCurrentOrganization()), eq(GraviteeContext.getCurrentEnvironment()));
 
         final Response response = envTarget()
             .path("import")
@@ -176,12 +166,7 @@ public class ApisResourceTest extends AbstractResourceTest {
         createdApi.setId("my-beautiful-api");
         doReturn(createdApi)
             .when(apiDuplicatorService)
-            .createWithImportedDefinition(
-                any(),
-                any(),
-                eq(GraviteeContext.getCurrentOrganization()),
-                eq(GraviteeContext.getCurrentEnvironment())
-            );
+            .createWithImportedDefinition(any(), eq(GraviteeContext.getCurrentOrganization()), eq(GraviteeContext.getCurrentEnvironment()));
 
         final Response response = envTarget()
             .path("import")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiDuplicatorService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiDuplicatorService.java
@@ -19,7 +19,7 @@ import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.api.DuplicateApiEntity;
 
 public interface ApiDuplicatorService {
-    ApiEntity createWithImportedDefinition(String apiDefinitionOrURL, String userId, String organizationId, String environmentId);
+    ApiEntity createWithImportedDefinition(String apiDefinitionOrURL, String organizationId, String environmentId);
 
     ApiEntity duplicate(ApiEntity apiEntity, DuplicateApiEntity duplicateApiEntity, String organizationId, String environmentId);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiDuplicatorService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiDuplicatorService.java
@@ -23,5 +23,9 @@ public interface ApiDuplicatorService {
 
     ApiEntity duplicate(ApiEntity apiEntity, DuplicateApiEntity duplicateApiEntity, String organizationId, String environmentId);
 
+    default ApiEntity updateWithImportedDefinition(String apiDefinitionOrURL, String organizationId, String environmentId) {
+        return updateWithImportedDefinition(null, apiDefinitionOrURL, organizationId, environmentId);
+    }
+
     ApiEntity updateWithImportedDefinition(String apiId, String apiDefinitionOrURL, String organizationId, String environmentId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
@@ -110,7 +110,7 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
     }
 
     @Override
-    public ApiEntity createWithImportedDefinition(String apiDefinitionOrURL, String userId, String organizationId, String environmentId) {
+    public ApiEntity createWithImportedDefinition(String apiDefinitionOrURL, String organizationId, String environmentId) {
         String apiDefinition = fetchApiDefinitionContentFromURL(apiDefinitionOrURL);
         try {
             // Read the whole input definition, and recalculate his ID
@@ -124,7 +124,11 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
 
             // import
             UpdateApiEntity importedApi = convertToEntity(apiJsonNode.toString(), apiJsonNode, environmentId);
-            ApiEntity createdApiEntity = apiService.createWithApiDefinition(importedApi, userId, apiJsonNode.getJsonNode());
+            ApiEntity createdApiEntity = apiService.createWithApiDefinition(
+                importedApi,
+                getAuthenticatedUsername(),
+                apiJsonNode.getJsonNode()
+            );
             createOrUpdateApiNestedEntities(createdApiEntity, apiJsonNode, organizationId, environmentId);
             createPageAndMedia(createdApiEntity, apiJsonNode, environmentId);
             return createdApiEntity;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceImpl.java
@@ -239,13 +239,7 @@ public class PromotionServiceImpl extends AbstractService implements PromotionSe
     }
 
     @Override
-    public PromotionEntity processPromotion(
-        final String organizationId,
-        final String environmentId,
-        String promotionId,
-        boolean accepted,
-        String user
-    ) {
+    public PromotionEntity processPromotion(final String organizationId, final String environmentId, String promotionId, boolean accepted) {
         try {
             final Promotion promotion = promotionRepository
                 .findById(promotionId)
@@ -271,7 +265,6 @@ public class PromotionServiceImpl extends AbstractService implements PromotionSe
                     promoted =
                         apiDuplicatorService.createWithImportedDefinition(
                             promotion.getApiDefinition(),
-                            user,
                             organizationId,
                             environment.getId()
                         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/promotion/PromotionService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/promotion/PromotionService.java
@@ -44,11 +44,5 @@ public interface PromotionService {
 
     Page<PromotionEntity> search(PromotionQuery query, Sortable sortable, Pageable pageable);
 
-    PromotionEntity processPromotion(
-        final String organizationId,
-        final String environmentId,
-        String promotion,
-        boolean accepted,
-        String user
-    );
+    PromotionEntity processPromotion(final String organizationId, final String environmentId, String promotion, boolean accepted);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_CreateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_CreateWithDefinitionTest.java
@@ -24,6 +24,7 @@ import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.Api;
+import io.gravitee.rest.api.idp.api.authentication.UserDetails;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.permissions.RoleScope;
@@ -40,6 +41,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -49,6 +51,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
 
 /**
  * @author Azize Elamrani (azize.elamrani at graviteesource.com)
@@ -105,6 +108,14 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
 
     @Mock
     private MediaService mediaService;
+
+    @Before
+    public void mockAuthenticatedUser() {
+        final Authentication authentication = mock(Authentication.class);
+        final UserDetails userDetails = new UserDetails("admin", "PASSWORD", Collections.emptyList());
+        when(authentication.getPrincipal()).thenReturn(userDetails);
+        SecurityContextHolder.setContext(new SecurityContextImpl(authentication));
+    }
 
     @AfterClass
     public static void cleanSecurityContextHolder() {
@@ -167,7 +178,6 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
 
         apiDuplicatorService.createWithImportedDefinition(
             toBeImport,
-            "admin",
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment()
         );
@@ -244,7 +254,6 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
 
         apiDuplicatorService.createWithImportedDefinition(
             toBeImport,
-            "admin",
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment()
         );
@@ -292,7 +301,6 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
 
         apiDuplicatorService.createWithImportedDefinition(
             toBeImport,
-            "admin",
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment()
         );
@@ -323,7 +331,6 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
 
         apiDuplicatorService.createWithImportedDefinition(
             toBeImport,
-            "admin",
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment()
         );
@@ -353,7 +360,6 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
 
         apiDuplicatorService.createWithImportedDefinition(
             toBeImport,
-            "admin",
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment()
         );
@@ -383,7 +389,6 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
 
         apiDuplicatorService.createWithImportedDefinition(
             toBeImport,
-            "admin",
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment()
         );
@@ -409,7 +414,6 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
 
         apiDuplicatorService.createWithImportedDefinition(
             toBeImport,
-            "admin",
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment()
         );
@@ -439,7 +443,6 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
 
         apiDuplicatorService.createWithImportedDefinition(
             toBeImport,
-            "admin",
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment()
         );
@@ -490,7 +493,6 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
 
         apiDuplicatorService.createWithImportedDefinition(
             toBeImport,
-            "admin",
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment()
         );
@@ -545,7 +547,6 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
 
         apiDuplicatorService.createWithImportedDefinition(
             toBeImport,
-            "admin",
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment()
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_UpdateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_UpdateWithDefinitionTest.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.rest.api.service;
 
+import static io.gravitee.rest.api.model.permissions.RolePermission.API_DEFINITION;
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.UPDATE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -25,6 +27,7 @@ import com.google.common.io.Resources;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.ApiLifecycleState;
+import io.gravitee.rest.api.idp.api.authentication.UserDetails;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.permissions.RoleScope;
@@ -33,13 +36,14 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.converter.PlanConverter;
 import io.gravitee.rest.api.service.exceptions.ApiImportException;
-import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
 import io.gravitee.rest.api.service.impl.ApiDuplicatorServiceImpl;
 import io.gravitee.rest.api.service.spring.ImportConfiguration;
 import java.io.IOException;
 import java.net.URL;
 import java.util.*;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -49,6 +53,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
 
 /**
  * @author Azize Elamrani (azize.elamrani at graviteesource.com)
@@ -108,6 +113,19 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
 
     @Mock
     private MediaService mediaService;
+
+    @Mock
+    private PermissionService permissionService;
+
+    @Before
+    public void mockUserWithPermissions() {
+        Authentication authentication = mock(Authentication.class);
+        UserDetails authenticatedUserDetails = new UserDetails("admin", "PASSWORD", Collections.emptyList());
+        when(authentication.getPrincipal()).thenReturn(authenticatedUserDetails);
+        SecurityContextHolder.setContext(new SecurityContextImpl(authentication));
+
+        when(permissionService.hasPermission(any(), any(), any())).thenReturn(true);
+    }
 
     @AfterClass
     public static void cleanSecurityContextHolder() {
@@ -576,6 +594,37 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         apiPlan.setCrossId("plan-cross-id-1");
 
         when(planService.anyPlanMismatchWithApi(anyList(), eq("id-api"))).thenReturn(true);
+
+        apiDuplicatorService.updateWithImportedDefinition(
+            API_ID,
+            toBeImport,
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
+    }
+
+    @Test(expected = ForbiddenAccessException.class)
+    public void shouldRaiseAForbiddenAccessException_whenUserNotAuthenticated() throws IOException {
+        // unauthenticate user
+        SecurityContextHolder.setContext(new SecurityContextImpl());
+
+        URL resource = Resources.getResource("io/gravitee/rest/api/management/service/import-api-update.definition+plans-missingData.json");
+        String toBeImport = Resources.toString(resource, Charsets.UTF_8);
+
+        apiDuplicatorService.updateWithImportedDefinition(
+            API_ID,
+            toBeImport,
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
+    }
+
+    @Test(expected = ForbiddenAccessException.class)
+    public void shouldRaiseAForbiddenAccessException_whenUserHasNoRequiredPermission() throws IOException {
+        when(permissionService.hasPermission(API_DEFINITION, "id-api", UPDATE)).thenReturn(false);
+
+        URL resource = Resources.getResource("io/gravitee/rest/api/management/service/import-api-update.definition+plans-missingData.json");
+        String toBeImport = Resources.toString(resource, Charsets.UTF_8);
 
         apiDuplicatorService.updateWithImportedDefinition(
             API_ID,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceTest.java
@@ -200,7 +200,7 @@ public class PromotionServiceTest {
         Page<Promotion> promotionPage = new Page<>(emptyList(), 0, 1, 1);
         when(promotionRepository.search(any(), any(), any())).thenReturn(promotionPage);
 
-        when(apiDuplicatorService.createWithImportedDefinition(any(), any(), any(), any())).thenReturn(new ApiEntity());
+        when(apiDuplicatorService.createWithImportedDefinition(any(), any(), any())).thenReturn(new ApiEntity());
 
         CockpitReply<PromotionEntity> cockpitReply = new CockpitReply<>(null, CockpitReplyStatus.SUCCEEDED);
         when(cockpitPromotionService.processPromotion(any())).thenReturn(cockpitReply);
@@ -211,11 +211,10 @@ public class PromotionServiceTest {
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment(),
             PROMOTION_ID,
-            true,
-            USER_ID
+            true
         );
 
-        verify(apiDuplicatorService, times(1)).createWithImportedDefinition(any(), eq(USER_ID), any(), any());
+        verify(apiDuplicatorService, times(1)).createWithImportedDefinition(any(), any(), any());
         verify(promotionRepository, times(1)).update(any());
     }
 
@@ -245,8 +244,7 @@ public class PromotionServiceTest {
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment(),
             PROMOTION_ID,
-            true,
-            USER_ID
+            true
         );
 
         verify(apiDuplicatorService, times(1)).updateWithImportedDefinition(any(), any(), any(), any());
@@ -271,11 +269,10 @@ public class PromotionServiceTest {
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment(),
             PROMOTION_ID,
-            false,
-            USER_ID
+            false
         );
 
-        verify(apiDuplicatorService, never()).createWithImportedDefinition(any(), eq(USER_ID), any(), any());
+        verify(apiDuplicatorService, never()).createWithImportedDefinition(any(), any(), any());
         verify(apiDuplicatorService, never()).updateWithImportedDefinition(any(), any(), any(), any());
         verify(promotionRepository, times(1)).update(any());
     }
@@ -288,8 +285,7 @@ public class PromotionServiceTest {
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment(),
             PROMOTION_ID,
-            true,
-            USER_ID
+            true
         );
     }
 
@@ -308,8 +304,7 @@ public class PromotionServiceTest {
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment(),
             PROMOTION_ID,
-            true,
-            USER_ID
+            true
         );
     }
 
@@ -337,8 +332,7 @@ public class PromotionServiceTest {
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment(),
             PROMOTION_ID,
-            true,
-            USER_ID
+            true
         );
 
         verify(apiDuplicatorService, times(1)).updateWithImportedDefinition(any(), any(), any(), any());


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7084

**Description**

feat(management): add PUT endpoint to import API from definition, without specifying his id

This simplifies using API import endpoints from CI/CD.

As this PUT endpoint doesn't contains API id, we have to check authenticated user permissions manually after recalculating target API id.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jyejyzodec.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/feat-import-cicd-putendpoint/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
