### PR TITLE
Add some coverage exclusion rules in SonarCloud config

### DIFF
--- a/gravitee-apim-gateway/sonar-project.properties
+++ b/gravitee-apim-gateway/sonar-project.properties
@@ -13,7 +13,10 @@ sonar.java.binaries=**/target/**
 # Source encoding
 sonar.sourceEncoding=UTF-8
 
-# Coverage
+# Test
 sonar.test=.
 sonar.test.inclusions=**/*Test.java
+
+# Coverage
 sonar.coverage.jacoco.xmlReportPaths=gravitee-apim-gateway-coverage/target/site/jacoco-aggregate/jacoco.xml
+sonar.coverage.exclusions=**/target/**, **/pom.xml

--- a/gravitee-apim-repository/sonar-project.properties
+++ b/gravitee-apim-repository/sonar-project.properties
@@ -13,7 +13,10 @@ sonar.java.binaries=**/target/**
 # Source encoding
 sonar.sourceEncoding=UTF-8
 
-# Coverage
+# Test
 sonar.test=.
 sonar.test.inclusions=**/*Test.java
+
+# Coverage
 sonar.coverage.jacoco.xmlReportPaths=gravitee-apim-repository-coverage/target/site/jacoco-aggregate/jacoco.xml
+sonar.coverage.exclusions=**/target/**, **/pom.xml, gravitee-apim-repository-test/**

--- a/gravitee-apim-rest-api/sonar-project.properties
+++ b/gravitee-apim-rest-api/sonar-project.properties
@@ -13,7 +13,10 @@ sonar.java.binaries=**/target/**
 # Source encoding
 sonar.sourceEncoding=UTF-8
 
-# Coverage
+# Test
 sonar.test=.
 sonar.test.inclusions=**/*Test.java
+
+# Coverage
 sonar.coverage.jacoco.xmlReportPaths=gravitee-apim-rest-api-coverage/target/site/jacoco-aggregate/jacoco.xml
+sonar.coverage.exclusions=**/target/**, **/pom.xml


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6779

**Description**

With the first setup done for SonarCloud we end up with irrelevant coverage info as the `coverage` maven module looks to contain all the code of the other modules. Which is totally false as this module is empty, so I added it to the exclusion list: 
![image](https://user-images.githubusercontent.com/4112568/159326113-bce3ad11-bc89-49b0-9c02-69cfa3659b8a.png)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-izfrqvyuju.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6779-tune-sonarcloud-config/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
