### PR TITLE
Bump `@gravitee/ui-components` to 3.30.1

### DIFF
--- a/gravitee-apim-console-webui/package-lock.json
+++ b/gravitee-apim-console-webui/package-lock.json
@@ -1284,9 +1284,9 @@
       "dev": true
     },
     "@codemirror/autocomplete": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.12.tgz",
-      "integrity": "sha512-zUQYo5gMdv7vhxlKoAY/vnNCGzlE9AU7+P649v3ovpQpoFdo3U1Nt01EJqFb4Sfaw6l1U/Elc9Iksd1lDy+MVw==",
+      "version": "0.19.13",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.13.tgz",
+      "integrity": "sha512-fI6lgTH2PlyTQqF2eWKDRBRUC+9MqvS2TfvE7aJ4Pu1oHM1w8JI16J9Qvwrd0iabJeF/QodU51Clok98c7fpCQ==",
       "requires": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/state": "^0.19.4",
@@ -1319,15 +1319,15 @@
       }
     },
     "@codemirror/closebrackets": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/closebrackets/-/closebrackets-0.19.0.tgz",
-      "integrity": "sha512-dFWX5OEVYWRNtGaifSbwIAlymnRRjxWMiMbffbAjF7p0zfGHDbdGkiT56q3Xud63h5/tQdSo5dK1iyNTzHz5vg==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/closebrackets/-/closebrackets-0.19.1.tgz",
+      "integrity": "sha512-ZiLXT6u+VuBK5QnfBbt/Vmfd9Pg6449wn1DIOWFZHUOldg5eFn3VGGjYY2XWuHQz5WuK+7dXamV2KE885O1gyA==",
       "requires": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
+        "@codemirror/state": "^0.19.2",
         "@codemirror/text": "^0.19.0",
-        "@codemirror/view": "^0.19.0"
+        "@codemirror/view": "^0.19.44"
       }
     },
     "@codemirror/commands": {
@@ -1344,11 +1344,11 @@
       }
     },
     "@codemirror/comment": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/comment/-/comment-0.19.0.tgz",
-      "integrity": "sha512-3hqAd0548fxqOBm4khFMcXVIivX8p0bSlbAuZJ6PNoUn/0wXhxkxowPp0FmFzU2+y37Z+ZQF5cRB5EREWPRIiQ==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/comment/-/comment-0.19.1.tgz",
+      "integrity": "sha512-uGKteBuVWAC6fW+Yt8u27DOnXMT/xV4Ekk2Z5mRsiADCZDqYvryrJd6PLL5+8t64BVyocwQwNfz1UswYS2CtFQ==",
       "requires": {
-        "@codemirror/state": "^0.19.0",
+        "@codemirror/state": "^0.19.9",
         "@codemirror/text": "^0.19.0",
         "@codemirror/view": "^0.19.0"
       }
@@ -1628,9 +1628,9 @@
       }
     },
     "@codemirror/rangeset": {
-      "version": "0.19.7",
-      "resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.7.tgz",
-      "integrity": "sha512-17zvQKjjUGjFCdFJAKFgiiQKFqGENmlVzS5vtiPQu1SCEs8ZKyvoFWwilM24+s21AlXxcUXulxEfOLGER5gOtg==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.8.tgz",
+      "integrity": "sha512-1vusIkxSD0vK5KQ22JO/4Ejfww5268PgM/CpKNBSpTpWZEFlZbmOPyRiY4HXO2oEzOpypbA/walMiNInWnrT0Q==",
       "requires": {
         "@codemirror/state": "^0.19.0"
       }
@@ -1659,9 +1659,9 @@
       }
     },
     "@codemirror/state": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.8.tgz",
-      "integrity": "sha512-f8iZJe+1czZNOdt/H6FnuiYnzLF9OKxc7PsKhdEDq0478U2kak5CBbS7JwxkJekeguTyaagoJbnZveqPY2wlmQ==",
+      "version": "0.19.9",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.9.tgz",
+      "integrity": "sha512-psOzDolKTZkx4CgUqhBQ8T8gBc0xN5z4gzed109aF6x7D7umpDRoimacI/O6d9UGuyl4eYuDCZmDFr2Rq7aGOw==",
       "requires": {
         "@codemirror/text": "^0.19.0"
       }
