### PR TITLE
feat: use crossId when importing API from Cockpit

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/CockpitAuthenticationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/CockpitAuthenticationResource.java
@@ -27,8 +27,10 @@ import com.nimbusds.jwt.proc.DefaultJWTProcessor;
 import com.nimbusds.jwt.proc.JWTProcessor;
 import io.gravitee.rest.api.idp.api.authentication.UserDetails;
 import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.security.cookies.CookieGenerator;
 import io.gravitee.rest.api.security.utils.AuthoritiesProvider;
+import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
@@ -40,6 +42,7 @@ import java.security.Key;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
 import java.security.interfaces.RSAPublicKey;
+import java.util.Optional;
 import java.util.Set;
 import javax.annotation.PostConstruct;
 import javax.inject.Singleton;
@@ -87,6 +90,9 @@ public class CockpitAuthenticationResource extends AbstractAuthenticationResourc
 
     @Autowired
     private AuthoritiesProvider authoritiesProvider;
+
+    @Autowired
+    private ApiService apiService;
 
     @PostConstruct
     public void afterPropertiesSet() {
@@ -139,14 +145,19 @@ public class CockpitAuthenticationResource extends AbstractAuthenticationResourc
             // Cockpit user is authenticated, connect user (ie: generate cookie).
             super.connectUser(user, httpResponse);
 
+            final String apiCrossId = jwtClaimsSet.getStringClaim(API_CLAIM);
+            final String apiId = Optional
+                .ofNullable(apiCrossId)
+                .flatMap(crossId -> this.apiService.findByEnvironmentIdAndCrossId(environmentId, crossId))
+                .map(ApiEntity::getId)
+                .orElse(null);
+
             String url = String.format(
                 "%s?organization=%s/#!/environments/%s/%s",
                 jwtClaimsSet.getStringClaim(REDIRECT_URI_CLAIM),
                 jwtClaimsSet.getStringClaim(ORG_CLAIM),
-                jwtClaimsSet.getStringClaim(ENVIRONMENT_CLAIM),
-                jwtClaimsSet.getStringClaim(API_CLAIM) == null
-                    ? ""
-                    : URLEncoder.encode(String.format("apis/%s/portal", jwtClaimsSet.getStringClaim(API_CLAIM)), "UTF-8")
+                environmentId,
+                apiId == null ? "" : URLEncoder.encode(String.format("apis/%s/portal", apiId), "UTF-8")
             );
 
             // Redirect the user.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeployModelCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeployModelCommandHandler.java
@@ -23,6 +23,7 @@ import io.gravitee.cockpit.api.command.designer.DeployModelPayload;
 import io.gravitee.cockpit.api.command.designer.DeployModelReply;
 import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.api.ApiEntityResult;
 import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.EnvironmentService;
@@ -33,6 +34,7 @@ import io.gravitee.rest.api.service.cockpit.services.CockpitApiPermissionChecker
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.reactivex.Single;
 import java.util.List;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -75,7 +77,7 @@ public class DeployModelCommandHandler implements CommandHandler<DeployModelComm
     public Single<DeployModelReply> handle(DeployModelCommand command) {
         DeployModelPayload payload = command.getPayload();
 
-        String apiId = payload.getModelId();
+        String apiCrossId = payload.getModelId();
         String userId = payload.getUserId();
         String swaggerDefinition = payload.getSwaggerDefinition();
         String environmentId = payload.getEnvironmentId();
@@ -90,8 +92,10 @@ public class DeployModelCommandHandler implements CommandHandler<DeployModelComm
 
             ApiEntityResult result;
 
-            if (apiService.exists(apiId)) {
-                var message = permissionChecker.checkUpdatePermission(user.getId(), environment.getId(), apiId, mode);
+            final Optional<ApiEntity> optApi = apiService.findByEnvironmentIdAndCrossId(environmentId, apiCrossId);
+            if (optApi.isPresent()) {
+                final ApiEntity api = optApi.get();
+                var message = permissionChecker.checkUpdatePermission(user.getId(), environment.getId(), api.getId(), mode);
 
                 if (message.isPresent()) {
                     var reply = new DeployModelReply(command.getId(), CommandStatus.FAILED);
@@ -99,7 +103,7 @@ public class DeployModelCommandHandler implements CommandHandler<DeployModelComm
                     return Single.just(reply);
                 }
 
-                result = cockpitApiService.updateApi(apiId, user.getId(), swaggerDefinition, environment.getId(), mode, labels);
+                result = cockpitApiService.updateApi(api.getId(), user.getId(), swaggerDefinition, environment.getId(), mode, labels);
             } else {
                 var message = permissionChecker.checkCreatePermission(user.getId(), environment.getId(), mode);
 
@@ -109,7 +113,7 @@ public class DeployModelCommandHandler implements CommandHandler<DeployModelComm
                     return Single.just(reply);
                 }
 
-                result = cockpitApiService.createApi(apiId, user.getId(), swaggerDefinition, environment.getId(), mode, labels);
+                result = cockpitApiService.createApi(apiCrossId, user.getId(), swaggerDefinition, environment.getId(), mode, labels);
             }
 
             if (result.isSuccess()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeployModelCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeployModelCommandHandlerTest.java
@@ -245,13 +245,16 @@ public class DeployModelCommandHandlerTest {
         DeployModelPayload payload = new DeployModelPayload();
         payload.setModelId("model#1");
         payload.setSwaggerDefinition("swagger-definition");
+        payload.setEnvironmentId("env#id");
         payload.setUserId("cockpit_user#id");
         payload.setMode(DeployModelPayload.DeploymentMode.API_DOCUMENTED);
         payload.setLabels(List.of("label1", "label2"));
 
         DeployModelCommand command = new DeployModelCommand(payload);
 
-        when(apiService.exists(payload.getModelId())).thenReturn(true);
+        ApiEntity apiEntity = new ApiEntity();
+        apiEntity.setId("api#id");
+        when(apiService.findByEnvironmentIdAndCrossId(payload.getEnvironmentId(), payload.getModelId())).thenReturn(Optional.of(apiEntity));
 
         UserEntity user = new UserEntity();
         user.setId("user#id");
@@ -262,14 +265,12 @@ public class DeployModelCommandHandlerTest {
         environment.setId(ENVIRONMENT_ID);
         when(environmentService.findByCockpitId(payload.getEnvironmentId())).thenReturn(environment);
 
-        when(
-            permissionChecker.checkUpdatePermission(user.getId(), environment.getId(), payload.getModelId(), DeploymentMode.API_DOCUMENTED)
-        )
+        when(permissionChecker.checkUpdatePermission(user.getId(), environment.getId(), apiEntity.getId(), DeploymentMode.API_DOCUMENTED))
             .thenReturn(Optional.empty());
 
         when(
             cockpitApiService.updateApi(
-                payload.getModelId(),
+                apiEntity.getId(),
                 user.getId(),
                 payload.getSwaggerDefinition(),
                 environment.getId(),
@@ -279,9 +280,9 @@ public class DeployModelCommandHandlerTest {
         )
             .thenAnswer(
                 i -> {
-                    ApiEntity apiEntity = new ApiEntity();
-                    apiEntity.setId(i.getArgument(0));
-                    return ApiEntityResult.success(apiEntity);
+                    ApiEntity result = new ApiEntity();
+                    result.setId(i.getArgument(0));
+                    return ApiEntityResult.success(result);
                 }
             );
 
@@ -296,13 +297,16 @@ public class DeployModelCommandHandlerTest {
         DeployModelPayload payload = new DeployModelPayload();
         payload.setModelId("model#1");
         payload.setSwaggerDefinition("swagger-definition");
+        payload.setEnvironmentId("env#id");
         payload.setUserId("cockpit_user#id");
         payload.setMode(DeployModelPayload.DeploymentMode.API_MOCKED);
         payload.setLabels(List.of("label1", "label2"));
 
         DeployModelCommand command = new DeployModelCommand(payload);
 
-        when(apiService.exists(payload.getModelId())).thenReturn(true);
+        ApiEntity apiEntity = new ApiEntity();
+        apiEntity.setId("api#id");
+        when(apiService.findByEnvironmentIdAndCrossId(payload.getEnvironmentId(), payload.getModelId())).thenReturn(Optional.of(apiEntity));
 
         UserEntity user = new UserEntity();
         user.setId("user#id");
@@ -313,12 +317,12 @@ public class DeployModelCommandHandlerTest {
         environment.setId(ENVIRONMENT_ID);
         when(environmentService.findByCockpitId(payload.getEnvironmentId())).thenReturn(environment);
 
-        when(permissionChecker.checkUpdatePermission(user.getId(), environment.getId(), payload.getModelId(), DeploymentMode.API_MOCKED))
+        when(permissionChecker.checkUpdatePermission(user.getId(), environment.getId(), apiEntity.getId(), DeploymentMode.API_MOCKED))
             .thenReturn(Optional.empty());
 
         when(
             cockpitApiService.updateApi(
-                payload.getModelId(),
+                apiEntity.getId(),
                 user.getId(),
                 payload.getSwaggerDefinition(),
                 environment.getId(),
@@ -328,9 +332,9 @@ public class DeployModelCommandHandlerTest {
         )
             .thenAnswer(
                 i -> {
-                    ApiEntity apiEntity = new ApiEntity();
-                    apiEntity.setId(i.getArgument(0));
-                    return ApiEntityResult.success(apiEntity);
+                    ApiEntity result = new ApiEntity();
+                    result.setId(i.getArgument(0));
+                    return ApiEntityResult.success(result);
                 }
             );
 
@@ -345,13 +349,16 @@ public class DeployModelCommandHandlerTest {
         DeployModelPayload payload = new DeployModelPayload();
         payload.setModelId("model#1");
         payload.setSwaggerDefinition("swagger-definition");
+        payload.setEnvironmentId("env#id");
         payload.setUserId("cockpit_user#id");
         payload.setMode(DeployModelPayload.DeploymentMode.API_PUBLISHED);
         payload.setLabels(List.of("label1", "label2"));
 
         DeployModelCommand command = new DeployModelCommand(payload);
 
-        when(apiService.exists(payload.getModelId())).thenReturn(true);
+        ApiEntity apiEntity = new ApiEntity();
+        apiEntity.setId("api#id");
+        when(apiService.findByEnvironmentIdAndCrossId(payload.getEnvironmentId(), payload.getModelId())).thenReturn(Optional.of(apiEntity));
 
         UserEntity user = new UserEntity();
         user.setId("user#id");
@@ -362,12 +369,12 @@ public class DeployModelCommandHandlerTest {
         environment.setId(ENVIRONMENT_ID);
         when(environmentService.findByCockpitId(payload.getEnvironmentId())).thenReturn(environment);
 
-        when(permissionChecker.checkUpdatePermission(user.getId(), environment.getId(), payload.getModelId(), DeploymentMode.API_PUBLISHED))
+        when(permissionChecker.checkUpdatePermission(user.getId(), environment.getId(), apiEntity.getId(), DeploymentMode.API_PUBLISHED))
             .thenReturn(Optional.empty());
 
         when(
             cockpitApiService.updateApi(
-                payload.getModelId(),
+                apiEntity.getId(),
                 user.getId(),
                 payload.getSwaggerDefinition(),
                 environment.getId(),
@@ -377,9 +384,9 @@ public class DeployModelCommandHandlerTest {
         )
             .thenAnswer(
                 i -> {
-                    ApiEntity apiEntity = new ApiEntity();
-                    apiEntity.setId(i.getArgument(0));
-                    return ApiEntityResult.success(apiEntity);
+                    ApiEntity result = new ApiEntity();
+                    result.setId(i.getArgument(0));
+                    return ApiEntityResult.success(result);
                 }
             );
 
@@ -527,13 +534,16 @@ public class DeployModelCommandHandlerTest {
         DeployModelPayload payload = new DeployModelPayload();
         payload.setModelId("model#1");
         payload.setSwaggerDefinition("swagger-definition");
+        payload.setEnvironmentId("env#id");
         payload.setUserId("user#id");
         payload.setMode(DeployModelPayload.DeploymentMode.API_DOCUMENTED);
         payload.setLabels(List.of("label1", "label2"));
 
         DeployModelCommand command = new DeployModelCommand(payload);
 
-        when(apiService.exists(payload.getModelId())).thenReturn(true);
+        ApiEntity apiEntity = new ApiEntity();
+        apiEntity.setId("api#id");
+        when(apiService.findByEnvironmentIdAndCrossId(payload.getEnvironmentId(), payload.getModelId())).thenReturn(Optional.of(apiEntity));
 
         UserEntity user = new UserEntity();
         user.setId("user#id");
@@ -544,9 +554,7 @@ public class DeployModelCommandHandlerTest {
         environment.setId(ENVIRONMENT_ID);
         when(environmentService.findByCockpitId(payload.getEnvironmentId())).thenReturn(environment);
 
-        when(
-            permissionChecker.checkUpdatePermission(user.getId(), environment.getId(), payload.getModelId(), DeploymentMode.API_DOCUMENTED)
-        )
+        when(permissionChecker.checkUpdatePermission(user.getId(), environment.getId(), apiEntity.getId(), DeploymentMode.API_DOCUMENTED))
             .thenReturn(Optional.of("You are not allowed to create APIs on this environment."));
 
         TestObserver<DeployModelReply> obs = cut.handle(command).test();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImplTest.java
@@ -56,6 +56,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 public class ApiServiceCockpitImplTest {
 
     private static final String API_ID = "api#id";
+    private static final String API_CROSS_ID = "api#crossId";
     private static final List<String> LABELS = List.of("label1", "label2");
     private static final String USER_ID = "user#id";
     private static final String ENVIRONMENT_ID = "environment#id";
@@ -135,6 +136,7 @@ public class ApiServiceCockpitImplTest {
         swaggerApi.setProxy(proxy);
 
         ApiEntity api = new ApiEntity();
+        api.setCrossId(API_CROSS_ID);
         api.setId(API_ID);
         api.setLabels(LABELS);
 
@@ -143,13 +145,13 @@ public class ApiServiceCockpitImplTest {
 
         GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
 
-        service.createApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_DOCUMENTED, LABELS);
+        service.createApi(API_CROSS_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_DOCUMENTED, LABELS);
 
         verify(swaggerService).createAPI(descriptorCaptor.capture(), eq(DefinitionVersion.V2));
         assertThat(descriptorCaptor.getValue()).usingRecursiveComparison().isEqualTo(expectedDescriptor);
 
         verify(apiService).createWithApiDefinition(eq(swaggerApi), eq(USER_ID), apiDefinitionCaptor.capture());
-        assertThat(apiDefinitionCaptor.getValue().get("id")).isEqualTo(new JsonNodeFactory(false).textNode(API_ID));
+        assertThat(apiDefinitionCaptor.getValue().get("crossId")).isEqualTo(new JsonNodeFactory(false).textNode(API_CROSS_ID));
 
         verify(pageService).createAsideFolder(API_ID, ENVIRONMENT_ID);
         verify(pageService).createOrUpdateSwaggerPage(eq(API_ID), any(ImportSwaggerDescriptorEntity.class), eq(true));
@@ -200,13 +202,13 @@ public class ApiServiceCockpitImplTest {
 
         GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
 
-        service.createApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_MOCKED, LABELS);
+        service.createApi(API_CROSS_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_MOCKED, LABELS);
 
         verify(swaggerService).createAPI(descriptorCaptor.capture(), eq(DefinitionVersion.V2));
         assertThat(descriptorCaptor.getValue()).usingRecursiveComparison().isEqualTo(expectedDescriptor);
 
         verify(apiService).createWithApiDefinition(eq(swaggerApi), eq(USER_ID), apiDefinitionCaptor.capture());
-        assertThat(apiDefinitionCaptor.getValue().get("id")).isEqualTo(new JsonNodeFactory(false).textNode(API_ID));
+        assertThat(apiDefinitionCaptor.getValue().get("crossId")).isEqualTo(new JsonNodeFactory(false).textNode(API_CROSS_ID));
 
         verify(pageService).createAsideFolder(API_ID, ENVIRONMENT_ID);
         verify(pageService).createOrUpdateSwaggerPage(eq(API_ID), any(ImportSwaggerDescriptorEntity.class), eq(true));
@@ -255,6 +257,7 @@ public class ApiServiceCockpitImplTest {
 
         ApiEntity api = new ApiEntity();
         api.setId(API_ID);
+        api.setCrossId(API_CROSS_ID);
 
         when(swaggerService.createAPI(any(ImportSwaggerDescriptorEntity.class), eq(DefinitionVersion.V2))).thenReturn(swaggerApi);
         when(apiService.createWithApiDefinition(eq(swaggerApi), eq(USER_ID), any(ObjectNode.class))).thenReturn(api);
@@ -264,13 +267,13 @@ public class ApiServiceCockpitImplTest {
 
         GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
 
-        service.createApi(API_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED, LABELS);
+        service.createApi(API_CROSS_ID, USER_ID, SWAGGER_DEFINITION, ENVIRONMENT_ID, DeploymentMode.API_PUBLISHED, LABELS);
 
         verify(swaggerService).createAPI(descriptorCaptor.capture(), eq(DefinitionVersion.V2));
         assertThat(descriptorCaptor.getValue()).usingRecursiveComparison().isEqualTo(expectedDescriptor);
 
         verify(apiService).createWithApiDefinition(eq(swaggerApi), eq(USER_ID), apiDefinitionCaptor.capture());
-        assertThat(apiDefinitionCaptor.getValue().get("id")).isEqualTo(new JsonNodeFactory(false).textNode(API_ID));
+        assertThat(apiDefinitionCaptor.getValue().get("crossId")).isEqualTo(new JsonNodeFactory(false).textNode(API_CROSS_ID));
 
         verify(pageService).createAsideFolder(API_ID, ENVIRONMENT_ID);
         verify(pageService).createOrUpdateSwaggerPage(eq(API_ID), any(ImportSwaggerDescriptorEntity.class), eq(true));


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/gravitee-cockpit/issues/2066

**Description**

Use crossId instead of apiId when importing API from Cockpit.
This allows to push API to multiple environments.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ukpwyqucte.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/cockpit-2066-push-api-to-other-env/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
