### PR TITLE
feat: implement 'Shared api key' envionment setting check in backoffice

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/InvalidApplicationApiKeyModeException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/InvalidApplicationApiKeyModeException.java
@@ -24,14 +24,8 @@ import java.util.Map;
  */
 public class InvalidApplicationApiKeyModeException extends AbstractManagementException {
 
-    public InvalidApplicationApiKeyModeException(String applicationId, ApiKeyMode currentApiKeyMode) {
-        super(
-            String.format(
-                "Can't update application %s Api key mode cause current Api Key Mode %s is not updatable",
-                applicationId,
-                currentApiKeyMode
-            )
-        );
+    public InvalidApplicationApiKeyModeException(String message) {
+        super(message);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_CreateTest.java
@@ -241,4 +241,19 @@ public class ApplicationService_CreateTest {
 
         applicationService.create(GraviteeContext.getCurrentEnvironment(), newApplication, USER_NAME);
     }
+
+    @Test(expected = InvalidApplicationApiKeyModeException.class)
+    public void shouldNotCreateCauseSharedApiKeyModeDisabled() {
+        ApplicationSettings settings = new ApplicationSettings();
+        SimpleApplicationSettings clientSettings = new SimpleApplicationSettings();
+        clientSettings.setClientId(CLIENT_ID);
+        settings.setApp(clientSettings);
+        when(newApplication.getSettings()).thenReturn(settings);
+
+        when(parameterService.findAsBoolean(Key.PLAN_SECURITY_APIKEY_SHARED_ALLOWED, ParameterReferenceType.ENVIRONMENT)).thenReturn(false);
+
+        when(newApplication.getApiKeyMode()).thenReturn(io.gravitee.rest.api.model.ApiKeyMode.SHARED);
+
+        applicationService.create(GraviteeContext.getCurrentEnvironment(), newApplication, USER_NAME);
+    }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6793

**Description**

feat: implement 'Shared api key' envionment setting check in backoffice
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dzmvowukqu.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/feat-6793-api-key-mode-checks/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
