### PR TITLE
fix(console): retrieve groups with member in transfer ownership compo…

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/apiAdmin.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/apiAdmin.controller.ts
@@ -230,7 +230,11 @@ class ApiAdminController {
   }
 
   canTransferOwnership(): boolean {
-    return this.UserService.currentUser.isAdmin() || this.UserService.isApiPrimaryOwner(this.api, this.resolvedApiGroups);
+    return this.isAdmin() || this.UserService.isApiPrimaryOwner(this.api, this.resolvedApiGroups);
+  }
+
+  isAdmin(): boolean {
+    return this.UserService.currentUser.roles['ORGANIZATION'] === 'ADMIN' || this.UserService.currentUser.roles['ENVIRONMENT'] === 'ADMIN';
   }
 
   isRequestForChanges(): boolean {

--- a/gravitee-apim-console-webui/src/management/api/portal/userGroupAccess/transferOwnership/transferOwnership.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/userGroupAccess/transferOwnership/transferOwnership.controller.ts
@@ -42,7 +42,6 @@ class ApiTransferOwnershipController {
     private resolvedApi,
     private resolvedMembers,
     private resolvedGroups,
-    private resolvedApiGroups,
     private $state,
     private $mdDialog: ng.material.IDialogService,
     private NotificationService,
@@ -65,8 +64,10 @@ class ApiTransferOwnershipController {
     _.forEach(resolvedGroups, (grp) => {
       this.displayGroups[grp.id] = false;
     });
-    this.groupMembers = resolvedApiGroups;
-    this.groupIdsWithMembers = Object.keys(this.groupMembers);
+
+    ApiService.getGroupsWithMembers(this.api.id).then(({ data: groupWithMembers }) => {
+      this.groupIdsWithMembers = groupWithMembers;
+    });
 
     RoleService.list('API').then((roles) => {
       this.roles = roles;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_GetGroupsWithMembersTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_GetGroupsWithMembersTest.java
@@ -24,13 +24,13 @@ import io.gravitee.repository.management.model.Api;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.model.permissions.SystemRole;
-import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.impl.ApiServiceImpl;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -68,28 +68,28 @@ public class ApiService_GetGroupsWithMembersTest {
         String apiId = UuidString.generateRandom();
         String groupId = UuidString.generateRandom();
 
-        Api api = mock(Api.class);
-        when(api.getId()).thenReturn(apiId);
-        when(api.getGroups()).thenReturn(Set.of(groupId));
+        Api api = new Api();
+        api.setId(apiId);
+        api.setGroups(Set.of(groupId));
         when(apiRepository.findById(apiId)).thenReturn(Optional.of(api));
 
-        GroupEntity group = Mockito.mock(GroupEntity.class);
-        when(group.getId()).thenReturn(groupId);
+        GroupEntity group = new GroupEntity();
+        group.setId(groupId);
         when(groupService.findById(eq(ENVIRONMENT), eq(groupId))).thenReturn(group);
 
         RoleEntity groupMemberApiRole = new RoleEntity();
         groupMemberApiRole.setName(SystemRole.PRIMARY_OWNER.name());
         groupMemberApiRole.setScope(RoleScope.API);
 
-        MemberEntity groupMember = Mockito.mock(MemberEntity.class);
-        when(groupMember.getReferenceId()).thenReturn(groupId);
-        when(groupMember.getRoles()).thenReturn(List.of(groupMemberApiRole));
+        MemberEntity groupMember = new MemberEntity();
+        groupMember.setReferenceId(groupId);
+        groupMember.setRoles(List.of(groupMemberApiRole));
         when(membershipService.getMembersByReferencesAndRole(MembershipReferenceType.GROUP, List.of(groupId), null))
             .thenReturn(Set.of(groupMember));
 
-        MembershipEntity apiPrimaryOwnerMembership = Mockito.mock(MembershipEntity.class);
-        when(apiPrimaryOwnerMembership.getMemberType()).thenReturn(MembershipMemberType.GROUP);
-        when(apiPrimaryOwnerMembership.getMemberId()).thenReturn(groupId);
+        MembershipEntity apiPrimaryOwnerMembership = new MembershipEntity();
+        apiPrimaryOwnerMembership.setMemberType(MembershipMemberType.GROUP);
+        apiPrimaryOwnerMembership.setMemberId(groupId);
         when(membershipService.getPrimaryOwner(any(), eq(MembershipReferenceType.API), eq(apiId))).thenReturn(apiPrimaryOwnerMembership);
 
         Map<String, List<GroupMemberEntity>> groupsWithMembers = apiService.getGroupsWithMembers(ENVIRONMENT, apiId);
@@ -115,37 +115,38 @@ public class ApiService_GetGroupsWithMembersTest {
         String groupId = UuidString.generateRandom();
         String apiPrimaryOwnerUserId = UuidString.generateRandom();
 
-        UserEntity apiPrimaryOwner = Mockito.mock(UserEntity.class);
-        when(apiPrimaryOwner.getId()).thenReturn(apiPrimaryOwnerUserId);
+        UserEntity apiPrimaryOwner = new UserEntity();
+        apiPrimaryOwner.setId(apiPrimaryOwnerUserId);
         when(userService.findById(apiPrimaryOwnerUserId)).thenReturn(apiPrimaryOwner);
 
-        Api api = mock(Api.class);
-        when(api.getId()).thenReturn(apiId);
-        when(api.getGroups()).thenReturn(Set.of(groupId));
+        Api api = new Api();
+        api.setId(apiId);
+        api.setGroups(Set.of(groupId));
         when(apiRepository.findById(apiId)).thenReturn(Optional.of(api));
 
-        GroupEntity group = Mockito.mock(GroupEntity.class);
-        when(group.getId()).thenReturn(groupId);
-        when(group.getRoles()).thenReturn(Map.of(RoleScope.API, expectedUserRole));
+        GroupEntity group = new GroupEntity();
+        group.setId(groupId);
+        group.setRoles(Map.of(RoleScope.API, expectedUserRole));
         when(groupService.findById(eq(ENVIRONMENT), eq(groupId))).thenReturn(group);
 
         RoleEntity groupMemberApiRole = new RoleEntity();
         groupMemberApiRole.setName(SystemRole.PRIMARY_OWNER.name());
         groupMemberApiRole.setScope(RoleScope.API);
 
-        MemberEntity groupMember = Mockito.mock(MemberEntity.class);
-        when(groupMember.getReferenceId()).thenReturn(groupId);
-        when(groupMember.getRoles()).thenReturn(List.of(groupMemberApiRole));
+        MemberEntity groupMember = new MemberEntity();
+        groupMember.setReferenceId(groupId);
+        groupMember.setRoles(List.of(groupMemberApiRole));
         when(membershipService.getMembersByReferencesAndRole(MembershipReferenceType.GROUP, List.of(groupId), null))
             .thenReturn(Set.of(groupMember));
 
-        MembershipEntity apiPrimaryOwnerMembership = Mockito.mock(MembershipEntity.class);
-        when(apiPrimaryOwnerMembership.getMemberType()).thenReturn(MembershipMemberType.USER);
-        when(apiPrimaryOwnerMembership.getMemberId()).thenReturn(apiPrimaryOwnerUserId);
+        MembershipEntity apiPrimaryOwnerMembership = new MembershipEntity();
+        apiPrimaryOwnerMembership.setMemberType(MembershipMemberType.USER);
+        apiPrimaryOwnerMembership.setMemberId(apiPrimaryOwnerUserId);
         when(membershipService.getPrimaryOwner(any(), eq(MembershipReferenceType.API), eq(apiId))).thenReturn(apiPrimaryOwnerMembership);
 
-        RoleEntity groupDefaultApiRole = Mockito.mock(RoleEntity.class);
-        when(groupDefaultApiRole.getName()).thenReturn(expectedUserRole);
+        RoleEntity groupDefaultApiRole = new RoleEntity();
+        groupDefaultApiRole.setScope(RoleScope.API);
+        groupDefaultApiRole.setName(expectedUserRole);
         when(roleService.findByScopeAndName(eq(RoleScope.API), eq(expectedUserRole))).thenReturn(Optional.of(groupDefaultApiRole));
 
         Map<String, List<GroupMemberEntity>> groupsWithMembers = apiService.getGroupsWithMembers(ENVIRONMENT, apiId);
@@ -171,33 +172,33 @@ public class ApiService_GetGroupsWithMembersTest {
         String groupId = UuidString.generateRandom();
         String apiPrimaryOwnerGroupId = UuidString.generateRandom();
 
-        GroupEntity apiPrimaryOwner = Mockito.mock(GroupEntity.class);
-        when(apiPrimaryOwner.getId()).thenReturn(apiPrimaryOwnerGroupId);
-        when(groupService.findById(anyString(), eq(apiPrimaryOwnerGroupId))).thenReturn(apiPrimaryOwner);
+        GroupEntity apiPrimaryOwner = new GroupEntity();
+        apiPrimaryOwner.setId(apiPrimaryOwnerGroupId);
+        when(groupService.findById(eq(ENVIRONMENT), eq(apiPrimaryOwnerGroupId))).thenReturn(apiPrimaryOwner);
 
-        Api api = mock(Api.class);
-        when(api.getId()).thenReturn(apiId);
-        when(api.getGroups()).thenReturn(Set.of(groupId));
+        Api api = new Api();
+        api.setId(apiId);
+        api.setGroups(Set.of(groupId));
         when(apiRepository.findById(apiId)).thenReturn(Optional.of(api));
 
-        GroupEntity group = Mockito.mock(GroupEntity.class);
-        when(group.getId()).thenReturn(groupId);
-        when(group.getRoles()).thenReturn(Map.of(RoleScope.API, expectedUserRole));
-        when(groupService.findById(eq(ENVIRONMENT), eq(groupId))).thenReturn(group);
+        GroupEntity group = new GroupEntity();
+        group.setId(groupId);
+        group.setRoles(Map.of(RoleScope.API, expectedUserRole));
+        when(groupService.findById(anyString(), eq(groupId))).thenReturn(group);
 
         RoleEntity groupMemberApiRole = new RoleEntity();
         groupMemberApiRole.setName(SystemRole.PRIMARY_OWNER.name());
         groupMemberApiRole.setScope(RoleScope.API);
 
-        MemberEntity groupMember = Mockito.mock(MemberEntity.class);
-        when(groupMember.getReferenceId()).thenReturn(groupId);
-        when(groupMember.getRoles()).thenReturn(List.of(groupMemberApiRole));
+        MemberEntity groupMember = new MemberEntity();
+        groupMember.setReferenceId(groupId);
+        groupMember.setRoles(List.of(groupMemberApiRole));
         when(membershipService.getMembersByReferencesAndRole(MembershipReferenceType.GROUP, List.of(groupId), null))
             .thenReturn(Set.of(groupMember));
 
-        MembershipEntity apiPrimaryOwnerMembership = Mockito.mock(MembershipEntity.class);
-        when(apiPrimaryOwnerMembership.getMemberType()).thenReturn(MembershipMemberType.GROUP);
-        when(apiPrimaryOwnerMembership.getMemberId()).thenReturn(apiPrimaryOwnerGroupId);
+        MembershipEntity apiPrimaryOwnerMembership = new MembershipEntity();
+        apiPrimaryOwnerMembership.setMemberType(MembershipMemberType.GROUP);
+        apiPrimaryOwnerMembership.setMemberId(apiPrimaryOwnerGroupId);
         when(membershipService.getPrimaryOwner(any(), eq(MembershipReferenceType.API), eq(apiId))).thenReturn(apiPrimaryOwnerMembership);
 
         RoleEntity groupDefaultApiRole = Mockito.mock(RoleEntity.class);
@@ -226,33 +227,33 @@ public class ApiService_GetGroupsWithMembersTest {
         String groupId = UuidString.generateRandom();
         String apiPrimaryOwnerGroupId = UuidString.generateRandom();
 
-        GroupEntity apiPrimaryOwner = Mockito.mock(GroupEntity.class);
-        when(apiPrimaryOwner.getId()).thenReturn(apiPrimaryOwnerGroupId);
+        GroupEntity apiPrimaryOwner = new GroupEntity();
+        apiPrimaryOwner.setId(apiPrimaryOwnerGroupId);
         when(groupService.findById(eq(ENVIRONMENT), eq(apiPrimaryOwnerGroupId))).thenReturn(apiPrimaryOwner);
 
-        Api api = mock(Api.class);
-        when(api.getId()).thenReturn(apiId);
-        when(api.getGroups()).thenReturn(Set.of(groupId));
+        Api api = new Api();
+        api.setId(apiId);
+        api.setGroups(Set.of(groupId));
         when(apiRepository.findById(apiId)).thenReturn(Optional.of(api));
 
-        GroupEntity group = Mockito.mock(GroupEntity.class);
-        when(group.getId()).thenReturn(groupId);
-        when(group.getRoles()).thenReturn(Map.of());
+        GroupEntity group = new GroupEntity();
+        group.setId(groupId);
+        group.setRoles(Map.of());
         when(groupService.findById(anyString(), eq(groupId))).thenReturn(group);
 
         RoleEntity groupMemberApiRole = new RoleEntity();
         groupMemberApiRole.setName(SystemRole.PRIMARY_OWNER.name());
         groupMemberApiRole.setScope(RoleScope.API);
 
-        MemberEntity groupMember = Mockito.mock(MemberEntity.class);
-        when(groupMember.getReferenceId()).thenReturn(groupId);
-        when(groupMember.getRoles()).thenReturn(List.of(groupMemberApiRole));
+        MemberEntity groupMember = new MemberEntity();
+        groupMember.setReferenceId(groupId);
+        groupMember.setRoles(List.of(groupMemberApiRole));
         when(membershipService.getMembersByReferencesAndRole(MembershipReferenceType.GROUP, List.of(groupId), null))
             .thenReturn(Set.of(groupMember));
 
-        MembershipEntity apiPrimaryOwnerMembership = Mockito.mock(MembershipEntity.class);
-        when(apiPrimaryOwnerMembership.getMemberType()).thenReturn(MembershipMemberType.GROUP);
-        when(apiPrimaryOwnerMembership.getMemberId()).thenReturn(apiPrimaryOwnerGroupId);
+        MembershipEntity apiPrimaryOwnerMembership = new MembershipEntity();
+        apiPrimaryOwnerMembership.setMemberType(MembershipMemberType.GROUP);
+        apiPrimaryOwnerMembership.setMemberId(apiPrimaryOwnerGroupId);
         when(membershipService.getPrimaryOwner(any(), eq(MembershipReferenceType.API), eq(apiId))).thenReturn(apiPrimaryOwnerMembership);
 
         Map<String, List<GroupMemberEntity>> groupsWithMembers = apiService.getGroupsWithMembers(ENVIRONMENT, apiId);
@@ -271,6 +272,93 @@ public class ApiService_GetGroupsWithMembersTest {
     }
 
     @Test
+    public void shouldGetApiGroupsWithMembers_RemovingPrimaryOwnerPrivilege_withTwoGroupsAssociated() throws TechnicalException {
+        final String expectedRoleForGroup1 = "REVIEWER";
+        final String expectedRoleForGroup2 = "USER";
+
+        String apiId = UuidString.generateRandom();
+
+        String groupId1 = UuidString.generateRandom();
+        String groupId2 = UuidString.generateRandom();
+
+        String apiPrimaryOwnerGroupId = UuidString.generateRandom();
+
+        Api api = new Api();
+        api.setId(apiId);
+        api.setGroups(Set.of(groupId1, groupId2));
+        when(apiRepository.findById(apiId)).thenReturn(Optional.of(api));
+
+        GroupEntity apiPrimaryOwner = new GroupEntity();
+        apiPrimaryOwner.setId(apiPrimaryOwnerGroupId);
+        when(groupService.findById(eq(ENVIRONMENT), eq(apiPrimaryOwnerGroupId))).thenReturn(apiPrimaryOwner);
+
+        GroupEntity group1 = new GroupEntity();
+        group1.setId(groupId1);
+        group1.setRoles(Map.of(RoleScope.API, expectedRoleForGroup1));
+        when(groupService.findById(anyString(), eq(groupId1))).thenReturn(group1);
+
+        GroupEntity group2 = new GroupEntity();
+        group2.setId(groupId2);
+        group2.setRoles(Map.of(RoleScope.API, expectedRoleForGroup2));
+        when(groupService.findById(anyString(), eq(groupId2))).thenReturn(group2);
+
+        RoleEntity groupMemberApiRole = new RoleEntity();
+        groupMemberApiRole.setName(SystemRole.PRIMARY_OWNER.name());
+        groupMemberApiRole.setScope(RoleScope.API);
+
+        MemberEntity groupMemberForGroup1 = new MemberEntity();
+        groupMemberForGroup1.setId(UuidString.generateRandom());
+        groupMemberForGroup1.setReferenceId(groupId1);
+        groupMemberForGroup1.setRoles(List.of(groupMemberApiRole));
+
+        MemberEntity groupMemberForGroup2 = new MemberEntity();
+        groupMemberForGroup2.setId(UuidString.generateRandom());
+        groupMemberForGroup2.setReferenceId(groupId2);
+        groupMemberForGroup2.setRoles(List.of(groupMemberApiRole));
+
+        when(
+            membershipService.getMembersByReferencesAndRole(
+                eq(MembershipReferenceType.GROUP),
+                argThat(groupIds -> groupIds.containsAll(List.of(groupId1, groupId2))),
+                isNull()
+            )
+        )
+            .thenReturn(Set.of(groupMemberForGroup1, groupMemberForGroup2));
+
+        MembershipEntity apiPrimaryOwnerMembership = new MembershipEntity();
+        apiPrimaryOwnerMembership.setMemberType(MembershipMemberType.GROUP);
+        apiPrimaryOwnerMembership.setMemberId(apiPrimaryOwnerGroupId);
+        when(membershipService.getPrimaryOwner(any(), eq(MembershipReferenceType.API), eq(apiId))).thenReturn(apiPrimaryOwnerMembership);
+
+        RoleEntity defaultApiRoleForGroup1 = new RoleEntity();
+        defaultApiRoleForGroup1.setScope(RoleScope.API);
+        defaultApiRoleForGroup1.setName(expectedRoleForGroup1);
+        when(roleService.findByScopeAndName(eq(RoleScope.API), eq(expectedRoleForGroup1))).thenReturn(Optional.of(defaultApiRoleForGroup1));
+
+        RoleEntity defaultApiRoleForGroup2 = new RoleEntity();
+        defaultApiRoleForGroup2.setScope(RoleScope.API);
+        defaultApiRoleForGroup2.setName(expectedRoleForGroup2);
+        when(roleService.findByScopeAndName(eq(RoleScope.API), eq(expectedRoleForGroup2))).thenReturn(Optional.of(defaultApiRoleForGroup2));
+
+        Map<String, List<GroupMemberEntity>> groupsWithMembers = apiService.getGroupsWithMembers(ENVIRONMENT, apiId);
+        assertEquals(2, groupsWithMembers.size());
+
+        List<GroupMemberEntity> membersForGroup1 = groupsWithMembers.get(groupId1);
+        assertNotNull(membersForGroup1);
+        assertEquals(1, membersForGroup1.size());
+        GroupMemberEntity updatedMemberForGroup1 = membersForGroup1.get(0);
+        String userRoleForGroup1 = updatedMemberForGroup1.getRoles().get(RoleScope.API.name());
+        assertEquals(expectedRoleForGroup1, userRoleForGroup1);
+
+        List<GroupMemberEntity> membersForGroup2 = groupsWithMembers.get(groupId2);
+        assertNotNull(membersForGroup2);
+        assertEquals(1, membersForGroup2.size());
+        GroupMemberEntity updatedMemberForGroup2 = membersForGroup2.get(0);
+        String userRoleForGroup2 = updatedMemberForGroup2.getRoles().get(RoleScope.API.name());
+        assertEquals(expectedRoleForGroup2, userRoleForGroup2);
+    }
+
+    @Test
     public void shouldGetApiGroupsWithMembers_RemovingPrimaryOwnerPrivilege_ifGroupIsNotTheApiPrimaryOwner_andDefaultRoleHasBeenDeleted()
         throws TechnicalException {
         final String deletedRole = "USER";
@@ -279,33 +367,33 @@ public class ApiService_GetGroupsWithMembersTest {
         String groupId = UuidString.generateRandom();
         String apiPrimaryOwnerUserId = UuidString.generateRandom();
 
-        UserEntity apiPrimaryOwner = Mockito.mock(UserEntity.class);
-        when(apiPrimaryOwner.getId()).thenReturn(apiPrimaryOwnerUserId);
+        UserEntity apiPrimaryOwner = new UserEntity();
+        apiPrimaryOwner.setId(apiPrimaryOwnerUserId);
         when(userService.findById(apiPrimaryOwnerUserId)).thenReturn(apiPrimaryOwner);
 
-        Api api = mock(Api.class);
-        when(api.getId()).thenReturn(apiId);
-        when(api.getGroups()).thenReturn(Set.of(groupId));
+        Api api = new Api();
+        api.setId(apiId);
+        api.setGroups(Set.of(groupId));
         when(apiRepository.findById(apiId)).thenReturn(Optional.of(api));
 
-        GroupEntity group = Mockito.mock(GroupEntity.class);
-        when(group.getId()).thenReturn(groupId);
-        when(group.getRoles()).thenReturn(Map.of(RoleScope.API, deletedRole));
-        when(groupService.findById(eq(ENVIRONMENT), eq(groupId))).thenReturn(group);
+        GroupEntity group = new GroupEntity();
+        group.setId(groupId);
+        group.setRoles(Map.of(RoleScope.API, deletedRole));
+        when(groupService.findById(anyString(), eq(groupId))).thenReturn(group);
 
         RoleEntity groupMemberApiRole = new RoleEntity();
         groupMemberApiRole.setName(SystemRole.PRIMARY_OWNER.name());
         groupMemberApiRole.setScope(RoleScope.API);
 
-        MemberEntity groupMember = Mockito.mock(MemberEntity.class);
-        when(groupMember.getReferenceId()).thenReturn(groupId);
-        when(groupMember.getRoles()).thenReturn(List.of(groupMemberApiRole));
+        MemberEntity groupMember = new MemberEntity();
+        groupMember.setReferenceId(groupId);
+        groupMember.setRoles(List.of(groupMemberApiRole));
         when(membershipService.getMembersByReferencesAndRole(MembershipReferenceType.GROUP, List.of(groupId), null))
             .thenReturn(Set.of(groupMember));
 
-        MembershipEntity apiPrimaryOwnerMembership = Mockito.mock(MembershipEntity.class);
-        when(apiPrimaryOwnerMembership.getMemberType()).thenReturn(MembershipMemberType.USER);
-        when(apiPrimaryOwnerMembership.getMemberId()).thenReturn(apiPrimaryOwnerUserId);
+        MembershipEntity apiPrimaryOwnerMembership = new MembershipEntity();
+        apiPrimaryOwnerMembership.setMemberType(MembershipMemberType.USER);
+        apiPrimaryOwnerMembership.setMemberId(apiPrimaryOwnerUserId);
         when(membershipService.getPrimaryOwner(any(), eq(MembershipReferenceType.API), eq(apiId))).thenReturn(apiPrimaryOwnerMembership);
 
         when(roleService.findByScopeAndName(eq(RoleScope.API), eq(deletedRole))).thenReturn(Optional.empty());


### PR DESCRIPTION
see https://github.com/gravitee-io/issues/issues/6360

Group members were not retrieved properly, making the primary owner role check fail in the "Transfert Ownership" component

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-transfert-ownership/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
