### PR TITLE
fix(jdbc): fix ApiKeyRepository findAll when apiKey has no subscription

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiKeyRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiKeyRepository.java
@@ -348,7 +348,7 @@ public class JdbcApiKeyRepository extends JdbcAbstractCrudRepository<ApiKey, Str
             String query =
                 getOrm().getSelectAllSql() +
                 " k" +
-                " join " +
+                " left join " +
                 KEY_SUBSCRIPTIONS +
                 " ks on ks.key_id = k.id" +
                 " order by k.updated_at desc ";

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/ApiKeyRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/ApiKeyRepositoryTest.java
@@ -272,4 +272,19 @@ public class ApiKeyRepositoryTest extends AbstractRepositoryTest {
         assertEquals(3, apiKey.getSubscriptions().size());
         assertTrue(apiKey.getSubscriptions().containsAll(Set.of("sub4", "sub5", "sub6")));
     }
+
+    @Test
+    public void findAll_should_find_all_api_keys_even_with_no_subscription() throws TechnicalException {
+        Set<ApiKey> apiKeys = apiKeyRepository.findAll();
+
+        assertEquals(9, apiKeys.size());
+        assertTrue(
+            apiKeys
+                .stream()
+                .anyMatch(
+                    apiKey ->
+                        apiKey.getId().equals("id-of-apikey-8") && apiKey.getSubscriptions() != null && apiKey.getSubscriptions().isEmpty()
+                )
+        );
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/ApiKeyRepositoryMock.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/ApiKeyRepositoryMock.java
@@ -44,6 +44,7 @@ public class ApiKeyRepositoryMock extends AbstractRepositoryMock<ApiKeyRepositor
 
     @Override
     void prepare(ApiKeyRepository apiKeyRepository) throws Exception {
+        final ApiKey apiKey0 = mockApiKey0();
         final ApiKey apiKey1 = mockApiKey1();
         final ApiKey apiKey2 = mockApiKey2();
         final ApiKey apiKey3 = mockApiKey3();
@@ -51,6 +52,7 @@ public class ApiKeyRepositoryMock extends AbstractRepositoryMock<ApiKeyRepositor
         final ApiKey apiKey5 = mockApiKey5();
         final ApiKey apiKey6 = mockApiKey6();
         final ApiKey apiKey7 = mockApiKey7();
+        final ApiKey apiKey8 = mockApiKey8();
 
         when(apiKey1.getDaysToExpirationOnLastNotification()).thenReturn(30);
         when(apiKeyRepository.findById(anyString())).thenReturn(empty());
@@ -88,6 +90,18 @@ public class ApiKeyRepositoryMock extends AbstractRepositoryMock<ApiKeyRepositor
 
         when(apiKeyRepository.findByApplication("app1")).thenReturn(List.of(apiKey5, apiKey4));
         when(apiKeyRepository.findByKeyAndApi("findByCriteria2", "api2")).thenReturn(Optional.of(apiKey6));
+
+        when(apiKeyRepository.findAll())
+            .thenReturn(Set.of(apiKey0, apiKey1, apiKey2, apiKey3, apiKey4, apiKey5, apiKey6, apiKey7, apiKey8));
+    }
+
+    private ApiKey mockApiKey0() {
+        ApiKey apiKey = mock(ApiKey.class);
+        when(apiKey.getId()).thenReturn("id-of-apikey-0");
+        when(apiKey.getKey()).thenReturn("d449098d-8c31-4275-ad59-8dd707865999");
+        when(apiKey.isRevoked()).thenReturn(true);
+        when(apiKey.getSubscriptions()).thenReturn(List.of("subscription2"));
+        return apiKey;
     }
 
     private ApiKey mockApiKey1() {
@@ -116,6 +130,7 @@ public class ApiKeyRepositoryMock extends AbstractRepositoryMock<ApiKeyRepositor
 
     private ApiKey mockApiKey3() {
         ApiKey apiKey = mock(ApiKey.class);
+        when(apiKey.getId()).thenReturn("id-of-apikey-3");
         when(apiKey.getKey()).thenReturn("d449098d-8c31-4275-ad59-8dd707865a35");
         when(apiKey.getSubscriptions()).thenReturn(List.of("subscription1"));
         return apiKey;
@@ -152,6 +167,15 @@ public class ApiKeyRepositoryMock extends AbstractRepositoryMock<ApiKeyRepositor
         when(apiKey.getApplication()).thenReturn("app4");
         when(apiKey.getKey()).thenReturn("the-key-of-api-key-7");
         when(apiKey.getSubscriptions()).thenReturn(List.of("sub4", "sub5", "sub6"));
+        return apiKey;
+    }
+
+    private ApiKey mockApiKey8() {
+        ApiKey apiKey = mock(ApiKey.class);
+        when(apiKey.getId()).thenReturn("id-of-apikey-8");
+        when(apiKey.getApplication()).thenReturn("app4");
+        when(apiKey.getKey()).thenReturn("the-key-of-api-key-8");
+        when(apiKey.getSubscriptions()).thenReturn(List.of());
         return apiKey;
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/apikey-tests/apiKeys.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/apikey-tests/apiKeys.json
@@ -72,6 +72,12 @@
 		"key": "the-key-of-api-key-7",
 		"subscriptions": ["sub4", "sub5", "sub6"],
 		"application": "app4"
+	},
+	{
+		"id": "id-of-apikey-8",
+		"key": "the-key-of-api-key-8",
+		"subscriptions": [],
+		"application": "app4"
 	}
 ]
 


### PR DESCRIPTION
When apiKey has no subscription, api key repository should behave like mongo repository ;
Returning the apiKey with an empty subscriptions list.
So, do a left join instead of a join.

Otherwise, it breaks ApiKeySubscriptionUpgrader, which has to retreive ApiKeys without subscriptions.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pomwmvuwdh.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-jdbc-apikey-findall-nosubscription/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
