### PR TITLE
6990 rest api securize api key mode

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/ApiKeyMode.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/ApiKeyMode.java
@@ -26,19 +26,29 @@ public enum ApiKeyMode {
      *
      * This mode is available only if the shared mode has been activated at the environment level.
      */
-    SHARED,
+    SHARED(false),
     /**
      * The `EXCLUSIVE` API key mode will result in a new API key being generated each time a subscription
      * is triggered within the application.
      *
      * This is the default mode if the shared mode has been de-activated at the environment level.
      */
-    EXCLUSIVE,
+    EXCLUSIVE(false),
     /**
      * The `UNSPECIFIED` API key mode is the default mode when shared mode has been activated at the environment level.
      * This marker value allows determining if the consumer has already made its choice when adding a second subscription
      * to the application (e.g. a second subscription has already been triggered and the choice has been made, but one
      * of the subscriptions has been deleted since)
      */
-    UNSPECIFIED,
+    UNSPECIFIED(true);
+
+    private boolean updatable;
+
+    ApiKeyMode(boolean updatable) {
+        this.updatable = updatable;
+    }
+
+    public boolean isUpdatable() {
+        return updatable;
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/UpdateApplicationEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/UpdateApplicationEntity.java
@@ -76,7 +76,7 @@ public class UpdateApplicationEntity {
     private boolean disableMembershipNotifications;
 
     @JsonProperty("api_key_mode")
-    @ApiModelProperty(value = "The API key mode used for this application.", allowableValues = "SHARED, EXCLUSIVE")
+    @ApiModelProperty(value = "The API key mode used for this application.", allowableValues = "UNSPECIFIED, SHARED, EXCLUSIVE")
     private ApiKeyMode apiKeyMode;
 
     private String background;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/InvalidApplicationApiKeyModeException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/InvalidApplicationApiKeyModeException.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.exceptions;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.repository.management.model.ApiKeyMode;
+import java.util.Map;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class InvalidApplicationApiKeyModeException extends AbstractManagementException {
+
+    public InvalidApplicationApiKeyModeException(String applicationId, ApiKeyMode currentApiKeyMode) {
+        super(
+            String.format(
+                "Can't update application %s Api key mode cause current Api Key Mode %s is not updatable",
+                applicationId,
+                currentApiKeyMode
+            )
+        );
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "application.apiKeyMode.invalid";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return null;
+    }
+}


### PR DESCRIPTION
feat: securize apikey mode update from REST api

Ensure that REST API consumer can't rollback an Api key mode choice.
He can go from UNSPECIFIED to SHARED or EXCLUSIVE. But no other transition is allowed.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pbmlgiegtp.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6990-restapi-securizeapikeymode/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
