### PR TITLE
chore: bump version of metrics-reporter policy to 1.1.1

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -65,7 +65,7 @@
         <gravitee-policy-jwt.version>1.20.0</gravitee-policy-jwt.version>
         <gravitee-policy-keyless.version>1.4.0</gravitee-policy-keyless.version>
         <gravitee-policy-latency.version>1.4.0</gravitee-policy-latency.version>
-        <gravitee-policy-metrics-reporter.version>1.1.0</gravitee-policy-metrics-reporter.version>
+        <gravitee-policy-metrics-reporter.version>1.1.1</gravitee-policy-metrics-reporter.version>
         <gravitee-policy-mock.version>1.12.0</gravitee-policy-mock.version>
         <gravitee-policy-oauth2.version>1.18.0</gravitee-policy-oauth2.version>
         <gravitee-policy-openid-connect-userinfo.version>1.4.0</gravitee-policy-openid-connect-userinfo.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7196

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-7196-reporting-after-response-end/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
