### PR TITLE
Display shared API Keys on application subscriptions page (portal)

### DIFF
--- a/gravitee-apim-portal-webui/projects/portal-webclient-sdk/src/lib/model/application.ts
+++ b/gravitee-apim-portal-webui/projects/portal-webclient-sdk/src/lib/model/application.ts
@@ -60,7 +60,20 @@ export interface Application {
      * Background of the application. This attribute is only used to update a picture.\\ To get the application picture, use /application/{applicationId}/background. 
      */
     background?: string;
+    /**
+     * The API key mode to use for this application.   - The `SHARED` API key mode allows consumer to use the same API key across all the subscriptions   - The `EXCLUSIVE` API key mode will result to a new API key being generated for each subscription   - The `UNSPECIFIED` API key mode is a marker value informing that no choice as been made yet regarding     the API key mode to use for the application. 
+     */
+    api_key_mode?: Application.ApiKeyModeEnum;
     settings?: ApplicationSettings;
     _links?: ApplicationLinks;
 }
+export namespace Application {
+    export type ApiKeyModeEnum = 'SHARED' | 'EXCLUSIVE' | 'UNSPECIFIED';
+    export const ApiKeyModeEnum = {
+        SHARED: 'SHARED' as ApiKeyModeEnum,
+        EXCLUSIVE: 'EXCLUSIVE' as ApiKeyModeEnum,
+        UNSPECIFIED: 'UNSPECIFIED' as ApiKeyModeEnum
+    };
+}
+
 

