### PR TITLE
fix(rest-api): set right executionContext for OrganizationCommand

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/OrganizationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/OrganizationService.java
@@ -29,11 +29,7 @@ public interface OrganizationService {
 
     OrganizationEntity findById(String organizationId);
 
-    OrganizationEntity createOrUpdate(
-        ExecutionContext executionContext,
-        String organizationId,
-        UpdateOrganizationEntity organizationEntity
-    );
+    OrganizationEntity createOrUpdate(ExecutionContext executionContext, UpdateOrganizationEntity organizationEntity);
 
     OrganizationEntity update(ExecutionContext executionContext, String organizationId, UpdateOrganizationEntity organizationEntity);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/OrganizationCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/OrganizationCommandHandler.java
@@ -66,11 +66,7 @@ public class OrganizationCommandHandler implements CommandHandler<OrganizationCo
             newOrganization.setDescription(organizationPayload.getDescription());
             newOrganization.setDomainRestrictions(organizationPayload.getDomainRestrictions());
 
-            final OrganizationEntity organization = organizationService.createOrUpdate(
-                executionContext,
-                organizationPayload.getId(),
-                newOrganization
-            );
+            final OrganizationEntity organization = organizationService.createOrUpdate(executionContext, newOrganization);
             logger.info("Organization [{}] handled with id [{}].", organization.getName(), organization.getId());
             return Single.just(new OrganizationReply(command.getId(), CommandStatus.SUCCEEDED));
         } catch (Exception e) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/OrganizationCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/OrganizationCommandHandler.java
@@ -21,9 +21,11 @@ import io.gravitee.cockpit.api.command.CommandStatus;
 import io.gravitee.cockpit.api.command.organization.OrganizationCommand;
 import io.gravitee.cockpit.api.command.organization.OrganizationPayload;
 import io.gravitee.cockpit.api.command.organization.OrganizationReply;
+import io.gravitee.rest.api.model.MembershipReferenceType;
 import io.gravitee.rest.api.model.OrganizationEntity;
 import io.gravitee.rest.api.model.UpdateOrganizationEntity;
 import io.gravitee.rest.api.service.OrganizationService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.reactivex.Single;
 import org.slf4j.Logger;
@@ -55,6 +57,8 @@ public class OrganizationCommandHandler implements CommandHandler<OrganizationCo
         OrganizationPayload organizationPayload = command.getPayload();
 
         try {
+            ExecutionContext executionContext = new ExecutionContext(organizationPayload.getId(), null);
+
             UpdateOrganizationEntity newOrganization = new UpdateOrganizationEntity();
             newOrganization.setCockpitId(organizationPayload.getCockpitId());
             newOrganization.setHrids(organizationPayload.getHrids());
@@ -63,7 +67,7 @@ public class OrganizationCommandHandler implements CommandHandler<OrganizationCo
             newOrganization.setDomainRestrictions(organizationPayload.getDomainRestrictions());
 
             final OrganizationEntity organization = organizationService.createOrUpdate(
-                GraviteeContext.getExecutionContext(),
+                executionContext,
                 organizationPayload.getId(),
                 newOrganization
             );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/producer/HelloCommandProducer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/producer/HelloCommandProducer.java
@@ -120,6 +120,6 @@ public class HelloCommandProducer implements CommandProducer<HelloCommand, Hello
         UpdateOrganizationEntity updateOrganization = new UpdateOrganizationEntity(defaultOrganization);
         updateOrganization.setCockpitId(defaultOrganizationCockpitId);
 
-        organizationService.createOrUpdate(GraviteeContext.getExecutionContext(), defaultOrganization.getId(), updateOrganization);
+        organizationService.createOrUpdate(GraviteeContext.getExecutionContext(), updateOrganization);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/OrganizationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/OrganizationServiceImpl.java
@@ -106,7 +106,7 @@ public class OrganizationServiceImpl extends TransactionalService implements Org
                 //create Default role for organization
                 roleService.initialize(executionContext, createdOrganization.getId());
                 roleService.createOrUpdateSystemRoles(executionContext, createdOrganization.getId());
-                createPublishOrganizationEvent(executionContext, createdOrganization, executionContext.getEnvironmentId());
+                createPublishOrganizationEvent(executionContext, createdOrganization);
 
                 return createdOrganization;
             }
@@ -132,7 +132,7 @@ public class OrganizationServiceImpl extends TransactionalService implements Org
                 Organization organization = convert(organizationEntity);
                 organization.setId(organizationId);
                 OrganizationEntity updatedOrganization = convert(organizationRepository.update(organization));
-                createPublishOrganizationEvent(executionContext, updatedOrganization, executionContext.getEnvironmentId());
+                createPublishOrganizationEvent(executionContext, updatedOrganization);
                 return updatedOrganization;
             } else {
                 throw new OrganizationNotFoundException(organizationId);
@@ -146,11 +146,8 @@ public class OrganizationServiceImpl extends TransactionalService implements Org
         }
     }
 
