### PR TITLE
docs: add comment for the usage of mysql connector in tests - 3.17.x

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
@@ -154,6 +154,11 @@
             <scope>test</scope>
         </dependency>
 
+        <!--
+          Gravitee only uses this dependency to test the connectivity to MySQL databases
+          and does not supply or bundle the mysql-connector-java in the software as per the license in:
+            https://github.com/mysql/mysql-connector-j/blob/release/8.0/LICENSE
+        -->
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7370

**Description**

Add a comment for the usage of mysql connector in tests
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-odifrmsoxr.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7370-add-comment-for-mysql-connector-usage-3-17-x/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
