### PR TITLE
Fix platform policies in multi environments context

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/openapi.yaml
@@ -10,7 +10,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0
-  version: "3.16.1"
+  version: "3.16.2-SNAPSHOT"
 servers:
   - url: http://localhost:8083/portal/environments/{envId}
     description: The portal API for a given environment


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7379

**Description**

Previously a call to `GraviteeContext.getCurrentEnvironment()` was used to set the environment ids when creating a PUBLISH_ORGANIZATION event.

Sadly, this method was called in some context where the current env was `null`, resulting in a weird: `"environments": [null]` attributes.

Everything was working fine on the gateway side if no `environments` env var was provided. Otherwise, the PUBLISH_ORGANIZATION event was never retrieved from the DB and so the Organization info never synchronized.

The current implementation now fetches all the envs of the organization being updated to be sure the event contains relevant information

In this commit, I also added a unit test on the repository side to ensure the same behavior across DB when querying events with an empty env list.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uxebscqxme.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-platform-policies/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
