### PR TITLE
fix: fix potential NPE and securize ApiKeySubscriptionsUpgrader execution

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/ApiKeySubscriptionsUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/ApiKeySubscriptionsUpgrader.java
@@ -19,7 +19,7 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.model.ApiKey;
 import io.gravitee.rest.api.service.InstallationService;
-import java.util.List;
+import java.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,7 +55,11 @@ public class ApiKeySubscriptionsUpgrader extends OneShotUpgrader {
     private void updateApiKeySubscriptions(ApiKey apiKey) {
         try {
             LOGGER.debug("Updating subscriptions for API key [{}]", apiKey);
-            apiKey.setSubscriptions(List.of(apiKey.getSubscription()));
+            List<String> allSubscriptions = apiKey.getSubscriptions() != null ? apiKey.getSubscriptions() : new ArrayList<>();
+            if (apiKey.getSubscription() != null && !allSubscriptions.contains(apiKey.getSubscription())) {
+                allSubscriptions.add(apiKey.getSubscription());
+            }
+            apiKey.setSubscriptions(allSubscriptions);
             apiKeyRepository.update(apiKey);
         } catch (TechnicalException e) {
             LOGGER.error("Failed to update subscriptions for API key [{}]", apiKey, e);


### PR DESCRIPTION
fix: fix potential NPE and securize ApiKeySubscriptionsUpgrader execution

Handle null apiKey.subscription in ApiKeySubscriptionsUpgrader.
This edge case can happen :
- re-launching the upgrader against database containing apikey created with gravitee>=3.17
- launching the upgrader against database containing anomalies (apikey without subscription)

Even if we run the upgrader a second time (there is no point to do that, but let's say user do it by mistake) ;
We have to ensure that existing subscriptions are not overriden,
By doing mergin subscription to subscriptions list, instead of setting it.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vrpkbswuiy.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-apikeysubscriptionsupgrader/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
