### PR TITLE
ci: save maven cache after test phase

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,6 +302,7 @@ jobs:
                       find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
                   when: always
             - notify-on-failure
+            - save-maven-cache
             - store_test_results:
                   path: ~/test-results
 


### PR DESCRIPTION
**Description**

This PR will allow all plugins and dependencies needed by tests to be cached. The goal is to reduce network traffic and potential 'connection reset' issues.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mpuuiabxdk.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/improve-ci-test-phase/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
