### PR TITLE
Create a job to run explicitly all testcontainers for JDBC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -990,7 +990,7 @@ jobs:
                 default: ""
         machine:
             image: ubuntu-2004:current
-        resource_class: medium
+        resource_class: large
         steps:
             - when:
                   condition: << parameters.version >>
@@ -1357,7 +1357,6 @@ workflows:
                                   "mariadb~10.2.43",
                                   "mariadb~10.3.34",
                                   "mariadb~10.4.24",
-                                  "mysql~5.6.51",
                                   "mysql~5.7.37",
                                   "mysql~8.0.28",
                                   "sqlserver~2017-CU12",

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,7 +136,8 @@ commands:
 parameters:
     gio_action:
         type: enum
-        enum: [release, standalone_release, standalone_release_replay, nexus_staging, pull_requests, build_docker_images]
+        enum:
+            [release, standalone_release, standalone_release_replay, nexus_staging, pull_requests, build_docker_images, jdbc_test_container]
         default: pull_requests
     dry_run:
         type: boolean
@@ -981,6 +982,45 @@ jobs:
                   command: |
                       mvn clean deploy --activate-profiles gravitee-release --batch-mode -DskipTests -Dskip.validation=true --settings .gravitee.settings.xml --update-snapshots
 
+    jdbc-test-container:
+        parameters:
+            version:
+                type: string
+                description: type and version of the database to test
+                default: ""
+        machine:
+            image: ubuntu-2004:current
+        resource_class: medium
+        steps:
+            - when:
+                  condition: << parameters.version >>
+                  steps:
+                      - checkout
+                      - attach_workspace:
+                            at: .
+                      - restore-maven-cache
+                      - run:
+                            name: Run tests
+                            command: |
+                                cd gravitee-apim-repository
+                                mvn -pl 'gravitee-apim-repository-jdbc' -am -s ../.gravitee.settings.xml clean package --no-transfer-progress -Dskip.validation=true -DjdbcType=<< parameters.version>> -T 2C
+                      - run:
+                            name: Save test results
+                            command: |
+                                mkdir -p ~/test-results/junit/
+                                find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
+                            when: always
+                      - save-maven-cache
+                      - store_test_results:
+                            path: ~/test-results
+            - when:
+                  condition:
+                      not: << parameters.version >>
+                  steps:
+                      - run:
+                            name: Version not set - nothing to run
+                            command: exit 0
+
 workflows:
     pull_requests:
         when:
@@ -1294,3 +1334,31 @@ workflows:
                   context: cicd-orchestrator
                   requires:
                       - setup
+
+    jdbc_test_container:
+        when:
+            equal: [jdbc_test_container, << pipeline.parameters.gio_action >>]
+        jobs:
+            - setup:
+                  context: cicd-orchestrator
+            - jdbc-test-container:
+                  requires:
+                      - setup
+                  matrix:
+                      parameters:
+                          version:
+                              [
+                                  "postgresql~9.6.24",
+                                  "postgresql~10.20",
+                                  "postgresql~11.15",
+                                  "postgresql~12.10",
+                                  "postgresql~13.6",
+                                  "mariadb~10.1.48",
+                                  "mariadb~10.2.43",
+                                  "mariadb~10.3.34",
+                                  "mariadb~10.4.24",
+                                  "mysql~5.6.51",
+                                  "mysql~5.7.37",
+                                  "mysql~8.0.28",
+                                  "sqlserver~2017-CU12",
+                              ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,8 +136,7 @@ commands:
 parameters:
     gio_action:
         type: enum
-        enum:
-            [release, standalone_release, standalone_release_replay, nexus_staging, pull_requests, build_docker_images, jdbc_test_container]
+        enum: [release, standalone_release, standalone_release_replay, nexus_staging, pull_requests, build_docker_images]
         default: pull_requests
     dry_run:
         type: boolean
@@ -1013,6 +1012,7 @@ jobs:
                       - save-maven-cache
                       - store_test_results:
                             path: ~/test-results
+                      - notify-on-failure
             - when:
                   condition:
                       not: << parameters.version >>
@@ -1336,8 +1336,13 @@ workflows:
                       - setup
 
     jdbc_test_container:
-        when:
-            equal: [jdbc_test_container, << pipeline.parameters.gio_action >>]
+        triggers:
+            - schedule:
+                  cron: "0 12 * * *"
+                  filters:
+                      branches:
+                          only:
+                              - master
         jobs:
             - setup:
                   context: cicd-orchestrator

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryConfiguration.java
@@ -92,6 +92,9 @@ public class JdbcTestRepositoryConfiguration {
         hikariConfig.setUsername(container.getUsername());
         hikariConfig.setPassword(container.getPassword());
         hikariConfig.setDriverClassName(container.getDriverClassName());
+        Properties properties = new Properties();
+        properties.setProperty("useSSL", "false");
+        hikariConfig.setDataSourceProperties(properties);
         return hikariConfig;
     }
 


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6898

**Description**

Create a job to run explicitly all testcontainers for JDBC. For this, this PR uses a "matrix" with all possible DB and versions (for JDBC repo).
The db versions correspond to the latest of each supported version in Gravitee:
https://docs.gravitee.io/apim/3.x/apim_installguide_repositories_jdbc.html#supported_databases

**Additional context**
⚠️ Depends on https://github.com/gravitee-io/gravitee-api-management/pull/1464 and https://github.com/gravitee-io/gravitee-api-management/pull/1465
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-sgohvlphmx.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6898-database-testcontainer-automation/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
