### PR TITLE
fix(gateway): keep multi values headers 

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandler.java
@@ -174,7 +174,7 @@ public class ApiReactorHandler extends AbstractReactorHandler<Api> {
         context.response().reason(proxyResponse.reason());
 
         // Copy HTTP headers
-        proxyResponse.headers().forEach(entry -> context.response().headers().set(entry.getKey(), entry.getValue()));
+        proxyResponse.headers().forEach(entry -> context.response().headers().add(entry.getKey(), entry.getValue()));
 
         final StreamableProcessor<ExecutionContext, Buffer> chain = responseProcessorChain.create();
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http/HttpHeadersTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http/HttpHeadersTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.standalone.http;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.Assert.assertEquals;
+
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.standalone.AbstractWiremockGatewayTest;
+import io.gravitee.gateway.standalone.junit.annotation.ApiDescriptor;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+@ApiDescriptor("/io/gravitee/gateway/standalone/http/teams.json")
+public class HttpHeadersTest extends AbstractWiremockGatewayTest {
+
+    @Test
+    public void should_conserve_multi_values() throws Exception {
+        String cookie1 = "JSESSIONID=ABSCDEDASDSSDSSE.oai007; path=/; Secure; HttpOnly";
+        String cookie2 = "JSESSIONID=BASCDEDASDSSDSSE.oai008; path=/another; Secure; HttpOnly";
+
+        wireMockRule.stubFor(
+            get(urlPathEqualTo("/team/my_team"))
+                .willReturn(ok().withHeader(HttpHeaderNames.SET_COOKIE, cookie1).withHeader(HttpHeaderNames.SET_COOKIE, cookie2))
+        );
+
+        URI target = new URIBuilder("http://localhost:8082/test/my_team").build();
+
+        HttpResponse response = execute(Request.Get(target)).returnResponse();
+
+        assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+        wireMockRule.verify(1, getRequestedFor(urlPathEqualTo("/team/my_team")));
+
+        List<String> cookieHeaders = Arrays
+            .stream(response.getAllHeaders())
+            .filter(header -> header.getName().equals(HttpHeaderNames.SET_COOKIE))
+            .map(h -> h.getValue())
+            .collect(Collectors.toList());
+
+        assertEquals(2, cookieHeaders.size());
+        assertEquals(cookie1, cookieHeaders.get(0));
+        assertEquals(cookie2, cookieHeaders.get(1));
+    }
+
+    @Test
+    public void should_conserve_custom_header() throws Exception {
+        wireMockRule.stubFor(get(urlPathEqualTo("/team/my_team")).willReturn(ok().withHeader("custom", "foobar")));
+
+        URI target = new URIBuilder("http://localhost:8082/test/my_team").build();
+
+        HttpResponse response = execute(Request.Get(target)).returnResponse();
+
+        assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+        wireMockRule.verify(1, getRequestedFor(urlPathEqualTo("/team/my_team")));
+
+        List<String> customHeaders = Arrays
+            .stream(response.getAllHeaders())
+            .filter(header -> header.getName().equals("custom"))
+            .map(h -> h.getValue())
+            .collect(Collectors.toList());
+
+        assertEquals(1, customHeaders.size());
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http2/Http2HeadersTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http2/Http2HeadersTest.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.standalone.http2;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.Assert.assertEquals;
+
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.standalone.AbstractWiremockGatewayTest;
+import io.gravitee.gateway.standalone.junit.annotation.ApiDescriptor;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.*;
+import java.util.List;
+import org.apache.http.HttpStatus;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+@ApiDescriptor("/io/gravitee/gateway/standalone/http/teams.json")
+public class Http2HeadersTest extends AbstractWiremockGatewayTest {
+
+    io.vertx.core.http.HttpClient httpClient = Vertx
+        .vertx()
+        .createHttpClient(new HttpClientOptions().setSsl(true).setTrustAll(true).setUseAlpn(true).setProtocolVersion(HttpVersion.HTTP_2));
+
+    @Test
+    public void should_conserve_multi_values() {
+        String cookie1 = "JSESSIONID=ABSCDEDASDSSDSSE.oai007; path=/; Secure; HttpOnly";
+        String cookie2 = "JSESSIONID=BASCDEDASDSSDSSE.oai008; path=/another; Secure; HttpOnly";
+
+        wireMockRule.stubFor(
+            get(urlPathEqualTo("/team/my_team"))
+                .willReturn(ok().withHeader(HttpHeaderNames.SET_COOKIE, cookie1).withHeader(HttpHeaderNames.SET_COOKIE, cookie2))
+        );
+
+        httpClient
+            .request(HttpMethod.GET, "https://localhost:8082/test/my_team")
+            .onComplete(
+                event -> {
+                    Assert.assertTrue(event.succeeded());
+                    event
+                        .result()
+                        .send()
+                        .onComplete(
+                            responseEvent -> {
+                                Assert.assertTrue(responseEvent.succeeded());
+
+                                HttpClientResponse response = responseEvent.result();
+
+                                assertEquals(HttpStatus.SC_OK, response.statusCode());
+                                wireMockRule.verify(1, getRequestedFor(urlPathEqualTo("/team/my_team")));
+
+                                List<String> cookieHeaders = response.headers().getAll(HttpHeaderNames.SET_COOKIE);
+                                assertEquals(2, cookieHeaders.size());
+                                assertEquals(cookie1, cookieHeaders.get(0));
+                                assertEquals(cookie2, cookieHeaders.get(1));
+                            }
+                        );
+                }
+            );
+    }
+
+    @Test
+    public void should_conserve_custom_header() {
+        wireMockRule.stubFor(get(urlPathEqualTo("/team/my_team")).willReturn(ok().withHeader("custom", "foobar")));
+
+        httpClient
+            .request(HttpMethod.GET, "https://localhost:8082/test/my_team")
+            .onComplete(
+                event -> {
+                    Assert.assertTrue(event.succeeded());
+                    event
+                        .result()
+                        .send()
+                        .onComplete(
+                            responseEvent -> {
+                                Assert.assertTrue(responseEvent.succeeded());
+
+                                HttpClientResponse response = responseEvent.result();
+
+                                assertEquals(HttpStatus.SC_OK, response.statusCode());
+                                wireMockRule.verify(1, getRequestedFor(urlPathEqualTo("/team/my_team")));
+
+                                List<String> customHeaders = response.headers().getAll("custom");
+                                assertEquals(1, customHeaders.size());
+                            }
+                        );
+                }
+            );
+    }
+}


### PR DESCRIPTION
gravitee-io/issues#7325
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tcaqwhofne.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7325-gateway-headers/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
