### PR TITLE
refactor: improve sharedApiKey environment settings usage

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/subscriptions.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/subscriptions.component.ts
@@ -25,6 +25,7 @@ import PortalConfigService from '../../../../services/portalConfig.service';
 import ApplicationService from '../../../../services/application.service';
 import { PlanSecurityType } from '../../../../entities/plan/plan';
 import { ApiKeyMode } from '../../../../entities/application/application';
+import { Constants } from '../../../../entities/Constants';
 
 const defaultStatus = ['ACCEPTED', 'PENDING', 'PAUSED'];
 
@@ -60,13 +61,12 @@ const ApiSubscriptionsComponent: ng.IComponentOptions = {
     };
 
     private subscriptionsFiltersForm: any;
-    private portalSettings: any;
 
     constructor(
       private ApiService: ApiService,
       private ApplicationService: ApplicationService,
       private NotificationService: NotificationService,
-      private PortalConfigService: PortalConfigService,
+      private Constants: Constants,
       private $mdDialog: angular.material.IDialogService,
       private $state: StateService,
       public $rootScope: IScope,
@@ -103,9 +103,6 @@ const ApiSubscriptionsComponent: ng.IComponentOptions = {
 
     $onInit() {
       this.getSubscriptionAnalytics();
-      this.PortalConfigService.get().then((response) => {
-        this.portalSettings = response.data;
-      });
     }
 
     onPaginate(page) {
@@ -306,7 +303,7 @@ const ApiSubscriptionsComponent: ng.IComponentOptions = {
     }
 
     get allowsSharedApiKeys(): boolean {
-      return this.portalSettings?.plan?.security?.sharedApiKey?.enabled;
+      return this.Constants.env?.settings?.plan?.security?.sharedApiKey?.enabled;
     }
   },
 };

--- a/gravitee-apim-console-webui/src/management/application/creation/steps/application-creation.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/creation/steps/application-creation.controller.ts
@@ -19,7 +19,6 @@ import { ApplicationType } from '../../../../entities/application';
 import { ApiService } from '../../../../services/api.service';
 import ApplicationService from '../../../../services/application.service';
 import NotificationService from '../../../../services/notification.service';
-import PortalConfigService from '../../../../services/portalConfig.service';
 import '@gravitee/ui-components/wc/gv-icon';
 import { PlanSecurityType } from '../../../..//entities/plan/plan';
 
@@ -34,7 +33,6 @@ class ApplicationCreationController {
   private applicationType: string;
   private apis: any[] = [];
   private groups: any[];
-  private portalSettings: any;
 
   constructor(
     private Constants,
@@ -42,7 +40,6 @@ class ApplicationCreationController {
     private $mdDialog,
     private ApplicationService: ApplicationService,
     private NotificationService: NotificationService,
-    private PortalConfigService: PortalConfigService,
     private $q,
     private ApiService: ApiService,
   ) {
@@ -74,9 +71,6 @@ class ApplicationCreationController {
 
   $onInit() {
     this.ApiService.list().then((response) => (this.apis = response.data));
-    this.PortalConfigService.get().then((response) => {
-      this.portalSettings = response.data;
-    });
   }
 
   next() {
@@ -208,7 +202,7 @@ class ApplicationCreationController {
   }
 
   get allowsSharedApiKeys(): boolean {
-    return this.portalSettings?.plan?.security?.sharedApiKey?.enabled;
+    return this.Constants.env?.settings?.plan?.security?.sharedApiKey?.enabled;
   }
 }
 

--- a/gravitee-apim-console-webui/src/management/application/details/subscribe/application-subscribe.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscribe/application-subscribe.controller.ts
@@ -18,15 +18,14 @@ import * as _ from 'lodash';
 import { ApiService } from '../../../../services/api.service';
 import ApplicationService from '../../../../services/application.service';
 import NotificationService from '../../../../services/notification.service';
-import PortalConfigService from '../../../../services/portalConfig.service';
 import { ApiKeyMode } from '../../../../entities/application/application';
 import { PlanSecurityType } from '../../../../entities/plan/plan';
+import { Constants } from '../../../../entities/Constants';
 
 class ApplicationSubscribeController {
   private subscriptions: any;
   private application: any;
   private selectedAPI: any;
-  private portalSettings: any;
 
   private readonly groups = [];
   private readonly subscribedAPIs = [];
@@ -37,9 +36,9 @@ class ApplicationSubscribeController {
 
   constructor(
     private ApiService: ApiService,
+    private Constants: Constants,
     private ApplicationService: ApplicationService,
     private NotificationService: NotificationService,
-    private PortalConfigService: PortalConfigService,
     private $mdDialog,
     private $state,
     private $transitions,
@@ -59,9 +58,6 @@ class ApplicationSubscribeController {
         }),
       );
     });
-
-    const { data: portalSettings } = await this.PortalConfigService.get();
-    this.portalSettings = portalSettings;
 
     this.subscribedPlans = _.map(this.subscriptions.data, 'plan');
   }
@@ -179,7 +175,7 @@ class ApplicationSubscribeController {
   }
 
   get allowsSharedApiKeys(): boolean {
-    return this.portalSettings?.plan?.security?.sharedApiKey?.enabled;
+    return this.Constants.env?.settings?.plan?.security?.sharedApiKey?.enabled;
   }
 }
 


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6793

**Description**

refactor: improve sharedApiKey environment settings usage

This avoids useless interactions with API to retrieve environment settings.
Use setting stored in Constants instead of calling PortalConfigService.get()

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zejnrhsujw.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/refactor-6990-improve-shared-api-key-settings/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