--- a/gravitee-apim-portal-webui/projects/portal-webclient-sdk/src/lib/model/configurationPlanSecurity.ts
+++ b/gravitee-apim-portal-webui/projects/portal-webclient-sdk/src/lib/model/configurationPlanSecurity.ts
@@ -13,6 +13,7 @@ import { Enabled } from './enabled';
 
 export interface ConfigurationPlanSecurity { 
     apikey?: Enabled;
+    sharedApiKey?: Enabled;
     oauth2?: Enabled;
     keyless?: Enabled;
     jwt?: Enabled;

--- a/gravitee-apim-portal-webui/projects/portal-webclient-sdk/src/lib/model/key.ts
+++ b/gravitee-apim-portal-webui/projects/portal-webclient-sdk/src/lib/model/key.ts
@@ -8,6 +8,8 @@
  * https://openapi-generator.tech
  * Do not edit the class manually.
  */
+import { Subscription } from './subscription';
+import { Application } from './application';
 
 
 /**
@@ -16,9 +18,8 @@
 export interface Key { 
     id?: string;
     key?: string;
-    api?: string;
-    application?: string;
-    plan?: string;
+    application?: Application;
+    subscriptions?: Array<Subscription>;
     paused?: boolean;
     revoked?: boolean;
     expired?: boolean;

--- a/gravitee-apim-portal-webui/src/app/pages/application/application-subscriptions/application-subscriptions.component.css
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-subscriptions/application-subscriptions.component.css
@@ -46,6 +46,7 @@ gv-confirm {
 
 .confirm__right {
   display: flex;
+  flex-direction: column;
   justify-content: flex-end;
 }
 
@@ -57,4 +58,53 @@ gv-confirm {
 .page__box-row {
   margin: 0.2rem;
   box-sizing: border-box;
+}
+
+.page__box-content_shared-key {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.application-subscriptions__shared-key-message,
+.application-subscriptions__shared-key-info,
+.application-subscriptions__shared-key-actions {
+  padding: 0 5px;
+}
+
+.application-subscriptions__shared-key-message {
+  flex: 1;
+}
+
+.application-subscriptions__shared-key-info {
+  flex: 2;
+}
+
+.application-subscriptions__shared-key-info__title {
+  text-transform: uppercase;
+  font-size: var(--gv-theme-font-size-xs, 10px);
+  font-style: normal;
+  font-weight: 700;
+  line-height: 14px;
+  letter-spacing: 0.25px;
+}
+
+.application-subscriptions__shared-key-info__row {
+  display: flex;
+  margin: 5px;
+}
+
+.application-subscriptions__shared-key-info__row__cell {
+  flex: 1;
+}
+
+.application-subscriptions__shared-key-actions,
+.application-subscriptions__shared-key-info__row__cell {
+  display: flex;
+  flex-direction: column;
+}
+
+.application-subscriptions__shared-key-actions__button,
+.application-subscriptions__search__button {
+  min-width: 160px;
 }

--- a/gravitee-apim-portal-webui/src/app/pages/application/application-subscriptions/application-subscriptions.component.html
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-subscriptions/application-subscriptions.component.html
@@ -15,8 +15,87 @@
     limitations under the License.
 
 -->
-<div class="page__content page__content-with-aside">
+<div class="page__content page__content-with-aside application-subscriptions">
   <div class="main">
+    <div class="page__box" *ngIf="applicationHasSharedKey()">
+      <div class="page__box-title">
+        <h3 class="title">
+          {{ 'application.shared-key.title' | translate }}
+        </h3>
+      </div>
+      <div class="page__box-content page__box-content_shared-key">
+        <div class="application-subscriptions__shared-key-info">
+          <div class="application-subscriptions__shared-key-info__row">
+            <div class="application-subscriptions__shared-key-info__row__cell">
+              {{ 'application.shared-key.message' | translate }}
+            </div>
+          </div>
+          <div class="application-subscriptions__shared-key-info__row" *ngIf="sharedAPIKeyLoaded && !sharedAPIKey">
+            <div class="application-subscriptions__shared-key-info__row__cell">
+              {{ 'application.shared-key.no-key.message' | translate }}
+            </div>
+          </div>
+          <div class="application-subscriptions__shared-key-info__row" *ngIf="sharedAPIKeyLoaded && !sharedAPIKey">
+            <div class="application-subscriptions__shared-key-info__row__cell" *ngIf="canRenewSharedApiKey()">
+              {{ 'application.shared-key.no-key.create' | translate }}
+            </div>
+            <div class="application-subscriptions__shared-key-info__row__cell" *ngIf="!canRenewSharedApiKey()">
+              {{ 'application.shared-key.no-key.recommendation' | translate }}
+            </div>
+          </div>
+        </div>
+
+        <div class="application-subscriptions__shared-key-info" *ngIf="sharedAPIKey">
+          <div class="application-subscriptions__shared-key-info__row">
+            <div class="application-subscriptions__shared-key-info__row__cell">
+              <h4 class="title">{{ 'application.shared-key.info.title' | translate }}</h4>
+              <gv-input readonly clipboard [value]="sharedAPIKey.key"></gv-input>
+            </div>
+          </div>
+          <div class="application-subscriptions__shared-key-info__row">
+            <div class="application-subscriptions__shared-key-info__row__cell">
+              <h5 class="title">{{ 'application.shared-key.info.created_at' | translate }}</h5>
+              {{ sharedAPIKey.created_at | localizedDate: 'shortDate':'--' }}
+            </div>
+            <div class="application-subscriptions__shared-key-info__row__cell" *ngIf="sharedAPIKey.expire_at">
+              <h5 class="title">{{ 'application.shared-key.info.end_at' | translate }}</h5>
+              <gv-relative-time [datetime]="sharedAPIKey.expire_at"></gv-relative-time>
+            </div>
+          </div>
+        </div>
+
+        <div
+          class="application-subscriptions__shared-key-actions"
+          *ngIf="canRenewSharedApiKey() || (canRevokeSharedApiKey && sharedAPIKey)"
+        >
+          <gv-confirm
+            *ngIf="canRenewSharedApiKey()"
+            [message]="'application.shared-key.renew.message' | translate"
+            (:gv-confirm:ok)="renewSharedApiKey()"
+            [cancelLabel]="'common.cancel' | translate"
+            [okLabel]="'common.ok' | translate"
+          >
+            <gv-button primary class="application-subscriptions__shared-key-actions__button">{{
+              'application.shared-key.renew.title' | translate
+            }}</gv-button>
+          </gv-confirm>
+
+          <gv-confirm
+            *ngIf="canRevokeSharedApiKey() && sharedAPIKey"
+            [message]="'application.shared-key.revoke.message' | translate"
+            danger
+            (:gv-confirm:ok)="revokeSharedApiKey()"
+            [cancelLabel]="'common.cancel' | translate"
+            [okLabel]="'common.ok' | translate"
+          >
+            <gv-button outlined class="application-subscriptions__shared-key-actions__button">
+              {{ 'application.shared-key.revoke.title' | translate }}</gv-button
+            >
+          </gv-confirm>
+        </div>
+      </div>
+    </div>
+
     <div class="page__box">
       <div class="page__box-title">
         <h3 class="title">{{ 'application.subscriptions.title' | translate }}</h3>
@@ -49,7 +128,13 @@
           </div>
 
           <div class="form__actions">
-            <gv-button type="submit" primary [loading]="isSearching" icon="general:search">
+            <gv-button
+              type="submit"
+              primary
+              [loading]="isSearching"
+              icon="general:search"
+              class="application-subscriptions__search__button"
+            >
               {{ 'common.search' | translate }}
             </gv-button>
           </div>
@@ -70,7 +155,7 @@
   </div>
 
   <aside class="aside form">
-    <div class="page__box" *ngIf="canRenew(selectedSubscription) || canRevoke(selectedSubscription)">
+    <div class="page__box" *ngIf="canCloseSubscription(selectedSubscription)">
       <div class="page__box-title">
         <h4 class="title">{{ 'application.subscriptions.selected.title' | translate }}</h4>
       </div>
@@ -90,14 +175,7 @@
       </div>
       <div class="page__box-footer form__actions">
         <gv-confirm
-          *ngIf="canRenew(selectedSubscription)"
-          [message]="'application.subscriptions.renew.message' | translate"
-          (:gv-confirm:ok)="renewSubscription(selectedSubscription.id)"
-        >
-          <gv-button primary>{{ 'application.subscriptions.renew.title' | translate }}</gv-button>
-        </gv-confirm>
-        <gv-confirm
-          *ngIf="canRevoke(selectedSubscription)"
+          *ngIf="canCloseSubscription(selectedSubscription)"
           [message]="'application.subscriptions.close.message' | translate"
           danger
           (:gv-confirm:ok)="closeSubscription(selectedSubscription.id)"
@@ -106,13 +184,13 @@
         </gv-confirm>
       </div>
     </div>
-    <div class="page__box" *ngIf="getValidApiKeys(selectedSubscription)">
+    <div class="page__box" *ngIf="getValidApiKeys(selectedSubscription) || getExpiredApiKeys(selectedSubscription)">
       <div class="page__box-title">
         <h4 class="title">{{ 'application.subscriptions.apiKey.title' | translate }}</h4>
       </div>
 
       <div class="page__box-content" *ngFor="let apiKey of getValidApiKeys(selectedSubscription)">
-        <gv-input clipboard [value]="apiKey.key"></gv-input>
+        <gv-input readonly clipboard [value]="apiKey.key"></gv-input>
 
         <div class="page__box-row">
           <span>{{ 'application.subscriptions.apiKey.created_at' | translate }}</span>
@@ -126,13 +204,22 @@
 
         <div class="confirm__right">
           <gv-confirm
+            *ngIf="canRenewApiKey(selectedSubscription) && !endAt(apiKey)"
+            [message]="'application.subscriptions.renew.message' | translate"
+            (:gv-confirm:ok)="renewApiKey(selectedSubscription.id)"
+          >
+            <gv-button primary>{{ 'application.subscriptions.renew.title' | translate }}</gv-button>
+          </gv-confirm>
+
+          <gv-confirm
+            *ngIf="canRevokeApiKey(selectedSubscription)"
             [message]="'application.subscriptions.apiKey.revoke.message' | translate"
             danger
             (:gv-confirm:ok)="revokeApiKey(selectedSubscription.id, apiKey.key)"
             [cancelLabel]="'common.cancel' | translate"
             [okLabel]="'common.ok' | translate"
           >
-            <gv-button *ngIf="canUpdate" link>
+            <gv-button outlined>
               {{ 'application.subscriptions.apiKey.revoke.label' | translate }}
             </gv-button>
           </gv-confirm>

--- a/gravitee-apim-portal-webui/src/app/pages/application/application-subscriptions/application-subscriptions.component.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-subscriptions/application-subscriptions.component.spec.ts
@@ -13,33 +13,196 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
-import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 import { LocalizedDatePipe } from '../../../pipes/localized-date.pipe';
 import { TranslateTestingModule } from '../../../test/translate-testing-module';
 
 import { ApplicationSubscriptionsComponent } from './application-subscriptions.component';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { fakeAsync, async, ComponentFixture, TestBed, tick } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { Application, Key, Plan, Subscription } from '../../../../../projects/portal-webclient-sdk/src/lib';
+import ApiKeyModeEnum = Application.ApiKeyModeEnum;
+import SecurityEnum = Plan.SecurityEnum;
 
 describe('ApplicationSubscriptionsComponent', () => {
-  const createComponent = createComponentFactory({
-    component: ApplicationSubscriptionsComponent,
+  let component: ApplicationSubscriptionsComponent;
+  let fixture: ComponentFixture<ApplicationSubscriptionsComponent>;
+  const defaultConf = {
+    declarations: [ApplicationSubscriptionsComponent, LocalizedDatePipe],
+    imports: [TranslateTestingModule, HttpClientTestingModule, RouterTestingModule, FormsModule, ReactiveFormsModule],
     schemas: [CUSTOM_ELEMENTS_SCHEMA],
-    imports: [HttpClientTestingModule, RouterTestingModule, TranslateTestingModule, FormsModule, ReactiveFormsModule],
-    declarations: [LocalizedDatePipe],
+  };
+
+  function initFixture(): void {
+    fixture = TestBed.createComponent(ApplicationSubscriptionsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  describe('empty app', () => {
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        ...defaultConf,
+        providers: [
+          {
+            provide: ActivatedRoute,
+            useValue: {
+              snapshot: {
+                data: {},
+              },
+            },
+          },
+        ],
+      }).compileComponents();
+      initFixture();
+    }));
+
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
   });
 
-  let spectator: Spectator<ApplicationSubscriptionsComponent>;
-  let component;
+  describe('shared key app', () => {
+    let httpTestingController: HttpTestingController;
 
-  beforeEach(() => {
-    spectator = createComponent();
-    component = spectator.component;
+    afterEach(() => {
+      httpTestingController.verify();
+    });
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        ...defaultConf,
+        providers: [
+          {
+            provide: ActivatedRoute,
+            useValue: {
+              snapshot: {
+                data: {
+                  application: {
+                    id: 'application1',
+                    name: 'applicationWithSharedKey',
+                    api_key_mode: ApiKeyModeEnum.SHARED,
+                  },
+                },
+                params: {
+                  applicationId: 'application1',
+                },
+                queryParams: {},
+              },
+            },
+          },
+        ],
+      }).compileComponents();
+      httpTestingController = TestBed.inject(HttpTestingController);
+      initFixture();
+    }));
+
+    it('should init sharedApiKey', fakeAsync(() => {
+      const subscription: Subscription = {
+        id: 'subscription1',
+        api: 'api1',
+        application: 'application1',
+        plan: 'plan1',
+        status: 'ACCEPTED',
+      };
+
+      const sharedApiKey: Key = { key: 'my-api-key', created_at: new Date('2022-02-22T22:22:22Z') };
+
+      httpTestingController.expectOne('http://localhost:8083/portal/environments/DEFAULT/applications/application1/subscribers?size=-1');
+
+      httpTestingController
+        .expectOne(
+          'http://localhost:8083/portal/environments/DEFAULT/subscriptions?applicationId=application1&statuses=ACCEPTED&statuses=PAUSED&statuses=PENDING',
+        )
+        .flush({
+          data: [subscription],
+          metadata: {
+            plan1: {
+              securityType: SecurityEnum.APIKEY as unknown as object,
+            },
+          },
+        });
+      tick();
+
+      httpTestingController
+        .expectOne('http://localhost:8083/portal/environments/DEFAULT/subscriptions/subscription1?include=keys')
+        .flush({ ...subscription, keys: [sharedApiKey] });
+      tick();
+
+      expect(component).toBeTruthy();
+      expect(component.sharedAPIKey).toEqual(sharedApiKey);
+      expect(component.subscriptions[0].keys).toContain(sharedApiKey);
+    }));
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  describe('Non shared key app', () => {
+    let httpTestingController: HttpTestingController;
+
+    afterEach(() => {
+      httpTestingController.verify();
+    });
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        ...defaultConf,
+        providers: [
+          {
+            provide: ActivatedRoute,
+            useValue: {
+              snapshot: {
+                data: {
+                  application: {
+                    id: 'application1',
+                    name: 'applicationWithSharedKey',
+                    api_key_mode: ApiKeyModeEnum.EXCLUSIVE,
+                  },
+                },
+                params: {
+                  applicationId: 'application1',
+                },
+                queryParams: {},
+              },
+            },
+          },
+        ],
+      }).compileComponents();
+      httpTestingController = TestBed.inject(HttpTestingController);
+
+      initFixture();
+    }));
+
+    it('should not init sharedApiKey', fakeAsync(() => {
+      const subscription: Subscription = {
+        id: 'subscription1',
+        api: 'api1',
+        application: 'application1',
+        plan: 'plan1',
+        status: 'ACCEPTED',
+      };
+
+      httpTestingController.expectOne('http://localhost:8083/portal/environments/DEFAULT/applications/application1/subscribers?size=-1');
+
+      httpTestingController
+        .expectOne(
+          'http://localhost:8083/portal/environments/DEFAULT/subscriptions?applicationId=application1&statuses=ACCEPTED&statuses=PAUSED&statuses=PENDING',
+        )
+        .flush({
+          data: [subscription],
+          metadata: {
+            plan1: {
+              securityType: SecurityEnum.APIKEY as unknown as object,
+            },
+          },
+        });
+      tick();
+
+      httpTestingController.expectNone('http://localhost:8083/portal/environments/DEFAULT/subscriptions/subscription1?include=keys');
+
+      expect(component).toBeTruthy();
+      expect(component.sharedAPIKey).toBeUndefined();
+    }));
   });
 });

--- a/gravitee-apim-portal-webui/src/assets/i18n/cs.json
+++ b/gravitee-apim-portal-webui/src/assets/i18n/cs.json
@@ -110,13 +110,13 @@
   "application": {
     "alerts": {
       "add": {
+        "description": {
+          "label": "Popis",
+          "placeholder": "Vysvětlete své upozornění..."
+        },
         "reset": "Resetovat",
         "success": "Výstraha vytvořena",
         "title": "Přidejte upozornění",
-        "description": {
-          "placeholder": "Vysvětlete své upozornění...",
-          "label": "Popis"
-        },
         "type": {
           "placeholder": "Vyberte typ",
           "status": {
@@ -140,9 +140,11 @@
       },
       "maximum": "Dosáhli jste maximálně 10 upozornění",
       "phrase": {
-        "on": "Upozornění, na",
-        "when": "Když",
+        "api": {
+          "all": "Všechny API"
+        },
         "last": "během posledního",
+        "on": "Upozornění, na",
         "response_time": {
           "second": "je konec",
           "third": "ms"
@@ -151,9 +153,7 @@
           "second": "je konec",
           "third": "%"
         },
-        "api": {
-          "all": "Všechny API"
-        }
+        "when": "Když"
       },
       "timeUnits": {
         "hours": "hodin",
@@ -168,18 +168,18 @@
         "success": "Upozornění aktualizováno"
       },
       "webhook": {
+        "method": {
+          "title": "Vyberte tuto metodu HTTP, která bude použita k vyvolání adresy URL pokaždé, když je tato výstraha vyvolána"
+        },
+        "notifierWarning": "Chcete-li používat oznámení webhooku, požádejte svého administrátora, aby nainstaloval plugin pro oznámení webhooku",
         "switch": {
           "label": "Oznámení webhooku",
           "title": "Povolit oznámení webhooku, aby vyvolalo volání HTTP pokaždé, když je toto upozornění vyvoláno"
         },
-        "method": {
-          "title": "Vyberte tuto metodu HTTP, která bude použita k vyvolání adresy URL pokaždé, když je tato výstraha vyvolána"
-        },
         "url": {
           "placeholder": "https://my.domain/my/example/url",
           "title": "Zadejte adresu URL, kterou chcete volat pokaždé, když je toto upozornění hozeno"
-        },
-        "notifierWarning": "Chcete-li používat oznámení webhooku, požádejte svého administrátora, aby nainstaloval plugin pro oznámení webhooku"
+        }
       }
     },
     "analytics": {
@@ -244,6 +244,10 @@
     "description": {
       "label": "Popište účel této aplikace",
       "title": "Description"
+    },
+    "domain": {
+      "label": "https://my-app.com",
+      "title": "Doména používaná touto aplikací"
     },
     "general": "General",
     "information": {
@@ -407,6 +411,28 @@
       "label": "Obnovte tajemství",
       "message": "Opravdu chcete obnovit tajemství své aplikace?<br/> Obnovením tajemství již nebudete moci generovat nové přístupové tokeny a volat API."
     },
+    "shared-key": {
+      "info": {
+        "created_at": "Vygenerováno dne",
+        "end_at": "Končí dál",
+        "title": "Klíče API"
+      },
+      "message": "Vaše aplikace je nakonfigurována tak, aby používala stejný klíč API pro všechna předplatná.",
+      "no-key": {
+        "create": "Nový můžete vytvořit kliknutím na \"Obnovte\".",
+        "message": "Bohužel nebyl nalezen žádný platný sdílený klíč API.",
+        "recommendation": "Kontaktujte prosím vlastníka aplikace."
+      },
+      "renew": {
+        "message": "Opravdu chcete obnovit tento sdíleným klíč API?",
+        "title": "Obnovte"
+      },
+      "revoke": {
+        "message": "Opravdu chcete zrušit tento sdíleným klíč API?",
+        "title": "Odvolat"
+      },
+      "title": "Aplikace se sdíleným klíč API"
+    },
     "subscriptions": {
       "api": "Api",
       "apiKey": {
@@ -449,6 +475,7 @@
         "message": "Opravdu chcete obnovit toto předplatné?",
         "title": "Obnovte"
       },
+      "security_type": "typ zabezpečení",
       "selected": {
         "title": "Informace o předplatném"
       },
@@ -478,6 +505,10 @@
       "description": {
         "label": "Popis",
         "placeholder": "Stačí popsat jeho účel"
+      },
+      "domain": {
+        "label": "Doména používaná touto aplikací",
+        "placeholder": "https://my-app.com"
       },
       "image": "Obrázek aplikace",
       "name": {
@@ -852,10 +883,8 @@
     }
   },
   "gv-pagination": {
-    "goTo": "Přejít na stránku",
     "next": "Další",
-    "previous": "Předchozí",
-    "results": "{count, plural, =0{žádné výsledky} one{{count} výsledky} other{{count} výsledky}}"
+    "previous": "Předchozí"
   },
   "gv-plans": {
     "characteristics": {

--- a/gravitee-apim-portal-webui/src/assets/i18n/en.json
+++ b/gravitee-apim-portal-webui/src/assets/i18n/en.json
@@ -110,13 +110,13 @@
   "application": {
     "alerts": {
       "add": {
+        "description": {
+          "label": "Description",
+          "placeholder": "Explain your alert..."
+        },
         "reset": "Reset",
         "success": "Alert created",
         "title": "Add an alert",
-        "description": {
-          "placeholder": "Explain your alert...",
-          "label": "Description"
-        },
         "type": {
           "placeholder": "Select a type",
           "status": {
@@ -140,9 +140,11 @@
       },
       "maximum": "You have reached the maximum of 10 alerts",
       "phrase": {
-        "on": "Alert on",
-        "when": "When",
+        "api": {
+          "all": "All APIs"
+        },
         "last": "during the last",
+        "on": "Alert on",
         "response_time": {
           "second": "is over",
           "third": "ms"
@@ -151,9 +153,7 @@
           "second": "is over",
           "third": "%"
         },
-        "api": {
-          "all": "All APIs"
-        }
+        "when": "When"
       },
       "timeUnits": {
         "hours": "hours",
@@ -168,18 +168,18 @@
         "success": "Alert updated"
       },
       "webhook": {
+        "method": {
+          "title": "Select ths HTTP method that will be used to invoke URL each time this alert his thrown"
+        },
+        "notifierWarning": "To use webhook notifications, ask your admin to install the webhook notifier plugin",
         "switch": {
           "label": "Webhook notification",
           "title": "Enable webhook notifications to invoke an HTTP call each time this alert his thrown"
         },
-        "method": {
-          "title": "Select ths HTTP method that will be used to invoke URL each time this alert his thrown"
-        },
         "url": {
           "placeholder": "https://my.domain/my/example/url",
           "title": "Enter the URL to call each time this alert his thrown"
-        },
-        "notifierWarning": "To use webhook notifications, ask your admin to install the webhook notifier plugin"
+        }
       }
     },
     "analytics": {
@@ -246,8 +246,8 @@
       "title": "Description"
     },
     "domain": {
-      "title": "Domain used by this application",
-      "label": "https://my-app.com"
+      "label": "https://my-app.com",
+      "title": "Domain used by this application"
     },
     "general": "General",
     "information": {
@@ -411,6 +411,28 @@
       "label": "Renew the secret",
       "message": "Are you sure you want to renew the secret of your application?<br/> By renewing the secret, you will no longer be able to generate new access tokens and call the API."
     },
+    "shared-key": {
+      "info": {
+        "created_at": "Created at",
+        "end_at": "Ends on",
+        "title": "API key"
+      },
+      "message": "Your application is configured to use the same API Key for all its subscriptions.",
+      "no-key": {
+        "create": "You can create a new one by clicking on \"Renew\".",
+        "message": "Unfortunately, no valid shared API key has been found.",
+        "recommendation": "Please contact the owner of the application."
+      },
+      "renew": {
+        "message": "Are you sure you want to renew this shared API key?",
+        "title": "Renew"
+      },
+      "revoke": {
+        "message": "Are you sure you want to revoke this shared API key?",
+        "title": "Revoke"
+      },
+      "title": "Application with a shared API Key"
+    },
     "subscriptions": {
       "api": "API",
       "apiKey": {
@@ -453,6 +475,7 @@
         "message": "Are you sure you want to renew this subscription?",
         "title": "Renew"
       },
+      "security_type": "Security type",
       "selected": {
         "title": "Subscription information"
       },
@@ -860,10 +883,8 @@
     }
   },
   "gv-pagination": {
-    "goTo": "Go to page",
     "next": "Next",
-    "previous": "Previous",
-    "results": "{count, plural, =0{No result} one{{count} result} other{{count} results}}"
+    "previous": "Previous"
   },
   "gv-plans": {
     "characteristics": {

--- a/gravitee-apim-portal-webui/src/assets/i18n/fr.json
+++ b/gravitee-apim-portal-webui/src/assets/i18n/fr.json
@@ -110,13 +110,13 @@
   "application": {
     "alerts": {
       "add": {
+        "description": {
+          "label": "Description",
+          "placeholder": "Expliquez votre alerte..."
+        },
         "reset": "Réinitialiser",
         "success": "Alerte ajoutée",
         "title": "Ajouter une alerte",
-        "description": {
-          "placeholder": "Expliquez votre alerte...",
-          "label": "Description"
-        },
         "type": {
           "placeholder": "Selectionner un type",
           "status": {
@@ -140,9 +140,11 @@
       },
       "maximum": "Vous avez atteint le maximum de 10 alertes",
       "phrase": {
-        "on": "Alerte sur",
-        "when": "Quand",
+        "api": {
+          "all": "Toutes les APIs"
+        },
         "last": "pendant les dernières",
+        "on": "Alerte sur",
         "response_time": {
           "second": "est supérieur à",
           "third": "ms"
@@ -151,9 +153,7 @@
           "second": "est supérieur à",
           "third": "%"
         },
-        "api": {
-          "all": "Toutes les APIs"
-        }
+        "when": "Quand"
       },
       "timeUnits": {
         "hours": "heures",
@@ -168,18 +168,18 @@
         "success": "Alerte mise à jour"
       },
       "webhook": {
+        "method": {
+          "title": "Sélectionnez la méthode HTTP utilisée pour appeler l'URL à chaque fois que cette alerte est levée"
+        },
+        "notifierWarning": "Pour utiliser les notifications via webhook, demandez à votre administrateur d'installer le webhook notifier plugin",
         "switch": {
           "label": "Notification via webhook",
           "title": "Activer les notifications webhook pour déclencher un appel HTTP à chaque fois que cette alerte est levée"
         },
-        "method": {
-          "title": "Sélectionnez la méthode HTTP utilisée pour appeler l'URL à chaque fois que cette alerte est levée"
-        },
         "url": {
           "placeholder": "https://mon.domaine/mon/example/url",
           "title": "Saisissez l'URL à appeler à chaque fois que cette alerte est levée"
-        },
-        "notifierWarning": "Pour utiliser les notifications via webhook, demandez à votre administrateur d'installer le webhook notifier plugin"
+        }
       }
     },
     "analytics": {
@@ -246,8 +246,8 @@
       "title": "Description"
     },
     "domain": {
-      "title": "Domaine utilisé par l'application",
-      "label": "https://mon-application.fr"
+      "label": "https://mon-application.fr",
+      "title": "Domaine utilisé par l'application"
     },
     "general": "Général",
     "information": {
@@ -411,6 +411,28 @@
       "label": "Renouveler le secret",
       "message": "Êtes-vous sûr de vouloir renouveler le secret de votre application ?<br/> En renouvelant le secret, vous ne pourrez plus générer de nouveaux jetons d'accès et appeler l'API."
     },
+    "shared-key": {
+      "info": {
+        "created_at": "Générée le",
+        "end_at": "Se termine",
+        "title": "Clé d'API"
+      },
+      "message": "Votre application est configurée pour utiliser la même clé d'API pour toutes ses souscriptions.",
+      "no-key": {
+        "create": "Vous pouvez en créer une nouvelle en cliquant sur \"Renouveler\".",
+        "message": "Malheureusement, aucune clé d'API partagée valide n'a été trouvée.",
+        "recommendation": "Veuillez contacter le propriétaire de l'application."
+      },
+      "renew": {
+        "message": "Êtes-vous sûr de vouloir renouveler cette clé d'API partagée?",
+        "title": "Renouveler"
+      },
+      "revoke": {
+        "message": "Êtes-vous sûr de vouloir révoquer cette clé d'API partagée ?",
+        "title": "Révoquer"
+      },
+      "title": "Application avec une clé d'API partagée"
+    },
     "subscriptions": {
       "api": "API",
       "apiKey": {
@@ -453,6 +475,7 @@
         "message": "Êtes-vous sûr de vouloir renouveler cette souscription ?",
         "title": "Renouveler"
       },
+      "security_type": "Type de plan",
       "selected": {
         "title": "Informations de souscription"
       },
@@ -860,10 +883,8 @@
     }
   },
   "gv-pagination": {
-    "goTo": "Aller à la page",
     "next": "Suivant",
-    "previous": "Précédent",
-    "results": "{count, plural, =0{Aucun résultat} one{{count} résultat} other{{count} résultats}}"
+    "previous": "Précédent"
   },
   "gv-plans": {
     "characteristics": {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationMapper.java
@@ -97,7 +97,11 @@ public class ApplicationMapper {
                 (settings.getApp() != null && settings.getApp().getClientId() != null && !settings.getApp().getClientId().isEmpty())
             )
         );
-        application.setApiKeyMode(ApiKeyModeEnum.valueOf(applicationListItem.getApiKeyMode().name()));
+        if (applicationListItem.getApiKeyMode() != null) {
+            application.setApiKeyMode(ApiKeyModeEnum.valueOf(applicationListItem.getApiKeyMode().name()));
+        } else {
+            application.setApiKeyMode(ApiKeyModeEnum.UNSPECIFIED);
+        }
         return application;
     }
 
@@ -178,6 +182,11 @@ public class ApplicationMapper {
             application.setSettings(appSettings);
         }
 
+        if (applicationEntity.getApiKeyMode() != null) {
+            application.setApiKeyMode(ApiKeyModeEnum.valueOf(applicationEntity.getApiKeyMode().name()));
+        } else {
+            application.setApiKeyMode(ApiKeyModeEnum.UNSPECIFIED);
+        }
         return application;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapper.java
@@ -132,6 +132,7 @@ public class ConfigurationMapper {
     private ConfigurationPlanSecurity convert(Plan.PlanSecurity security) {
         ConfigurationPlanSecurity configuration = new ConfigurationPlanSecurity();
         configuration.setApikey(convert(security.getApikey()));
+        configuration.setSharedApiKey(convert(security.getSharedApiKey()));
         configuration.setJwt(convert(security.getJwt()));
         configuration.setKeyless(convert(security.getKeyless()));
         configuration.setOauth2(convert(security.getOauth2()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/openapi.yaml
@@ -4405,6 +4405,8 @@ components:
       properties:
         apikey:
           $ref: '#/components/schemas/Enabled'
+        sharedApiKey:
+          $ref: '#/components/schemas/Enabled'
         oauth2:
           $ref: '#/components/schemas/Enabled'
         keyless:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationMapperTest.java
@@ -65,7 +65,7 @@ public class ApplicationMapperTest {
     private static final String APPLICATION_GROUP_NAME = "my-application-group-name";
     private static final String APPLICATION_STATUS = "my-application-status";
     private static final String APPLICATION_TYPE = "my-application-type";
-    private static final ApiKeyMode APPLICATION_API_KEY_MODE = ApiKeyMode.UNSPECIFIED;
+    private static final ApiKeyMode APPLICATION_API_KEY_MODE = ApiKeyMode.SHARED;
     private static final String APPLICATION_USER_ID = "my-application-user-id";
     private static final String APPLICATION_USER_DISPLAYNAME = "my-application-user-display-name";
     private static final String APPLICATION_USER_EMAIL = "my-application-user-email";
@@ -144,6 +144,7 @@ public class ApplicationMapperTest {
         applicationEntity.setPrimaryOwner(primaryOwner);
         applicationEntity.setStatus(APPLICATION_STATUS);
         applicationEntity.setType(APPLICATION_TYPE);
+        applicationEntity.setApiKeyMode(APPLICATION_API_KEY_MODE);
         applicationEntity.setUpdatedAt(nowDate);
 
         applicationListItem.setCreatedAt(nowDate);
@@ -217,6 +218,7 @@ public class ApplicationMapperTest {
         assertEquals(APPLICATION_ID, responseApplication.getId());
         assertEquals(APPLICATION_NAME, responseApplication.getName());
         assertEquals(now.toEpochMilli(), responseApplication.getUpdatedAt().toInstant().toEpochMilli());
+        assertEquals(APPLICATION_API_KEY_MODE.name(), responseApplication.getApiKeyMode().getValue());
 
         List<Group> groups = responseApplication.getGroups();
         assertNotNull(groups);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/resources/io/gravitee/rest/api/portal/rest/mapper/expectedPortalConfiguration.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/resources/io/gravitee/rest/api/portal/rest/mapper/expectedPortalConfiguration.json
@@ -61,6 +61,9 @@
       "apikey" : {
         "enabled" : true
       },
+      "sharedApiKey" : {
+        "enabled" : true
+      },
       "oauth2" : {
         "enabled" : true
       },

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/resources/io/gravitee/rest/api/portal/rest/mapper/portalSettingsEntity.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/resources/io/gravitee/rest/api/portal/rest/mapper/portalSettingsEntity.json
@@ -97,6 +97,9 @@
       },
       "jwt" : {
         "enabled" : true
+      },
+      "sharedApiKey" : {
+        "enabled" : true
       }
     }
   },

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
@@ -1290,6 +1290,7 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
         if (plans.containsKey(subscription.getPlan())) {
             PlanEntity plan = plans.get(subscription.getPlan());
             metadata.put(plan.getId(), "name", plan.getName());
+            metadata.put(plan.getId(), "securityType", plan.getSecurity());
         }
         return metadata;
     }


### PR DESCRIPTION
**Issue**
https://github.com/gravitee-io/issues/issues/6817

**Description**

Rearrange the application>subscriptions screen to display the shared API key when it exists

**Additional context**
And also
- update translations files
- update sdk with missing fields
- solve NPE about sharedApiKeyMode mapping
- add sharedApiKeyMode in the settings


New screen for a "non shared key" application:
![image](https://user-images.githubusercontent.com/13161768/158145559-ff469550-d157-4650-b23d-6b06834d26ec.png)

New screen for a "shared key" application:
![image](https://user-images.githubusercontent.com/13161768/158145483-196153ef-94a7-49fd-8efc-327d2be7ba23.png)



<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gwhyvcvhia.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6718-display-shared-api-keys-on-application-page/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
