### PR TITLE
fix: change DebugExecutionContext base type

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/handler/context/DebugExecutionContext.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/handler/context/DebugExecutionContext.java
@@ -20,6 +20,7 @@ import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.context.MutableExecutionContext;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.debug.core.invoker.InvokerResponse;
 import io.gravitee.gateway.debug.reactor.handler.context.steps.DebugRequestStep;
@@ -37,9 +38,9 @@ import java.util.Map;
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class DebugExecutionContext implements ExecutionContext {
+public class DebugExecutionContext implements MutableExecutionContext {
 
-    private final ExecutionContext context;
+    private final MutableExecutionContext context;
 
     private final List<DebugStep<?>> steps = new ArrayList<>();
     private final Map<String, Serializable> initialAttributes;
@@ -47,7 +48,7 @@ public class DebugExecutionContext implements ExecutionContext {
     private final HttpHeaders initialHeaders;
 
     public DebugExecutionContext(ExecutionContext context) {
-        this.context = context;
+        this.context = (MutableExecutionContext) context;
         this.initialAttributes = AttributeHelper.filterAndSerializeAttributes(context.getAttributes());
         this.initialHeaders = HttpHeaders.create(request().headers());
     }
@@ -143,5 +144,17 @@ public class DebugExecutionContext implements ExecutionContext {
 
     public HttpHeaders getInitialHeaders() {
         return initialHeaders;
+    }
+
+    @Override
+    public MutableExecutionContext request(Request request) {
+        context.request(request);
+        return this;
+    }
+
+    @Override
+    public MutableExecutionContext response(Response response) {
+        context.response(response);
+        return this;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/reactor/handler/context/DebugExecutionContextTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/reactor/handler/context/DebugExecutionContextTest.java
@@ -19,15 +19,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-import io.gravitee.definition.model.PolicyScope;
-import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.context.MutableExecutionContext;
 import io.gravitee.gateway.api.http.HttpHeaders;
-import io.gravitee.gateway.debug.reactor.handler.context.steps.DebugRequestStep;
 import io.gravitee.gateway.debug.reactor.handler.context.steps.DebugResponseStep;
-import io.gravitee.gateway.debug.reactor.handler.context.steps.DebugStep;
-import io.gravitee.gateway.policy.StreamType;
-import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,7 +37,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class DebugExecutionContextTest {
 
     @Mock
-    private ExecutionContext executionContext;
+    private MutableExecutionContext executionContext;
 
     @Mock
     private DebugResponseStep debugStep;


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7165

**Description**

Some policies change the request or response in the current execution context. It's the case for RetryPolicies.
Being able to do that is possible thanks to MutableExecutionContext interface.

Unfortunately, with the current way DebugExecutionContext is implemented, it only implements `ExecutionContext` interface, which prevents to do the needed cast to `MutableExecutionContext`.

This pull request changes the base type of `DebugExecutionContext` to be `MutableExecutionContext`
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-enrytzhwpa.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-7165-debugexecutioncontenxt-type/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
