### PR TITLE
chore: bump ssl-enforcement policy to 1.2.1

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -88,7 +88,7 @@
         <gravitee-policy-rest-to-soap.version>1.12.0</gravitee-policy-rest-to-soap.version>
         <gravitee-policy-retry.version>2.0.0</gravitee-policy-retry.version>
         <gravitee-policy-role-based-access-control.version>1.1.0</gravitee-policy-role-based-access-control.version>
-        <gravitee-policy-ssl-enforcement.version>1.2.0</gravitee-policy-ssl-enforcement.version>
+        <gravitee-policy-ssl-enforcement.version>1.2.1</gravitee-policy-ssl-enforcement.version>
         <gravitee-policy-traffic-shadowing.version>1.1.0</gravitee-policy-traffic-shadowing.version>
         <gravitee-policy-transformheaders.version>1.8.2</gravitee-policy-transformheaders.version>
         <gravitee-policy-transformqueryparams.version>1.6.0</gravitee-policy-transformqueryparams.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7276

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-7276-ssl-x509/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
