### PR TITLE
chore: move mongodb upgrade scripts to monorepo

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/1-copy-members-to-memberships.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/1-copy-members-to-memberships.js
@@ -1,0 +1,37 @@
+db.apis.find().forEach(
+    function(api) {
+        for(var i = 0; i < api.members.length; i++) {
+            var member = api.members[i];
+            db.memberships.insert({
+                _id: {
+                    userId: member.user.$id, 
+                    referenceId: api._id, 
+                    referenceType: "API"
+                },
+                _class: "io.gravitee.repository.mongodb.management.internal.model.MembershipMongo",
+                type: member.type,
+                createdAt: member.createdAt,
+                updatedAt: member.updatedAt
+            });
+        }
+    }
+);
+
+db.applications.find().forEach(
+    function(application) {
+        for(var i = 0; i < application.members.length; i++) {
+            var member = application.members[i];
+            db.memberships.insert({
+                _id: {
+                    userId: member.user.$id, 
+                    referenceId: application._id, 
+                    referenceType: "APPLICATION"
+                },
+                _class: "io.gravitee.repository.mongodb.management.internal.model.MembershipMongo",
+                type: member.type,
+                createdAt: member.createdAt,
+                updatedAt: member.updatedAt
+            });
+        }
+    }
+);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/2-remove-members.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/2-remove-members.js
@@ -1,0 +1,10 @@
+db.applications.update(
+    {},
+    {$unset: {members: ""}},
+    {multi: true}
+);
+db.apis.update(
+    {},
+    {$unset: {members: ""}},
+    {multi: true}
+);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/3-endpoint-configuration.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/3-endpoint-configuration.js
@@ -1,0 +1,39 @@
+db.apis.find().forEach(
+    function(api) {
+        var definition = JSON.parse(api.definition);
+        var dumpRequest = false;
+        
+        if (definition.proxy.http !== undefined) {
+            dumpRequest = definition.proxy.http.configuration.dumpRequest;
+        }
+	
+	if (definition.proxy.endpoints !== undefined) {        
+        for (var i = 0 ; i < definition.proxy.endpoints.length ; i++) {
+            var endpoint = definition.proxy.endpoints[i];
+            endpoint.name = 'endpoint_' + i;
+            
+            if (definition.proxy.http !== undefined) {
+                endpoint.http = definition.proxy.http.configuration;
+                
+                if (definition.proxy.http.http_proxy) {
+                    endpoint.proxy = definition.proxy.http.http_proxy;
+                }
+                
+                if (definition.proxy.http.ssl) {
+                    endpoint.ssl = definition.proxy.http.ssl;
+                }
+                
+                delete endpoint.http.dumpRequest;
+            }
+        }
+	}
+        
+	delete definition.proxy.http;
+
+        if (dumpRequest) {
+            definition.proxy.dumpRequest = dumpRequest;
+        }
+        
+        db.apis.updateOne({ _id: api._id}, {$set: {definition: JSON.stringify(definition)}}, { upsert: true} );
+    }
+);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/4-remove-api-key-policy.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/4-remove-api-key-policy.js
@@ -1,0 +1,28 @@
+db.apis.find().forEach(
+    function(api) {
+        var definition = JSON.parse(api.definition);
+        var paths = Object.keys(definition.paths);
+        
+        for (var i = 0 ; i < paths.length ; i++) {
+            var path = definition.paths[paths[i]];
+            var apiKey = -1;
+            
+            for (var j = 0 ; j < path.length ; j++) {
+                var fields = Object.keys(path[j]);
+                for(var k = 0 ; k < fields.length ; k++) {
+                    if (fields[k] === 'api-key') {
+                        apiKey = j;
+                        break;
+                    }
+                }
+
+            }
+            
+            if (apiKey !== -1) {
+                path.splice(apiKey, 1);
+            }
+        }
+        
+        db.apis.updateOne({ _id: api._id}, {$set: {definition: JSON.stringify(definition)}}, { upsert: true} );
+    }
+);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/5-update-published-api.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/5-update-published-api.js
@@ -1,0 +1,67 @@
+db.apis.find().forEach(
+    function(api) {
+        db.events.find({'type': 'PUBLISH_API', 'properties.api_id': api._id}).sort({'createdAt':-1}).limit(1).forEach(
+            function(event) {
+                    var payload = JSON.parse(event.payload);
+                    var definition = JSON.parse(payload.definition);
+
+                    var dumpRequest = false;
+
+                    if (definition.proxy.http !== undefined) {
+                        dumpRequest = definition.proxy.http.configuration.dumpRequest;
+                    }
+		    
+		    if (definition.proxy.endpoints !== undefined) {
+                    for (var i = 0 ; i < definition.proxy.endpoints.length ; i++) {
+                        var endpoint = definition.proxy.endpoints[i];
+                        endpoint.name = 'endpoint_' + i;
+
+                        if (definition.proxy.http !== undefined) {
+                            endpoint.http = definition.proxy.http.configuration;
+
+                            if (definition.proxy.http.http_proxy) {
+                                endpoint.proxy = definition.proxy.http.http_proxy;
+                            }
+
+                            if (definition.proxy.http.ssl) {
+                                endpoint.ssl = definition.proxy.http.ssl;
+                            }
+
+                            delete endpoint.http.dumpRequest;
+                        }
+                    }
+		    }
+		    
+ 		    delete definition.proxy.http;
+                    if (dumpRequest) {
+                        definition.proxy.dumpRequest = dumpRequest;
+                    }
+                    
+                    var paths = Object.keys(definition.paths);
+
+                    for (var i = 0 ; i < paths.length ; i++) {
+                        var path = definition.paths[paths[i]];
+                        var apiKey = -1;
+
+                        for (var j = 0 ; j < path.length ; j++) {
+                            var fields = Object.keys(path[j]);
+                            for(var k = 0 ; k < fields.length ; k++) {
+                                if (fields[k] === 'api-key') {
+                                    apiKey = j;
+                                    break;
+                                }
+                            }
+
+                        }
+
+                        if (apiKey !== -1) {
+                            path.splice(apiKey, 1);
+                        }
+                    }
+
+                    payload.definition = JSON.stringify(definition);
+                    db.events.updateOne({ _id: event._id}, {$set: {payload: JSON.stringify(payload)}}, { upsert: true} );
+            }
+        );
+    }
+);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/6-default-plan-with-existing-apikeys.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/6-default-plan-with-existing-apikeys.js
@@ -26,7 +26,7 @@ db.apis.find().forEach(
             updatedAt: new Date(),
         };
         
-        db.plans.save(plan);
+        db.plans.insertOne(plan);
     }
 );
 
@@ -61,7 +61,7 @@ db.keys.group(
             'updatedAt' : new Date()
        };
        
-       db.subscriptions.save(subscription);
+       db.subscriptions.insertOne(subscription);
    }
 );
    
@@ -88,7 +88,7 @@ db.keys.find().forEach(
         } 
         
         db.keys.remove(apikey);
