### PR TITLE
fix: build conditional logging expression properly

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/analytics/logs/configure-logging-editor.dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/logs/configure-logging-editor.dialog.controller.ts
@@ -70,8 +70,8 @@ function DialogConfigureLoggingEditorController($scope, $mdDialog, plans, subscr
   $scope.types = [ConditionType];
   $scope.conditions = [];
 
-  $scope.types.push(new ConditionType('Plan', 'plan', '#context.plan'));
-  $scope.types.push(new ConditionType('Application', 'application', '#context.application'));
+  $scope.types.push(new ConditionType('Plan', 'plan', '#context.attributes.plan'));
+  $scope.types.push(new ConditionType('Application', 'application', '#context.attributes.application'));
   $scope.types.push(new ConditionType('Request header', 'request-header', '#request.headers'));
   $scope.types.push(new ConditionType('Request query-parameter', 'request-param', '#request.params'));
   $scope.types.push(new ConditionType('HTTP Method', 'request-method', '#request.method'));
@@ -83,8 +83,9 @@ function DialogConfigureLoggingEditorController($scope, $mdDialog, plans, subscr
     const type: ConditionType = _.find($scope.types, (conditionType: ConditionType) => conditionType.id === $scope.selectedType);
     if (type !== undefined) {
       $scope.conditions.push(new Condition(type, '==', ''));
+    } else {
+      $scope.selectedType = null;
     }
-    $scope.selectedType = null;
   };
 
   this.removeCondition = (idx: number) => {

--- a/gravitee-apim-console-webui/src/management/api/analytics/logs/configure-logging-editor.dialog.html
+++ b/gravitee-apim-console-webui/src/management/api/analytics/logs/configure-logging-editor.dialog.html
@@ -26,7 +26,7 @@
           <md-input-container class="md-block" flex-gt-sm>
             <label>Condition type</label>
             <md-select ng-model="selectedType" md-auto-focus>
-              <md-option ng-repeat="type in types" value="{{type.id}}"> {{type.title}} </md-option>
+              <md-option ng-repeat="type in types" value="{{ type.id }}"> {{ type.title }} </md-option>
             </md-select>
           </md-input-container>
           <md-button md-no-ink class="md-primary" ng-click="$ctrl.addCondition()" ng-disabled="!selectedType"> Add </md-button>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscribersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscribersResource.java
@@ -15,9 +15,12 @@
  */
 package io.gravitee.rest.api.management.rest.resource;
 
+import static io.gravitee.rest.api.model.SubscriptionStatus.*;
+
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.model.ApplicationEntity;
 import io.gravitee.rest.api.model.SubscriptionEntity;
+import io.gravitee.rest.api.model.SubscriptionStatus;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
@@ -27,6 +30,7 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
 import io.swagger.annotations.*;
 import java.util.Collection;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -80,8 +84,10 @@ public class ApiSubscribersResource extends AbstractResource {
 
         SubscriptionQuery subscriptionQuery = new SubscriptionQuery();
         subscriptionQuery.setApi(api);
+        subscriptionQuery.setStatuses(Set.of(PENDING, ACCEPTED));
 
         Collection<SubscriptionEntity> subscriptions = subscriptionService.search(subscriptionQuery);
+
         return subscriptions
             .stream()
             .map(SubscriptionEntity::getApplication)

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <gravitee-cockpit-api.version>1.9.0</gravitee-cockpit-api.version>
         <gravitee-common.version>1.25.0</gravitee-common.version>
         <gravitee-connector-api.version>1.1.0</gravitee-connector-api.version>
-        <gravitee-expression-language.version>1.9.1</gravitee-expression-language.version>
+        <gravitee-expression-language.version>1.9.2</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>1.31.1</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>


### PR DESCRIPTION
The conditional logging expression computed by the condition editor
was wrong, leading to error logs at the proxy level and condition
not being honored.

Additionally, the `[GET] /subscribers` endpoint was returning applications
linked to closed subscriptions and the condition type input was wiped when
hitting the `Add` button in the editor.

see https://github.com/gravitee-io/issues/issues/7329
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-phlaifdyef.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-conditional-logging-expression/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
