### PR TITLE
Feat/shared apikey forbid endpoints for shared key

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionApiKeysResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionApiKeysResource.java
@@ -19,14 +19,20 @@ import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.management.rest.security.Permission;
 import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.model.ApiKeyEntity;
+import io.gravitee.rest.api.model.ApplicationEntity;
 import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.ApiKeyService;
+import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.ParameterService;
 import io.gravitee.rest.api.service.SubscriptionService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
+import io.gravitee.rest.api.service.exceptions.InvalidApplicationApiKeyModeException;
+import io.gravitee.rest.api.service.exceptions.SubscriptionNotFoundException;
 import io.gravitee.rest.api.validator.CustomApiKey;
 import io.swagger.annotations.*;
 import java.net.URI;
@@ -55,6 +61,9 @@ public class ApiSubscriptionApiKeysResource extends AbstractResource {
 
     @Inject
     private SubscriptionService subscriptionService;
+
+    @Inject
+    private ApplicationService applicationService;
 
     @SuppressWarnings("UnresolvedRestParam")
     @PathParam("api")
@@ -111,6 +120,10 @@ public class ApiSubscriptionApiKeysResource extends AbstractResource {
         }
 
         SubscriptionEntity subscriptionEntity = subscriptionService.findById(subscription);
+        if (subscriptionEntity == null) {
+            throw new SubscriptionNotFoundException(subscription);
+        }
+        checkApplicationApiKeyModeAllowed(subscriptionEntity.getApplication());
 
         ApiKeyEntity apiKeyEntity = apiKeyService.renew(subscriptionEntity, customApiKey);
 
@@ -120,6 +133,21 @@ public class ApiSubscriptionApiKeysResource extends AbstractResource {
 
     @Path("{apikey}")
     public ApiSubscriptionApiKeyResource getApiSubscriptionApiKeyResource() {
+        SubscriptionEntity subscriptionEntity = subscriptionService.findById(subscription);
+        if (subscriptionEntity == null) {
+            throw new SubscriptionNotFoundException(subscription);
+        }
+        checkApplicationApiKeyModeAllowed(subscriptionEntity.getApplication());
         return resourceContext.getResource(ApiSubscriptionApiKeyResource.class);
+    }
+
+    private void checkApplicationApiKeyModeAllowed(String applicationId) {
+        ApplicationEntity applicationEntity = applicationService.findById(GraviteeContext.getCurrentEnvironment(), applicationId);
+        if (applicationEntity == null) {
+            throw new ApplicationNotFoundException(applicationId);
+        }
+        if (applicationEntity.hasApiKeySharedMode()) {
+            throw new InvalidApplicationApiKeyModeException("Can't access API key by API subscription cause it's a shared Api Key");
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionApiKeysResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionApiKeysResource.java
@@ -19,11 +19,16 @@ import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.management.rest.security.Permission;
 import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.model.ApiKeyEntity;
+import io.gravitee.rest.api.model.ApplicationEntity;
 import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.ApiKeyService;
+import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.SubscriptionService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
+import io.gravitee.rest.api.service.exceptions.InvalidApplicationApiKeyModeException;
 import io.swagger.annotations.*;
 import java.net.URI;
 import java.util.List;
@@ -47,6 +52,9 @@ public class ApplicationSubscriptionApiKeysResource extends AbstractResource {
 
     @Inject
     private SubscriptionService subscriptionService;
+
+    @Inject
+    private ApplicationService applicationService;
 
     @SuppressWarnings("UnresolvedRestParam")
     @PathParam("application")
@@ -89,6 +97,7 @@ public class ApplicationSubscriptionApiKeysResource extends AbstractResource {
     )
     @Permissions({ @Permission(value = RolePermission.APPLICATION_SUBSCRIPTION, acls = RolePermissionAction.UPDATE) })
     public Response renewApiKeyForApplicationSubscription() {
+        checkApplicationApiKeyModeAllowed(application);
         SubscriptionEntity subscriptionEntity = subscriptionService.findById(subscription);
         ApiKeyEntity apiKeyEntity = apiKeyService.renew(subscriptionEntity);
         URI location = URI.create(uriInfo.getPath().replace("_renew", apiKeyEntity.getId()));
@@ -97,6 +106,17 @@ public class ApplicationSubscriptionApiKeysResource extends AbstractResource {
 
     @Path("{apikey}")
     public ApplicationSubscriptionApiKeyResource getApplicationSubscriptionApiKeyResource() {
+        checkApplicationApiKeyModeAllowed(application);
         return resourceContext.getResource(ApplicationSubscriptionApiKeyResource.class);
+    }
+
+    private void checkApplicationApiKeyModeAllowed(String applicationId) {
+        ApplicationEntity applicationEntity = applicationService.findById(GraviteeContext.getCurrentEnvironment(), applicationId);
+        if (applicationEntity == null) {
+            throw new ApplicationNotFoundException(applicationId);
+        }
+        if (applicationEntity.hasApiKeySharedMode()) {
+            throw new InvalidApplicationApiKeyModeException("Can't access API key by application subscription cause it's a shared API Key");
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionApikeyResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionApikeyResourceTest.java
@@ -21,10 +21,11 @@ import static org.mockito.Mockito.*;
 
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.model.ApiKeyEntity;
+import io.gravitee.rest.api.model.ApiKeyMode;
+import io.gravitee.rest.api.model.ApplicationEntity;
 import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
-import java.util.List;
 import java.util.Set;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
@@ -40,6 +41,7 @@ public class ApiSubscriptionApikeyResourceTest extends AbstractResourceTest {
     private static final String API_ID = "my-api";
     private static final String APIKEY_ID = "my-apikey";
     private static final String SUBSCRIPTION_ID = "my-subscription";
+    private static final String APPLICATION_ID = "my-application";
 
     @Override
     protected String contextPath() {
@@ -48,7 +50,7 @@ public class ApiSubscriptionApikeyResourceTest extends AbstractResourceTest {
 
     @Before
     public void setUp() {
-        reset(apiKeyService);
+        reset(apiKeyService, subscriptionService, applicationService);
         GraviteeContext.cleanContext();
     }
 
@@ -59,6 +61,8 @@ public class ApiSubscriptionApikeyResourceTest extends AbstractResourceTest {
 
     @Test
     public void delete_should_call_revoke_service_and_return_http_204() {
+        mockExistingSubscriptionWithApplication(ApiKeyMode.EXCLUSIVE);
+
         ApiKeyEntity existingApiKey = new ApiKeyEntity();
         SubscriptionEntity subscription = new SubscriptionEntity();
         subscription.setId(SUBSCRIPTION_ID);
@@ -73,6 +77,8 @@ public class ApiSubscriptionApikeyResourceTest extends AbstractResourceTest {
 
     @Test
     public void delete_should_return_http_400_when_apikey_on_another_subscription() {
+        mockExistingSubscriptionWithApplication(ApiKeyMode.EXCLUSIVE);
+
         ApiKeyEntity existingApiKey = new ApiKeyEntity();
         SubscriptionEntity subscription = new SubscriptionEntity();
         subscription.setId("another-subscription");
@@ -88,6 +94,8 @@ public class ApiSubscriptionApikeyResourceTest extends AbstractResourceTest {
 
     @Test
     public void delete_should_return_http_500_on_exception() {
+        mockExistingSubscriptionWithApplication(ApiKeyMode.EXCLUSIVE);
+
         doThrow(TechnicalManagementException.class).when(apiKeyService).revoke(any(String.class), any(Boolean.class));
 
         Response response = envTarget().request().delete();
@@ -97,6 +105,8 @@ public class ApiSubscriptionApikeyResourceTest extends AbstractResourceTest {
 
     @Test
     public void put_should_return_http_400_if_entity_id_does_not_match() {
+        mockExistingSubscriptionWithApplication(ApiKeyMode.EXCLUSIVE);
+
         ApiKeyEntity apiKey = new ApiKeyEntity();
         apiKey.setId("another-api-key-id");
 
@@ -107,6 +117,8 @@ public class ApiSubscriptionApikeyResourceTest extends AbstractResourceTest {
 
     @Test
     public void put_should_call_service_update_and_return_http_200() {
+        mockExistingSubscriptionWithApplication(ApiKeyMode.EXCLUSIVE);
+
         ApiKeyEntity apiKey = new ApiKeyEntity();
         apiKey.setId(APIKEY_ID);
 
@@ -118,6 +130,8 @@ public class ApiSubscriptionApikeyResourceTest extends AbstractResourceTest {
 
     @Test
     public void put_should_return_http_500_on_exception() {
+        mockExistingSubscriptionWithApplication(ApiKeyMode.EXCLUSIVE);
+
         ApiKeyEntity apiKey = new ApiKeyEntity();
         apiKey.setId(APIKEY_ID);
 
@@ -129,7 +143,31 @@ public class ApiSubscriptionApikeyResourceTest extends AbstractResourceTest {
     }
 
     @Test
+    public void put_should_return_http_404_when_subscription_not_found() {
+        ApiKeyEntity apiKey = new ApiKeyEntity();
+        apiKey.setId(APIKEY_ID);
+
+        Response response = envTarget().request().put(Entity.json(apiKey));
+
+        assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
+    }
+
+    @Test
+    public void put_should_return_http_400_when_its_a_shared_api_key() {
+        mockExistingSubscriptionWithApplication(ApiKeyMode.SHARED);
+
+        ApiKeyEntity apiKey = new ApiKeyEntity();
+        apiKey.setId(APIKEY_ID);
+
+        Response response = envTarget().request().put(Entity.json(apiKey));
+
+        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+    }
+
+    @Test
     public void post_on_reactivate_should_call_reactivate_service_and_return_http_200() {
+        mockExistingSubscriptionWithApplication(ApiKeyMode.EXCLUSIVE);
+
         ApiKeyEntity existingApiKey = new ApiKeyEntity();
         SubscriptionEntity subscription = new SubscriptionEntity();
         subscription.setId(SUBSCRIPTION_ID);
@@ -144,6 +182,8 @@ public class ApiSubscriptionApikeyResourceTest extends AbstractResourceTest {
 
     @Test
     public void post_on_reactivate_should_return_http_400_when_apikey_on_another_subscription() {
+        mockExistingSubscriptionWithApplication(ApiKeyMode.EXCLUSIVE);
+
         ApiKeyEntity existingApiKey = new ApiKeyEntity();
         SubscriptionEntity subscription = new SubscriptionEntity();
         subscription.setId("another-subscription");
@@ -155,5 +195,15 @@ public class ApiSubscriptionApikeyResourceTest extends AbstractResourceTest {
 
         verify(apiKeyService, never()).reactivate(any(ApiKeyEntity.class));
         assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+    }
+
+    private void mockExistingSubscriptionWithApplication(ApiKeyMode apiKeyMode) {
+        SubscriptionEntity subscription = new SubscriptionEntity();
+        subscription.setApplication(APPLICATION_ID);
+        when(subscriptionService.findById(SUBSCRIPTION_ID)).thenReturn(subscription);
+
+        ApplicationEntity application = new ApplicationEntity();
+        application.setApiKeyMode(apiKeyMode);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(application);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionApikeysResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionApikeysResourceTest.java
@@ -23,7 +23,10 @@ import static org.mockito.Mockito.when;
 
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.model.ApiKeyEntity;
+import io.gravitee.rest.api.model.ApiKeyMode;
+import io.gravitee.rest.api.model.ApplicationEntity;
 import io.gravitee.rest.api.model.SubscriptionEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.List;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
@@ -37,6 +40,7 @@ public class ApiSubscriptionApikeysResourceTest extends AbstractResourceTest {
 
     private static final String API_ID = "my-api";
     private static final String SUBSCRIPTION_ID = "my-subscription";
+    private static final String APPLICATION_ID = "my-application";
 
     @Override
     protected String contextPath() {
@@ -63,12 +67,11 @@ public class ApiSubscriptionApikeysResourceTest extends AbstractResourceTest {
 
     @Test
     public void post_on_renew_should_return_renew_apikeys_and_return_http_201_with_location_header() {
-        ApiKeyEntity renewedApiKey = new ApiKeyEntity();
-        SubscriptionEntity subscription = new SubscriptionEntity();
-        renewedApiKey.setId("test-id");
-        subscription.setId("test-subscription-id");
+        mockExistingSubscriptionWithApplication(ApiKeyMode.EXCLUSIVE);
 
-        when(subscriptionService.findById(anyString())).thenReturn(subscription);
+        ApiKeyEntity renewedApiKey = new ApiKeyEntity();
+        renewedApiKey.setId("test-id");
+
         when(apiKeyService.renew(any(), any())).thenReturn(renewedApiKey);
 
         Response response = envTarget("/_renew").request().post(null);
@@ -76,5 +79,25 @@ public class ApiSubscriptionApikeysResourceTest extends AbstractResourceTest {
         assertEquals(HttpStatusCode.CREATED_201, response.getStatus());
         assertEquals(renewedApiKey, response.readEntity(ApiKeyEntity.class));
         assertTrue(response.getLocation().toString().endsWith("/apis/my-api/subscriptions/my-subscription/apikeys/test-id"));
+    }
+
+    @Test
+    public void post_on_renew_should_return_400_when_shared_api_key_mode() {
+        mockExistingSubscriptionWithApplication(ApiKeyMode.SHARED);
+
+        Response response = envTarget("/_renew").request().post(null);
+
+        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+    }
+
+    private void mockExistingSubscriptionWithApplication(ApiKeyMode apiKeyMode) {
+        SubscriptionEntity subscription = new SubscriptionEntity();
+        subscription.setId("test-subscription-id");
+        subscription.setApplication(APPLICATION_ID);
+        when(subscriptionService.findById(SUBSCRIPTION_ID)).thenReturn(subscription);
+
+        ApplicationEntity application = new ApplicationEntity();
+        application.setApiKeyMode(apiKeyMode);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(application);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionApikeysResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionApikeysResourceTest.java
@@ -22,7 +22,10 @@ import static org.mockito.Mockito.when;
 
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.model.ApiKeyEntity;
+import io.gravitee.rest.api.model.ApiKeyMode;
+import io.gravitee.rest.api.model.ApplicationEntity;
 import io.gravitee.rest.api.model.SubscriptionEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.List;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
@@ -44,7 +47,7 @@ public class ApplicationSubscriptionApikeysResourceTest extends AbstractResource
 
     @Before
     public void setUp() {
-        reset(apiKeyService);
+        reset(apiKeyService, applicationService);
     }
 
     @Test
@@ -62,6 +65,8 @@ public class ApplicationSubscriptionApikeysResourceTest extends AbstractResource
 
     @Test
     public void post_on_renew_should_return_renew_apikeys_and_return_http_201_with_location_header() {
+        mockExistingApplication(ApiKeyMode.EXCLUSIVE);
+
         ApiKeyEntity renewedApiKey = new ApiKeyEntity();
         renewedApiKey.setId("test-id");
 
@@ -77,5 +82,29 @@ public class ApplicationSubscriptionApikeysResourceTest extends AbstractResource
         assertTrue(
             response.getLocation().toString().endsWith("/applications/my-application/subscriptions/my-subscription/apikeys/test-id")
         );
+    }
+
+    @Test
+    public void post_on_renew_should_return_http_404_if_application_not_found() {
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(null);
+
+        Response response = envTarget("/_renew").request().post(null);
+
+        assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
+    }
+
+    @Test
+    public void post_on_renew_should_return_http_400_if_application_found_has_shared_apiKey_mode() {
+        mockExistingApplication(ApiKeyMode.SHARED);
+
+        Response response = envTarget("/_renew").request().post(null);
+
+        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+    }
+
+    private void mockExistingApplication(ApiKeyMode apiKeyMode) {
+        ApplicationEntity application = new ApplicationEntity();
+        application.setApiKeyMode(apiKeyMode);
+        when(applicationService.findById(GraviteeContext.getCurrentEnvironment(), APPLICATION_ID)).thenReturn(application);
     }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6804
https://github.com/gravitee-io/issues/issues/6796

**Description**

feat: forbid usage of subscription's apiKey endpoints on shared Api Key mode

When an application uses the shared ApiKey mode,
Api key update actions (renewal, revoke, update, reactivate) have to be done using the Application's ApiKey endpoint, cause it will impact multiple subscriptions.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/feat-shared-apikey-forbidendpointsforsharedkey/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xiebmwghoj.chromatic.com)
<!-- Storybook placeholder end -->
