### PR TITLE
chore: bump ui-particules to 3.10.1

### DIFF
--- a/gravitee-apim-console-webui/package-lock.json
+++ b/gravitee-apim-console-webui/package-lock.json
@@ -9319,9 +9319,9 @@
       }
     },
     "@gravitee/ui-particles-angular": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@gravitee/ui-particles-angular/-/ui-particles-angular-2.10.0.tgz",
-      "integrity": "sha512-txjUOcvfG0T/apExDIc+90AL/vwdfEWKskjaCkngtt5qxCEyxPh9CRcefbH9hcHXK9y1rWaMm7bdJSS360wzdA==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@gravitee/ui-particles-angular/-/ui-particles-angular-2.10.1.tgz",
+      "integrity": "sha512-tLoYJXQ0Zvt3h4ev3EILzGstJ8JuvuSJwJjTRSBhqREyEsAfxsqgkPheWh/3jPV8T0ICuafvkRYu01whAWEKRA==",
       "requires": {
         "@fontsource/fira-mono": "4.5.0",
         "@fontsource/golos-ui": "^4.5.1",

--- a/gravitee-apim-console-webui/package.json
+++ b/gravitee-apim-console-webui/package.json
@@ -16,7 +16,7 @@
     "@asyncapi/web-component": "1.0.0-next.15",
     "@fontsource/libre-franklin": "4.4.5",
     "@gravitee/ui-components": "3.31.0",
-    "@gravitee/ui-particles-angular": "2.10.0",
+    "@gravitee/ui-particles-angular": "2.10.1",
     "@gravitee/ui-policy-studio-angular": "2.7.0",
     "@highcharts/map-collection": "1.1.3",
     "@toast-ui/editor": "2.5.2",


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7149
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tcsoyssaih.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/form-headers/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