@@ -1685,18 +1685,18 @@
       "integrity": "sha512-T9jnREMIygx+TPC1bOuepz18maGq/92q2a+n4qTqObKwvNMg+8cMTslb8yxeEDEq7S3kpgGWxgO1UWbQRij0dA=="
     },
     "@codemirror/tooltip": {
-      "version": "0.19.14",
-      "resolved": "https://registry.npmjs.org/@codemirror/tooltip/-/tooltip-0.19.14.tgz",
-      "integrity": "sha512-amLSIJ7LROjCOytbP3a8FMP2gm6xD+i/ftvLWTB2mjhu71/zdIZiFrK/lfuoNVoNoKAVjWMTD9Dl5IIuu5SsWQ==",
+      "version": "0.19.15",
+      "resolved": "https://registry.npmjs.org/@codemirror/tooltip/-/tooltip-0.19.15.tgz",
+      "integrity": "sha512-Fb4fKgVziUNSOAhclsvsqHw+1bCfh5po8xT/hw2UQW0UV41t73tJqX5AiqSwmtaDHExN7DFyzG8VQa05d/7g3Q==",
       "requires": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/view": "^0.19.0"
       }
     },
     "@codemirror/view": {
-      "version": "0.19.42",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.42.tgz",
-      "integrity": "sha512-sGpuHYesqNThkAdJHTf4BO0hBeYnAHwamnCGkM6a2G/W5svRJGsFb5Vk/LQPQurDKK9V5fBTRqXH8nKGrIszng==",
+      "version": "0.19.44",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.44.tgz",
+      "integrity": "sha512-vahNUE6hSXdjzs1gcztKPJQhZu+ZIwRpK4ZGZTSD81/CZUVqtlF75W3RCYVgEdjTI1l6ogJmIL6FM2Xj7ltn7Q==",
       "requires": {
         "@codemirror/rangeset": "^0.19.5",
         "@codemirror/state": "^0.19.3",
@@ -1858,9 +1858,9 @@
       }
     },
     "@gravitee/ui-components": {
-      "version": "3.29.4",
-      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.29.4.tgz",
-      "integrity": "sha512-e71i4UA92KyVnshtC7My2Yx84X/mGCklX5NevDiZw+6SgLuYzRYBTMzVyGGFNvE+J1evZk1kejimWKvvZK2VJw==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.30.1.tgz",
+      "integrity": "sha512-mI2J172M+uKU2ty/cLjOyDwqyt/63/FXzEj/63PwYGrFr52Bmg0qXA2m0uRvCH/wnSr/ZjBH3fY9vSmyoOf+bQ==",
       "requires": {
         "@codemirror/basic-setup": "^0.19.1",
         "@codemirror/language-data": "^0.19.1",
@@ -2631,9 +2631,9 @@
       }
     },
     "@lezer/html": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-0.15.0.tgz",
-      "integrity": "sha512-ErmgP/Vv0AhYJvs/Ekb9oue4IzBHemKLi7K8tJ0jgS+20Y8FGC9foK6knCXtEHqdPaxVGQH9PVp7gecLnzLd9Q==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-0.15.1.tgz",
+      "integrity": "sha512-0ZYVhu+RwN6ZMM0gNnTxenRAdoycKc2wvpLfMjP0JkKR0vMxhtuLaIpsq9KW2Mv6l7ux5vdjq8CQ7fKDvia8KA==",
       "requires": {
         "@lezer/lr": "^0.15.0"
       }
@@ -2671,9 +2671,9 @@
       }
     },
     "@lezer/markdown": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-0.15.4.tgz",
