### PR TITLE
Use `vertx-junit5` to fix flaky websocket tests in the Gateway

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -331,6 +331,11 @@
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
+            <artifactId>vertx-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
             <artifactId>vertx-grpc</artifactId>
             <scope>test</scope>
         </dependency>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketAcceptTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketAcceptTest.java
@@ -22,11 +22,13 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.WebSocket;
-import java.util.concurrent.CountDownLatch;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
@@ -34,6 +36,7 @@ import org.junit.rules.TestRule;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@ExtendWith(VertxExtension.class)
 @ApiDescriptor("/io/gravitee/gateway/standalone/websocket/teams.json")
 public class WebsocketAcceptTest extends AbstractWebSocketGatewayTest {
 
@@ -43,6 +46,7 @@ public class WebsocketAcceptTest extends AbstractWebSocketGatewayTest {
     @Test
     public void websocket_accepted_request() throws InterruptedException {
         Vertx vertx = Vertx.vertx();
+        VertxTestContext testContext = new VertxTestContext();
 
         HttpServer httpServer = vertx.createHttpServer();
         httpServer
@@ -53,9 +57,6 @@ public class WebsocketAcceptTest extends AbstractWebSocketGatewayTest {
                 }
             )
             .listen(16664);
-
-        // Wait for result
-        final CountDownLatch latch = new CountDownLatch(1);
 
         HttpClient httpClient = vertx.createHttpClient(new HttpClientOptions().setDefaultPort(8082).setDefaultHost("localhost"));
 
@@ -71,7 +72,7 @@ public class WebsocketAcceptTest extends AbstractWebSocketGatewayTest {
                         frame -> {
                             if (frame.isText()) {
                                 Assert.assertEquals("PING", frame.textData());
-                                latch.countDown();
+                                testContext.completeNow();
                             }
                         }
                     );
@@ -79,7 +80,8 @@ public class WebsocketAcceptTest extends AbstractWebSocketGatewayTest {
             }
         );
 
-        Assert.assertTrue(latch.await(10, TimeUnit.SECONDS));
+        testContext.awaitCompletion(10, TimeUnit.SECONDS);
         httpServer.close();
+        Assert.assertTrue(testContext.completed());
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketBidirectionalTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketBidirectionalTest.java
@@ -22,11 +22,13 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.WebSocket;
-import java.util.concurrent.CountDownLatch;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
@@ -34,6 +36,7 @@ import org.junit.rules.TestRule;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@ExtendWith(VertxExtension.class)
 @ApiDescriptor("/io/gravitee/gateway/standalone/websocket/teams.json")
 public class WebsocketBidirectionalTest extends AbstractWebSocketGatewayTest {
 
@@ -43,9 +46,7 @@ public class WebsocketBidirectionalTest extends AbstractWebSocketGatewayTest {
     @Test
     public void websocket_bidirectional_request() throws InterruptedException {
         Vertx vertx = Vertx.vertx();
-
-        // Wait for result
-        final CountDownLatch latch = new CountDownLatch(1);
+        VertxTestContext testContext = new VertxTestContext();
 
         HttpServer httpServer = vertx.createHttpServer();
         httpServer
@@ -56,7 +57,7 @@ public class WebsocketBidirectionalTest extends AbstractWebSocketGatewayTest {
                         frame -> {
                             if (frame.isText()) {
                                 Assert.assertEquals("PONG", frame.textData());
-                                latch.countDown();
+                                testContext.completeNow();
                             }
                         }
                     );
@@ -87,7 +88,8 @@ public class WebsocketBidirectionalTest extends AbstractWebSocketGatewayTest {
             }
         );
 
-        Assert.assertTrue(latch.await(10, TimeUnit.SECONDS));
+        testContext.awaitCompletion(10, TimeUnit.SECONDS);
         httpServer.close();
+        Assert.assertTrue(testContext.completed());
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketCloseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketCloseTest.java
@@ -23,11 +23,13 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.WebSocket;
-import java.util.concurrent.CountDownLatch;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
@@ -35,6 +37,7 @@ import org.junit.rules.TestRule;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@ExtendWith(VertxExtension.class)
 @ApiDescriptor("/io/gravitee/gateway/standalone/websocket/teams.json")
 public class WebsocketCloseTest extends AbstractWebSocketGatewayTest {
 
@@ -44,6 +47,7 @@ public class WebsocketCloseTest extends AbstractWebSocketGatewayTest {
     @Test
     public void websocket_accepted_request() throws InterruptedException {
         Vertx vertx = Vertx.vertx();
+        VertxTestContext testContext = new VertxTestContext();
 
         HttpServer httpServer = vertx.createHttpServer();
         httpServer
@@ -55,9 +59,6 @@ public class WebsocketCloseTest extends AbstractWebSocketGatewayTest {
             )
             .listen(16664);
 
-        // Wait for result
-        final CountDownLatch latch = new CountDownLatch(1);
-
         HttpClient httpClient = vertx.createHttpClient(new HttpClientOptions().setDefaultPort(8082).setDefaultHost("localhost"));
 
         httpClient.webSocket(
@@ -68,12 +69,13 @@ public class WebsocketCloseTest extends AbstractWebSocketGatewayTest {
                     Assert.fail();
                 } else {
                     final WebSocket webSocket = event.result();
-                    webSocket.closeHandler(event1 -> latch.countDown());
+                    webSocket.closeHandler(__ -> testContext.completeNow());
                 }
             }
         );
 
-        Assert.assertTrue(latch.await(10, TimeUnit.SECONDS));
+        testContext.awaitCompletion(10, TimeUnit.SECONDS);
         httpServer.close();
+        Assert.assertTrue(testContext.completed());
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketPingFrameTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketPingFrameTest.java
@@ -23,11 +23,13 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.WebSocket;
-import java.util.concurrent.CountDownLatch;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
@@ -35,6 +37,7 @@ import org.junit.rules.TestRule;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@ExtendWith(VertxExtension.class)
 @ApiDescriptor("/io/gravitee/gateway/standalone/websocket/teams.json")
 public class WebsocketPingFrameTest extends AbstractWebSocketGatewayTest {
 
@@ -44,9 +47,7 @@ public class WebsocketPingFrameTest extends AbstractWebSocketGatewayTest {
     @Test
     public void websocket_bidirectional_request() throws InterruptedException {
         Vertx vertx = Vertx.vertx();
-
-        // Wait for result
-        final CountDownLatch latch = new CountDownLatch(1);
+        VertxTestContext testContext = new VertxTestContext();
 
         HttpServer httpServer = vertx.createHttpServer();
         httpServer
@@ -57,7 +58,7 @@ public class WebsocketPingFrameTest extends AbstractWebSocketGatewayTest {
                         frame -> {
                             if (frame.isPing()) {
                                 Assert.assertEquals("PING", frame.textData());
-                                latch.countDown();
+                                testContext.completeNow();
                             }
                         }
                     );
@@ -80,7 +81,8 @@ public class WebsocketPingFrameTest extends AbstractWebSocketGatewayTest {
             }
         );
 
-        Assert.assertTrue(latch.await(10, TimeUnit.SECONDS));
+        testContext.awaitCompletion(10, TimeUnit.SECONDS);
         httpServer.close();
+        Assert.assertTrue(testContext.completed());
     }
 }

--- a/gravitee-apim-gateway/pom.xml
+++ b/gravitee-apim-gateway/pom.xml
@@ -98,6 +98,16 @@
             <artifactId>powermock-api-mockito2</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <!-- Vert.X version is mandatory for vertx-grpc-protoc-plugin in gravitee-gateway-standalone-container -->
         <vertx.version>4.2.5</vertx.version>
         <!-- Gravitee dependencies version -->
-        <gravitee-bom.version>2.1</gravitee-bom.version>
+        <gravitee-bom.version>2.3</gravitee-bom.version>
         <gravitee-alert-api.version>1.8.0</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>1.9.0</gravitee-cockpit-api.version>
         <gravitee-common.version>1.25.0</gravitee-common.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7142

**Description**

A couple of tests of the Gateway are failing ~1 time out of 2: 
`src/test/java/io/gravitee/gateway/standalone/websocket/Websocket********Test.java`

This PR replace handly managed CountDownLatch with tooling from `vertx-junit5`, it should make the tests more readable and robust 🤞🏻 

Some documentation and examples of use of  `vertx-junit5`are available here: https://vertx.io/docs/vertx-junit5/java

With that changes `test` job was 🟢 at least 3 times in a row.


⚠️  Needs https://github.com/gravitee-io/gravitee-bom/pull/30 to be merged and released first.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tfphbuhwoy.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7142-fix-flaky-tests/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
