### PR TITLE
feat(console): display shared API keys application subscriptions

### DIFF
--- a/gravitee-apim-console-webui/src/management/application/_applications.scss
+++ b/gravitee-apim-console-webui/src/management/application/_applications.scss
@@ -1,5 +1,6 @@
 @import '../../constants';
 @import './details/subscribe/application-subscribe';
+@import './details/subscriptions/application-subscriptions';
 
 .application-type-box {
   border: 1px solid #bdbdbd;

--- a/gravitee-apim-console-webui/src/management/application/applications.route.ts
+++ b/gravitee-apim-console-webui/src/management/application/applications.route.ts
@@ -176,27 +176,9 @@ function applicationsConfig($stateProvider) {
       template: '<div ui-view></div>',
     })
     .state('management.applications.application.subscriptions.list', {
-      url: '?page&size&:api&:status&:api_key',
+      url: '?page&size&:shared_page&:shared_size&:api&:status&:api_key',
       component: 'applicationSubscriptions',
       resolve: {
-        subscriptions: ($stateParams, ApplicationService: ApplicationService) => {
-          let query = '?page=' + $stateParams.page + '&size=' + $stateParams.size;
-
-          if ($stateParams.status) {
-            query += '&status=' + $stateParams.status;
-          }
-
-          if ($stateParams.api) {
-            query += '&api=' + $stateParams.api;
-          }
-
-          if ($stateParams.api_key) {
-            query += '&api_key=' + $stateParams.api_key;
-          }
-
-          return ApplicationService.listSubscriptions($stateParams.applicationId, query).then((response) => response.data);
-        },
-
         subscribers: ($stateParams, ApplicationService: ApplicationService) =>
           ApplicationService.getSubscribedAPI($stateParams.applicationId).then((response) => response.data),
       },
@@ -231,6 +213,16 @@ function applicationsConfig($stateProvider) {
           value: 10,
           dynamic: true,
         },
+        shared_page: {
+          type: 'int',
+          value: 1,
+          dynamic: true,
+        },
+        shared_size: {
+          type: 'int',
+          value: 10,
+          dynamic: true,
+        },
         api_key: {
           type: 'string',
           dynamic: true,
@@ -238,7 +230,7 @@ function applicationsConfig($stateProvider) {
       },
     })
     .state('management.applications.application.subscriptions.subscription', {
-      url: '/:subscriptionId?page&size&:api&:status&:api_key',
+      url: '/:subscriptionId?page&size&:shared_page&:shared_size&:api&:status&:api_key',
       component: 'applicationSubscription',
       resolve: {
         subscription: ($stateParams, ApplicationService: ApplicationService) =>
@@ -267,6 +259,16 @@ function applicationsConfig($stateProvider) {
           dynamic: true,
         },
         size: {
+          type: 'int',
+          value: 10,
+          dynamic: true,
+        },
+        shared_page: {
+          type: 'int',
+          value: 1,
+          dynamic: true,
+        },
+        shared_size: {
           type: 'int',
           value: 10,
           dynamic: true,

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscription.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscription.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { StateService } from '@uirouter/core';
+import { StateParams, StateService } from '@uirouter/core';
 
 import ApplicationService from '../../../../services/application.service';
 import NotificationService from '../../../../services/notification.service';
@@ -29,7 +29,7 @@ const ApplicationSubscriptionComponent: ng.IComponentOptions = {
     private subscription: any;
     private keys: any[];
     private application: any;
-    private backStateParams: any;
+    private backStateParams: StateParams;
 
     constructor(
       private $mdDialog: angular.material.IDialogService,
@@ -38,14 +38,7 @@ const ApplicationSubscriptionComponent: ng.IComponentOptions = {
       private $state: StateService,
     ) {
       'ngInject';
-
-      this.backStateParams = {
-        api: $state.params.api,
-        status: $state.params.status,
-        page: $state.params.page,
-        size: $state.params.size,
-        api_key: $state.params.api_key,
-      };
+      this.backStateParams = $state.params;
     }
 
     $onInit() {

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscriptions-list.component.html
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscriptions-list.component.html
@@ -1,0 +1,66 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="application-subscriptions-list" ng-if="$ctrl.subscriptions.data.length > 0">
+  <h2>{{ $ctrl.listLabel }}</h2>
+  <div class="gv-form-content" layout="column">
+    <md-table-container>
+      <table md-table class="gv-table-dense">
+        <thead md-head>
+          <tr md-row>
+            <th md-column>API</th>
+            <th md-column>Plan</th>
+            <th md-column>Created at</th>
+            <th md-column>Processed at</th>
+            <th md-column>Start at</th>
+            <th md-column>End at</th>
+            <th md-column>Status</th>
+          </tr>
+        </thead>
+        <tbody md-body>
+          <tr md-row ng-repeat="subscription in $ctrl.subscriptions.data track by subscription.id">
+            <td md-cell>
+              <a ng-click="$ctrl.navigateToSubscription(subscription.id)">
+                {{ $ctrl.subscriptions.metadata[subscription.api].name }}
+              </a>
+            </td>
+            <td md-cell>{{ $ctrl.subscriptions.metadata[subscription.plan].name }}</td>
+            <td md-cell>{{ subscription.created_at | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
+            <td md-cell>{{ subscription.processed_at | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
+            <td md-cell>{{ subscription.starting_at || '-' | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
+            <td md-cell>{{ subscription.ending_at || '-' | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
+            <td md-cell class="status-cell">
+              <md-tooltip ng-if="subscription.reason" md-direction="left">{{ subscription.reason }}</md-tooltip>
+              {{ subscription.status }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </md-table-container>
+
+    <md-table-pagination
+      ng-if="$ctrl.subscriptions.data.length > 0"
+      md-limit="$ctrl.query.size"
+      md-limit-options="[10, 25, 50, 75, 100]"
+      md-page="$ctrl.query.page"
+      md-total="{{ $ctrl.subscriptions.page.total_elements }}"
+      md-on-paginate="$ctrl.onPaginate"
+      md-page-select
+    >
+    </md-table-pagination>
+  </div>
+</div>

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscriptions-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscriptions-list.component.ts
@@ -13,13 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const ApplicationSubscriptionsComponent: ng.IComponentOptions = {
+const ApplicationSubscriptionsListComponent: ng.IComponentOptions = {
   bindings: {
+    listLabel: '<',
     application: '<',
     subscribers: '<',
+    filterEvent: '<',
+    queryParamsPrefix: '<',
+    securityTypes: '<',
+    subscriptions: '=',
   },
-  controller: 'ApplicationSubscriptionsController',
-  template: require('./application-subscriptions.html'),
+  controller: 'ApplicationSubscriptionsListController',
+  template: require('./application-subscriptions-list.component.html'),
 };
 
-export default ApplicationSubscriptionsComponent;
+export default ApplicationSubscriptionsListComponent;

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscriptions-list.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscriptions-list.controller.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as _ from 'lodash';
+import { BehaviorSubject } from 'rxjs';
+import { StateService } from '@uirouter/core';
+
+import { SubscriptionFilter } from './application-subscriptions.controller';
+
+import { PagedResult } from '../../../../entities/pagedResult';
+import ApplicationService from '../../../../services/application.service';
+
+export class SubscriptionQuery {
+  securityTypes?: string[];
+  page?: number = 1;
+  size?: number = 10;
+}
+
+class ApplicationSubscriptionsListController {
+  private listLabel: string;
+  private subscriptions: PagedResult;
+  private query: SubscriptionQuery = new SubscriptionQuery();
+  private filter: SubscriptionFilter = new SubscriptionFilter();
+  private filterEvent: BehaviorSubject<SubscriptionFilter>;
+  private application: any;
+  private securityTypes: string[];
+
+  private queryParamsPrefix: string;
+  private pageQueryParamName: string;
+  private sizeQueryParamName: string;
+
+  private isFirstFilter = true;
+
+  constructor(private ApplicationService: ApplicationService, private $state: StateService) {
+    'ngInject';
+    this.onPaginate = this.onPaginate.bind(this);
+  }
+
+  $onInit(): void {
+    this.query.securityTypes = this.securityTypes;
+    this.pageQueryParamName = `${this.queryParamsPrefix || ''}page`;
+    this.sizeQueryParamName = `${this.queryParamsPrefix || ''}size`;
+
+    if (this.$state.params[this.pageQueryParamName]) {
+      this.query.page = this.$state.params[this.pageQueryParamName];
+    }
+    if (this.$state.params[this.sizeQueryParamName]) {
+      this.query.size = this.$state.params[this.sizeQueryParamName];
+    }
+
+    this.filterEvent.subscribe((filter) => {
+      this.filter = filter;
+      this.doFilter();
+    });
+  }
+
+  onPaginate(page): void {
+    this.query.page = page;
+    this.updatePaginationQueryParams();
+    this.doSearch();
+  }
+
+  doFilter(): void {
+    if (!this.isFirstFilter) {
+      this.query.page = 1; // go back to first page on each new filter search from user
+      this.updatePaginationQueryParams();
+    }
+    this.isFirstFilter = false;
+    this.doSearch();
+  }
+
+  doSearch(): void {
+    const query = this.buildQuery();
+    this.ApplicationService.listSubscriptions(this.application.id, query).then((response) => {
+      this.subscriptions = response.data as PagedResult;
+    });
+  }
+
+  updatePaginationQueryParams(): void {
+    this.$state.transitionTo(
+      this.$state.current,
+      _.merge(this.$state.params, {
+        [this.pageQueryParamName]: this.query.page,
+        [this.sizeQueryParamName]: this.query.size,
+      }),
+      { notify: false },
+    );
+  }
+
+  buildQuery(): string {
+    let query = '?';
+    const parameters: any = {};
+
+    parameters.page = this.query.page;
+    parameters.size = this.query.size;
+
+    if (this.filter.status !== undefined) {
+      parameters.status = this.filter.status.join(',');
+    }
+    if (this.filter.apis !== undefined) {
+      parameters.api = this.filter.apis.join(',');
+    }
+    if (this.filter.apiKey !== undefined) {
+      parameters.api_key = this.filter.apiKey;
+    }
+    if (this.query.securityTypes !== undefined) {
+      parameters.security_types = this.query.securityTypes.join(',');
+    }
+    _.mapKeys(parameters, (value, key) => {
+      return (query += key + '=' + value + '&');
+    });
+
+    return query;
+  }
+
+  navigateToSubscription(subscriptionId: string): void {
+    this.$state.transitionTo('management.applications.application.subscriptions.subscription', { subscriptionId, ...this.$state.params });
+  }
+}
+
+export default ApplicationSubscriptionsListController;

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscriptions.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscriptions.controller.ts
@@ -14,33 +14,27 @@
  * limitations under the License.
  */
 
-import { StateService } from '@uirouter/core';
-import * as angular from 'angular';
 import * as _ from 'lodash';
+import { BehaviorSubject } from 'rxjs';
+import { StateService } from '@uirouter/core';
 
 import { PagedResult } from '../../../../entities/pagedResult';
-import { ApiService } from '../../../../services/api.service';
-import ApplicationService from '../../../../services/application.service';
-import NotificationService from '../../../../services/notification.service';
 
 const defaultStatus = ['ACCEPTED', 'PENDING', 'PAUSED'];
 
-export class SubscriptionQuery {
+export class SubscriptionFilter {
   status?: string[] = defaultStatus;
   apis?: string[];
-  applications?: string[];
-  plans?: string[];
-  api_key: string;
-  page?: number = 1;
-  size?: number = 10;
+  apiKey?: string;
 }
 
 class ApplicationSubscriptionsController {
-  private subscriptions: PagedResult;
   private subscribers: any[];
   private application: any;
-
-  private query: SubscriptionQuery = new SubscriptionQuery();
+  private exclusiveSubscriptions = new PagedResult();
+  private sharedSubscriptions = new PagedResult();
+  private filter = new SubscriptionFilter();
+  private $filterEvent = new BehaviorSubject<SubscriptionFilter>(new SubscriptionFilter());
 
   private status = {
     ACCEPTED: 'Accepted',
@@ -50,209 +44,58 @@ class ApplicationSubscriptionsController {
     REJECTED: 'Rejected',
   };
 
-  private subscriptionsFiltersForm: any;
-
-  constructor(
-    private ApplicationService: ApplicationService,
-    private NotificationService: NotificationService,
-    private $mdDialog: angular.material.IDialogService,
-    private ApiService: ApiService,
-    private $state: StateService,
-  ) {
+  constructor(private $state: StateService) {
     'ngInject';
+  }
 
-    this.onPaginate = this.onPaginate.bind(this);
+  $onInit(): void {
     if (this.$state.params.status) {
       if (Array.isArray(this.$state.params.status)) {
-        this.query.status = this.$state.params.status;
+        this.filter.status = this.$state.params.status;
       } else {
-        this.query.status = this.$state.params.status.split(',');
+        this.filter.status = this.$state.params.status.split(',');
       }
     }
     if (this.$state.params.api) {
       if (Array.isArray(this.$state.params.api)) {
-        this.query.apis = this.$state.params.api;
+        this.filter.apis = this.$state.params.api;
       } else {
-        this.query.apis = this.$state.params.api.split(',');
+        this.filter.apis = this.$state.params.api.split(',');
       }
     }
     if (this.$state.params.api_key) {
-      this.query.api_key = this.$state.params.api_key;
-    }
-  }
-
-  onPaginate(page) {
-    this.query.page = page;
-    this.doSearch();
-  }
-
-  clearFilters() {
-    this.subscriptionsFiltersForm.$setPristine();
-    this.query = new SubscriptionQuery();
-    this.doSearch();
-  }
-
-  search() {
-    this.query.page = 1;
-    this.query.size = 10;
-    this.doSearch();
-  }
-
-  buildQuery() {
-    let query = '?page=' + this.query.page + '&size=' + this.query.size + '&';
-    const parameters: any = {};
-
-    if (this.query.status !== undefined) {
-      parameters.status = this.query.status.join(',');
+      this.filter.apiKey = this.$state.params.api_key;
     }
 
-    if (this.query.apis !== undefined) {
-      parameters.api = this.query.apis.join(',');
-    }
-
-    if (this.query.api_key !== undefined) {
-      parameters.api_key = this.query.api_key;
-    }
-
-    _.mapKeys(parameters, (value, key) => {
-      return (query += key + '=' + value + '&');
-    });
-
-    return query;
+    this.doFilter();
   }
 
-  doSearch() {
-    const query = this.buildQuery();
+  hasFilter(): boolean {
+    return (
+      (this.filter.apis && this.filter.apis.length > 0) ||
+      !_.isEmpty(this.filter.apiKey) ||
+      _.difference(defaultStatus, this.filter.status).length > 0 ||
+      _.difference(this.filter.status, defaultStatus).length > 0
+    );
+  }
+
+  clearFilter(): void {
+    this.filter = new SubscriptionFilter();
+    this.doFilter();
+  }
+
+  doFilter(): void {
     this.$state.transitionTo(
       this.$state.current,
       _.merge(this.$state.params, {
-        status: this.query.status ? this.query.status.join(',') : '',
-        api: this.query.apis ? this.query.apis.join(',') : '',
-        page: this.query.page,
-        size: this.query.size,
-        api_key: this.query.api_key,
+        status: this.filter.status ? this.filter.status.join(',') : '',
+        api: this.filter.apis ? this.filter.apis.join(',') : '',
+        api_key: this.filter.apiKey ? this.filter.apiKey : '',
       }),
       { notify: false },
     );
 
-    this.ApplicationService.listSubscriptions(this.application.id, query).then((response) => {
-      this.subscriptions = response.data as PagedResult;
-    });
-  }
-
-  toggleSubscription(scope, subscription) {
-    scope.toggle();
-    if (!subscription.apiKeys) {
-      this.listApiKeys(subscription);
-    }
-  }
-
-  listApiKeys(subscription) {
-    this.ApplicationService.listApiKeys(this.application.id, subscription.id).then((response) => {
-      subscription.apiKeys = response.data;
-    });
-  }
-
-  hasKeysDefined() {
-    return this.subscriptions !== null && Object.keys(this.subscriptions).length > 0;
-  }
-
-  generateAPIKey(applicationId, subscription) {
-    this.$mdDialog
-      .show({
-        controller: 'DialogConfirmController',
-        controllerAs: 'ctrl',
-        template: require('../../../../components/dialog/confirmWarning.dialog.html'),
-        clickOutsideToClose: true,
-        locals: {
-          title: 'Are you sure you want to renew your API Key?',
-          msg: 'Your previous API Key will be no longer valid in 1 hour !',
-          confirmButton: 'Renew',
-        },
-      })
-      .then((response) => {
-        if (response) {
-          this.ApplicationService.renewApiKey(applicationId, subscription.id).then(() => {
-            this.NotificationService.show('A new API Key has been generated');
-            this.listApiKeys(subscription);
-          });
-        }
-      });
-  }
-
-  revoke(subscription, apiKey) {
-    this.$mdDialog
-      .show({
-        controller: 'DialogConfirmController',
-        controllerAs: 'ctrl',
-        template: require('../../../../components/dialog/confirmWarning.dialog.html'),
-        clickOutsideToClose: true,
-        locals: {
-          title: "Are you sure you want to revoke API Key '" + apiKey.key + "'?",
-          confirmButton: 'Revoke',
-        },
-      })
-      .then((response) => {
-        if (response) {
-          this.ApplicationService.revokeApiKey(this.application.id, subscription.id, apiKey.id).then(() => {
-            this.NotificationService.show('API Key ' + apiKey.key + ' has been revoked !');
-            this.listApiKeys(subscription);
-          });
-        }
-      });
-  }
-
-  onClipboardSuccess(e) {
-    this.NotificationService.show('API Key has been copied to clipboard');
-    e.clearSelection();
-  }
-
-  /*
-  showSubscribeApiModal(ev) {
-    this.$mdDialog.show({
-      controller: 'DialogSubscribeApiController',
-      templateUrl: 'application/dialog/subscribeApi.dialog.html',
-      parent: angular.element(document.body),
-      targetEvent: ev,
-      clickOutsideToClose: true,
-      locals: {
-        application: this.application,
-        subscriptions: this.subscriptions
-      }
-    }).then(application =>{
-      if (application) {
-        // TODO : check it ! There was no ApiService...
-        this.ApiService.getSubscriptions(application.id);
-      }
-    });
-  }
-  */
-
-  showExpirationModal(apiId, subscriptionId, apiKey) {
-    this.$mdDialog
-      .show({
-        controller: 'DialogApiKeyExpirationController',
-        controllerAs: 'dialogApiKeyExpirationController',
-        template: require('../../../api/portal/subscriptions/dialog/apikey.expiration.dialog.html'),
-        clickOutsideToClose: true,
-      })
-      .then((expirationDate) => {
-        apiKey.expire_at = expirationDate;
-
-        this.ApiService.updateApiKey(apiId, subscriptionId, apiKey).then(() => {
-          this.NotificationService.show('An expiration date has been settled for API Key');
-        });
-      });
-  }
-
-  hasFilter() {
-    return (
-      _.difference(defaultStatus, this.query.status).length > 0 ||
-      _.difference(this.query.status, defaultStatus).length > 0 ||
-      (this.query.applications && this.query.applications.length) ||
-      (this.query.plans && this.query.plans.length) ||
-      this.query.api_key
-    );
+    this.$filterEvent.next(this.filter);
   }
 }
 

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscriptions.html
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscriptions.html
@@ -15,104 +15,70 @@
     limitations under the License.
 
 -->
-<div class="gv-forms gv-forms-fluid" layout="column">
+<div class="application-subscriptions gv-forms gv-forms-fluid" layout="column">
   <application-header application="$ctrl.application"></application-header>
-  <div class="gv-form">
-    <h2>Subscriptions</h2>
-    <div class="gv-form-content" layout="column">
-      <form ng-submit="$ctrl.search()" name="$ctrl.subscriptionsFiltersForm">
-        <div layout-gt-sm="row">
-          <md-input-container class="md-block" flex-gt-sm flex="40">
-            <label>Api</label>
-            <md-select ng-model="$ctrl.query.apis" placeholder="Apis" multiple>
-              <md-option ng-value="subscriber.id" ng-repeat="subscriber in $ctrl.subscribers track by subscriber.id"
-                >{{ subscriber.name }} ()
-              </md-option>
-            </md-select>
-          </md-input-container>
-          <md-input-container class="md-block" flex-gt-sm flex="40">
-            <label>Status</label>
-            <md-select ng-model="$ctrl.query.status" placeholder="Status" multiple>
-              <md-option ng-value="key" ng-repeat="(key, value) in $ctrl.status">{{ value }}</md-option>
-            </md-select>
-          </md-input-container>
-          <md-input-container class="md-block" flex-gt-sm flex="20">
-            <label>API key</label>
-            <input ng-model="$ctrl.query.api_key" />
-          </md-input-container>
-          <div>
-            <md-button type="submit" class="md-raised md-primary"> Search </md-button>
-            <md-button type="button" class="md-raised" ng-click="$ctrl.clearFilters()" ng-disabled="!$ctrl.hasFilter()"> Clear </md-button>
-          </div>
-        </div>
-      </form>
 
-      <md-table-container ng-if="$ctrl.subscriptions.data.length > 0">
-        <table md-table class="gv-table-dense">
-          <thead md-head>
-            <tr md-row>
-              <th md-column>API</th>
-              <th md-column>Plan</th>
-              <th md-column>Created at</th>
-              <th md-column>Processed at</th>
-              <th md-column>Start at</th>
-              <th md-column>End at</th>
-              <th md-column>Status</th>
-            </tr>
-          </thead>
-          <tbody md-body>
-            <tr md-row ng-repeat="subscription in $ctrl.subscriptions.data track by subscription.id">
-              <td md-cell>
-                <a
-                  style="font-weight: bold"
-                  ui-sref="management.applications.application.subscriptions.subscription({subscriptionId: subscription.id,
-            page: $ctrl.query.page,
-            size: $ctrl.query.size,
-            status: $ctrl.query.status,
-            api: $ctrl.query.apis,
-            api_key: $ctrl.query.api_key})"
-                >
-                  {{$ctrl.subscriptions.metadata[subscription.api].name}}
-                </a>
-              </td>
-              <td md-cell>{{$ctrl.subscriptions.metadata[subscription.plan].name}}</td>
-              <td md-cell>{{subscription.created_at | date:'yyyy-MM-dd HH:mm:ss'}}</td>
-              <td md-cell>{{subscription.processed_at | date:'yyyy-MM-dd HH:mm:ss'}}</td>
-              <td md-cell>{{subscription.starting_at || '-' | date:'yyyy-MM-dd HH:mm:ss'}}</td>
-              <td md-cell>{{subscription.ending_at || '-' | date:'yyyy-MM-dd HH:mm:ss'}}</td>
-              <td md-cell style="text-transform: capitalize">
-                <md-tooltip ng-if="subscription.reason" md-direction="left">{{subscription.reason}}</md-tooltip>
-                {{subscription.status}}
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </md-table-container>
-
-      <md-table-pagination
-        ng-if="$ctrl.subscriptions.data.length > 0"
-        md-limit="$ctrl.subscriptions.page.per_page"
-        md-limit-options="[10, 25, 50, 75, 100]"
-        md-page="$ctrl.subscriptions.page.current"
-        md-total="{{$ctrl.subscriptions.page.total_elements}}"
-        md-on-paginate="$ctrl.onPaginate"
-        md-page-select
-      >
-      </md-table-pagination>
-
-      <gravitee-empty-state
-        ng-if="$ctrl.subscriptions.data.length === 0"
-        icon="vpn_key"
-        model="Subscription"
-        message="Application's subscriptions will appear here"
-      ></gravitee-empty-state>
-      <md-button
-        ng-if="$ctrl.subscriptions.data.length === 0"
-        class="md-raised"
-        style="width: 200px; margin: 0 auto"
-        ui-sref="management.applications.application.subscriptions.subscribe"
-        >Start playing with APIs</md-button
-      >
+  <form ng-submit="$ctrl.doFilter()" name="$ctrl.subscriptionsFiltersForm">
+    <div layout-gt-sm="row">
+      <md-input-container class="md-block" flex-gt-sm flex="40">
+        <label>Api</label>
+        <md-select ng-model="$ctrl.filter.apis" placeholder="Apis" multiple>
+          <md-option ng-value="subscriber.id" ng-repeat="subscriber in $ctrl.subscribers track by subscriber.id"
+            >{{ subscriber.name }}
+          </md-option>
+        </md-select>
+      </md-input-container>
+      <md-input-container class="md-block" flex-gt-sm flex="40">
+        <label>Status</label>
+        <md-select ng-model="$ctrl.filter.status" placeholder="Status" multiple>
+          <md-option ng-value="key" ng-repeat="(key, value) in $ctrl.status">{{ value }}</md-option>
+        </md-select>
+      </md-input-container>
+      <md-input-container class="md-block" flex-gt-sm flex="20">
+        <label>API key</label>
+        <input ng-model="$ctrl.filter.apiKey" />
+      </md-input-container>
+      <div>
+        <md-button type="submit" class="md-raised md-primary"> Search </md-button>
+        <md-button type="button" class="md-raised" ng-click="$ctrl.clearFilter()" ng-disabled="!$ctrl.hasFilter()"> Clear </md-button>
+      </div>
     </div>
+  </form>
+
+  <div ng-if="$ctrl.application.api_key_mode !== 'SHARED'">
+    <application-subscriptions-list
+      list-label="'Subscriptions'"
+      application="$ctrl.application"
+      subscribers="$ctrl.subscribers"
+      filter-event="$ctrl.$filterEvent"
+      subscriptions="$ctrl.exclusiveSubscriptions"
+    ></application-subscriptions-list>
+  </div>
+
+  <div ng-if="$ctrl.application.api_key_mode === 'SHARED'">
+    <application-subscriptions-list
+      list-label="'Subscriptions'"
+      application="$ctrl.application"
+      subscribers="$ctrl.subscribers"
+      filter-event="$ctrl.$filterEvent"
+      subscriptions="$ctrl.exclusiveSubscriptions"
+      security-types="['OAUTH2','JWT']"
+    ></application-subscriptions-list>
+    <application-subscriptions-list
+      list-label="'Subscriptions using shared API Key'"
+      application="$ctrl.application"
+      subscribers="$ctrl.subscribers"
+      filter-event="$ctrl.$filterEvent"
+      security-types="['API_KEY']"
+      subscriptions="$ctrl.sharedSubscriptions"
+      query-params-prefix="'shared_'"
+    ></application-subscriptions-list>
+  </div>
+
+  <div class="empty-list" ng-if="$ctrl.exclusiveSubscriptions.data.length === 0 && $ctrl.sharedSubscriptions.data.length === 0">
+    <gravitee-empty-state icon="vpn_key" model="Subscription" message="Application's subscriptions will appear here"></gravitee-empty-state>
+    <md-button class="subscribe-button md-raised" ui-sref="management.applications.application.subscriptions.subscribe"
+      >Start playing with APIs</md-button
+    >
   </div>
 </div>

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscriptions.scss
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscriptions.scss
@@ -1,0 +1,20 @@
+.application-subscriptions {
+  .empty-list {
+    text-align: center;
+
+    .subscribe-button {
+      width: 200px;
+      margin: 0 auto;
+    }
+  }
+
+  .application-subscriptions-list {
+    .api-link {
+      font-weight: bold;
+    }
+
+    .status-cell {
+      text-transform: capitalize;
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/management.module.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/management.module.ajs.ts
@@ -574,6 +574,8 @@ import { OrgSettingsRoleComponent } from '../organization/configuration/roles/ro
 
 import { upgradeModule } from '@uirouter/angular-hybrid';
 import uiRouter from '@uirouter/angularjs';
+import ApplicationSubscriptionsListComponent from '../management/application/details/subscriptions/application-subscriptions-list.component';
+import ApplicationSubscriptionsListController from '../management/application/details/subscriptions/application-subscriptions-list.controller';
 
 (<any>window).moment = moment;
 require('angular-moment-picker');
@@ -948,6 +950,7 @@ graviteeManagementModule.component('applicationHeader', ApplicationHeaderCompone
 graviteeManagementModule.component('applicationGeneral', ApplicationGeneralComponent);
 graviteeManagementModule.component('applicationSubscriptions', ApplicationSubscriptionsComponent);
 graviteeManagementModule.component('applicationSubscription', ApplicationSubscriptionComponent);
+graviteeManagementModule.component('applicationSubscriptionsList', ApplicationSubscriptionsListComponent);
 graviteeManagementModule.component('applicationMembers', ApplicationMembersComponent);
 graviteeManagementModule.component('applicationAnalytics', ApplicationAnalyticsComponent);
 graviteeManagementModule.component('applicationLogs', ApplicationLogsComponent);
@@ -957,6 +960,7 @@ graviteeManagementModule.controller('ApplicationsController', ApplicationsContro
 graviteeManagementModule.controller('ApplicationGeneralController', ApplicationGeneralController);
 graviteeManagementModule.controller('ApplicationMembersController', ApplicationMembersController);
 graviteeManagementModule.controller('ApplicationSubscriptionsController', ApplicationSubscriptionsController);
+graviteeManagementModule.controller('ApplicationSubscriptionsListController', ApplicationSubscriptionsListController);
 graviteeManagementModule.controller('ApplicationAnalyticsController', ApplicationAnalyticsController);
 graviteeManagementModule.controller('ApplicationLogsController', ApplicationLogsController);
 graviteeManagementModule.controller('DialogTransferApplicationController', DialogTransferApplicationController);


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6794
https://github.com/gravitee-io/issues/issues/6795

**Description**

feat(console): display shared API keys application subscriptions

In application subscriptions list, display 2 subscriptions lists :
- 1 containing subscriptions not using the shared API key (if there are some)
- 1 containing subscriptions using the shared API key (if there are some)

Both lists share same filters, but have independant server-side pagination.
Filters and paginations parameters are persisted in URL, that permit to get back to the same view during navigation.

![image](https://user-images.githubusercontent.com/87964124/156383987-d21dfad5-0459-4dc3-a2d0-6ac9a762304f.png)



<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/feat-6795-shared-api-key-display/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lyipmjhwhj.chromatic.com)
<!-- Storybook placeholder end -->
