### PR TITLE
Adapt resource-auth-provider to new class loader system

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -194,6 +194,11 @@
 
         <dependency>
             <groupId>io.gravitee.resource</groupId>
+            <artifactId>gravitee-resource-auth-provider</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.resource</groupId>
             <artifactId>gravitee-resource-cache-provider-api</artifactId>
         </dependency>
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/pom.xml
@@ -74,6 +74,10 @@
             <groupId>io.gravitee.resource</groupId>
             <artifactId>gravitee-resource-cache-provider-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.gravitee.resource</groupId>
+            <artifactId>gravitee-resource-auth-provider</artifactId>
+        </dependency>
 
         <!-- To override Spring commons-logging -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <gravitee-plugin.version>1.22.0</gravitee-plugin.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>1.22.0</gravitee-reporter-api.version>
+        <gravitee-resource-auth-provider-api.version>1.3.0</gravitee-resource-auth-provider-api.version>
         <gravitee-resource-cache-provider-api.version>1.1.0</gravitee-resource-cache-provider-api.version>
         <gravitee-resource-oauth2-provider-api.version>1.3.0</gravitee-resource-oauth2-provider-api.version>
         <gravitee-service-discovery-api.version>1.1.1</gravitee-service-discovery-api.version>
@@ -321,6 +322,12 @@
                 <groupId>io.gravitee.reporter</groupId>
                 <artifactId>gravitee-reporter-api</artifactId>
                 <version>${gravitee-reporter-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.gravitee.resource</groupId>
+                <artifactId>gravitee-resource-auth-provider</artifactId>
+                <version>${gravitee-resource-auth-provider-api.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7198

**Description**

embed the resource-auth-provider api so plugins of this type can be loaded with the new classloader mechanism
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lisundyoeq.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7198-fix-classloading-pb-with-resource-auth-provider/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
