### PR TITLE
feat: personal token matching performance improvment

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/TokenServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/TokenServiceTest.java
@@ -22,8 +22,8 @@ import static io.gravitee.rest.api.model.TokenReferenceType.USER;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.Optional.of;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.anyMap;
@@ -37,14 +37,12 @@ import io.gravitee.rest.api.model.NewTokenEntity;
 import io.gravitee.rest.api.model.TokenEntity;
 import io.gravitee.rest.api.service.exceptions.TokenNameAlreadyExistsException;
 import io.gravitee.rest.api.service.impl.TokenServiceImpl;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -227,5 +225,57 @@ public class TokenServiceTest {
 
         verify(auditService).createEnvironmentAuditLog(anyMap(), eq(TOKEN_DELETED), any(Date.class), isNull(), eq(token));
         verify(tokenRepository).delete(TOKEN_ID);
+    }
+
+    @Test
+    public void findByToken_should_prioritize_last_used_token() throws TechnicalException {
+        Token tokens[] = { mock(Token.class), mock(Token.class), mock(Token.class), mock(Token.class) };
+
+        when(tokens[0].getLastUseAt()).thenReturn(null);
+
+        when(tokens[1].getLastUseAt()).thenReturn(new Date(1486772200000L));
+        when(tokens[1].getToken()).thenReturn("encodedToken1");
+
+        when(tokens[2].getLastUseAt()).thenReturn(new Date(1486772200999L));
+        when(tokens[2].getToken()).thenReturn("encodedToken2");
+
+        when(tokens[3].getLastUseAt()).thenReturn(null);
+
+        when(tokenRepository.findAll()).thenReturn(newHashSet(tokens));
+        doAnswer(returnsFirstArg()).when(tokenRepository).update(any());
+
+        when(passwordEncoder.matches("inputToken", "encodedToken2")).thenReturn(false);
+        when(passwordEncoder.matches("inputToken", "encodedToken1")).thenReturn(true);
+
+        Token resultToken = tokenService.findByToken("inputToken");
+
+        // Assert that token1 has been returned cause it's the one matching input token
+        assertSame(resultToken, tokens[1]);
+
+        // Assert that there was only 2 interactions with the passwordEncoder check, in this order :
+        //   - first, token2 cause it's the most recently used
+        //   - then, token1 cause it's the next most recently used
+        // Token0 and token3 has not been checked
+        InOrder inOrder = inOrder(passwordEncoder);
+        inOrder.verify(passwordEncoder, times(1)).matches("inputToken", "encodedToken2");
+        inOrder.verify(passwordEncoder, times(1)).matches("inputToken", "encodedToken1");
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void findByToken_should_throw_IllegalStateException_when_no_token_matches() throws TechnicalException {
+        Token tokens[] = { mock(Token.class), mock(Token.class), mock(Token.class), mock(Token.class) };
+        when(tokenRepository.findAll()).thenReturn(newHashSet(tokens));
+        when(passwordEncoder.matches(any(), any())).thenReturn(false);
+
+        try {
+            tokenService.findByToken("inputToken");
+        } catch (Exception e) {
+            // Assert that all 4 tokens have been checked using passwordEncoder
+            // And none of them have been updated
+            verify(passwordEncoder, times(4)).matches(any(), any());
+            verify(tokenRepository, never()).update(any());
+            throw e;
+        }
     }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7187

**Description**

feat: personal token matching performance improvment

In TokenServiceImpl, the process matching the incoming request token with the token stored in database is not optimized and consumes a lot of CPU, causing troubles to our customer.

It searches all tokens in tokens collection, and, for each token : bcrypt the input token in order to compare it to database token.

So, for example, if there are 100 tokens in database,
According to the database tokens ordering ; if the second token is matching, there will be 2 bcrypt operations.
But if the 99th token is matching, there will be 99 bcrypt operations, which is consuming lot of time and CPU.

With the current Bcrypt algorithm (using a random salt), there is no way to compare the input token with the database token without Bcrypting it.

The workaround is to prioritize the checks of the token that were used most recently.
In this way, if there are 2 successive calls with the same token, the 2nd call will check only 1 token.

**Benchmark**

**Scenario 1 :**
On local computer.
100 tokens in database, none have been used yet.
100 **successive** calls to MAPI, on GET /apis.

|| Before      | After |
| ----------- | ----------- | ----------- |
|bCrypt operations count| 5451 | 149 |
|bCrypt count explanation| =100*random(1->100) | =random(1->100)+99 |
|max CPU| 7% | 7% |
|Execution time| > 6 minutes | 13 seconds |

In the `after`, first call parse mutliple tokens according to database ordering, but all 99 subsequent calls check only the first token.

**Scenario 2 :**
On local computer.
100 tokens in database, none have been used yet.
100 **parrallel simultaneous** calls to MAPI, on GET /apis.

|| Before      | After |
| ----------- | ----------- | ----------- |
|bCrypt operations count| 2900 | SAME |
|bCrypt count explanation| =100*random(1->100) | SAME |
|max CPU| 100% | SAME |
|Execution time| 30 seconds | SAME |

Launch scenario 2 again (now, the use date of the token has been set by the first launch).

|| Before      | After |
| ----------- | ----------- | ----------- |
|bCrypt operations count| 2900 | 100 |
|bCrypt count explanation| =100*random(1->100) | 100 |
|max CPU| 100% | 60% |
|Execution time| 30 seconds | 1 second |

