### PR TITLE
ci: add every existing plugins in 3.16.x env

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -67,7 +67,7 @@
         <gravitee-policy-jwt.version>1.22.0</gravitee-policy-jwt.version>
         <gravitee-policy-keyless.version>1.4.0</gravitee-policy-keyless.version>
         <gravitee-policy-latency.version>1.4.0</gravitee-policy-latency.version>
-        <gravitee-policy-metrics-reporter.version>1.2.0</gravitee-policy-metrics-reporter.version>
+        <gravitee-policy-metrics-reporter.version>1.2.1</gravitee-policy-metrics-reporter.version>
         <gravitee-policy-mock.version>1.13.0</gravitee-policy-mock.version>
         <gravitee-policy-oauth2.version>1.19.0</gravitee-policy-oauth2.version>
         <gravitee-policy-openid-connect-userinfo.version>1.5.0</gravitee-policy-openid-connect-userinfo.version>
@@ -592,7 +592,22 @@
             <properties>
                 <!-- Versions of the plugins for the full distribution on dev environment-->
                 <!-- Management API & Gateway -->
-                <gravitee-connector-kafka.version>1.1.0-SNAPSHOT</gravitee-connector-kafka.version>
+                <gravitee-connector-kafka.version>1.1.0</gravitee-connector-kafka.version>
+                <gravitee-policy-aws-lambda.version>1.1.0</gravitee-policy-aws-lambda.version>
+                <gravitee-policy-basic-authentication.version>1.2.0</gravitee-policy-basic-authentication.version>
+                <gravitee-policy-circuit-breaker.version>1.0.1</gravitee-policy-circuit-breaker.version>
+                <gravitee-policy-geoip-filtering.version>1.1.0</gravitee-policy-geoip-filtering.version>
+                <gravitee-policy-wssecurity-authentication.version>1.0.0</gravitee-policy-wssecurity-authentication.version>
+                <gravitee-resource-auth-provider-http.version>1.1.0</gravitee-resource-auth-provider-http.version>
+                <gravitee-resource-auth-provider-inline.version>1.1.0</gravitee-resource-auth-provider-inline.version>
+                <gravitee-resource-auth-provider-ldap.version>1.1.0</gravitee-resource-auth-provider-ldap.version>
+                <gravitee-resource-cache-redis.version>1.0.1</gravitee-resource-cache-redis.version>
+                <gravitee-resource-oauth2-provider-keycloak.version>1.9.1</gravitee-resource-oauth2-provider-keycloak.version>
+
+                <!-- Using service GeoIP requires to adapt Java HeapSpace: https://github.com/gravitee-io/gravitee-service-geoip/blob/master/README.adoc -->
+                <!-- So keep it commented for the moment -->
+                <!-- <gravitee-service-geoip.version>1.1.0</gravitee-service-geoip.version>-->
+
                 <!-- Management API Only -->
                 <!-- Gateway Only -->
             </properties>
@@ -605,6 +620,88 @@
                     <type>zip</type>
                     <scope>runtime</scope>
                 </dependency>
