### PR TITLE
Feat/shared api key console management

### DIFF
--- a/gravitee-apim-console-webui/src/management/api-key/api-keys.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-key/api-keys.component.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const ApiKeysComponent: ng.IComponentOptions = {
+  bindings: {
+    application: '<',
+    subscription: '<',
+    api: '<',
+    listLabel: '<',
+    listEvent: '<',
+  },
+  template: require('./api-keys.html'),
+  controller: 'ApiKeysController',
+};
+
+export default ApiKeysComponent;

--- a/gravitee-apim-console-webui/src/management/api-key/api-keys.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api-key/api-keys.controller.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { StateParams, StateService } from '@uirouter/core';
+import { Observable } from 'rxjs';
+
+import NotificationService from '../../services/notification.service';
+import ApplicationService from '../../services/application.service';
+
+class ApiKeysController {
+  private subscription: any;
+  private keys: any[];
+  private application: any;
+  private listLabel: string;
+  private listEvent: Observable<void>;
+  private backStateParams: StateParams;
+
+  constructor(
+    private $mdDialog: angular.material.IDialogService,
+    private NotificationService: NotificationService,
+    private ApplicationService: ApplicationService,
+    private $state: StateService,
+  ) {
+    'ngInject';
+    this.backStateParams = $state.params;
+  }
+
+  $onInit() {
+    this.listApiKeys();
+    if (this.listEvent) {
+      this.listEvent.subscribe(() => this.listApiKeys());
+    }
+  }
+
+  listApiKeys(): void {
+    this.ApplicationService.listApiKeys(this.application, this.subscription).then((response) => {
+      this.keys = response.data;
+    });
+  }
+
+  renewApiKey(): void {
+    this.$mdDialog
+      .show({
+        controller: 'DialogConfirmController',
+        controllerAs: 'ctrl',
+        template: require('../../components/dialog/confirmWarning.dialog.html'),
+        clickOutsideToClose: true,
+        locals: {
+          title: 'Are you sure you want to renew your API Key?',
+          msg: 'Your previous API Key will be no longer valid in 2 hours!',
+          confirmButton: 'Renew',
+        },
+      })
+      .then((response) => {
+        if (response) {
+          this.ApplicationService.renewApiKey(this.application, this.subscription).then(() => {
+            this.NotificationService.show('A new API Key has been generated');
+            this.listApiKeys();
+          });
+        }
+      });
+  }
+
+  isValid(key): boolean {
+    return !key.revoked && !key.expired;
+  }
+
+  // keys are editable if subscription is accepted or if application uses shared API key mode
+  areKeysEditable(): boolean {
+    return (this.subscription && this.subscription.status === 'ACCEPTED') || this.application.api_key_mode === 'SHARED';
+  }
+
+  revokeApiKey(apiKey): void {
+    this.$mdDialog
+      .show({
+        controller: 'DialogConfirmController',
+        controllerAs: 'ctrl',
+        template: require('../../components/dialog/confirmWarning.dialog.html'),
+        clickOutsideToClose: true,
+        locals: {
+          title: "Are you sure you want to revoke API Key '" + apiKey.key + "'?",
+          confirmButton: 'Revoke',
+        },
+      })
+      .then((response) => {
+        if (response) {
+          this.ApplicationService.revokeApiKey(this.application, this.subscription, apiKey.id).then(() => {
+            this.NotificationService.show('API Key ' + apiKey.key + ' has been revoked!');
+            this.listApiKeys();
+          });
+        }
+      });
+  }
+
+  onCopyApiKeySuccess(e): void {
+    this.NotificationService.show('API Key has been copied to clipboard');
+    e.clearSelection();
+  }
+}
+
+export default ApiKeysController;

