### PR TITLE
feat: ensure ApplicationApiKeyModeUpgrader won't override api key modes already set

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/ApplicationApiKeyModeUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/ApplicationApiKeyModeUpgrader.java
@@ -75,8 +75,10 @@ public class ApplicationApiKeyModeUpgrader extends OneShotUpgrader {
             .findAll()
             .forEach(
                 application -> {
-                    Long apiKeysSubscriptionCount = apiKeySubscriptionsCountByApplication.getOrDefault(application.getId(), 0L);
-                    updateApplicationApiKeyMode(application, apiKeysSubscriptionCount > 1 ? EXCLUSIVE : UNSPECIFIED);
+                    if (application.getApiKeyMode() == null || application.getApiKeyMode() == UNSPECIFIED) {
+                        Long apiKeysSubscriptionCount = apiKeySubscriptionsCountByApplication.getOrDefault(application.getId(), 0L);
+                        updateApplicationApiKeyMode(application, apiKeysSubscriptionCount > 1 ? EXCLUSIVE : UNSPECIFIED);
+                    }
                 }
             );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/ApplicationApiKeyModeUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/ApplicationApiKeyModeUpgraderTest.java
@@ -15,8 +15,7 @@
  */
 package io.gravitee.rest.api.service.impl.upgrade;
 
-import static io.gravitee.repository.management.model.ApiKeyMode.EXCLUSIVE;
-import static io.gravitee.repository.management.model.ApiKeyMode.UNSPECIFIED;
+import static io.gravitee.repository.management.model.ApiKeyMode.*;
 import static io.gravitee.repository.management.model.Plan.PlanSecurityType.*;
 import static org.mockito.Mockito.*;
 
@@ -77,7 +76,10 @@ public class ApplicationApiKeyModeUpgraderTest {
                     buildTestSubscription("plan-2", "application-3"),
                     // application-4 has 2 subscription to api key plans
                     buildTestSubscription("plan-1", "application-4"),
-                    buildTestSubscription("plan-4", "application-4")
+                    buildTestSubscription("plan-4", "application-4"),
+                    // application-4 has 2 subscription to api key plans
+                    buildTestSubscription("plan-1", "application-6"),
+                    buildTestSubscription("plan-4", "application-6")
                 )
             );
 
@@ -88,7 +90,8 @@ public class ApplicationApiKeyModeUpgraderTest {
                     buildTestApplication("application-2"),
                     buildTestApplication("application-3"),
                     buildTestApplication("application-4"),
-                    buildTestApplication("application-5")
+                    buildTestApplication("application-5"),
+                    buildTestApplication("application-6", SHARED) // application-6 won't be updated as its api key mode is already defined
                 )
             );
 
@@ -123,8 +126,13 @@ public class ApplicationApiKeyModeUpgraderTest {
     }
 
     private Application buildTestApplication(String id) {
+        return buildTestApplication(id, null);
+    }
+
+    private Application buildTestApplication(String id, ApiKeyMode apiKeyMode) {
         Application application = new Application();
         application.setId(id);
+        application.setApiKeyMode(apiKeyMode);
         return application;
     }
 }


### PR DESCRIPTION
feat: ensure ApplicationApiKeyModeUpgrader won't override api key modes already set

This securizes ApplicationApiKeyModeUpgrader to ensure it doesn't override applications api key modes that have already been set to SHARED
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cfmxqwbwxt.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/feat-securizeapplicationapikeymodeupgrader/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
