### PR TITLE
feat: validate the virtual hosts for an existing API

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImpl.java
@@ -183,7 +183,7 @@ public class ApiServiceCockpitImpl implements ApiServiceCockpit {
         final SwaggerApiEntity api = swaggerService.createAPI(swaggerDescriptor, DefinitionVersion.V2);
         api.setPaths(null);
 
-        return checkContextPath(api)
+        return checkContextPath(api, apiId)
             .map(ApiEntityResult::failure)
             .orElseGet(() -> ApiEntityResult.success(this.apiService.updateFromSwagger(apiId, api, swaggerDescriptor)));
     }
@@ -211,6 +211,15 @@ public class ApiServiceCockpitImpl implements ApiServiceCockpit {
     Optional<String> checkContextPath(SwaggerApiEntity api) {
         try {
             virtualHostService.sanitizeAndValidate(api.getProxy().getVirtualHosts());
+            return Optional.empty();
+        } catch (Exception e) {
+            return Optional.of(e.getMessage());
+        }
+    }
+
+    Optional<String> checkContextPath(SwaggerApiEntity api, String apiId) {
+        try {
+            virtualHostService.sanitizeAndValidate(api.getProxy().getVirtualHosts(), apiId);
             return Optional.empty();
         } catch (Exception e) {
             return Optional.of(e.getMessage());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImplTest.java
@@ -406,7 +406,7 @@ public class ApiServiceCockpitImplTest {
         api.setProxy(proxy);
 
         when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
-        when(virtualHostService.sanitizeAndValidate(any(Collection.class))).thenReturn(List.of(virtualHost));
+        when(virtualHostService.sanitizeAndValidate(any(), eq(API_ID))).thenReturn(List.of(virtualHost));
 
         ApiEntity updatedApiEntity = new ApiEntity();
         updatedApiEntity.setName("updated api");
@@ -511,7 +511,7 @@ public class ApiServiceCockpitImplTest {
         api.setProxy(proxy);
 
         when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
-        when(virtualHostService.sanitizeAndValidate(any(Collection.class))).thenReturn(List.of(virtualHost));
+        when(virtualHostService.sanitizeAndValidate(any(), eq(API_ID))).thenReturn(List.of(virtualHost));
 
         ApiEntity updatedApiEntity = new ApiEntity();
         updatedApiEntity.setName("updated api");
@@ -549,7 +549,7 @@ public class ApiServiceCockpitImplTest {
 
         when(apiService.start(API_ID, USER_ID)).thenReturn(updatedApiEntity);
         when(planService.findByApi(API_ID)).thenReturn(null);
-        when(virtualHostService.sanitizeAndValidate(any())).thenReturn(List.of(virtualHost));
+        when(virtualHostService.sanitizeAndValidate(any(), eq(API_ID))).thenReturn(List.of(virtualHost));
 
         service.updateApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED);
 
@@ -585,7 +585,7 @@ public class ApiServiceCockpitImplTest {
         when(apiService.start(API_ID, USER_ID)).thenReturn(updatedApiEntity);
 
         when(planService.findByApi(API_ID)).thenReturn(null);
-        when(virtualHostService.sanitizeAndValidate(any())).thenReturn(List.of(virtualHost));
+        when(virtualHostService.sanitizeAndValidate(any(), eq(API_ID))).thenReturn(List.of(virtualHost));
 
         preparePageServiceMock();
         GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
@@ -628,7 +628,7 @@ public class ApiServiceCockpitImplTest {
             .thenReturn(updatedApiEntity);
 
         when(planService.findByApi(API_ID)).thenReturn(Collections.singleton(new PlanEntity()));
-        when(virtualHostService.sanitizeAndValidate(any())).thenReturn(List.of(virtualHost));
+        when(virtualHostService.sanitizeAndValidate(any(), eq(API_ID))).thenReturn(List.of(virtualHost));
 
         preparePageServiceMock();
         GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);


### PR DESCRIPTION
**Description**

Check the context path of an API pushed by Cockpit on APIM, no matter the chosen mode. here we check if the context path already exist or not but we specify that we war working on an api update.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wrpfzbgqpx.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/feat-check-context-path/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
