### PR TITLE
feat: de-corellate subscription lifecycle from shared API key lifecycle

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/subscription.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/subscription.component.ts
@@ -74,7 +74,7 @@ const ApiSubscriptionComponent: ng.IComponentOptions = {
     close() {
       let msg =
         '<code>' + this.subscription.application.name + '</code> will not be able to consume <code>' + this.api.name + '</code> anymore.';
-      if (this.subscription.plan.security === PlanSecurityType.API_KEY) {
+      if (this.subscription.plan.security === PlanSecurityType.API_KEY && !this.hasSharedApiKeyMode) {
         msg += '<br/>All Api-keys associated to this subscription will be closed and could not be used.';
       }
 
@@ -103,7 +103,7 @@ const ApiSubscriptionComponent: ng.IComponentOptions = {
 
     pause() {
       let msg = 'The application will not be able to consume this API anymore.';
-      if (this.subscription.plan.security === PlanSecurityType.API_KEY) {
+      if (this.subscription.plan.security === PlanSecurityType.API_KEY && !this.hasSharedApiKeyMode) {
         msg += '<br/>All Api-keys associated to this subscription will be paused and could not be used.';
       }
 

--- a/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscription.component.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscriptions/application-subscription.component.ts
@@ -19,6 +19,7 @@ import { Subject } from 'rxjs';
 import ApplicationService from '../../../../services/application.service';
 import NotificationService from '../../../../services/notification.service';
 import { PlanSecurityType } from '../../../../entities/plan/plan';
+import { ApiKeyMode } from '../../../../entities/application/application';
 
 const ApplicationSubscriptionComponent: ng.IComponentOptions = {
   bindings: {
@@ -45,7 +46,7 @@ const ApplicationSubscriptionComponent: ng.IComponentOptions = {
 
     close() {
       let msg = 'The application will not be able to consume this API anymore.';
-      if (this.subscription.plan.security === PlanSecurityType.API_KEY) {
+      if (this.subscription.plan.security === PlanSecurityType.API_KEY && this.application.api_key_mode !== ApiKeyMode.SHARED) {
         msg += '<br/>All Api-keys associated to this subscription will be closed and could not be used.';
       }
 


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/7266

feat: de-corellate subscription lifecycle from shared API key lifecycle

When a subscription is closed, paused or reseume, it doesn't impact his associated shared API Keys.
Cause those API keys are used by other subscriptions.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zjtwtgswyx.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/feat-7266-decorelate-subscription-apikeys-lifecycle/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
