### PR TITLE
feat: allow to revoke a shared API key

### DIFF
--- a/gravitee-apim-portal-webui/projects/portal-webclient-sdk/src/lib/api/application.service.ts
+++ b/gravitee-apim-portal-webui/projects/portal-webclient-sdk/src/lib/api/application.service.ts
@@ -268,6 +268,12 @@ export interface RenewSharedKeyRequestParams {
     applicationId: string;
 }
 
+export interface RevokeSharedKeyRequestParams {
+    /** Id of an application. */
+    applicationId: string;
+    apiKey: string;
+}
+
 export interface TransferMemberOwnershipRequestParams {
     /** Id of an application. */
     applicationId: string;
@@ -2220,6 +2226,69 @@ export class ApplicationService {
         }
 
         return this.httpClient.post<Key>(`${this.configuration.basePath}/applications/${encodeURIComponent(String(applicationId))}/keys/_renew`,
+            null,
+            {
+                responseType: <any>responseType,
+                withCredentials: this.configuration.withCredentials,
+                headers: headers,
+                observe: observe,
+                reportProgress: reportProgress
+            }
+        );
+    }
+
+    /**
+     * Revoke the shared api key of on application.
+     * Revoke the shared api key of on application. The application must have the ApiKeyMode set to SHARED User must have APPLICATION_SUBSCRIPTION[UPDATE] permission. 
+     * @param requestParameters
+     * @param observe set whether or not to return the data Observable as the body, response or events. defaults to returning the body.
+     * @param reportProgress flag to report request and response progress.
+     */
+    public revokeSharedKey(requestParameters: RevokeSharedKeyRequestParams, observe?: 'body', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json'}): Observable<any>;
+    public revokeSharedKey(requestParameters: RevokeSharedKeyRequestParams, observe?: 'response', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json'}): Observable<HttpResponse<any>>;
+    public revokeSharedKey(requestParameters: RevokeSharedKeyRequestParams, observe?: 'events', reportProgress?: boolean, options?: {httpHeaderAccept?: 'application/json'}): Observable<HttpEvent<any>>;
+    public revokeSharedKey(requestParameters: RevokeSharedKeyRequestParams, observe: any = 'body', reportProgress: boolean = false, options?: {httpHeaderAccept?: 'application/json'}): Observable<any> {
+        const applicationId = requestParameters.applicationId;
+        if (applicationId === null || applicationId === undefined) {
+            throw new Error('Required parameter applicationId was null or undefined when calling revokeSharedKey.');
+        }
+        const apiKey = requestParameters.apiKey;
+        if (apiKey === null || apiKey === undefined) {
+            throw new Error('Required parameter apiKey was null or undefined when calling revokeSharedKey.');
+        }
+
+        let headers = this.defaultHeaders;
+
+        // authentication (BasicAuth) required
+        if (this.configuration.username || this.configuration.password) {
+            headers = headers.set('Authorization', 'Basic ' + btoa(this.configuration.username + ':' + this.configuration.password));
+        }
+        // authentication (CookieAuth) required
+        if (this.configuration.apiKeys) {
+            const key: string | undefined = this.configuration.apiKeys["CookieAuth"] || this.configuration.apiKeys["Auth-Graviteeio-APIM"];
+            if (key) {
+            }
+        }
+
+        let httpHeaderAcceptSelected: string | undefined = options && options.httpHeaderAccept;
+        if (httpHeaderAcceptSelected === undefined) {
+            // to determine the Accept header
+            const httpHeaderAccepts: string[] = [
+                'application/json'
+            ];
+            httpHeaderAcceptSelected = this.configuration.selectHeaderAccept(httpHeaderAccepts);
+        }
+        if (httpHeaderAcceptSelected !== undefined) {
+            headers = headers.set('Accept', httpHeaderAcceptSelected);
+        }
+
+
+        let responseType: 'text' | 'json' = 'json';
+        if(httpHeaderAcceptSelected && httpHeaderAcceptSelected.startsWith('text')) {
+            responseType = 'text';
+        }
+
+        return this.httpClient.post<any>(`${this.configuration.basePath}/applications/${encodeURIComponent(String(applicationId))}/keys/${encodeURIComponent(String(apiKey))}/_revoke`,
             null,
             {
                 responseType: <any>responseType,

--- a/gravitee-apim-portal-webui/src/app/pages/application/application-subscriptions/application-subscriptions.component.html
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-subscriptions/application-subscriptions.component.html
@@ -17,7 +17,7 @@
 -->
 <div class="page__content page__content-with-aside application-subscriptions">
   <div class="main">
-    <div class="page__box" *ngIf="applicationHasSharedKey()">
+    <div class="page__box" *ngIf="applicationHasSharedKey() && sharedAPIKeyLoaded">
       <div class="page__box-title">
         <h3 class="title">
           {{ 'application.shared-key.title' | translate }}
@@ -30,12 +30,12 @@
               {{ 'application.shared-key.message' | translate }}
             </div>
           </div>
-          <div class="application-subscriptions__shared-key-info__row" *ngIf="sharedAPIKeyLoaded && !sharedAPIKey">
+          <div class="application-subscriptions__shared-key-info__row" *ngIf="!sharedAPIKey">
             <div class="application-subscriptions__shared-key-info__row__cell">
               {{ 'application.shared-key.no-key.message' | translate }}
             </div>
           </div>
-          <div class="application-subscriptions__shared-key-info__row" *ngIf="sharedAPIKeyLoaded && !sharedAPIKey">
+          <div class="application-subscriptions__shared-key-info__row" *ngIf="!sharedAPIKey">
             <div class="application-subscriptions__shared-key-info__row__cell" *ngIf="canRenewSharedApiKey()">
               {{ 'application.shared-key.no-key.create' | translate }}
             </div>

--- a/gravitee-apim-portal-webui/src/app/pages/application/application-subscriptions/application-subscriptions.component.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-subscriptions/application-subscriptions.component.spec.ts
@@ -68,6 +68,56 @@ describe('ApplicationSubscriptionsComponent', () => {
   describe('shared key app', () => {
     let httpTestingController: HttpTestingController;
 
+    const application: Application = {
+      id: 'application1',
+      name: 'applicationWithSharedKey',
+      api_key_mode: ApiKeyModeEnum.SHARED,
+    };
+
+    // Because of time management during the test, we need to use dates in the past to ensure that tests won't fail
+    const initialSharedApiKey: Key = { id: 'my-api-key-id', key: 'my-api-key', created_at: new Date(Date.now() - 86400000) }; // 24H ago
+    const newSharedApiKey: Key = { id: 'my-new-api-key-id', key: 'my-new-api-key', created_at: new Date(Date.now() - 43200000) }; // 12H ago
+
+    const subscription: Subscription = {
+      id: 'subscription1',
+      api: 'api1',
+      application: application.id,
+      plan: 'plan1',
+      status: 'ACCEPTED',
+    };
+
+    function mockSearch() {
+      httpTestingController
+        .expectOne(
+          `http://localhost:8083/portal/environments/DEFAULT/subscriptions?applicationId=${application.id}&statuses=ACCEPTED&statuses=PAUSED&statuses=PENDING`,
+        )
+        .flush({
+          data: [subscription],
+          metadata: {
+            plan1: {
+              securityType: SecurityEnum.APIKEY as unknown as object,
+            },
+          },
+        });
+      tick();
+    }
+
+    function mockLoadSubscription(keys: Key[]) {
+      httpTestingController
+        .expectOne(`http://localhost:8083/portal/environments/DEFAULT/subscriptions/${subscription.id}?include=keys`)
+        .flush({ ...subscription, keys });
+      tick();
+    }
+
+    function initSharedKey(): void {
+      httpTestingController.expectOne(
+        `http://localhost:8083/portal/environments/DEFAULT/applications/${application.id}/subscribers?size=-1`,
+      );
+
+      mockSearch();
+      mockLoadSubscription([initialSharedApiKey]);
+    }
+
     afterEach(() => {
       httpTestingController.verify();
     });
@@ -81,14 +131,10 @@ describe('ApplicationSubscriptionsComponent', () => {
             useValue: {
               snapshot: {
                 data: {
-                  application: {
-                    id: 'application1',
-                    name: 'applicationWithSharedKey',
-                    api_key_mode: ApiKeyModeEnum.SHARED,
-                  },
+                  application,
                 },
                 params: {
-                  applicationId: 'application1',
+                  applicationId: application.id,
                 },
                 queryParams: {},
               },
@@ -101,86 +147,91 @@ describe('ApplicationSubscriptionsComponent', () => {
     }));
 
     it('should init sharedApiKey', fakeAsync(() => {
-      const subscription: Subscription = {
-        id: 'subscription1',
-        api: 'api1',
-        application: 'application1',
-        plan: 'plan1',
-        status: 'ACCEPTED',
-      };
-
-      const sharedApiKey: Key = { key: 'my-api-key', created_at: new Date('2022-02-22T22:22:22Z') };
-
-      httpTestingController.expectOne('http://localhost:8083/portal/environments/DEFAULT/applications/application1/subscribers?size=-1');
-
-      httpTestingController
-        .expectOne(
-          'http://localhost:8083/portal/environments/DEFAULT/subscriptions?applicationId=application1&statuses=ACCEPTED&statuses=PAUSED&statuses=PENDING',
-        )
-        .flush({
-          data: [subscription],
-          metadata: {
-            plan1: {
-              securityType: SecurityEnum.APIKEY as unknown as object,
-            },
-          },
-        });
-      tick();
-
-      httpTestingController
-        .expectOne('http://localhost:8083/portal/environments/DEFAULT/subscriptions/subscription1?include=keys')
-        .flush({ ...subscription, keys: [sharedApiKey] });
-      tick();
+      initSharedKey();
 
       expect(component).toBeTruthy();
-      expect(component.sharedAPIKey).toEqual(sharedApiKey);
-      expect(component.subscriptions[0].keys).toContain(sharedApiKey);
+      expect(component.sharedAPIKey).toEqual(initialSharedApiKey);
+      expect(component.subscriptions[0].keys).toContain(initialSharedApiKey);
     }));
 
-    it('should renew sharedApiKey', fakeAsync(() => {
-      const subscription: Subscription = {
-        id: 'subscription1',
-        api: 'api1',
-        application: 'application1',
-        plan: 'plan1',
-        status: 'ACCEPTED',
-      };
-
-      const sharedApiKey: Key = { key: 'my-api-key', created_at: new Date('2022-02-22T22:22:22Z') };
-
-      httpTestingController.expectOne('http://localhost:8083/portal/environments/DEFAULT/applications/application1/subscribers?size=-1');
-
-      httpTestingController
-        .expectOne(
-          'http://localhost:8083/portal/environments/DEFAULT/subscriptions?applicationId=application1&statuses=ACCEPTED&statuses=PAUSED&statuses=PENDING',
-        )
-        .flush({
-          data: [subscription],
-          metadata: {
-            plan1: {
-              securityType: SecurityEnum.APIKEY as unknown as object,
-            },
-          },
-        });
-      tick();
-
-      httpTestingController
-        .expectOne('http://localhost:8083/portal/environments/DEFAULT/subscriptions/subscription1?include=keys')
-        .flush({ ...subscription, keys: [sharedApiKey] });
-      tick();
-
-      const newSharedApiKey: Key = { key: 'my-new-api-key', created_at: new Date('2022-02-23T22:22:22Z') };
+    it('should renew initialSharedApiKey', fakeAsync(() => {
+      initSharedKey();
 
       component.renewSharedApiKey();
       httpTestingController
-        .expectOne('http://localhost:8083/portal/environments/DEFAULT/applications/application1/keys/_renew')
+        .expectOne(`http://localhost:8083/portal/environments/DEFAULT/applications/${application.id}/keys/_renew`)
         .flush(newSharedApiKey);
       tick();
+
+      mockSearch();
+
+      const endDate = new Date();
+      endDate.setHours(endDate.getHours() + 2);
+      const endedInitialSharedApiKey: Key = { ...initialSharedApiKey, revoked_at: endDate, expire_at: endDate };
+      mockLoadSubscription([newSharedApiKey, endedInitialSharedApiKey]);
+
+      expect(component.sharedAPIKey).toEqual(newSharedApiKey);
+    }));
+
+    it('should revoke initialSharedApiKey', fakeAsync(() => {
+      initSharedKey();
+
+      const revokedDate = new Date(initialSharedApiKey.created_at);
+      revokedDate.setHours(revokedDate.getHours() + 1);
+      const revokedSharedApiKey: Key = { ...initialSharedApiKey, revoked_at: revokedDate, expire_at: revokedDate };
+
+      component.revokeSharedApiKey();
+      httpTestingController
+        .expectOne(
+          `http://localhost:8083/portal/environments/DEFAULT/applications/${application.id}/keys/${initialSharedApiKey.id}/_revoke`,
+        )
+        .flush(null);
+      tick();
+
+      mockSearch();
+      mockLoadSubscription([revokedSharedApiKey]);
+
+      expect(component.sharedAPIKey).toBeUndefined();
+    }));
+
+    it('should renew initialSharedApiKey, revoke it and display the initial shared key', fakeAsync(() => {
+      initSharedKey();
+
+      // First renew
+      component.renewSharedApiKey();
+      httpTestingController
+        .expectOne(`http://localhost:8083/portal/environments/DEFAULT/applications/${application.id}/keys/_renew`)
+        .flush(newSharedApiKey);
+      tick();
+
+      const endDate = new Date();
+      endDate.setHours(endDate.getHours() + 2);
+      const endedInitialSharedApiKey: Key = { ...initialSharedApiKey, revoked_at: endDate, expire_at: endDate };
+
+      mockSearch();
+      mockLoadSubscription([newSharedApiKey, endedInitialSharedApiKey]);
+
       expect(component.sharedAPIKey).toEqual(newSharedApiKey);
 
-      httpTestingController.expectOne(
-        'http://localhost:8083/portal/environments/DEFAULT/subscriptions?applicationId=application1&statuses=ACCEPTED&statuses=PAUSED&statuses=PENDING',
-      );
+      // then revoke
+      const newSharedApiKeyRevokedDate = new Date(newSharedApiKey.created_at);
+      newSharedApiKeyRevokedDate.setHours(newSharedApiKeyRevokedDate.getHours() + 1);
+      const revokedNewSharedApiKey: Key = {
+        ...newSharedApiKey,
+        revoked_at: newSharedApiKeyRevokedDate,
+        expire_at: newSharedApiKeyRevokedDate,
+      };
+
+      component.revokeSharedApiKey();
+      httpTestingController
+        .expectOne(`http://localhost:8083/portal/environments/DEFAULT/applications/${application.id}/keys/${newSharedApiKey.id}/_revoke`)
+        .flush(null);
+      tick();
+
+      mockSearch();
+      mockLoadSubscription([revokedNewSharedApiKey, endedInitialSharedApiKey]);
+
+      expect(component.sharedAPIKey).toEqual(endedInitialSharedApiKey);
     }));
   });
 

--- a/gravitee-apim-portal-webui/src/assets/i18n/cs.json
+++ b/gravitee-apim-portal-webui/src/assets/i18n/cs.json
@@ -430,6 +430,7 @@
       },
       "revoke": {
         "message": "Opravdu chcete zrušit tento sdíleným klíč API?",
+        "success": "Sdílené klíč API byl úspěšně odvolání",
         "title": "Odvolat"
       },
       "title": "Aplikace se sdíleným klíč API"

--- a/gravitee-apim-portal-webui/src/assets/i18n/en.json
+++ b/gravitee-apim-portal-webui/src/assets/i18n/en.json
@@ -430,6 +430,7 @@
       },
       "revoke": {
         "message": "Are you sure you want to revoke this shared API key?",
+        "success": "The shared API key has been successfully revoked",
         "title": "Revoke"
       },
       "title": "Application with a shared API Key"

--- a/gravitee-apim-portal-webui/src/assets/i18n/fr.json
+++ b/gravitee-apim-portal-webui/src/assets/i18n/fr.json
@@ -424,12 +424,13 @@
         "recommendation": "Veuillez contacter le propriétaire de l'application."
       },
       "renew": {
-        "message": "Êtes-vous sûr de vouloir renouveler cette clé d'API partagée?",
+        "message": "Êtes-vous sûr de vouloir renouveler cette clé d'API partagée ?",
         "success": "La clé d'API partagée a été renouvelée avec succès",
         "title": "Renouveler"
       },
       "revoke": {
         "message": "Êtes-vous sûr de vouloir révoquer cette clé d'API partagée ?",
+        "success": "La clé d'API partagée a été revoquée avec succès",
         "title": "Révoquer"
       },
       "title": "Application avec une clé d'API partagée"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/openapi.yaml
@@ -1551,7 +1551,7 @@ paths:
     post:
       tags:
         - Application
-      summary: Renew the shared api key of on application.
+      summary: Renew the shared api key of an application.
       description: |
         Renew the shared api key of on application.
         The application must have the ApiKeyMode set to SHARED
@@ -1574,6 +1574,42 @@ paths:
           $ref: '#/components/responses/PermissionError'
         404:
           description: Application not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+  /applications/{applicationId}/keys/{apiKey}/_revoke:
+    parameters:
+      -   $ref: '#/components/parameters/applicationIdParam'
+      -   name: apiKey
+          in: path
+          required: true
+          schema:
+            type: string
+    post:
+      tags:
+        - Application
+      summary: Revoke the shared api key of an application.
+      description: |
+        Revoke the shared api key of on application.
+        The application must have the ApiKeyMode set to SHARED
+        User must have APPLICATION_SUBSCRIPTION[UPDATE] permission.
+      operationId: revokeSharedKey
+      responses:
+        204:
+          description: No-Content
+        400:
+          description: ApiKey parameter does not correspond to the application
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        403:
+          $ref: '#/components/responses/PermissionError'
+        404:
+          description: Application or key not found
           content:
             application/json:
               schema:


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6818

**Description**

allow to revoke a shared API key on Portal
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jwccqcxjpg.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6818-revoke-apikey-from-portal/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