-    private void createPublishOrganizationEvent(
-        ExecutionContext executionContext,
-        OrganizationEntity organizationEntity,
-        String environmentId
-    ) throws JsonProcessingException {
+    private void createPublishOrganizationEvent(ExecutionContext executionContext, OrganizationEntity organizationEntity)
+        throws JsonProcessingException {
         Map<String, String> properties = new HashMap<>();
         properties.put(Event.EventProperties.ORGANIZATION_ID.getValue(), organizationEntity.getId());
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/OrganizationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/OrganizationServiceImpl.java
@@ -89,12 +89,9 @@ public class OrganizationServiceImpl extends TransactionalService implements Org
     }
 
     @Override
-    public OrganizationEntity createOrUpdate(
-        ExecutionContext executionContext,
-        String organizationId,
-        final UpdateOrganizationEntity organizationEntity
-    ) {
+    public OrganizationEntity createOrUpdate(ExecutionContext executionContext, final UpdateOrganizationEntity organizationEntity) {
         try {
+            String organizationId = executionContext.getOrganizationId();
             try {
                 return this.update(executionContext, organizationId, organizationEntity);
             } catch (OrganizationNotFoundException e) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/OrganizationCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/OrganizationCommandHandlerTest.java
@@ -27,7 +27,6 @@ import io.gravitee.cockpit.api.command.organization.OrganizationReply;
 import io.gravitee.rest.api.model.OrganizationEntity;
 import io.gravitee.rest.api.model.UpdateOrganizationEntity;
 import io.gravitee.rest.api.service.OrganizationService;
-import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.reactivex.observers.TestObserver;
 import java.util.Arrays;
 import java.util.Collections;
@@ -73,7 +72,7 @@ public class OrganizationCommandHandlerTest {
 
         when(
             organizationService.createOrUpdate(
-                eq(GraviteeContext.getExecutionContext()),
+                argThat(executionContext -> executionContext.getOrganizationId().equals("orga#1")),
                 eq("orga#1"),
                 argThat(
                     newOrganization ->
@@ -104,7 +103,11 @@ public class OrganizationCommandHandlerTest {
         organizationPayload.setDomainRestrictions(Arrays.asList("domain.restriction1.io", "domain.restriction2.io"));
 
         when(
-            organizationService.createOrUpdate(eq(GraviteeContext.getExecutionContext()), eq("orga#1"), any(UpdateOrganizationEntity.class))
+            organizationService.createOrUpdate(
+                argThat(executionContext -> executionContext.getOrganizationId().equals("orga#1")),
+                eq("orga#1"),
+                any(UpdateOrganizationEntity.class)
+            )
         )
             .thenThrow(new RuntimeException("fake error"));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/OrganizationCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/OrganizationCommandHandlerTest.java
@@ -73,7 +73,6 @@ public class OrganizationCommandHandlerTest {
         when(
             organizationService.createOrUpdate(
                 argThat(executionContext -> executionContext.getOrganizationId().equals("orga#1")),
-                eq("orga#1"),
                 argThat(
                     newOrganization ->
                         newOrganization.getCockpitId().equals(organizationPayload.getCockpitId()) &&
@@ -105,7 +104,6 @@ public class OrganizationCommandHandlerTest {
         when(
             organizationService.createOrUpdate(
                 argThat(executionContext -> executionContext.getOrganizationId().equals("orga#1")),
-                eq("orga#1"),
                 any(UpdateOrganizationEntity.class)
             )
         )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/producer/HelloCommandProducerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/producer/HelloCommandProducerTest.java
@@ -161,8 +161,7 @@ public class HelloCommandProducerTest {
 
         verify(organizationService)
             .createOrUpdate(
-                eq(GraviteeContext.getExecutionContext()),
-                eq(defaultOrgId),
+                argThat(executionContext -> executionContext.getOrganizationId().equals(defaultOrgId)),
                 argThat(org -> org.getCockpitId().equals("org#cockpit-1"))
             );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/OrganizationService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/OrganizationService_CreateTest.java
@@ -109,7 +109,9 @@ public class OrganizationService_CreateTest {
         when(mockOrganizationRepository.create(any())).thenReturn(createdOrganization);
         when(mockFlowService.findByReference(FlowReferenceType.ORGANIZATION, "org_id")).thenReturn(new ArrayList<>());
 
-        OrganizationEntity organization = organizationService.createOrUpdate(GraviteeContext.getExecutionContext(), "org_id", org1);
+        GraviteeContext.setCurrentOrganization("org_id");
+
+        OrganizationEntity organization = organizationService.createOrUpdate(GraviteeContext.getExecutionContext(), org1);
 
         assertNotNull("result is null", organization);
         verify(mockOrganizationRepository, times(1))
@@ -161,7 +163,9 @@ public class OrganizationService_CreateTest {
 
         when(environmentService.findByOrganization(createdOrganization.getId())).thenReturn(List.of(env1, env2));
 
-        OrganizationEntity organization = organizationService.createOrUpdate(GraviteeContext.getExecutionContext(), "org_id", org1);
+        GraviteeContext.setCurrentOrganization("org_id");
+
+        OrganizationEntity organization = organizationService.createOrUpdate(GraviteeContext.getExecutionContext(), org1);
 
         assertNotNull("result is null", organization);
         verify(mockOrganizationRepository, times(1))


### PR DESCRIPTION

**Issue**
https://github.com/gravitee-io/issues/issues/7461

**Description**

set right executionContext for OrganizationCommand 
Context with only organisation and null environment

And remove unused code

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jjdwmpcydm.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7461-fix-cockpit-context/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
