### PR TITLE
fix(debug): add metrics to DebugResponse

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/policy-studio/debug/models/DebugResponse.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/debug/models/DebugResponse.ts
@@ -16,7 +16,7 @@
 import { uniqueId } from 'lodash';
 
 import { RequestDebugStep, DebugSteps, RequestPolicyDebugStep, ResponsePolicyDebugStep, ResponseDebugStep } from './DebugStep';
-import { DebugEvent } from './DebugEvent';
+import { DebugEvent, DebugEventMetrics } from './DebugEvent';
 
 export type DebugResponse = {
   isLoading: boolean;
@@ -54,6 +54,8 @@ export type DebugResponse = {
     headers?: Record<string, string[]>;
     body?: string;
   };
+
+  metrics?: DebugEventMetrics;
 };
 
 export const convertDebugEventToDebugResponse = (event: DebugEvent): DebugResponse => {
@@ -158,6 +160,7 @@ export const convertDebugEventToDebugResponse = (event: DebugEvent): DebugRespon
       input: responseInputDebugStep,
       output: responseOutputDebugStep,
     },
+    metrics: event.payload.metrics,
   };
 };
 


### PR DESCRIPTION
gravitee-io/issues#7111
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-yekkiolhhc.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7111-view-call-metrics/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
