### PR TITLE
Cicd/3.15.x secrethub to keeper

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
     slack: circleci/slack@4.4.4
     gravitee: gravitee-io/gravitee@1.0.44
-    secrethub: secrethub/cli@1.1.0
+    keeper: gravitee-io/keeper@0.6.0
     gh: circleci/github-cli@1.0.5
     aws-cli: circleci/aws-cli@2.0.6
 
@@ -86,13 +86,13 @@ commands:
     prepare-gpg:
         description: Prepare GPG command
         steps:
-            - secrethub/install
+            - keeper/install
             - run:
                   command: |
-                      secrethub read graviteeio/cicd/graviteebot/gpg/armor_format_pub_key -o pub.key
+                      ksm secret notation keeper://u2dz7IP-w9E0NKsUeyCAYA/custom_field/public_key -o pub.key
                       gpg --import pub.key
 
-                      secrethub read graviteeio/cicd/graviteebot/gpg/armor_format_private_key -o private.key
+                      ksm secret notation keeper://u2dz7IP-w9E0NKsUeyCAYA/custom_field/private_key -o private.key
                       # Need --batch to be able to import private key
                       gpg --import --batch private.key
     prepare-tar-for-s3-glacier:
@@ -152,10 +152,9 @@ jobs:
     load-snapshot-configuration:
         docker:
             - image: cimg/base:stable
-        environment:
-            MAVEN_SETTINGS: "secrethub://graviteeio/cicd/graviteebot/infra/maven/gravitee-snapshot.settings.xml"
         steps:
-            - secrethub/exec:
+            - run:
+                  name: Store maven settings env variable in a file
                   command: echo $MAVEN_SETTINGS > /tmp/.gravitee-snapshot.settings.xml
             - persist_to_workspace:
                   root: /tmp
@@ -219,9 +218,10 @@ jobs:
             - checkout
             - attach_workspace:
                   at: .
-            - secrethub/env-export:
-                  secret-path: graviteeio/cicd/graviteebot/infra/sonarcloud.io.token
+            - keeper/env-export:
+                  secret-url: keeper://9x9YgyU6DWzux4DPoHAzDQ/field/password
                   var-name: SONAR_TOKEN
+            - get-apim-version
             - run:
                   name: Run Sonarcloud Analysis
                   command: sonar-scanner
@@ -569,11 +569,12 @@ jobs:
             - checkout
             - attach_workspace:
                   at: .
-            - secrethub/exec:
-                  step-name: Running Chromatic
+            - run:
+                  name: Running Chromatic
                   # TODO:
                   #  - Handle npx chromatic command failure, make the job fails
                   #  - Create a new project in Chromatic and update the token
+                  #  - Move CHROMATIC_PROJECT_TOKEN token in keeper instead of env var
                   command: |
                       SB_URL=$(cd gravitee-apim-console-webui && npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --exit-once-uploaded -d=storybook-static | grep -o "View your Storybook at https:\/\/[0-9a-z-]*\.chromatic\.com" | grep -o "https:.*")
                       echo "export SB_URL=$SB_URL" >> $BASH_ENV
@@ -908,7 +909,6 @@ jobs:
         steps:
             - setup_remote_docker
             - checkout
-            - secrethub/install
             - run:
                   name: "Parse GRAVITEEIO_VERSION to extract major, minor and patch version"
                   command: |
@@ -982,6 +982,10 @@ workflows:
         jobs:
             - load-snapshot-configuration:
                   context: cicd-orchestrator
+                  pre-steps:
+                      - keeper/env-export:
+                            secret-url: keeper://zy9yQmXus2_LRA0lkydEkw/custom_field/xml
+                            var-name: MAVEN_SETTINGS
             - compute-apim-tag:
                   requires:
                       - load-snapshot-configuration
@@ -1030,11 +1034,11 @@ workflows:
                   requires:
                       - test
                   pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/username
+                      - keeper/env-export:
+                            secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
                             var-name: AZURE_DOCKER_REGISTRY_USERNAME
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/password
+                      - keeper/env-export:
+                            secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
                             var-name: AZURE_DOCKER_REGISTRY_PASSWORD
                   filters:
                       branches:
@@ -1059,8 +1063,8 @@ workflows:
                   requires:
                       - console-webui-build-storybook
                   pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/github_personal_access_token
+                      - keeper/env-export:
+                            secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
                             var-name: GITHUB_TOKEN
             - webui-build:
                   name: Build APIM Console
@@ -1070,22 +1074,22 @@ workflows:
             - console-webui-deploy-on-azure-storage:
                   context: cicd-orchestrator
                   pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/application-id
+                      - keeper/env-export:
+                            secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
                             var-name: AZURE_APPLICATION_ID
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/tenant
+                      - keeper/env-export:
+                            secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
                             var-name: AZURE_TENANT
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/application-secret
+                      - keeper/env-export:
+                            secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
                             var-name: AZURE_APPLICATION_SECRET
                   requires:
                       - Build APIM Console
             - console-webui-comment-pr-after-deployment:
                   context: cicd-orchestrator
                   pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/github_personal_access_token
+                      - keeper/env-export:
+                            secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
                             var-name: GITHUB_TOKEN
                   requires:
                       - console-webui-deploy-on-azure-storage
