### PR TITLE
fix: best match flow mode should select only the best match

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-flow/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-flow/pom.xml
@@ -36,5 +36,46 @@
             <artifactId>gravitee-apim-gateway-policy</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- JMH -->
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>auto-clean-generated-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                        <configuration>
+                            <filesets>
+                                <fileset>
+                                    <directory>${project.build.directory}/generated-sources/test-annotations</directory>
+                                    <includes>
+                                        <include>**</include>
+                                    </includes>
+                                </fileset>
+                            </filesets>
+                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/main/java/io/gravitee/gateway/flow/BestMatchFlowResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/main/java/io/gravitee/gateway/flow/BestMatchFlowResolver.java
@@ -1,0 +1,164 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.flow;
+
+import io.gravitee.definition.model.flow.Flow;
+import io.gravitee.gateway.api.ExecutionContext;
+import java.util.List;
+
+/**
+ * This flow provider is resolving only the {@link Flow} which best match according to the incoming request.
+ * This flow provider relies on the result of the {@link io.gravitee.gateway.flow.condition.ConditionalFlowResolver} use to build this instance.
+ * This means that the flows list patterns to filter for Best Match mode already matches the request.
+ *
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class BestMatchFlowResolver implements FlowResolver {
+
+    private static final String PATH_SEPARATOR = "/";
+    private static final String PATH_PARAM_PREFIX = ":";
+
+    private final FlowResolver flowResolver;
+
+    public BestMatchFlowResolver(final FlowResolver flowResolver) {
+        this.flowResolver = flowResolver;
+    }
+
+    @Override
+    public List<Flow> resolve(ExecutionContext context) {
+        return filter(flowResolver.resolve(context), context);
+    }
+
+    /**
+     * Filters the flows to get the one best matching the request.
+     * <br/>
+     * <strong>
+     *     We assume the {@code List<Flow>} parameter is already filtered by the {@link BestMatchFlowResolver#flowResolver} to be sure the Flows' path match the request according to Flows' operator.
+     * </strong>
+     * <br/>
+     * For each part of the flow path (splitted by {@link BestMatchFlowResolver#PATH_SEPARATOR}), a score is attributed:
+     * - 1 if the string strictly equals the same part of the request
+     * - 0.5 if the part is a path parameter (starting with {@link BestMatchFlowResolver#PATH_PARAM_PREFIX})
+     * - else 0
+     * <br/>
+     * Then, for each flow, we compare the scores arrays to the current selected best matching flow, reading from left to right.
+     * As soon as a score is greater, then the flow becomes the best match.
+     * <br/>
+     *
+     * Here is an example with those flows configured:
+     *     <ul>
+     *         <li>/myPath/staticId</li>
+     *         <li>/:id/staticId</li>
+     *         <li>/myPath/:id</li>
+     *     </ul>
+     * <blockquote>
+     *<table border="1">
+     *     <col width="25%"/>
+     *     <col width="50%"/>
+     *     <col width="25%"/>
+     *     <thead>
+     *         <tr>
+     *             <th scope="col">Request path</th>
+     *             <th scope="col">Flow path <> score</th>
+     *             <th scope="col">Selected path</th>
+     *         </tr>
+     *     </thead>
+     *     <tbody>
+     *         <tr>
+     *             <td>/myPath/staticId</td>
+     *             <td>
+     *                 <p>- /myPath/staticId  <>  [1, 1]</p>
+     *                 <p>- /:id/staticId  <>  [0.5, 1]</p>
+     *                 <p>- /myPath/:id  <>  [1, 0.5]</p>
+     *             </td>
+     *             <td>/myPath/staticId</td>
+     *         </tr>
+     *         <tr>
+     *             <td>/myPath/553</td>
+     *             <td>
+     *                 <p>- /myPath/staticId  <>  [1, 0]</p>
+     *                 <p>- /:id/staticId  <>  [0.5, 0]</p>
+     *                 <p>- /myPath/:id  <>  [1, 0.5]</p>
+     *             </td>
+     *             <td>/myPath/:id</td>
+     *         </tr>
+     *         <tr>
+     *             <td>/random/staticId</td>
+     *             <td>
+     *                 <p>- /myPath/staticId  <>  [0, 1]</p>
+     *                 <p>- /:id/staticId  <>  [0.5, 1]</p>
+     *                 <p>- /myPath/:id  <>  [0, 0.5]</p>
+     *             </td>
+     *             <td>/:id/staticId</td>
+     *         </tr>
+     *     </tbody>
+     * </table>
+     * </blockquote>
+     * @param flows: the flows already filtered by {@link BestMatchFlowResolver#flowResolver}
+     * @param context: the current execution request
+     * @return a list containing the best matching flow.
+     */
+    private List<Flow> filter(List<Flow> flows, ExecutionContext context) {
+        // Do not process empty flows
+        if (flows == null || flows.isEmpty()) {
+            return List.of();
+        }
+
+        // Compare against the incoming request path
+        final String path = context.request().pathInfo();
+
+        Flow selectedFlow = null;
+        Float[] selectedFlowScore = null;
+
+        for (Flow flow : flows) {
+            String[] splits = flow.getPath().split(PATH_SEPARATOR);
+            final String[] pathSplits = path.split(PATH_SEPARATOR);
+            final Float[] scores = new Float[splits.length];
+
+            for (int i = 0; i < splits.length; i++) {
+                // First, compute a score foreach split
+                if (splits[i].equals(pathSplits[i])) {
+                    scores[i] = 1.0f;
+                } else if (splits[i].startsWith(PATH_PARAM_PREFIX)) {
+                    scores[i] = 0.5f;
+                } else {
+                    scores[i] = 0f;
+                }
+                if (selectedFlow == null) {
+                    selectedFlow = flow;
+                    selectedFlowScore = scores;
+                }
+
+                // Then, if current splits array is longer than selected flow one, the current flow is selected as best
+                if (i == selectedFlowScore.length) {
+                    selectedFlow = flow;
+                    selectedFlowScore = scores;
+                }
+                // Finally, if split score is fewer than selected, no need to continue, else we have a better matching, so we can select the flow
+                if (scores[i] < selectedFlowScore[i]) {
+                    break;
+                } else if (scores[i] > selectedFlowScore[i]) {
+                    selectedFlow = flow;
+                    selectedFlowScore = scores;
+                    break;
+                }
+            }
+        }
+
+        return selectedFlow != null ? List.of(selectedFlow) : List.of();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/flow/BestMatchFlowResolverTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/flow/BestMatchFlowResolverTest.java
@@ -1,0 +1,303 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.flow;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.definition.model.FlowMode;
+import io.gravitee.definition.model.flow.Flow;
+import io.gravitee.definition.model.flow.Operator;
+import io.gravitee.definition.model.flow.PathOperator;
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.flow.condition.CompositeConditionEvaluator;
+import io.gravitee.gateway.flow.condition.ConditionEvaluator;
+import io.gravitee.gateway.flow.condition.ConditionalFlowResolver;
+import io.gravitee.gateway.flow.condition.evaluation.PathBasedConditionEvaluator;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(Parameterized.class)
+public class BestMatchFlowResolverTest {
+
+    private BestMatchFlowResolver cut;
+
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    @Mock
+    private FlowResolver flowResolver;
+
+    @Mock
+    private ExecutionContext executionContext;
+
+    @Mock
+    private Request request;
+
+    @Parameterized.Parameter(0)
+    public List<String> flowPaths;
+
+    @Parameterized.Parameter(1)
+    public Operator operator;
+
+    @Parameterized.Parameter(2)
+    public String expectedBestMatchResult;
+
+    @Parameterized.Parameter(3)
+    public String requestPath;
+
+    private final ConditionEvaluator evaluator = new CompositeConditionEvaluator(new PathBasedConditionEvaluator());
+
+    @Before
+    public void setUp() {
+        cut = new BestMatchFlowResolver(new TestFlowResolver(evaluator, buildFlows()));
+    }
+
+    @Test
+    public void shouldResolveBestMatchFlowApiResolver() {
+        when(executionContext.request()).thenReturn(request);
+        when(request.pathInfo()).thenReturn(requestPath);
+
+        final List<Flow> result = cut.resolve(executionContext);
+
+        if (expectedBestMatchResult == null) {
+            assertThat(result).isEmpty();
+        } else {
+            assertThat(result).hasSize(1);
+            final Flow bestMatchFlow = result.get(0);
+            assertThat(bestMatchFlow.getPath()).isEqualTo(expectedBestMatchResult);
+        }
+    }
+
+    /**
+     * Build list of parameters for test case.
+     * @return Tests parameter objects with this structure:
+     * { list of flow paths, expected path result, path used by request}
+     */
+    @Parameterized.Parameters(name = "{index}: Configured flows={0}, Request={3}, Operator={1}, Expected BestMatch={2}")
+    public static Iterable<Object> data() {
+        return Arrays.asList(
+            new Object[][] {
+                { List.of(), Operator.STARTS_WITH, null, "/path/55" },
+                { List.of("/path/:id"), Operator.STARTS_WITH, "/path/:id", "/path/55" },
+                { List.of("/path/:id"), Operator.STARTS_WITH, "/path/:id", "/path/55" },
+                { List.of("/path/:id"), Operator.EQUALS, "/path/:id", "/path/55" },
+                { List.of("/path/:id", "/path/staticId"), Operator.STARTS_WITH, "/path/:id", "/path/55" },
+                { List.of("/path/:id", "/path/staticId"), Operator.EQUALS, "/path/:id", "/path/55" },
+                { List.of("/path/:id", "/path/staticId"), Operator.STARTS_WITH, "/path/staticId", "/path/staticId" },
+                {
+                    List.of("/path/:id", "/path/staticId", "/path/:id/secondId", "/path/:id/:id2"),
+                    Operator.STARTS_WITH,
+                    "/path/staticId",
+                    "/path/staticId",
+                },
+                {
+                    List.of("/path/:id", "/path/staticId", "/path/:id/secondId", "/path/:id/:id2"),
+                    Operator.EQUALS,
+                    "/path/staticId",
+                    "/path/staticId",
+                },
+                {
+                    List.of("/path/:id", "/path/staticId", "/path/:id/secondId", "/path/:id/:id2"),
+                    Operator.STARTS_WITH,
+                    "/path/staticId",
+                    "/path/staticId/secondId",
+                },
+                {
+                    List.of("/path/:id", "/path/staticId", "/path/:id/secondId", "/path/:id/:id2"),
+                    Operator.EQUALS,
+                    "/path/:id/secondId",
+                    "/path/staticId/secondId",
+                },
+                {
+                    List.of("/path/:id", "/path/staticId", "/path/:id/secondId", "/path/:id/:id2"),
+                    Operator.STARTS_WITH,
+                    "/path/:id/secondId",
+                    "/path/5555/secondId",
+                },
+                {
+                    List.of("/path/:id", "/path/staticId", "/path/:id/secondId", "/path/:id/:id2"),
+                    Operator.EQUALS,
+                    "/path/:id/secondId",
+                    "/path/5555/secondId",
+                },
+                {
+                    List.of("/path/:id", "/path/staticId", "/path/:id/secondId", "/path/:id/:id2"),
+                    Operator.STARTS_WITH,
+                    "/path/:id",
+                    "/path/5555",
+                },
+                {
+                    List.of("/path/:id", "/path/staticId", "/path/:id/secondId", "/path/:id/:id2"),
+                    Operator.EQUALS,
+                    "/path/:id",
+                    "/path/5555",
+                },
+                {
+                    List.of("/path/:id", "/path/staticId", "/path/:id/secondId", "/path/:id/:id2"),
+                    Operator.STARTS_WITH,
+                    "/path/:id/:id2",
+                    "/path/5555/5959",
+                },
+                {
+                    List.of("/path/:id", "/path/staticId", "/path/:id/secondId", "/path/:id/:id2"),
+                    Operator.EQUALS,
+                    "/path/:id/:id2",
+                    "/path/5555/5959",
+                },
+                {
+                    List.of("/path/:id", "/path/staticId", "/path/:id/secondId", "/path/:id/:id2"),
+                    Operator.STARTS_WITH,
+                    "/path/:id/:id2",
+                    "/path/5555/5559/5553",
+                },
+                {
+                    List.of("/path/:id", "/path/staticId", "/path/:id/secondId", "/path/:id/:id2"),
+                    Operator.EQUALS,
+                    "/path/:id/:id2",
+                    "/path/5555/5559/5553",
+                },
+                {
+                    List.of("/path/:id", "/path/staticId", "/path/:id/secondId", "/path/:id/:id2", "/path/:id/subResource/:id2"),
+                    Operator.STARTS_WITH,
+                    "/path/:id/subResource/:id2",
+                    "/path/5555/subResource/5553",
+                },
+                {
+                    List.of("/path/:id", "/path/staticId", "/path/:id/secondId", "/path/:id/:id2", "/path/:id/subResource/:id2"),
+                    Operator.EQUALS,
+                    "/path/:id/subResource/:id2",
+                    "/path/5555/subResource/5553",
+                },
+                {
+                    List.of(
+                        "/book",
+                        "/book/9999/chapter/145/page/200/line",
+                        "/book/9999/chapter/145/page",
+                        "/city/washington/street/first/library/amazon/book/9999/chapter/145",
+                        "/book/7777/chapter/145",
+                        "/book/9999/chapter/147",
+                        "/book/9999/chapter/145",
+                        "/book/9999/chapter/148",
+                        "/book/9999/chapter"
+                    ),
+                    Operator.STARTS_WITH,
+                    "/book/9999/chapter/145",
+                    "/book/9999/chapter/145",
+                },
+                {
+                    List.of(
+                        "/book",
+                        "/book/9999/chapter/145/page/200/line",
+                        "/book/9999/chapter/145/page",
+                        "/city/washington/street/first/library/amazon/book/9999/chapter/145",
+                        "/book/7777/chapter/145",
+                        "/book/9999/chapter/147",
+                        "/book/9999/chapter/145",
+                        "/book/9999/chapter/148",
+                        "/book/9999/chapter"
+                    ),
+                    Operator.EQUALS,
+                    "/book/9999/chapter/145",
+                    "/book/9999/chapter/145",
+                },
+                {
+                    List.of(
+                        "/book",
+                        "/book/:bookId/chapter/:chapterId/page/:pageId",
+                        "/book/:bookId",
+                        "/book/:bookId/chapter/:chapterId",
+                        "/book/9999/chapter"
+                    ),
+                    Operator.STARTS_WITH,
+                    "/book/9999/chapter",
+                    "/book/9999/chapter/145",
+                },
+                {
+                    List.of(
+                        "/book",
+                        "/book/:bookId/chapter/:chapterId/page/:pageId",
+                        "/book/:bookId",
+                        "/book/:bookId/chapter/:chapterId",
+                        "/book/9999/chapter"
+                    ),
+                    Operator.EQUALS,
+                    "/book/:bookId/chapter/:chapterId",
+                    "/book/9999/chapter/145",
+                },
+                {
+                    List.of("/book", "/book/:bookId/chapter/:chapterId/page/:pageId", "/book/:bookId", "/book/:bookId/chapter/:chapterId"),
+                    Operator.STARTS_WITH,
+                    "/book/:bookId/chapter/:chapterId",
+                    "/book/9999/chapter/145",
+                },
+                {
+                    List.of("/book", "/book/:bookId/chapter/:chapterId/page/:pageId", "/book/:bookId", "/book/:bookId/chapter/:chapterId"),
+                    Operator.EQUALS,
+                    "/book/:bookId/chapter/:chapterId",
+                    "/book/9999/chapter/145",
+                },
+            }
+        );
+    }
+
+    private List<Flow> buildFlows() {
+        return flowPaths
+            .stream()
+            .map(
+                path -> {
+                    Flow flow = new Flow();
+                    PathOperator pathOperator = new PathOperator();
+                    pathOperator.setPath(path);
+                    // No need to test different operator in this test.
+                    // Input of BestMatchPolicyResolver is already filtered by PathBasedConditionEvaluator
+                    pathOperator.setOperator(operator);
+                    flow.setPathOperator(pathOperator);
+                    return flow;
+                }
+            )
+            .collect(Collectors.toList());
+    }
+
+    private static class TestFlowResolver extends ConditionalFlowResolver {
+
+        private List<Flow> flows;
+
+        public TestFlowResolver(ConditionEvaluator evaluator, List<Flow> flows) {
+            super(evaluator);
+            this.flows = flows;
+        }
+
+        @Override
+        protected List<Flow> resolve0(ExecutionContext context) {
+            return flows;
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/flow/benchmark/BestMatchFlowResolverBenchmark.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/flow/benchmark/BestMatchFlowResolverBenchmark.java
@@ -1,0 +1,281 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.flow.benchmark;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.http.HttpHeaders;
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.common.http.HttpVersion;
+import io.gravitee.common.util.MultiValueMap;
+import io.gravitee.definition.model.flow.Flow;
+import io.gravitee.definition.model.flow.Operator;
+import io.gravitee.definition.model.flow.PathOperator;
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.context.SimpleExecutionContext;
+import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.gateway.api.http2.HttpFrame;
+import io.gravitee.gateway.api.stream.ReadStream;
+import io.gravitee.gateway.api.ws.WebSocket;
+import io.gravitee.gateway.flow.BestMatchFlowResolver;
+import io.gravitee.gateway.flow.FlowResolver;
+import io.gravitee.gateway.flow.condition.CompositeConditionEvaluator;
+import io.gravitee.gateway.flow.condition.ConditionEvaluator;
+import io.gravitee.gateway.flow.condition.ConditionalFlowResolver;
+import io.gravitee.gateway.flow.condition.evaluation.PathBasedConditionEvaluator;
+import io.gravitee.reporter.api.http.Metrics;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import javax.net.ssl.SSLSession;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@BenchmarkMode(Mode.All)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1)
+public class BestMatchFlowResolverBenchmark {
+
+    FlowResolver flowResolver;
+    SimpleExecutionContext executionContext;
+
+    private final ConditionEvaluator evaluator = new CompositeConditionEvaluator(new PathBasedConditionEvaluator());
+
+    // used to run benchmark directly from IDE
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder().include(BestMatchFlowResolverBenchmark.class.getSimpleName()).forks(1).build();
+
+        new Runner(opt).run();
+    }
+
+    @Setup
+    public void setUp() {
+        flowResolver = new TestFlowResolver(evaluator, buildFlows());
+        executionContext =
+            new SimpleExecutionContext(new TestRequest("/book/99/chapter/888/page/7777/paragraph/6666/line/5/char/10"), null);
+    }
+
+    @Benchmark
+    public void benchOldBestMatch() {
+        new OldBestMatchFlowResolver(flowResolver).resolve(executionContext);
+    }
+
+    @Benchmark
+    public void benchBestMatch() {
+        new BestMatchFlowResolver(flowResolver).resolve(executionContext);
+    }
+
+    private List<Flow> buildFlows() {
+        return List
+            .of(
+                "/book",
+                "/book/99",
+                "/book/:id",
+                "/book/99/chapter/888",
+                "/book/:id/chapter/:chapterId",
+                "/book/99/chapter/888",
+                "/book/:id/chapter/:chapterId/page/:pageId",
+                "/book/99/chapter/888/page/7777",
+                "/book/:id/chapter/:chapterId/page/:pageId/paragraph/:paragraphId",
+                "/book/99/chapter/888/page/7777/paragraph/6666",
+                "/book/:id/chapter/:chapterId/page/:pageId/paragraph/:paragraphId/line/:lineId",
+                "/book/99/chapter/888/page/7777/paragraph/6666/line/5",
+                "/book/:id/chapter/:chapterId/page/:pageId/paragraph/:paragraphId/line/:lineId/char/:charid",
+                "/book/99/chapter/888/page/7777/paragraph/6666/line/5/char/1"
+            )
+            .stream()
+            .map(
+                path -> {
+                    Flow flow = new Flow();
+                    PathOperator pathOperator = new PathOperator();
+                    pathOperator.setPath(path);
+                    // No need to test different operator in this test.
+                    // Input of BestMatchPolicyResolver is already filtered by PathBasedConditionEvaluator
+                    pathOperator.setOperator(Operator.STARTS_WITH);
+                    flow.setPathOperator(pathOperator);
+                    return flow;
+                }
+            )
+            .collect(Collectors.toList());
+    }
+
+    private static class TestFlowResolver extends ConditionalFlowResolver {
+
+        private List<Flow> flows;
+
+        public TestFlowResolver(ConditionEvaluator evaluator, List<Flow> flows) {
+            super(evaluator);
+            this.flows = flows;
+        }
+
+        @Override
+        protected List<Flow> resolve0(ExecutionContext context) {
+            return flows;
+        }
+    }
+
+    private class TestRequest implements Request {
+
+        private String path;
+
+        public TestRequest(String path) {
+            this.path = path;
+        }
+
+        @Override
+        public String id() {
+            return null;
+        }
+
+        @Override
+        public String transactionId() {
+            return null;
+        }
+
+        @Override
+        public String uri() {
+            return null;
+        }
+
+        @Override
+        public String path() {
+            return null;
+        }
+
+        @Override
+        public String pathInfo() {
+            return path;
+        }
+
+        @Override
+        public String contextPath() {
+            return null;
+        }
+
+        @Override
+        public MultiValueMap<String, String> parameters() {
+            return null;
+        }
+
+        @Override
+        public MultiValueMap<String, String> pathParameters() {
+            return null;
+        }
+
+        @Override
+        public HttpHeaders headers() {
+            return null;
+        }
+
+        @Override
+        public HttpMethod method() {
+            return null;
+        }
+
+        @Override
+        public String scheme() {
+            return null;
+        }
+
+        @Override
+        public HttpVersion version() {
+            return null;
+        }
+
+        @Override
+        public long timestamp() {
+            return 0;
+        }
+
+        @Override
+        public String remoteAddress() {
+            return null;
+        }
+
+        @Override
+        public String localAddress() {
+            return null;
+        }
+
+        @Override
+        public SSLSession sslSession() {
+            return null;
+        }
+
+        @Override
+        public Metrics metrics() {
+            return null;
+        }
+
+        @Override
+        public boolean ended() {
+            return false;
+        }
+
+        @Override
+        public Request timeoutHandler(Handler<Long> handler) {
+            return null;
+        }
+
+        @Override
+        public Handler<Long> timeoutHandler() {
+            return null;
+        }
+
+        @Override
+        public boolean isWebSocket() {
+            return false;
+        }
+
+        @Override
+        public WebSocket websocket() {
+            return null;
+        }
+
+        @Override
+        public Request customFrameHandler(Handler<HttpFrame> handler) {
+            return null;
+        }
+
+        @Override
+        public ReadStream<Buffer> bodyHandler(Handler<Buffer> handler) {
+            return null;
+        }
+
+        @Override
+        public ReadStream<Buffer> endHandler(Handler<Void> handler) {
+            return null;
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/flow/benchmark/OldBestMatchFlowResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/flow/benchmark/OldBestMatchFlowResolver.java
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.gateway.flow;
+package io.gravitee.gateway.flow.benchmark;
 
 import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.flow.BestMatchFlowResolver;
+import io.gravitee.gateway.flow.FlowResolver;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -24,12 +26,11 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 /**
- * This flow provider is resolving only the {@link Flow} which best match according to the incoming request.
- *
- * @author David BRASSELY (david.brassely at graviteesource.com)
+ * Implementation of BestMatchFlowResolver before improvement
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class BestMatchPolicyResolver implements FlowResolver {
+public class OldBestMatchFlowResolver extends BestMatchFlowResolver {
 
     private final Map<String, Pattern> cache = new ConcurrentHashMap<>();
 
@@ -40,7 +41,8 @@ public class BestMatchPolicyResolver implements FlowResolver {
 
     private final FlowResolver flowResolver;
 
-    public BestMatchPolicyResolver(final FlowResolver flowResolver) {
+    public OldBestMatchFlowResolver(FlowResolver flowResolver) {
+        super(flowResolver);
         this.flowResolver = flowResolver;
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/RequestProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/RequestProcessorChainFactory.java
@@ -22,7 +22,7 @@ import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.core.processor.provider.StreamableProcessorSupplier;
 import io.gravitee.gateway.env.GatewayConfiguration;
-import io.gravitee.gateway.flow.BestMatchPolicyResolver;
+import io.gravitee.gateway.flow.BestMatchFlowResolver;
 import io.gravitee.gateway.flow.SimpleFlowPolicyChainProvider;
 import io.gravitee.gateway.flow.SimpleFlowProvider;
 import io.gravitee.gateway.flow.condition.CompositeConditionEvaluator;
@@ -138,7 +138,7 @@ public class RequestProcessorChainFactory extends ApiProcessorChainFactory {
                     new PlanFlowPolicyChainProvider(
                         new SimpleFlowProvider(
                             StreamType.ON_REQUEST,
-                            new BestMatchPolicyResolver(new PlanFlowResolver(api, evaluator)),
+                            new BestMatchFlowResolver(new PlanFlowResolver(api, evaluator)),
                             chainFactory
                         )
                     )
@@ -147,7 +147,7 @@ public class RequestProcessorChainFactory extends ApiProcessorChainFactory {
                     new SimpleFlowPolicyChainProvider(
                         new SimpleFlowProvider(
                             StreamType.ON_REQUEST,
-                            new BestMatchPolicyResolver(new ApiFlowResolver(api, evaluator)),
+                            new BestMatchFlowResolver(new ApiFlowResolver(api, evaluator)),
                             chainFactory
                         )
                     )

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/ResponseProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/ResponseProcessorChainFactory.java
@@ -18,7 +18,7 @@ package io.gravitee.gateway.handlers.api.processor;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.FlowMode;
 import io.gravitee.gateway.env.GatewayConfiguration;
-import io.gravitee.gateway.flow.BestMatchPolicyResolver;
+import io.gravitee.gateway.flow.BestMatchFlowResolver;
 import io.gravitee.gateway.flow.SimpleFlowPolicyChainProvider;
 import io.gravitee.gateway.flow.SimpleFlowProvider;
 import io.gravitee.gateway.flow.condition.CompositeConditionEvaluator;
@@ -87,7 +87,7 @@ public class ResponseProcessorChainFactory extends ApiProcessorChainFactory {
                     new SimpleFlowPolicyChainProvider(
                         new SimpleFlowProvider(
                             StreamType.ON_RESPONSE,
-                            new BestMatchPolicyResolver(new ApiFlowResolver(api, evaluator)),
+                            new BestMatchFlowResolver(new ApiFlowResolver(api, evaluator)),
                             chainFactory
                         )
                     )
@@ -96,7 +96,7 @@ public class ResponseProcessorChainFactory extends ApiProcessorChainFactory {
                     new PlanFlowPolicyChainProvider(
                         new SimpleFlowProvider(
                             StreamType.ON_RESPONSE,
-                            new BestMatchPolicyResolver(new PlanFlowResolver(api, evaluator)),
+                            new BestMatchFlowResolver(new PlanFlowResolver(api, evaluator)),
                             chainFactory
                         )
                     )

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/flow/BestMatchFlowTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/flow/BestMatchFlowTest.java
@@ -42,8 +42,8 @@ public class BestMatchFlowTest extends AbstractWiremockGatewayTest {
 
         final HttpResponse response = execute(Request.Get("http://localhost:8082/test/teams/team1")).returnResponse();
         assertEquals(HttpStatusCode.OK_200, response.getStatusLine().getStatusCode());
-        assertEquals("2", response.getFirstHeader("my-counter").getValue());
-        wireMockRule.verify(getRequestedFor(urlPathEqualTo("/team/teams/team1")).withHeader("my-counter", equalTo("2")));
+        assertEquals("1", response.getFirstHeader("my-counter").getValue());
+        wireMockRule.verify(getRequestedFor(urlPathEqualTo("/team/teams/team1")).withHeader("my-counter", equalTo("1")));
     }
 
     @Override

--- a/gravitee-apim-gateway/pom.xml
+++ b/gravitee-apim-gateway/pom.xml
@@ -93,6 +93,11 @@
             <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6654

**Current behaviour**

With two flows configured:
- `/test/:id`
- `/test/plainId`

If user do a request on `/test/plainId`, the best match resolves both flows.

**Description**

What we need, is to only have the best matching flow, with plain text taking precedence over path parameter (in the previous example, the result should be `/test/plainId`)

- Improve the selection of the best matching flow. (comparing each part of the path)
- only select the best flow (only one result)

**Bonus**

Rename `BestMatchPolicyResolver` to `BestMatchFlowResolver`


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6654-best-match-improvment/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
