### PR TITLE
chore: bump version of jws, jsontojson, jsontoxml, xmltojson, xslt policies

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -65,10 +65,10 @@
         <gravitee-policy-http-signature.version>1.3.0</gravitee-policy-http-signature.version>
         <gravitee-policy-ipfiltering.version>1.8.0</gravitee-policy-ipfiltering.version>
         <gravitee-policy-json-threat-protection.version>1.2.2</gravitee-policy-json-threat-protection.version>
-        <gravitee-policy-json-to-json.version>1.6.0</gravitee-policy-json-to-json.version>
+        <gravitee-policy-json-to-json.version>1.6.1</gravitee-policy-json-to-json.version>
         <gravitee-policy-json-validation.version>1.6.0</gravitee-policy-json-validation.version>
-        <gravitee-policy-json-xml.version>1.0.0</gravitee-policy-json-xml.version>
-        <gravitee-policy-jws.version>1.3.0</gravitee-policy-jws.version>
+        <gravitee-policy-json-xml.version>1.0.1</gravitee-policy-json-xml.version>
+        <gravitee-policy-jws.version>1.3.2</gravitee-policy-jws.version>
         <gravitee-policy-jwt.version>1.20.0</gravitee-policy-jwt.version>
         <gravitee-policy-keyless.version>1.4.0</gravitee-policy-keyless.version>
         <gravitee-policy-latency.version>1.4.0</gravitee-policy-latency.version>
@@ -94,10 +94,10 @@
         <gravitee-policy-transformqueryparams.version>1.6.0</gravitee-policy-transformqueryparams.version>
         <gravitee-policy-url-rewriting.version>1.4.0</gravitee-policy-url-rewriting.version>
         <gravitee-policy-wssecurity-authentication.version>1.0.0</gravitee-policy-wssecurity-authentication.version>
-        <gravitee-policy-xml-json.version>1.7.0</gravitee-policy-xml-json.version>
+        <gravitee-policy-xml-json.version>1.7.1</gravitee-policy-xml-json.version>
         <gravitee-policy-xml-threat-protection.version>1.2.1</gravitee-policy-xml-threat-protection.version>
         <gravitee-policy-xml-validation.version>1.1.0</gravitee-policy-xml-validation.version>
-        <gravitee-policy-xslt.version>1.6.0</gravitee-policy-xslt.version>
+        <gravitee-policy-xslt.version>1.6.1</gravitee-policy-xslt.version>
         <gravitee-resource-auth-provider-http.version>1.1.0</gravitee-resource-auth-provider-http.version>
         <gravitee-resource-auth-provider-inline.version>1.1.0</gravitee-resource-auth-provider-inline.version>
         <gravitee-resource-auth-provider-ldap.version>1.1.0</gravitee-resource-auth-provider-ldap.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7130


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-7130-transformationexception-chain/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