@@ -1095,11 +1099,11 @@ workflows:
                   docker-image-name: apim-management-ui
                   context: cicd-orchestrator
                   pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/username
+                      - keeper/env-export:
+                            secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
                             var-name: AZURE_DOCKER_REGISTRY_USERNAME
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/password
+                      - keeper/env-export:
+                            secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
                             var-name: AZURE_DOCKER_REGISTRY_PASSWORD
                   requires:
                       - Build APIM Console
@@ -1142,11 +1146,11 @@ workflows:
                   docker-image-name: apim-portal-ui
                   context: cicd-orchestrator
                   pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/username
+                      - keeper/env-export:
+                            secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/login
                             var-name: AZURE_DOCKER_REGISTRY_USERNAME
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/password
+                      - keeper/env-export:
+                            secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
                             var-name: AZURE_DOCKER_REGISTRY_PASSWORD
                   requires:
                       - Build APIM Portal
@@ -1159,14 +1163,14 @@ workflows:
             - deploy-on-azure-cluster:
                   context: cicd-orchestrator
                   pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/application-id
+                      - keeper/env-export:
+                            secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/login
                             var-name: AZURE_APPLICATION_ID
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/tenant
+                      - keeper/env-export:
+                            secret-url: keeper://UryantA7MvZe8fkWwcUt8g/custom_field/tenant
                             var-name: AZURE_TENANT
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/azure/application-secret
+                      - keeper/env-export:
+                            secret-url: keeper://UryantA7MvZe8fkWwcUt8g/field/password
                             var-name: AZURE_APPLICATION_SECRET
                   requires:
                       - publish-images-azure-registry
@@ -1197,11 +1201,11 @@ workflows:
                   context: cicd-orchestrator
                   name: Build and push docker images for APIM CE << pipeline.parameters.graviteeio_version >><<# pipeline.parameters.dry_run >> - Dry Run<</ pipeline.parameters.dry_run >>
                   pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-name
+                      - keeper/env-export:
+                            secret-url: keeper://cooU9UoXIk8Kj0hsP2rkBw/field/login
                             var-name: DOCKERHUB_BOT_USER_NAME
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-token
+                      - keeper/env-export:
+                            secret-url: keeper://cooU9UoXIk8Kj0hsP2rkBw/field/password
                             var-name: DOCKERHUB_BOT_USER_TOKEN
             - publish_prod_docker_images:
                   graviteeio_version: << pipeline.parameters.graviteeio_version >>
@@ -1211,11 +1215,11 @@ workflows:
                   context: cicd-orchestrator
                   name: Build and push docker images for APIM EE << pipeline.parameters.graviteeio_version >><<# pipeline.parameters.dry_run >> - Dry Run<</ pipeline.parameters.dry_run >>
                   pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-name
+                      - keeper/env-export:
+                            secret-url: keeper://cooU9UoXIk8Kj0hsP2rkBw/field/login
                             var-name: DOCKERHUB_BOT_USER_NAME
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-token
+                      - keeper/env-export:
+                            secret-url: keeper://cooU9UoXIk8Kj0hsP2rkBw/field/password
                             var-name: DOCKERHUB_BOT_USER_TOKEN
     release:
         when:
@@ -1232,22 +1236,22 @@ workflows:
                       - prepare-settings
                   context: cicd-orchestrator
                   pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/git/user/name
+                      - keeper/env-export:
+                            secret-url: keeper://IZd-yvsMopfQEa_0j1SDvg/field/login
                             var-name: GIT_USER_NAME
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/git/user/email
+                      - keeper/env-export:
+                            secret-url: keeper://IZd-yvsMopfQEa_0j1SDvg/custom_field/email
                             var-name: GIT_USER_EMAIL
             - nexus-staging-prepare-component:
                   requires:
                       - release
                   context: cicd-orchestrator
                   pre-steps:
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/infra/zip-bundle-server/clever-cloud-s3/s3cmd/aws_access_key
+                      - keeper/env-export:
+                            secret-url: keeper://Mqmplmfu17bDR5XRLmO1mQ/field/password
                             var-name: AWS_ACCESS_KEY_ID
-                      - secrethub/env-export:
-                            secret-path: graviteeio/cicd/graviteebot/infra/zip-bundle-server/clever-cloud-s3/s3cmd/aws_secret_key
+                      - keeper/env-export:
+                            secret-url: keeper://3-pU56sIqcyWWw7HxhxjaQ/field/password
                             var-name: AWS_SECRET_ACCESS_KEY
     # ---
     # CICD Workflow For APIM Orchestrated Nexus Staging, Container-based : Circle CI Docker Executor


### PR DESCRIPTION
This PR is created in purpose of migrating the secrets retrieving from the keeper CLI as secrethub will be soon migrated to 1password secrets management,

New keeper orb is developped, and it works the same way as the secrethub orb, so the changes in this PR are mostly replacement of secrethub with keeper

Keeper orb link : https://github.com/gravitee-io/keeper-circleci-orb/tree/v0.5.0

CCI Pipeline link : https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/5425/workflows/e533e098-b0d0-44bc-a834-fa34380478e4
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-toqwzabhlb.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/cicd-3-15-x-secrethub-to-keeper/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
