### PR TITLE
chore: bump resource-oauth2-provider-am to 1.14.2

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -103,7 +103,7 @@
         <gravitee-resource-auth-provider-ldap.version>1.1.0</gravitee-resource-auth-provider-ldap.version>
         <gravitee-resource-cache.version>1.6.2</gravitee-resource-cache.version>
         <gravitee-resource-cache-redis.version>1.0.1</gravitee-resource-cache-redis.version>
-        <gravitee-resource-oauth2-provider-am.version>1.14.1</gravitee-resource-oauth2-provider-am.version>
+        <gravitee-resource-oauth2-provider-am.version>1.14.2</gravitee-resource-oauth2-provider-am.version>
         <gravitee-resource-oauth2-provider-generic.version>1.16.1</gravitee-resource-oauth2-provider-generic.version>
         <gravitee-resource-oauth2-provider-keycloak.version>1.9.1</gravitee-resource-oauth2-provider-keycloak.version>
         <gravitee-service-discovery-consul.version>1.3.0</gravitee-service-discovery-consul.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6454


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-6454-v3-default-am-resource/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
