### PR TITLE
feat(bridge): deprecate and replace bridge server /keys/_search endpoint

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/task/ApiKeyRefresher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/task/ApiKeyRefresher.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.services.sync.cache.task;
 
 import static io.gravitee.repository.management.model.Subscription.Status.ACCEPTED;
+import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.*;
 
 import io.gravitee.gateway.handlers.api.definition.ApiKey;
@@ -25,7 +26,10 @@ import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.api.SubscriptionRepository;
 import io.gravitee.repository.management.api.search.ApiKeyCriteria;
 import io.gravitee.repository.management.model.Subscription;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -79,8 +83,11 @@ public abstract class ApiKeyRefresher implements Callable<Result<Boolean>> {
 
     private List<ApiKey> findApiKeys(ApiKeyCriteria criteria) throws TechnicalException {
         List<io.gravitee.repository.management.model.ApiKey> apiKeys = apiKeyRepository.findByCriteria(criteria);
-        Map<String, Subscription> subscriptionsById = findSubscriptions(apiKeys);
+        if (apiKeys.isEmpty()) {
+            return emptyList();
+        }
 
+        Map<String, Subscription> subscriptionsById = findSubscriptions(apiKeys);
         return apiKeys.stream().flatMap(apiKey -> this.getApiKeysDefinitionsFromModel(apiKey, subscriptionsById)).collect(toList());
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApiKeyRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApiKeyRepository.java
@@ -69,7 +69,7 @@ public class HttpApiKeyRepository extends AbstractRepository implements ApiKeyRe
 
     @Override
     public List<ApiKey> findByCriteria(ApiKeyCriteria filter) throws TechnicalException {
-        return blockingGet(post("/keys/_search", BodyCodecs.list(ApiKey.class)).send(filter)).payload();
+        return blockingGet(post("/keys/_findByCriteria", BodyCodecs.list(ApiKey.class)).send(filter)).payload();
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpSubscriptionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpSubscriptionRepository.java
@@ -22,6 +22,8 @@ import io.gravitee.repository.management.api.SubscriptionRepository;
 import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.repository.management.model.Environment;
 import io.gravitee.repository.management.model.Subscription;
 import java.util.Collection;
 import java.util.List;
@@ -83,7 +85,7 @@ public class HttpSubscriptionRepository extends AbstractRepository implements Su
     }
 
     @Override
-    public List<Subscription> findByIdIn(Collection<String> ids) {
-        throw new IllegalStateException();
+    public List<Subscription> findByIdIn(Collection<String> ids) throws TechnicalException {
+        return blockingGet(post("/subscriptions/_findByIds", BodyCodecs.list(Subscription.class)).send(ids)).payload();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/BridgeService.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/BridgeService.java
@@ -133,7 +133,8 @@ public class BridgeService extends AbstractService {
             // API Keys handler
             ApiKeysHandler apiKeysHandler = new ApiKeysHandler();
             applicationContext.getAutowireCapableBeanFactory().autowireBean(apiKeysHandler);
-            bridgeRouter.post("/keys/_search").handler(apiKeysHandler::findByCriteria);
+            bridgeRouter.post("/keys/_findByCriteria").handler(apiKeysHandler::findByCriteria);
+            bridgeRouter.post("/keys/_search").handler(apiKeysHandler::search);
             bridgeRouter.get("/apis/:apiId/keys/:key").handler(apiKeysHandler::findByKeyAndApi);
 
             // Subscriptions handler

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/BridgeService.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/BridgeService.java
@@ -141,6 +141,7 @@ public class BridgeService extends AbstractService {
             SubscriptionsHandler subscriptionsHandler = new SubscriptionsHandler();
             applicationContext.getAutowireCapableBeanFactory().autowireBean(subscriptionsHandler);
             bridgeRouter.post("/subscriptions/_search").handler(subscriptionsHandler::search);
+            bridgeRouter.post("/subscriptions/_findByIds").handler(subscriptionsHandler::findByIds);
 
             // Events handler
             EventsHandler eventsHandler = new EventsHandler();

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/test/java/io/gravitee/repository/bridge/server/handler/SubscriptionsHandlerTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/test/java/io/gravitee/repository/bridge/server/handler/SubscriptionsHandlerTest.java
@@ -1,0 +1,167 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.bridge.server.handler;
+
+import static org.mockito.Mockito.when;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.SubscriptionRepository;
+import io.gravitee.repository.management.model.Subscription;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
+import io.vertx.ext.web.client.predicate.ResponsePredicate;
+import io.vertx.ext.web.codec.BodyCodec;
+import io.vertx.ext.web.handler.BodyHandler;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * @author GraviteeSource Team
+ */
+@RunWith(VertxUnitRunner.class)
+public class SubscriptionsHandlerTest {
+
+    @Mock
+    private SubscriptionRepository subscriptionRepository;
+
+    @InjectMocks
+    private final SubscriptionsHandler subscriptionsHandler = new SubscriptionsHandler();
+
+    private WebClient client;
+    private Vertx vertx;
+
+    @Before
+    public void setUp(TestContext context) throws Exception {
+        MockitoAnnotations.openMocks(this);
+
+        vertx = Vertx.vertx();
+        Router router = Router.router(vertx);
+
+        router.route().handler(BodyHandler.create());
+        router.post("/_findByIds").handler(subscriptionsHandler::findByIds);
+
+        int port = getRandomPort();
+
+        client = WebClient.create(vertx, new WebClientOptions().setDefaultHost("localhost").setDefaultPort(port));
+
+        vertx.deployVerticle(
+            new AbstractVerticle() {
+                @Override
+                public void start() {
+                    vertx.createHttpServer().requestHandler(router).listen(port);
+                }
+            },
+            context.asyncAssertSuccess()
+        );
+    }
+
+    @After
+    public void tearDown(TestContext context) {
+        vertx.close(context.asyncAssertSuccess());
+    }
+
+    @Test
+    public void findByIds_should_return_subscription_list(TestContext context) throws TechnicalException {
+        when(subscriptionRepository.findByIdIn(List.of("id1", "idX", "id4")))
+            .thenReturn(List.of(buildSubscription("sub-id1"), buildSubscription("sub-idX"), buildSubscription("sub-id4")));
+
+        Async async = context.async();
+
+        client
+            .post("/_findByIds")
+            .expect(ResponsePredicate.SC_OK)
+            .expect(ResponsePredicate.JSON)
+            .as(BodyCodec.jsonArray())
+            .sendJson(List.of("id1", "idX", "id4"))
+            .onSuccess(
+                response -> {
+                    JsonArray responseBody = response.body();
+                    context.assertEquals(3, responseBody.size());
+                    context.assertEquals("sub-id1", responseBody.getJsonObject(0).getString("id"));
+                    context.assertEquals("sub-idX", responseBody.getJsonObject(1).getString("id"));
+                    context.assertEquals("sub-id4", responseBody.getJsonObject(2).getString("id"));
+                    async.complete();
+                }
+            )
+            .onFailure(
+                err -> {
+                    context.fail(err);
+                    async.complete();
+                }
+            );
+    }
+
+    @Test
+    public void findByIds_with_empty_id_list_returns_http_500_server_error(TestContext context) {
+        Async async = context.async();
+
+        client
+            .post("/_findByIds")
+            .expect(ResponsePredicate.SC_INTERNAL_SERVER_ERROR)
+            .sendJson(List.of())
+            .onSuccess(response -> async.complete())
+            .onFailure(
+                err -> {
+                    context.fail(err);
+                    async.complete();
+                }
+            );
+    }
+
+    @Test
+    public void findByIds_without_id_list_returns_http_500_server_error(TestContext context) {
+        Async async = context.async();
+        client
+            .post("/_findByIds")
+            .expect(ResponsePredicate.SC_INTERNAL_SERVER_ERROR)
+            .send()
+            .onSuccess(response -> async.complete())
+            .onFailure(
+                err -> {
+                    context.fail(err);
+                    async.complete();
+                }
+            );
+    }
+
+    private int getRandomPort() throws IOException {
+        ServerSocket socket = new ServerSocket(0);
+        int port = socket.getLocalPort();
+        socket.close();
+        return port;
+    }
+
+    private Subscription buildSubscription(String id) {
+        Subscription subscription = new Subscription();
+        subscription.setId(id);
+        return subscription;
+    }
+}


### PR DESCRIPTION
feat(bridge): deprecate and replace bridge server /keys/_search endpoint

On gateway bridge server side, /keys/_search endpoint is deprecated.
We keep it to ensure 0 downtime during Gravitee migration, running with a 3.16 client and a 3.17 server.

In 3.17, it's replaced with /keys/_findByCriteria, so, HttpApiKeyRepository calls this new route

--

feat: prevent ApiKeyRefresher for doing useless database reads

When there is no ApiKey retreived from repository, there is no need to read associated subscriptions

-- 

feat(bridge): implement HttpSubscriptionRepository.findByIds in bridge server

Cause it is used by gateway's ApiKeyRefresher



<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-egohfpphzc.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/feat-sharedapikey-bridge-deprecated-endpoint/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
