### PR TITLE
chore: bump version of metrics-reporter policy to 1.2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -601,7 +601,10 @@ jobs:
                   command: |
                       export BRANCH_ID=$(echo "$CIRCLE_BRANCH" | sed -E 's/[~^]+//g' | sed -E 's/[^a-zA-Z0-9]+/-/g' | sed -E 's/^-+|-+$//g' | tr "[:upper:]" "[:lower:]" | cut -c -60)
                       az login --service-principal -u $AZURE_APPLICATION_ID --tenant $AZURE_TENANT -p $AZURE_APPLICATION_SECRET
-                      az storage container create -n $BRANCH_ID --public-access blob
+                      CONTAINER_EXISTS=$(az storage container exists -n $BRANCH_ID | jq .exists)
+                      if [ "$CONTAINER_EXISTS" = false ] ; then
+                        az storage container create -n $BRANCH_ID --public-access blob
+                      fi             
                       az storage blob upload-batch -s gravitee-apim-console-webui/dist -d $BRANCH_ID
             - notify-on-failure
 

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -67,7 +67,7 @@
         <gravitee-policy-jwt.version>1.22.0</gravitee-policy-jwt.version>
         <gravitee-policy-keyless.version>1.4.0</gravitee-policy-keyless.version>
         <gravitee-policy-latency.version>1.4.0</gravitee-policy-latency.version>
-        <gravitee-policy-metrics-reporter.version>1.2.0</gravitee-policy-metrics-reporter.version>
+        <gravitee-policy-metrics-reporter.version>1.2.1</gravitee-policy-metrics-reporter.version>
         <gravitee-policy-mock.version>1.13.0</gravitee-policy-mock.version>
         <gravitee-policy-oauth2.version>1.19.0</gravitee-policy-oauth2.version>
         <gravitee-policy-openid-connect-userinfo.version>1.5.0</gravitee-policy-openid-connect-userinfo.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7194


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cnsghuwhws.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-7194-reporting-after-response-end/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
