### PR TITLE
feat: add labels in DeployModelCommand

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeployModelCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeployModelCommandHandler.java
@@ -32,6 +32,7 @@ import io.gravitee.rest.api.service.cockpit.services.ApiServiceCockpit;
 import io.gravitee.rest.api.service.cockpit.services.CockpitApiPermissionChecker;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.reactivex.Single;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -79,6 +80,7 @@ public class DeployModelCommandHandler implements CommandHandler<DeployModelComm
         String swaggerDefinition = payload.getSwaggerDefinition();
         String environmentId = payload.getEnvironmentId();
         DeploymentMode mode = DeploymentMode.fromDeployModelPayload(payload);
+        List<String> labels = payload.getLabels();
 
         try {
             final EnvironmentEntity environment = environmentService.findByCockpitId(environmentId);
@@ -97,7 +99,7 @@ public class DeployModelCommandHandler implements CommandHandler<DeployModelComm
                     return Single.just(reply);
                 }
 
-                result = cockpitApiService.updateApi(apiId, user.getId(), swaggerDefinition, environment.getId(), mode);
+                result = cockpitApiService.updateApi(apiId, user.getId(), swaggerDefinition, environment.getId(), mode, labels);
             } else {
                 var message = permissionChecker.checkCreatePermission(user.getId(), environment.getId(), mode);
 
@@ -107,7 +109,7 @@ public class DeployModelCommandHandler implements CommandHandler<DeployModelComm
                     return Single.just(reply);
                 }
 
