### PR TITLE
fix: on response, platform policies should be executed last

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/ResponseProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/ResponseProcessorChainFactory.java
@@ -68,7 +68,6 @@ public class ResponseProcessorChainFactory extends ApiProcessorChainFactory {
 
     private void initialize() {
         add(() -> new ShutdownProcessor(node));
-        addAll(policyChainProviderLoader.get(PolicyChainOrder.BEFORE_API, StreamType.ON_RESPONSE));
 
         final ConditionEvaluator<Flow> evaluator = new CompositeConditionEvaluator<>(
             new HttpMethodConditionEvaluator(),
@@ -120,5 +119,7 @@ public class ResponseProcessorChainFactory extends ApiProcessorChainFactory {
         if (api.getPathMappings() != null && !api.getPathMappings().isEmpty()) {
             add(() -> new PathMappingProcessor(api.getPathMappings()));
         }
+
+        addAll(policyChainProviderLoader.get(PolicyChainOrder.AFTER_API, StreamType.ON_RESPONSE));
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-platform/src/main/java/io/gravitee/gateway/platform/providers/OnResponsePlatformPolicyChainProvider.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-platform/src/main/java/io/gravitee/gateway/platform/providers/OnResponsePlatformPolicyChainProvider.java
@@ -64,6 +64,6 @@ public class OnResponsePlatformPolicyChainProvider extends ConfigurablePolicyCha
 
     @Override
     public PolicyChainOrder getChainOrder() {
-        return PolicyChainOrder.BEFORE_API;
+        return PolicyChainOrder.AFTER_API;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/PolicyChainOrder.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/PolicyChainOrder.java
@@ -21,4 +21,5 @@ package io.gravitee.gateway.policy;
  */
 public enum PolicyChainOrder {
     BEFORE_API,
+    AFTER_API,
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7138

**Description**

Just move the `PolicyChainProviderLoader` at the end of the list of processor providers for `ResponseProcessorChainFactory`

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nhqfdrsass.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-7138-platform-policies-response-order/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
