### PR TITLE
CI improvements for Azure deployments - master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -686,15 +686,16 @@ jobs:
             - run:
                   name: 🚀 to APIM cluster
                   command: |
+                      export K8S_NAME=apim-${CIRCLE_BRANCH//\./-}
                       export K8S_NAMESPACE=apim-${CIRCLE_BRANCH//\./-}
 
                       az login --service-principal -u $AZURE_APPLICATION_ID --tenant $AZURE_TENANT -p $AZURE_APPLICATION_SECRET
                       az aks get-credentials --resource-group apim-hprod --name apim-hprod
 
-                      kubectl rollout restart deployment/apim-apim3-api -n ${K8S_NAMESPACE}
-                      kubectl rollout restart deployment/apim-apim3-portal -n ${K8S_NAMESPACE}
-                      kubectl rollout restart deployment/apim-apim3-ui -n ${K8S_NAMESPACE}
-                      kubectl rollout restart deployment/apim-apim3-gateway -n ${K8S_NAMESPACE}
+                      kubectl rollout restart deployment/${K8S_NAME}-apim3-api -n ${K8S_NAMESPACE}
+                      kubectl rollout restart deployment/${K8S_NAME}-apim3-portal -n ${K8S_NAMESPACE}
+                      kubectl rollout restart deployment/${K8S_NAME}-apim3-ui -n ${K8S_NAMESPACE}
+                      kubectl rollout restart deployment/${K8S_NAME}-apim3-gateway -n ${K8S_NAMESPACE}
 
             - notify-on-failure
 


### PR DESCRIPTION
**Description**

A PR to clean the CI process regarding Azure stuffs:
 - fix the deployment name since it is now linked to the apim version
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fceuplidsg.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-deploy-on-azure-cluster-master/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
