### PR TITLE
ci: bump keeper orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
     slack: circleci/slack@4.4.4
     gravitee: gravitee-io/gravitee@1.0.38
     gh: circleci/github-cli@1.0.4
-    keeper: gravitee-io/keeper@0.5.0
+    keeper: gravitee-io/keeper@0.6.2
 
 executors:
     node-lts:


### PR DESCRIPTION
Bump keeper orb to fix the pb with keeper.ini file
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-pb-with-keeper-orb/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
