### PR TITLE
fix: find members by references and roles

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcMembershipRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcMembershipRepository.java
@@ -148,6 +148,10 @@ public class JdbcMembershipRepository extends JdbcAbstractCrudRepository<Members
         throws TechnicalException {
         LOGGER.debug("JdbcMembershipRepository.findByReferencesAndRoleId({}, {}, {})", referenceType, referenceIds, roleId);
         try {
+            if (CollectionUtils.isEmpty(referenceIds)) {
+                return Set.of();
+            }
+
             StringBuilder query = new StringBuilder("select m.* from " + this.tableName + " m ");
             boolean first = true;
             if (referenceType != null) {

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/MembershipRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/MembershipRepositoryTest.java
@@ -97,6 +97,13 @@ public class MembershipRepositoryTest extends AbstractRepositoryTest {
     }
 
     @Test
+    public void shouldReturnEmptyListWithEmptyReferenceIdList() throws TechnicalException {
+        Set<Membership> memberships = membershipRepository.findByReferencesAndRoleId(MembershipReferenceType.API, List.of(), null);
+        assertNotNull("result must not be null", memberships);
+        assertTrue(memberships.isEmpty());
+    }
+
+    @Test
     public void shouldFindApisOwners() throws TechnicalException {
         Set<Membership> memberships = membershipRepository.findByReferencesAndRoleId(
             MembershipReferenceType.API,


### PR DESCRIPTION
With a JDBC datasource, filtering was not applied when searching
by reference IDs and roles with an empty list, leading to the
whole result set to be returned

see https://github.com/gravitee-io/issues/issues/7429
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-jdbc-find-members-by-references/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
