### PR TITLE
ci: bump keeper orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
     slack: circleci/slack@4.4.4
     gravitee: gravitee-io/gravitee@1.0.44
-    keeper: gravitee-io/keeper@0.6.0
+    keeper: gravitee-io/keeper@0.6.2
     gh: circleci/github-cli@1.0.5
     aws-cli: circleci/aws-cli@2.0.6
 


### PR DESCRIPTION
Bump keeper orb to fix the pb with keeper.ini file and downloaded version
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kaxzzinnnj.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/bump-keeper-orb/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
