### PR TITLE
refactor: use a dedicated for preprocessor step

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-response-try-it/policy-studio-debug-response-try-it.component.stories.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-response-try-it/policy-studio-debug-response-try-it.component.stories.ts
@@ -84,7 +84,7 @@ export const ResponseSuccess: Story = {
       responseDebugSteps: [],
       backendResponse: {},
       requestDebugSteps: [],
-      initialAttributes: {},
+      preprocessorStep: {},
     } as DebugResponse,
   },
 };
@@ -109,7 +109,7 @@ export const ResponseError: Story = {
       responseDebugSteps: [],
       backendResponse: {},
       requestDebugSteps: [],
-      initialAttributes: {},
+      preprocessorStep: {},
     } as DebugResponse,
   },
 };

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-response/policy-studio-debug-response.component.stories.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-response/policy-studio-debug-response.component.stories.ts
@@ -90,7 +90,7 @@ export const Loading: Story = {
       responseDebugSteps: [],
       backendResponse: {},
       requestDebugSteps: [],
-      initialAttributes: {},
+      preprocessorStep: {},
     } as DebugResponse,
   },
 };
@@ -136,7 +136,7 @@ export const ResponseErrorFullEmpty: Story = {
       responseDebugSteps: [],
       backendResponse: {},
       requestDebugSteps: [],
-      initialAttributes: {},
+      preprocessorStep: {},
     } as DebugResponse,
   },
 };

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-response/policy-studio-debug-response.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-response/policy-studio-debug-response.component.ts
@@ -74,7 +74,6 @@ export class PolicyStudioDebugResponseComponent implements OnChanges {
 
       const outputIndex = steps.findIndex((value) => value.id === timelineStep.id);
 
-      // FIXME: replace by preprocessStep
       this.selectedStep.input =
         outputIndex > 0
           ? steps[outputIndex - 1]
@@ -86,7 +85,7 @@ export class PolicyStudioDebugResponseComponent implements OnChanges {
               status: 'COMPLETED',
               duration: 0,
               policyOutput: {
-                attributes: this.debugResponse.initialAttributes,
+                ...this.debugResponse.preprocessorStep,
               },
             };
       this.selectedStep.output = steps[outputIndex];

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/debug/models/DebugEvent.fixture.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/debug/models/DebugEvent.fixture.ts
@@ -165,8 +165,14 @@ export function fakeDebugEvent(attributes?: Partial<DebugEvent>): DebugEvent {
           },
         },
       ],
