### PR TITLE
fix: toggle off shared api key when parent toggle is toggled off

### DIFF
--- a/gravitee-apim-console-webui/src/management/configuration/portal/portal.component.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/portal/portal.component.ts
@@ -83,6 +83,13 @@ const PortalSettingsComponent: ng.IComponentOptions = {
       }
     };
 
+    this.toggleApiKeyPlan = () => {
+      if (!this.settings.plan.security.apikey.enabled) {
+        this.settings.plan.security.customApiKey.enabled = false;
+        this.settings.plan.security.sharedApiKey.enabled = false;
+      }
+    };
+
     this.isReadonlySetting = (property: string): boolean => {
       return PortalSettingsService.isReadonly(this.settings, property);
     };

--- a/gravitee-apim-console-webui/src/management/configuration/portal/portal.html
+++ b/gravitee-apim-console-webui/src/management/configuration/portal/portal.html
@@ -52,7 +52,7 @@
       <md-input-container class="gv-input-container-dense">
         <md-checkbox
           ng-model="$ctrl.settings.plan.security.apikey.enabled"
-          ng-change="$ctrl.settings.plan.security.customApiKey.enabled = $ctrl.settings.plan.security.apikey.enabled ? $ctrl.settings.plan.security.customApiKey.enabled : false"
+          ng-change="$ctrl.toggleApiKeyPlan()"
           aria-label="apikey"
           ng-disabled="$ctrl.isReadonlySetting('plan.security.apikey.enabled')"
         >


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6990

fix: toggle off shared api key when parent toggle is toggled off
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mmfjqxdrez.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6990-fix-shared-api-key-toggle/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
