### PR TITLE
feat: be able to use context-path in EL during debug call

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/AbstractReactorHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/AbstractReactorHandler.java
@@ -76,9 +76,7 @@ public abstract class AbstractReactorHandler<T extends Reactable>
     @Override
     public void handle(ExecutionContext context) {
         // Wrap the actual request to contextualize it
-        ((MutableExecutionContext) context).request(
-                new ContextualizedHttpServerRequest(((Entrypoint) context.getAttribute(ATTR_ENTRYPOINT)).path(), context.request())
-            );
+        contextualizeRequest(context);
 
         try {
             doHandle(executionContextFactory.create(context));
@@ -93,6 +91,12 @@ public abstract class AbstractReactorHandler<T extends Reactable>
 
             handler.handle(context);
         }
+    }
+
+    protected void contextualizeRequest(ExecutionContext context) {
+        ((MutableExecutionContext) context).request(
+                new ContextualizedHttpServerRequest(((Entrypoint) context.getAttribute(ATTR_ENTRYPOINT)).path(), context.request())
+            );
     }
 
     protected void dumpVirtualHosts() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/definition/DebugApi.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/definition/DebugApi.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.debug.definition;
 
 import io.gravitee.definition.model.HttpRequest;
 import io.gravitee.definition.model.HttpResponse;
+import io.gravitee.gateway.debug.reactor.handler.context.PathTransformer;
 import io.gravitee.gateway.handlers.api.definition.Api;
 import io.gravitee.gateway.reactor.Reactable;
 import java.io.Serializable;
@@ -38,7 +39,9 @@ public class DebugApi extends Api implements Reactable, Serializable {
         // Instead of doing it here, we could implement a custom DebugHandlerEntrypointFactory which allows to override
         // path(), create a new virtual host with this new path to accept an overriden request targeting this path.
         if (getProxy() != null && getProxy().getVirtualHosts() != null) {
-            getProxy().getVirtualHosts().forEach(virtualHost -> virtualHost.setPath(computeNewPath(virtualHost.getPath())));
+            getProxy()
+                .getVirtualHosts()
+                .forEach(virtualHost -> virtualHost.setPath(PathTransformer.computePathWithEventId(eventId, virtualHost.getPath())));
         }
     }
 
