### PR TITLE
Cicd/3.15.x secrethub to keeper

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,7 +253,6 @@ jobs:
             - attach_workspace:
                   at: .
             - restore-maven-cache
-            - prepare-env-var
             - run:
                   name: "Build project"
                   command: |
@@ -493,7 +492,7 @@ jobs:
                   command: npm run build:prod
                   environment:
                       NODE_OPTIONS: --max_old_space_size=4086
-                      BACKEND_ENV: apim-master
+                      BACKEND_ENV: element-zero
                   working_directory: << parameters.apim-ui-project >>
             - run:
                   name: Zip dist folder
@@ -657,7 +656,7 @@ jobs:
                       export PR_BODY_UI_SECTION="
                       <!-- UI placeholder -->
                       🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/${BRANCH_ID}/index.html)
-                      _Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
+                      _Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
                       <!-- UI placeholder end -->
                       "
 
@@ -797,9 +796,8 @@ jobs:
                       # Remove `-SNAPSHOT` from versions
                       mvn -Duser.home=${HOME} -s /tmp/release.settings.xml -B versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
             - prepare-gpg
-            - prepare-env-var
             - run:
-                  name: Maven deploy to Gravitee's private Artifactory"
+                  name: Prepare env variables used in [version.properties] files and Maven deploy to Gravitee's private Artifactory"
                   command: |
                       echo "  MAVEN_PROFILE_ID=[${MAVEN_PROFILE_ID}]  "
                       mvn -Duser.home=${HOME} -s /tmp/release.settings.xml -B -U -P ${MAVEN_PROFILE_ID} clean deploy -DskipTests=true -Dskip.validation

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,10 @@ version: 2.1
 orbs:
     slack: circleci/slack@4.4.4
     gravitee: gravitee-io/gravitee@1.0.44
-    secrethub: secrethub/cli@1.1.0
+    #secrethub: secrethub/cli@1.1.0
     gh: circleci/github-cli@1.0.5
     aws-cli: circleci/aws-cli@2.0.6
+    apim: gravitee-io/gravitee-apim@1.0
 
 executors:
     node-lts:
@@ -33,6 +34,16 @@ executors:
         resource_class: <<parameters.resource_class>>
 
 commands:
+    prepare-env-var:
+        description: Prepare env variables used in [version.properties] files
+        steps:
+            - run:
+                  name: Prepare env variables
+                  command: |
+                      export BUILD_ID=${CIRCLE_BUILD_NUM}
+                      export BUILD_NUMBER=${CIRCLE_BUILD_NUM}
+                      export GIT_COMMIT=$(git rev-parse --short HEAD)
+
     restore-maven-cache:
         description: Restore Maven cache
         steps:
@@ -86,13 +97,13 @@ commands:
     prepare-gpg:
         description: Prepare GPG command
         steps:
-            - secrethub/install
+            - apim/keeper_cli
             - run:
                   command: |
-                      secrethub read graviteeio/cicd/graviteebot/gpg/armor_format_pub_key -o pub.key
+                      ksm secret notation keeper://u2dz7IP-w9E0NKsUeyCAYA/custom_field/public_key -o pub.key
                       gpg --import pub.key
 
-                      secrethub read graviteeio/cicd/graviteebot/gpg/armor_format_private_key -o private.key
+                      ksm secret notation keeper://u2dz7IP-w9E0NKsUeyCAYA/custom_field/private_key -o private.key
                       # Need --batch to be able to import private key
                       gpg --import --batch private.key
     prepare-tar-for-s3-glacier:
@@ -149,19 +160,6 @@ parameters:
         description: "Version of APIM to be used in docker images"
 
 jobs:
-    load-snapshot-configuration:
-        docker:
-            - image: cimg/base:stable
-        environment:
-            MAVEN_SETTINGS: "secrethub://graviteeio/cicd/graviteebot/infra/maven/gravitee-snapshot.settings.xml"
-        steps:
-            - secrethub/exec:
-                  command: echo $MAVEN_SETTINGS > /tmp/.gravitee-snapshot.settings.xml
-            - persist_to_workspace:
-                  root: /tmp
-                  paths:
-                      - .gravitee-snapshot.settings.xml
-
     compute-apim-tag:
         docker:
             - image: cimg/openjdk:11.0
@@ -218,10 +216,11 @@ jobs:
                   command: apk add --no-cache openssh
             - checkout
             - attach_workspace:
-                  at: .
-            - secrethub/env-export:
-                  secret-path: graviteeio/cicd/graviteebot/infra/sonarcloud.io.token
-                  var-name: SONAR_TOKEN
+                at: .
+           # - run:
+            #    name: sonar_token
+             #   command: |
+              #    echo "export SONAR_TOKEN=$(cat /tmp/gravit33bot/.secrets/sonarcloud_token)" >> $BASH_ENV
             - run:
                   name: Run Sonarcloud Analysis
                   command: sonar-scanner
