### PR TITLE
fix(cockpit): installation informations are reset at each APIM startup

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/producer/HelloCommandProducer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/producer/HelloCommandProducer.java
@@ -88,7 +88,7 @@ public class HelloCommandProducer implements CommandProducer<HelloCommand, Hello
     @Override
     public Single<HelloReply> handleReply(HelloReply reply) {
         if (reply.getCommandStatus() == CommandStatus.SUCCEEDED) {
-            final Map<String, String> additionalInformation = new HashMap<>();
+            final Map<String, String> additionalInformation = installationService.getOrInitialize().getAdditionalInformation();
             additionalInformation.put(InstallationService.COCKPIT_INSTALLATION_ID, reply.getInstallationId());
             additionalInformation.put(InstallationService.COCKPIT_INSTALLATION_STATUS, reply.getInstallationStatus());
             installationService.setAdditionalInformation(additionalInformation);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/producer/HelloCommandProducerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/producer/HelloCommandProducerTest.java
@@ -19,8 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import io.gravitee.cockpit.api.command.Command;
 import io.gravitee.cockpit.api.command.CommandStatus;
@@ -28,6 +27,7 @@ import io.gravitee.cockpit.api.command.hello.HelloCommand;
 import io.gravitee.cockpit.api.command.hello.HelloPayload;
 import io.gravitee.cockpit.api.command.hello.HelloReply;
 import io.gravitee.node.api.Node;
+import io.gravitee.repository.management.model.Installation;
 import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.InstallationEntity;
 import io.gravitee.rest.api.model.OrganizationEntity;
@@ -37,6 +37,8 @@ import io.gravitee.rest.api.service.OrganizationService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.reactivex.observers.TestObserver;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -119,7 +121,7 @@ public class HelloCommandProducerTest {
     }
 
     @Test
-    public void handleReplay_shouldUpdateDefaultEnvironmentCockpitId() {
+    public void handleReply_shouldUpdateDefaultEnvironmentCockpitId() {
         HelloReply helloReply = new HelloReply();
         helloReply.setCommandStatus(CommandStatus.SUCCEEDED);
         helloReply.setDefaultEnvironmentCockpitId("env#cockpit-1");
@@ -129,6 +131,7 @@ public class HelloCommandProducerTest {
         defaultEnvironment.setId(defaultEnvId);
         defaultEnvironment.setOrganizationId("org#1");
 
+        when(installationService.getOrInitialize()).thenReturn(new InstallationEntity());
         when(environmentService.findById(defaultEnvId)).thenReturn(defaultEnvironment);
 
         cut.handleReply(helloReply);
@@ -142,7 +145,7 @@ public class HelloCommandProducerTest {
     }
 
     @Test
-    public void handleReplay_shouldUpdateDefaultOrganizationCockpitId() {
+    public void handleReply_shouldUpdateDefaultOrganizationCockpitId() {
         HelloReply helloReply = new HelloReply();
         helloReply.setCommandStatus(CommandStatus.SUCCEEDED);
         helloReply.setDefaultOrganizationCockpitId("org#cockpit-1");
@@ -151,6 +154,7 @@ public class HelloCommandProducerTest {
         OrganizationEntity defaultOrganization = new OrganizationEntity();
         defaultOrganization.setId(defaultOrgId);
 
+        when(installationService.getOrInitialize()).thenReturn(new InstallationEntity());
         when(organizationService.findById(defaultOrgId)).thenReturn(defaultOrganization);
 
         cut.handleReply(helloReply);
@@ -160,6 +164,50 @@ public class HelloCommandProducerTest {
                 eq(GraviteeContext.getExecutionContext()),
                 eq(defaultOrgId),
                 argThat(org -> org.getCockpitId().equals("org#cockpit-1"))
+            );
+    }
+
+    @Test
+    public void handleReply_shouldUpdateCockpitInstallationStatusAndId_butKeepAlreadyExistingInstallationInformations() {
+        // mock already existing installation with informations
+        InstallationEntity installation = new InstallationEntity();
+        installation.setAdditionalInformation(
+            new HashMap(
+                Map.of(
+                    "key1",
+                    "value1",
+                    "key2",
+                    "value2",
+                    "COCKPIT_INSTALLATION_STATUS",
+                    "old-installation-status",
+                    "COCKPIT_INSTALLATION_ID",
+                    "old-installation-id"
+                )
+            )
+        );
+        when(installationService.getOrInitialize()).thenReturn(installation);
+
+        HelloReply helloReply = new HelloReply();
+        helloReply.setInstallationId("new-installation-id");
+        helloReply.setInstallationStatus("new-installation-status");
+        helloReply.setCommandStatus(CommandStatus.SUCCEEDED);
+
+        cut.handleReply(helloReply);
+
+        verify(installationService, times(1))
+            .setAdditionalInformation(
+                eq(
+                    Map.of(
+                        "key1",
+                        "value1",
+                        "key2",
+                        "value2",
+                        "COCKPIT_INSTALLATION_STATUS",
+                        "new-installation-status",
+                        "COCKPIT_INSTALLATION_ID",
+                        "new-installation-id"
+                    )
+                )
             );
     }
 }


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/7450

fix(cockpit): installation informations are reset at each APIM startup

When APIM is linked to cockpit, HelloCommandProducer resets existing installation informations at each startup.
That causes OneShotUpgraders to run at each startup cause their flag is deleted from installation collection.

The new behavior keeps existing installation informations, and updates only COCKPIT_INSTALLATION_STATUS and COCKPIT_INSTALLATION_ID.

It's the same behavior that is implemented in InstallationCommandHandler or GoodbyeCommandHandler.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-cockpitinstallationinformationsreset/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-neickxdmae.chromatic.com)
<!-- Storybook placeholder end -->