-                result = cockpitApiService.createApi(apiId, user.getId(), swaggerDefinition, environment.getId(), mode);
+                result = cockpitApiService.createApi(apiId, user.getId(), swaggerDefinition, environment.getId(), mode, labels);
             }
 
             if (result.isSuccess()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpit.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpit.java
@@ -17,12 +17,27 @@ package io.gravitee.rest.api.service.cockpit.services;
 
 import io.gravitee.rest.api.model.api.ApiEntityResult;
 import io.gravitee.rest.api.service.cockpit.model.DeploymentMode;
+import java.util.List;
 
 /**
  * @author Julien GIOVARESCO (julien.giovaresco at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface ApiServiceCockpit {
-    ApiEntityResult createApi(String apiId, String userId, String swaggerDefinition, String environmentId, DeploymentMode mode);
-    ApiEntityResult updateApi(String apiId, String userId, String swaggerDefinition, String environmentId, DeploymentMode mode);
+    ApiEntityResult createApi(
+        String apiId,
+        String userId,
+        String swaggerDefinition,
+        String environmentId,
+        DeploymentMode mode,
+        List<String> labels
+    );
+    ApiEntityResult updateApi(
+        String apiId,
+        String userId,
+        String swaggerDefinition,
+        String environmentId,
+        DeploymentMode mode,
+        List<String> labels
+    );
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImpl.java
@@ -80,50 +80,76 @@ public class ApiServiceCockpitImpl implements ApiServiceCockpit {
     }
 
     @Override
-    public ApiEntityResult createApi(String apiId, String userId, String swaggerDefinition, String environmentId, DeploymentMode mode) {
+    public ApiEntityResult createApi(
+        String apiId,
+        String userId,
+        String swaggerDefinition,
+        String environmentId,
+        DeploymentMode mode,
+        List<String> labels
+    ) {
         if (mode == DeploymentMode.API_MOCKED) {
             logger.debug("Create Mocked Api [{}].", apiId);
-            return createMockedApi(apiId, userId, swaggerDefinition, environmentId);
+            return createMockedApi(apiId, userId, swaggerDefinition, environmentId, labels);
         }
 
         if (mode == DeploymentMode.API_PUBLISHED) {
             logger.debug("Create Published Api [{}].", apiId);
-            return createPublishedApi(apiId, userId, swaggerDefinition, environmentId);
+            return createPublishedApi(apiId, userId, swaggerDefinition, environmentId, labels);
         }
 
         logger.debug("Create Documented Api [{}].", apiId);
-        return createDocumentedApi(apiId, userId, swaggerDefinition, environmentId);
+        return createDocumentedApi(apiId, userId, swaggerDefinition, environmentId, labels);
     }
 
     @Override
-    public ApiEntityResult updateApi(String apiId, String userId, String swaggerDefinition, String environmentId, DeploymentMode mode) {
+    public ApiEntityResult updateApi(
+        String apiId,
+        String userId,
+        String swaggerDefinition,
+        String environmentId,
+        DeploymentMode mode,
+        List<String> labels
+    ) {
         if (mode == DeploymentMode.API_DOCUMENTED) {
             logger.debug("Update Documented Api [{}].", apiId);
-            return updateDocumentedApi(apiId, swaggerDefinition);
+            return updateDocumentedApi(apiId, swaggerDefinition, labels);
         }
 
         if (mode == DeploymentMode.API_MOCKED) {
             logger.debug("Update Mocked Api [{}].", apiId);
-            return updateMockedApi(apiId, userId, swaggerDefinition, environmentId);
+            return updateMockedApi(apiId, userId, swaggerDefinition, environmentId, labels);
         }
 
         logger.debug("Update Published Api [{}].", apiId);
-        return updatePublishedApi(apiId, userId, swaggerDefinition, environmentId);
+        return updatePublishedApi(apiId, userId, swaggerDefinition, environmentId, labels);
     }
 
-    private ApiEntityResult createDocumentedApi(String apiId, String userId, String swaggerDefinition, String environmentId) {
+    private ApiEntityResult createDocumentedApi(
+        String apiId,
+        String userId,
+        String swaggerDefinition,
+        String environmentId,
+        List<String> labels
+    ) {
         ImportSwaggerDescriptorEntity swaggerDescriptor = buildForDocumentedApi(swaggerDefinition);
-        return createApiEntity(apiId, userId, swaggerDescriptor);
+        return createApiEntity(apiId, userId, swaggerDescriptor, labels);
     }
 
-    private ApiEntityResult updateDocumentedApi(String apiId, String swaggerDefinition) {
-        return updateApiEntity(apiId, buildForDocumentedApi(swaggerDefinition));
+    private ApiEntityResult updateDocumentedApi(String apiId, String swaggerDefinition, List<String> labels) {
+        return updateApiEntity(apiId, buildForDocumentedApi(swaggerDefinition), labels);
     }
 
-    private ApiEntityResult createMockedApi(String apiId, String userId, String swaggerDefinition, String environmentId) {
+    private ApiEntityResult createMockedApi(
+        String apiId,
+        String userId,
+        String swaggerDefinition,
+        String environmentId,
+        List<String> labels
+    ) {
         ImportSwaggerDescriptorEntity swaggerDescriptor = buildForMockedApi(swaggerDefinition);
 
-        ApiEntityResult createApiResult = createApiEntity(apiId, userId, swaggerDescriptor);
+        ApiEntityResult createApiResult = createApiEntity(apiId, userId, swaggerDescriptor, labels);
 
         if (createApiResult.isSuccess()) {
             this.planService.create(createKeylessPlan(apiId, environmentId));
@@ -133,8 +159,14 @@ public class ApiServiceCockpitImpl implements ApiServiceCockpit {
         return createApiResult;
     }
 
-    private ApiEntityResult updateMockedApi(String apiId, String userId, String swaggerDefinition, String environmentId) {
-        ApiEntityResult apiEntityResult = updateApiEntity(apiId, buildForMockedApi(swaggerDefinition));
+    private ApiEntityResult updateMockedApi(
+        String apiId,
+        String userId,
+        String swaggerDefinition,
+        String environmentId,
+        List<String> labels
+    ) {
+        ApiEntityResult apiEntityResult = updateApiEntity(apiId, buildForMockedApi(swaggerDefinition), labels);
 
         ApiDeploymentEntity apiDeployment = new ApiDeploymentEntity();
         apiDeployment.setDeploymentLabel("Model updated");
@@ -152,10 +184,16 @@ public class ApiServiceCockpitImpl implements ApiServiceCockpit {
         return ApiEntityResult.success(apiService.deploy(apiId, userId, EventType.PUBLISH_API, apiDeployment));
     }
 
-    private ApiEntityResult createPublishedApi(String apiId, String userId, String swaggerDefinition, String environmentId) {
+    private ApiEntityResult createPublishedApi(
+        String apiId,
+        String userId,
+        String swaggerDefinition,
+        String environmentId,
+        List<String> labels
+    ) {
         ImportSwaggerDescriptorEntity swaggerDescriptor = buildForMockedApi(swaggerDefinition);
 
-        ApiEntityResult createApiResult = createApiEntity(apiId, userId, swaggerDescriptor);
+        ApiEntityResult createApiResult = createApiEntity(apiId, userId, swaggerDescriptor, labels);
 
         if (createApiResult.isSuccess()) {
             this.planService.create(createKeylessPlan(apiId, environmentId));
@@ -172,8 +210,14 @@ public class ApiServiceCockpitImpl implements ApiServiceCockpit {
         return createApiResult;
     }
 
-    private ApiEntityResult updatePublishedApi(String apiId, String userId, String swaggerDefinition, String environmentId) {
-        ApiEntityResult updatedApiResult = updateMockedApi(apiId, userId, swaggerDefinition, environmentId);
+    private ApiEntityResult updatePublishedApi(
+        String apiId,
+        String userId,
+        String swaggerDefinition,
+        String environmentId,
+        List<String> labels
+    ) {
+        ApiEntityResult updatedApiResult = updateMockedApi(apiId, userId, swaggerDefinition, environmentId, labels);
 
         if (updatedApiResult.isSuccess() && !ApiLifecycleState.PUBLISHED.equals(updatedApiResult.getApi().getLifecycleState())) {
             publishSwaggerDocumentation(apiId);
@@ -186,18 +230,25 @@ public class ApiServiceCockpitImpl implements ApiServiceCockpit {
         return updatedApiResult;
     }
 
-    private ApiEntityResult updateApiEntity(String apiId, ImportSwaggerDescriptorEntity swaggerDescriptor) {
+    private ApiEntityResult updateApiEntity(String apiId, ImportSwaggerDescriptorEntity swaggerDescriptor, List<String> labels) {
         final SwaggerApiEntity api = swaggerService.createAPI(swaggerDescriptor, DefinitionVersion.V2);
         api.setPaths(null);
+        api.setLabels(labels);
 
         return checkContextPath(api, apiId)
             .map(ApiEntityResult::failure)
             .orElseGet(() -> ApiEntityResult.success(this.apiService.updateFromSwagger(apiId, api, swaggerDescriptor)));
     }
 
-    private ApiEntityResult createApiEntity(String apiId, String userId, ImportSwaggerDescriptorEntity swaggerDescriptor) {
+    private ApiEntityResult createApiEntity(
+        String apiId,
+        String userId,
+        ImportSwaggerDescriptorEntity swaggerDescriptor,
+        List<String> labels
+    ) {
         final SwaggerApiEntity api = swaggerService.createAPI(swaggerDescriptor, DefinitionVersion.V2);
         api.setPaths(null);
+        api.setLabels(labels);
 
         final Optional<String> result = checkContextPath(api);
         if (result.isEmpty()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeployModelCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeployModelCommandHandlerTest.java
@@ -35,6 +35,7 @@ import io.gravitee.rest.api.service.cockpit.services.ApiServiceCockpit;
 import io.gravitee.rest.api.service.cockpit.services.CockpitApiPermissionChecker;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.reactivex.observers.TestObserver;
+import java.util.List;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
@@ -92,6 +93,7 @@ public class DeployModelCommandHandlerTest {
         payload.setSwaggerDefinition("swagger-definition");
         payload.setUserId("cockpit_user#id");
         payload.setMode(DeployModelPayload.DeploymentMode.API_DOCUMENTED);
+        payload.setLabels(List.of("label1", "label2"));
 
         DeployModelCommand command = new DeployModelCommand(payload);
 
@@ -116,7 +118,8 @@ public class DeployModelCommandHandlerTest {
                 user.getId(),
                 payload.getSwaggerDefinition(),
                 environment.getId(),
-                DeploymentMode.API_DOCUMENTED
+                DeploymentMode.API_DOCUMENTED,
+                payload.getLabels()
             )
         )
             .thenAnswer(
@@ -144,6 +147,7 @@ public class DeployModelCommandHandlerTest {
         payload.setSwaggerDefinition("swagger-definition");
         payload.setUserId("cockpit_user#id");
         payload.setMode(DeployModelPayload.DeploymentMode.API_MOCKED);
+        payload.setLabels(List.of("label1", "label2"));
 
         DeployModelCommand command = new DeployModelCommand(payload);
 
@@ -167,7 +171,8 @@ public class DeployModelCommandHandlerTest {
                 user.getId(),
                 payload.getSwaggerDefinition(),
                 environment.getId(),
-                DeploymentMode.API_MOCKED
+                DeploymentMode.API_MOCKED,
+                payload.getLabels()
             )
         )
             .thenAnswer(
@@ -191,6 +196,7 @@ public class DeployModelCommandHandlerTest {
         payload.setSwaggerDefinition("swagger-definition");
         payload.setUserId("cockpit_user#id");
         payload.setMode(DeployModelPayload.DeploymentMode.API_PUBLISHED);
+        payload.setLabels(List.of("label1", "label2"));
 
         DeployModelCommand command = new DeployModelCommand(payload);
 
@@ -214,7 +220,8 @@ public class DeployModelCommandHandlerTest {
                 user.getId(),
                 payload.getSwaggerDefinition(),
                 environment.getId(),
-                DeploymentMode.API_PUBLISHED
+                DeploymentMode.API_PUBLISHED,
+                payload.getLabels()
             )
         )
             .thenAnswer(
@@ -238,6 +245,7 @@ public class DeployModelCommandHandlerTest {
         payload.setSwaggerDefinition("swagger-definition");
         payload.setUserId("cockpit_user#id");
         payload.setMode(DeployModelPayload.DeploymentMode.API_DOCUMENTED);
+        payload.setLabels(List.of("label1", "label2"));
 
         DeployModelCommand command = new DeployModelCommand(payload);
 
@@ -263,7 +271,8 @@ public class DeployModelCommandHandlerTest {
                 user.getId(),
                 payload.getSwaggerDefinition(),
                 environment.getId(),
-                DeploymentMode.API_DOCUMENTED
+                DeploymentMode.API_DOCUMENTED,
+                payload.getLabels()
             )
         )
             .thenAnswer(
@@ -287,6 +296,7 @@ public class DeployModelCommandHandlerTest {
         payload.setSwaggerDefinition("swagger-definition");
         payload.setUserId("cockpit_user#id");
         payload.setMode(DeployModelPayload.DeploymentMode.API_MOCKED);
+        payload.setLabels(List.of("label1", "label2"));
 
         DeployModelCommand command = new DeployModelCommand(payload);
 
@@ -310,7 +320,8 @@ public class DeployModelCommandHandlerTest {
                 user.getId(),
                 payload.getSwaggerDefinition(),
                 environment.getId(),
-                DeploymentMode.API_MOCKED
+                DeploymentMode.API_MOCKED,
+                payload.getLabels()
             )
         )
             .thenAnswer(
@@ -334,6 +345,7 @@ public class DeployModelCommandHandlerTest {
         payload.setSwaggerDefinition("swagger-definition");
         payload.setUserId("cockpit_user#id");
         payload.setMode(DeployModelPayload.DeploymentMode.API_PUBLISHED);
+        payload.setLabels(List.of("label1", "label2"));
 
         DeployModelCommand command = new DeployModelCommand(payload);
 
@@ -357,7 +369,8 @@ public class DeployModelCommandHandlerTest {
                 user.getId(),
                 payload.getSwaggerDefinition(),
                 environment.getId(),
-                DeploymentMode.API_PUBLISHED
+                DeploymentMode.API_PUBLISHED,
+                payload.getLabels()
             )
         )
             .thenAnswer(
@@ -381,6 +394,7 @@ public class DeployModelCommandHandlerTest {
         payload.setSwaggerDefinition("swagger-definition");
         payload.setUserId("cockpit_user#id");
         payload.setMode(null);
+        payload.setLabels(List.of("label1", "label2"));
 
         DeployModelCommand command = new DeployModelCommand(payload);
 
@@ -404,7 +418,8 @@ public class DeployModelCommandHandlerTest {
                 user.getId(),
                 payload.getSwaggerDefinition(),
                 environment.getId(),
-                DeploymentMode.API_DOCUMENTED
+                DeploymentMode.API_DOCUMENTED,
+                payload.getLabels()
             )
         )
             .thenAnswer(
@@ -428,6 +443,7 @@ public class DeployModelCommandHandlerTest {
         payload.setSwaggerDefinition("swagger-definition");
         payload.setUserId("user#id");
         payload.setMode(DeployModelPayload.DeploymentMode.API_DOCUMENTED);
+        payload.setLabels(List.of("label1", "label2"));
 
         DeployModelCommand command = new DeployModelCommand(payload);
 
@@ -451,7 +467,8 @@ public class DeployModelCommandHandlerTest {
                 payload.getUserId(),
                 payload.getSwaggerDefinition(),
                 environment.getId(),
-                DeploymentMode.API_DOCUMENTED
+                DeploymentMode.API_DOCUMENTED,
+                payload.getLabels()
             )
         )
             .thenThrow(new RuntimeException("fake error"));
@@ -470,6 +487,7 @@ public class DeployModelCommandHandlerTest {
         payload.setSwaggerDefinition("swagger-definition");
         payload.setUserId("user#id");
         payload.setMode(DeployModelPayload.DeploymentMode.API_DOCUMENTED);
+        payload.setLabels(List.of("label1", "label2"));
 
         DeployModelCommand command = new DeployModelCommand(payload);
 
@@ -509,6 +527,7 @@ public class DeployModelCommandHandlerTest {
         payload.setSwaggerDefinition("swagger-definition");
         payload.setUserId("user#id");
         payload.setMode(DeployModelPayload.DeploymentMode.API_DOCUMENTED);
+        payload.setLabels(List.of("label1", "label2"));
 
         DeployModelCommand command = new DeployModelCommand(payload);
 
@@ -550,6 +569,7 @@ public class DeployModelCommandHandlerTest {
         payload.setSwaggerDefinition("swagger-definition");
         payload.setUserId("cockpit_user#id");
         payload.setMode(DeployModelPayload.DeploymentMode.API_DOCUMENTED);
+        payload.setLabels(List.of("label1", "label2"));
 
         DeployModelCommand command = new DeployModelCommand(payload);
 
@@ -573,7 +593,8 @@ public class DeployModelCommandHandlerTest {
                 user.getId(),
                 payload.getSwaggerDefinition(),
                 environment.getId(),
-                DeploymentMode.API_DOCUMENTED
+                DeploymentMode.API_DOCUMENTED,
+                payload.getLabels()
             )
         )
             .thenAnswer(
@@ -599,6 +620,7 @@ public class DeployModelCommandHandlerTest {
         payload.setSwaggerDefinition("swagger-definition");
         payload.setUserId("user#id");
         payload.setMode(DeployModelPayload.DeploymentMode.API_DOCUMENTED);
+        payload.setLabels(List.of("label1", "label2"));
 
         DeployModelCommand command = new DeployModelCommand(payload);
 
@@ -632,6 +654,7 @@ public class DeployModelCommandHandlerTest {
         payload.setSwaggerDefinition("swagger-definition");
         payload.setUserId("cockpit_user#id");
         payload.setMode(DeployModelPayload.DeploymentMode.API_DOCUMENTED);
+        payload.setLabels(List.of("label1", "label2"));
 
         DeployModelCommand command = new DeployModelCommand(payload);
 
@@ -655,7 +678,8 @@ public class DeployModelCommandHandlerTest {
                 user.getId(),
                 payload.getSwaggerDefinition(),
                 environment.getId(),
-                DeploymentMode.API_DOCUMENTED
+                DeploymentMode.API_DOCUMENTED,
+                payload.getLabels()
             )
         )
             .thenReturn(ApiEntityResult.failure("context path not available"));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImplTest.java
@@ -57,6 +57,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 public class ApiServiceCockpitImplTest {
 
     private static final String API_ID = "api#id";
+    private static final List<String> LABELS = List.of("label1", "label2");
     private static final String USER_ID = "user#id";
     private static final String ENVIRONMENT_ID = "environment#id";
     private static final String PAGE_ID = "page#id";
@@ -136,13 +137,14 @@ public class ApiServiceCockpitImplTest {
 
         ApiEntity api = new ApiEntity();
         api.setId(API_ID);
+        api.setLabels(LABELS);
 
         when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
         when(apiService.createWithApiDefinition(eq(swaggerApi), eq(USER_ID), any(ObjectNode.class))).thenReturn(api);
 
         GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
 
-        service.createApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_DOCUMENTED);
+        service.createApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_DOCUMENTED, LABELS);
 
         verify(swaggerService).createAPI(descriptorCaptor.capture(), eq(DefinitionVersion.V2));
         assertThat(descriptorCaptor.getValue()).usingRecursiveComparison().isEqualTo(expectedDescriptor);
@@ -170,7 +172,7 @@ public class ApiServiceCockpitImplTest {
         when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
         when(apiService.createWithApiDefinition(eq(swaggerApi), eq(USER_ID), any(ObjectNode.class))).thenReturn(api);
 
-        service.createApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_DOCUMENTED);
+        service.createApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_DOCUMENTED, LABELS);
 
         verifyNoInteractions(planService);
         verify(apiService, never()).start(anyString(), anyString());
@@ -199,7 +201,7 @@ public class ApiServiceCockpitImplTest {
 
         GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
 
-        service.createApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_MOCKED);
+        service.createApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_MOCKED, LABELS);
 
         verify(swaggerService).createAPI(descriptorCaptor.capture(), eq(DefinitionVersion.V2));
         assertThat(descriptorCaptor.getValue()).usingRecursiveComparison().isEqualTo(expectedDescriptor);
@@ -227,7 +229,7 @@ public class ApiServiceCockpitImplTest {
         when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
         when(apiService.createWithApiDefinition(eq(swaggerApi), eq(USER_ID), any(ObjectNode.class))).thenReturn(api);
 
-        service.createApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_MOCKED);
+        service.createApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_MOCKED, LABELS);
 
         verify(planService).create(newPlanCaptor.capture());
         assertThat(newPlanCaptor.getValue())
@@ -263,7 +265,7 @@ public class ApiServiceCockpitImplTest {
 
         GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
 
-        service.createApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED);
+        service.createApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED, LABELS);
 
         verify(swaggerService).createAPI(descriptorCaptor.capture(), eq(DefinitionVersion.V2));
         assertThat(descriptorCaptor.getValue()).usingRecursiveComparison().isEqualTo(expectedDescriptor);
@@ -294,7 +296,7 @@ public class ApiServiceCockpitImplTest {
 
         preparePageServiceMock();
 
-        service.createApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED);
+        service.createApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED, LABELS);
 
         verify(planService).create(newPlanCaptor.capture());
         assertThat(newPlanCaptor.getValue())
@@ -322,7 +324,7 @@ public class ApiServiceCockpitImplTest {
 
         preparePageServiceMock();
 
-        service.createApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED);
+        service.createApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED, LABELS);
 
         verify(apiService).update(eq(API_ID), updateApiCaptor.capture());
         assertThat(updateApiCaptor.getValue())
@@ -350,7 +352,7 @@ public class ApiServiceCockpitImplTest {
 
         GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
 
-        service.createApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED);
+        service.createApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED, LABELS);
 
         verify(pageService).update(eq(PAGE_ID), updatePageCaptor.capture());
         assertThat(updatePageCaptor.getValue()).extracting(UpdatePageEntity::isPublished).isEqualTo(true);
@@ -383,7 +385,7 @@ public class ApiServiceCockpitImplTest {
 
         GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
 
-        final var result = service.updateApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_DOCUMENTED);
+        final var result = service.updateApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_DOCUMENTED, LABELS);
 
         verify(swaggerService).createAPI(descriptorCaptor.capture(), eq(DefinitionVersion.V2));
         assertThat(descriptorCaptor.getValue()).usingRecursiveComparison().isEqualTo(expectedDescriptor);
@@ -427,7 +429,7 @@ public class ApiServiceCockpitImplTest {
 
         GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
 
-        final var result = service.updateApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_MOCKED);
+        final var result = service.updateApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_MOCKED, LABELS);
         assertThat(result.getApi()).isEqualTo(updatedApiEntity);
 
         verify(swaggerService).createAPI(descriptorCaptor.capture(), eq(DefinitionVersion.V2));
@@ -456,7 +458,7 @@ public class ApiServiceCockpitImplTest {
         when(apiService.updateFromSwagger(eq(API_ID), eq(swaggerApi), any(ImportSwaggerDescriptorEntity.class)))
             .thenReturn(updatedApiEntity);
 
-        service.updateApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_MOCKED);
+        service.updateApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_MOCKED, LABELS);
 
         verify(apiService).deploy(eq(API_ID), eq(USER_ID), eq(EventType.PUBLISH_API), apiDeploymentCaptor.capture());
         assertThat(apiDeploymentCaptor.getValue().getDeploymentLabel()).isEqualTo("Model updated");
@@ -495,7 +497,7 @@ public class ApiServiceCockpitImplTest {
 
         GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
 
-        final var result = service.updateApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED);
+        final var result = service.updateApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED, LABELS);
         assertThat(result.getApi()).isEqualTo(updatedApiEntity);
 
         verify(swaggerService).createAPI(descriptorCaptor.capture(), eq(DefinitionVersion.V2));
@@ -528,7 +530,7 @@ public class ApiServiceCockpitImplTest {
         when(apiService.deploy(eq(API_ID), eq(USER_ID), eq(EventType.PUBLISH_API), any(ApiDeploymentEntity.class)))
             .thenReturn(updatedApiEntity);
 
-        service.updateApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED);
+        service.updateApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED, LABELS);
 
         verify(apiService).deploy(eq(API_ID), eq(USER_ID), eq(EventType.PUBLISH_API), apiDeploymentCaptor.capture());
         assertThat(apiDeploymentCaptor.getValue().getDeploymentLabel()).isEqualTo("Model updated");
@@ -559,7 +561,7 @@ public class ApiServiceCockpitImplTest {
         when(planService.findByApi(API_ID)).thenReturn(null);
         when(virtualHostService.sanitizeAndValidate(any(), eq(API_ID))).thenReturn(List.of(virtualHost));
 
-        service.updateApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED);
+        service.updateApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED, LABELS);
 
         verify(planService).findByApi(eq(API_ID));
         verify(planService).create(newPlanCaptor.capture());
@@ -598,7 +600,7 @@ public class ApiServiceCockpitImplTest {
         preparePageServiceMock();
         GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
 
-        service.updateApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED);
+        service.updateApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED, LABELS);
 
         verify(planService).findByApi(eq(API_ID));
         verify(planService).create(newPlanCaptor.capture());
@@ -641,7 +643,7 @@ public class ApiServiceCockpitImplTest {
         preparePageServiceMock();
         GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
 
-        service.updateApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED);
+        service.updateApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED, LABELS);
 
         verify(planService).findByApi(eq(API_ID));
         verify(planService, never()).create(any(NewPlanEntity.class));

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <!-- Gravitee dependencies version -->
         <gravitee-bom.version>2.3</gravitee-bom.version>
         <gravitee-alert-api.version>1.8.0</gravitee-alert-api.version>
-        <gravitee-cockpit-api.version>1.9.0</gravitee-cockpit-api.version>
+        <gravitee-cockpit-api.version>1.10.0</gravitee-cockpit-api.version>
         <gravitee-common.version>1.25.0</gravitee-common.version>
         <gravitee-connector-api.version>1.1.0</gravitee-connector-api.version>
         <gravitee-definition.version>1.32.0</gravitee-definition.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/gravitee-cockpit/issues/702

**Description**

Add labels in DeployModelPayload in order to push the labels declared in API Designer into APIM

![screenshot-localhost_3000-2022 03 01-16_38_05](https://user-images.githubusercontent.com/1655950/156200748-435966a5-4b92-4e72-8487-e0f3a8ec60d4.png)


**Additional context**

Requires [this PR](https://github.com/gravitee-io/gravitee-cockpit-api/pull/82) to be merged and dependency to be updated in `pom.xml` 

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-sbpenxjaft.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/702-push-labels-to-apim/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
