### PR TITLE
feat: ApiKeyRefresher takes care of subscription status to populate his cache

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/subscription.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/subscription.component.ts
@@ -74,7 +74,7 @@ const ApiSubscriptionComponent: ng.IComponentOptions = {
     close() {
       let msg =
         '<code>' + this.subscription.application.name + '</code> will not be able to consume <code>' + this.api.name + '</code> anymore.';
-      if (this.subscription.plan.security === PlanSecurityType.API_KEY) {
+      if (this.subscription.plan.security === PlanSecurityType.API_KEY && !this.hasSharedApiKeyMode) {
         msg += '<br/>All Api-keys associated to this subscription will be closed and could not be used.';
       }
 
@@ -103,7 +103,7 @@ const ApiSubscriptionComponent: ng.IComponentOptions = {
 
     pause() {
       let msg = 'The application will not be able to consume this API anymore.';
-      if (this.subscription.plan.security === PlanSecurityType.API_KEY) {
+      if (this.subscription.plan.security === PlanSecurityType.API_KEY && !this.hasSharedApiKeyMode) {
         msg += '<br/>All Api-keys associated to this subscription will be paused and could not be used.';
       }
 

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscription.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscription.component.ts
@@ -19,6 +19,7 @@ import { Subject } from 'rxjs';
 import ApplicationService from '../../../../services/application.service';
 import NotificationService from '../../../../services/notification.service';
 import { PlanSecurityType } from '../../../../entities/plan/plan';
+import { ApiKeyMode } from '../../../../entities/application/application';
 
 const ApplicationSubscriptionComponent: ng.IComponentOptions = {
   bindings: {
@@ -45,7 +46,7 @@ const ApplicationSubscriptionComponent: ng.IComponentOptions = {
 
     close() {
       let msg = 'The application will not be able to consume this API anymore.';
-      if (this.subscription.plan.security === PlanSecurityType.API_KEY) {
+      if (this.subscription.plan.security === PlanSecurityType.API_KEY && this.application.api_key_mode !== ApiKeyMode.SHARED) {
         msg += '<br/>All Api-keys associated to this subscription will be closed and could not be used.';
       }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/definition/ApiKey.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/definition/ApiKey.java
@@ -16,8 +16,6 @@
 package io.gravitee.gateway.handlers.api.definition;
 
 import io.gravitee.repository.management.model.Subscription;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * @author GraviteeSource Team
@@ -27,12 +25,14 @@ public class ApiKey extends io.gravitee.repository.management.model.ApiKey {
     private final String plan;
     private final String api;
     private final String subscription;
+    private final Subscription.Status subscriptionStatus;
 
     public ApiKey(io.gravitee.repository.management.model.ApiKey key, Subscription subscription) {
         super(key);
         this.plan = subscription.getPlan();
         this.api = subscription.getApi();
         this.subscription = subscription.getId();
+        this.subscriptionStatus = subscription.getStatus();
     }
 
     @SuppressWarnings("removal")
@@ -48,5 +48,9 @@ public class ApiKey extends io.gravitee.repository.management.model.ApiKey {
     @SuppressWarnings("removal")
     public String getSubscription() {
         return subscription;
+    }
+
+    public Subscription.Status getSubscriptionStatus() {
+        return subscriptionStatus;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/cache/task/ApiKeyRefresherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/cache/task/ApiKeyRefresherTest.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.cache.task;
+
+import static io.gravitee.repository.management.model.Subscription.Status.*;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.gateway.services.sync.cache.ApiKeysCache;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiKeyRepository;
+import io.gravitee.repository.management.api.SubscriptionRepository;
+import io.gravitee.repository.management.api.search.ApiKeyCriteria;
+import io.gravitee.repository.management.model.ApiKey;
+import io.gravitee.repository.management.model.Subscription;
+import java.util.List;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ApiKeyRefresherTest {
+
+    @InjectMocks
+    private FullApiKeyRefresher apiKeyRefresher;
+
+    @Mock
+    private ApiKeyRepository apiKeyRepository;
+
+    @Mock
+    private SubscriptionRepository subscriptionRepository;
+
+    @Mock
+    private ApiKeysCache cache;
+
+    @Before
+    public void setup() {
+        apiKeyRefresher.setApiKeyRepository(apiKeyRepository);
+        apiKeyRefresher.setSubscriptionRepository(subscriptionRepository);
+        apiKeyRefresher.setCache(cache);
+    }
+
+    @Test
+    public void doRefresh_should_cache_subscriptions() throws TechnicalException {
+        ApiKeyCriteria apiKeyCriteria = mock(ApiKeyCriteria.class);
+
+        List<ApiKey> apiKeysList = List.of(
+            buildTestApiKey("key-1", List.of("sub-1", "sub-2", "sub-3")),
+            buildTestApiKey("key-2", List.of("sub-1", "sub-4"), true, false),
+            buildTestApiKey("key-3", List.of()),
+            buildTestApiKey("key-4", List.of("sub-1", "sub-4", "sub-5")),
+            buildTestApiKey("key-5", List.of("sub-1", "sub-4"), false, true),
+            buildTestApiKey("key-6", List.of("sub-unknown"))
+        );
+
+        when(apiKeyRepository.findByCriteria(apiKeyCriteria)).thenReturn(apiKeysList);
+
+        when(subscriptionRepository.findByIdIn(Set.of("sub-1", "sub-2", "sub-3", "sub-4", "sub-5", "sub-unknown")))
+            .thenReturn(
+                List.of(
+                    buildTestSubscription("sub-1", CLOSED),
+                    buildTestSubscription("sub-2", ACCEPTED),
+                    buildTestSubscription("sub-3", REJECTED),
+                    buildTestSubscription("sub-4", ACCEPTED),
+                    buildTestSubscription("sub-5", ACCEPTED)
+                )
+            );
+
+        apiKeyRefresher.doRefresh(apiKeyCriteria);
+
+        // those API keys have been put in cache because they are active and their subscription is active
+        verify(cache, times(1)).put(argThat(apiKey -> apiKey.getId().equals("key-1") && apiKey.getSubscription().equals("sub-2")));
+        verify(cache, times(1)).put(argThat(apiKey -> apiKey.getId().equals("key-4") && apiKey.getSubscription().equals("sub-4")));
+        verify(cache, times(1)).put(argThat(apiKey -> apiKey.getId().equals("key-4") && apiKey.getSubscription().equals("sub-5")));
+
+        // those API keys have been removed from cache because they are inactive, or their subscription is not active
+        verify(cache, times(1)).remove(argThat(apiKey -> apiKey.getId().equals("key-1") && apiKey.getSubscription().equals("sub-1")));
+        verify(cache, times(1)).remove(argThat(apiKey -> apiKey.getId().equals("key-1") && apiKey.getSubscription().equals("sub-3")));
+        verify(cache, times(1)).remove(argThat(apiKey -> apiKey.getId().equals("key-2") && apiKey.getSubscription().equals("sub-1")));
+        verify(cache, times(1)).remove(argThat(apiKey -> apiKey.getId().equals("key-2") && apiKey.getSubscription().equals("sub-4")));
+        verify(cache, times(1)).remove(argThat(apiKey -> apiKey.getId().equals("key-4") && apiKey.getSubscription().equals("sub-1")));
+        verify(cache, times(1)).remove(argThat(apiKey -> apiKey.getId().equals("key-5") && apiKey.getSubscription().equals("sub-1")));
+        verify(cache, times(1)).remove(argThat(apiKey -> apiKey.getId().equals("key-5") && apiKey.getSubscription().equals("sub-4")));
+
+        verifyNoMoreInteractions(cache);
+    }
+
+    private ApiKey buildTestApiKey(String id, List<String> subscriptions) {
+        return buildTestApiKey(id, subscriptions, false, false);
+    }
+
+    private ApiKey buildTestApiKey(String id, List<String> subscriptions, boolean revoked, boolean paused) {
+        ApiKey apiKey = new ApiKey();
+        apiKey.setId(id);
+        apiKey.setSubscriptions(subscriptions);
+        apiKey.setRevoked(revoked);
+        apiKey.setPaused(paused);
+        return apiKey;
+    }
+
+    private Subscription buildTestSubscription(String id, Subscription.Status status) {
+        Subscription subscription = new Subscription();
+        subscription.setId(id);
+        subscription.setStatus(status);
+        return subscription;
+    }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7266

**Description**

feat: ApiKeyRefresher takes care of subscription status to populate his cache

When subscription associated to API key is not ACCEPTED, the API key is removed from cache.

That permits to de-corellate subscription lifecycle and API key lifecycle :
With 'shared API key' feature, a subscription can be close, and have related API keys still actives.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vkmgxqjuae.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/feat-7266-shared-apikey-decorrelate-subscription-lifecycle/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
