### PR TITLE
fix(jdbc): JdbcApiKeyRepository.findByCriteria reads API key subscriptions

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/ApiKeyRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/ApiKeyRepositoryTest.java
@@ -234,6 +234,16 @@ public class ApiKeyRepositoryTest extends AbstractRepositoryTest {
     }
 
     @Test
+    public void findByCriteria_should_read_subscriptions_list() throws Exception {
+        List<ApiKey> apiKeys = apiKeyRepository.findByCriteria(new Builder().expireAfter(30019401755L).build());
+
+        assertEquals(2, apiKeys.get(0).getSubscriptions().size());
+        assertTrue(apiKeys.get(0).getSubscriptions().containsAll(Set.of("subscription2", "subscriptionX")));
+        assertEquals(1, apiKeys.get(1).getSubscriptions().size());
+        assertEquals("subscription1", apiKeys.get(1).getSubscriptions().get(0));
+    }
+
+    @Test
     public void findByApplication_should_find_api_keys() throws TechnicalException {
         List<ApiKey> apiKeys = apiKeyRepository.findByApplication("app1");
         assertEquals(2, apiKeys.size());

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/ApiKeyRepositoryMock.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/ApiKeyRepositoryMock.java
@@ -122,7 +122,7 @@ public class ApiKeyRepositoryMock extends AbstractRepositoryMock<ApiKeyRepositor
         when(apiKey.getId()).thenReturn("id-of-apikey-2");
         when(apiKey.getKey()).thenReturn("d449098d-8c31-4275-ad59-8dd707865a34");
         when(apiKey.getExpireAt()).thenReturn(parse("11/02/2016"));
-        when(apiKey.getSubscriptions()).thenReturn(List.of("subscription2"));
+        when(apiKey.getSubscriptions()).thenReturn(List.of("subscription2", "subscriptionX"));
         when(apiKey.isRevoked()).thenReturn(false);
         when(apiKey.isPaused()).thenReturn(false);
         return apiKey;

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/apikey-tests/apiKeys.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/apikey-tests/apiKeys.json
@@ -24,7 +24,7 @@
 		"key": "d449098d-8c31-4275-ad59-8dd707865a34",
 		"revoked": false,
 		"expireAt": 1439022010883,
-		"subscriptions": ["subscription2"],
+		"subscriptions": ["subscription2", "subscriptionX"],
 		"createdAt": 1439022010883,
 		"updatedAt": 1439022010000
 	},


### PR DESCRIPTION
fix(jdbc): JdbcApiKeyRepository.findByCriteria reads API key subscriptions

ApiKeyRepository.findByCriteria should behave the same way between JDBC and mongo, reading the api key subscriptions list.
Otherwise, it breaks APIKeyRefresher, which needs subscriptions in order to populate his cache.

So we have to always join with key_subscriptions, and use the custom row mapper.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wxntyvoyvc.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-fix-jdbc-apikeyrepository-findbycriteria/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
