### PR TITLE
fix: handle properly instance events without props

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/InstanceServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/InstanceServiceImpl.java
@@ -34,6 +34,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
@@ -54,9 +55,6 @@ public class InstanceServiceImpl implements InstanceService {
 
     @Autowired
     private EventService eventService;
-
-    @Autowired
-    private EnvironmentService environmentService;
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -144,7 +142,6 @@ public class InstanceServiceImpl implements InstanceService {
 
             EventEntity event = eventService.findById(eventId);
             List<String> environments = extractProperty(event, Event.EventProperties.ENVIRONMENTS_HRIDS_PROPERTY.getValue());
-
             List<String> organizations = extractProperty(event, Event.EventProperties.ORGANIZATIONS_HRIDS_PROPERTY.getValue());
 
             return convert(event, environments, organizations);
@@ -175,7 +172,11 @@ public class InstanceServiceImpl implements InstanceService {
     }
 
     private List<String> extractProperty(EventEntity event, String property) {
-        return Stream.of(event.getProperties().get(property).split(", ")).filter(StringUtils::hasText).collect(Collectors.toList());
+        final String extractedProperty = event.getProperties().get(property);
+
+        return extractedProperty == null
+            ? List.of()
+            : Stream.of(extractedProperty.split(", ")).filter(StringUtils::hasText).collect(Collectors.toList());
     }
 
     private InstanceEntity convert(EventEntity event) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/InstanceServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/InstanceServiceImpl.java
@@ -52,6 +52,7 @@ import org.springframework.util.StringUtils;
 public class InstanceServiceImpl implements InstanceService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(InstanceServiceImpl.class);
+    private static final Pattern PROPERTY_SPLITTER = Pattern.compile(", ");
 
     @Autowired
     private EventService eventService;
@@ -176,7 +177,7 @@ public class InstanceServiceImpl implements InstanceService {
 
         return extractedProperty == null
             ? List.of()
-            : Stream.of(extractedProperty.split(", ")).filter(StringUtils::hasText).collect(Collectors.toList());
+            : Stream.of(PROPERTY_SPLITTER.split(extractedProperty)).filter(StringUtils::hasText).collect(Collectors.toList());
     }
 
     private InstanceEntity convert(EventEntity event) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/InstanceServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/InstanceServiceTest.java
@@ -15,8 +15,16 @@
  */
 package io.gravitee.rest.api.service;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 
+import io.gravitee.repository.management.model.Event;
+import io.gravitee.rest.api.model.EventEntity;
+import io.gravitee.rest.api.model.EventQuery;
+import io.gravitee.rest.api.model.InstanceEntity;
 import io.gravitee.rest.api.model.InstanceListItem;
 import io.gravitee.rest.api.model.InstanceState;
 import io.gravitee.rest.api.service.impl.InstanceServiceImpl;
@@ -24,16 +32,126 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * @author Eric LELEU (eric.leleu at graviteesource.com)
  * @author GraviteeSource Team
  */
+@RunWith(MockitoJUnitRunner.class)
 public class InstanceServiceTest {
+
+    @Mock
+    private EventService eventService;
+
+    @InjectMocks
+    private InstanceService cut = new InstanceServiceImpl();
+
+    @Test
+    public void shouldFindByEventIfNoEnvOrOrgProperty() {
+        final EventEntity evt = new EventEntity();
+        evt.setProperties(Map.of("id", "evt-id"));
+
+        when(eventService.findById("evt-id")).thenReturn(evt);
+
+        final InstanceEntity result = cut.findByEvent("evt-id");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getEnvironmentsHrids()).isEmpty();
+        assertThat(result.getOrganizationsHrids()).isEmpty();
+    }
+
+    @Test
+    public void shouldFindByEventIfNoOrgProperty() {
+        final EventEntity evt = new EventEntity();
+        evt.setProperties(Map.of("id", "evt-id", Event.EventProperties.ENVIRONMENTS_HRIDS_PROPERTY.getValue(), "evt-env"));
+
+        when(eventService.findById("evt-id")).thenReturn(evt);
+
+        final InstanceEntity result = cut.findByEvent("evt-id");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getEnvironmentsHrids()).hasSize(1);
+        assertThat(result.getOrganizationsHrids()).isEmpty();
+    }
+
+    @Test
+    public void shouldFindByEventIfNoEnvProperty() {
+        final EventEntity evt = new EventEntity();
+        evt.setProperties(Map.of("id", "evt-id", Event.EventProperties.ORGANIZATIONS_HRIDS_PROPERTY.getValue(), "evt-org"));
+
+        when(eventService.findById("evt-id")).thenReturn(evt);
+
+        final InstanceEntity result = cut.findByEvent("evt-id");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getEnvironmentsHrids()).isEmpty();
+        assertThat(result.getOrganizationsHrids()).hasSize(1);
+    }
+
+    @Test
+    public void shouldFindByEvent() {
+        final EventEntity evt = new EventEntity();
+        evt.setProperties(
+            Map.of(
+                "id",
+                "evt-id",
+                Event.EventProperties.ENVIRONMENTS_HRIDS_PROPERTY.getValue(),
+                "evt-env",
+                Event.EventProperties.ORGANIZATIONS_HRIDS_PROPERTY.getValue(),
+                "evt-org"
+            )
+        );
+
+        when(eventService.findById("evt-id")).thenReturn(evt);
+
+        final InstanceEntity result = cut.findByEvent("evt-id");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getEnvironmentsHrids()).hasSize(1);
+        assertThat(result.getOrganizationsHrids()).hasSize(1);
+    }
+
+    @Test
+    public void shouldFindAllStartedEvenIfNoEnvOrOrgProperty() {
+        final EventEntity evt = new EventEntity();
+        evt.setProperties(Map.of("id", "evt-id"));
+
+        final EventEntity evtWithEnv = new EventEntity();
+        evtWithEnv.setProperties(Map.of("id", "evt-id", Event.EventProperties.ENVIRONMENTS_HRIDS_PROPERTY.getValue(), "evt-env"));
+
+        final EventEntity evtWithOrg = new EventEntity();
+        evtWithOrg.setProperties(Map.of("id", "evt-id", Event.EventProperties.ORGANIZATIONS_HRIDS_PROPERTY.getValue(), "evt-org"));
+
+        final EventEntity evtWithEnvAndOrg = new EventEntity();
+        evtWithEnvAndOrg.setProperties(
+            Map.of(
+                "id",
+                "evt-id",
+                Event.EventProperties.ENVIRONMENTS_HRIDS_PROPERTY.getValue(),
+                "evt-env",
+                Event.EventProperties.ORGANIZATIONS_HRIDS_PROPERTY.getValue(),
+                "evt-org"
+            )
+        );
+
+        when(eventService.search(any(EventQuery.class))).thenReturn(List.of(evt, evtWithEnv, evtWithOrg, evtWithEnvAndOrg));
+
+        final List<InstanceEntity> result = cut.findAllStarted();
+
+        assertThat(result).hasSize(4);
+    }
 
     @Test
     public void expirePredicateShouldFilterOldUnknownState() {


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7277

**Description**

Prior to version 3.11, events for `GATEWAY_STARTED` and `GATEWAY_STOPPED` did not contain `environments_hrids` and `organizations_hrids`.

So, when migrating from 3.10 to 3.15, it might happen that gateway not properly stopped (that appears as `UNKNOWN` in the Console) generate an NPE when getting instances (for exemple when running a Debug mode request).

This fixes just checks the nullity of the property, then return an empty list if `null`

I also take the opportunity to replace usage of `String#split` which was used in a stream by `Pattern#split`


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-flhmqaeweg.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-7277-started-gateway-event-npe/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
