### PR TITLE
On-Response platform policies should be executed last

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/ResponseProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/ResponseProcessorChainFactory.java
@@ -60,7 +60,6 @@ public class ResponseProcessorChainFactory extends ApiProcessorChainFactory {
     @Override
     public void afterPropertiesSet() {
         add(() -> new ShutdownProcessor(node));
-        addAll(policyChainProviderLoader.get(PolicyChainOrder.BEFORE_API, StreamType.ON_RESPONSE));
 
         final ConditionEvaluator evaluator = new CompositeConditionEvaluator(
             new HttpMethodConditionEvaluator(),
@@ -112,5 +111,7 @@ public class ResponseProcessorChainFactory extends ApiProcessorChainFactory {
         if (api.getPathMappings() != null && !api.getPathMappings().isEmpty()) {
             add(() -> new PathMappingProcessor(api.getPathMappings()));
         }
+
+        addAll(policyChainProviderLoader.get(PolicyChainOrder.AFTER_API, StreamType.ON_RESPONSE));
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-platform/src/main/java/io/gravitee/gateway/platform/providers/OnResponsePlatformPolicyChainProvider.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-platform/src/main/java/io/gravitee/gateway/platform/providers/OnResponsePlatformPolicyChainProvider.java
@@ -62,6 +62,6 @@ public class OnResponsePlatformPolicyChainProvider extends ConfigurablePolicyCha
 
     @Override
     public PolicyChainOrder getChainOrder() {
-        return PolicyChainOrder.BEFORE_API;
+        return PolicyChainOrder.AFTER_API;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/PolicyChainOrder.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/PolicyChainOrder.java
@@ -21,4 +21,5 @@ package io.gravitee.gateway.policy;
  */
 public enum PolicyChainOrder {
     BEFORE_API,
+    AFTER_API,
 }


### PR DESCRIPTION

**Issue**

https://github.com/gravitee-io/issues/issues/7143

**Description**

Backporting https://github.com/gravitee-io/gravitee-api-management/pull/1299 to `3.10.x`

(cherry picked from commit 09ba8b87da5496dcdbece806f9b636c82197c95c)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7143-fix-plateform-policies/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
