### PR TITLE
fix: shared API key retrieval

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/ApiKeyEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/ApiKeyEntity.java
@@ -165,15 +165,6 @@ public class ApiKeyEntity {
         return getSubscriptionIds().stream().anyMatch(subscriptionId::equals);
     }
 
-    public void addSubscription(SubscriptionEntity subscription) {
-        Set<SubscriptionEntity> updatedSubscriptions = new HashSet<>();
-        updatedSubscriptions.add(subscription);
-        if (subscriptions != null) {
-            updatedSubscriptions.addAll(subscriptions);
-        }
-        setSubscriptions(updatedSubscriptions);
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
@@ -148,7 +148,7 @@ public class ApiKeyServiceTest {
         when(apiKeyRepository.findById(sharedApiKeyId)).thenReturn(Optional.of(sharedKey));
         when(apiKeyRepository.findByApplication(APPLICATION_ID)).thenReturn(List.of(sharedKey));
         when(subscriptionService.findByIdIn(any())).thenReturn(Set.of(firstSubscription, subscription));
-
+        when(apiKeyRepository.update(any())).then(returnsFirstArg());
         ApiKeyEntity newKey = apiKeyService.generate(application, subscription, null);
         assertEquals(sharedApiKeyValue, newKey.getKey());
         assertEquals(sharedApiKeyId, newKey.getId());
@@ -677,7 +677,7 @@ public class ApiKeyServiceTest {
         apiKeyEntity.setApplication(application);
         apiKeyEntity.setKey("ABC");
         apiKeyEntity.setPaused(true);
-        apiKeyEntity.addSubscription(subscription);
+        apiKeyEntity.setSubscriptions(Set.of(subscription));
         apiKeyEntity.setApplication(application);
         apiKeyEntity.setExpireAt(new Date());
 


### PR DESCRIPTION
Retrieve shared API key even if they are revoked, giving priority with non revoked key which has the latest expiration date

If the key is revoked, it is up to the application owner to renew the key at the application level

see https://github.com/gravitee-io/issues/issues/7282


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vshznesjpv.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7282-fix-shared-api-key-retrieval/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
