### PR TITLE
fix: don't use SpEL syntax to get the environment variable

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryConfiguration.java
@@ -39,7 +39,7 @@ import org.testcontainers.utility.DockerImageName;
 @ComponentScan("io.gravitee.repository.jdbc")
 public class JdbcTestRepositoryConfiguration {
 
-    @Value("#{environment.jdbcType}")
+    @Value("${jdbcType:postgresql}")
     private String jdbcType;
 
     @Bean

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/MongoTestRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/MongoTestRepositoryConfiguration.java
@@ -41,7 +41,7 @@ public class MongoTestRepositoryConfiguration extends AbstractRepositoryConfigur
 
     private static final Logger LOG = LoggerFactory.getLogger(MongoTestRepositoryConfiguration.class);
 
-    @Value("${environment.mongoVersion:4.4.6}")
+    @Value("${mongoVersion:4.4.6}")
     private String mongoVersion;
 
     @Inject


### PR DESCRIPTION
**Description**

don't use SpEL syntax to get the environment variable
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ooaqjwngmg.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-mongo-test-container-execution/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
