### PR TITLE
test: use correct jna dependencies for testcontainers

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
@@ -40,7 +40,6 @@
         <mysql-connector-java.version>8.0.17</mysql-connector-java.version>
         <postgresql.version>42.3.3</postgresql.version>
         <postgresql-embedded.version>2.10</postgresql-embedded.version>
-        <testcontainers.version>1.16.2</testcontainers.version>
         <wix-embedded-mysql.version>4.6.1</wix-embedded-mysql.version>
 
         <!-- Plugin configuration -->
@@ -142,6 +141,16 @@
             <groupId>com.wix</groupId>
             <artifactId>wix-embedded-mysql</artifactId>
             <version>${wix-embedded-mysql.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.java.dev.jna</groupId>
+                    <artifactId>jna</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.java.dev.jna</groupId>
+                    <artifactId>jna-platform</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <swagger-core.version>2.1.12</swagger-core.version>
         <swagger-parser.version>2.0.29</swagger-parser.version>
         <swagger-models.version>1.6.4</swagger-models.version>
-        <testcontainers.version>1.15.3</testcontainers.version>
+        <testcontainers.version>1.16.3</testcontainers.version>
         <xmlbeans.version>3.1.0</xmlbeans.version>
         <wiremock.version>2.27.2</wiremock.version>
         <wiremock-jre8.version>2.32.0</wiremock-jre8.version>


### PR DESCRIPTION
**Issue**

N/A

**Description**

jdbc repositories tests weren't working properly on mac with Apple chip (M1). Wrong jna versions was used and incompatible with apple chip. 

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jaoaxaymoo.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-testcontainers-mac-m1/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
