### PR TITLE
fix: allow admin to view the transfer ownership link

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/apiAdmin.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/apiAdmin.controller.ts
@@ -230,11 +230,7 @@ class ApiAdminController {
   }
 
   canTransferOwnership(): boolean {
-    return this.isAdmin() || this.UserService.isApiPrimaryOwner(this.api, this.resolvedApiGroups);
-  }
-
-  isAdmin(): boolean {
-    return this.UserService.currentUser.roles['ORGANIZATION'] === 'ADMIN' || this.UserService.currentUser.roles['ENVIRONMENT'] === 'ADMIN';
+    return this.UserService.currentUser.isAdmin() || this.UserService.isApiPrimaryOwner(this.api, this.resolvedApiGroups);
   }
 
   isRequestForChanges(): boolean {


### PR DESCRIPTION
As an admin, without being the API primary owner, the "transfer ownership" link was not displayed in the UI.

see https://github.com/gravitee-io/issues/issues/7395
see https://github.com/gravitee-io/issues/issues/7430
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-transfert-ownership-as-admin/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
