### PR TITLE
feat: cockpit apis incremental upgrade

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImplTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.gravitee.common.component.Lifecycle;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.Proxy;
 import io.gravitee.definition.model.VirtualHost;
@@ -35,6 +36,7 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApiContextPathAlreadyExistsException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -449,7 +451,7 @@ public class ApiServiceCockpitImplTest {
     }
 
     @Test
-    public void should_update_an_published_api() {
+    public void should_update_a_published_api() {
         ImportSwaggerDescriptorEntity expectedDescriptor = new ImportSwaggerDescriptorEntity();
         expectedDescriptor.setPayload(SWAGGER_DEFINITION);
         expectedDescriptor.setWithDocumentation(true);
@@ -475,6 +477,7 @@ public class ApiServiceCockpitImplTest {
             .thenReturn(updatedApiEntity);
         when(apiService.deploy(anyString(), anyString(), any(EventType.class), any(ApiDeploymentEntity.class)))
             .thenReturn(updatedApiEntity);
+        when(apiService.update(eq(API_ID), any(UpdateApiEntity.class))).thenReturn(updatedApiEntity);
 
         GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
 
@@ -505,11 +508,130 @@ public class ApiServiceCockpitImplTest {
         updatedApiEntity.setName("updated api");
         when(apiService.updateFromSwagger(eq(API_ID), eq(swaggerApi), any(ImportSwaggerDescriptorEntity.class)))
             .thenReturn(updatedApiEntity);
+        when(apiService.deploy(eq(API_ID), eq(USER_ID), eq(EventType.PUBLISH_API), any(ApiDeploymentEntity.class)))
+            .thenReturn(updatedApiEntity);
 
         service.updateApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED);
 
         verify(apiService).deploy(eq(API_ID), eq(USER_ID), eq(EventType.PUBLISH_API), apiDeploymentCaptor.capture());
         assertThat(apiDeploymentCaptor.getValue().getDeploymentLabel()).isEqualTo("Model updated");
+    }
+
+    @Test
+    public void should_upgrade_documented_to_mocked_api() {
+        SwaggerApiEntity swaggerApi = new SwaggerApiEntity();
+        swaggerApi.setMetadata(new ArrayList<>());
+        ApiEntity api = new ApiEntity();
+        api.setId(API_ID);
+        Proxy proxy = new Proxy();
+        VirtualHost virtualHost = new VirtualHost();
+        proxy.setVirtualHosts(List.of(virtualHost));
+        api.setProxy(proxy);
+        when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
+
+        ApiEntity updatedApiEntity = new ApiEntity();
+        updatedApiEntity.setName("updated api");
+        updatedApiEntity.setState(Lifecycle.State.STOPPED);
+        when(apiService.updateFromSwagger(eq(API_ID), eq(swaggerApi), any(ImportSwaggerDescriptorEntity.class)))
+            .thenReturn(updatedApiEntity);
+        when(apiService.deploy(eq(API_ID), eq(USER_ID), eq(EventType.PUBLISH_API), any(ApiDeploymentEntity.class)))
+            .thenReturn(updatedApiEntity);
+
+        when(apiService.start(API_ID, USER_ID)).thenReturn(updatedApiEntity);
+        when(planService.findByApi(API_ID)).thenReturn(null);
+
+        service.updateApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED);
+
+        verify(planService).findByApi(eq(API_ID));
+        verify(planService).create(newPlanCaptor.capture());
+        assertThat(newPlanCaptor.getValue())
+            .extracting(NewPlanEntity::getApi, NewPlanEntity::getSecurity, NewPlanEntity::getStatus)
+            .containsExactly(API_ID, PlanSecurityType.KEY_LESS, PlanStatus.PUBLISHED);
+        verify(apiService).start(eq(API_ID), eq(USER_ID));
+    }
+
+    @Test
+    public void should_upgrade_documented_to_published_api() {
+        SwaggerApiEntity swaggerApi = new SwaggerApiEntity();
+        swaggerApi.setMetadata(new ArrayList<>());
+        ApiEntity api = new ApiEntity();
+        api.setId(API_ID);
+        Proxy proxy = new Proxy();
+        VirtualHost virtualHost = new VirtualHost();
+        proxy.setVirtualHosts(List.of(virtualHost));
+        api.setProxy(proxy);
+        when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
+
+        ApiEntity updatedApiEntity = new ApiEntity();
+        updatedApiEntity.setName("updated api");
+        updatedApiEntity.setState(Lifecycle.State.STOPPED);
+        when(apiService.updateFromSwagger(eq(API_ID), eq(swaggerApi), any(ImportSwaggerDescriptorEntity.class)))
+            .thenReturn(updatedApiEntity);
+        when(apiService.deploy(eq(API_ID), eq(USER_ID), eq(EventType.PUBLISH_API), any(ApiDeploymentEntity.class)))
+            .thenReturn(updatedApiEntity);
+        when(apiService.start(API_ID, USER_ID)).thenReturn(updatedApiEntity);
+
+        when(planService.findByApi(API_ID)).thenReturn(null);
+
+        preparePageServiceMock();
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
+
+        service.updateApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED);
+
+        verify(planService).findByApi(eq(API_ID));
+        verify(planService).create(newPlanCaptor.capture());
+        assertThat(newPlanCaptor.getValue())
+            .extracting(NewPlanEntity::getApi, NewPlanEntity::getSecurity, NewPlanEntity::getStatus)
+            .containsExactly(API_ID, PlanSecurityType.KEY_LESS, PlanStatus.PUBLISHED);
+
+        verify(apiService).start(eq(API_ID), eq(USER_ID));
+        verify(apiService).update(eq(API_ID), updateApiCaptor.capture());
+        assertThat(updateApiCaptor.getValue())
+            .extracting(UpdateApiEntity::getLifecycleState, UpdateApiEntity::getVisibility)
+            .containsExactly(ApiLifecycleState.PUBLISHED, Visibility.PUBLIC);
+
+        verify(pageService).update(eq(PAGE_ID), updatePageCaptor.capture());
+        assertThat(updatePageCaptor.getValue()).extracting(UpdatePageEntity::isPublished).isEqualTo(true);
+    }
+
+    @Test
+    public void should_upgrade_mocked_to_published_api() {
+        SwaggerApiEntity swaggerApi = new SwaggerApiEntity();
+        swaggerApi.setMetadata(new ArrayList<>());
+        ApiEntity api = new ApiEntity();
+        api.setId(API_ID);
+        Proxy proxy = new Proxy();
+        VirtualHost virtualHost = new VirtualHost();
+        proxy.setVirtualHosts(List.of(virtualHost));
+        api.setProxy(proxy);
+        when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
+
+        ApiEntity updatedApiEntity = new ApiEntity();
+        updatedApiEntity.setName("updated api");
+        updatedApiEntity.setState(Lifecycle.State.STARTED);
+        when(apiService.updateFromSwagger(eq(API_ID), eq(swaggerApi), any(ImportSwaggerDescriptorEntity.class)))
+            .thenReturn(updatedApiEntity);
+        when(apiService.deploy(eq(API_ID), eq(USER_ID), eq(EventType.PUBLISH_API), any(ApiDeploymentEntity.class)))
+            .thenReturn(updatedApiEntity);
+
+        when(planService.findByApi(API_ID)).thenReturn(Collections.singleton(new PlanEntity()));
+
+        preparePageServiceMock();
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
+
+        service.updateApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED);
+
+        verify(planService).findByApi(eq(API_ID));
+        verify(planService, never()).create(any(NewPlanEntity.class));
+
+        verify(apiService, never()).start(eq(API_ID), eq(USER_ID));
+        verify(apiService).update(eq(API_ID), updateApiCaptor.capture());
+        assertThat(updateApiCaptor.getValue())
+            .extracting(UpdateApiEntity::getLifecycleState, UpdateApiEntity::getVisibility)
+            .containsExactly(ApiLifecycleState.PUBLISHED, Visibility.PUBLIC);
+
+        verify(pageService).update(eq(PAGE_ID), updatePageCaptor.capture());
+        assertThat(updatePageCaptor.getValue()).extracting(UpdatePageEntity::isPublished).isEqualTo(true);
     }
 
     @Test


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/gravitee-cockpit/issues/1912

**Description**

The goal of this pull request is to enable the incremental update of the apis pushed by cockpit.

Now a user will be able to push a documented api. He can upgrade it as a mocked or directly as published api.
Same same but different for the mocked api that can be upgrade to publish.

No downgrade from cockpit
No sync between cockpit and APIM. If the user do something wrong on APIM side we assume that we will be unsynchronized between cockpit and APIM.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fawjaynbuo.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/feat-cockpit-incremental-api-upgrade/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