@@ -254,6 +253,7 @@ jobs:
             - attach_workspace:
                   at: .
             - restore-maven-cache
+            - prepare-env-var
             - run:
                   name: "Build project"
                   command: |
@@ -493,7 +493,7 @@ jobs:
                   command: npm run build:prod
                   environment:
                       NODE_OPTIONS: --max_old_space_size=4086
-                      BACKEND_ENV: element-zero
+                      BACKEND_ENV: apim-master
                   working_directory: << parameters.apim-ui-project >>
             - run:
                   name: Zip dist folder
@@ -569,7 +569,7 @@ jobs:
             - checkout
             - attach_workspace:
                   at: .
-            - secrethub/exec:
+        #    - secrethub/exec:
                   step-name: Running Chromatic
                   # TODO:
                   #  - Handle npx chromatic command failure, make the job fails
@@ -657,7 +657,7 @@ jobs:
                       export PR_BODY_UI_SECTION="
                       <!-- UI placeholder -->
                       🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/${BRANCH_ID}/index.html)
-                      _Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
+                      _Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
                       <!-- UI placeholder end -->
                       "
 
@@ -797,13 +797,10 @@ jobs:
                       # Remove `-SNAPSHOT` from versions
                       mvn -Duser.home=${HOME} -s /tmp/release.settings.xml -B versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false
             - prepare-gpg
+            - prepare-env-var
             - run:
-                  name: Prepare env variables used in [version.properties] files and Maven deploy to Gravitee's private Artifactory"
+                  name: Maven deploy to Gravitee's private Artifactory"
                   command: |
-                      export BUILD_ID=${CIRCLE_BUILD_NUM}
-                      export BUILD_NUMBER=${CIRCLE_BUILD_NUM}
-                      export GIT_COMMIT=$(git rev-parse --short HEAD)
-
                       echo "  MAVEN_PROFILE_ID=[${MAVEN_PROFILE_ID}]  "
                       mvn -Duser.home=${HOME} -s /tmp/release.settings.xml -B -U -P ${MAVEN_PROFILE_ID} clean deploy -DskipTests=true -Dskip.validation
             - run:
@@ -908,7 +905,7 @@ jobs:
         steps:
             - setup_remote_docker
             - checkout
-            - secrethub/install
+          #  - secrethub/install
             - run:
                   name: "Parse GRAVITEEIO_VERSION to extract major, minor and patch version"
                   command: |
@@ -980,11 +977,13 @@ workflows:
             and:
                 - equal: [pull_requests, << pipeline.parameters.gio_action >>]
         jobs:
-            - load-snapshot-configuration:
+
+            - apim/keeper_secrets:
+                  name: fetching secrets
                   context: cicd-orchestrator
             - compute-apim-tag:
                   requires:
-                      - load-snapshot-configuration
+                      - fetching secrets
             - validate:
                   context: gravitee-qa
                   requires:
@@ -1030,12 +1029,14 @@ workflows:
                   requires:
                       - test
                   pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/username
-                            var-name: AZURE_DOCKER_REGISTRY_USERNAME
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/password
-                            var-name: AZURE_DOCKER_REGISTRY_PASSWORD
+                    - attach_workspace:
+                        at: /tmp
+                    - run:
+                        name: azure env variables
+                        command: |
+                            echo "export AZURE_DOCKER_REGISTRY_USERNAME=$(cat /tmp/gravit33bot/.secrets/azure_registry_username)" >> $BASH_ENV
+                            echo "export AZURE_DOCKER_REGISTRY_PASSWORD=$(cat /tmp/gravit33bot/.secrets/azure_registry_pwd)" >> $BASH_ENV
+
                   filters:
                       branches:
                           only:
@@ -1045,7 +1046,7 @@ workflows:
                   name: Install APIM Console
                   apim-ui-project: gravitee-apim-console-webui
                   requires:
-                      - load-snapshot-configuration
+                      - fetching secrets
             - webui-lint-test:
                   name: Lint & test APIM Console
                   apim-ui-project: gravitee-apim-console-webui
@@ -1059,9 +1060,12 @@ workflows:
                   requires:
                       - console-webui-build-storybook
                   pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/github_personal_access_token
-                            var-name: GITHUB_TOKEN
+                      - attach_workspace:
+                            at: /tmp
+                      - run:
+                            name: github token env
+                            command: |
+                                echo "export GITHUB_TOKEN=$(cat /tmp/gravit33bot/.secrets/github-personal-token)" >> $BASH_ENV
             - webui-build:
                   name: Build APIM Console
                   apim-ui-project: gravitee-apim-console-webui
@@ -1070,23 +1074,25 @@ workflows:
             - console-webui-deploy-on-azure-storage:
                   context: cicd-orchestrator
                   pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/application-id
