### PR TITLE
fix: best match default flow not well handled

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/main/java/io/gravitee/gateway/flow/BestMatchFlowResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/main/java/io/gravitee/gateway/flow/BestMatchFlowResolver.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.flow;
 import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.gateway.api.ExecutionContext;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * This flow provider is resolving only the {@link Flow} which best match according to the incoming request.
@@ -29,8 +30,8 @@ import java.util.List;
  */
 public class BestMatchFlowResolver implements FlowResolver {
 
-    private static final String PATH_SEPARATOR = "/";
     private static final String PATH_PARAM_PREFIX = ":";
+    private static final Pattern SEPARATOR_SPLITTER = Pattern.compile("/");
 
     private final FlowResolver flowResolver;
 
@@ -50,7 +51,7 @@ public class BestMatchFlowResolver implements FlowResolver {
      *     We assume the {@code List<Flow>} parameter is already filtered by the {@link BestMatchFlowResolver#flowResolver} to be sure the Flows' path match the request according to Flows' operator.
      * </strong>
      * <br/>
-     * For each part of the flow path (splitted by {@link BestMatchFlowResolver#PATH_SEPARATOR}), a score is attributed:
+     * For each part of the flow path (splitted by {@link BestMatchFlowResolver#SEPARATOR_SPLITTER}), a score is attributed:
      * - 1 if the string strictly equals the same part of the request
      * - 0.5 if the part is a path parameter (starting with {@link BestMatchFlowResolver#PATH_PARAM_PREFIX})
      * - else 0
@@ -125,13 +126,13 @@ public class BestMatchFlowResolver implements FlowResolver {
         Float[] selectedFlowScore = null;
 
         for (Flow flow : flows) {
-            String[] splits = flow.getPath().split(PATH_SEPARATOR);
-            final String[] pathSplits = path.split(PATH_SEPARATOR);
+            String[] splits = splitPath(flow.getPath());
+            final String[] pathSplits = splitPath(path);
             final Float[] scores = new Float[splits.length];
 
             for (int i = 0; i < splits.length; i++) {
                 // First, compute a score foreach split
-                if (splits[i].equals(pathSplits[i])) {
+                if (i >= pathSplits.length || splits[i].equals(pathSplits[i])) {
                     scores[i] = 1.0f;
                 } else if (splits[i].startsWith(PATH_PARAM_PREFIX)) {
                     scores[i] = 0.5f;
@@ -160,5 +161,22 @@ public class BestMatchFlowResolver implements FlowResolver {
         }
 
         return selectedFlow != null ? List.of(selectedFlow) : List.of();
+    }
+
+    /**
+     * Split string with "/" character. We use an already compiled Pattern to avoid using {@link String#split(String)} which is compiling a new one for each call.
+     * <br/>
+     * Also, we choose a negative limit to split the string, to avoid discarding trailing empty string.
+     * <br/>
+     * For more information, you can see {@link Pattern#split(CharSequence, int)}.
+     * <br/>
+     * <quote>
+     *     If the limit is negative then the pattern will be applied as many times as possible and the array can have any length.
+     * </quote>
+     * @param path to split
+     * @return The array of strings computed by splitting the input path
+     */
+    private String[] splitPath(String path) {
+        return SEPARATOR_SPLITTER.split(path, -1);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/flow/BestMatchFlowResolverTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/flow/BestMatchFlowResolverTest.java
@@ -106,6 +106,14 @@ public class BestMatchFlowResolverTest {
         return Arrays.asList(
             new Object[][] {
                 { List.of(), Operator.STARTS_WITH, null, "/path/55" },
+                { List.of("/"), Operator.STARTS_WITH, "/", "" },
+                { List.of("/"), Operator.STARTS_WITH, "/", "/" },
+                { List.of("/"), Operator.STARTS_WITH, "/", "/path/55" },
+                { List.of("/"), Operator.EQUALS, "/", "" },
+                { List.of("/"), Operator.EQUALS, "/", "/" },
+                { List.of("/"), Operator.EQUALS, null, "/path/55" },
+                { List.of("/", "/path"), Operator.STARTS_WITH, "/", "/random" },
+                { List.of("/", "/path"), Operator.STARTS_WITH, "/path", "/path/55" },
                 { List.of("/path/:id"), Operator.STARTS_WITH, "/path/:id", "/path/55" },
                 { List.of("/path/:id"), Operator.STARTS_WITH, "/path/:id", "/path/55" },
                 { List.of("/path/:id"), Operator.EQUALS, "/path/:id", "/path/55" },
@@ -198,6 +206,7 @@ public class BestMatchFlowResolverTest {
                 },
                 {
                     List.of(
+                        "/",
                         "/book",
                         "/book/9999/chapter/145/page/200/line",
                         "/book/9999/chapter/145/page",
@@ -214,6 +223,7 @@ public class BestMatchFlowResolverTest {
                 },
                 {
                     List.of(
+                        "/",
                         "/book",
                         "/book/9999/chapter/145/page/200/line",
                         "/book/9999/chapter/145/page",
@@ -227,6 +237,23 @@ public class BestMatchFlowResolverTest {
                     Operator.EQUALS,
                     "/book/9999/chapter/145",
                     "/book/9999/chapter/145",
+                },
+                {
+                    List.of(
+                        "/",
+                        "/book",
+                        "/book/9999/chapter/145/page/200/line",
+                        "/book/9999/chapter/145/page",
+                        "/city/washington/street/first/library/amazon/book/9999/chapter/145",
+                        "/book/7777/chapter/145",
+                        "/book/9999/chapter/147",
+                        "/book/9999/chapter/145",
+                        "/book/9999/chapter/148",
+                        "/book/9999/chapter"
+                    ),
+                    Operator.STARTS_WITH,
+                    "/",
+                    "/food",
                 },
                 {
                     List.of(


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7412

**Description**

New BestMatch implementation was not working well because of `String.split(path)` which was discarding trailing empty strings. That means for a simple path  (`/*` ), the best match did not resolved any flow.


**What the fix does ?**

First, it solves the problem 🥳 

Technically, to important points to understand:
- `split` function accepts a limit: 

> If the limit is negative then the pattern will be applied as many times as possible and the array can have any length.
It means that we will have an entry in our array even with a single path.

- We replaced the usage of `String.split(String)` by `Pattern.split(String)` (with the pattern compiled in a static way for the class. Internally, each time we do a `String.split(string)` the pattern is compiled. 

Benchmark test has been launched and we keep the same range of values as in https://github.com/gravitee-io/gravitee-api-management/pull/1459
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-bestmatch-simple-path/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
