### PR TITLE
Fix endpoint switching

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/EndpointHealthcheckResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/EndpointHealthcheckResolver.java
@@ -160,7 +160,12 @@ public class EndpointHealthcheckResolver implements InitializingBean {
     private HttpEndpoint convertToHttpEndpoint(Endpoint endpoint) {
         if (isHttpEndpoint(endpoint)) {
             try {
-                return mapper.readValue(endpoint.getConfiguration(), HttpEndpoint.class);
+                // FIXME: This creates a new instance of HttpEndpoint (and so definition.model.Endpoint) instead of using
+                // the one from the ManagedEndpoint. This is a temporary fix that need to be addressed, for details see
+                // https://github.com/gravitee-io/issues/issues/6437
+                HttpEndpoint httpEndpoint = mapper.readValue(endpoint.getConfiguration(), HttpEndpoint.class);
+                endpoint.getEndpointAvailabilityListeners().forEach(httpEndpoint::addEndpointAvailabilityListener);
+                return httpEndpoint;
             } catch (JsonProcessingException e) {
                 LOGGER.warn("Cannot convert endpoint to http endpoint", e);
             }

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <gravitee-cockpit-api.version>1.9.0</gravitee-cockpit-api.version>
         <gravitee-common.version>1.25.0</gravitee-common.version>
         <gravitee-connector-api.version>1.1.0</gravitee-connector-api.version>
-        <gravitee-definition.version>1.31.0</gravitee-definition.version>
+        <gravitee-definition.version>1.31.1</gravitee-definition.version>
         <gravitee-expression-language.version>1.9.0</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>1.31.1</gravitee-gateway-api.version>


### PR DESCRIPTION
**Issue**

Related to:
 - https://github.com/gravitee-io/issues/issues/7250
 - https://github.com/gravitee-io/issues/issues/7135

**Description**

Keep listeners when creating HttpEndpoint to fix endpoint switching
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7135-fix-endpoint-switching/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uwyvnfklom.chromatic.com)
<!-- Storybook placeholder end -->