-                            var-name: AZURE_APPLICATION_ID
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/tenant
-                            var-name: AZURE_TENANT
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/application-secret
-                            var-name: AZURE_APPLICATION_SECRET
+                    - attach_workspace:
+                        at: /tmp
+                    - run:
+                        name: azure app env
+                        command: |
+                            echo "export AZURE_APPLICATION_ID=$(cat /tmp/gravit33bot/.secrets/azure_application_id)" >> $BASH_ENV
+                            echo "export AZURE_TENANT=$(cat /tmp/gravit33bot/.secrets/azure_tenant_id)" >> $BASH_ENV
+                            echo "export AZURE_APPLICATION_SECRET=$(cat /tmp/gravit33bot/.secrets/azure_application_pwd)" >> $BASH_ENV
                   requires:
                       - Build APIM Console
             - console-webui-comment-pr-after-deployment:
                   context: cicd-orchestrator
                   pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/github_personal_access_token
-                            var-name: GITHUB_TOKEN
+                    - attach_workspace:
+                        at: /tmp
+                    - run:
+                        name: github token env
+                        command: |
+                            echo "export GITHUB_TOKEN=$(cat /tmp/gravit33bot/.secrets/github-personal-token)" >> $BASH_ENV
                   requires:
                       - console-webui-deploy-on-azure-storage
             - webui-publish-images-azure-registry:
@@ -1095,12 +1101,13 @@ workflows:
                   docker-image-name: apim-management-ui
                   context: cicd-orchestrator
                   pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/username
-                            var-name: AZURE_DOCKER_REGISTRY_USERNAME
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/password
-                            var-name: AZURE_DOCKER_REGISTRY_PASSWORD
+                    - attach_workspace:
+                        at: /tmp
+                    - run:
+                        name: azure env variables
+                        command: |
+                            echo "export AZURE_DOCKER_REGISTRY_USERNAME=$(cat /tmp/gravit33bot/.secrets/azure_registry_username)" >> $BASH_ENV
+                            echo "export AZURE_DOCKER_REGISTRY_PASSWORD=$(cat /tmp/gravit33bot/.secrets/azure_registry_pwd)" >> $BASH_ENV
                   requires:
                       - Build APIM Console
                       - compute-apim-tag
@@ -1113,7 +1120,7 @@ workflows:
                   name: Install APIM Portal
                   apim-ui-project: gravitee-apim-portal-webui
                   requires:
-                      - load-snapshot-configuration
+                      - fetching secrets
             - webui-lint-test:
                   name: Lint & test APIM Portal
                   apim-ui-project: gravitee-apim-portal-webui
@@ -1142,12 +1149,13 @@ workflows:
                   docker-image-name: apim-portal-ui
                   context: cicd-orchestrator
                   pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/username
-                            var-name: AZURE_DOCKER_REGISTRY_USERNAME
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/password
-                            var-name: AZURE_DOCKER_REGISTRY_PASSWORD
+                    - attach_workspace:
+                        at: /tmp
+                    - run:
+                        name: azure env variables
+                        command: |
+                            echo "export AZURE_DOCKER_REGISTRY_USERNAME=$(cat /tmp/gravit33bot/.secrets/azure_registry_username)" >> $BASH_ENV
+                            echo "export AZURE_DOCKER_REGISTRY_PASSWORD=$(cat /tmp/gravit33bot/.secrets/azure_registry_pwd)" >> $BASH_ENV
                   requires:
                       - Build APIM Portal
                       - compute-apim-tag
@@ -1159,15 +1167,14 @@ workflows:
             - deploy-on-azure-cluster:
                   context: cicd-orchestrator
                   pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/application-id
-                            var-name: AZURE_APPLICATION_ID
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/tenant
-                            var-name: AZURE_TENANT
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/application-secret
-                            var-name: AZURE_APPLICATION_SECRET
+                    - attach_workspace:
+                            at: /tmp
+                    - run:
+                        name: azure app env
+                        command: |
+                            echo "export AZURE_APPLICATION_ID=$(cat /tmp/gravit33bot/.secrets/azure_application_id)" >> $BASH_ENV
+                            echo "export AZURE_TENANT=$(cat /tmp/gravit33bot/.secrets/azure_tenant_id)" >> $BASH_ENV
+                            echo "export AZURE_APPLICATION_SECRET=$(cat /tmp/gravit33bot/.secrets/azure_application_pwd)" >> $BASH_ENV
                   requires:
                       - publish-images-azure-registry
                       - Build and publish APIM Console docker image
@@ -1189,6 +1196,10 @@ workflows:
         when:
             equal: [build_docker_images, << pipeline.parameters.gio_action >>]
         jobs:
