### PR TITLE
fix: return request's path instead of contextPath during debug mode

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/handler/http/ContextualizedDebugHttpServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/handler/http/ContextualizedDebugHttpServerRequest.java
@@ -20,21 +20,26 @@ import io.gravitee.gateway.debug.reactor.handler.context.PathTransformer;
 import io.gravitee.gateway.reactor.handler.http.ContextualizedHttpServerRequest;
 
 /**
+ * Transforms the debug request to get rid of the debug eventId.
+ * This id has to be removed from contextPath and request's path.
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
 public class ContextualizedDebugHttpServerRequest extends ContextualizedHttpServerRequest {
 
     private final String contextPath;
+    private final String path;
 
     public ContextualizedDebugHttpServerRequest(String contextPath, Request request, String eventId) {
         super(contextPath, request);
+        // Remove eventId from contextPath and request path.
         this.contextPath = PathTransformer.removeEventIdFromPath(eventId, contextPath);
+        this.path = PathTransformer.removeEventIdFromPath(eventId, super.path());
     }
 
     @Override
     public String path() {
-        return contextPath();
+        return path;
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/reactor/handler/http/ContextualizedDebugHttpServerRequestTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/reactor/handler/http/ContextualizedDebugHttpServerRequestTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.debug.reactor.handler.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.gateway.api.Request;
+import org.junit.Test;
+
+public class ContextualizedDebugHttpServerRequestTest {
+
+    private static final String EVENT_ID = "my-event-id";
+    private static final String DEBUG_CONTEXT_PATH = String.format("/%s-echo", EVENT_ID);
+
+    @Test
+    public void shouldRemoveEventIdFromContextPathAndPath() {
+        final Request request = mock(Request.class);
+        when(request.path()).thenReturn(String.format("%s/another/path", DEBUG_CONTEXT_PATH));
+
+        final ContextualizedDebugHttpServerRequest contextualizedRequest = new ContextualizedDebugHttpServerRequest(
+            DEBUG_CONTEXT_PATH,
+            request,
+            EVENT_ID
+        );
+        assertThat(contextualizedRequest.contextPath()).isEqualTo("/echo");
+        assertThat(contextualizedRequest.path()).isEqualTo("/echo/another/path");
+    }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7220

**Description**

Get rid of eventId when accessing request's path

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rajzkmnsns.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-7220-debug-request-path/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
