### PR TITLE
Fix debug selection

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-response/policy-studio-debug-response.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-response/policy-studio-debug-response.component.ts
@@ -51,6 +51,9 @@ export class PolicyStudioDebugResponseComponent implements OnChanges {
   };
 
   ngOnChanges(): void {
+    this.responseDisplayableVM = undefined;
+    this.inspectorVM = undefined;
+
     if (this.debugResponse && !this.debugResponse.isLoading) {
       this.responseDisplayableVM = {
         statusCode: this.debugResponse.response?.statusCode,

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/debug/policy-studio-debug.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/debug/policy-studio-debug.component.spec.ts
@@ -176,6 +176,29 @@ describe('PolicyStudioDebugComponent', () => {
       const expectedDebugStepAttributes = fakeDebugEvent().payload.debugSteps[1].result.attributes as Record<string, unknown>;
       expect(inspectorContent).toContain(expectedDebugStepAttributes.dev);
     });
+
+    it('should clear inspector selection after new request', fakeAsync(async () => {
+      const getInspectorContent = () =>
+        fixture.nativeElement.querySelector('.policy-studio-debug-response__display-response__inspector')?.textContent ?? null;
+
+      // Select card and expect inspector content
+      [...fixture.nativeElement.querySelectorAll('.policy-studio-debug-timeline-card').values()]
+        .find((card) => card.textContent.includes('Header  policy-assign-attributes'))
+        .click();
+      fixture.detectChanges();
+      expect(getInspectorContent()).not.toEqual(null);
+
+      // Send new debug request and expect empty inspector content
+      const sendButton = await loader.getHarness(MatButtonHarness.with({ text: 'Send' }));
+      await sendButton.click();
+      tick();
+      expectSendDebugEvent(EVENT_ID);
+      tick(1000);
+      expectGetDebugEvent(EVENT_ID, true);
+      fixture.detectChanges();
+
+      expect(getInspectorContent()).toEqual(null);
+    }));
   });
 
   function expectSendDebugEvent(eventId: string) {


### PR DESCRIPTION
**Issue**
https://github.com/gravitee-io/issues/issues/7199

**Description**
Reset inspector selection on each debug request

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tcwfesoftn.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-debug-selection/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
