### PR TITLE
chore: add mongo upgrade template to script dir

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/mongo-upgrade-template.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/mongo-upgrade-template.js
@@ -1,0 +1,7 @@
+print('Title of the upgrade operation');
+// Override this variable if you use prefix
+const prefix = "";
+
+// ... your instructions goes here
+// You can access a collection with
+db.getCollection(`${prefix}myCollection`)


### PR DESCRIPTION
This file was forgotten while moving the scripts from release

see https://github.com/gravitee-io/issues/issues/7041

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xitdrqzbcm.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/chore-add-mongo-upgrade-template/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
