### PR TITLE
fix: allow users with read only permission to read APIs

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -1288,17 +1288,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         return (
             role != null &&
             role.getScope().equals(RoleScope.API) &&
-            role
-                .getPermissions()
-                .entrySet()
-                .stream()
-                .filter(entry -> isApiManagementPermission(entry.getKey()))
-                .anyMatch(
-                    entry -> {
-                        String stringPerm = new String(entry.getValue());
-                        return stringPerm.contains("C") || stringPerm.contains("U") || stringPerm.contains("D");
-                    }
-                )
+            role.getPermissions().entrySet().stream().anyMatch(entry -> isApiManagementPermission(entry.getKey()))
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_FindByUserTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_FindByUserTest.java
@@ -35,12 +35,15 @@ import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.model.common.SortableImpl;
+import io.gravitee.rest.api.model.permissions.ApiPermission;
 import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.impl.ApiServiceImpl;
 import io.gravitee.rest.api.service.jackson.filter.ApiPermissionFilter;
 import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -275,5 +278,57 @@ public class ApiService_FindByUserTest {
             .getMembershipsByMemberAndReference(MembershipMemberType.USER, null, MembershipReferenceType.GROUP);
         verify(applicationService, times(0))
             .findByUser(GraviteeContext.getCurrentOrganization(), GraviteeContext.getCurrentEnvironment(), null);
+    }
+
+    @Test
+    public void shouldFindApisWithReadOnlyApiRoleInGroup() {
+        final String readOnlyRoleId = "read-only-role";
+        final String groupId = "read-only-group";
+        final String apiId = "read-only-group-api";
+
+        final Map<String, char[]> readOnlyPermissions = Stream
+            .of(ApiPermission.values())
+            .collect(Collectors.toMap(ApiPermission::name, value -> "R".toCharArray()));
+
+        final Api api = new Api();
+        api.setId(apiId);
+        api.setGroups(Set.of(groupId));
+
+        when(apiRepository.search(new ApiCriteria.Builder().environmentId("DEFAULT").groups(groupId).build())).thenReturn(List.of(api));
+
+        RoleEntity readOnlyRole = new RoleEntity();
+        readOnlyRole.setId(readOnlyRoleId);
+        readOnlyRole.setScope(RoleScope.API);
+        readOnlyRole.setPermissions(readOnlyPermissions);
+
+        when(roleService.findById(readOnlyRoleId)).thenReturn(readOnlyRole);
+
+        MembershipEntity userGroupMembership = new MembershipEntity();
+        userGroupMembership.setId("group-member-ship");
+        userGroupMembership.setMemberId(USER_NAME);
+        userGroupMembership.setMemberType(MembershipMemberType.USER);
+        userGroupMembership.setReferenceType(MembershipReferenceType.GROUP);
+        userGroupMembership.setReferenceId(groupId);
+        userGroupMembership.setRoleId(readOnlyRoleId);
+
+        when(membershipService.getMembershipsByMemberAndReference(MembershipMemberType.USER, USER_NAME, MembershipReferenceType.GROUP))
+            .thenReturn(Set.of(userGroupMembership));
+
+        when(roleService.findPrimaryOwnerRoleByOrganization(any(), eq(RoleScope.API))).thenReturn(new RoleEntity());
+
+        when(membershipService.getMembersByReferencesAndRole(eq(MembershipReferenceType.API), any(), any()))
+            .thenReturn(Set.of(new MemberEntity()));
+
+        final Page<ApiEntity> apiPage = apiService.findByUser(
+            USER_NAME,
+            null,
+            new SortableImpl("name", false),
+            new PageableImpl(1, 1),
+            false
+        );
+
+        assertNotNull(apiPage);
+        assertEquals(1, apiPage.getContent().size());
+        assertEquals(api.getId(), apiPage.getContent().get(0).getId());
     }
 }


### PR DESCRIPTION
:warning: This is a report of the bugfix of https://github.com/gravitee-io/issues/issues/6475, that has been done in 3.5 :warning: 
:warning: But we didn't delivered it in 3.5 cause some customers are using this bug as a feature :warning: 
:warning: Before merging, wait for confirmation that the new behavior is OK for all our customers :warning: 

https://github.com/gravitee-io/issues/issues/7243

fix: allow users with read only permission to read APIs

The required permissions to access APIs from the console were set
to Create, Update or Delete, making user with the Read permission
attached to their role unable to access APIs, be it from a group
or a direct membership.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-7243-fix-readonlyroles-cantseeapi/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
