### PR TITLE
fix(cockpit): improve error message when contextPath is duplicated

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImpl.java
@@ -31,6 +31,7 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.converter.PageConverter;
+import io.gravitee.rest.api.service.exceptions.ApiContextPathAlreadyExistsException;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -267,21 +268,19 @@ public class ApiServiceCockpitImpl implements ApiServiceCockpit {
     }
 
     Optional<String> checkContextPath(SwaggerApiEntity api) {
-        try {
-            virtualHostService.sanitizeAndValidate(api.getProxy().getVirtualHosts());
-            return Optional.empty();
-        } catch (Exception e) {
-            return Optional.of(e.getMessage());
-        }
+        return checkContextPath(api, null);
     }
 
     Optional<String> checkContextPath(SwaggerApiEntity api, String apiId) {
         try {
             virtualHostService.sanitizeAndValidate(api.getProxy().getVirtualHosts(), apiId);
-            return Optional.empty();
+        } catch (ApiContextPathAlreadyExistsException e) {
+            String ctxPath = e.getParameters().get("contextPath");
+            return Optional.of("The context [" + ctxPath + "] automatically generated from the name is already covered by another API.");
         } catch (Exception e) {
             return Optional.of(e.getMessage());
         }
+        return Optional.empty();
     }
 
     private NewPlanEntity createKeylessPlan(String apiId, String environmentId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImplTest.java
@@ -37,7 +37,6 @@ import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.converter.PageConverter;
 import io.gravitee.rest.api.service.exceptions.ApiContextPathAlreadyExistsException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import org.junit.Before;
@@ -101,9 +100,9 @@ public class ApiServiceCockpitImplTest {
     @Captor
     private ArgumentCaptor<UpdatePageEntity> updatePageCaptor;
 
-    private ApiConverter apiConverter = new ApiConverter();
+    private final ApiConverter apiConverter = new ApiConverter();
 
-    private PageConverter pageConverter = new PageConverter();
+    private final PageConverter pageConverter = new PageConverter();
 
     @Before
     public void setUp() throws Exception {
@@ -666,10 +665,10 @@ public class ApiServiceCockpitImplTest {
         proxy.setVirtualHosts(List.of(virtualHost));
         api.setProxy(proxy);
 
-        when(virtualHostService.sanitizeAndValidate(any(Collection.class))).thenReturn(List.of(virtualHost));
+        when(virtualHostService.sanitizeAndValidate(anyCollection(), eq(null))).thenReturn(List.of(virtualHost));
         var message = service.checkContextPath(api);
 
-        verify(virtualHostService).sanitizeAndValidate(eq(List.of(virtualHost)));
+        verify(virtualHostService).sanitizeAndValidate(eq(List.of(virtualHost)), eq(null));
         assertThat(message.isPresent()).isFalse();
     }
 
@@ -681,13 +680,14 @@ public class ApiServiceCockpitImplTest {
         proxy.setVirtualHosts(List.of(virtualHost));
         api.setProxy(proxy);
 
-        when(virtualHostService.sanitizeAndValidate(any(Collection.class)))
+        when(virtualHostService.sanitizeAndValidate(anyCollection(), eq(null)))
             .thenThrow(new ApiContextPathAlreadyExistsException("contextPath"));
         var message = service.checkContextPath(api);
 
-        verify(virtualHostService).sanitizeAndValidate(eq(List.of(virtualHost)));
+        verify(virtualHostService).sanitizeAndValidate(eq(List.of(virtualHost)), eq(null));
         assertThat(message.isPresent()).isTrue();
-        assertThat(message.get()).isEqualTo("The path [contextPath] is already covered by an other API.");
+        assertThat(message.get())
+            .isEqualTo("The context [contextPath] automatically generated from the name is already covered by another API.");
     }
 
     private void preparePageServiceMock() {


### PR DESCRIPTION
The possibility of configuring context-paths was removed from cockpit (see https://github.com/gravitee-io/gravitee-cockpit/issues/2009)

Hence, a specific message was needed to better signal duplication errors.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/2009-fix-cockpit-error-msg/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vrbypmdark.chromatic.com)
<!-- Storybook placeholder end -->
