### PR TITLE
ci: add ssh_keys for nexus-staging job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -954,8 +954,10 @@ jobs:
         docker:
             - image: cimg/openjdk:11.0
         resource_class: medium
-
         steps:
+            - add_ssh_keys:
+                  fingerprints:
+                      - "ac:88:23:8f:c6:0f:7d:f0:fc:df:73:20:34:56:02:6c"
             - run:
                   name: Get tag to release from bucket name
                   command: |


### PR DESCRIPTION
**Issue**

To fix this : https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/5805/workflows/116749b3-b3ff-41cc-a6e9-71565e6156d9/jobs/63387 


**Description**

add ssh_keys for nexus-staging job

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mjdflfnoxu.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/ci-fix-nexus-staging/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
