### PR TITLE
reintroduce gravitee-license-node in dependencies management for EE maven profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.graviteesource.license</groupId>
+                <artifactId>gravitee-license-node</artifactId>
+                <version>${gravitee-license-node.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>io.gravitee.node</groupId>
                 <artifactId>gravitee-node-api</artifactId>
                 <version>${gravitee-node.version}</version>


### PR DESCRIPTION
**Description**

reintroduce gravitee-license-node in dependencies management for EE maven profile (to allow starting EE version of APIM in IntelliJ for instance)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pqpadtfeui.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-maven-ee-profile/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