-        db.keys.save(apikey2);
+        db.keys.insertOne(apikey2);
     }
 );
     

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/6-default-plan-with-existing-apikeys.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/6-default-plan-with-existing-apikeys.js
@@ -1,0 +1,100 @@
+function guid() {
+  function s4() {
+    return Math.floor((1 + Math.random()) * 0x10000)
+      .toString(16)
+      .substring(1);
+  }
+  return s4() + s4() + '-' + s4() + '-' + s4() + '-' +
+    s4() + '-' + s4() + s4() + s4();
+}
+
+// For each API, create a default plan
+db.apis.find().forEach(
+    function(api) {
+        var plan = {
+            _id: guid(),
+            _class: 'io.gravitee.repository.mongodb.management.internal.model.PlanMongo',
+            name: api.name + ' Plan',
+            description: 'Default ' + api.name + ' Plan',
+            validation: 'AUTO',
+            type: 'API',
+            order: new NumberInt(1),
+            apis: [api._id],
+            definition: '{"/" : [ ]}',
+            characteristics: [],
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        };
+        
+        db.plans.save(plan);
+    }
+);
+
+// For each api / application group, create a subscription
+db.keys.group(
+   {
+     key: { 'application.$id': 1, 'api.$id': 1 },
+     cond: { },
+     reduce: function ( curr, result ) { },
+     initial: { }
+   }
+).forEach(
+    function(group) {
+        var app = group['application.$id'];
+        var api = group['api.$id'];
+        
+        var plan = db.plans.findOne({'apis': api, 'type': 'API'});
+        
+       // Get the plan relative to the API
+       var subscription = {
+           '_id': guid(),
+            '_class' : "io.gravitee.repository.mongodb.management.internal.model.SubscriptionMongo",
+            'plan' : plan._id,
+            'application' : app,
+            'api' : api,
+            'status' : 'ACCEPTED',
+            'processedAt' : new Date(),
+            'processedBy' : "system",
+            'subscribedBy' : "admin",
+            'startingAt' : new Date(),
+            'createdAt' : new Date(),
+            'updatedAt' : new Date()
+       };
+       
+       db.subscriptions.save(subscription);
+   }
+);
+   
+// Now, existing api-keys must be based on previously created subscriptions
+db.keys.find().forEach(
+    function(apikey) {
+        var app = apikey.application.$id;
+        var api = apikey.api.$id;
+        
+        var subscription = db.subscriptions.findOne({'api': api, 'application': app});
+        var apikey2 = {
+            '_id' : apikey.key.key,
+            '_class' : 'io.gravitee.repository.mongodb.management.internal.model.ApiKeyMongo',
+            'subscription' : subscription._id,
+            'application' : app,
+            'plan' : subscription.plan,
+            'createdAt' : apikey.key.createdAt,
+            'updatedAt' : apikey.key.createdAt,
+            'revoked' : apikey.key.revoked
+        }
+        
+        if (apikey.key.expiration !== undefined) {
+            apikey2.expireAt = apikey.key.expiration;
+        } 
+        
+        db.keys.remove(apikey);
+        db.keys.save(apikey2);
+    }
+);
+    
+// Clear subscriptions
+db.subscriptions.update(
+    {},
+    {$unset: {api: ''}},
+    {multi: true}
+);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/7-copy-views-to-api.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.0.0/7-copy-views-to-api.js
@@ -1,0 +1,10 @@
+db.apis.find().forEach(
+    function(api) {
+        var definition = JSON.parse(api.definition);
+        var views = definition.views;
+        
+        delete definition.views;
+
+        db.apis.updateOne({ _id: api._id}, {$set: {views: views, definition: JSON.stringify(definition)}}, { upsert: true} );
+    }
+);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.1.0/1-update-plan.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.1.0/1-update-plan.js
@@ -1,0 +1,5 @@
+db.plans.find().forEach(
+    function(plan) {
+        db.plans.updateOne({_id: plan._id}, {$set: {status: 'PUBLISHED'}}, { upsert: true} );
+    }
+);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.13.0/1-move-api.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.13.0/1-move-api.js
@@ -1,0 +1,25 @@
+print("\n\Move API reference into the subscription.");
+
+db.subscriptions.find().forEach(
+    function (subscription) {
+        var plan = db.plans.findOne({'_id': subscription.plan});
+        if (plan !== null) {
+            if (subscription.api) {
+                print("Subscription id["+subscription._id+"] already associated to an API. Skipping.");
+            } else {
+                db.subscriptions.updateOne(
+                    {_id: subscription._id},
+                    {
+                      $set:
+                        {
+                          api: plan.apis[0],
+                        }
+                    },
+                    {upsert: false}
+                  );
+            }
+        } else {
+            print('No plan for subscription: id[' + subscription._id + '] plan[' + subscription.plan + ']')
+        }
+    }
+);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.14.0/1-users-migration.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.14.0/1-users-migration.js
@@ -1,0 +1,141 @@
+function guid() {
+    function s4() {
+        return Math.floor((1 + Math.random()) * 0x10000)
+            .toString(16)
+            .substring(1);
+    }
+    return s4() + s4() + '-' + s4() + '-' + s4() + '-' +
+        s4() + '-' + s4() + s4() + s4();
+}
+
+print('Users migration');
+
+db.users.find().forEach(
+    function(user) {
+        if (user.username === undefined) {
+            var oldUserId = user._id;
+            print('Updating user: ' + oldUserId);
+
+            user._id = guid();
+            user.username = oldUserId;
+
+            // insert the user, using the new _id
+            db.users.insert(user)
+
+            // remove the user with the old _id
+            db.users.remove({'_id': oldUserId})
+
+            print('Updating memberships for user: ' + oldUserId);
+            db.memberships.find({'_id.userId': oldUserId}).forEach(
+                function(membership) {
+		    if (membership !== undefined) {
+                        membership._id.userId = user._id;
+
+                        // insert the membership, using the new _id
+                        print('Create new membership for new user ID: ' + membership._id.userId);
+                        db.memberships.insert(membership)
+
+                        // remove the membership with the old _id
+                        print('Removing memberships for old user ID: ' + oldUserId);
+                        db.memberships.remove({'_id.userId': oldUserId, '_id.referenceType': membership._id.referenceType, '_id.referenceId': membership._id.referenceId})
+		    }
+                }
+            );
+        } else {
+            print('User: ' + user._id + ' already have a username [' + user.username+ '], skipping');
+	}
+    }
+)
+
+print('Audits migration');
+
+db.audits.find({ 'username': { $exists: true } }).forEach(
+    function(audit) {
+        if (audit.username !== undefined) {
+            var user = db.users.findOne({'username': audit.username});
+            if (user === undefined || user === null) {
+                print('User: ' + audit.username+ ' does not exist, skipping');
+            } else {
+                db.audits.updateOne(
+                    { _id: audit._id },
+                    { $set:{ 'user': user._id }, $unset: { 'username': "" }},
+                    { upsert: false });
+            }
+        }
+    }
+)
+
+print('System audit migration');
+db.audits.find( { 'username': { $exists: true } } ).forEach(
+    function(audit) {
+        db.audits.updateOne(
+            { _id: audit._id },
+            { $set:{ 'user': audit.username }, $unset: { 'username': "" }},
+            { upsert: false });
+    }
+)
+
+print('Rating migration');
+
+db.rating.find().forEach(
+    function(rating) {
+        var user = db.users.findOne({'username': rating.user});
+        if (user === undefined || user === null) {
+            print('User: ' + rating.user + ' does not exist, skipping');
+        } else {
+            db.rating.updateOne(
+                { _id: rating._id },
+                { $set:{ 'user': user._id }},
+                { upsert: false });
+        }
+    }
+)
+
+print('Events migration');
+
+db.events.find( { 'properties.username': { $exists: true } } ).forEach(
+    function(event) {
+        var user = db.users.findOne( {'username': event.properties.username});
+        if (user === undefined || user === null) {
+            print('User: ' + event.properties.username + ' does not exist. Use current username as the user system reference');
+            db.events.updateOne(
+                { _id: event._id },
+                { $set:{ 'properties.user': event.properties.username }, $unset: { 'properties.username': "" }},
+                { upsert: false });
+        } else {
+            db.events.updateOne(
+                { _id: event._id },
+                { $set:{ 'properties.user': user._id }, $unset: { 'properties.username': "" }},
+                { upsert: false });
+        }
+    }
+)
+
+print('Subscriptions migration');
+db.subscriptions.find().forEach(
+    function(subscription) {
+        if (subscription.subscribedBy !== undefined) {
+            var subscriber = db.users.findOne( {'username': subscription.subscribedBy});
+            if (subscriber === undefined || subscriber === null) {
+                print('User: ' + subscription.subscribedBy + ' does not exist. Skipping');
+            } else {
+                db.subscriptions.updateOne(
+                    { _id: subscription._id },
+                    { $set:{ 'subscribedBy': subscriber._id } },
+                    { upsert: false });
+            }
+        }
+
+        if (subscription.processedBy !== undefined) {
+            var processedBy = db.users.findOne( {'username': subscription.processedBy});
+            if (processedBy === undefined || processedBy === null) {
+                print('User: ' + subscription.processedBy + ' does not exist. Skipping');
+            } else {
+                db.subscriptions.updateOne(
+                    { _id: subscription._id },
+                    { $set:{ 'processedBy': processedBy._id } },
+                    { upsert: false });
+            }
+        }
+    }
+)

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.14.0/2-init-email-notifications.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.14.0/2-init-email-notifications.js
@@ -1,0 +1,59 @@
+var now = new Date();
+
+function guid() {
+  function s4() {
+    return Math.floor((1 + Math.random()) * 0x10000)
+      .toString(16)
+      .substring(1);
+  }
+  return s4() + s4() + '-' + s4() + '-' + s4() + '-' +
+    s4() + '-' + s4() + s4() + s4();
+}
+
+function getConfig(membership, user) {
+  var hooks = [];
+  if ("API" === membership._id.referenceType) {
+    hooks = [
+      "APIKEY_EXPIRED",
+      "APIKEY_REVOKED",
+      "SUBSCRIPTION_NEW",
+      "SUBSCRIPTION_ACCEPTED",
+      "SUBSCRIPTION_CLOSED",
+      "SUBSCRIPTION_REJECTED"
+    ];
+  } else {
+    hooks = [
+      "SUBSCRIPTION_NEW",
+      "SUBSCRIPTION_ACCEPTED",
+      "SUBSCRIPTION_CLOSED",
+      "SUBSCRIPTION_REJECTED"
+    ];
+  }
+  return {
+    _id: guid(),
+    _class: 'io.gravitee.repository.mongodb.management.internal.model.GenericNotificationConfigMongo',
+    name: "Default Mail Notifications",
+    referenceType: membership._id.referenceType,
+    referenceId: membership._id.referenceId,
+    notifier: "default-email",
+    config: user.email,
+    hooks: hooks,
+    createdAt: now,
+    updatedAt: now
+  }
+}
+
+db.memberships.find({'roles': {$in: ['3:PRIMARY_OWNER', '4:PRIMARY_OWNER']}}).forEach(
+  function (membership) {
+    var user = db.users.findOne({'_id': membership._id.userId});
+    if (user && user.email) {
+      print ("Create an email notification for "
+        + user.email
+        + " and " + membership._id.referenceType
+        + " " + membership._id.referenceId);
+
+      db.genericnotificationconfigs.insert(getConfig(membership, user))
+    }
+  }
+);
+

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.20.0/Migration.120.SSL.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.20.0/Migration.120.SSL.js
@@ -1,0 +1,122 @@
+function guid() {
+    function s4() {
+      return Math.floor((1 + Math.random()) * 0x10000)
+        .toString(16)
+        .substring(1);
+    }
+    return s4() + s4() + '-' + s4() + '-' + s4() + '-' +
+      s4() + '-' + s4() + s4() + s4();
+  }
+
+function fixSSLConfig(endpoint, src) {
+    // endpoint https sans config ssl
+    if (endpoint.target && endpoint.target.startsWith("https") &&
+            (      !endpoint.ssl
+                || !endpoint.ssl.enabled
+                || (endpoint.ssl.trustAll && endpoint.ssl.hasOwnProperty("pem"))
+                || ( endpoint.ssl.hasOwnProperty("pem")
+                  && endpoint.ssl.pem != null
+                  && ( 0 === endpoint.ssl.pem.trim().length
+                    || "null" === endpoint.ssl.pem))
+        )) {
+        print("    mise à jour du endpoint d'", src, ": ", endpoint.name);
+
+        endpoint.ssl = {
+            "enabled": true,
+            "trustAll": true,
+            "hostnameVerifier" : false
+        };
+        return true;
+    }
+    return false;
+}
+
+updatedApiIds = [];
+now = new ISODate();
+
+db.events.find({"type": {$in: ["PUBLISH_API", "UNPUBLISH_API", "START_API", "STOP_API"]}}).sort({"updatedAt":-1}).forEach(
+    function(event) {
+        var curApiId = event.properties.api_id;
+        if (updatedApiIds.indexOf(curApiId) < 0) {
+            print("API ID : ", curApiId);
+            updatedApiIds.push(curApiId);
+
+            //deserialisation de la definition
+            var payload = JSON.parse(event.payload);
+            var definition = JSON.parse(payload.definition);
+            var toUpdate = false;
+
+            // gestion des endpoints avant les groupes
+            if (definition.proxy.endpoints) {
+                definition.proxy.endpoints.forEach(
+                    function (endpoint) {
+                        toUpdate = fixSSLConfig(endpoint, "event") || toUpdate
+                    }
+                );
+            }
+            // gestion des endpoints apres les groupes
+            else if (definition.proxy.groups) {
+                definition.proxy.groups.forEach(
+                    function (group) {
+                        group.endpoints.forEach(
+                            function (endpoint) {
+                                toUpdate = fixSSLConfig(endpoint, "event") || toUpdate
+                            }
+                        );
+                    }
+                );
+            }
+
+            if (toUpdate) {
+                // mise à jour de la définition d'API
+                db.apis.find({ _id: curApiId }).forEach(
+                    function (api) {
+                        var def = JSON.parse(api.definition)
+                        // gestion des endpoints avant les groupes
+                        if (def.proxy.endpoints) {
+                            def.proxy.endpoints.forEach(
+                                function (endpoint) {
+                                    fixSSLConfig(endpoint, "api")
+                                }
+                            );
+                        }
+                        // gestion des endpoints apres les groupes
+                        else if (def.proxy.groups) {
+                            def.proxy.groups.forEach(
+                                function (group) {
+                                    group.endpoints.forEach(
+                                        function (endpoint) {
+                                            fixSSLConfig(endpoint, "api")
+                                        }
+                                    );
+                                }
+                            );
+                        }
+
+                        print("    update the api")
+                        db.apis.updateOne(
+                            { _id: api._id },
+                            {
+                                $set: {
+                                    definition: JSON.stringify(def),
+                                    updatedAt: now,
+                                    deployedAt: now
+                                }
+                            });
+                    }
+                );
+
+                // ajout d'un event
+                print("    copie depuis l'event:", event._id)
+                event._id = guid();
+                print("    insert de l'event ", event._id);
+                payload.deployedAt = now
+                payload.definition = JSON.stringify(definition);
+                event.payload = JSON.stringify(payload);
+                event.updatedAt = now;
+                event.createdAt = now;
+                db.events.insert(event);
+            }
+        }
+    }
+);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.20.13/Find.Endpoints.duplicated.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.20.13/Find.Endpoints.duplicated.js
@@ -1,0 +1,43 @@
+db.apis.find().forEach(
+    function (api) {
+        var endpointNames = [];
+        var definition = JSON.parse(api.definition);
+
+        if (definition.proxy.endpoints) {
+            definition.proxy.endpoints.forEach(
+                function (endpoint) {
+                    endpointNames.push(endpoint.name);
+                }
+            );
+        }
+        else if (definition.proxy.groups) {
+            definition.proxy.groups.forEach(
+                function (group) {
+                    endpointNames.push(group.name);
+                    if (group.endpoints) {
+                        group.endpoints.forEach(
+                            function (endpoint) {
+                                endpointNames.push(endpoint.name);
+                            }
+                        );
+                    }
+                }
+            );
+        }
+
+        // test uniqueness of each name ans if contains :
+        let inError = false;
+        for (name of endpointNames) {
+            if (!inError && (endpointNames.indexOf(name) != endpointNames.lastIndexOf(name) || (name.indexOf(":") > -1))) {
+                inError = true;
+            }
+        }
+
+        if (inError) {
+            print("api.id: ", api._id);
+            print("api.name: ", api.name);
+            print("api.endpoints: [", endpointNames, "]");
+            print();
+        }
+    }
+);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.23.0/1-set-groups-invitation-mode.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.23.0/1-set-groups-invitation-mode.js
@@ -1,0 +1,7 @@
+db.groups.find().forEach( function(group) {
+  db.groups.updateOne(
+    { _id: group._id },
+    {
+      $set: { "systemInvitation" : true }
+    });
+});

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.25.0/1-applications-migration.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.25.0/1-applications-migration.js
@@ -1,0 +1,31 @@
+
+print('Applications migration');
+db.applications.find().forEach(
+    function (application) {
+        print("    update the application");
+
+        if (application.type && !("metadata" in application)) {
+            print("    set the SIMPLE application type for: " + application._id);
+            db.applications.updateOne(
+                { _id: application._id },
+                {
+                    $set: { "metadata.type" : application.type },
+                    $unset: { type: "" }
+                });
+        }
+
+        if (application.clientId) {
+            print("    put the clientId of the application into metadata: " + application._id);
+            db.applications.updateOne(
+                { _id: application._id },
+                {
+                    $set: { "metadata.client_id" : application.clientId },
+                    $unset: { clientId: "" }
+                });
+        }
+
+        db.applications.updateOne(
+            { _id: application._id },
+            { $set: { type: 'SIMPLE' }});
+    }
+);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.25.0/2-users-archived-upgrade.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.25.0/2-users-archived-upgrade.js
@@ -1,0 +1,11 @@
+
+print('Archived users migration');
+db.users.find({"status" : "ARCHIVED", "sourceId": {$regex : /^(?!deleted-).*/}}).forEach(
+  function (user) {
+    print("    update user: ", user._id, "    {source: ", user.source, ",sourceId: ", user.sourceId,"}");
+    db.users.updateOne(
+      { _id: user._id },
+      { $set: { sourceId: 'deleted-' + user.sourceId }}
+    );
+  }
+);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.25.23/1-memberships-archived-apps-migration.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.25.23/1-memberships-archived-apps-migration.js
@@ -1,0 +1,22 @@
+print('Archived apps migration');
+db.applications.find({status: 'ARCHIVED'}).forEach(
+    function (application) {
+        db.memberships.find({"_id.referenceType": "APPLICATION", "_id.referenceId": application._id}).forEach(
+            function (membership) {
+                db.users.find({"_id": membership._id.userId}).forEach(
+                    function (user) {
+                        print("Clean application memberships for the archived app '" + application.name + "' and user '" + user.sourceId + "'");
+                        db.memberships.deleteOne(membership);
+                    })
+            })
+    });
+
+print('Deleted API\'s Memberships migration');
+db.memberships.find({'_id.referenceType': 'API'}).forEach(
+    function (membership) {
+        const existingApiCursor = db.apis.find({"_id": membership._id.referenceId})
+        if (!existingApiCursor.hasNext()) {
+            print("Clean API memberships for the deleted API '" + membership._id.referenceId + "' and user '" + membership._id.userId + "'");
+            db.memberships.deleteOne(membership);
+        }
+    });

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.26.0/1-apis-migration.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.26.0/1-apis-migration.js
@@ -1,0 +1,10 @@
+
+print('APIs migration');
+db.apis.find().forEach(
+    function (api) {
+        print("    update the api", api._id);
+        db.apis.updateOne(
+            { _id: api._id },
+            { $set: { apiLifecycleState: 'PUBLISHED' }});
+    }
+);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.4.0/1-update-application.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.4.0/1-update-application.js
@@ -1,0 +1,5 @@
+db.applications.find().forEach(
+    function(app) {
+        db.applications.updateOne({_id: app._id}, {$set: {status: 'ACTIVE'}}, { upsert: true} );
+    }
+);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.4.0/2-create-archived-app.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.4.0/2-create-archived-app.js
@@ -1,0 +1,52 @@
+var subAppIds = [];
+var allAppIds = [];
+
+db.subscriptions.find({},{application: 1}).forEach(
+  function(sub) {
+    subAppIds.push(sub.application);
+  }
+);
+
+db.applications.find({}, {_id: 1}).forEach(
+  function(app) {
+    allAppIds.push(app._id);
+  }
+);
+
+now = new Date();
+subAppIds.forEach(
+  function (appId) {
+    if (allAppIds.indexOf(appId) === -1) {
+      db.applications.insertOne(
+        {
+          _id: appId,
+          _class : "io.gravitee.repository.mongodb.management.internal.model.ApplicationMongo",
+          name: "Archived App",
+          description: "Archived application created in version 1.4.0",
+          status: "ARCHIVED",
+          createdAt: now,
+          updatedAt: now
+        }
+      );
+
+      /*
+        Applications must have a PRIMARY_OWNER member. 
+        Fill the `userId` attribute with the one you choose.
+        Choose the Administration by defaut.
+       */
+      db.memberships.insertOne(
+        {
+          _id : {
+            userId : "Fill with the user ID",
+            referenceId : appId,
+            referenceType : "APPLICATION"
+          },
+          _class : "io.gravitee.repository.mongodb.management.internal.model.MembershipMongo",
+          type : "PRIMARY_OWNER",
+          createdAt : now,
+          updatedAt : now
+        }
+      );
+    }
+  }
+);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.5.0/1-remove-event-picture.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.5.0/1-remove-event-picture.js
@@ -1,0 +1,14 @@
+db.events.find().forEach(
+    function(event) {
+        var payload = JSON.parse(event.payload);
+        if (payload.definition !== undefined) {
+            var definition = JSON.parse(payload.definition);
+            delete payload.picture;
+            delete definition.picture;
+
+            payload.definition = JSON.stringify(definition);
+
+            db.events.updateOne({ _id: event._id}, {$set: {payload: JSON.stringify(payload)}}, { upsert: true} );
+        }
+    }
+);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.5.0/2-update-pages.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.5.0/2-update-pages.js
@@ -1,0 +1,5 @@
+db.pages.find().forEach(
+    function(page) {
+        db.pages.updateOne({_id: page._id}, {$set: {homepage: false}}, { upsert: true} );
+    }
+);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.8.0/1-convert-roles.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.8.0/1-convert-roles.js
@@ -1,0 +1,100 @@
+var now = new Date();
+
+// update memberships type
+print("\n\nUpdate existing memberships to add scope");
+db.memberships.find().forEach(
+  function (membership) {
+    var referenceType = membership._id.referenceType;
+    if (   !membership.type.startsWith("1:")
+      && !membership.type.startsWith("2:")
+      && !membership.type.startsWith("3:")
+      && !membership.type.startsWith("4:")) {
+      var roleScope;
+      if (referenceType === "API" || referenceType === "API_GROUP") {
+        roleScope = "3:"
+      } else if (referenceType === "APPLICATION" || referenceType === "APPLICATION_GROUP") {
+        roleScope = "4:"
+      }
+      print("    - id[" + membership._id.userId + ":" + membership._id.referenceId + ":" + membership._id.referenceType + "]");
+      print("        " + membership.type + " -> " + roleScope + membership.type);
+      db.memberships.updateOne(
+        {_id: membership._id},
+        {
+          $set:
+            {type: roleScope + membership.type}
+        },
+        {upsert: true}
+      );
+    }
+  }
+);
+
+// create default roles for scope MANAGEMENT and PORTAL
+print("\n\nCreate default memberships");
+//get all userIds with MANAGEMENT role
+var migratedUsers = db.memberships.
+  find({"_id.referenceId": "DEFAULT", "_id.referenceType": "MANAGEMENT"}, {"_id": 1}).
+  toArray().
+  map( function(id) {
+    return id._id.userId;
+  });
+db.users.find().forEach(
+  function(user) {
+    if (migratedUsers.indexOf(user._id) === -1) {
+      print("    - user = " + user._id);
+      var mgmt_role = "USER";
+      var portal_role = "USER";
+      if (user.roles) {
+        var roles = user.roles;
+        if (roles && roles.length > 0) {
+          mgmt_role = roles[0];
+          portal_role = roles[0];
+          if (mgmt_role === "API_CONSUMER") {
+            mgmt_role = "USER";
+            portal_role = "USER";
+          }
+        }
+      }
+      if (user._id === "admin") {
+        mgmt_role = "ADMIN";
+        portal_role = "ADMIN";
+      } else if (user._id === "api1") {
+        mgmt_role = "API_PUBLISHER";
+        portal_role = "USER";
+      }
+      print("    - mgmt_role = " + mgmt_role);
+      print("    - portal_role = " + portal_role);
+      db.memberships.insert([
+        {
+          _id: {
+            userId: user._id,
+            referenceId: "DEFAULT",
+            referenceType: "MANAGEMENT"
+          },
+          _class: "io.gravitee.repository.mongodb.management.internal.model.MembershipMongo",
+          type: "1:" + mgmt_role,
+          createdAt: now,
+          updatedAt: now
+        },
+        {
+          _id: {
+            userId: user._id,
+            referenceId: "DEFAULT",
+            referenceType: "PORTAL"
+          },
+          _class: "io.gravitee.repository.mongodb.management.internal.model.MembershipMongo",
+          type: "2:" + portal_role,
+          createdAt: now,
+          updatedAt: now
+        }
+      ]);
+    }
+  }
+);
+
+print("\n\n remove old roles for all users");
+db.users.update(
+  {},
+  {$unset: {roles: ""}},
+  {multi: true}
+);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.9.0/1-convert-groups.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.9.0/1-convert-groups.js
@@ -1,0 +1,84 @@
+// convert type to roles in Membership collection
+print("\n\nConvert type to roles in Membership collection");
+db.memberships.find().forEach(
+  function (membership) {
+    print(' - membership: ' + membership._id.userId + "/" + membership._id.referenceId + "/" + membership._id.referenceType);
+    print('   type: ' + membership.type);
+    var roles = [membership.type];
+    print('   roles: ' + roles);
+    // if membership is about groups, we have to modify the mongo id
+    if (membership._id.referenceType === "API_GROUP" || membership._id.referenceType === "APPLICATION_GROUP") {
+      print('   referenceType: ' + membership._id.referenceType);
+      var oldId = membership._id;
+      membership._id = {
+        userId: membership._id.userId,
+        referenceId: membership._id.referenceId,
+        referenceType: "GROUP"
+      };
+      membership.roles = roles;
+      print('   ...... insert new group');
+      db.memberships.insert(membership);
+      print('   ...... remove old group: ');
+      db.memberships.remove({_id: oldId});
+    } else if (!membership.roles) {
+      print('   ...... update');
+      db.memberships.updateOne(
+        {_id: membership._id},
+        {
+          $set:
+            {
+              roles: roles,
+            }
+        },
+        {upsert: true}
+      );
+    }
+    print('   ...... done. \n');
+  });
+
+//update api groups
+print("\n\nMove group -> groups for APIs");
+db.apis.find().forEach(
+  function(api) {
+    if (api.group) {
+      print(" - api: " + api._id);
+      print("   name: " + api.name);
+      print("   group: " + api.group);
+      var groups = [api.group];
+      print("   groups: " + groups);
+      print('   ...... update');
+      db.apis.updateOne(
+        {_id: api._id},
+        {
+          $set:
+            {groups: groups}
+        },
+        {upsert: true}
+      );
+      print('   ...... done. \n');
+    }
+  });
+
+//update api groups
+print("\n\nMove group -> groups for Applications");
+db.applications.find().forEach(
+  function(application) {
+    if (application.group) {
+      print(" - application: " + application._id);
+      print("   name: " + application.name);
+      print("   group: " + application.group);
+      var groups = [application.group];
+      print("   groups: " + groups);
+      print('   ...... update');
+      db.applications.updateOne(
+        {_id: application._id},
+        {
+          $set:
+            {groups: groups}
+        },
+        {upsert: true}
+      );
+      print('   ...... done. \n');
+    }
+  });
+

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.9.0/2-remove-old-attributes.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.9.0/2-remove-old-attributes.js
@@ -1,0 +1,32 @@
+// remove group type
+print("\n\n remove type attribute for all groups");
+db.groups.update(
+  {},
+  {$unset: {type: ""}},
+  {multi: true}
+);
+print("Done!");
+
+print("\n\nRemove old type in Membership collection");
+db.memberships.update(
+  {},
+  {$unset: {type: ""}},
+  {multi: true}
+);
+print("Done!");
+
+print("\n\nRemove old group in API collection");
+db.apis.update(
+  {},
+  {$unset: {group: ""}},
+  {multi: true}
+);
+print("Done!");
+
+print("\n\nRemove old group in Application collection");
+db.applications.update(
+  {},
+  {$unset: {group: ""}},
+  {multi: true}
+);
+print("Done!");

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.9.0/3-upgrade-groups-in-events-payload.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/1.9.0/3-upgrade-groups-in-events-payload.js
@@ -1,0 +1,29 @@
+print("\n\nConvert group to groups in events payload");
+db.events.find().forEach(
+  function (event) {
+    if (event.payload && event.payload.indexOf("group\"") > 0) {
+      var payloadAsJson = JSON.parse(event.payload);
+      print(" - event id: " + event._id);
+      print("         payload.group: " + payloadAsJson.group);
+      payloadAsJson.groups = [payloadAsJson.group];
+      delete payloadAsJson.group;
+      print("         payload.groups: " + payloadAsJson.groups);
+      event.payload = JSON.stringify(payloadAsJson);
+      print(event.payload);
+      db.events.updateOne(
+        {
+          _id: event._id
+        },
+        {
+          $set: {
+            payload: event.payload
+          }
+        },
+        {
+          upsert :true
+        }
+      );
+      print('   ...... done. \n');
+    }
+  }
+);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.0/1-collections-linked-to-environment-or-organization.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.0/1-collections-linked-to-environment-or-organization.js
@@ -1,0 +1,114 @@
+print('Apiheaders migration - add environmentId field');
+db.apiheaders.find().forEach(
+    function(apiHeader) {
+        if (!apiHeader.environmentId) {
+            let existingApiHeaderCursor = db.apiheaders.find({'_id': apiHeader._id, environmentId: 'DEFAULT'});
+            if(!existingApiHeaderCursor.hasNext()) {
+                apiHeader.environmentId = 'DEFAULT';
+                db.apiheaders.save(apiHeader);
+            }
+        }
+    }
+);
+
+print('Apis migration - add environmentId field');
+db.apis.update({}, {$set: {'environmentId': 'DEFAULT'}}, false, true);
+
+print('Applications migration - add environmentId field');
+db.applications.update({}, {$set: {'environmentId': 'DEFAULT'}}, false, true);
+
+print('Commands migration - add environmentId field');
+db.commands.update({}, {$set: {'environmentId': 'DEFAULT'}}, false, true);
+
+print('Dictionaries migration - add environmentId field');
+db.dictionaries.update({}, {$set: {'environmentId': 'DEFAULT'}}, false, true);
+
+print('Events migration - add environmentId field');
+db.events.update({}, {$set: {'environmentId': 'DEFAULT'}}, false, true);
+
+print('Entrypoints migration - add environmentId field');
+db.entrypoints.update({}, {$set: {'environmentId': 'DEFAULT'}}, false, true);
+
+print('Views migration - add environmentId field');
+db.views.find().forEach(
+    function(view) {
+        if (!view.environmentId) {
+            let existingViewCursor = db.views.find({'_id': view._id, environmentId: 'DEFAULT'});
+            if(!existingViewCursor.hasNext()) {
+                view.environmentId = 'DEFAULT';
+                db.views.save(view);
+            }
+        }
+    }
+);
+
+print('IdentityProviders migration - add referenceId and referenceType field');
+db.identity_providers.find().forEach(
+    function(idp) {
+        if (!idp.referenceId) {
+            let existingIDPCursor = db.identity_providers.find({'_id': idp._id, referenceId: 'DEFAULT', referenceType: 'ENVIRONMENT'});
+            if(!existingIDPCursor.hasNext()) {
+                idp.referenceId = 'DEFAULT';
+                idp.referenceType = 'ENVIRONMENT';
+                db.identity_providers.save(idp);
+            }
+        }
+    }
+);
+print('Parameters migration - add referenceId and referenceType field');
+db.parameters.update({}, {$set: {referenceId: 'DEFAULT', referenceType: 'ENVIRONMENT'}}, false, true);
+
+print('Users migration - add referenceId and referenceType field');
+db.users.update({}, {$set: {referenceId: 'DEFAULT', referenceType: 'ORGANIZATION'}}, false, true);
+
+print('Pages migration - add referenceId and referenceType field');
+db.pages.find().forEach(
+    function(page) {
+        var referenceId ='';
+        var referenceType = '';
+
+        if(!page.referenceId) {
+            if(page.api) {
+                referenceId = page.api;
+                referenceType = 'API';
+            } else {
+                referenceId = 'DEFAULT';
+                referenceType = 'ENVIRONMENT';
+            }
+            
+            db.pages.updateOne(
+                { '_id': page._id },
+                {
+                    $set: { 'referenceId': referenceId, 'referenceType': referenceType },
+                    $unset: { 'api': ''}
+                }
+            );
+        }
+    }
+);
+
+print('Rating migration - add referenceId and referenceType field');
+db.rating.find().forEach(
+    function(rating) {
+        var referenceId ='';
+        var referenceType = '';
+        
+        if(!rating.referenceId) {
+            if(rating.api) {
+                referenceId = rating.api;
+                referenceType = 'API';
+            } else {
+                referenceId = 'DEFAULT';
+                referenceType = 'ENVIRONMENT';
+            }
+            
+            db.rating.updateOne(
+                { '_id': rating._id },
+                {
+                    $set: { 'referenceId': referenceId, 'referenceType': referenceType },
+                    $unset: { 'api': ''}
+                }
+            );
+        }
+    }
+);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.0/1-collections-linked-to-environment-or-organization.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.0/1-collections-linked-to-environment-or-organization.js
@@ -5,7 +5,7 @@ db.apiheaders.find().forEach(
             let existingApiHeaderCursor = db.apiheaders.find({'_id': apiHeader._id, environmentId: 'DEFAULT'});
             if(!existingApiHeaderCursor.hasNext()) {
                 apiHeader.environmentId = 'DEFAULT';
-                db.apiheaders.save(apiHeader);
+                db.apiheaders.replaceOne({ _id: apiHeader._id }, apiHeader);
             }
         }
     }
