### PR TITLE
fix: build correct URL for redirect after Cockpit login

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/CockpitAuthenticationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/CockpitAuthenticationResource.java
@@ -144,11 +144,13 @@ public class CockpitAuthenticationResource extends AbstractAuthenticationResourc
                 jwtClaimsSet.getStringClaim(REDIRECT_URI_CLAIM),
                 jwtClaimsSet.getStringClaim(ORG_CLAIM),
                 jwtClaimsSet.getStringClaim(ENVIRONMENT_CLAIM),
-                jwtClaimsSet.getStringClaim(API_CLAIM) == null ? "" : String.format("api/%s", jwtClaimsSet.getStringClaim(API_CLAIM))
+                jwtClaimsSet.getStringClaim(API_CLAIM) == null
+                    ? ""
+                    : URLEncoder.encode(String.format("apis/%s/portal", jwtClaimsSet.getStringClaim(API_CLAIM)), "UTF-8")
             );
 
             // Redirect the user.
-            return Response.temporaryRedirect(new URI(URLEncoder.encode(url, "UTF-8"))).build();
+            return Response.temporaryRedirect(new URI(url)).build();
         } catch (Exception e) {
             LOGGER.error("Error occurred when trying to log user using cockpit.", e);
             return Response.serverError().build();


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/gravitee-cockpit/issues/1996

**Description**

Fix the target URL for redirection after Cockpit login


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gzuokkstdc.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/1996-fix-login-from-cockpit/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
