### PR TITLE
Feat/shared apikey prevent updates

### DIFF
--- a/gravitee-apim-console-webui/src/index.scss
+++ b/gravitee-apim-console-webui/src/index.scss
@@ -59,6 +59,7 @@
 @import 'management/dashboard/analytics-dashboard/analytics-dashboard';
 @import 'management/dashboard/apis-status-dashboard/apis-status-dashboard';
 @import 'management/dashboard/home-dashboard/home-dashboard';
+@import 'management/api-key/api-keys';
 
 @import 'organization/organization';
 

--- a/gravitee-apim-console-webui/src/management/api-key/api-keys.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-key/api-keys.component.ts
@@ -19,7 +19,6 @@ const ApiKeysComponent: ng.IComponentOptions = {
     application: '<',
     subscription: '<',
     api: '<',
-    listLabel: '<',
     listEvent: '<',
   },
   template: require('./api-keys.html'),

--- a/gravitee-apim-console-webui/src/management/api-key/api-keys.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api-key/api-keys.controller.ts
@@ -24,7 +24,6 @@ class ApiKeysController {
   private subscription: any;
   private keys: any[];
   private application: any;
-  private listLabel: string;
   private listEvent: Observable<void>;
   private backStateParams: StateParams;
 
@@ -83,6 +82,10 @@ class ApiKeysController {
     return (this.subscription && this.subscription.status === 'ACCEPTED') || this.application.api_key_mode === 'SHARED';
   }
 
+  isSharedApiKey(): boolean {
+    return this.application.api_key_mode === 'SHARED';
+  }
+
   revokeApiKey(apiKey): void {
     this.$mdDialog
       .show({
@@ -108,6 +111,10 @@ class ApiKeysController {
   onCopyApiKeySuccess(e): void {
     this.NotificationService.show('API Key has been copied to clipboard');
     e.clearSelection();
+  }
+
+  getTitle(): string {
+    return this.isSharedApiKey() ? 'Shared API Key' : 'API Keys';
   }
 }
 

--- a/gravitee-apim-console-webui/src/management/api-key/api-keys.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api-key/api-keys.controller.ts
@@ -77,9 +77,13 @@ class ApiKeysController {
     return !key.revoked && !key.expired;
   }
 
-  // keys are editable if subscription is accepted or if application uses shared API key mode
   areKeysEditable(): boolean {
-    return (this.subscription && this.subscription.status === 'ACCEPTED') || this.application.api_key_mode === 'SHARED';
+    // shared api keys are editable if this is not a subscription related screen
+    if (this.isSharedApiKey()) {
+      return !this.subscription;
+    }
+    // other keys are editable if subscription is accepted
+    return this.subscription && this.subscription.status === 'ACCEPTED';
   }
 
   isSharedApiKey(): boolean {

--- a/gravitee-apim-console-webui/src/management/api-key/api-keys.html
+++ b/gravitee-apim-console-webui/src/management/api-key/api-keys.html
@@ -16,7 +16,7 @@
 
 -->
 <h2>{{ $ctrl.getTitle() }}</h2>
-<div class="gv-form-content" layout="column">
+<div id="api-keys" class="gv-form-content" layout="column">
   <md-table-container>
     <table md-table>
       <thead md-head>
@@ -29,8 +29,8 @@
       </thead>
       <tbody md-body>
         <tr md-row ng-repeat="key in $ctrl.keys | orderBy:['-revoked_at','-expire_at','created_at'] track by key.key ">
-          <td md-cell style="line-height: 30px">
-            <ng-md-icon icon="{{key.revoked?'clear':'done'}}" ng-style="{'fill': key.revoked ? '#BE2628':'#107F20'}"></ng-md-icon>
+          <td md-cell class="api-key-cell">
+            <ng-md-icon icon="{{key.revoked?'clear':'done'}}" ng-class="key.revoked ? 'revoked-icon' : 'active-icon'"></ng-md-icon>
             <code>{{key.key}}</code>
             <span ng-if="!key.revoked && $ctrl.areKeysEditable()">
               <md-tooltip md-direction="right">Copy to clipboard</md-tooltip>
@@ -49,9 +49,9 @@
             <span ng-if="!key.revoked && $ctrl.areKeysEditable()">
               <md-tooltip md-direction="left">Revoke</md-tooltip>
               <ng-md-icon
+                class="revoke-icon"
                 permission
                 permission-only="'api-subscription-u'"
-                style="top: 0"
                 icon="not_interested"
                 ng-click="$ctrl.revokeApiKey(key)"
               ></ng-md-icon>
@@ -70,7 +70,7 @@
     ng-if="$ctrl.areKeysEditable()"
   >
     <md-button class="md-raised md-primary" ng-click="$ctrl.renewApiKey()">
-      <ng-md-icon icon="autorenew" style="fill: white"></ng-md-icon>
+      <ng-md-icon class="renew-icon" icon="autorenew"></ng-md-icon>
       Renew API Key
     </md-button>
   </div>

--- a/gravitee-apim-console-webui/src/management/api-key/api-keys.html
+++ b/gravitee-apim-console-webui/src/management/api-key/api-keys.html
@@ -15,7 +15,7 @@
     limitations under the License.
 
 -->
-<h2>{{ $ctrl.listLabel }}</h2>
+<h2>{{ $ctrl.getTitle() }}</h2>
 <div class="gv-form-content" layout="column">
   <md-table-container>
     <table md-table>

--- a/gravitee-apim-console-webui/src/management/api-key/api-keys.html
+++ b/gravitee-apim-console-webui/src/management/api-key/api-keys.html
@@ -17,6 +17,11 @@
 -->
 <h2>{{ $ctrl.getTitle() }}</h2>
 <div id="api-keys" class="gv-form-content" layout="column">
+  <ng-banner ng-if="$ctrl.isSharedApiKey() && !$ctrl.areKeysEditable()">
+    This subscription uses a shared API key.<br />
+    You can renew or revoke the shared API key at the application level.
+  </ng-banner>
+
   <md-table-container>
     <table md-table>
       <thead md-head>

--- a/gravitee-apim-console-webui/src/management/api-key/api-keys.scss
+++ b/gravitee-apim-console-webui/src/management/api-key/api-keys.scss
@@ -1,0 +1,21 @@
+#api-keys {
+  .api-key-cell {
+    line-height: 20px;
+  }
+
+  .revoke-icon {
+    top: 0;
+  }
+
+  .renew-icon {
+    fill: white;
+  }
+
+  .revoked-icon {
+    fill: #be2628;
+  }
+
+  .active-icon {
+    fill: #107f20;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscription.html
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscription.html
@@ -101,11 +101,6 @@
     ng-if="$ctrl.subscription.status === 'PENDING' && $ctrl.keys.length > 0
           || $ctrl.subscription.status !== 'PENDING' && $ctrl.subscription.status !== 'REJECTED' && $ctrl.subscription.plan.security === 'API_KEY'"
   >
-    <api-keys
-      list-label="'API Keys'"
-      list_event="$ctrl.$listApiKeysEvent"
-      application="$ctrl.application"
-      subscription="$ctrl.subscription"
-    />
+    <api-keys list_event="$ctrl.$listApiKeysEvent" application="$ctrl.application" subscription="$ctrl.subscription" />
   </div>
 </div>

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscriptions.html
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscriptions.html
@@ -83,6 +83,6 @@
   </div>
 
   <div ng-if="$ctrl.areSharedApiKeysDisplayed()">
-    <api-keys list-label="'Shared API Key'" application="$ctrl.application" />
+    <api-keys application="$ctrl.application" />
   </div>
 </div>

--- a/gravitee-apim-console-webui/src/management/management.module.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/management.module.ajs.ts
@@ -578,6 +578,7 @@ import ApplicationSubscriptionsListComponent from '../management/application/det
 import ApplicationSubscriptionsListController from '../management/application/details/subscriptions/application-subscriptions-list.controller';
 import ApiKeysComponent from '../management/api-key/api-keys.component';
 import ApiKeysController from '../management/api-key/api-keys.controller';
+import { GioBannerComponent } from '@gravitee/ui-particles-angular';
 
 (<any>window).moment = moment;
 require('angular-moment-picker');
@@ -935,6 +936,7 @@ graviteeManagementModule.controller('ApiKeysController', ApiKeysController);
 
 graviteeManagementModule.component('apiSubscriptions', ApiSubscriptionsComponent);
 graviteeManagementModule.component('apiSubscription', ApiSubscriptionComponent);
+graviteeManagementModule.directive('ngBanner', downgradeComponent({ component: GioBannerComponent }));
 
 graviteeManagementModule.component('applications', ApplicationsComponent);
 graviteeManagementModule.component('application', ApplicationComponent);


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6799
https://github.com/gravitee-io/issues/issues/6800

**Description**

feat: prevent shared api key update on application subscription screen

This displays a banner and removes the update buttons for shared api key on application subscription screen.

Management API already checks shared API key updates, returning a HTTP 400 if not allowed.

![image](https://user-images.githubusercontent.com/87964124/157474697-38c74f55-b3c2-440b-8ac7-4cac1bf8575b.png)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rqjrwgbhph.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/feat-shared-apikey-prevent-updates/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
