### PR TITLE
wip: force application apiKeyMode on second subscription

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/ApplicationConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/ApplicationConverter.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.converter;
+
+import io.gravitee.rest.api.model.ApplicationEntity;
+import io.gravitee.rest.api.model.UpdateApplicationEntity;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component
+public class ApplicationConverter {
+
+    public UpdateApplicationEntity toUpdateApplicationEntity(ApplicationEntity application) {
+        UpdateApplicationEntity updateApplicationEntity = new UpdateApplicationEntity();
+        updateApplicationEntity.setSettings(application.getSettings());
+        updateApplicationEntity.setBackground(application.getBackground());
+        updateApplicationEntity.setDescription(application.getDescription());
+        updateApplicationEntity.setDomain(application.getDomain());
+        updateApplicationEntity.setGroups(application.getGroups());
+        updateApplicationEntity.setPicture(application.getPicture());
+        updateApplicationEntity.setName(application.getName());
+        updateApplicationEntity.setApiKeyMode(application.getApiKeyMode());
+        updateApplicationEntity.setDisableMembershipNotifications(application.isDisableMembershipNotifications());
+        updateApplicationEntity.setType(application.getType());
+        return updateApplicationEntity;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
@@ -18,6 +18,8 @@ package io.gravitee.rest.api.service.impl;
 import static io.gravitee.repository.management.model.Audit.AuditProperties.API;
 import static io.gravitee.repository.management.model.Audit.AuditProperties.APPLICATION;
 import static io.gravitee.repository.management.model.Subscription.AuditEvent.*;
+import static io.gravitee.rest.api.model.ApiKeyMode.*;
+import static io.gravitee.rest.api.model.PlanSecurityType.API_KEY;
 import static java.lang.System.lineSeparator;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
@@ -30,6 +32,7 @@ import io.gravitee.repository.management.api.search.SubscriptionCriteria;
 import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.model.*;
 import io.gravitee.rest.api.model.*;
+import io.gravitee.rest.api.model.ApiKeyMode;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.model.common.Pageable;
@@ -41,6 +44,7 @@ import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.UuidString;
+import io.gravitee.rest.api.service.converter.ApplicationConverter;
 import io.gravitee.rest.api.service.exceptions.*;
 import io.gravitee.rest.api.service.notification.ApiHook;
 import io.gravitee.rest.api.service.notification.ApplicationHook;
@@ -106,6 +110,9 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
 
     @Autowired
     private PageService pageService;
+
+    @Autowired
+    private ApplicationConverter applicationConverter;
 
     @Override
     public SubscriptionEntity findById(String subscription) {
@@ -299,6 +306,8 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                 }
             }
 
+            updateApplicationApiKeyMode(planEntity, applicationEntity);
+
             Subscription subscription = new Subscription();
             subscription.setPlan(plan);
             subscription.setId(UuidString.generateRandom());
@@ -368,6 +377,19 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
         } catch (TechnicalException ex) {
             logger.error("An error occurs while trying to subscribe to the plan {}", plan, ex);
             throw new TechnicalManagementException(String.format("An error occurs while trying to subscribe to the plan %s", plan), ex);
+        }
+    }
+
+    private void updateApplicationApiKeyMode(PlanEntity plan, ApplicationEntity application) {
+        if (plan.getSecurity() == API_KEY && application.getApiKeyMode() == UNSPECIFIED && countApiKeySubscriptions(application) > 0) {
+            logger.debug("Force application {} Api Key mode to EXCLUSIVE, as it's his second subscription", application.getId());
+            application.setApiKeyMode(EXCLUSIVE);
+            applicationService.update(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
+                application.getId(),
+                applicationConverter.toUpdateApplicationEntity(application)
+            );
         }
     }
 
@@ -442,7 +464,7 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
 
                 // Update the expiration date for not yet revoked api-keys relative to this subscription
                 Date endingAt = subscription.getEndingAt();
-                if (plan.getSecurity() == PlanSecurityType.API_KEY && endingAt != null) {
+                if (plan.getSecurity() == API_KEY && endingAt != null) {
                     List<ApiKeyEntity> apiKeys = apiKeyService.findBySubscription(subscription.getId());
                     for (ApiKeyEntity apiKey : apiKeys) {
                         Date expireAt = apiKey.getExpireAt();
@@ -572,12 +594,8 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                     );
             }
 
-            if (plan.getSecurity() == PlanSecurityType.API_KEY && subscription.getStatus() == Subscription.Status.ACCEPTED) {
-                if (StringUtils.isNotEmpty(processSubscription.getCustomApiKey())) {
-                    apiKeyService.generate(subscription.getId(), processSubscription.getCustomApiKey());
-                } else {
-                    apiKeyService.generate(subscription.getId());
-                }
+            if (plan.getSecurity() == API_KEY && subscription.getStatus() == Subscription.Status.ACCEPTED) {
+                acceptApiKeySubscription(processSubscription, subscription, application);
             }
 
             return subscriptionEntity;
@@ -1297,5 +1315,32 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
     ) {
         auditService.createApiAuditLog(apiId, Collections.singletonMap(APPLICATION, applicationId), event, createdAt, oldValue, newValue);
         auditService.createApplicationAuditLog(applicationId, Collections.singletonMap(API, apiId), event, createdAt, oldValue, newValue);
+    }
+
+    protected void acceptApiKeySubscription(
+        ProcessSubscriptionEntity processSubscription,
+        Subscription subscription,
+        ApplicationEntity application
+    ) {
+        if (application.getApiKeyMode() == SHARED) {
+            // TODO : FIND THE ALREADY EXISTING SHARED API KEY, AND LINK SUBSCRIPTION TO IT
+            // TODO : IF NOT YET EXISTING, GENERATE A NEW ONE
+            throw new RuntimeException("TODO");
+        } else {
+            if (StringUtils.isNotEmpty(processSubscription.getCustomApiKey())) {
+                apiKeyService.generate(subscription.getId(), processSubscription.getCustomApiKey());
+            } else {
+                apiKeyService.generate(subscription.getId());
+            }
+        }
+    }
+
+    private long countApiKeySubscriptions(ApplicationEntity application) {
+        SubscriptionQuery subscriptionQuery = new SubscriptionQuery();
+        subscriptionQuery.setApplication(application.getId());
+        return search(subscriptionQuery)
+            .stream()
+            .filter(subscription -> planService.findById(subscription.getPlan()).getSecurity() == API_KEY)
+            .count();
     }
 }


### PR DESCRIPTION
As discussed together, this forces the application apiKeyMode on second subscription.

I prepared the way to handle API key on "shared api key" subscription acceptance.
For now, I throw a "TODO" exception cause it's not yet implemented.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-myemdpzley.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6990-forceapplicationapikeymode/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