+                <!-- Policies -->
+                <dependency>
+                    <groupId>io.gravitee.policy</groupId>
+                    <artifactId>gravitee-policy-aws-lambda</artifactId>
+                    <version>${gravitee-policy-aws-lambda.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>io.gravitee.policy</groupId>
+                    <artifactId>gravitee-policy-basic-authentication</artifactId>
+                    <version>${gravitee-policy-basic-authentication.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>io.gravitee.policy</groupId>
+                    <artifactId>gravitee-policy-circuit-breaker</artifactId>
+                    <version>${gravitee-policy-circuit-breaker.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>io.gravitee.policy</groupId>
+                    <artifactId>gravitee-policy-geoip-filtering</artifactId>
+                    <version>${gravitee-policy-geoip-filtering.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>io.gravitee.policy</groupId>
+                    <artifactId>gravitee-policy-wssecurity-authentication</artifactId>
+                    <version>${gravitee-policy-wssecurity-authentication.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+                <!-- Resources -->
+                <dependency>
+                    <groupId>io.gravitee.resource</groupId>
+                    <artifactId>gravitee-resource-auth-provider-http</artifactId>
+                    <version>${gravitee-resource-auth-provider-http.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>io.gravitee.resource</groupId>
+                    <artifactId>gravitee-resource-auth-provider-inline</artifactId>
+                    <version>${gravitee-resource-auth-provider-inline.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>io.gravitee.resource</groupId>
+                    <artifactId>gravitee-resource-auth-provider-ldap</artifactId>
+                    <version>${gravitee-resource-auth-provider-ldap.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>io.gravitee.resource</groupId>
+                    <artifactId>gravitee-resource-cache-redis</artifactId>
+                    <version>${gravitee-resource-cache-redis.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>io.gravitee.resource</groupId>
+                    <artifactId>gravitee-resource-oauth2-provider-keycloak</artifactId>
+                    <version>${gravitee-resource-oauth2-provider-keycloak.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+                <!-- Services -->
+                <!-- Using service GeoIP requires to adapt Java HeapSpace: https://github.com/gravitee-io/gravitee-service-geoip/blob/master/README.adoc -->
+                <!-- So keep it commented for the moment -->
+                <!-- <dependency>-->
+                <!--     <groupId>io.gravitee.service</groupId>-->
+                <!--     <artifactId>gravitee-service-geoip</artifactId>-->
+                <!--     <version>${gravitee-service-geoip.version}</version>-->
+                <!--     <type>zip</type>-->
+                <!--     <scope>runtime</scope>-->
+                <!-- </dependency>-->
             </dependencies>
         </profile>
         <profile>
@@ -614,8 +711,11 @@
                 <!-- Management API & Gateway -->
                 <gravitee-ae-connectors-ws.version>1.5.4</gravitee-ae-connectors-ws.version>
                 <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
+                <gravitee-policy-assign-metrics.version>1.0.1</gravitee-policy-assign-metrics.version>
+                <gravitee-policy-data-logging-masking.version>1.0.1</gravitee-policy-data-logging-masking.version>
+
                 <!-- Management API Only -->
-                <gravitee-notifier-email.version>1.3.1</gravitee-notifier-email.version>
+                <gravitee-notifier-email.version>1.3.2</gravitee-notifier-email.version>
                 <gravitee-notifier-slack.version>1.2.1</gravitee-notifier-slack.version>
                 <gravitee-notifier-webhook.version>1.1.0</gravitee-notifier-webhook.version>
                 <!-- Gateway Only -->
@@ -654,6 +754,21 @@
                     <groupId>io.gravitee.notifier</groupId>
                     <artifactId>gravitee-notifier-webhook</artifactId>
                     <version>${gravitee-notifier-webhook.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+                <!-- Policies -->
+                <dependency>
+                    <groupId>com.graviteesource.policy</groupId>
+                    <artifactId>gravitee-policy-assign-metrics</artifactId>
+                    <version>${gravitee-policy-assign-metrics.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.policy</groupId>
+                    <artifactId>gravitee-policy-data-logging-masking</artifactId>
+                    <version>${gravitee-policy-data-logging-masking.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
                 </dependency>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7219

**Description**

Add every possible plugins in the dev environments, even those not included in default bundle and EE ones

**Additional context**

- Current dev environment are build with `distribution-dev` maven profile. To include EE plugins, we need to also build with `distribution-ee` maven profile. However, including EE plugins without license generates error and  stacktraces in ManagementAPI & GW startup log.
- Not including the kafka reporter since it is not maintained by us
- service-geoip has been added but commented since it requires to customize the java heap space of the gateway
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tfoyzshkhk.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7219-all-plugins-on-dev-environments-3-16-x/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