-      "integrity": "sha512-lJ/zzm8j8H4h3rVzUG2/z3mtOLjeiXIV/kosxVYB+RmJS8dpS1QLUx9p8/F3/HU6bivzmFO3lii97/VDtmKMXA==",
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-0.15.5.tgz",
+      "integrity": "sha512-ZWCZn1FTQFw70RZFmyWRKHsKYTw8OTPc1SmYWMf6xwz83SNd/MIlXcOoyLLwE3/THfUMmnnSjj2ozfPtqA3mFg==",
       "requires": {
         "@lezer/common": "^0.15.0"
       }
@@ -2711,9 +2711,9 @@
       }
     },
     "@lit/reactive-element": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.2.3.tgz",
-      "integrity": "sha512-fu0HW3VpeQdTx2BxjcMD0pEXB6M3xYi7Cgmqr7+jtyN7hNZJGFWqqQFfyJRwP8cBGQz3WW1txBiPPf9dK2xdUg=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.3.0.tgz",
+      "integrity": "sha512-0TKSIuJHXNLM0k98fi0AdMIdUoHIYlDHTP+0Vruc2SOs4T6vU1FinXgSvYd8mSrkt+8R+qdRAXvjpqrMXMyBgw=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
@@ -11315,28 +11315,28 @@
       "dev": true
     },
     "lit": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.1.4.tgz",
-      "integrity": "sha512-m1tHAZdXQhiBe0ReAjyVIUeKnHZpBfx+A5R5dkia8dtvIBwOR6KhD+RxaDnCwrEavRqkZAy5ntLv7chiOZCdNg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.2.0.tgz",
+      "integrity": "sha512-FDyxUuczo6cJJY/2Bkgfh1872U4ikUvmK1Cb6+lYC1CW+QOo8CaWXCpvPKFzYsz0ojUxoruBLVrECc7VI2f1dQ==",
       "requires": {
-        "@lit/reactive-element": "^1.1.0",
-        "lit-element": "^3.1.0",
-        "lit-html": "^2.1.0"
+        "@lit/reactive-element": "^1.3.0",
+        "lit-element": "^3.2.0",
+        "lit-html": "^2.2.0"
       }
     },
     "lit-element": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.1.2.tgz",
-      "integrity": "sha512-5VLn5a7anAFH7oz6d7TRG3KiTZQ5GEFsAgOKB8Yc+HDyuDUGOT2cL1CYTz/U4b/xlJxO+euP14pyji+z3Z3kOg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.2.0.tgz",
+      "integrity": "sha512-HbE7yt2SnUtg5DCrWt028oaU4D5F4k/1cntAFHTkzY8ZIa8N0Wmu92PxSxucsQSOXlODFrICkQ5x/tEshKi13g==",
       "requires": {
-        "@lit/reactive-element": "^1.1.0",
-        "lit-html": "^2.1.0"
+        "@lit/reactive-element": "^1.3.0",
+        "lit-html": "^2.2.0"
       }
     },
     "lit-html": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.1.3.tgz",
-      "integrity": "sha512-WgvdwiNeuoT0mYEEJI+AAV2DEtlqzVM4lyDSaeQSg5ZwhS/CkGJBO/4n66alApEuSS9WXw9+ADBp8SPvtDEKSg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.0.tgz",
+      "integrity": "sha512-dJnevgV8VkCuOXLWrjQopDE8nSy8CzipZ/ATfYQv7z7Dct4abblcKecf50gkIScuwCTzKvRLgvTgV0zzagW4gA==",
       "requires": {
         "@types/trusted-types": "^2.0.2"
       }

--- a/gravitee-apim-console-webui/package.json
+++ b/gravitee-apim-console-webui/package.json
@@ -4,7 +4,7 @@
   "description": "Gravitee.io APIM - UI Console",
   "dependencies": {
     "@fontsource/libre-franklin": "^4.4.5",
-    "@gravitee/ui-components": "3.29.4",
+    "@gravitee/ui-components": "3.30.1",
     "@highcharts/map-collection": "^1.1.3",
     "@toast-ui/editor": "^2.5.2",
     "@toast-ui/editor-plugin-code-syntax-highlight": "^1.0.0",

--- a/gravitee-apim-portal-webui/package-lock.json
+++ b/gravitee-apim-portal-webui/package-lock.json
@@ -2241,9 +2241,9 @@
       }
     },
     "@codemirror/autocomplete": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.12.tgz",
