### PR TITLE
feat(console): display debug errors to dedicated component

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-inspector/policy-studio-debug-inspector-error/policy-studio-debug-inspector-error.component.html
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-inspector/policy-studio-debug-inspector-error/policy-studio-debug-inspector-error.component.html
@@ -1,0 +1,31 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<table class="gio-table-light" attr.aria-label="Debug errors for {{ name }}">
+  <thead>
+    <tr>
+      <th>{{ name }}</th>
+      <th>{{ name }}</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{ input }}</td>
+      <td>{{ output }}</td>
+    </tr>
+  </tbody>
+</table>

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-inspector/policy-studio-debug-inspector-error/policy-studio-debug-inspector-error.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-inspector/policy-studio-debug-inspector-error/policy-studio-debug-inspector-error.component.scss
@@ -1,0 +1,14 @@
+:host {
+  display: flex;
+
+  > * {
+    width: 100%;
+    flex: 1;
+  }
+
+  th,
+  td {
+    width: 50%;
+    word-break: break-all;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-inspector/policy-studio-debug-inspector-error/policy-studio-debug-inspector-error.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-inspector/policy-studio-debug-inspector-error/policy-studio-debug-inspector-error.component.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'policy-studio-debug-inspector-error',
+  template: require('./policy-studio-debug-inspector-error.component.html'),
+  styles: [require('./policy-studio-debug-inspector-error.component.scss')],
+})
+export class PolicyStudioDebugInspectorErrorComponent {
+  @Input()
+  name: string;
+
+  @Input()
+  input: string;
+
+  @Input()
+  output: string;
+}

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-inspector/policy-studio-debug-inspector.component.html
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-inspector/policy-studio-debug-inspector.component.html
@@ -43,6 +43,13 @@
             [output]="node.output"
           ></policy-studio-debug-inspector-body>
 
+          <policy-studio-debug-inspector-error
+            *ngSwitchCase="'error'"
+            [name]="node.name"
+            [input]="node.input"
+            [output]="node.output"
+          ></policy-studio-debug-inspector-error>
+
           <policy-studio-debug-inspector-text
             *ngSwitchDefault
             [name]="node.name"

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-inspector/policy-studio-debug-inspector.component.stories.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-inspector/policy-studio-debug-inspector.component.stories.ts
@@ -23,8 +23,9 @@ import { MatTreeModule } from '@angular/material/tree';
 import { MatButtonModule } from '@angular/material/button';
 
 import { PolicyStudioDebugInspectorComponent } from './policy-studio-debug-inspector.component';
-import { PolicyStudioDebugInspectorTableComponent } from './policy-studio-debug-inspector-table/policy-studio-debug-inspector-table.component';
 import { PolicyStudioDebugInspectorBodyComponent } from './policy-studio-debug-inspector-body/policy-studio-debug-inspector-body.component';
+import { PolicyStudioDebugInspectorErrorComponent } from './policy-studio-debug-inspector-error/policy-studio-debug-inspector-error.component';
+import { PolicyStudioDebugInspectorTableComponent } from './policy-studio-debug-inspector-table/policy-studio-debug-inspector-table.component';
 import { PolicyStudioDebugInspectorTextComponent } from './policy-studio-debug-inspector-text/policy-studio-debug-inspector-text.component';
 
 import { fakeErrorRequestDebugStep, fakeRequestDebugStep } from '../../models/DebugStep.fixture';
@@ -35,8 +36,9 @@ export default {
   decorators: [
     moduleMetadata({
       declarations: [
-        PolicyStudioDebugInspectorTableComponent,
         PolicyStudioDebugInspectorBodyComponent,
+        PolicyStudioDebugInspectorErrorComponent,
+        PolicyStudioDebugInspectorTableComponent,
         PolicyStudioDebugInspectorTextComponent,
       ],
       imports: [CommonModule, BrowserAnimationsModule, MatIconModule, GioIconsModule, MatTreeModule, MatButtonModule],

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-inspector/policy-studio-debug-inspector.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-inspector/policy-studio-debug-inspector.component.ts
@@ -138,7 +138,7 @@ export class PolicyStudioDebugInspectorComponent implements OnChanges {
     const name = key.replace('error.', '');
     return {
       name,
-      type: 'text',
+      type: 'error',
       input,
       output,
     };

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/debug/policy-studio-debug.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/debug/policy-studio-debug.module.ts
@@ -29,6 +29,7 @@ import { GioIconsModule } from '@gravitee/ui-particles-angular';
 import { PolicyStudioDebugComponent } from './policy-studio-debug.component';
 import { PolicyStudioDebugInspectorBodyComponent } from './components/policy-studio-debug-inspector/policy-studio-debug-inspector-body/policy-studio-debug-inspector-body.component';
 import { PolicyStudioDebugInspectorComponent } from './components/policy-studio-debug-inspector/policy-studio-debug-inspector.component';
+import { PolicyStudioDebugInspectorErrorComponent } from './components/policy-studio-debug-inspector/policy-studio-debug-inspector-error/policy-studio-debug-inspector-error.component';
 import { PolicyStudioDebugInspectorTableComponent } from './components/policy-studio-debug-inspector/policy-studio-debug-inspector-table/policy-studio-debug-inspector-table.component';
 import { PolicyStudioDebugRequestComponent } from './components/policy-studio-debug-request/policy-studio-debug-request.component';
 import { PolicyStudioDebugResponseComponent } from './components/policy-studio-debug-response/policy-studio-debug-response.component';
@@ -58,6 +59,7 @@ import { PolicyStudioDebugInspectorTextComponent } from './components/policy-stu
     PolicyStudioDebugComponent,
     PolicyStudioDebugInspectorComponent,
     PolicyStudioDebugInspectorBodyComponent,
+    PolicyStudioDebugInspectorErrorComponent,
     PolicyStudioDebugInspectorTableComponent,
     PolicyStudioDebugInspectorTextComponent,
     PolicyStudioDebugRequestComponent,


### PR DESCRIPTION
gravitee-io/issues#6765


<img width="1453" alt="Capture d’écran 2022-02-16 à 11 11 18" src="https://user-images.githubusercontent.com/1457497/154243439-57d6d20b-8010-4e9b-82df-027ee9ae3ace.png">


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xiguzvaulm.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/debug-inspector-errors/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