+
+            - apim/keeper_secrets:
+                  name: fetching secrets
+                  context: cicd-orchestrator
             - publish_prod_docker_images:
                   graviteeio_version: << pipeline.parameters.graviteeio_version >>
                   docker_tag_as_latest: << pipeline.parameters.docker_tag_as_latest >>
@@ -1197,12 +1208,13 @@ workflows:
                   context: cicd-orchestrator
                   name: Build and push docker images for APIM CE << pipeline.parameters.graviteeio_version >><<# pipeline.parameters.dry_run >> - Dry Run<</ pipeline.parameters.dry_run >>
                   pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-name
-                            var-name: DOCKERHUB_BOT_USER_NAME
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-token
-                            var-name: DOCKERHUB_BOT_USER_TOKEN
+                    - attach_workspace:
+                            at: /tmp
+                    - run:
+                        name: dockerhub credentials
+                        command: |
+                            echo "export DOCKERHUB_BOT_USER_NAME=$(cat /tmp/gravit33bot/.secrets/dockerhub/user_name)" >> $BASH_ENV
+                            echo "export DOCKERHUB_BOT_USER_TOKEN=$(cat /tmp/gravit33bot/.secrets/dockerhub/user_token)" >> $BASH_ENV
             - publish_prod_docker_images:
                   graviteeio_version: << pipeline.parameters.graviteeio_version >>
                   docker_tag_as_latest: << pipeline.parameters.docker_tag_as_latest >>
@@ -1211,12 +1223,13 @@ workflows:
                   context: cicd-orchestrator
                   name: Build and push docker images for APIM EE << pipeline.parameters.graviteeio_version >><<# pipeline.parameters.dry_run >> - Dry Run<</ pipeline.parameters.dry_run >>
                   pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-name
-                            var-name: DOCKERHUB_BOT_USER_NAME
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-token
-                            var-name: DOCKERHUB_BOT_USER_TOKEN
+                    - attach_workspace:
+                            at: /tmp
+                    - run:
+                        name: dockerhub credentials
+                        command: |
+                            echo "export DOCKERHUB_BOT_USER_NAME=$(cat /tmp/gravit33bot/.secrets/dockerhub/user_name)" >> $BASH_ENV
+                            echo "export DOCKERHUB_BOT_USER_TOKEN=$(cat /tmp/gravit33bot/.secrets/dockerhub/user_token)" >> $BASH_ENV
     release:
         when:
             equal: [release, << pipeline.parameters.gio_action >>]
@@ -1232,23 +1245,25 @@ workflows:
                       - prepare-settings
                   context: cicd-orchestrator
                   pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/git/user/name
-                            var-name: GIT_USER_NAME
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/git/user/email
-                            var-name: GIT_USER_EMAIL
+                    - attach_workspace:
+                            at: /tmp
+                    - run:
+                        name: dockerhub credentials
+                        command: |
+                            echo "export GIT_USER_NAME=$(cat /tmp/gravit33bot/.secrets/git_user_name)" >> $BASH_ENV
+                            echo "export GIT_USER_EMAIL=$(cat /tmp/gravit33bot/.secrets/git_user_email)" >> $BASH_ENV
             - nexus-staging-prepare-component:
                   requires:
                       - release
                   context: cicd-orchestrator
                   pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/infra/zip-bundle-server/clever-cloud-s3/s3cmd/aws_access_key
-                            var-name: AWS_ACCESS_KEY_ID
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/infra/zip-bundle-server/clever-cloud-s3/s3cmd/aws_secret_key
-                            var-name: AWS_SECRET_ACCESS_KEY
+                    - attach_workspace:
+                            at: /tmp
+                    - run:
+                        name: AWS keys
+                        command: |
+                            echo "export AWS_ACCESS_KEY_ID=$(cat /tmp/gravit33bot/.secrets/.s3cmd/aws_access_key)" >> $BASH_ENV
+                            echo "export AWS_SECRET_ACCESS_KEY=$(cat /tmp/gravit33bot/.secrets/.s3cmd/aws_secret_key)" >> $BASH_ENV
     # ---
     # CICD Workflow For APIM Orchestrated Nexus Staging, Container-based : Circle CI Docker Executor
     nexus_staging:


### PR DESCRIPTION
This PR is created in purpose of migrating the secrets retrieving from the keeper CLI as secrethub will be soon migrated to 1password secrets management,

the load-snapshot-configuration job is removed and i added the keeper_secrets job stored in the apim orb and which fetch all needed secrets from the cli,

APIM orb link : https://github.com/gravitee-io/gravitee-apim-cci-orb/blob/1.0.x/src/jobs/keeper_secrets.yml

CCI Pipeline link : https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/5279/workflows/f98592f1-6d28-44e1-af8a-3cfb6def6082

Slab keeper documentation : https://gravitee.slab.com/posts/keeper-secrets-retrieved-z04ucghk

