### PR TITLE
allow to import openapi with server without basepath

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/swagger/converter/api/OAIToAPIConverter.java
@@ -183,7 +183,7 @@ public class OAIToAPIConverter implements SwaggerToApiConverter<OAIDescriptor>, 
             if (defaultEndpoint != null) {
                 contextPath = URI.create(defaultEndpoint).getPath();
             }
-            if (contextPath == null || contextPath.equals("/")) {
+            if (contextPath == null || contextPath.isEmpty() || contextPath.equals("/")) {
                 contextPath = apiEntity.getName().replaceAll("\\s+", "").toLowerCase();
             }
             proxy.setVirtualHosts(singletonList(new VirtualHost(contextPath)));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/SwaggerService_CreateAPITest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/SwaggerService_CreateAPITest.java
@@ -139,7 +139,7 @@ public class SwaggerService_CreateAPITest {
             true,
             true
         );
-        validate(swaggerApiEntity);
+        validate(swaggerApiEntity, "myPath");
         validateExtensions(swaggerApiEntity);
     }
 
@@ -160,7 +160,7 @@ public class SwaggerService_CreateAPITest {
             true,
             true
         );
-        validate(swaggerApiEntity);
+        validate(swaggerApiEntity, "myPath");
         validateExtensions(swaggerApiEntity);
     }
 
@@ -168,6 +168,16 @@ public class SwaggerService_CreateAPITest {
     @Test
     public void shouldPrepareAPIFromSwaggerV3_URL_json() throws IOException {
         validate(prepareUrl("io/gravitee/rest/api/management/service/openapi.json", true, true));
+    }
+
+    @Test
+    public void shouldPrepareAPIFromSwaggerV3WithoutBasePath_URL_json() throws IOException {
+        final SwaggerApiEntity swaggerApiEntity = prepareUrl(
+            "io/gravitee/rest/api/management/service/openapi-no-basepath.json",
+            true,
+            true
+        );
+        validate(swaggerApiEntity, "https://demo.gravitee.io", "gravitee.ioswaggerapi");
     }
 
     @Test
@@ -182,7 +192,7 @@ public class SwaggerService_CreateAPITest {
             true,
             true
         );
-        validate(swaggerApiEntity);
+        validate(swaggerApiEntity, "myPath");
         validateExtensions(swaggerApiEntity);
     }
 
@@ -203,7 +213,7 @@ public class SwaggerService_CreateAPITest {
             true,
             true
         );
-        validate(swaggerApiEntity);
+        validate(swaggerApiEntity, "myPath");
         validateExtensions(swaggerApiEntity);
     }
 
@@ -249,13 +259,23 @@ public class SwaggerService_CreateAPITest {
     }
 
     protected void validate(SwaggerApiEntity api) {
+        validate(api, "https://demo.gravitee.io/gateway/echo", "/gateway/echo");
+    }
+
+    protected void validate(SwaggerApiEntity api, String expectedContextPath) {
+        validate(api, "https://demo.gravitee.io/gateway/echo", expectedContextPath);
+    }
+
+    protected void validate(SwaggerApiEntity api, String expectedEndpoint, String expectedContextPath) {
+        validateApi(api, expectedEndpoint, expectedContextPath);
+        validatePolicies(api, 2, 0, asList("/pets", "/pets/:petId"));
+    }
+
+    protected void validateApi(SwaggerApiEntity api, String expectedEndpoint, String expectedContextPath) {
         assertEquals("1.2.3", api.getVersion());
         assertEquals("Gravitee.io Swagger API", api.getName());
-        assertEquals(
-            "https://demo.gravitee.io/gateway/echo",
-            api.getProxy().getGroups().iterator().next().getEndpoints().iterator().next().getTarget()
-        );
-        validatePolicies(api, 2, 0, asList("/pets", "/pets/:petId"));
+        assertEquals(expectedEndpoint, api.getProxy().getGroups().iterator().next().getEndpoints().iterator().next().getTarget());
+        assertEquals(expectedContextPath, api.getProxy().getVirtualHosts().iterator().next().getPath());
     }
 
     protected void validatePolicies(SwaggerApiEntity api, int expectedPathSize, int expectedOperationSize, List<String> expectedPaths) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/SwaggerService_CreateAPIV2Test.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/SwaggerService_CreateAPIV2Test.java
@@ -47,13 +47,8 @@ public class SwaggerService_CreateAPIV2Test extends SwaggerService_CreateAPITest
     }
 
     @Override
-    protected void validate(SwaggerApiEntity api) {
-        assertEquals("1.2.3", api.getVersion());
-        assertEquals("Gravitee.io Swagger API", api.getName());
-        assertEquals(
-            "https://demo.gravitee.io/gateway/echo",
-            api.getProxy().getGroups().iterator().next().getEndpoints().iterator().next().getTarget()
-        );
+    protected void validate(SwaggerApiEntity api, String expectedEndpoint, String expectedContextPath) {
+        validateApi(api, expectedEndpoint, expectedContextPath);
         validatePolicies(api, 2, 4, asList("/pets", "/pets/:petId"));
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/openapi-no-basepath.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/openapi-no-basepath.json
@@ -1,0 +1,222 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.2.3",
+    "title": "Gravitee.io Swagger API",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://demo.gravitee.io"
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "summary": "List all pets",
+        "operationId": "listPets",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "How many items to return at one time (max 100)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An paged array of pets",
+            "headers": {
+              "x-next": {
+                "description": "A link to the next page of responses",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pets"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a pet",
+        "operationId": "createPets",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "201": {
+            "description": "Null response"
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{petId}": {
+      "get": {
+        "summary": "Info for a specific pet",
+        "operationId": "showPetById",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "description": "The id of the pet to retrieve",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Expected response to a valid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pets"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "deletes a single pet based on the ID supplied",
+        "operationId": "deletePet",
+        "tags": [
+          "pets"
+        ],
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to delete",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "pet deleted"
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/definitions/errorModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "oauth2Scheme": {
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://example.com/authorize",
+            "tokenUrl": "https://example.com/token",
+            "scopes": {
+              "user": "simple user rights"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "Pet": {
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        }
+      },
+      "Pets": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Pet"
+        }
+      },
+      "Error": {
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7227

**Description**

allow to import openapi with server without basepath
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7227-import-openapi-without-basepath/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-arvtuzhsrt.chromatic.com)
<!-- Storybook placeholder end -->
