### PR TITLE
CI improvements for Azure deployments - 3.5.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -549,11 +549,6 @@ jobs:
                   at: .
             - get-apim-tag
             - run:
-                  name: Install Helm
-                  command: |
-                      curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
-                      helm version
-            - run:
                   name: Install Kubectl
                   command: |
                       curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
@@ -561,27 +556,12 @@ jobs:
                       mv ./kubectl /usr/local/bin/kubectl
                       kubectl version --client=true
             - run:
-                  name: Helm upgrade and 🚀 to APIM cluster
+                  name: Restart APIM cluster pods
                   command: |
                       export K8S_NAMESPACE=apim-${CIRCLE_BRANCH//\./-}
 
                       az login --service-principal -u $AZURE_APPLICATION_ID --tenant $AZURE_TENANT -p $AZURE_APPLICATION_SECRET
                       az aks get-credentials --resource-group apim-hprod --name apim-hprod
-
-                      helm upgrade --repo https://helm.gravitee.io \
-                                   --install apim \
-                                   -n ${K8S_NAMESPACE} \
-                                   --reuse-values \
-                                   apim3 \
-                                   --set "api.image.repository=graviteeio.azurecr.io/apim-management-api" \
-                                   --set "api.image.tag=${TAG}" \
-                                   --set "portal.image.repository=graviteeio.azurecr.io/apim-portal-ui" \
-                                   --set "portal.image.tag=${TAG}" \
-                                   --set "ui.image.repository=graviteeio.azurecr.io/apim-management-ui" \
-                                   --set "ui.image.tag=${TAG}" \
-                                   --set "gateway.image.repository=graviteeio.azurecr.io/apim-gateway" \
-                                   --set "gateway.image.tag=${TAG}" \
-                                   --set "redis.repositoryVersion=3.12.1"
 
                       kubectl rollout restart deployment/apim-apim3-api -n ${K8S_NAMESPACE}
                       kubectl rollout restart deployment/apim-apim3-portal -n ${K8S_NAMESPACE}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -558,15 +558,16 @@ jobs:
             - run:
                   name: Restart APIM cluster pods
                   command: |
+                      export K8S_NAME=apim-${CIRCLE_BRANCH//\./-}
                       export K8S_NAMESPACE=apim-${CIRCLE_BRANCH//\./-}
 
                       az login --service-principal -u $AZURE_APPLICATION_ID --tenant $AZURE_TENANT -p $AZURE_APPLICATION_SECRET
                       az aks get-credentials --resource-group apim-hprod --name apim-hprod
 
-                      kubectl rollout restart deployment/apim-apim3-api -n ${K8S_NAMESPACE}
-                      kubectl rollout restart deployment/apim-apim3-portal -n ${K8S_NAMESPACE}
-                      kubectl rollout restart deployment/apim-apim3-ui -n ${K8S_NAMESPACE}
-                      kubectl rollout restart deployment/apim-apim3-gateway -n ${K8S_NAMESPACE}
+                      kubectl rollout restart deployment/${K8S_NAME}-apim3-api -n ${K8S_NAMESPACE}
+                      kubectl rollout restart deployment/${K8S_NAME}-apim3-portal -n ${K8S_NAMESPACE}
+                      kubectl rollout restart deployment/${K8S_NAME}-apim3-ui -n ${K8S_NAMESPACE}
+                      kubectl rollout restart deployment/${K8S_NAME}-apim3-gateway -n ${K8S_NAMESPACE}
 
             - notify-on-failure
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -561,29 +561,6 @@ jobs:
                       mv ./kubectl /usr/local/bin/kubectl
                       kubectl version --client=true
             - run:
-                  name: Helm upgrade and 🚀 to Element Zero cluster
-                  command: |
-                      if [ "master" == "${CIRCLE_BRANCH}" ]
-                      then
-                          az login --service-principal -u $AZURE_APPLICATION_ID --tenant $AZURE_TENANT -p $AZURE_APPLICATION_SECRET
-                          az aks get-credentials --resource-group element-zero --name element-zero
-
-                          helm upgrade --repo https://helm.gravitee.io \
-                                      --install apim \
-                                      -n apim \
-                                      --reuse-values \
-                                      apim3 \
-                                       --set "api.image.repository=graviteeio.azurecr.io/apim-management-api" \
-                                       --set "api.image.tag=${TAG}" \
-                                       --set "portal.image.repository=graviteeio.azurecr.io/apim-portal-ui" \
-                                       --set "portal.image.tag=${TAG}" \
-                                       --set "ui.image.repository=graviteeio.azurecr.io/apim-management-ui" \
-                                       --set "ui.image.tag=${TAG}" \
-                                       --set "gateway.image.repository=graviteeio.azurecr.io/apim-gateway" \
-                                       --set "gateway.image.tag=${TAG}" \
-                                       --set "redis.repositoryVersion=3.12.1"
-                      fi
-            - run:
                   name: Helm upgrade and 🚀 to APIM cluster
                   command: |
                       export K8S_NAMESPACE=apim-${CIRCLE_BRANCH//\./-}


### PR DESCRIPTION
**Description**

A PR to clean the CI process regarding Azure stuffs:
 - stop deploying on ElementZero cluster
 - stop upgrading helm chart and just restart the pods instead
 - fix the deployment name since it is now linked to the apim version
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-deploy-on-azure-cluster-3-5-x/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