-      initialAttributes: {
-        'gravitee.attribute.context-path': '/09770e92ee2112001ade3747-echo/',
+      preprocessorStep: {
+        attributes: {
+          'gravitee.attribute.context-path': '/09770e92ee2112001ade3747-echo/',
+        },
+        headers: {
+          'X-Gravitee-Transaction-Id': ['b39875e9-7fc7-4980-9875-e97fc7b980b7'],
+          'X-Gravitee-Request-Id': ['303247f6-5811-4a90-b247-f658115a9033'],
+        },
       },
       backendResponse: {
         body: '{"headers":{"X-Gravitee-Transaction-Id":"b39875e9-7fc7-4980-9875-e97fc7b980b7","X-Gravitee-Request-Id":"303247f6-5811-4a90-b247-f658115a9033","a-header-platform":"WOW","Host":"api.gravitee.io","accept-encoding":"deflate, gzip"},"query_params":{}}',

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/debug/models/DebugEvent.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/debug/models/DebugEvent.ts
@@ -34,7 +34,10 @@ interface DebugEventPayload {
     body?: string;
   };
   debugSteps?: DebugEventDebugStep[];
-  initialAttributes?: Record<string, boolean | number | string>;
+  preprocessorStep: {
+    attributes?: Record<string, boolean | number | string>;
+    headers?: Record<string, string[]>;
+  };
   backendResponse: {
     statusCode?: number;
     method?: string;

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/debug/models/DebugResponse.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/debug/models/DebugResponse.spec.ts
@@ -32,7 +32,8 @@ describe('convertDebugEventToDebugResponse', () => {
         method: 'GET',
         body: '{}',
         headers: {
-          'initial-header': ['init'],
+          'X-Gravitee-Request-Id': ['303247f6-5811-4a90-b247-f658115a9033'],
+          'X-Gravitee-Transaction-Id': ['b39875e9-7fc7-4980-9875-e97fc7b980b7'],
         },
         attributes: {
           'gravitee.attribute.context-path': '/09770e92ee2112001ade3747-echo/',
@@ -58,7 +59,8 @@ describe('convertDebugEventToDebugResponse', () => {
         method: 'GET',
         body: '{}',
         headers: {
-          'initial-header': ['init'],
+          'X-Gravitee-Request-Id': ['303247f6-5811-4a90-b247-f658115a9033'],
+          'X-Gravitee-Transaction-Id': ['b39875e9-7fc7-4980-9875-e97fc7b980b7'],
         },
         attributes: {
           'gravitee.attribute.context-path': '/09770e92ee2112001ade3747-echo/',
@@ -85,7 +87,8 @@ describe('convertDebugEventToDebugResponse', () => {
         method: 'GET',
         body: '{}',
         headers: {
-          'initial-header': ['init'],
+          'X-Gravitee-Request-Id': ['303247f6-5811-4a90-b247-f658115a9033'],
+          'X-Gravitee-Transaction-Id': ['b39875e9-7fc7-4980-9875-e97fc7b980b7'],
         },
         attributes: {
           'gravitee.attribute.context-path': '/09770e92ee2112001ade3747-echo/',
@@ -245,7 +248,7 @@ describe('convertDebugEventToDebugResponse', () => {
 
     const debugResponse = convertDebugEventToDebugResponse(mockDebugEvent);
 
-    expect(debugResponse.initialAttributes).toStrictEqual(mockDebugEvent.payload.initialAttributes);
+    expect(debugResponse.preprocessorStep).toStrictEqual(mockDebugEvent.payload.preprocessorStep);
     expect(debugResponse.backendResponse).toStrictEqual(mockDebugEvent.payload.backendResponse);
     expect(debugResponse.request).toStrictEqual(mockDebugEvent.payload.request);
     expect(debugResponse.response).toStrictEqual(mockDebugEvent.payload.response);

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/debug/policy-studio-debug.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/debug/policy-studio-debug.component.ts
@@ -74,7 +74,7 @@ export class PolicyStudioDebugComponent implements OnInit {
       responseDebugSteps: [],
       backendResponse: {},
       requestDebugSteps: [],
-      initialAttributes: {},
+      preprocessorStep: {},
     };
 
     this.policyStudioDebugService
@@ -90,7 +90,7 @@ export class PolicyStudioDebugComponent implements OnInit {
             responseDebugSteps: [],
             backendResponse: {},
             requestDebugSteps: [],
-            initialAttributes: {},
+            preprocessorStep: {},
           };
           return EMPTY;
         }),

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/debug/policy-studio-debug.service.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/debug/policy-studio-debug.service.spec.ts
@@ -59,7 +59,8 @@ describe('PolicyStudioDebugService', () => {
             method: 'GET',
             body: '{}',
             headers: {
-              'initial-header': ['init'],
+              'X-Gravitee-Request-Id': ['303247f6-5811-4a90-b247-f658115a9033'],
+              'X-Gravitee-Transaction-Id': ['b39875e9-7fc7-4980-9875-e97fc7b980b7'],
             },
             attributes: {
               'gravitee.attribute.context-path': '/09770e92ee2112001ade3747-echo/',
@@ -85,7 +86,8 @@ describe('PolicyStudioDebugService', () => {
             method: 'GET',
             body: '{}',
             headers: {
-              'initial-header': ['init'],
+              'X-Gravitee-Request-Id': ['303247f6-5811-4a90-b247-f658115a9033'],
+              'X-Gravitee-Transaction-Id': ['b39875e9-7fc7-4980-9875-e97fc7b980b7'],
             },
             attributes: {
               'gravitee.attribute.context-path': '/09770e92ee2112001ade3747-echo/',
@@ -112,7 +114,8 @@ describe('PolicyStudioDebugService', () => {
             method: 'GET',
             body: '{}',
             headers: {
-              'initial-header': ['init'],
+              'X-Gravitee-Request-Id': ['303247f6-5811-4a90-b247-f658115a9033'],
+              'X-Gravitee-Transaction-Id': ['b39875e9-7fc7-4980-9875-e97fc7b980b7'],
             },
             attributes: {
               'gravitee.attribute.context-path': '/09770e92ee2112001ade3747-echo/',
@@ -275,7 +278,7 @@ describe('PolicyStudioDebugService', () => {
           path: '',
         })
         .subscribe((response) => {
-          expect(response.initialAttributes).toStrictEqual(mockDebugEvent.payload.initialAttributes);
+          expect(response.preprocessorStep).toStrictEqual(mockDebugEvent.payload.preprocessorStep);
           expect(response.backendResponse).toStrictEqual(mockDebugEvent.payload.backendResponse);
           expect(response.request).toStrictEqual(mockDebugEvent.payload.request);
           expect(response.response).toStrictEqual(mockDebugEvent.payload.response);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/handler/context/DebugExecutionContext.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/handler/context/DebugExecutionContext.java
@@ -20,6 +20,7 @@ import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.debug.core.invoker.InvokerResponse;
 import io.gravitee.gateway.debug.reactor.handler.context.steps.DebugRequestStep;
 import io.gravitee.gateway.debug.reactor.handler.context.steps.DebugResponseStep;
@@ -43,10 +44,12 @@ public class DebugExecutionContext implements ExecutionContext {
     private final List<DebugStep<?>> steps = new ArrayList<>();
     private final Map<String, Serializable> initialAttributes;
     private final InvokerResponse invokerResponse = new InvokerResponse();
+    private final HttpHeaders initialHeaders;
 
     public DebugExecutionContext(ExecutionContext context) {
         this.context = context;
         this.initialAttributes = AttributeHelper.filterAndSerializeAttributes(context.getAttributes());
+        this.initialHeaders = HttpHeaders.create(request().headers());
     }
 
     public Map<String, Serializable> getInitialAttributes() {
@@ -133,5 +136,9 @@ public class DebugExecutionContext implements ExecutionContext {
 
     public InvokerResponse getInvokerResponse() {
         return invokerResponse;
+    }
+
+    public HttpHeaders getInitialHeaders() {
+        return initialHeaders;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/processor/DebugEventCompletionProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/processor/DebugEventCompletionProcessor.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.Api;
 import io.gravitee.definition.model.HttpResponse;
+import io.gravitee.definition.model.debug.PreprocessorStep;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaders;
@@ -80,7 +81,8 @@ public class DebugEventCompletionProcessor extends AbstractProcessor<ExecutionCo
         DebugApi debugApiComponent
     ) {
         final io.gravitee.definition.model.debug.DebugApi debugApi = convert(debugApiComponent);
-        debugApi.setInitialAttributes(debugContext.getInitialAttributes());
+        PreprocessorStep preprocessorStep = createPreprocessorStep(debugContext);
+        debugApi.setPreprocessorStep(preprocessorStep);
         debugApi.setDebugSteps(convert(debugContext.getDebugSteps()));
 
         HttpResponse response = createResponse(
@@ -98,6 +100,13 @@ public class DebugEventCompletionProcessor extends AbstractProcessor<ExecutionCo
         debugApi.setBackendResponse(invokerResponse);
 
         return debugApi;
+    }
+
+    private PreprocessorStep createPreprocessorStep(DebugExecutionContext debugContext) {
+        final PreprocessorStep preprocessorStep = new PreprocessorStep();
+        preprocessorStep.setAttributes(debugContext.getInitialAttributes());
+        preprocessorStep.setHeaders(convertHeaders(debugContext.getInitialHeaders()));
+        return preprocessorStep;
     }
 
     private HttpResponse createResponse(HttpHeaders httpHeaders, int statusCode, Buffer bodyBuffer) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/vertx/VertxDebugConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/vertx/VertxDebugConfiguration.java
@@ -29,7 +29,6 @@ import io.gravitee.node.vertx.VertxHttpServerFactory;
 import io.gravitee.node.vertx.configuration.HttpServerConfiguration;
 import io.gravitee.repository.management.api.EventRepository;
 import io.vertx.core.Vertx;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Bean;


### PR DESCRIPTION
**Description**

Use a preprocessorStep object to hold initial attributes and headers


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-etavmaspyx.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/debug-use-preprocessor-step/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
