### PR TITLE
Using id in sorting to "group" lines by id

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Page.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Page.java
@@ -256,7 +256,7 @@ public class Page {
             "id='" +
             id +
             '\'' +
-            "crossId='" +
+            ", crossId='" +
             crossId +
             '\'' +
             ", referenceId='" +
@@ -267,8 +267,9 @@ public class Page {
             ", name='" +
             name +
             '\'' +
-            ", type=" +
+            ", type='" +
             type +
+            '\'' +
             ", content='" +
             content +
             '\'' +
@@ -279,8 +280,9 @@ public class Page {
             order +
             ", published=" +
             published +
-            ", visibility=" +
+            ", visibility='" +
             visibility +
+            '\'' +
             ", source=" +
             source +
             ", configuration=" +
@@ -296,10 +298,12 @@ public class Page {
             '\'' +
             ", excludedAccessControls=" +
             excludedAccessControls +
-            ", accessControlList=" +
+            ", accessControls=" +
             accessControls +
             ", metadata=" +
             metadata +
+            ", useAutoFetch=" +
+            useAutoFetch +
             ", attachedMedia=" +
             attachedMedia +
             '}'

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPageRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPageRepository.java
@@ -570,7 +570,9 @@ public class JdbcPageRepository extends JdbcAbstractCrudRepository<Page, String>
                 select += " where ";
             }
 
-            jdbcTemplate.query(select + where.toString() + "order by " + ESCAPED_ORDER_COLUMN_NAME, rowMapper, params.toArray());
+            final String sql =
+                select + where.toString() + "order by " + ESCAPED_ORDER_COLUMN_NAME + ", p.id, p.reference_id, p.reference_type";
+            jdbcTemplate.query(sql, rowMapper, params.toArray());
 
             List<Page> items = rowMapper.getRows();
             for (Page page : items) {


### PR DESCRIPTION
**Description**

A page contain some attributes but also a list of `<key, value>` called configuration and another list of `<key, value>` called metadata.

In JDBC, these configuration and metadata are stored in dedicated tables.

When we search all pages, we made a big SELECT with `LEFT JOIN` statements for these dedicated tables. Since you can have multiple configuration and metadata entries, we end up with this kind of result set:
![image](https://user-images.githubusercontent.com/13161768/161242629-2451c7af-f172-4fdd-8870-86ef5f8d932a.png)

Then, thanks to RowMapper class, these lines are mixed in a single Page object (grouped by id).


But, this mapping assumes that lines are sorted by id. If not, we can ends up with multiple page object with the same id.
And in our case, the big select query was sorted by `order` field and not by id.

**How to fix**
Add id & reference into the sort part of the query
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wpcqavcghq.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-mysql-tests/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
