### PR TITLE
6990 add apikey mode on api subscription

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/dialog/subscription.create.dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/dialog/subscription.create.dialog.controller.ts
@@ -46,8 +46,8 @@ function DialogSubscriptionCreateController(
   this.save = function () {
     if (this.selectedApp && this.selectedPlan) {
       $mdDialog.hide({
-        applicationId: this.selectedApp.id,
-        planId: this.selectedPlan,
+        application: this.selectedApp,
+        plan: this.selectedPlan,
         customApiKey: this.selectedPlanCustomApiKey,
       });
     }
@@ -69,7 +69,7 @@ function DialogSubscriptionCreateController(
         this.plansWithSubscriptions = _.map(response.data.data, (subscription) => {
           return subscription.plan;
         });
-        if (this.selectedPlan && this.planAlreadyHaveSubscriptions(this.selectedPlan)) {
+        if (this.selectedPlan && this.planAlreadyHaveSubscriptions(this.selectedPlan.id)) {
           this.selectedPlan = null;
         }
       });

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/dialog/subscription.create.dialog.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/dialog/subscription.create.dialog.html
@@ -50,7 +50,7 @@
         <md-radio-group ng-model="dialogSubscriptionCreateController.selectedPlan" style="width: 100%">
           <div ng-repeat="plan in dialogSubscriptionCreateController.plans | orderBy: 'order'">
             <md-radio-button
-              value="{{plan.id}}"
+              ng-value="plan"
               ng-disabled="dialogSubscriptionCreateController.planAlreadyHaveSubscriptions(plan.id) || dialogSubscriptionCreateController.hasGeneralConditions(plan)"
             >
               {{plan.name}}

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/subscriptions.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/subscriptions.component.ts
@@ -14,14 +14,17 @@
  * limitations under the License.
  */
 import { StateService } from '@uirouter/core';
-import { IScope } from 'angular';
+import { IPromise, IScope } from 'angular';
 import * as _ from 'lodash';
 import * as moment from 'moment';
 
 import { PagedResult } from '../../../../entities/pagedResult';
 import { ApiService } from '../../../../services/api.service';
 import NotificationService from '../../../../services/notification.service';
+import PortalConfigService from '../../../../services/portalConfig.service';
+import ApplicationService from '../../../../services/application.service';
 import { PlanSecurityType } from '../../../../entities/plan/plan';
+import { ApiKeyMode } from '../../../../entities/application/application';
 
 const defaultStatus = ['ACCEPTED', 'PENDING', 'PAUSED'];
 
@@ -57,10 +60,13 @@ const ApiSubscriptionsComponent: ng.IComponentOptions = {
     };
 
     private subscriptionsFiltersForm: any;
+    private portalSettings: any;
 
     constructor(
       private ApiService: ApiService,
+      private ApplicationService: ApplicationService,
       private NotificationService: NotificationService,
+      private PortalConfigService: PortalConfigService,
       private $mdDialog: angular.material.IDialogService,
       private $state: StateService,
       public $rootScope: IScope,
@@ -97,6 +103,9 @@ const ApiSubscriptionsComponent: ng.IComponentOptions = {
 
     $onInit() {
       this.getSubscriptionAnalytics();
+      this.PortalConfigService.get().then((response) => {
+        this.portalSettings = response.data;
+      });
     }
 
     onPaginate(page) {
@@ -219,15 +228,15 @@ const ApiSubscriptionsComponent: ng.IComponentOptions = {
             },
           })
           .then((data) => {
-            if (data && data.applicationId && data.planId) {
-              this.ApiService.subscribe(this.api.id, data.applicationId, data.planId, data.customApiKey).then((response) => {
-                const subscription = response.data;
-                this.NotificationService.show('A new subscription has been created.');
-                this.$state.go(
-                  'management.apis.detail.portal.subscriptions.subscription',
-                  { subscriptionId: subscription.id },
-                  { reload: true },
-                );
+            if (data && data.application && data.plan) {
+              this.$shouldPromptForKeyMode(data.application, data.plan).then((shouldPrompt) => {
+                if (shouldPrompt) {
+                  this.selectKeyMode()
+                    .then((mode) => this.ApplicationService.update({ ...data.application, api_key_mode: mode }))
+                    .then(() => this.doSubscribe(data.application, data.plan, data.customApiKey));
+                } else {
+                  this.doSubscribe(data.application, data.plan, data.customApiKey);
+                }
               });
             }
           });
@@ -259,6 +268,45 @@ const ApiSubscriptionsComponent: ng.IComponentOptions = {
         (this.query.plans && this.query.plans.length) ||
         this.query.api_key
       );
+    }
+
+    doSubscribe(application: any, plan: any, customApiKey: string) {
+      this.ApiService.subscribe(this.api.id, application.id, plan.id, customApiKey).then((response) => {
+        const subscription = response.data;
+        this.NotificationService.show('A new subscription has been created.');
+        this.$state.go('management.apis.detail.portal.subscriptions.subscription', { subscriptionId: subscription.id }, { reload: true });
+      });
+    }
+
+    selectKeyMode() {
+      const dialog = {
+        controller: 'ApplicationKeyDialogController',
+        controllerAs: '$ctrl',
+        template: require('../../../application/details/subscribe/application-key.dialog.html'),
+        clickOutsideToClose: true,
+      };
+
+      return this.$mdDialog.show(dialog);
+    }
+
+    $shouldPromptForKeyMode(application: any, plan: any): IPromise<boolean> {
+      if (plan.security === PlanSecurityType.API_KEY && this.allowsSharedApiKeys && application.api_key_mode === ApiKeyMode.UNSPECIFIED) {
+        return this.$getApiKeySubscriptionsCount(application).then((count) => {
+          return count >= 1;
+        });
+      }
+      return Promise.resolve(false);
+    }
+
+    $getApiKeySubscriptionsCount(application: any): IPromise<number> {
+      return this.ApplicationService.listSubscriptions(application.id, '?expand=security').then((response) => {
+        const applicationSubscriptions = response.data as PagedResult;
+        return applicationSubscriptions.data.filter((subscription) => subscription.security === PlanSecurityType.API_KEY).length;
+      });
+    }
+
+    get allowsSharedApiKeys(): boolean {
+      return this.portalSettings?.plan?.security?.sharedApiKey?.enabled;
     }
   },
 };

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApplicationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApplicationRepository.java
@@ -86,7 +86,7 @@ public class JdbcApplicationRepository extends JdbcAbstractCrudRepository<Applic
     }
 
     private static final String PROJECTION_WITHOUT_PICTURES =
-        "a.id, a.environment_id, a.name, a.description, a.type, a.created_at, a.updated_at, a.status, a.disable_membership_notifications";
+        "a.id, a.environment_id, a.name, a.description, a.type, a.created_at, a.updated_at, a.status, a.disable_membership_notifications, a.api_key_mode";
 
     private static final JdbcHelper.ChildAdder<Application> CHILD_ADDER = (Application parent, ResultSet rs) -> {
         Map<String, String> metadata = parent.getMetadata();

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/ApplicationRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/ApplicationRepositoryTest.java
@@ -25,6 +25,7 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.config.AbstractRepositoryTest;
 import io.gravitee.repository.management.api.search.ApplicationCriteria;
 import io.gravitee.repository.management.api.search.builder.SortableBuilder;
+import io.gravitee.repository.management.model.ApiKeyMode;
 import io.gravitee.repository.management.model.Application;
 import io.gravitee.repository.management.model.ApplicationStatus;
 import io.gravitee.repository.management.model.ApplicationType;
@@ -241,6 +242,13 @@ public class ApplicationRepositoryTest extends AbstractRepositoryTest {
         Set<Application> apps = applicationRepository.findByNameAndStatuses("aRcHEd", ApplicationStatus.ACTIVE);
         assertNotNull(apps);
         assertEquals(2, apps.size());
+    }
+
+    @Test
+    public void findByName_shouldReadApiKeyMode() throws Exception {
+        Set<Application> apps = applicationRepository.findByNameAndStatuses("searched-app1");
+        assertEquals(1, apps.size());
+        assertEquals(ApiKeyMode.SHARED, apps.iterator().next().getApiKeyMode());
     }
 
     @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/ApplicationRepositoryMock.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/ApplicationRepositoryMock.java
@@ -28,6 +28,7 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.repository.management.api.search.ApplicationCriteria;
 import io.gravitee.repository.management.api.search.builder.SortableBuilder;
+import io.gravitee.repository.management.model.ApiKeyMode;
 import io.gravitee.repository.management.model.Application;
 import io.gravitee.repository.management.model.ApplicationStatus;
 import io.gravitee.repository.management.model.ApplicationType;
@@ -136,6 +137,7 @@ public class ApplicationRepositoryMock extends AbstractRepositoryMock<Applicatio
         final Application searchedApp2 = mock(Application.class);
         when(searchedApp1.getId()).thenReturn("searched-app1");
         when(searchedApp1.getName()).thenReturn("searched-app1");
+        when(searchedApp1.getApiKeyMode()).thenReturn(ApiKeyMode.SHARED);
         when(searchedApp2.getId()).thenReturn("searched-app2");
         when(searchedApp2.getName()).thenReturn("searched-app2");
         when(applicationRepository.findByNameAndStatuses("searched-app1")).thenReturn(singleton(searchedApp1));

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/application-tests/applications.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/application-tests/applications.json
@@ -87,7 +87,8 @@
     "metadata": {
       "type": "Web"
     },
-    "disableMembershipNotifications": false
+    "disableMembershipNotifications": false,
+    "apiKeyMode": "SHARED"
   },
   {
     "id": "searched-app2",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionsResourceTest.java
@@ -15,17 +15,21 @@
  */
 package io.gravitee.rest.api.management.rest.resource;
 
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import io.gravitee.common.data.domain.Page;
 import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.model.*;
+import io.gravitee.rest.api.model.pagedresult.Metadata;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.util.List;
 import javax.ws.rs.core.Response;
 import org.junit.Before;
 import org.junit.Test;
@@ -202,5 +206,41 @@ public class ApiSubscriptionsResourceTest extends AbstractResourceTest {
         Response response = envTarget("/_canCreate").queryParam("key", API_KEY).queryParam("application", APP_NAME).request().get();
 
         assertEquals(HttpStatusCode.INTERNAL_SERVER_ERROR_500, response.getStatus());
+    }
+
+    @Test
+    public void get_subscriptions_with_expand_security_queryParam_should_call_service_with_boolean() {
+        when(subscriptionService.search(any(), any(), eq(false), eq(true)))
+            .thenReturn(new Page<>(List.of(new SubscriptionEntity()), 1, 1, 1));
+        when(subscriptionService.getMetadata(any())).thenReturn(mock(Metadata.class));
+
+        final Response response = envTarget("/").queryParam("expand", "security").request().get();
+
+        assertEquals(OK_200, response.getStatus());
+        verify(subscriptionService, times(1)).search(any(), any(), eq(false), eq(true));
+    }
+
+    @Test
+    public void get_subscriptions_with_expand_security_and_keys_queryParam_should_call_service_with_boolean() {
+        when(subscriptionService.search(any(), any(), eq(true), eq(true)))
+            .thenReturn(new Page<>(List.of(new SubscriptionEntity()), 1, 1, 1));
+        when(subscriptionService.getMetadata(any())).thenReturn(mock(Metadata.class));
+
+        final Response response = envTarget("/").queryParam("expand", "security", "keys").request().get();
+
+        assertEquals(OK_200, response.getStatus());
+        verify(subscriptionService, times(1)).search(any(), any(), eq(true), eq(true));
+    }
+
+    @Test
+    public void get_subscriptions_with_expand_keys_queryParam_should_call_service_with_boolean() {
+        when(subscriptionService.search(any(), any(), eq(true), eq(false)))
+            .thenReturn(new Page<>(List.of(new SubscriptionEntity()), 1, 1, 1));
+        when(subscriptionService.getMetadata(any())).thenReturn(mock(Metadata.class));
+
+        final Response response = envTarget("/").queryParam("expand", "keys").request().get();
+
+        assertEquals(OK_200, response.getStatus());
+        verify(subscriptionService, times(1)).search(any(), any(), eq(true), eq(false));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/SubscriptionService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/SubscriptionService.java
@@ -70,6 +70,8 @@ public interface SubscriptionService {
 
     Page<SubscriptionEntity> search(SubscriptionQuery query, Pageable pageable);
 
+    Page<SubscriptionEntity> search(SubscriptionQuery query, Pageable pageable, boolean fillApiKeys, boolean fillPlansSecurityType);
+
     Metadata getMetadata(SubscriptionMetadataQuery query);
 
     SubscriptionEntity transfer(TransferSubscriptionEntity transferSubscription, String userId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/SubscriptionServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/SubscriptionServiceTest.java
@@ -1265,6 +1265,64 @@ public class SubscriptionServiceTest {
         Mockito.verify(delegate, times(1)).apply(any(Metadata.class), eq(apiEntity));
     }
 
+    @Test
+    public void search_should_not_fill_planSecurity_nor_apiKeys_if_boolean_to_false() throws TechnicalException {
+        SubscriptionQuery query = new SubscriptionQuery();
+        query.setApis(List.of("api-id-1"));
+
+        Subscription subscription1 = buildTestSubscription("sub1", "api-id-1", Subscription.Status.ACCEPTED, "plan-id");
+        when(subscriptionRepository.search(any(), any())).thenReturn(new Page<>(List.of(subscription1), 1, 1, 1));
+
+        Page<SubscriptionEntity> page = subscriptionService.search(query, Mockito.mock(Pageable.class), false, false);
+
+        assertEquals("sub1", page.getContent().get(0).getId());
+        assertNull(page.getContent().get(0).getSecurity());
+        assertNull(page.getContent().get(0).getKeys());
+        verifyNoInteractions(planService);
+        verifyNoInteractions(apiKeyService);
+    }
+
+    @Test
+    public void search_should_fill_plan_security_if_boolean_to_true() throws TechnicalException {
+        SubscriptionQuery query = new SubscriptionQuery();
+        query.setApis(List.of("api-id-1"));
+
+        Subscription subscription1 = buildTestSubscription("sub1", "api-id-1", Subscription.Status.ACCEPTED, "plan-id");
+        when(subscriptionRepository.search(any(), any())).thenReturn(new Page<>(List.of(subscription1), 1, 1, 1));
+
+        PlanEntity foundPlan = new PlanEntity();
+        foundPlan.setId("plan-id");
+        foundPlan.setSecurity(PlanSecurityType.OAUTH2);
+        when(planService.findByIdIn(Set.of("plan-id"))).thenReturn(Set.of(foundPlan));
+
+        Page<SubscriptionEntity> page = subscriptionService.search(query, Mockito.mock(Pageable.class), false, true);
+
+        assertEquals("sub1", page.getContent().get(0).getId());
+        assertEquals("OAUTH2", page.getContent().get(0).getSecurity());
+        assertNull(page.getContent().get(0).getKeys());
+        verifyNoInteractions(apiKeyService);
+    }
+
+    @Test
+    public void search_should_fill_apikeys_if_boolean_to_true() throws TechnicalException {
+        SubscriptionQuery query = new SubscriptionQuery();
+        query.setApis(List.of("api-id-1"));
+
+        Subscription subscription1 = buildTestSubscription("sub1", "api-id-1", Subscription.Status.ACCEPTED, "plan-id");
+        when(subscriptionRepository.search(any(), any())).thenReturn(new Page<>(List.of(subscription1), 1, 1, 1));
+
+        ApiKeyEntity apiKey = new ApiKeyEntity();
+        apiKey.setKey("my-api-key");
+        when(apiKeyService.findBySubscription("sub1")).thenReturn(List.of(apiKey));
+
+        Page<SubscriptionEntity> page = subscriptionService.search(query, Mockito.mock(Pageable.class), true, false);
+
+        assertEquals("sub1", page.getContent().get(0).getId());
+        assertNull(page.getContent().get(0).getSecurity());
+        assertEquals("my-api-key", page.getContent().get(0).getKeys().get(0));
+        verifyNoInteractions(planService);
+    }
+
     private ApiKeyEntity buildTestApiKeyForSubscription(String subscription) {
         ApiKeyEntity apikey = new ApiKeyEntity();
         apikey.setSubscription(subscription);
@@ -1272,10 +1330,15 @@ public class SubscriptionServiceTest {
     }
 
     private Subscription buildTestSubscription(String id, String api, Subscription.Status status) {
+        return buildTestSubscription(id, api, status, null);
+    }
+
+    private Subscription buildTestSubscription(String id, String api, Subscription.Status status, String plan) {
         Subscription subscription = new Subscription();
         subscription.setId(id);
         subscription.setApi(api);
         subscription.setStatus(status);
+        subscription.setPlan(plan);
         return subscription;
     }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6990

**Description**

This implements the API key mode proposal on "api subscriptions" screen.

**Note**

There is a 3rd screen where to implement this API key mode proposal.

I don't like the way to reference the template here :
`template: require('../../../application/details/subscribe/application-key.dialog.html')`

We will have to change that after this has been implemented on the 3rd screen, I put a comment on the feature branch