### PR TITLE
chore: disable liquibase schema updates in Gateway

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -63,6 +63,12 @@
 #  failOnDuplicate: true
 
 # Management repository is used to store global configuration such as APIs, applications, apikeys, ...
+# If you use a JDBC repository, we recommend disabling liquibase scripts execution by the Gateway. Let the Management API do it.
+# management:
+#   type: jdbc
+#   jdbc:
+#     liquibase: false
+
 # This is the default configuration using MongoDB (single server)
 # For more information about MongoDB configuration, please have a look to:
 # - http://mongodb.github.io/mongo-java-driver/4.1/apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.Builder.html


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5650

**Description**

Liquibase scripts are ran at startup for both management and gateway.
This deactivate liquibase by default on the gateway and let the administrator decide whether it should be enabled or not.

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/5650-disable-liquibase-on-gw-by-default/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
