### PR TITLE
fix: let the API Owner choose the Accept-Encoding

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/connector/http/HttpProxyConnection.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/connector/http/HttpProxyConnection.java
@@ -94,6 +94,9 @@ public class HttpProxyConnection<T extends HttpProxyResponse> extends AbstractHt
             proxyRequest.headers().remove(header.toString());
         }
 
+        // Let the API Owner choose the Accept-Encoding between the gateway and the backend
+        proxyRequest.headers().remove(io.gravitee.common.http.HttpHeaders.ACCEPT_ENCODING);
+
         Future<HttpClientRequest> request = prepareUpstreamRequest(httpClient, port, host, uri);
         request.onComplete(
             new io.vertx.core.Handler<>() {


### PR DESCRIPTION
gravitee-io/issues#7181
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6967-remove-accept-encoding-client-header-3-10/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
