### PR TITLE
Add UI tests for User Creation screen

### DIFF
--- a/gravitee-apim-console-webui/package-lock.json
+++ b/gravitee-apim-console-webui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gravitee-apim-console-webui",
-  "version": "3.17.0-SNAPSHOT",
+  "version": "3.17.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gravitee-apim-console-webui",
-      "version": "3.17.0-SNAPSHOT",
+      "version": "3.17.0",
       "hasInstallScript": true,
       "dependencies": {
         "@angular/animations": "12.2.3",

--- a/gravitee-apim-console-webui/src/organization/configuration/user/new/org-settings-new-user.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/new/org-settings-new-user.component.html
@@ -40,19 +40,19 @@
       <h2>User</h2>
       <mat-form-field class="org-settings-new-user__card__form-field" appearance="fill">
         <mat-label>First Name</mat-label>
-        <input matInput formControlName="firstName" required />
+        <input matInput formControlName="firstName" required data-testid="firstName" />
         <mat-error *ngIf="userForm.get('firstName').errors?.required">This field is required.</mat-error>
       </mat-form-field>
 
       <mat-form-field class="org-settings-new-user__card__form-field" appearance="fill">
         <mat-label>Last Name</mat-label>
-        <input matInput formControlName="lastName" required />
+        <input matInput formControlName="lastName" required data-testid="lastName" />
         <mat-error *ngIf="userForm.get('lastName').errors?.required">This field is required.</mat-error>
       </mat-form-field>
 
       <mat-form-field class="org-settings-new-user__card__form-field" appearance="fill">
         <mat-label>Email</mat-label>
-        <input matInput formControlName="email" type="email" required />
+        <input matInput formControlName="email" type="email" required data-testid="email" />
         <mat-error *ngIf="userForm.get('email').errors?.required">This field is required.</mat-error>
         <mat-error *ngIf="userForm.get('email').errors?.email">This field should be a valid email.</mat-error>
       </mat-form-field>
@@ -87,14 +87,14 @@
 
       <mat-form-field class="org-settings-new-user__card__form-field" appearance="fill">
         <mat-label>Service Name</mat-label>
-        <input matInput formControlName="lastName" required />
+        <input matInput formControlName="lastName" required data-testid="lastName" />
         <mat-hint>Choose a meaningful name for your service account.</mat-hint>
         <mat-error *ngIf="userForm.get('lastName').errors?.required">This field is required.</mat-error>
       </mat-form-field>
 
       <mat-form-field class="org-settings-new-user__card__form-field" appearance="fill">
         <mat-label>Email</mat-label>
-        <input matInput formControlName="email" type="email" />
+        <input matInput formControlName="email" type="email" data-testid="email" />
         <mat-error *ngIf="userForm.get('email').errors?.email">This field should be a valid email.</mat-error>
       </mat-form-field>
     </mat-card-content>

--- a/gravitee-apim-console-webui/src/organization/configuration/users/org-settings-users.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/users/org-settings-users.component.html
@@ -19,7 +19,9 @@
 <div class="title">
   <h1>Users</h1>
 
-  <button (click)="onAddUserClick()" mat-raised-button color="primary"><mat-icon>person_add</mat-icon> Add user</button>
+  <button (click)="onAddUserClick()" mat-raised-button color="primary" data-testid="add-user">
+    <mat-icon>person_add</mat-icon> Add user
+  </button>
 </div>
 
 <gio-table-wrapper [length]="nbTotalUsers" [filters]="filters" (filtersChange)="onFiltersChanged($event)">
@@ -73,6 +75,7 @@
             *ngIf="!element.primary_owner"
             (click)="onDeleteUserClick(element)"
             mat-icon-button
+            data-testid="delete-user"
             aria-label="Button to delete user"
             matTooltip="Delete user"
           >

--- a/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.component.html
+++ b/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.component.html
@@ -20,7 +20,7 @@
   <mat-form-field class="gio-table-wrapper__header-bar__search-field" appearance="outline">
     <mat-icon matPrefix>search</mat-icon>
     <mat-label>Search</mat-label>
-    <input class="search-input" [formControl]="inputSearch" type="search" matInput />
+    <input class="search-input" [formControl]="inputSearch" type="search" matInput data-testid="search" />
   </mat-form-field>
 
   <mat-paginator

--- a/gravitee-apim-cypress/cypress/commands/common/http.commands.ts
+++ b/gravitee-apim-cypress/cypress/commands/common/http.commands.ts
@@ -38,6 +38,10 @@ export class HttpClient extends RequestInfoHolder {
   }
 
   post<T extends string | object, R = T>(path: string, body: T, queryParams?: ParamMap): Cypress.Chainable<Response<R>> {
+    // FIXME: Need to clear cookies before each request to avoid any issue with the session cookie,
+    // a Bearer token is stored in the session cookie and is inherited when we are login in the UI (in some UI tests).
+    cy.clearCookie('Auth-Graviteeio-APIM');
+
     const queryParamString = this.buildQueryParamString(queryParams);
     return cy
       .request<R>({
@@ -55,6 +59,10 @@ export class HttpClient extends RequestInfoHolder {
   }
 
   get<T extends string | object, R = T>(path: string, queryParams?: ParamMap): Cypress.Chainable<Response<R>> {
+    // FIXME: Need to clear cookies before each request to avoid any issue with the session cookie,
+    // a Bearer token is stored in the session cookie and is inherited when we are login in the UI (in some UI tests).
+    cy.clearCookie('Auth-Graviteeio-APIM');
+
     const queryParamString = this.buildQueryParamString(queryParams);
     return cy
       .request<R>({
@@ -67,6 +75,10 @@ export class HttpClient extends RequestInfoHolder {
   }
 
   delete<T extends string | object, R = T>(path: string, queryParams?: ParamMap): Cypress.Chainable<Response<R>> {
+    // FIXME: Need to clear cookies before each request to avoid any issue with the session cookie,
+    // a Bearer token is stored in the session cookie and is inherited when we are login in the UI (in some UI tests).
+    cy.clearCookie('Auth-Graviteeio-APIM');
+
     const queryParamString = this.buildQueryParamString(queryParams);
     return cy
       .request<R>({
@@ -79,6 +91,10 @@ export class HttpClient extends RequestInfoHolder {
   }
 
   put<T extends string | object, R = T>(path: string, body: T): Cypress.Chainable<Response<R>> {
+    // FIXME: Need to clear cookies before each request to avoid any issue with the session cookie,
+    // a Bearer token is stored in the session cookie and is inherited when we are login in the UI (in some UI tests).
+    cy.clearCookie('Auth-Graviteeio-APIM');
+
     return cy
       .request<R>({
         method: 'PUT',

--- a/gravitee-apim-cypress/cypress/integration/apim/ui/apis/ui-api-list.spec.ts
+++ b/gravitee-apim-cypress/cypress/integration/apim/ui/apis/ui-api-list.spec.ts
@@ -21,7 +21,6 @@ import { gio } from '@commands/gravitee.commands';
 
 describe('API List feature', () => {
   let createdApi: Api;
-
   before(() => {
     gio
       .management(ADMIN_USER)
@@ -32,18 +31,19 @@ describe('API List feature', () => {
         createdApi = response.body;
         cy.log('Created api id:', createdApi.id);
       });
+  });
+
+  beforeEach(() => {
     cy.loginInAPIM(ADMIN_USER.username, ADMIN_USER.password);
   });
 
   it(`Visit Home board`, () => {
     cy.visit(Cypress.env('managementUI'));
-    cy.wait(3000);
     cy.contains('Home board');
   });
 
   it(`Visit Search Apis`, () => {
     cy.visit(`${Cypress.env('managementUI')}/#!/environments/DEFAULT/apis/`);
-    cy.wait(3000);
     cy.contains(createdApi.name);
   });
 

--- a/gravitee-apim-cypress/cypress/integration/apim/ui/cypress-config.json
+++ b/gravitee-apim-cypress/cypress/integration/apim/ui/cypress-config.json
@@ -1,6 +1,6 @@
 {
   "projectId": "gravitee-apim-cypress-ui",
-  "integrationFolder": "cypress/integration/ui",
+  "integrationFolder": "cypress/integration/apim/ui",
   "video": true,
   "screenshotOnRunFailure": true,
   "viewportWidth": 1920,
@@ -19,7 +19,7 @@
     "admin_user_password": "admin",
     "managementOrganizationApi": "/management/organizations/DEFAULT",
     "managementApi": "/management/organizations/DEFAULT/environments/DEFAULT",
-    "managementUI": "http://localhost:8084",
+    "managementUI": "http://localhost:3000",
     "gatewayServer": "http://localhost:8082",
     "portalApi": "/portal/environments/DEFAULT"
   }

--- a/gravitee-apim-cypress/cypress/integration/apim/ui/organization-settings/ui-users.spec.ts
+++ b/gravitee-apim-cypress/cypress/integration/apim/ui/organization-settings/ui-users.spec.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ADMIN_USER } from '@fakers/users/users';
+import faker from 'faker';
+
+describe('Users', () => {
+  beforeEach(() => {
+    cy.loginInAPIM(ADMIN_USER.username, ADMIN_USER.password);
+    cy.visit(`${Cypress.env('managementUI')}/#!/organization/settings/users`);
+  });
+
+  it('should create a new user', () => {
+    const firstName = faker.name.firstName();
+    const lastName = faker.name.lastName();
+    const email = faker.internet.email(firstName, lastName);
+
+    cy.getByDataTestId('add-user').click();
+    cy.contains('Pre-register a user');
+
+    cy.getByDataTestId('firstName').type(firstName);
+    cy.getByDataTestId('lastName').type(lastName);
+    cy.getByDataTestId('email').type(email);
+
+    // FIXME:
+    // Clicking in the save bar -> need test id on Particles components
+    cy.contains('Create').click();
+
+    cy.contains('Users');
+
+    // FIXME:
+    // Search isn't working with numbers or special characters for now, @Yann will handle it
+    // cy.getByDataTestId('search').type(email).wait(500);
+
+    cy.contains(firstName);
+    cy.contains(lastName);
+    cy.contains(email)
+      .parent()
+      .within(() => cy.getByDataTestId('delete-user').click());
+
+    cy.get('mat-dialog-actions').within(() => {
+      cy.contains('Delete').click();
+    });
+
+    cy.contains(email).should('not.exist');
+  });
+
+  it('should create a new service account user', () => {
+    const serviceAccountName = faker.commerce.productName();
+    const email = faker.internet.email(serviceAccountName);
+
+    cy.getByDataTestId('add-user').click();
+    cy.contains('Pre-register a user');
+
+    cy.contains('Service Account').click();
+
+    // FIXME:
+    // Search isn't working with numbers or special characters for now, @Yann will handle it
+    // cy.getByDataTestId('search').type(email).wait(500);
+
+    cy.getByDataTestId('lastName').type(serviceAccountName);
+    cy.getByDataTestId('email').type(email);
+
+    cy.contains('Create').click();
+
+    cy.contains('Users');
+    cy.contains(serviceAccountName);
+    cy.contains(email)
+      .parent()
+      .within(() => cy.getByDataTestId('delete-user').click());
+
+    cy.get('mat-dialog-actions').within(() => {
+      cy.contains('Delete').click();
+    });
+
+    cy.contains(email).should('not.exist');
+  });
+});

--- a/gravitee-apim-cypress/cypress/support/common/ui.commands.ts
+++ b/gravitee-apim-cypress/cypress/support/common/ui.commands.ts
@@ -13,13 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { gio } from '@commands/gravitee.commands';
+import { ADMIN_USER } from '@fakers/users/users';
+
 declare namespace Cypress {
   interface Chainable {
     /**
-     * Custom command to select DOM element by data-cy attribute.
-     * @example cy.dataCy('greeting')
+     * Custom command to type into a gv text input
      */
     gvType(selector: string, value: string): Chainable<Element>;
+
+    /**
+     * Custom command to select DOM element by data-testid attribute.
+     * @example cy.getByDataTestId('greeting')
+     */
+    getByDataTestId(selector: string): Chainable<Element>;
 
     /**
      * Custom command to setup authentication token/cookie to visit directly some pages instead of
@@ -34,6 +42,10 @@ declare namespace Cypress {
 
 Cypress.Commands.add('gvType', (selector, value) => {
   cy.get(selector).within(() => cy.get('input').focus().type(value, { force: true }).trigger('input', { bubbles: true, composed: true }));
+});
+
+Cypress.Commands.add('getByDataTestId', (selector) => {
+  cy.get(`[data-testid=${selector}]`);
 });
 
 Cypress.Commands.add('loginInAPIM', (username: string, password: string) => {

--- a/gravitee-apim-cypress/cypress/support/index.ts
+++ b/gravitee-apim-cypress/cypress/support/index.ts
@@ -22,12 +22,3 @@ import './common/api.commands';
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
 require('cypress-terminal-report/src/installLogsCollector')({ enableExtendedCollector: Cypress.env('printLogsToConsole') === 'always' });
-
-Cypress.Cookies.defaults({ preserve: ['Auth-Graviteeio-APIM'] });
-before(() => {
-  cy.clearCookie('Auth-Graviteeio-APIM');
-});
-
-after(() => {
-  cy.clearCookie('Auth-Graviteeio-APIM');
-});

--- a/gravitee-apim-cypress/package.json
+++ b/gravitee-apim-cypress/package.json
@@ -10,6 +10,7 @@
         "test:apim:rest-api": "cypress run --config-file cypress/integration/apim/rest-api/cypress-config.json",
         "test:apim:e2e": "cypress open --config-file cypress/integration/apim/e2e/cypress-config.json",
         "test:apim:ui": "cypress open --config-file cypress/integration/apim/ui/cypress-config.json",
+        "ci:apim:ui": "cypress run --config-file cypress/integration/apim/ui/cypress-config.json",
         "test:apim:dev": "cypress run --env printLogsToConsole=always --config-file cypress/integration/apim/rest-api/cypress-config.json",
         "test:apim:parallel": "cypress run --record --group apis --spec 'cypress/integration/apim/rest-api/apis/**/*' --config-file cypress/integration/apim/rest-api/cypress-config.json",
         "test:platform": "cypress open --config-file cypress/integration/platform/cypress-config.json",


### PR DESCRIPTION
**Issue**

NA

**Description**

This PR contains changes we've done in mob programming with @ctschacher @a-cordier @ytvnr about UI tests for User Creation screen.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-swcybgmjar.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/add-e2e-test/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