@@ -36,7 +36,7 @@ db.views.find().forEach(
             let existingViewCursor = db.views.find({'_id': view._id, environmentId: 'DEFAULT'});
             if(!existingViewCursor.hasNext()) {
                 view.environmentId = 'DEFAULT';
-                db.views.save(view);
+                db.views.replaceOne({ _id: view._id }, view);
             }
         }
     }
@@ -50,7 +50,7 @@ db.identity_providers.find().forEach(
             if(!existingIDPCursor.hasNext()) {
                 idp.referenceId = 'DEFAULT';
                 idp.referenceType = 'ENVIRONMENT';
-                db.identity_providers.save(idp);
+                db.identity_providers.replaceOne({ _id: idp._id }, idp);
             }
         }
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.0/2-roles-groups-and-memberships-migration.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.0/2-roles-groups-and-memberships-migration.js
@@ -1,0 +1,344 @@
+
+loadMigrationArray = function () {
+    let roleMigrationArray = [];
+    roleMigrationArray[1] = [];
+    roleMigrationArray[2] = [];
+    roleMigrationArray[1][1000]={'newScope':6,'newPermission':1000};
+    roleMigrationArray[1][1200]={'newScope':6,'newPermission':1200};
+    roleMigrationArray[1][1300]={'newScope':6,'newPermission':1300};
+    roleMigrationArray[1][1400]={'newScope':6,'newPermission':1400};
+    roleMigrationArray[1][1500]={'newScope':6,'newPermission':1500};
+    roleMigrationArray[1][1600]={'newScope':7,'newPermission':1200};
+    roleMigrationArray[1][1700]={'newScope':6,'newPermission':1700};
+    roleMigrationArray[1][1800]={'newScope':6,'newPermission':1800};
+    roleMigrationArray[1][1900]={'newScope':6,'newPermission':1900};
+    roleMigrationArray[1][2000]={'newScope':6,'newPermission':2000};
+    roleMigrationArray[1][2100]={'newScope':7,'newPermission':1000};
+    roleMigrationArray[1][2200]={'newScope':6,'newPermission':2200};
+    roleMigrationArray[1][2300]={'newScope':6,'newPermission':2300};
+    roleMigrationArray[1][2400]={'newScope':6,'newPermission':2400};
+    roleMigrationArray[1][2500]={'newScope':6,'newPermission':2500};
+    roleMigrationArray[1][2600]={'newScope':6,'newPermission':2600};
+    roleMigrationArray[1][2700]={'newScope':6,'newPermission':2700};
+    roleMigrationArray[1][2800]={'newScope':6,'newPermission':2800};
+    roleMigrationArray[2][1000]={'newScope':6,'newPermission':2900};
+    roleMigrationArray[2][1100]={'newScope':6,'newPermission':3000};
+    roleMigrationArray[2][1200]={'newScope':6,'newPermission':1700};
+    roleMigrationArray[2][1300]={'newScope':6,'newPermission':3100};
+    roleMigrationArray[2][1400]={'newScope':6,'newPermission':3200};
+    roleMigrationArray[2][1500]={'newScope':6,'newPermission':2600};
+    roleMigrationArray[2][1600]={'newScope':6,'newPermission':3300};
+    roleMigrationArray[2][1700]={'newScope':6,'newPermission':3400};
+    roleMigrationArray[2][1800]={'newScope':6,'newPermission':3500};
+    return roleMigrationArray;
+}
+roleMigrationArray = loadMigrationArray();
+
+hasPermValue = function (permissions, permValue) {
+    for (let index = 0; index < permissions.length; index++) {
+        var currentPermValue = permissions[index] - (permissions[index] % 100);
+        if (currentPermValue === permValue) {
+            return true;
+        }
+    }
+    return false;
+}
+
+print('Roles migration - scope renaming & new Id & MANAGEMENT and PORTAL replaced by ENVIRONMENT and ORGANIZATION');
+db.roles.dropIndexes();
+db.roles.find().sort( { '_id.scope': 1 } ).forEach(
+    function(role) {
+        const oldId = role._id;
+        const oldScope = role._id.scope;
+        if (oldScope === 1) {
+            if (hasPermValue(role.permissions, 1600) || hasPermValue(role.permissions, 2100)) {
+
+                let newRole = Object.assign({}, role);
+                newRole._id = 'ORGANIZATION_' + oldId.name;
+                newRole.scope = 'ORGANIZATION';
+                newRole.name = oldId.name;
+                newRole.referenceId = 'DEFAULT';
+                newRole.referenceType = 'ORGANIZATION';
+
+                newRole.permissions = [];
+                let roleNewPermissions = []
+                role.permissions.forEach(
+                    function(permission) {
+                        let permValue = permission - (permission % 100);
+                        if (permValue === 1600) {
+                            newRole.permissions.push(1200 + permission % 100);
+                        } else if (permValue === 2100) {
+                            newRole.permissions.push(1000 + permission % 100);
+                        } else {
+                            roleNewPermissions.push(permission);
+                        }
+                    }
+                );
+                role.permissions = roleNewPermissions;
+
+                let existingRoleCursor = db.roles.find({scope: 'ORGANIZATION', name: oldId.name, referenceId: 'DEFAULT', referenceType: 'ORGANIZATION'});
+                if (existingRoleCursor.hasNext()) {
+                    db.roles.remove({'_id': existingRoleCursor.next()._id});
+                }
+                db.roles.insert(newRole);
+            }
+
+            let roleNewPermissions = []
+            role.permissions.forEach(
+                function(permission) {
+                    let permValue = permission - (permission % 100);
+                    let migData = roleMigrationArray[oldScope][permValue];
+                    if (migData) {
+                        roleNewPermissions.push(migData.newPermission + permission % 100);
+                    }
+                }
+            );
+            role.permissions = roleNewPermissions;
+
+            let portalRoleCursor = db.roles.find({'_id.scope':2,'_id.name':oldId.name});
+            if (portalRoleCursor.hasNext()) {
+                let portalRole = portalRoleCursor.next();
+
+                portalRole.permissions.forEach(
+                    function(permission) {
+                        let permValue = permission - (permission % 100);
+                        let migData = roleMigrationArray[2][permValue];
+                        if (migData) {
+                            let newPermission = migData.newPermission + permission % 100;
+                            if(!role.permissions.includes(newPermission)) {
+                                role.permissions.push(newPermission);
+                            }
+                        }
+                    }
+                );
+                db.roles.remove({ '_id' : portalRole._id });
+            }
+            role._id = 'ENVIRONMENT_' + oldId.name;
+            role.scope = 'ENVIRONMENT';
+            role.name = oldId.name;
+            role.referenceId = 'DEFAULT';
+            role.referenceType = 'ORGANIZATION';
+
+            db.roles.remove({ '_id' : oldId });
+
+            let existingRoleCursor = db.roles.find({scope: 'ENVIRONMENT', name: oldId.name, referenceId: 'DEFAULT', referenceType: 'ORGANIZATION'});
+            if (existingRoleCursor.hasNext()) {
+                db.roles.remove({'_id': existingRoleCursor.next()._id});
+            }
+            db.roles.insert(role);
+    } else if (oldScope === 2) {
+            // has already been treated and deleted ?
+            let portalRoleCursor = db.roles.find({'_id':oldId});
+            if (portalRoleCursor.hasNext()) {
+                let roleNewPermissions = []
+
+                role.permissions.forEach(
+                    function(permission) {
+                        let permValue = permission - (permission % 100);
+                        let migData = roleMigrationArray[oldScope][permValue];
+                        if (migData) {
+                            roleNewPermissions.push(migData.newPermission + permission % 100);
+                        }
+                    }
+                );
+                role.permissions = roleNewPermissions;
+
+                role._id = 'ENVIRONMENT_' + oldId.name;
+                role.scope = 'ENVIRONMENT';
+                role.name = oldId.name;
+                role.referenceId = 'DEFAULT';
+                role.referenceType = 'ORGANIZATION';
+
+                db.roles.remove({ '_id' : oldId });
+                let existingRoleCursor = db.roles.find({scope: 'ENVIRONMENT', name: oldId.name, referenceId: 'DEFAULT', referenceType: 'ORGANIZATION'});
+                if (existingRoleCursor.hasNext()) {
+                    db.roles.remove({'_id': existingRoleCursor.next()._id});
+                }
+                db.roles.insert(role);
+
+            }
+        } else if (oldScope === 3) {
+            role._id = 'API_' + oldId.name;
+            role.scope = 'API';
+            role.name = oldId.name;
+            role.referenceId = 'DEFAULT';
+            role.referenceType = 'ORGANIZATION';
+
+            db.roles.remove({ '_id' : oldId });
+            let existingRoleCursor = db.roles.find({scope: 'API', name: oldId.name, referenceId: 'DEFAULT', referenceType: 'ORGANIZATION'});
+            if (existingRoleCursor.hasNext()) {
+                db.roles.remove({'_id': existingRoleCursor.next()._id});
+            }
+            db.roles.insert(role);
+
+        } else if (oldScope === 4) {
+            role._id = 'APPLICATION_' + oldId.name;
+            role.scope = 'APPLICATION';
+            role.name = oldId.name;
+            role.referenceId = 'DEFAULT';
+            role.referenceType = 'ORGANIZATION';
+
+            db.roles.remove({ '_id' : oldId });
+            let existingRoleCursor = db.roles.find({scope: 'APPLICATION', name: oldId.name, referenceId: 'DEFAULT', referenceType: 'ORGANIZATION'});
+            if (existingRoleCursor.hasNext()) {
+                db.roles.remove({'_id': existingRoleCursor.next()._id});
+            }
+            db.roles.insert(role);
+
+        } else if (oldScope === 5) {
+            role._id = 'GROUP_' + oldId.name;
+            role.scope = 'GROUP';
+            role.name = oldId.name;
+            role.referenceId = 'DEFAULT';
+            role.referenceType = 'ORGANIZATION';
+
+            db.roles.remove({ '_id' : oldId });
+            let existingRoleCursor = db.roles.find({scope: 'GROUP', name: oldId.name, referenceId: 'DEFAULT', referenceType: 'ORGANIZATION'});
+            if (existingRoleCursor.hasNext()) {
+                db.roles.remove({'_id': existingRoleCursor.next()._id});
+            }
+            db.roles.insert(role);
+
+        }
+    }
+);
+db.roles.createIndex( {"id": 1 } );
+db.roles.createIndex( {"scope": 1 } );
+db.roles.reIndex();
+
+print('Memberships migration - new structure + MANAGEMENT and PORTAL replaced by ENVIRONMENT and ORGANIZATION');
+db.memberships.dropIndexes();
+db.memberships.find().forEach(
+    function(membership) {
+        if(!membership.roleId) {
+            const oldId = membership._id;
+
+            membership.roles.forEach(role => {
+                let roleArray = role.split(':');
+                let newRoleId;
+                let newReferenceId;
+                let newReferenceType;
+                if (roleArray[0] == 1) {
+                    let newOrganizationRoleId = 'ORGANIZATION_' + roleArray[1];
+                    let portalRoleCursor = db.roles.find({'_id':newOrganizationRoleId});
+                    if (portalRoleCursor.hasNext()) {
+                        let newOrganizationMembership = {
+                            '_id': UUID().toString().split('"')[1],
+                            'memberId': oldId.userId,
+                            'memberType': 'USER',
+                            'referenceId': 'DEFAULT',
+                            'referenceType': 'ORGANIZATION',
+                            'roleId': newOrganizationRoleId,
+                            'createdAt': membership.createdAt,
+                            'updatedAt': membership.updatedAt
+                        };
+
+                        db.memberships.insert(newOrganizationMembership);
+                    }
+
+                    newRoleId = 'ENVIRONMENT_' + roleArray[1];
+                    newReferenceId = 'DEFAULT';
+                    newReferenceType = 'ENVIRONMENT';
+                } else if (roleArray[0] == 2) {
+                    newRoleId = 'ENVIRONMENT_' + roleArray[1];
+                    newReferenceId = 'DEFAULT';
+                    newReferenceType = 'ENVIRONMENT';
+                } else if (roleArray[0] == 3) {
+                    newRoleId = 'API_' + roleArray[1];
+                    newReferenceId = oldId.referenceId;
+                    newReferenceType = oldId.referenceType;
+                } else if (roleArray[0] == 4) {
+                    newRoleId = 'APPLICATION_' + roleArray[1];
+                    newReferenceId = oldId.referenceId;
+                    newReferenceType = oldId.referenceType;
+                } else if (roleArray[0] == 5) {
+                    newRoleId = 'GROUP_' + roleArray[1];
+                    newReferenceId = oldId.referenceId;
+                    newReferenceType = oldId.referenceType;
+                }
+
+                let newMembership = {
+                    '_id': UUID().toString().split('"')[1],
+                    'memberId': oldId.userId,
+                    'memberType': 'USER',
+                    'referenceId': newReferenceId,
+                    'referenceType': newReferenceType,
+                    'roleId': newRoleId,
+                };
+                if (membership.createdAt) {
+                    newMembership['createdAt'] = membership.createdAt;
+                }
+                if (membership.updatedAt) {
+                    newMembership['updatedAt'] = membership.updatedAt;
+                }
+
+                let countMembership = db.memberships.count({
+                    'memberId': newMembership['memberId'],
+                    'memberType': newMembership['memberType'],
+                    'referenceId': newMembership['referenceId'],
+                    'referenceType': newMembership['referenceType'],
+                    'roleId': newMembership['roleId']
+                });
+
+                if (countMembership === 0) {
+                    db.memberships.insert(newMembership);
+                }
+            });
+            db.memberships.remove({'_id' : oldId});
+        }
+    }
+);
+db.memberships.createIndex( { "id" : 1 }, { unique : true } );
+db.memberships.createIndex( { "memberId" : 1 } );
+db.memberships.createIndex( { "member" : 1 } );
+db.memberships.createIndex( { "referenceId" : 1 } );
+db.memberships.createIndex( { "referenceType" : 1 } );
+db.memberships.createIndex( { "referenceId":1, "referenceType":1 } );
+db.memberships.createIndex( { "referenceId":1, "referenceType":1, "roleId":1 } );
+db.memberships.createIndex( { "roleId" : 1 } );
+db.memberships.createIndex( { "memberId":1, "memberType":1, "referenceType":1 });
+db.memberships.createIndex( { "memberId":1, "memberType":1, "referenceType":1, "roleId":1 });
+db.memberships.createIndex( { "memberId":1, "memberType":1, "referenceType":1, "referenceId":1 });
+db.memberships.createIndex( { "memberId":1, "memberType":1, "referenceType":1, "referenceId":1, "roleId":1 });
+db.memberships.createIndex( { "memberId":1, "memberType":1 });
+db.memberships.reIndex();
+
+print('Groups migration - default role are now store in "memberships" collection + add environmentId field');
+db.groups.find().forEach(
+    function(group) {
+        if(group.roles) {
+            group.roles.forEach(role => {
+                let roleArray = role.split(':');
+                let newRoleId;
+                let newReferenceType;
+                if (roleArray[0] == 3) {
+                    newRoleId = 'API_' + roleArray[1];
+                    newReferenceType = 'API';
+                } else if (roleArray[0] == 4) {
+                    newRoleId = 'APPLICATION_' + roleArray[1];
+                    newReferenceType = 'APPLICATION';
+                }
+
+                let newMembership = {
+                    '_id': UUID().toString().split('"')[1],
+                    'memberId': group._id,
+                    'memberType': 'GROUP',
+                    'referenceId': null,
+                    'referenceType': newReferenceType,
+                    'roleId': newRoleId,
+                    'createdAt': new Date(),
+                    'updatedAt': new Date()
+                };
+
+                db.memberships.insert(newMembership);
+            });
+        }
+        db.groups.updateOne(
+            { _id: group._id },
+            {
+                $set: {'environmentId': 'DEFAULT'},
+                $unset: { roles: '' }
+            }
+        );
+    }
+);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.0/3-replace-apiArray-by-unique-api.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.0/3-replace-apiArray-by-unique-api.js
@@ -1,0 +1,21 @@
+print('Plans migration - plans have now only one api');
+db.plans.dropIndexes();
+db.plans.find().forEach(
+    function(plan) {
+        
+        var apiId = plan.apis && plan.apis[0];
+         
+        if(apiId) {
+            db.plans.updateOne(
+                { _id: plan._id },
+                {
+                    $set: { api: apiId},
+                    $unset: { apis: '' }
+                }
+            );
+        }
+        
+    }
+);
+db.plans.createIndex( { "api" : 1 } );
+db.plans.reIndex();

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.0/4-remove-devMode.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.0/4-remove-devMode.js
@@ -1,0 +1,2 @@
+print('Remove devmode parameter');
+db.parameters.remove({'_id': 'portal.devMode.enabled'});

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.0/5-remove-orphan-documentation-pages.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.0/5-remove-orphan-documentation-pages.js
@@ -1,0 +1,8 @@
+print('find all orphan pages and remove them from db')
+db.pages.find({parentId: {$exists: true}}).forEach(doc => {
+  const parentCursor = db.pages.find({_id: doc.parentId});
+  if (!parentCursor.hasNext()) {
+    //printjson(doc);  
+    db.pages.remove(doc);  
+  }
+});

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.0/6-remove-ALL-view-and-defaultView-field.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.0/6-remove-ALL-view-and-defaultView-field.js
@@ -1,0 +1,3 @@
+print('Remove default view "ALL" and "defaultView" field  from others views');
+db.views.remove({'_id': 'all'});
+db.views.update({}, {$unset: {'defaultView': ''}}, false, true);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.2/1-rename-view-in-category.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.2/1-rename-view-in-category.js
@@ -12,20 +12,20 @@ db.pages.updateMany(
 
 print('Change parameters keys');
 db.parameters.find({ _id: {$in: ['portal.apis.viewMode.enabled','portal.apis.apiheader.showviews.enabled','api.quality.metrics.views.weight']}}).forEach( param => {
-  let newId = '';
-  let oldId = param._id;
-  if (param._id === 'portal.apis.viewMode.enabled') {
-      newId = 'portal.apis.categoryMode.enabled';
-  } else if (param._id === 'portal.apis.apiheader.showviews.enabled') {
-      newId = 'portal.apis.apiheader.showcategories.enabled';
-  } else if (param._id === 'api.quality.metrics.views.weight') {
-      newId = 'api.quality.metrics.categories.weight';
-  }
-  if (newId) {
-      param._id = newId;
-      db.parameters.save(param);
-      db.parameters.deleteOne({_id: oldId});
-  }
+    let newId = '';
+    let oldId = param._id;
+    if (param._id === 'portal.apis.viewMode.enabled') {
+        newId = 'portal.apis.categoryMode.enabled';
+    } else if (param._id === 'portal.apis.apiheader.showviews.enabled') {
+        newId = 'portal.apis.apiheader.showcategories.enabled';
+    } else if (param._id === 'api.quality.metrics.views.weight') {
+        newId = 'api.quality.metrics.categories.weight';
+    }
+    if (newId) {
+        param._id = newId;
+        db.parameters.insertOne(param);
+        db.parameters.deleteOne({_id: oldId});
+    }
 });
 
 print ('Update Audit logs to replace VIEW with CATEGORY');
@@ -33,11 +33,11 @@ db.audits.find({event: /VIEW/}).forEach(audit => {
   audit.event = audit.event.replace('VIEW', 'CATEGORY');
   audit.properties.CATEGORY = audit.properties.VIEW;
   delete audit.properties.VIEW;
-  db.audits.save(audit);
+  db.audits.replaceOne({ _id: audit._id }, audit);
 });
 
 print ('Update events payloads');
 db.events.find({payload: /views/}).forEach( e => {
     e.payload=e.payload.replace('"views"','"categories"');
-    db.events.save(e);
+    db.events.replaceOne({ _id: e._id }, e);
 });

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.2/1-rename-view-in-category.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.0.2/1-rename-view-in-category.js
@@ -1,0 +1,43 @@
+print('In apis collection, \'views\' becomes \'categories\'');
+db.apis.updateMany( {}, { $rename: { 'views': 'categories' } } );
+
+print('Rename \'views\' collection in \'categories\'');
+db.views.renameCollection('categories');
+
+print('Change view links to category links');
+db.pages.updateMany(
+  { type: 'LINK', 'configuration.resourceType': 'view'},
+  { $set: { 'configuration.resourceType': 'category' } }
+);
+
+print('Change parameters keys');
+db.parameters.find({ _id: {$in: ['portal.apis.viewMode.enabled','portal.apis.apiheader.showviews.enabled','api.quality.metrics.views.weight']}}).forEach( param => {
+  let newId = '';
+  let oldId = param._id;
+  if (param._id === 'portal.apis.viewMode.enabled') {
+      newId = 'portal.apis.categoryMode.enabled';
+  } else if (param._id === 'portal.apis.apiheader.showviews.enabled') {
+      newId = 'portal.apis.apiheader.showcategories.enabled';
+  } else if (param._id === 'api.quality.metrics.views.weight') {
+      newId = 'api.quality.metrics.categories.weight';
+  }
+  if (newId) {
+      param._id = newId;
+      db.parameters.save(param);
+      db.parameters.deleteOne({_id: oldId});
+  }
+});
+
+print ('Update Audit logs to replace VIEW with CATEGORY');
+db.audits.find({event: /VIEW/}).forEach(audit => {
+  audit.event = audit.event.replace('VIEW', 'CATEGORY');
+  audit.properties.CATEGORY = audit.properties.VIEW;
+  delete audit.properties.VIEW;
+  db.audits.save(audit);
+});
+
+print ('Update events payloads');
+db.events.find({payload: /views/}).forEach( e => {
+    e.payload=e.payload.replace('"views"','"categories"');
+    db.events.save(e);
+});

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.10.1/1-upgrade-parameters-for-theme-console.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.10.1/1-upgrade-parameters-for-theme-console.js
@@ -1,0 +1,11 @@
+print('Update default theme logo in parameters');
+// Override this variable if you use prefix
+const prefix = '';
+
+const parameters = db.getCollection(`${prefix}parameters`);
+
+parameters.find({ '_id.key': 'theme.logo', 'value': 'themes/assets/GRAVITEE_LOGO1-01.png' }).forEach(parameter => {
+  parameter.value = 'themes/assets/gravitee-logo.svg';
+  parameters.save(parameter);
+  print('Default theme logo has been updated');
+});

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.10.1/1-upgrade-parameters-for-theme-console.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.10.1/1-upgrade-parameters-for-theme-console.js
@@ -6,6 +6,6 @@ const parameters = db.getCollection(`${prefix}parameters`);
 
 parameters.find({ '_id.key': 'theme.logo', 'value': 'themes/assets/GRAVITEE_LOGO1-01.png' }).forEach(parameter => {
   parameter.value = 'themes/assets/gravitee-logo.svg';
-  parameters.save(parameter);
+  parameters.replaceOne({ _id: parameter._id }, parameter);
   print('Default theme logo has been updated');
 });

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.11.1/1-event-debug-migration.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.11.1/1-event-debug-migration.js
@@ -7,7 +7,7 @@ const events = db.getCollection(`${prefix}events`);
 events.find({type: "DEBUG_API"}).forEach((event) => {
   if(event.properties.api_id) {
     delete event.properties.api_id;
-    events.save(event);
+    events.replaceOne({ _id: event.id }, event);
   }
 });
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.11.1/1-event-debug-migration.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.11.1/1-event-debug-migration.js
@@ -1,0 +1,14 @@
+print('Remove the `API_ID` property for events of type `DEBUG_API`');
+// Override this variable if you use prefix
+const prefix = '';
+
+const events = db.getCollection(`${prefix}events`);
+
+events.find({type: "DEBUG_API"}).forEach((event) => {
+  if(event.properties.api_id) {
+    delete event.properties.api_id;
+    events.save(event);
+  }
+});
+
+print('`DEBUG_API` has been updated');

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.12.0/api-keys-migration.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.12.0/api-keys-migration.js
@@ -10,7 +10,7 @@ keys.find({}).forEach((key) => {
     subscriptions.find({_id: key.subscription}).forEach((subscription) => {
         key.key = key._id;
         key.api = subscription.api;
-        keys.save(key);
+        keys.replaceOne({ _id: key._id }, key);
     });
 });
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.12.0/api-keys-migration.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.12.0/api-keys-migration.js
@@ -1,0 +1,21 @@
+// Override this variable if you use prefix
+const prefix = '';
+
+print(`Add 'key' and 'api' columns in 'keys' table`);
+
+const keys = db.getCollection(`${prefix}keys`);
+const subscriptions = db.getCollection(`${prefix}subscriptions`);
+
+keys.find({}).forEach((key) => {
+    subscriptions.find({_id: key.subscription}).forEach((subscription) => {
+        key.key = key._id;
+        key.api = subscription.api;
+        keys.save(key);
+    });
+});
+
+print(`Create new indexes in 'keys' table`);
+
+keys.createIndex( { "key" : 1 } );
+keys.createIndex( { "key" : 1, "api" : 1 } );
+keys.reIndex();

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.3.0/1-update-users-and-identityProviders.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.3.0/1-update-users-and-identityProviders.js
@@ -1,0 +1,27 @@
+print('In users collection, \'referenceId\' and \'referenceType\' are replaced with \'organizationId\'');
+db.users.find({}).forEach(user => {
+    if (!user.organizationId) {
+        const organizationId = user.referenceId;
+        db.users.updateOne(
+            { '_id': user._id },
+            {
+                $set: { 'organizationId': organizationId },
+                $unset: { 'referenceId': '', 'referenceType': '' }
+            }
+        );
+    }
+});
+
+print('In identity_providers collection, \'referenceId\' and \'referenceType\' are replaced with \'organizationId\'');
+db.identity_providers.find({}).forEach(idp => {
+    if (!idp.organizationId) {
+        const organizationId = idp.referenceId;
+        db.identity_providers.updateOne(
+            { '_id': idp._id },
+            {
+                $set: { 'organizationId': organizationId },
+                $unset: { 'referenceId': '', 'referenceType': '' }
+            }
+        );
+    }
+});

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.3.0/2-update-json-validation-policy-scopes.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.3.0/2-update-json-validation-policy-scopes.js
@@ -3,5 +3,5 @@ db.apis.find({ definition: /"json-validation" : {"scope":"REQUEST"|"json-validat
     api.definition = api.definition
         .replace(/"json-validation" : {"scope":"REQUEST"/, "\"json-validation\" : {\"scope\":\"REQUEST_CONTENT\"")
         .replace(/"json-validation" : {"scope":"RESPONSE"/, "\"json-validation\" : {\"scope\":\"RESPONSE_CONTENT\"");
-    db.apis.save(api);
+    db.apis.replaceOne({ _id: api._id }, api);
 });

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.3.0/2-update-json-validation-policy-scopes.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.3.0/2-update-json-validation-policy-scopes.js
@@ -1,0 +1,7 @@
+print('In apis collection, scopes of json-validation policy have to be changed from REQUEST/RESPONSE to REQUEST_CONTENT/RESPONSE_CONTENT');
+db.apis.find({ definition: /"json-validation" : {"scope":"REQUEST"|"json-validation" : {"scope":"RESPONSE"/}).forEach(api => {
+    api.definition = api.definition
+        .replace(/"json-validation" : {"scope":"REQUEST"/, "\"json-validation\" : {\"scope\":\"REQUEST_CONTENT\"")
+        .replace(/"json-validation" : {"scope":"RESPONSE"/, "\"json-validation\" : {\"scope\":\"RESPONSE_CONTENT\"");
+    db.apis.save(api);
+});

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.4.0/1-update-audit-to-replace-PORTAL-with_ORGANIZATION-and-ENVIRONMENT.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.4.0/1-update-audit-to-replace-PORTAL-with_ORGANIZATION-and-ENVIRONMENT.js
@@ -1,0 +1,47 @@
+print('In audits collection replace PORTAL with ENVIRONMENT or ORGANIZATION regarding audit type');
+const organizationFilter = { $or: [
+        { event: /^IDENTITY_PROVIDER/ },
+        { event: /^ROLE/ },
+        { event: /^USER/ },
+        { $and:[
+                {event: /^MEMBERSHIP/},
+                {patch: /"organization"/i}
+            ]}
+    ]};
+const environmentFilter = { $and: [
+        { event: { $not: /^IDENTITY_PROVIDER/ }},
+        { event: { $not: /^ROLE/ }},
+        { event: { $not: /^USER/ }},
+        { $or:[
+                {event: { $not: /^MEMBERSHIP/}},
+                {patch: { $not: /"organization"/i}}
+            ]}
+    ]};
+try {
+    const orgUpdateResult = db.audits.updateMany({
+        $and: [
+            { referenceType:'PORTAL' },
+            organizationFilter
+        ]}, { $set: { referenceType: "ORGANIZATION" } });
+    if (orgUpdateResult.matchedCount && orgUpdateResult.modifiedCount) {
+        print(`Successfully modified ${orgUpdateResult.modifiedCount} lines to ORGANIZATION.`)
+    } else {
+        print(`No audit has been modified to ORGANIZATION.`)
+    }
+} catch(e) {
+    print(`Error while updating audits to ORGANIZATION.\nError: ${e}`);
+}
+try {
+    const envUpdateResult = db.audits.updateMany({
+        $and: [
+            { referenceType:'PORTAL' },
+            environmentFilter
+        ]}, { $set: { referenceType: "ENVIRONMENT" } })
+    if (envUpdateResult.matchedCount && envUpdateResult.modifiedCount) {
+        print(`Successfully modified ${envUpdateResult.modifiedCount} lines to ENVIRONMENT.`)
+    } else {
+        print(`No audit has been modified to ENVIRONMENT.`)
+    }
+} catch(e) {
+    print(`Error while updating audits to ENVIRONMENT.\nError: ${e}`);
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.4.0/2-update-default-role-REVIEWER.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.4.0/2-update-default-role-REVIEWER.js
@@ -3,5 +3,5 @@ db.roles.find({ scope:'API', name:'REVIEWER'}).forEach(role => {
     let newPermissions = role.permissions.filter( p => p < 3000 || p > 3015);
     newPermissions.push(3014);
     role.permissions = newPermissions;
-    db.roles.save(role);
+    db.roles.replaceOne({ _id: role._id }, role);
 });

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.4.0/2-update-default-role-REVIEWER.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.4.0/2-update-default-role-REVIEWER.js
@@ -1,0 +1,7 @@
+print('Add new permissions to the default REVIEWER role');
+db.roles.find({ scope:'API', name:'REVIEWER'}).forEach(role => {
+    let newPermissions = role.permissions.filter( p => p < 3000 || p > 3015);
+    newPermissions.push(3014);
+    role.permissions = newPermissions;
+    db.roles.save(role);
+});

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.5.0/1-duplicate-some-parameters-for-console.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.5.0/1-duplicate-some-parameters-for-console.js
@@ -1,0 +1,58 @@
+const duplicatedKeysForConsole = [
+    'authentication.localLogin.enabled',
+    'portal.support.enabled',
+    'portal.userCreation.enabled',
+    'portal.userCreation.automaticValidation.enabled',
+    'scheduler.tasks',
+    'scheduler.notifications',
+    'reCaptcha.enabled',
+    'reCaptcha.siteKey',
+    'http.cors.allow-origin',
+    'http.cors.allow-headers',
+    'http.cors.allow-methods',
+    'http.cors.exposed-headers',
+    'http.cors.max-age'
+];
+
+print('In parameters collection duplicate some key for authentication, recaptcha, schedulers and cors, and change the _id to add refId/refType');
+db.parameters.find({ referenceId: { $exists: true }}).forEach(parameter => {
+    if (duplicatedKeysForConsole.includes(parameter._id)) {
+        const consoleParameterKey = parameter._id.startsWith('portal') ? parameter._id.replace('portal', 'console') : 'console.' + parameter._id;
+        const consoleParameter = {
+            _id: {
+                key: consoleParameterKey,
+                referenceId: 'DEFAULT',
+                referenceType: 'ORGANIZATION',
+            },
+            value: parameter.value
+        }
+        db.parameters.save(consoleParameter);
+        print('Console parameter created: ' + consoleParameterKey);
+    }
+
+    let portalParameter = {};
+    if (duplicatedKeysForConsole.includes(parameter._id) || parameter._id === 'authentication.forceLogin.enabled') {
+        const portalParameterKey = parameter._id.startsWith('portal') ? parameter._id : 'portal.' + parameter._id;
+        portalParameter = {
+            _id: {
+                key: portalParameterKey,
+                referenceId: parameter.referenceId,
+                referenceType: parameter.referenceType,
+            },
+            value: parameter.value
+        }
+    } else {
+        portalParameter = {
+            _id: {
+                key: parameter._id,
+                referenceId: parameter.referenceId,
+                referenceType: parameter.referenceType,
+            },
+            value: parameter.value
+        }
+    }
+    db.parameters.save(portalParameter);
+    db.parameters.remove(parameter);
+
+    print('Portal parameter key updated: ' + portalParameter._id.key);
+});

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.5.0/1-duplicate-some-parameters-for-console.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.5.0/1-duplicate-some-parameters-for-console.js
@@ -26,7 +26,7 @@ db.parameters.find({ referenceId: { $exists: true }}).forEach(parameter => {
             },
             value: parameter.value
         }
-        db.parameters.save(consoleParameter);
+        db.parameters.insertOne(consoleParameter);
         print('Console parameter created: ' + consoleParameterKey);
     }
 
@@ -51,7 +51,7 @@ db.parameters.find({ referenceId: { $exists: true }}).forEach(parameter => {
             value: parameter.value
         }
     }
-    db.parameters.save(portalParameter);
+    db.parameters.insertOne(portalParameter);
     db.parameters.remove(parameter);
 
     print('Portal parameter key updated: ' + portalParameter._id.key);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.5.14/1-fix-cors-env-vars.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.5.14/1-fix-cors-env-vars.js
@@ -1,0 +1,31 @@
+const duplicatedKeysForConsole = [
+    'portal.http.cors.allow-origin',
+    'portal.http.cors.allow-headers',
+    'portal.http.cors.allow-methods',
+    'portal.http.cors.exposed-headers',
+    'portal.http.cors.max-age',
+    'console.http.cors.allow-origin',
+    'console.http.cors.allow-headers',
+    'console.http.cors.allow-methods',
+    'console.http.cors.exposed-headers',
+    'console.http.cors.max-age'
+];
+
+print('Rename portal/console CORS parameters');
+db.parameters.find({ '_id.referenceId': { $exists: true }}).forEach(parameter => {
+    if (duplicatedKeysForConsole.includes(parameter._id.key)) {
+        const parameterKey = parameter._id.key.replace('portal.http.cors', 'http.api.portal.cors')
+            .replace('console.http.cors', 'http.api.management.cors');
+        const parameterUpdated = {
+            _id: {
+                key: parameterKey,
+                referenceId: parameter._id.referenceId,
+                referenceType: parameter._id.referenceType,
+            },
+            value: parameter.value
+        }
+        db.parameters.save(parameterUpdated);
+        print('Parameter created: ' + parameterKey);
+        db.parameters.remove(parameter);
+    }
+});

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.5.14/1-fix-cors-env-vars.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.5.14/1-fix-cors-env-vars.js
@@ -24,7 +24,7 @@ db.parameters.find({ '_id.referenceId': { $exists: true }}).forEach(parameter =>
             },
             value: parameter.value
         }
-        db.parameters.save(parameterUpdated);
+        db.parameters.insertOne(parameterUpdated);
         print('Parameter created: ' + parameterKey);
         db.parameters.remove(parameter);
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.5.2/1-add-DEFAULT-referenceId-in-memberships.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.5.2/1-add-DEFAULT-referenceId-in-memberships.js
@@ -1,0 +1,12 @@
+print('Use DEFAULT in memberhips with null referenceId');
+
+try {
+    let refUpdateResult = db.memberships.updateMany({ referenceId: null, referenceType: "ENVIRONMENT" }, { $set: { referenceId: "DEFAULT" }});
+    if (refUpdateResult.matchedCount && refUpdateResult.modifiedCount) {
+        print(`Successfully modified ${refUpdateResult.modifiedCount} memberships referenceId to DEFAULT.`)
+    } else {
+        print(`No memberships referenceId has been modified to DEFAULT.`)
+    }
+} catch(e) {
+    print(`Error while updating memberships referenceId to DEFAULT.\nError: ${e}`);
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.7.0/1-rename-collections-with-prefix.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.7.0/1-rename-collections-with-prefix.js
@@ -1,0 +1,63 @@
+print('Add a prefix to all collections');
+
+const collections = [
+    'apiqualityrules',
+    'applications',
+    'keys',
+    'identity_provider_activations',
+    'users',
+    'tickets',
+    'genericnotificationconfigs',
+    'workflows',
+    'environments',
+    'invitations',
+    'client_registration_providers',
+    'page_revisions',
+    'ratingAnswers',
+    'apis',
+    'rating',
+    'themes',
+    'metadata',
+    'alert_triggers',
+    'parameters',
+    'dashboards',
+    'events',
+    'identity_providers',
+    'audits',
+    'categories',
+    'tenants',
+    'portalnotifications',
+    'custom_user_fields',
+    'alert_events',
+    'roles',
+    'entrypoints',
+    'metadatas',
+    'memberships',
+    'dictionaries',
+    'qualityrules',
+    'pages',
+    'groups',
+    'portalnotificationconfigs',
+    'installation',
+    'notificationTemplates',
+    'commands',
+    'tokens',
+    'apiheaders',
+    'plans',
+    'tags',
+    'subscriptions',
+    'organizations',
+];
+
+try {
+    // Use your prefix here
+    const prefix = "";
+    const rateLimitPrefix = "";
+    collections.forEach(collectionName => {
+        db.getCollection(collectionName).renameCollection(`${prefix}${collectionName}`);
+    })
+
+    db.ratelimit.renameCollection(`${rateLimitPrefix}ratelimit`);
+} catch(e) {
+    print(`Error while renaming collection.\nError: ${e}`);
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.8.0/1-page-acl-migration.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.8.0/1-page-acl-migration.js
@@ -1,0 +1,14 @@
+print('Migrate excluded_groups of Pages to new ACL format');
+// Override this variable if you use prefix
+const prefix = '';
+
+const pages = db.getCollection(`${prefix}pages`);
+
+pages.find({ excluded_groups: { $exists: true, $not: { $size: 0 } } }).forEach((page) => {
+    page.visibility = 'PRIVATE';
+    page.excludedAccessControls = true;
+    page.accessControls = page.excluded_groups.map((referenceId) => ({ referenceId, referenceType: 'GROUP' }));
+    delete page.excluded_groups;
+    pages.save(page);
+  }
+);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.8.0/1-page-acl-migration.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.8.0/1-page-acl-migration.js
@@ -9,6 +9,6 @@ pages.find({ excluded_groups: { $exists: true, $not: { $size: 0 } } }).forEach((
     page.excludedAccessControls = true;
     page.accessControls = page.excluded_groups.map((referenceId) => ({ referenceId, referenceType: 'GROUP' }));
     delete page.excluded_groups;
-    pages.save(page);
+    pages.replaceOne({ _id: page._id }, page);
   }
 );

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.9.0/1-tags-and-tenants-migration.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.9.0/1-tags-and-tenants-migration.js
@@ -1,0 +1,33 @@
+print('Migrate tags, tenants and entrypoints to reference DEFAULT organization');
+// Override this variable if you use prefix
+const prefix = '';
+
+const tags = db.getCollection(`${prefix}tags`);
+
+tags.find({referenceId: {$exists: false}}).forEach((tag) => {
+        tag.referenceId = 'DEFAULT';
+        tag.referenceType = 'ORGANIZATION';
+        tags.save(tag);
+    }
+);
+
+const tenants = db.getCollection(`${prefix}tenants`);
+
+tenants.find({referenceId: {$exists: false}}).forEach((tenant) => {
+        tenant.referenceId = 'DEFAULT';
+        tenant.referenceType = 'ORGANIZATION';
+        tenants.save(tenant);
+    }
+);
+
+const entrypoints = db.getCollection(`${prefix}entrypoints`);
+
+entrypoints.find({}).forEach(entrypoint => {
+    db.getCollection(`${prefix}environments`).find({'_id': entrypoint.environmentId}).forEach(env => {
+        entrypoint.referenceId = env.organizationId;
+        entrypoint.referenceType = 'ORGANIZATION';
+        delete entrypoint.environmentId;
+        entrypoints.save(entrypoint);
+    });
+
+})

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.9.0/1-tags-and-tenants-migration.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.9.0/1-tags-and-tenants-migration.js
@@ -7,7 +7,7 @@ const tags = db.getCollection(`${prefix}tags`);
 tags.find({referenceId: {$exists: false}}).forEach((tag) => {
         tag.referenceId = 'DEFAULT';
         tag.referenceType = 'ORGANIZATION';
-        tags.save(tag);
+        tags.replaceOne({ _id: tag._id }, tag);
     }
 );
 
@@ -16,7 +16,7 @@ const tenants = db.getCollection(`${prefix}tenants`);
 tenants.find({referenceId: {$exists: false}}).forEach((tenant) => {
         tenant.referenceId = 'DEFAULT';
         tenant.referenceType = 'ORGANIZATION';
-        tenants.save(tenant);
+        tenants.replaceOne({ _id: tenant._id }, tenant);
     }
 );
 
@@ -27,7 +27,7 @@ entrypoints.find({}).forEach(entrypoint => {
         entrypoint.referenceId = env.organizationId;
         entrypoint.referenceType = 'ORGANIZATION';
         delete entrypoint.environmentId;
-        entrypoints.save(entrypoint);
+        entrypoints.replaceOne({ _id: entrypoint._id }, entrypoint);
     });
 
 })

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.9.0/2-events-migration.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.9.0/2-events-migration.js
@@ -7,6 +7,6 @@ const events = db.getCollection(`${prefix}events`);
 events.find({environments: {$exists: false}}).forEach((event) => {
         event.environments = [event.environmentId];
         delete event.environmentId;
-        events.save(event);
+        events.replaceOne({ _id: event.id }, event);
     }
 );

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.9.0/2-events-migration.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.9.0/2-events-migration.js
@@ -1,0 +1,12 @@
+print('Migrate events to reference multiple environments');
+// Override this variable if you use prefix
+const prefix = '';
+
+const events = db.getCollection(`${prefix}events`);
+
+events.find({environments: {$exists: false}}).forEach((event) => {
+        event.environments = [event.environmentId];
+        delete event.environmentId;
+        events.save(event);
+    }
+);


### PR DESCRIPTION
 - In the process of moving the upgrade guide to gravitee-docs, mongodb scripts have moved from release to this repository

see https://github.com/gravitee-io/issues/issues/7041
see https://github.com/gravitee-io/gravitee-docs/pull/704

- mongodb migration scripts have been updated to stop using the deprecated `collection.save` method

see https://github.com/gravitee-io/issues/issues/6260

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-aeedklhkhu.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/chore-move-upgrade-guide/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
