### PR TITLE
refactor: reduce upgraders code duplication by creating a OneShotUpgrader

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/OneShotUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/OneShotUpgrader.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade;
+
+import static io.gravitee.rest.api.service.impl.upgrade.UpgradeStatus.*;
+
+import io.gravitee.rest.api.model.InstallationEntity;
+import io.gravitee.rest.api.service.InstallationService;
+import io.gravitee.rest.api.service.Upgrader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.Ordered;
+
+/**
+ * An upgrader that will run at APIM startup, only once.
+ * It stores his status in 'installations' table, and won't execute once he has already succeeded.
+ *
+ * Implementations can disable the upgrader by overriding 'isEnabled'.
+ * Or run in dry mode, by overriding 'isDryRun'.
+ *
+ * Implementations have to provide the 'installationStatusKey' in builder,
+ * Which is the status property key of this upgrader in the 'installations' collection.
+ *
+ * @author GraviteeSource Team
+ */
+public abstract class OneShotUpgrader implements Upgrader, Ordered {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OneShotUpgrader.class);
+
+    @Autowired
+    private InstallationService installationService;
+
+    private String installationStatusKey;
+
+    protected abstract void processOneShotUpgrade() throws Exception;
+
+    public OneShotUpgrader(String installationStatusKey) {
+        super();
+        this.installationStatusKey = installationStatusKey;
+    }
+
+    @Override
+    public final boolean upgrade() {
+        if (!isEnabled()) {
+            LOGGER.info("Skipping {} execution cause it's not enabled in configuration", this.getClass().getSimpleName());
+            return false;
+        }
+
+        InstallationEntity installation = installationService.getOrInitialize();
+        if (isDryRun() && isStatus(installation, DRY_SUCCESS)) {
+            LOGGER.info(
+                "Skipping {} execution cause it has already been successfully executed in dry mode",
+                this.getClass().getSimpleName()
+            );
+            return false;
+        }
+        if (isStatus(installation, SUCCESS)) {
+            LOGGER.info("Skipping {} execution cause it has already been successfully executed", this.getClass().getSimpleName());
+            return false;
+        }
+        if (isStatus(installation, RUNNING)) {
+            LOGGER.warn("Skipping {} execution cause it's already running", this.getClass().getSimpleName());
+            return false;
+        }
+
+        try {
+            LOGGER.info("Starting {} execution with dry-run {}", this.getClass().getSimpleName(), isDryRun() ? "enabled" : "disabled");
+            setExecutionStatus(installation, RUNNING);
+            processOneShotUpgrade();
+            setExecutionStatus(installation, isDryRun() ? DRY_SUCCESS : SUCCESS);
+        } catch (Throwable e) {
+            LOGGER.error("{} execution failed", this.getClass().getSimpleName(), e);
+            setExecutionStatus(installation, FAILURE);
+            return false;
+        }
+        LOGGER.info("Finishing {} execution", this.getClass().getSimpleName());
+        return true;
+    }
+
+    private void setExecutionStatus(InstallationEntity installation, UpgradeStatus status) {
+        installation.getAdditionalInformation().put(installationStatusKey, status.toString());
+        installationService.setAdditionalInformation(installation.getAdditionalInformation());
+    }
+
+    private boolean isStatus(InstallationEntity installation, UpgradeStatus status) {
+        return status.toString().equals(installation.getAdditionalInformation().get(installationStatusKey));
+    }
+
+    protected boolean isDryRun() {
+        return false;
+    }
+
+    protected boolean isEnabled() {
+        return true;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/PlansDataFixUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/PlansDataFixUpgraderTest.java
@@ -29,8 +29,6 @@ import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.EmailService;
 import io.gravitee.rest.api.service.InstallationService;
-import io.gravitee.rest.api.service.MembershipService;
-import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -98,7 +96,7 @@ public class PlansDataFixUpgraderTest {
     public void upgrade_should_run_and_set_failure_status_on_exception() throws Exception {
         ReflectionTestUtils.setField(upgrader, "enabled", true);
         InstallationEntity installation = mockInstallationWithExecutionStatus(null);
-        doThrow(new Exception("test exception")).when(upgrader).fixPlansData();
+        doThrow(new Exception("test exception")).when(upgrader).processOneShotUpgrade();
 
         boolean success = upgrader.upgrade();
 
@@ -112,7 +110,7 @@ public class PlansDataFixUpgraderTest {
     public void upgrade_should_run_and_set_success_status() throws Exception {
         ReflectionTestUtils.setField(upgrader, "enabled", true);
         InstallationEntity installation = mockInstallationWithExecutionStatus(null);
-        doNothing().when(upgrader).fixPlansData();
+        doNothing().when(upgrader).processOneShotUpgrade();
 
         boolean success = upgrader.upgrade();
 
@@ -127,7 +125,7 @@ public class PlansDataFixUpgraderTest {
         ReflectionTestUtils.setField(upgrader, "enabled", true);
         ReflectionTestUtils.setField(upgrader, "dryRun", true);
         InstallationEntity installation = mockInstallationWithExecutionStatus(null);
-        doNothing().when(upgrader).fixPlansData();
+        doNothing().when(upgrader).processOneShotUpgrade();
 
         boolean success = upgrader.upgrade();
 
@@ -156,7 +154,7 @@ public class PlansDataFixUpgraderTest {
         apiv2_2.setDefinition("{\"gravitee\": \"2.0.0\"}");
         when(apiRepository.findAll()).thenReturn(Set.of(apiv1_1, apiv2_1, apiv1_2, apiv2_2));
 
-        upgrader.fixPlansData();
+        upgrader.processOneShotUpgrade();
 
         verify(upgrader, times(1)).fixApiPlans(same(apiv2_1), any());
         verify(upgrader, times(1)).fixApiPlans(same(apiv2_2), any());


### PR DESCRIPTION
refactor: reduce upgraders code duplication by creating a OneShotUpgrader

OneShotUpgrader is an upgrader running at APIM startup only once.
There are actually 2 implementations : OrphanCategoryUpgrader and PlansDataFixUpgrader.

This refactor prepares the introduction of a new OneShotUpgrader for the "shared API key" feature (https://github.com/gravitee-io/issues/issues/6793)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-essprudtbg.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/refactor-ontshotupgrader/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
