### PR TITLE
feat: allow to renew a shared API key

### DIFF
--- a/gravitee-apim-portal-webui/projects/portal-webclient-sdk/src/lib/api/application.service.ts
+++ b/gravitee-apim-portal-webui/projects/portal-webclient-sdk/src/lib/api/application.service.ts
@@ -27,6 +27,7 @@ import { ApplicationsResponse } from '../model/models';
 import { CountAnalytics, DateHistoAnalytics, GroupByAnalytics } from '../model/models';
 import { ErrorResponse } from '../model/models';
 import { Hook } from '../model/models';
+import { Key } from '../model/models';
 import { Log } from '../model/models';
 import { LogsResponse } from '../model/models';
 import { Member } from '../model/models';
@@ -258,6 +259,11 @@ export interface GetSubscriberApisByApplicationIdRequestParams {
 }
 
 export interface RenewApplicationSecretRequestParams {
+    /** Id of an application. */
+    applicationId: string;
+}
+
+export interface RenewSharedKeyRequestParams {
     /** Id of an application. */
     applicationId: string;
 }
@@ -2155,6 +2161,65 @@ export class ApplicationService {
         }
 
         return this.httpClient.post<Application>(`${this.configuration.basePath}/applications/${encodeURIComponent(String(applicationId))}/_renew_secret`,
+            null,
+            {
+                responseType: <any>responseType,
+                withCredentials: this.configuration.withCredentials,
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
+            }
+        );
+    }
+
+    /**
+     * Renew the shared api key of on application.
+     * Renew the shared api key of on application. The application must have the ApiKeyMode set to SHARED User must have APPLICATION_SUBSCRIPTION[UPDATE] permission. 
+     * @param requestParameters
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
+     */
+    public renewSharedKey(requestParameters: RenewSharedKeyRequestParams, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json'}): Observable<Key>;
+    public renewSharedKey(requestParameters: RenewSharedKeyRequestParams, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json'}): Observable<HttpResponse<Key>>;
+    public renewSharedKey(requestParameters: RenewSharedKeyRequestParams, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json'}): Observable<HttpEvent<Key>>;
+    public renewSharedKey(requestParameters: RenewSharedKeyRequestParams, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json'}): Observable<any> {
+        const applicationId = requestParameters.applicationId;
+        if (applicationId === null || applicationId === undefined) {
+            throw new Error('Required parameter applicationId was null or undefined when calling renewSharedKey.');
+        }
+
+        let headers = this.defaultHeaders;
+
+        // authentication (BasicAuth) required
+        if (this.configuration.username || this.configuration.password) {
+            headers = headers.set('Authorization', 'Basic ' + btoa(this.configuration.username + ':' + this.configuration.password));
+        }
+        // authentication (CookieAuth) required
+        if (this.configuration.apiKeys) {
+            const key: string | undefined = this.configuration.apiKeys["CookieAuth"] || this.configuration.apiKeys["Auth-Graviteeio-APIM"];
+            if (key) {
+            }
+        }
+
+        let httpHeaderAcceptSelected: string | undefined = options && options.httpHeaderAccept;
+        if (httpHeaderAcceptSelected === undefined) {
+            // to determine the Accept header
+            const httpHeaderAccepts: string[] = [
+                'application/json'
+            ];
+            httpHeaderAcceptSelected = this.configuration.selectHeaderAccept(httpHeaderAccepts);
+        }
+        if (httpHeaderAcceptSelected !== undefined) {
+            headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+
+
+        let responseType: 'text' | 'json' = 'json';
+        if(httpHeaderAcceptSelected && httpHeaderAcceptSelected.startsWith('text')) {
+            responseType = 'text';
+        }
+
+        return this.httpClient.post<Key>(`${this.configuration.basePath}/applications/${encodeURIComponent(String(applicationId))}/keys/_renew`,
             null,
             {
                 responseType: <any>responseType,

--- a/gravitee-apim-portal-webui/src/app/pages/application/application-subscriptions/application-subscriptions.component.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-subscriptions/application-subscriptions.component.ts
@@ -309,7 +309,14 @@ export class ApplicationSubscriptionsComponent implements OnInit {
   }
 
   renewSharedApiKey() {
-    // FIXME: to implement
+    this.applicationService
+      .renewSharedKey({ applicationId: this.application.id })
+      .toPromise()
+      .then((newKey) => {
+        this.notificationService.success(i18n('application.shared-key.renew.success'));
+        this.sharedAPIKey = newKey;
+        this.search(true);
+      });
   }
 
   revokeSharedApiKey() {

--- a/gravitee-apim-portal-webui/src/assets/i18n/cs.json
+++ b/gravitee-apim-portal-webui/src/assets/i18n/cs.json
@@ -425,6 +425,7 @@
       },
       "renew": {
         "message": "Opravdu chcete obnovit tento sdíleným klíč API?",
+        "success": "Sdílený klíč API byl úspěšně obnoven",
         "title": "Obnovte"
       },
       "revoke": {

--- a/gravitee-apim-portal-webui/src/assets/i18n/en.json
+++ b/gravitee-apim-portal-webui/src/assets/i18n/en.json
@@ -425,6 +425,7 @@
       },
       "renew": {
         "message": "Are you sure you want to renew this shared API key?",
+        "success": "The shared API key has been successfully renewed",
         "title": "Renew"
       },
       "revoke": {

--- a/gravitee-apim-portal-webui/src/assets/i18n/fr.json
+++ b/gravitee-apim-portal-webui/src/assets/i18n/fr.json
@@ -425,6 +425,7 @@
       },
       "renew": {
         "message": "Êtes-vous sûr de vouloir renouveler cette clé d'API partagée?",
+        "success": "La clé d'API partagée a été renouvelée avec succès",
         "title": "Renouveler"
       },
       "revoke": {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationKeysResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationKeysResource.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource;
+
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.model.ApplicationEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.portal.rest.mapper.KeyMapper;
+import io.gravitee.rest.api.portal.rest.model.Key;
+import io.gravitee.rest.api.portal.rest.security.Permission;
+import io.gravitee.rest.api.portal.rest.security.Permissions;
+import io.gravitee.rest.api.service.ApiKeyService;
+import io.gravitee.rest.api.service.ApplicationService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.swagger.annotations.ApiParam;
+import javax.inject.Inject;
+import javax.ws.rs.*;
+import javax.ws.rs.container.ResourceContext;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+
+/**
+ * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ApplicationKeysResource extends AbstractResource {
+
+    @Context
+    private ResourceContext resourceContext;
+
+    @Inject
+    private ApplicationService applicationService;
+
+    @Inject
+    private ApiKeyService apiKeyService;
+
+    @Inject
+    private KeyMapper keyMapper;
+
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("applicationId")
+    private String applicationId;
+
+    @POST
+    @Path("/_renew")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.APPLICATION_SUBSCRIPTION, acls = RolePermissionAction.UPDATE) })
+    public Response renewSharedKey() {
+        ApplicationEntity applicationEntity = applicationService.findById(GraviteeContext.getCurrentEnvironment(), applicationId);
+        final Key createdKey = keyMapper.convert(apiKeyService.renew(applicationEntity));
+        return Response.status(Response.Status.CREATED).entity(createdKey).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationResource.java
@@ -228,4 +228,9 @@ public class ApplicationResource extends AbstractResource {
     public ApplicationAlertsResource getApplicationAlertsResource() {
         return resourceContext.getResource(ApplicationAlertsResource.class);
     }
+
+    @Path("keys")
+    public ApplicationKeysResource getApplicationKeysResource() {
+        return resourceContext.getResource(ApplicationKeysResource.class);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/openapi.yaml
@@ -1545,6 +1545,41 @@ paths:
           $ref: '#/components/responses/ApplicationNotFoundError'
         500:
           $ref: '#/components/responses/InternalServerError'
+  /applications/{applicationId}/keys/_renew:
+    parameters:
+      - $ref: '#/components/parameters/applicationIdParam'
+    post:
+      tags:
+        - Application
+      summary: Renew the shared api key of on application.
+      description: |
+        Renew the shared api key of on application.
+        The application must have the ApiKeyMode set to SHARED
+        User must have APPLICATION_SUBSCRIPTION[UPDATE] permission.
+      operationId: renewSharedKey
+      responses:
+        201:
+          description: Renewed Key.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Key'
+        400:
+          description: Application does not use shared API key mode
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        403:
+          $ref: '#/components/responses/PermissionError'
+        404:
+          description: Application not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        500:
+          $ref: '#/components/responses/InternalServerError'
 
   /groups:
     get:


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6819

**Description**

Call a new portal API resource to renew a shared API key
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fcnittfxzl.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6819-renew-apikey-from-portal/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
