### PR TITLE
feat: add guard for API Key subscriptions in shared mode

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/subscriptions.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/subscriptions.component.ts
@@ -287,17 +287,19 @@ const ApiSubscriptionsComponent: ng.IComponentOptions = {
 
     $shouldPromptForKeyMode(application: any, plan: any): IPromise<boolean> {
       if (plan.security === PlanSecurityType.API_KEY && this.allowsSharedApiKeys && application.api_key_mode === ApiKeyMode.UNSPECIFIED) {
-        return this.$getApiKeySubscriptionsCount(application).then((count) => {
+        return this.$getApiKeySubscriptionsCount(application, plan).then((count) => {
           return count >= 1;
         });
       }
       return Promise.resolve(false);
     }
 
-    $getApiKeySubscriptionsCount(application: any): IPromise<number> {
+    $getApiKeySubscriptionsCount(application: any, plan: any): IPromise<number> {
       return this.ApplicationService.listSubscriptions(application.id, '?expand=security').then((response) => {
         const applicationSubscriptions = response.data as PagedResult;
-        return applicationSubscriptions.data.filter((subscription) => subscription.security === PlanSecurityType.API_KEY).length;
+        return applicationSubscriptions.data.filter(
+          (subscription) => subscription.security === PlanSecurityType.API_KEY && subscription.api !== plan.api,
+        ).length;
       });
     }
 

--- a/gravitee-apim-console-webui/src/management/application/creation/steps/application-creation.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/creation/steps/application-creation.controller.ts
@@ -169,7 +169,7 @@ class ApplicationCreationController {
   }
 
   getReadableApiSubscriptions(): string {
-    const plansByApi = _.groupBy(this.selectedPlans, 'apis');
+    const plansByApi = _.groupBy(this.selectedPlans, 'api');
     const multipleApis = _.keys(plansByApi).length > 1;
     return (
       `Subscribed to API${multipleApis ? 's:' : ''} ` +

--- a/gravitee-apim-console-webui/src/management/application/creation/steps/application-creation.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/creation/steps/application-creation.controller.ts
@@ -187,8 +187,9 @@ class ApplicationCreationController {
   }
 
   shouldPromptForKeyMode(): boolean {
-    const apiKeysPlansCount = this.selectedPlans.filter((plan) => plan.security === PlanSecurityType.API_KEY).length;
-    return this.allowsSharedApiKeys && apiKeysPlansCount > 1;
+    const apiKeyPlans = this.selectedPlans.filter((plan) => plan.security === PlanSecurityType.API_KEY);
+    const uniqueApiKeyPlans = _.uniqBy(apiKeyPlans, 'api');
+    return this.allowsSharedApiKeys && uniqueApiKeyPlans.length === apiKeyPlans.length && apiKeyPlans.length > 1;
   }
 
   selectKeyMode() {

--- a/gravitee-apim-console-webui/src/management/application/details/subscribe/application-subscribe.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscribe/application-subscribe.controller.ts
@@ -164,9 +164,10 @@ class ApplicationSubscribeController {
   shouldPromptForKeyMode(plan: any): boolean {
     return (
       plan.security === PlanSecurityType.API_KEY &&
-      this.allowsSharedApiKeys &&
+      this.isSharedApiKeyEnabled &&
+      this.application.api_key_mode === ApiKeyMode.UNSPECIFIED &&
       this.apiKeySubscriptionsCount >= 1 &&
-      this.application.api_key_mode === ApiKeyMode.UNSPECIFIED
+      this.canShareKey(plan)
     );
   }
 
@@ -174,8 +175,12 @@ class ApplicationSubscribeController {
     return this.subscriptions.data.filter((subscription) => subscription.security === PlanSecurityType.API_KEY).length;
   }
 
-  get allowsSharedApiKeys(): boolean {
+  get isSharedApiKeyEnabled(): boolean {
     return this.Constants.env?.settings?.plan?.security?.sharedApiKey?.enabled;
+  }
+
+  canShareKey(plan: any): boolean {
+    return !this.subscriptions.data.some((subscription) => subscription.api === plan.api && subscription.security === ApiKeyMode.SHARED);
   }
 }
 

--- a/gravitee-apim-console-webui/src/management/application/details/subscribe/application-subscribe.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscribe/application-subscribe.controller.ts
@@ -167,7 +167,7 @@ class ApplicationSubscribeController {
       this.isSharedApiKeyEnabled &&
       this.application.api_key_mode === ApiKeyMode.UNSPECIFIED &&
       this.apiKeySubscriptionsCount >= 1 &&
-      this.canShareKey(plan)
+      !this.hasAlreadySubscribedApiKeyPlanOnApi(plan)
     );
   }
 
@@ -179,8 +179,10 @@ class ApplicationSubscribeController {
     return this.Constants.env?.settings?.plan?.security?.sharedApiKey?.enabled;
   }
 
-  canShareKey(plan: any): boolean {
-    return !this.subscriptions.data.some((subscription) => subscription.api === plan.api && subscription.security === ApiKeyMode.SHARED);
+  hasAlreadySubscribedApiKeyPlanOnApi(plan: any): boolean {
+    return this.subscriptions.data.some(
+      (subscription) => subscription.api === plan.api && subscription.security === PlanSecurityType.API_KEY,
+    );
   }
 }
 


### PR DESCRIPTION

see https://github.com/gravitee-io/issues/issues/7248
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7248-feat-shared-api-key-subscription-gards/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-awaxryhdro.chromatic.com)
<!-- Storybook placeholder end -->
