### PR TITLE
fix: fix application subscriptions API key list permissions

### DIFF
--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscription.html
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscription.html
@@ -136,7 +136,7 @@
                   <md-tooltip md-direction="left">Revoke</md-tooltip>
                   <ng-md-icon
                     permission
-                    permission-only="'api-subscription-u'"
+                    permission-only="'application-subscription-u'"
                     style="top: 0"
                     icon="not_interested"
                     ng-click="$ctrl.revokeApiKey(key)"
@@ -152,7 +152,7 @@
         class="md-actions gravitee-api-save-button"
         layout="row"
         permission
-        permission-only="'api-subscription-u'"
+        permission-only="'application-subscription-u'"
         ng-if="$ctrl.subscription.status === 'ACCEPTED'"
       >
         <md-button class="md-raised md-primary" ng-click="$ctrl.renewApiKey()">


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/7273

fix: fix application subscriptions API key list permissions

It has to use application- permission instead of api- permissions,
Cause it's under application route, and application.route.ts populates only application- permissions.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-yblnbnpvbv.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-applicationsubscriptionapikeyspermissions/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
