### PR TITLE
fix: remove service geoip from dev env

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -107,7 +107,6 @@
         <gravitee-resource-oauth2-provider-generic.version>1.16.1</gravitee-resource-oauth2-provider-generic.version>
         <gravitee-resource-oauth2-provider-keycloak.version>1.9.1</gravitee-resource-oauth2-provider-keycloak.version>
         <gravitee-service-discovery-consul.version>1.3.0</gravitee-service-discovery-consul.version>
-        <gravitee-service-geoip.version>1.1.0</gravitee-service-geoip.version>
         <!-- Management API Only -->
         <gravitee-cockpit-connectors-ws.version>2.0.1</gravitee-cockpit-connectors-ws.version>
         <gravitee-fetcher-bitbucket.version>1.7.0</gravitee-fetcher-bitbucket.version>
@@ -696,12 +695,6 @@
                                         <groupId>io.gravitee.discovery</groupId>
                                         <artifactId>gravitee-service-discovery-consul</artifactId>
                                         <version>${gravitee-service-discovery-consul.version}</version>
-                                        <type>zip</type>
-                                    </artifactItem>
-                                    <artifactItem>
-                                        <groupId>io.gravitee.service</groupId>
-                                        <artifactId>gravitee-service-geoip</artifactId>
-                                        <version>${gravitee-service-geoip.version}</version>
                                         <type>zip</type>
                                     </artifactItem>
                                     <artifactItem>


### PR DESCRIPTION
Removing service-geoip from dev env since it generates java heap space.
![image](https://user-images.githubusercontent.com/13161768/156771205-6dc0ad93-aaf6-40e1-9c4d-5fd8baa25253.png)