--- a/gravitee-apim-console-webui/src/management/api-key/api-keys.html
+++ b/gravitee-apim-console-webui/src/management/api-key/api-keys.html
@@ -1,0 +1,77 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h2>{{ $ctrl.listLabel }}</h2>
+<div class="gv-form-content" layout="column">
+  <md-table-container>
+    <table md-table>
+      <thead md-head>
+        <tr md-row>
+          <th md-column>Key</th>
+          <th md-column>Created at</th>
+          <th md-column>Revoked / Expire at</th>
+          <th md-column></th>
+        </tr>
+      </thead>
+      <tbody md-body>
+        <tr md-row ng-repeat="key in $ctrl.keys track by key.key">
+          <td md-cell style="line-height: 30px">
+            <ng-md-icon icon="{{key.revoked?'clear':'done'}}" ng-style="{'fill': key.revoked ? '#BE2628':'#107F20'}"></ng-md-icon>
+            <code>{{key.key}}</code>
+            <span ng-if="!key.revoked && $ctrl.areKeysEditable()">
+              <md-tooltip md-direction="right">Copy to clipboard</md-tooltip>
+              <ng-md-icon
+                icon="content_copy"
+                ngclipboard
+                data-clipboard-text="{{key.key}}"
+                ngclipboard-success="$ctrl.onCopyApiKeySuccess(e);"
+                role="button"
+              ></ng-md-icon>
+            </span>
+          </td>
+          <td md-cell>{{key.created_at | date:'yyyy-MM-dd HH:mm:ss'}}</td>
+          <td md-cell>{{key.revoked_at || key.expire_at | date:'yyyy-MM-dd HH:mm:ss'}}</td>
+          <td md-cell>
+            <span ng-if="!key.revoked && $ctrl.areKeysEditable()">
+              <md-tooltip md-direction="left">Revoke</md-tooltip>
+              <ng-md-icon
+                permission
+                permission-only="'api-subscription-u'"
+                style="top: 0"
+                icon="not_interested"
+                ng-click="$ctrl.revokeApiKey(key)"
+              ></ng-md-icon>
+            </span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </md-table-container>
+
+  <div
+    class="md-actions gravitee-api-save-button"
+    layout="row"
+    permission
+    permission-only="'api-subscription-u'"
+    ng-if="$ctrl.areKeysEditable()"
+  >
+    <md-button class="md-raised md-primary" ng-click="$ctrl.renewApiKey()">
+      <ng-md-icon icon="autorenew" style="fill: white"></ng-md-icon>
+      Renew API Key
+    </md-button>
+  </div>
+</div>

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscription.html
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscription.html
@@ -101,65 +101,11 @@
     ng-if="$ctrl.subscription.status === 'PENDING' && $ctrl.keys.length > 0
           || $ctrl.subscription.status !== 'PENDING' && $ctrl.subscription.status !== 'REJECTED' && $ctrl.subscription.plan.security === 'API_KEY'"
   >
-    <h2>Api Keys</h2>
-    <div class="gv-form-content" layout="column">
-      <md-table-container>
-        <table md-table>
-          <thead md-head>
-            <tr md-row>
-              <th md-column>Key</th>
-              <th md-column>Created at</th>
-              <th md-column>Revoked / Expire at</th>
-              <th md-column></th>
-            </tr>
-          </thead>
-          <tbody md-body>
-            <tr md-row ng-repeat="key in $ctrl.keys track by key.key">
-              <td md-cell style="line-height: 30px">
-                <ng-md-icon icon="{{key.revoked?'clear':'done'}}" ng-style="{'fill': key.revoked ? '#BE2628':'#107F20'}"></ng-md-icon>
-                <code>{{key.key}}</code>
-                <span ng-if="!key.revoked && $ctrl.subscription.status === 'ACCEPTED'">
-                  <md-tooltip md-direction="right">Copy to clipboard</md-tooltip>
-                  <ng-md-icon
-                    icon="content_copy"
-                    ngclipboard
-                    data-clipboard-text="{{key.key}}"
-                    ngclipboard-success="$ctrl.onCopyApiKeySuccess(e);"
-                    role="button"
-                  ></ng-md-icon>
-                </span>
-              </td>
-              <td md-cell>{{key.created_at | date:'yyyy-MM-dd HH:mm:ss'}}</td>
-              <td md-cell>{{key.revoked_at || key.expire_at | date:'yyyy-MM-dd HH:mm:ss'}}</td>
-              <td md-cell>
-                <span ng-if="!key.revoked && $ctrl.subscription.status === 'ACCEPTED'">
-                  <md-tooltip md-direction="left">Revoke</md-tooltip>
-                  <ng-md-icon
-                    permission
-                    permission-only="'api-subscription-u'"
-                    style="top: 0"
-                    icon="not_interested"
-                    ng-click="$ctrl.revokeApiKey(key)"
-                  ></ng-md-icon>
-                </span>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </md-table-container>
-
-      <div
-        class="md-actions gravitee-api-save-button"
-        layout="row"
-        permission
-        permission-only="'api-subscription-u'"
-        ng-if="$ctrl.subscription.status === 'ACCEPTED'"
-      >
-        <md-button class="md-raised md-primary" ng-click="$ctrl.renewApiKey()">
-          <ng-md-icon icon="autorenew" style="fill: white"></ng-md-icon>
-          Renew API Key
-        </md-button>
-      </div>
-    </div>
+    <api-keys
+      list-label="'API Keys'"
+      list_event="$ctrl.$listApiKeysEvent"
+      application="$ctrl.application"
+      subscription="$ctrl.subscription"
+    />
   </div>
 </div>

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscriptions.html
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscriptions.html
@@ -81,4 +81,8 @@
       >Start playing with APIs</md-button
     >
   </div>
