### PR TITLE
fix: avoid null application.apiKeyMode in database

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/ApplicationConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/ApplicationConverter.java
@@ -100,6 +100,6 @@ public class ApplicationConverter {
     }
 
     private ApiKeyMode toModelApiKeyMode(io.gravitee.rest.api.model.ApiKeyMode apiKeyMode) {
-        return apiKeyMode != null ? ApiKeyMode.valueOf(apiKeyMode.name()) : null;
+        return apiKeyMode != null ? ApiKeyMode.valueOf(apiKeyMode.name()) : ApiKeyMode.UNSPECIFIED;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/converter/ApplicationConverterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/converter/ApplicationConverterTest.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.rest.api.service.converter;
 
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
 import io.gravitee.repository.management.model.Application;
@@ -39,13 +38,13 @@ public class ApplicationConverterTest {
     }
 
     @Test
-    public void newApplicationEntity_toApplication_should_not_convert_null_ApiKeyMode() {
+    public void newApplicationEntity_toApplication_should_set_unspecified_byDefault_if_null_ApiKeyMode() {
         NewApplicationEntity newApplicationEntity = new NewApplicationEntity();
         newApplicationEntity.setApiKeyMode(null);
 
         Application application = applicationConverter.toApplication(newApplicationEntity);
 
-        assertNull(application.getApiKeyMode());
+        assertSame(io.gravitee.repository.management.model.ApiKeyMode.UNSPECIFIED, application.getApiKeyMode());
     }
 
     @Test
@@ -59,12 +58,12 @@ public class ApplicationConverterTest {
     }
 
     @Test
-    public void updateApplicationEntity_toApplication_should_not_convert_null_ApiKeyMode() {
+    public void updateApplicationEntity_toApplication_should_set_unspecified_byDefault_if_null_ApiKeyMode() {
         UpdateApplicationEntity updateApplicationEntity = new UpdateApplicationEntity();
         updateApplicationEntity.setApiKeyMode(null);
 
         Application application = applicationConverter.toApplication(updateApplicationEntity);
 
-        assertNull(application.getApiKeyMode());
+        assertSame(io.gravitee.repository.management.model.ApiKeyMode.UNSPECIFIED, application.getApiKeyMode());
     }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6793

**Description**

fix: avoid null application.apiKeyMode in database
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-neextqaspj.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6990-fix-null-apikeymode/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
