### PR TITLE
chore: bump gravitee-policy-cache to version 1.15.0

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -50,7 +50,7 @@
         <gravitee-policy-apikey.version>2.4.0</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>1.5.0</gravitee-policy-assign-attributes.version>
         <gravitee-policy-assign-content.version>1.7.0</gravitee-policy-assign-content.version>
-        <gravitee-policy-cache.version>1.14.0</gravitee-policy-cache.version>
+        <gravitee-policy-cache.version>1.15.0</gravitee-policy-cache.version>
         <gravitee-policy-callout-http.version>1.15.0</gravitee-policy-callout-http.version>
         <gravitee-policy-dynamic-routing.version>1.11.1</gravitee-policy-dynamic-routing.version>
         <gravitee-policy-generate-http-signature.version>1.1.0</gravitee-policy-generate-http-signature.version>


### PR DESCRIPTION
Bump gravitee-policy-cache to version 1.15.0

This new version of cache policy has been released in : https://github.com/gravitee-io/issues/issues/6980
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bqtqwzvnnv.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/chore-bump-cache-policy-on-3-15/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
