### PR TITLE
fix(jdbc): fix invalid SQL syntax when finding plans by IDs or APIs

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAlertRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAlertRepository.java
@@ -15,8 +15,9 @@
  */
 package io.gravitee.repository.jdbc.management;
 
-import static io.gravitee.repository.jdbc.common.AbstractJdbcRepositoryConfiguration.escapeReservedWord;
 import static java.lang.String.format;
+import static java.util.Collections.emptyList;
+import static org.springframework.util.CollectionUtils.isEmpty;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
@@ -77,6 +78,9 @@ public class JdbcAlertRepository extends JdbcAbstractCrudRepository<AlertTrigger
     public List<AlertTrigger> findByReferenceAndReferenceIds(final String referenceType, final List<String> referenceIds)
         throws TechnicalException {
         LOGGER.debug("JdbcAlertRepository.findByReferenceAndReferenceIds({}, {})", referenceType, referenceIds);
+        if (isEmpty(referenceIds)) {
+            return emptyList();
+        }
         try {
             List<AlertTrigger> rows = jdbcTemplate.query(
                 getOrm().getSelectAllSql() +

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPlanRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPlanRepository.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.jdbc.management;
 
 import static java.lang.String.format;
+import static org.springframework.util.CollectionUtils.isEmpty;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
@@ -243,6 +244,9 @@ public class JdbcPlanRepository extends JdbcAbstractFindAllRepository<Plan> impl
     @Override
     public List<Plan> findByApis(List<String> apiIds) throws TechnicalException {
         LOGGER.debug("JdbcPlanRepository.findByApis({})", apiIds);
+        if (isEmpty(apiIds)) {
+            return Collections.emptyList();
+        }
         try {
             List<Plan> plans = jdbcTemplate.query(
                 getOrm().getSelectAllSql() + " where api in (" + getOrm().buildInClause(apiIds) + ")",

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/AlertRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/AlertRepositoryTest.java
@@ -159,6 +159,13 @@ public class AlertRepositoryTest extends AbstractRepositoryTest {
         assertEquals(2, alerts.size());
     }
 
+    @Test
+    public void shouldFindByReferenceAndReferenceIds_andReturnEmptyListWhenInputListIsEmpty() throws Exception {
+        final List<AlertTrigger> alerts = alertRepository.findByReferenceAndReferenceIds("API", Collections.emptyList());
+        assertNotNull(alerts);
+        assertEquals(0, alerts.size());
+    }
+
     @Test(expected = IllegalStateException.class)
     public void shouldNotUpdateUnknownAlert() throws Exception {
         AlertTrigger unknownAlert = new AlertTrigger();

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/PlanRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/PlanRepositoryTest.java
@@ -125,6 +125,13 @@ public class PlanRepositoryTest extends AbstractRepositoryTest {
     }
 
     @Test
+    public void shouldFindByApis_andReturnEmptyListIfInputIsEmpty() throws Exception {
+        final List<Plan> plans = planRepository.findByApis(Arrays.asList());
+        assertNotNull(plans);
+        assertEquals(0, plans.size());
+    }
+
+    @Test
     public void shouldCreate() throws Exception {
         String planName = "new-plan";
 


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7163
https://github.com/gravitee-io/_support_team/issues/123

**Description**

fix invalid SQL syntax when finding plans by IDs or APIs
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7163-fix-invalid-sql-syntax/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