@@ -69,10 +72,5 @@ public class DebugApi extends Api implements Reactable, Serializable {
 
     public String getEventId() {
         return eventId;
-    }
-
-    private String computeNewPath(String path) {
-        final String strippedPath = path.startsWith("/") ? path.substring(1) : path;
-        return "/" + eventId + "-" + strippedPath;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/handlers/api/DebugApiReactorHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/handlers/api/DebugApiReactorHandler.java
@@ -17,9 +17,14 @@ package io.gravitee.gateway.debug.handlers.api;
 
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Invoker;
+import io.gravitee.gateway.api.context.MutableExecutionContext;
 import io.gravitee.gateway.debug.core.invoker.InvokerDebugDecorator;
+import io.gravitee.gateway.debug.definition.DebugApi;
+import io.gravitee.gateway.debug.reactor.handler.context.PathTransformer;
+import io.gravitee.gateway.debug.reactor.handler.http.ContextualizedDebugHttpServerRequest;
 import io.gravitee.gateway.handlers.api.ApiReactorHandler;
 import io.gravitee.gateway.handlers.api.definition.Api;
+import io.gravitee.gateway.reactor.handler.Entrypoint;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -29,6 +34,14 @@ public class DebugApiReactorHandler extends ApiReactorHandler {
 
     public DebugApiReactorHandler(Api api) {
         super(api);
+    }
+
+    @Override
+    protected void contextualizeRequest(ExecutionContext context) {
+        final String path = ((Entrypoint) context.getAttribute(ATTR_ENTRYPOINT)).path();
+        ((MutableExecutionContext) context).request(
+                new ContextualizedDebugHttpServerRequest(path, context.request(), ((DebugApi) reactable).getEventId())
+            );
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/DebugReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/DebugReactor.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.gateway.debug.reactor;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.common.event.Event;
 import io.gravitee.definition.model.HttpRequest;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/handler/context/AttributeHelper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/handler/context/AttributeHelper.java
@@ -17,7 +17,6 @@ package io.gravitee.gateway.debug.reactor.handler.context;
 
 import java.io.Serializable;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public abstract class AttributeHelper {
@@ -27,16 +26,10 @@ public abstract class AttributeHelper {
             return null;
         }
 
-        // FIXME: context-path is removed for now as it is updated with the event id in the debug mode context
-        // we need to rework that before making it accessible to the user
-        // https://github.com/gravitee-io/issues/issues/7072
-        List<String> attributesToExclude = List.of("gravitee.attribute.context-path");
-
         Map<String, Serializable> filteredAttributes = new HashMap<>();
         attributes
             .keySet()
             .stream()
-            .filter(key -> !attributesToExclude.contains(key))
             .filter(key -> attributes.get(key) != null)
             .filter(key -> attributes.get(key) instanceof Serializable)
             .forEach(

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/handler/context/PathTransformer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/handler/context/PathTransformer.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.debug.reactor.handler.context;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public abstract class PathTransformer {
+
+    public static String computePathWithEventId(String eventId, String path) {
+        final String strippedPath = path.startsWith("/") ? path.substring(1) : path;
+        return String.format("/%s-%s", eventId, strippedPath);
+    }
+
+    public static String removeEventIdFromPath(String eventId, String path) {
+        return path.replace(eventId + "-", "");
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/handler/http/ContextualizedDebugHttpServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/handler/http/ContextualizedDebugHttpServerRequest.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.debug.reactor.handler.http;
+
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.debug.reactor.handler.context.PathTransformer;
+import io.gravitee.gateway.reactor.handler.http.ContextualizedHttpServerRequest;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ContextualizedDebugHttpServerRequest extends ContextualizedHttpServerRequest {
+
+    private final String contextPath;
+
+    public ContextualizedDebugHttpServerRequest(String contextPath, Request request, String eventId) {
+        super(contextPath, request);
+        this.contextPath = PathTransformer.removeEventIdFromPath(eventId, contextPath);
+    }
+
+    @Override
+    public String path() {
+        return contextPath();
+    }
+
+    @Override
+    public String contextPath() {
+        return this.contextPath;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/reactor/handler/context/AttributeHelperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/reactor/handler/context/AttributeHelperTest.java
@@ -78,7 +78,8 @@ public class AttributeHelperTest {
         attributes.put("gravitee.attribute.context-path", "a value");
         attributes.put("gravitee.attribute.path", "a value");
 
-        assertThat(AttributeHelper.filterAndSerializeAttributes(attributes)).isEqualTo(Map.of("gravitee.attribute.path", "a value"));
+        assertThat(AttributeHelper.filterAndSerializeAttributes(attributes))
+            .isEqualTo(Map.of("gravitee.attribute.context-path", "a value", "gravitee.attribute.path", "a value"));
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/reactor/handler/context/PathTransformerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/reactor/handler/context/PathTransformerTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.debug.reactor.handler.context;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.Test;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class PathTransformerTest {
+
+    private static final String EVENT_ID = "18199-511ff-15fdv-156fdv";
+
+    @Test
+    public void shouldAddEventIdToPath() {
+        final String result = PathTransformer.computePathWithEventId(EVENT_ID, "/api/");
+        assertThat(result).isEqualTo("/" + EVENT_ID + "-api/");
+    }
+
+    @Test
+    public void shouldAddEventIdToBiggerPath() {
+        final String result = PathTransformer.computePathWithEventId(EVENT_ID, "/api/chicken/");
+        assertThat(result).isEqualTo("/" + EVENT_ID + "-api/chicken/");
+    }
+
+    @Test
+    public void shouldRemoveEventIdFromPath() {
+        final String result = PathTransformer.removeEventIdFromPath(EVENT_ID, "/" + EVENT_ID + "-api/chicken/");
+        assertThat(result).isEqualTo("/api/chicken/");
+    }
+
+    @Test
+    public void shouldNotRemoveEventIdFromPathIfAbsent() {
+        final String result = PathTransformer.removeEventIdFromPath(EVENT_ID, "/anotherEventId-api/chicken/");
+        assertThat(result).isEqualTo("/anotherEventId-api/chicken/");
+    }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7128

**Description**

Be able to use `request.contextPath` or `attributes["context-path"]` EL during a debug mode call

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ofntlizoun.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-7128-debug-context-ath/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
