### PR TITLE
fix: display content policies returning null stream in debug mode

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/policy/impl/PolicyDebugDecorator.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/policy/impl/PolicyDebugDecorator.java
@@ -77,10 +77,10 @@ public class PolicyDebugDecorator implements Policy {
         final DebugPolicyChain debugPolicyChain = new DebugStreamablePolicyChain(chain, debugStep, debugContext);
 
         try {
-            final ReadWriteStream<Buffer> stream = policy.stream(debugPolicyChain, context);
+            ReadWriteStream<Buffer> stream = policy.stream(debugPolicyChain, context);
 
             if (stream == null) {
-                return null;
+                debugContext.saveNoTransformationDebugStep(debugStep);
             }
 
             return new DebugReadWriteStream(debugContext, stream, debugStep);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/handler/context/DebugExecutionContext.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/handler/context/DebugExecutionContext.java
@@ -57,6 +57,17 @@ public class DebugExecutionContext implements MutableExecutionContext {
         return initialAttributes;
     }
 
+    /**
+     * Some streamable policies returns null when a condition is not fulfilled as a fail-fast strategy.
+     * This method allows to save the debug step as a regular one, with the {@link io.gravitee.definition.model.debug.DebugStepStatus#NO_TRANSFORMATION} status
+     * @param debugStep, the debug step to save
+     */
+    public void saveNoTransformationDebugStep(DebugStep<?> debugStep) {
+        debugStep.noTransformation();
+        beforePolicyExecution(debugStep);
+        afterPolicyExecution(debugStep);
+    }
+
     public void beforePolicyExecution(DebugStep<?> debugStep) {
         if (!steps.contains(debugStep)) {
             steps.add(debugStep);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/handler/context/steps/DebugStep.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/handler/context/steps/DebugStep.java
@@ -104,6 +104,10 @@ public abstract class DebugStep<T> {
         }
     }
 
+    public void noTransformation() {
+        this.status = DebugStepStatus.NO_TRANSFORMATION;
+    }
+
     public void error(Throwable ex) {
         this.stop();
         this.status = DebugStepStatus.ERROR;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/policy/NoTransformationPolicy.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/policy/NoTransformationPolicy.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.debug.policy;
+
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.stream.ReadWriteStream;
+import io.gravitee.policy.api.PolicyChain;
+import io.gravitee.policy.api.annotations.OnRequest;
+import io.gravitee.policy.api.annotations.OnRequestContent;
+import io.gravitee.policy.api.annotations.OnResponse;
+import io.gravitee.policy.api.annotations.OnResponseContent;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class NoTransformationPolicy {
+
+    @OnRequest
+    public void onRequest(PolicyChain chain, Request request, Response response) {
+        // Do nothing
+        chain.doNext(request, response);
+    }
+
+    @OnResponse
+    public void onResponse(PolicyChain chain, Request request, Response response) {
+        // Do nothing
+        chain.doNext(request, response);
+    }
+
+    @OnRequestContent
+    public ReadWriteStream<Buffer> onRequestContent(PolicyChain chain, Request request, Response response) {
+        return null;
+    }
+
+    @OnResponseContent
+    public ReadWriteStream<Buffer> onResponseContent(PolicyChain chain, Request request, Response response) {
+        return null;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/policy/impl/PolicyDebugDecoratorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/policy/impl/PolicyDebugDecoratorTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.atMostOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -32,6 +33,7 @@ import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.core.condition.ExpressionLanguageStringConditionEvaluator;
 import io.gravitee.gateway.debug.policy.DummyPolicy;
+import io.gravitee.gateway.debug.policy.NoTransformationPolicy;
 import io.gravitee.gateway.debug.reactor.handler.context.DebugExecutionContext;
 import io.gravitee.gateway.debug.reactor.handler.context.steps.DebugRequestStep;
 import io.gravitee.gateway.debug.reactor.handler.context.steps.DebugResponseStep;
@@ -192,6 +194,34 @@ public class PolicyDebugDecoratorTest {
     }
 
     @Test
+    public void onRequestContentNoTransformation() throws Exception {
+        PolicyMetadata policyMetadata = mock(PolicyMetadata.class);
+        when(policyMetadata.policy()).then((Answer<Class>) invocationOnMock -> NoTransformationPolicy.class);
+        Method onRequestContentMethod = resolvePolicyMethod(NoTransformationPolicy.class, OnRequestContent.class);
+        when(policyMetadata.method(OnRequestContent.class)).thenReturn(onRequestContentMethod);
+
+        NoTransformationPolicy noTransformationPolicy = mock(NoTransformationPolicy.class);
+        when(policyPluginFactory.create(NoTransformationPolicy.class, null)).thenReturn(noTransformationPolicy);
+        final ArgumentCaptor<PolicyChain> chainCaptor = ArgumentCaptor.forClass(PolicyChain.class);
+
+        io.gravitee.gateway.policy.Policy policy = Mockito.spy(policyFactory.create(StreamType.ON_REQUEST, policyMetadata, null));
+        final PolicyDebugDecorator debugPolicy = spy(new PolicyDebugDecorator(StreamType.ON_REQUEST, policy));
+
+        debugPolicy.stream(policyChain, context);
+
+        Assert.assertFalse(debugPolicy.isRunnable());
+        Assert.assertTrue(debugPolicy.isStreamable());
+        verify(noTransformationPolicy, never()).onRequest(policyChain, request, response);
+        verify(noTransformationPolicy, atLeastOnce()).onRequestContent(chainCaptor.capture(), eq(request), eq(response));
+        verify(noTransformationPolicy, never()).onResponse(policyChain, request, response);
+        verify(noTransformationPolicy, never()).onResponseContent(policyChain, request, response);
+        verify(debugPolicy, atLeastOnce()).stream(policyChain, context);
+
+        verify(context, times(1)).saveNoTransformationDebugStep(any());
+        assertThat(chainCaptor.getValue()).isInstanceOf(DebugStreamablePolicyChain.class);
+    }
+
+    @Test
     public void onResponseContent() throws Exception {
         PolicyMetadata policyMetadata = mock(PolicyMetadata.class);
         when(policyMetadata.policy()).then((Answer<Class>) invocationOnMock -> DummyPolicy.class);
@@ -217,6 +247,34 @@ public class PolicyDebugDecoratorTest {
 
         verify(context, never()).beforePolicyExecution(any());
         verify(context, never()).afterPolicyExecution(any());
+        assertThat(chainCaptor.getValue()).isInstanceOf(DebugStreamablePolicyChain.class);
+    }
+
+    @Test
+    public void onResponseContentNoTransformation() throws Exception {
+        PolicyMetadata policyMetadata = mock(PolicyMetadata.class);
+        when(policyMetadata.policy()).then((Answer<Class>) invocationOnMock -> NoTransformationPolicy.class);
+        Method onResponseContentMethod = resolvePolicyMethod(NoTransformationPolicy.class, OnResponseContent.class);
+        when(policyMetadata.method(OnResponseContent.class)).thenReturn(onResponseContentMethod);
+
+        NoTransformationPolicy noTransformationPolicy = mock(NoTransformationPolicy.class);
+        when(policyPluginFactory.create(NoTransformationPolicy.class, null)).thenReturn(noTransformationPolicy);
+
+        io.gravitee.gateway.policy.Policy policy = Mockito.spy(policyFactory.create(StreamType.ON_RESPONSE, policyMetadata, null));
+        final PolicyDebugDecorator debugPolicy = spy(new PolicyDebugDecorator(StreamType.ON_RESPONSE, policy));
+        final ArgumentCaptor<PolicyChain> chainCaptor = ArgumentCaptor.forClass(PolicyChain.class);
+
+        debugPolicy.stream(policyChain, context);
+
+        Assert.assertFalse(debugPolicy.isRunnable());
+        Assert.assertTrue(debugPolicy.isStreamable());
+        verify(noTransformationPolicy, never()).onRequest(policyChain, request, response);
+        verify(noTransformationPolicy, never()).onRequestContent(policyChain, request, response);
+        verify(noTransformationPolicy, never()).onResponse(policyChain, request, response);
+        verify(noTransformationPolicy, atLeastOnce()).onResponseContent(chainCaptor.capture(), eq(request), eq(response));
+        verify(debugPolicy, atLeastOnce()).stream(policyChain, context);
+
+        verify(context, times(1)).saveNoTransformationDebugStep(any());
         assertThat(chainCaptor.getValue()).isInstanceOf(DebugStreamablePolicyChain.class);
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/reactor/handler/context/DebugExecutionContextTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/reactor/handler/context/DebugExecutionContextTest.java
@@ -53,6 +53,15 @@ public class DebugExecutionContextTest {
     }
 
     @Test
+    public void shouldAddNoTransformationStep() {
+        doNothing().when(debugStep).before(any(), any());
+        cut.saveNoTransformationDebugStep(debugStep);
+        assertThat(cut.getDebugSteps()).hasSize(1);
+        assertThat(cut.getDebugSteps()).contains(debugStep);
+        verify(debugStep, times(1)).noTransformation();
+    }
+
+    @Test
     public void shouldNotAddAStepTwice() {
         doNothing().when(debugStep).before(any(), any());
         cut.beforePolicyExecution(debugStep);


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7396

**Description**

Policies executing on "content" are building internally and returning a ReadWriteStream.
Some policies, like `XmlThreatProtection` or `JsonThreatProtection` build this stream only if `Content-Type` header is set to a good value, to fail fast and avoid build useless ReadWriteStream.

If the condition is not met, then the result is `null`. In this case, debug mode do not handle it.

This pull request save the debug step even if result from `stream()` is null. The step is flagged with status `NO_TRANSFORMATION`


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rjupjdzpwc.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-7396-null-stream-policies/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
