### PR TITLE
chore: remove Element Zero to GH CodeOwners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,3 @@
 
 # Archi
 /gravitee-apim-gateway/                                       @gravitee-io/archi
-
-# Element-zero
-/gravitee-apim-console-webui/                                 @gravitee-io/element-zero
-/gravitee-apim-portal-webui/                                  @gravitee-io/element-zero


### PR DESCRIPTION
**Issue**
na

**Description**
👻

Element Zero aims to become a ""cross-team/guild"" for design system and his implementation. It should not be owner of APIM code anymore.

I wouldn't mind adding Dark Matter but it doesn't exist

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ugskbxgylg.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/codeowners/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
