### PR TITLE
ci: reduce the content put in the workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,7 +274,6 @@ jobs:
             - persist_to_workspace:
                   root: ./
                   paths:
-                      - ./gravitee-*/*/target/*
                       - ./rest-api-docker-context
                       - ./gateway-docker-context
 


### PR DESCRIPTION
**Description**

Removing some unnecessary files from the workspace.
Basically, we only need the two `distribution` folders, to be able to build dev docker images.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/improve-pull-request-workflow/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
