### PR TITLE
Feat/shared apikey prevent updates on publisher side

### DIFF
--- a/gravitee-apim-console-webui/src/management/api-key/api-keys.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api-key/api-keys.controller.ts
@@ -19,6 +19,7 @@ import { Observable } from 'rxjs';
 
 import NotificationService from '../../services/notification.service';
 import ApplicationService from '../../services/application.service';
+import { ApiKeyMode } from '../../entities/application/application';
 
 class ApiKeysController {
   private subscription: any;
@@ -87,7 +88,7 @@ class ApiKeysController {
   }
 
   isSharedApiKey(): boolean {
-    return this.application.api_key_mode === 'SHARED';
+    return this.application.api_key_mode === ApiKeyMode.SHARED;
   }
 
   revokeApiKey(apiKey): void {

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/subscription.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/subscription.component.ts
@@ -19,6 +19,7 @@ import * as _ from 'lodash';
 import { ApiService } from '../../../../services/api.service';
 import NotificationService from '../../../../services/notification.service';
 import { PlanSecurityType } from '../../../../entities/plan/plan';
+import { ApiKeyMode } from '../../../../entities/application/application';
 
 const ApiSubscriptionComponent: ng.IComponentOptions = {
   bindings: {
@@ -341,6 +342,14 @@ const ApiSubscriptionComponent: ng.IComponentOptions = {
 
     isValid(key) {
       return !key.revoked && !key.expired;
+    }
+
+    get hasSharedApiKeyMode(): boolean {
+      return this.subscription?.application?.apiKeyMode === ApiKeyMode.SHARED;
+    }
+
+    get apiKeysTitle(): string {
+      return this.hasSharedApiKeyMode ? 'Shared API Key' : 'API Keys';
     }
 
     private getApiPlans() {

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/subscription.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/subscription.html
@@ -165,8 +165,13 @@
     ng-if="$ctrl.subscription.status === 'PENDING' && $ctrl.keys.length > 0
        || $ctrl.subscription.status !== 'PENDING' && $ctrl.subscription.status !== 'REJECTED' && $ctrl.subscription.plan.security === 'API_KEY'"
   >
-    <h2>Api Keys</h2>
+    <h2>{{$ctrl.apiKeysTitle}}</h2>
     <div class="gv-form-content" layout="column">
+      <ng-banner ng-if="$ctrl.hasSharedApiKeyMode">
+        This subscription uses a shared API key.<br />
+        You can renew or revoke the shared API key at the application level.
+      </ng-banner>
+
       <md-table-container>
         <table md-table>
           <thead md-head>
@@ -199,7 +204,7 @@
               <td md-cell>{{key.created_at | date:'yyyy-MM-dd HH:mm:ss'}}</td>
               <td md-cell>{{key.revoked_at || key.expire_at | date:'yyyy-MM-dd HH:mm:ss'}}</td>
               <td md-cell>
-                <span ng-if="$ctrl.isValid(key) && $ctrl.subscription.status === 'ACCEPTED'">
+                <span ng-if="!$ctrl.hasSharedApiKeyMode && $ctrl.isValid(key) && $ctrl.subscription.status === 'ACCEPTED'">
                   <md-tooltip md-direction="left">Revoke</md-tooltip>
                   <ng-md-icon
                     permission
@@ -209,7 +214,7 @@
                     ng-click="$ctrl.revokeApiKey(key)"
                   ></ng-md-icon>
                 </span>
-                <span ng-if="$ctrl.isValid(key) && $ctrl.subscription.status === 'ACCEPTED'">
+                <span ng-if="!$ctrl.hasSharedApiKeyMode && $ctrl.isValid(key) && $ctrl.subscription.status === 'ACCEPTED'">
                   <md-tooltip md-direction="left">Set expiration date</md-tooltip>
                   <ng-md-icon
                     permission
@@ -219,7 +224,9 @@
                     ng-click="$ctrl.expireApiKey(key)"
                   ></ng-md-icon>
                 </span>
-                <span ng-if="!$ctrl.isValid(key) && ($ctrl.subscription.status === 'ACCEPTED' || $ctrl.subscription.status === 'PAUSED')">
+                <span
+                  ng-if="!$ctrl.hasSharedApiKeyMode && !$ctrl.isValid(key) && ($ctrl.subscription.status === 'ACCEPTED' || $ctrl.subscription.status === 'PAUSED')"
+                >
                   <md-tooltip md-direction="left">Reactivate</md-tooltip>
                   <ng-md-icon
                     permission
@@ -240,7 +247,7 @@
         layout="row"
         permission
         permission-only="'api-subscription-u'"
-        ng-if="$ctrl.subscription.status === 'ACCEPTED'"
+        ng-if="!$ctrl.hasSharedApiKeyMode && $ctrl.subscription.status === 'ACCEPTED'"
       >
         <md-button class="md-raised md-primary" ng-click="$ctrl.renewApiKey()">
           <ng-md-icon icon="autorenew" style="fill: white"></ng-md-icon>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/Subscription.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/Subscription.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.management.rest.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.gravitee.rest.api.model.ApiKeyMode;
 import io.gravitee.rest.api.model.PlanSecurityType;
 import io.gravitee.rest.api.model.SubscriptionStatus;
 import java.util.Date;
@@ -263,6 +264,7 @@ public class Subscription {
         private final String description;
         private final String domain;
         private final User owner;
+        private final ApiKeyMode apiKeyMode;
 
         public Application(
             final String id,
@@ -270,7 +272,8 @@ public class Subscription {
             final String type,
             final String description,
             final String domain,
-            final User owner
+            final User owner,
+            final ApiKeyMode apiKeyMode
         ) {
             this.id = id;
             this.name = name;
@@ -278,6 +281,7 @@ public class Subscription {
             this.description = description;
             this.domain = domain;
             this.owner = owner;
+            this.apiKeyMode = apiKeyMode;
         }
 
         public String getId() {
@@ -302,6 +306,10 @@ public class Subscription {
 
         public User getOwner() {
             return owner;
+        }
+
+        public ApiKeyMode getApiKeyMode() {
+            return apiKeyMode;
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionResource.java
@@ -23,15 +23,11 @@ import io.gravitee.rest.api.management.rest.model.Subscription;
 import io.gravitee.rest.api.management.rest.security.Permission;
 import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.model.*;
-import io.gravitee.rest.api.model.parameters.Key;
-import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.validator.CustomApiKey;
 import io.swagger.annotations.*;
-import java.util.List;
 import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -39,7 +35,6 @@ import javax.ws.rs.*;
 import javax.ws.rs.container.ResourceContext;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -247,7 +242,8 @@ public class ApiSubscriptionResource extends AbstractResource {
                 application.getType(),
                 application.getDescription(),
                 application.getDomain(),
-                new Subscription.User(application.getPrimaryOwner().getId(), application.getPrimaryOwner().getDisplayName())
+                new Subscription.User(application.getPrimaryOwner().getId(), application.getPrimaryOwner().getDisplayName()),
+                application.getApiKeyMode()
             )
         );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionsResource.java
@@ -251,7 +251,8 @@ public class ApiSubscriptionsResource extends AbstractResource {
                 application.getType(),
                 application.getDescription(),
                 application.getDomain(),
-                new Subscription.User(application.getPrimaryOwner().getId(), application.getPrimaryOwner().getDisplayName())
+                new Subscription.User(application.getPrimaryOwner().getId(), application.getPrimaryOwner().getDisplayName()),
+                application.getApiKeyMode()
             )
         );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/SubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/SubscriptionsResource.java
@@ -88,7 +88,8 @@ public class SubscriptionsResource {
                 application.getType(),
                 application.getDescription(),
                 application.getDomain(),
-                new Subscription.User(application.getPrimaryOwner().getId(), application.getPrimaryOwner().getDisplayName())
+                new Subscription.User(application.getPrimaryOwner().getId(), application.getPrimaryOwner().getDisplayName()),
+                application.getApiKeyMode()
             )
         );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionResourceTest.java
@@ -78,6 +78,7 @@ public class ApiSubscriptionResourceTest extends AbstractResourceTest {
         fakeApplicationEntity.setName("applicationName");
         fakeApplicationEntity.setType("applicationType");
         fakeApplicationEntity.setDescription("applicationDescription");
+        fakeApplicationEntity.setApiKeyMode(ApiKeyMode.UNSPECIFIED);
         fakeApplicationEntity.setPrimaryOwner(new PrimaryOwnerEntity(fakeUserEntity));
 
         when(userService.findById(any(), anyBoolean())).thenReturn(fakeUserEntity);


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6799
https://github.com/gravitee-io/issues/issues/6800

**Description**

feat: prevent shared api key update on api subscription screen

This displays a banner and removes the update buttons for shared api key on api subscription screen.

Management API already checks shared API key updates, returning a HTTP 400 if not allowed.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vfpiatlqsu.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/feat-shared-apikey-prevent-updates-publisherside/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
