### PR TITLE
fix: avoid finding by hrids or id in undefined environments collection

### DIFF
--- a/gravitee-apim-console-webui/src/services/environment.service.ts
+++ b/gravitee-apim-console-webui/src/services/environment.service.ts
@@ -73,7 +73,7 @@ class EnvironmentService {
   }
 
   getEnvironmentFromHridOrId(environments, id) {
-    return environments.find((environment) => environment.id === id || (environment.hrids && environment.hrids.includes(id)));
+    return environments?.find((environment) => environment.id === id || (environment.hrids && environment.hrids.includes(id)));
   }
 }
 


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7300

**Description**

Unable to reproduce the bug but fix the code to prevent this error to appear again.

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-7300-events-display/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
