### PR TITLE
fix(console): hide action buttons for an expired api key

### DIFF
--- a/gravitee-apim-console-webui/src/management/api-key/api-keys.html
+++ b/gravitee-apim-console-webui/src/management/api-key/api-keys.html
@@ -39,7 +39,7 @@
               ng-class="$ctrl.isValid(key)? 'active-icon' : 'revoked-icon'"
             ></ng-md-icon>
             <code>{{key.key}}</code>
-            <span ng-if="!key.revoked && $ctrl.areKeysEditable()">
+            <span ng-if="$ctrl.isValid(key) && $ctrl.areKeysEditable()">
               <md-tooltip md-direction="right">Copy to clipboard</md-tooltip>
               <ng-md-icon
                 icon="content_copy"
@@ -53,7 +53,7 @@
           <td md-cell>{{key.created_at | date:'yyyy-MM-dd HH:mm:ss'}}</td>
           <td md-cell>{{key.revoked_at || key.expire_at | date:'yyyy-MM-dd HH:mm:ss'}}</td>
           <td md-cell>
-            <span ng-if="!key.revoked && $ctrl.areKeysEditable()">
+            <span ng-if="$ctrl.isValid(key) && $ctrl.areKeysEditable()">
               <md-tooltip md-direction="left">Revoke</md-tooltip>
               <ng-md-icon
                 class="revoke-icon"


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7280

**Description**

fix(console): hide action buttons for an expired api key
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rnzvhhavwq.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-fixexpiredapikeysbuttons/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