-      "integrity": "sha512-zUQYo5gMdv7vhxlKoAY/vnNCGzlE9AU7+P649v3ovpQpoFdo3U1Nt01EJqFb4Sfaw6l1U/Elc9Iksd1lDy+MVw==",
+      "version": "0.19.13",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.13.tgz",
+      "integrity": "sha512-fI6lgTH2PlyTQqF2eWKDRBRUC+9MqvS2TfvE7aJ4Pu1oHM1w8JI16J9Qvwrd0iabJeF/QodU51Clok98c7fpCQ==",
       "requires": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/state": "^0.19.4",
@@ -2276,15 +2276,15 @@
       }
     },
     "@codemirror/closebrackets": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/closebrackets/-/closebrackets-0.19.0.tgz",
-      "integrity": "sha512-dFWX5OEVYWRNtGaifSbwIAlymnRRjxWMiMbffbAjF7p0zfGHDbdGkiT56q3Xud63h5/tQdSo5dK1iyNTzHz5vg==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/closebrackets/-/closebrackets-0.19.1.tgz",
+      "integrity": "sha512-ZiLXT6u+VuBK5QnfBbt/Vmfd9Pg6449wn1DIOWFZHUOldg5eFn3VGGjYY2XWuHQz5WuK+7dXamV2KE885O1gyA==",
       "requires": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
+        "@codemirror/state": "^0.19.2",
         "@codemirror/text": "^0.19.0",
-        "@codemirror/view": "^0.19.0"
+        "@codemirror/view": "^0.19.44"
       }
     },
     "@codemirror/commands": {
@@ -2301,11 +2301,11 @@
       }
     },
     "@codemirror/comment": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/comment/-/comment-0.19.0.tgz",
-      "integrity": "sha512-3hqAd0548fxqOBm4khFMcXVIivX8p0bSlbAuZJ6PNoUn/0wXhxkxowPp0FmFzU2+y37Z+ZQF5cRB5EREWPRIiQ==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/comment/-/comment-0.19.1.tgz",
+      "integrity": "sha512-uGKteBuVWAC6fW+Yt8u27DOnXMT/xV4Ekk2Z5mRsiADCZDqYvryrJd6PLL5+8t64BVyocwQwNfz1UswYS2CtFQ==",
       "requires": {
-        "@codemirror/state": "^0.19.0",
+        "@codemirror/state": "^0.19.9",
         "@codemirror/text": "^0.19.0",
         "@codemirror/view": "^0.19.0"
       }
@@ -2585,9 +2585,9 @@
       }
     },
     "@codemirror/rangeset": {
-      "version": "0.19.7",
-      "resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.7.tgz",
-      "integrity": "sha512-17zvQKjjUGjFCdFJAKFgiiQKFqGENmlVzS5vtiPQu1SCEs8ZKyvoFWwilM24+s21AlXxcUXulxEfOLGER5gOtg==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.8.tgz",
+      "integrity": "sha512-1vusIkxSD0vK5KQ22JO/4Ejfww5268PgM/CpKNBSpTpWZEFlZbmOPyRiY4HXO2oEzOpypbA/walMiNInWnrT0Q==",
       "requires": {
         "@codemirror/state": "^0.19.0"
       }
@@ -2616,9 +2616,9 @@
       }
     },
     "@codemirror/state": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.8.tgz",
-      "integrity": "sha512-f8iZJe+1czZNOdt/H6FnuiYnzLF9OKxc7PsKhdEDq0478U2kak5CBbS7JwxkJekeguTyaagoJbnZveqPY2wlmQ==",
+      "version": "0.19.9",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.9.tgz",
+      "integrity": "sha512-psOzDolKTZkx4CgUqhBQ8T8gBc0xN5z4gzed109aF6x7D7umpDRoimacI/O6d9UGuyl4eYuDCZmDFr2Rq7aGOw==",
       "requires": {
         "@codemirror/text": "^0.19.0"
       }
