### PR TITLE
Clean flaky tests by removing unneeded VertxExtension 

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketAcceptTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketAcceptTest.java
@@ -22,13 +22,11 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.WebSocket;
-import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
@@ -36,7 +34,6 @@ import org.junit.rules.TestRule;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-@ExtendWith(VertxExtension.class)
 @ApiDescriptor("/io/gravitee/gateway/standalone/websocket/teams.json")
 public class WebsocketAcceptTest extends AbstractWebSocketGatewayTest {
 
@@ -73,6 +70,8 @@ public class WebsocketAcceptTest extends AbstractWebSocketGatewayTest {
                             if (frame.isText()) {
                                 Assert.assertEquals("PING", frame.textData());
                                 testContext.completeNow();
+                            } else {
+                                testContext.failNow("The frame is not a text frame");
                             }
                         }
                     );

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketBidirectionalTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketBidirectionalTest.java
@@ -36,7 +36,6 @@ import org.junit.rules.TestRule;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-@ExtendWith(VertxExtension.class)
 @ApiDescriptor("/io/gravitee/gateway/standalone/websocket/teams.json")
 public class WebsocketBidirectionalTest extends AbstractWebSocketGatewayTest {
 
@@ -58,6 +57,8 @@ public class WebsocketBidirectionalTest extends AbstractWebSocketGatewayTest {
                             if (frame.isText()) {
                                 Assert.assertEquals("PONG", frame.textData());
                                 testContext.completeNow();
+                            } else {
+                                testContext.failNow("The frame is not a text frame");
                             }
                         }
                     );

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketCloseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketCloseTest.java
@@ -37,7 +37,6 @@ import org.junit.rules.TestRule;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-@ExtendWith(VertxExtension.class)
 @ApiDescriptor("/io/gravitee/gateway/standalone/websocket/teams.json")
 public class WebsocketCloseTest extends AbstractWebSocketGatewayTest {
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketPingFrameTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketPingFrameTest.java
@@ -37,7 +37,6 @@ import org.junit.rules.TestRule;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-@ExtendWith(VertxExtension.class)
 @ApiDescriptor("/io/gravitee/gateway/standalone/websocket/teams.json")
 public class WebsocketPingFrameTest extends AbstractWebSocketGatewayTest {
 
@@ -59,6 +58,8 @@ public class WebsocketPingFrameTest extends AbstractWebSocketGatewayTest {
                             if (frame.isPing()) {
                                 Assert.assertEquals("PING", frame.textData());
                                 testContext.completeNow();
+                            } else {
+                                testContext.failNow("The frame is not a text frame");
                             }
                         }
                     );

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketRejectTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketRejectTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
-@ExtendWith(VertxExtension.class)
 @ApiDescriptor("/io/gravitee/gateway/standalone/websocket/teams.json")
 public class WebsocketRejectTest extends AbstractWebSocketGatewayTest {
 


### PR DESCRIPTION
**Issue**

NA

**Description**

The Vertx documentation about `vertx-junit5` was misleading as code snippets have both `@ExtendWith(VertxExtension.class)` and `VertxTestContext testContext = new VertxTestContext();`

See https://vertx.io/docs/vertx-junit5/java/#_a_test_context_for_asynchronous_executions

However, we only need `VertxExtension` if we want to have `VertxTestContext` and `Vertx` injected as test arguments. I tried that and it wasn't working. I will do some extra investigation on that but at the same time, I don't want this "bad" practice to spread in our codebase so I removed it.

Also, I added some failing conditions to make the test more robust.


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pkqmcqwabo.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/update-flaky-tests/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
