### PR TITLE
Fix plugins version in APIM distribution - 3.15.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -771,7 +771,7 @@ jobs:
                   name: Update maven dependencies versions from properties and remove `-SNAPSHOT` from versions
                   command: |
                       # Update maven dependencies versions from properties
-                      mvn -Duser.home=${HOME} -s /tmp/release.settings.xml -B -U versions:update-properties -Dmaven.version.rules.serverId=artifactory-gravitee-releases -Dincludes="io.gravitee.*:*" -Dexcludes="io.gravitee.policy:*" -DallowMajorUpdates=false -DallowMinorUpdates=false -DallowIncrementalUpdates=true -DgenerateBackupPoms=false
+                      mvn -Duser.home=${HOME} -s /tmp/release.settings.xml -B -U versions:update-properties -Dmaven.version.rules.serverId=artifactory-gravitee-releases -Dincludes="io.gravitee.*:*" -Dexcludes="io.gravitee.policy:*,io.gravitee.connector:*,io.gravitee.resource:*,io.gravitee.service:*,io.gravitee.fetcher:*,io.gravitee.tracer:*,io.gravitee.repository:*,io.gravitee.reporter:*,io.gravitee.cockpit:*,io.gravitee.discovery:*" -DallowMajorUpdates=false -DallowMinorUpdates=false -DallowIncrementalUpdates=true -DgenerateBackupPoms=false -T 2C
 
                       # Remove `-SNAPSHOT` from versions
                       mvn -Duser.home=${HOME} -s /tmp/release.settings.xml -B versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -46,7 +46,7 @@
     <properties>
         <!-- Versions of the plugins for the full distribution -->
         <!-- Management API & Gateway -->
-        <gravitee-connector-http.version>1.1.1-SNAPSHOT.6967-remove-accept-encoding-client-header</gravitee-connector-http.version>
+        <gravitee-connector-http.version>1.1.0</gravitee-connector-http.version>
         <gravitee-connector-kafka.version>1.0.1</gravitee-connector-kafka.version>
         <gravitee-policy-apikey.version>2.4.0</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>1.5.0</gravitee-policy-assign-attributes.version>
@@ -93,25 +93,25 @@
         <gravitee-policy-xml-threat-protection.version>1.3.0</gravitee-policy-xml-threat-protection.version>
         <gravitee-policy-xml-validation.version>1.1.0</gravitee-policy-xml-validation.version>
         <gravitee-policy-xslt.version>1.6.0</gravitee-policy-xslt.version>
-        <gravitee-resource-cache.version>1.7.1-SNAPSHOT.renovate-gravitee-node-version</gravitee-resource-cache.version>
+        <gravitee-resource-cache.version>1.7.0</gravitee-resource-cache.version>
         <gravitee-resource-oauth2-provider-am.version>1.14.1</gravitee-resource-oauth2-provider-am.version>
         <gravitee-resource-oauth2-provider-generic.version>1.16.1</gravitee-resource-oauth2-provider-generic.version>
-        <gravitee-service-discovery-consul.version>1.3.1-SNAPSHOT.renovate-gravitee-common-version</gravitee-service-discovery-consul.version>
+        <gravitee-service-discovery-consul.version>1.3.0</gravitee-service-discovery-consul.version>
         <!-- Management API Only -->
         <gravitee-cockpit-connectors-ws.version>2.3.0</gravitee-cockpit-connectors-ws.version>
-        <gravitee-fetcher-bitbucket.version>1.7.1-SNAPSHOT.renovate-gravitee-node-api-version</gravitee-fetcher-bitbucket.version>
+        <gravitee-fetcher-bitbucket.version>1.7.0</gravitee-fetcher-bitbucket.version>
         <gravitee-fetcher-git.version>1.7.0</gravitee-fetcher-git.version>
-        <gravitee-fetcher-github.version>1.6.1-SNAPSHOT.renovate-gravitee-bom-version</gravitee-fetcher-github.version>
+        <gravitee-fetcher-github.version>1.6.0</gravitee-fetcher-github.version>
         <gravitee-fetcher-gitlab.version>1.11.0</gravitee-fetcher-gitlab.version>
-        <gravitee-fetcher-http.version>1.12.1-SNAPSHOT.renovate-gravitee-node-api-version</gravitee-fetcher-http.version>
+        <gravitee-fetcher-http.version>1.12.0</gravitee-fetcher-http.version>
         <gravitee-repository-elasticsearch.version>3.11.0</gravitee-repository-elasticsearch.version>
         <!-- Gateway Only -->
         <gravitee-reporter-elasticsearch.version>3.11.0</gravitee-reporter-elasticsearch.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->
         <!--    <gravitee-gateway-services-ratelimit.version>1.15.0</gravitee-gateway-services-ratelimit.version>    -->
-        <gravitee-reporter-file.version>2.5.1-SNAPSHOT.renovate-gravitee-common-version</gravitee-reporter-file.version>
-        <gravitee-reporter-tcp.version>1.4.1-SNAPSHOT.renovate-gravitee-common-version</gravitee-reporter-tcp.version>
-        <gravitee-tracer-jaeger.version>1.1.1-SNAPSHOT.renovate-gravitee-node-api-version</gravitee-tracer-jaeger.version>
+        <gravitee-reporter-file.version>2.5.0</gravitee-reporter-file.version>
+        <gravitee-reporter-tcp.version>1.4.0</gravitee-reporter-tcp.version>
+        <gravitee-tracer-jaeger.version>1.1.0</gravitee-tracer-jaeger.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
**Issue**

NA

**Description**

 - Set back correct version of plugins in APIM distribution because they have been updated automatically during the release with a non-stable version
 - Update release script to ignore all plugins released with semantic release
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lytgbselay.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-distribution/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