+
+  <div ng-if="$ctrl.sharedSubscriptions.data.length !== 0">
+    <api-keys list-label="'Shared API Key'" application="$ctrl.application" />
+  </div>
 </div>

--- a/gravitee-apim-console-webui/src/management/management.module.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/management.module.ajs.ts
@@ -576,6 +576,8 @@ import { upgradeModule } from '@uirouter/angular-hybrid';
 import uiRouter from '@uirouter/angularjs';
 import ApplicationSubscriptionsListComponent from '../management/application/details/subscriptions/application-subscriptions-list.component';
 import ApplicationSubscriptionsListController from '../management/application/details/subscriptions/application-subscriptions-list.controller';
+import ApiKeysComponent from '../management/api-key/api-keys.component';
+import ApiKeysController from '../management/api-key/api-keys.controller';
 
 (<any>window).moment = moment;
 require('angular-moment-picker');
@@ -928,6 +930,9 @@ graviteeManagementModule.component('planWizardRestrictions', ApiEditPlanWizardRe
 
 // API subscriptions
 graviteeManagementModule.component('apiKeyValidatedInput', ApiKeyValidatedInput);
+graviteeManagementModule.component('apiKeys', ApiKeysComponent);
+graviteeManagementModule.controller('ApiKeysController', ApiKeysController);
+
 graviteeManagementModule.component('apiSubscriptions', ApiSubscriptionsComponent);
 graviteeManagementModule.component('apiSubscription', ApiSubscriptionComponent);
 

--- a/gravitee-apim-console-webui/src/services/application.service.ts
+++ b/gravitee-apim-console-webui/src/services/application.service.ts
@@ -45,15 +45,15 @@ class ApplicationService {
   }
 
   get(applicationId: string): ng.IHttpPromise<any> {
-    return this.$http.get(`${this.Constants.env.baseURL}/applications/` + applicationId);
+    return this.$http.get(`${this.applicationURL(applicationId)}`);
   }
 
   getApplicationType(applicationId: string): ng.IHttpPromise<any> {
-    return this.$http.get(`${this.Constants.env.baseURL}/applications/` + applicationId + '/configuration');
+    return this.$http.get(`${this.applicationURL(applicationId)}` + '/configuration');
   }
 
   getMembers(applicationId): ng.IHttpPromise<any> {
-    return this.$http.get(`${this.Constants.env.baseURL}/applications/` + applicationId + '/members');
+    return this.$http.get(`${this.applicationURL(applicationId)}` + '/members');
   }
 
   addOrUpdateMember(applicationId: string, membership: IMembership): ng.IHttpPromise<any> {
@@ -61,11 +61,11 @@ class ApplicationService {
   }
 
   deleteMember(applicationId: string, userId: string): ng.IHttpPromise<any> {
-    return this.$http.delete(`${this.Constants.env.baseURL}/applications/` + applicationId + '/members?user=' + userId);
+    return this.$http.delete(`${this.applicationURL(applicationId)}` + '/members?user=' + userId);
   }
 
   transferOwnership(applicationId: string, ownership: IMembership): ng.IHttpPromise<any> {
-    return this.$http.post(`${this.Constants.env.baseURL}/applications/` + applicationId + '/members/transfer_ownership', ownership);
+    return this.$http.post(`${this.applicationURL(applicationId)}` + '/members/transfer_ownership', ownership);
   }
 
   list(status = 'active'): ng.IHttpPromise<any> {
@@ -96,7 +96,7 @@ class ApplicationService {
   }
 
   delete(applicationId: string): ng.IHttpPromise<any> {
-    return this.$http.delete(`${this.Constants.env.baseURL}/applications/` + applicationId);
+    return this.$http.delete(`${this.applicationURL(applicationId)}`);
   }
 
   search(query) {
@@ -126,7 +126,7 @@ class ApplicationService {
   }
 
   getSubscribedAPI(applicationId: string): ng.IHttpPromise<any> {
-    return this.$http.get(`${this.Constants.env.baseURL}/applications/` + applicationId + '/subscribed');
+    return this.$http.get(`${this.applicationURL(applicationId)}` + '/subscribed');
   }
 
   getSubscription(applicationId, subscriptionId) {
@@ -137,16 +137,28 @@ class ApplicationService {
     return this.$http.delete(this.subscriptionsURL(applicationId) + subscriptionId);
   }
 
-  listApiKeys(applicationId, subscriptionId): ng.IHttpPromise<any> {
-    return this.$http.get(this.subscriptionsURL(applicationId) + subscriptionId + '/apikeys');
+  listApiKeys(application, subscription): ng.IHttpPromise<any> {
+    if (subscription) {
+      return this.$http.get(this.subscriptionsURL(application.id) + subscription.id + '/apikeys');
+    } else {
+      return this.$http.get(this.applicationURL(application.id) + '/apikeys');
+    }
   }
 
-  renewApiKey(applicationId, subscriptionId) {
-    return this.$http.post(this.subscriptionsURL(applicationId) + subscriptionId + '/apikeys/_renew', '');
+  renewApiKey(application, subscription) {
+    if (subscription) {
+      return this.$http.post(this.subscriptionsURL(application.id) + subscription.id + '/apikeys/_renew', '');
+    } else {
+      return this.$http.post(this.applicationURL(application.id) + '/apikeys/_renew', '');
+    }
   }
 
-  revokeApiKey(applicationId, subscriptionId, apiKeyId) {
-    return this.$http.delete(this.subscriptionsURL(applicationId) + subscriptionId + '/apikeys/' + apiKeyId);
+  revokeApiKey(application, subscription, apiKeyId) {
+    if (subscription) {
+      return this.$http.delete(this.subscriptionsURL(application.id) + subscription.id + '/apikeys/' + apiKeyId);
+    } else {
+      return this.$http.delete(this.applicationURL(application.id) + '/apikeys/' + apiKeyId);
+    }
   }
 
   /*
@@ -227,23 +239,27 @@ class ApplicationService {
   }
 
   listMetadata(applicationId): ng.IPromise<any> {
-    return this.$http.get(`${this.Constants.env.baseURL}/applications/` + applicationId + '/metadata');
+    return this.$http.get(`${this.applicationURL(applicationId)}` + '/metadata');
   }
 
   createMetadata(applicationId, metadata): ng.IPromise<any> {
-    return this.$http.post(`${this.Constants.env.baseURL}/applications/` + applicationId + '/metadata', metadata);
+    return this.$http.post(`${this.applicationURL(applicationId)}` + '/metadata', metadata);
   }
 
   updateMetadata(applicationId, metadata): ng.IPromise<any> {
-    return this.$http.put(`${this.Constants.env.baseURL}/applications/` + applicationId + '/metadata/' + metadata.key, metadata);
+    return this.$http.put(`${this.applicationURL(applicationId)}` + '/metadata/' + metadata.key, metadata);
   }
 
   deleteMetadata(applicationId, metadataId): ng.IPromise<any> {
-    return this.$http.delete(`${this.Constants.env.baseURL}/applications/` + applicationId + '/metadata/' + metadataId);
+    return this.$http.delete(`${this.applicationURL(applicationId)}` + '/metadata/' + metadataId);
+  }
+
+  private applicationURL(applicationId: string): string {
+    return `${this.Constants.env.baseURL}/applications/${applicationId}`;
   }
 
   private subscriptionsURL(applicationId: string): string {
-    return `${this.Constants.env.baseURL}/applications/${applicationId}/subscriptions/`;
+    return `${this.applicationURL(applicationId)}/subscriptions/`;
   }
 
   /*


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6795
https://github.com/gravitee-io/issues/issues/6796
https://github.com/gravitee-io/issues/issues/6804

**Description**

feat: manage shared API key in application subscriptions screen

If there are shared API keys for the application,
This add the shared API key management part at the bottom of the application subscriptions screen.

It externalize the application API key list in a dedicated component,
As it's used to manage the application API keys in :
- the application subscriptions list screen (for shared API key)
- the application subscription screen

![image](https://user-images.githubusercontent.com/87964124/157289893-df508dc1-893c-45e3-b81d-df2fdab434ce.png)


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/feat-shared-api-key-console-management/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-btmkxovqjt.chromatic.com)
<!-- Storybook placeholder end -->