@@ -2642,18 +2642,18 @@
       "integrity": "sha512-T9jnREMIygx+TPC1bOuepz18maGq/92q2a+n4qTqObKwvNMg+8cMTslb8yxeEDEq7S3kpgGWxgO1UWbQRij0dA=="
     },
     "@codemirror/tooltip": {
-      "version": "0.19.14",
-      "resolved": "https://registry.npmjs.org/@codemirror/tooltip/-/tooltip-0.19.14.tgz",
-      "integrity": "sha512-amLSIJ7LROjCOytbP3a8FMP2gm6xD+i/ftvLWTB2mjhu71/zdIZiFrK/lfuoNVoNoKAVjWMTD9Dl5IIuu5SsWQ==",
+      "version": "0.19.15",
+      "resolved": "https://registry.npmjs.org/@codemirror/tooltip/-/tooltip-0.19.15.tgz",
+      "integrity": "sha512-Fb4fKgVziUNSOAhclsvsqHw+1bCfh5po8xT/hw2UQW0UV41t73tJqX5AiqSwmtaDHExN7DFyzG8VQa05d/7g3Q==",
       "requires": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/view": "^0.19.0"
       }
     },
     "@codemirror/view": {
-      "version": "0.19.42",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.42.tgz",
-      "integrity": "sha512-sGpuHYesqNThkAdJHTf4BO0hBeYnAHwamnCGkM6a2G/W5svRJGsFb5Vk/LQPQurDKK9V5fBTRqXH8nKGrIszng==",
+      "version": "0.19.44",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.44.tgz",
+      "integrity": "sha512-vahNUE6hSXdjzs1gcztKPJQhZu+ZIwRpK4ZGZTSD81/CZUVqtlF75W3RCYVgEdjTI1l6ogJmIL6FM2Xj7ltn7Q==",
       "requires": {
         "@codemirror/rangeset": "^0.19.5",
         "@codemirror/state": "^0.19.3",
@@ -2744,9 +2744,9 @@
       "integrity": "sha512-WF3oU6l2WqJjN4OWvnjF9AHyQjHpjcfpyuckM7euFeX6ZGRPpPj+ZCqzf41g81MSksf9aZI4fFCZXWTBusgcWA=="
     },
     "@gravitee/ui-components": {
-      "version": "3.29.4",
-      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.29.4.tgz",
-      "integrity": "sha512-e71i4UA92KyVnshtC7My2Yx84X/mGCklX5NevDiZw+6SgLuYzRYBTMzVyGGFNvE+J1evZk1kejimWKvvZK2VJw==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.30.1.tgz",
+      "integrity": "sha512-mI2J172M+uKU2ty/cLjOyDwqyt/63/FXzEj/63PwYGrFr52Bmg0qXA2m0uRvCH/wnSr/ZjBH3fY9vSmyoOf+bQ==",
       "requires": {
         "@codemirror/basic-setup": "^0.19.1",
         "@codemirror/language-data": "^0.19.1",
@@ -3444,9 +3444,9 @@
       }
     },
     "@lezer/html": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-0.15.0.tgz",
-      "integrity": "sha512-ErmgP/Vv0AhYJvs/Ekb9oue4IzBHemKLi7K8tJ0jgS+20Y8FGC9foK6knCXtEHqdPaxVGQH9PVp7gecLnzLd9Q==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-0.15.1.tgz",
+      "integrity": "sha512-0ZYVhu+RwN6ZMM0gNnTxenRAdoycKc2wvpLfMjP0JkKR0vMxhtuLaIpsq9KW2Mv6l7ux5vdjq8CQ7fKDvia8KA==",
       "requires": {
         "@lezer/lr": "^0.15.0"
       }
@@ -3484,9 +3484,9 @@
       }
     },
     "@lezer/markdown": {
-      "version": "0.15.4",
-      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-0.15.4.tgz",
-      "integrity": "sha512-lJ/zzm8j8H4h3rVzUG2/z3mtOLjeiXIV/kosxVYB+RmJS8dpS1QLUx9p8/F3/HU6bivzmFO3lii97/VDtmKMXA==",
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-0.15.5.tgz",
+      "integrity": "sha512-ZWCZn1FTQFw70RZFmyWRKHsKYTw8OTPc1SmYWMf6xwz83SNd/MIlXcOoyLLwE3/THfUMmnnSjj2ozfPtqA3mFg==",
       "requires": {
         "@lezer/common": "^0.15.0"
       }
@@ -3524,9 +3524,9 @@
       }
     },
     "@lit/reactive-element": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.2.3.tgz",
