### PR TITLE
fix: display expired shared API keys properly

### DIFF
--- a/gravitee-apim-console-webui/src/management/api-key/api-keys.html
+++ b/gravitee-apim-console-webui/src/management/api-key/api-keys.html
@@ -21,7 +21,6 @@
     This subscription uses a shared API key.<br />
     You can renew or revoke the shared API key at the application level.
   </ng-banner>
-
   <md-table-container>
     <table md-table>
       <thead md-head>
@@ -35,7 +34,10 @@
       <tbody md-body>
         <tr md-row ng-repeat="key in $ctrl.keys | orderBy:['-revoked_at','-expire_at','created_at'] track by key.key ">
           <td md-cell class="api-key-cell">
-            <ng-md-icon icon="{{key.revoked?'clear':'done'}}" ng-class="key.revoked ? 'revoked-icon' : 'active-icon'"></ng-md-icon>
+            <ng-md-icon
+              icon="{{$ctrl.isValid(key)?'done':'clear'}}"
+              ng-class="$ctrl.isValid(key)? 'active-icon' : 'revoked-icon'"
+            ></ng-md-icon>
             <code>{{key.key}}</code>
             <span ng-if="!key.revoked && $ctrl.areKeysEditable()">
               <md-tooltip md-direction="right">Copy to clipboard</md-tooltip>


### PR DESCRIPTION
see https://github.com/gravitee-io/issues/issues/7280

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uqpxwnxtwn.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7280-fix-api-key-renewal/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
