### PR TITLE
fix(jdbc): fix JdbcApiKeyRepository subscriptions inconsistencies

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/ApiKeyRepositoryMock.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/ApiKeyRepositoryMock.java
@@ -61,6 +61,7 @@ public class ApiKeyRepositoryMock extends AbstractRepositoryMock<ApiKeyRepositor
         when(apiKeyRepository.findById("id-of-new-apikey")).thenReturn(of(apiKey1));
         when(apiKeyRepository.findByKey("d449098d-8c31-4275-ad59-8dd707865a34")).thenReturn(List.of(apiKey1, apiKey2));
         when(apiKeyRepository.findBySubscription("subscription1")).thenReturn(newSet(apiKey1, mock(ApiKey.class)));
+        when(apiKeyRepository.findBySubscription("subscriptionX")).thenReturn(newSet(apiKey2));
         when(apiKeyRepository.findByKeyAndApi("d449098d-8c31-4275-ad59-8dd707865a34", "api2")).thenReturn(of(apiKey2));
 
         when(apiKeyRepository.update(argThat(o -> o == null || o.getId().equals("unknown_key_id")))).thenThrow(new IllegalStateException());
@@ -71,7 +72,10 @@ public class ApiKeyRepositoryMock extends AbstractRepositoryMock<ApiKeyRepositor
         when(mockCriteria1.getKey()).thenReturn("findByCriteria1");
         when(mockCriteria1Revoked.getKey()).thenReturn("findByCriteria1Revoked");
         when(mockCriteria2.getKey()).thenReturn("findByCriteria2");
-        when(apiKeyRepository.findByCriteria(argThat(o -> o == null || o.getFrom() == 0))).thenReturn(asList(mockCriteria1, mockCriteria2));
+
+        when(apiKeyRepository.findByCriteria(argThat(o -> o != null && o.getPlans() != null && o.getPlans().equals(Set.of("plan1")))))
+            .thenReturn(asList(mockCriteria1, mockCriteria2));
+
         when(apiKeyRepository.findByCriteria(argThat(o -> o == null || o.getTo() == 1486771400000L)))
             .thenReturn(singletonList(mockCriteria1));
         when(apiKeyRepository.findByCriteria(argThat(o -> o == null || o.isIncludeRevoked())))
@@ -87,6 +91,23 @@ public class ApiKeyRepositoryMock extends AbstractRepositoryMock<ApiKeyRepositor
             )
         )
             .thenReturn(asList(apiKey2, apiKey3));
+
+        when(apiKeyRepository.findByCriteria(argThat(o -> o != null && o.getPlans() != null && o.getPlans().equals(Set.of("plan5")))))
+            .thenReturn(List.of(apiKey7));
+
+        when(
+            apiKeyRepository.findByCriteria(
+                argThat(
+                    o ->
+                        o != null &&
+                        o.getFrom() == 1486771200000L &&
+                        o.getTo() == 1486771900000L &&
+                        o.getPlans() != null &&
+                        o.getPlans().containsAll(Set.of("plan1", "plan5"))
+                )
+            )
+        )
+            .thenReturn(List.of(apiKey4, apiKey6, apiKey7));
 
         when(apiKeyRepository.findByApplication("app1")).thenReturn(List.of(apiKey5, apiKey4));
         when(apiKeyRepository.findByKeyAndApi("findByCriteria2", "api2")).thenReturn(Optional.of(apiKey6));

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/apikey-tests/apiKeys.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/apikey-tests/apiKeys.json
@@ -71,11 +71,15 @@
 		"id": "id-of-apikey-7",
 		"key": "the-key-of-api-key-7",
 		"subscriptions": ["sub4", "sub5", "sub6"],
+		"createdAt": 1486771200000,
+		"updatedAt": 1486771600000,
 		"application": "app4"
 	},
 	{
 		"id": "id-of-apikey-8",
 		"key": "the-key-of-api-key-8",
+		"createdAt": 1486771200000,
+		"updatedAt": 1486771600000,
 		"subscriptions": [],
 		"application": "app4"
 	}


### PR DESCRIPTION
fix(jdbc): fix JdbcApiKeyRepository subscriptions inconsistencies

Fix inconsistencies, and make JDBC ApiKeyRepository behave like mongo repository.

When searching with a criteria on a subscription data (his id, or a plan id) ;
We should not do it in the join, or resulting api key subscriptions will contain only the one in the criteria.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rccksmgwer.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-jdbcapikeyrepository/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