-      "integrity": "sha512-fu0HW3VpeQdTx2BxjcMD0pEXB6M3xYi7Cgmqr7+jtyN7hNZJGFWqqQFfyJRwP8cBGQz3WW1txBiPPf9dK2xdUg=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.3.0.tgz",
+      "integrity": "sha512-0TKSIuJHXNLM0k98fi0AdMIdUoHIYlDHTP+0Vruc2SOs4T6vU1FinXgSvYd8mSrkt+8R+qdRAXvjpqrMXMyBgw=="
     },
     "@ngneat/spectator": {
       "version": "5.13.4",
@@ -11834,28 +11834,28 @@
       "dev": true
     },
     "lit": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.1.4.tgz",
-      "integrity": "sha512-m1tHAZdXQhiBe0ReAjyVIUeKnHZpBfx+A5R5dkia8dtvIBwOR6KhD+RxaDnCwrEavRqkZAy5ntLv7chiOZCdNg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.2.0.tgz",
+      "integrity": "sha512-FDyxUuczo6cJJY/2Bkgfh1872U4ikUvmK1Cb6+lYC1CW+QOo8CaWXCpvPKFzYsz0ojUxoruBLVrECc7VI2f1dQ==",
       "requires": {
-        "@lit/reactive-element": "^1.1.0",
-        "lit-element": "^3.1.0",
-        "lit-html": "^2.1.0"
+        "@lit/reactive-element": "^1.3.0",
+        "lit-element": "^3.2.0",
+        "lit-html": "^2.2.0"
       }
     },
     "lit-element": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.1.2.tgz",
-      "integrity": "sha512-5VLn5a7anAFH7oz6d7TRG3KiTZQ5GEFsAgOKB8Yc+HDyuDUGOT2cL1CYTz/U4b/xlJxO+euP14pyji+z3Z3kOg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.2.0.tgz",
+      "integrity": "sha512-HbE7yt2SnUtg5DCrWt028oaU4D5F4k/1cntAFHTkzY8ZIa8N0Wmu92PxSxucsQSOXlODFrICkQ5x/tEshKi13g==",
       "requires": {
-        "@lit/reactive-element": "^1.1.0",
-        "lit-html": "^2.1.0"
+        "@lit/reactive-element": "^1.3.0",
+        "lit-html": "^2.2.0"
       }
     },
     "lit-html": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.1.3.tgz",
-      "integrity": "sha512-WgvdwiNeuoT0mYEEJI+AAV2DEtlqzVM4lyDSaeQSg5ZwhS/CkGJBO/4n66alApEuSS9WXw9+ADBp8SPvtDEKSg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.0.tgz",
+      "integrity": "sha512-dJnevgV8VkCuOXLWrjQopDE8nSy8CzipZ/ATfYQv7z7Dct4abblcKecf50gkIScuwCTzKvRLgvTgV0zzagW4gA==",
       "requires": {
         "@types/trusted-types": "^2.0.2"
       }

--- a/gravitee-apim-portal-webui/package.json
+++ b/gravitee-apim-portal-webui/package.json
@@ -34,7 +34,7 @@
     "@angular/platform-browser-dynamic": "^9.1.1",
     "@angular/router": "^9.1.1",
     "@formatjs/intl-relativetimeformat": "^4.5.11",
-    "@gravitee/ui-components": "3.29.4",
+    "@gravitee/ui-components": "3.30.1",
     "@highcharts/map-collection": "^1.1.3",
     "@ibm/plex": "^5.1.0",
     "@ngx-translate/core": "^12.1.2",


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7159

**Description**

Bump `@gravitee/ui-components` to 3.30.1
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/update-ui-components/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
