### PR TITLE
fix: do not rely on context environment when processing a promotion

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceImpl.java
@@ -257,6 +257,7 @@ public class PromotionServiceImpl extends AbstractService implements PromotionSe
                 .orElseThrow(() -> new PromotionNotFoundException(promotionId));
 
             EnvironmentEntity environment = environmentService.findByCockpitId(promotion.getTargetEnvCockpitId());
+            ExecutionContext targetExecutionContext = new ExecutionContext(executionContext.getOrganizationId(), environment.getId());
 
             promotion.setStatus(accepted ? PromotionStatus.ACCEPTED : PromotionStatus.REJECTED);
 
@@ -266,8 +267,6 @@ public class PromotionServiceImpl extends AbstractService implements PromotionSe
 
             if (PromotionStatus.ACCEPTED.equals(promotion.getStatus())) {
                 ApiEntity promoted = null;
-
-                ExecutionContext targetExecutionContext = new ExecutionContext(executionContext.getOrganizationId(), environment.getId());
 
                 if (apiToUpdate == null) {
                     if (!permissionService.hasPermission(targetExecutionContext, ENVIRONMENT_API, environment.getId(), CREATE)) {
@@ -291,7 +290,10 @@ public class PromotionServiceImpl extends AbstractService implements PromotionSe
 
             final PromotionEntity promotionEntity = convert(promotion);
 
-            final CockpitReply<PromotionEntity> cockpitReply = cockpitPromotionService.processPromotion(executionContext, promotionEntity);
+            final CockpitReply<PromotionEntity> cockpitReply = cockpitPromotionService.processPromotion(
+                targetExecutionContext,
+                promotionEntity
+            );
 
             if (cockpitReply.getStatus() != CockpitReplyStatus.SUCCEEDED) {
                 throw new BridgeOperationException(BridgeOperation.PROMOTE_API);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceTest.java
@@ -192,9 +192,13 @@ public class PromotionServiceTest {
 
     @Test
     public void shouldProcessAcceptedPromotionCreateApi() throws Exception {
+        final Promotion promotion = getAPromotion();
+        final EnvironmentEntity targetEnvironment = new EnvironmentEntity();
+        targetEnvironment.setId("target-env-id");
+
         when(objectMapper.readTree(anyString())).thenReturn(mock(ObjectNode.class));
-        when(promotionRepository.findById(any())).thenReturn(Optional.of(getAPromotion()));
-        when(environmentService.findByCockpitId(any())).thenReturn(new EnvironmentEntity());
+        when(promotionRepository.findById(any())).thenReturn(Optional.of(promotion));
+        when(environmentService.findByCockpitId(any())).thenReturn(targetEnvironment);
         when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(true);
 
         Page<Promotion> promotionPage = new Page<>(emptyList(), 0, 1, 1);
@@ -203,9 +207,15 @@ public class PromotionServiceTest {
         when(apiDuplicatorService.createWithImportedDefinition(any(), any())).thenReturn(new ApiEntity());
 
         CockpitReply<PromotionEntity> cockpitReply = new CockpitReply<>(null, CockpitReplyStatus.SUCCEEDED);
-        when(cockpitPromotionService.processPromotion(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(cockpitReply);
+        when(
+            cockpitPromotionService.processPromotion(
+                argThat(context -> targetEnvironment.getId().equals(context.getEnvironmentId())),
+                any()
+            )
+        )
+            .thenReturn(cockpitReply);
 
-        when(promotionRepository.update(any())).thenReturn(getAPromotion());
+        when(promotionRepository.update(any())).thenReturn(promotion);
 
         promotionService.processPromotion(GraviteeContext.getExecutionContext(), PROMOTION_ID, true);
 
@@ -215,12 +225,16 @@ public class PromotionServiceTest {
 
     @Test
     public void shouldProcessAcceptedPromotionUpdateApi() throws Exception {
+        final Promotion promotion = getAPromotion();
+        final EnvironmentEntity targetEnvironment = new EnvironmentEntity();
+        targetEnvironment.setId("target-env-id");
+
         when(objectMapper.readTree(anyString())).thenReturn(mock(ObjectNode.class));
-        when(promotionRepository.findById(any())).thenReturn(Optional.of(getAPromotion()));
-        when(environmentService.findByCockpitId(any())).thenReturn(new EnvironmentEntity());
+        when(promotionRepository.findById(any())).thenReturn(Optional.of(promotion));
+        when(environmentService.findByCockpitId(any())).thenReturn(targetEnvironment);
         when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(true);
 
-        Page<Promotion> promotionPage = new Page<>(singletonList(getAPromotion()), 0, 1, 1);
+        Page<Promotion> promotionPage = new Page<>(singletonList(promotion), 0, 1, 1);
         when(promotionRepository.search(any(), any(), any())).thenReturn(promotionPage);
 
         when(apiDuplicatorService.updateWithImportedDefinition(any(), any(), any())).thenReturn(new ApiEntity());
@@ -231,9 +245,15 @@ public class PromotionServiceTest {
         when(apiService.findById(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(existingApi);
 
         CockpitReply<PromotionEntity> cockpitReply = new CockpitReply<>(null, CockpitReplyStatus.SUCCEEDED);
-        when(cockpitPromotionService.processPromotion(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(cockpitReply);
+        when(
+            cockpitPromotionService.processPromotion(
+                argThat(context -> targetEnvironment.getId().equals(context.getEnvironmentId())),
+                any()
+            )
+        )
+            .thenReturn(cockpitReply);
 
-        when(promotionRepository.update(any())).thenReturn(getAPromotion());
+        when(promotionRepository.update(any())).thenReturn(promotion);
 
         promotionService.processPromotion(GraviteeContext.getExecutionContext(), PROMOTION_ID, true);
 
@@ -243,17 +263,27 @@ public class PromotionServiceTest {
 
     @Test
     public void shouldProcessRejectedPromotion() throws Exception {
-        when(objectMapper.readTree(anyString())).thenReturn(mock(ObjectNode.class));
-        when(promotionRepository.findById(any())).thenReturn(Optional.of(getAPromotion()));
-        when(environmentService.findByCockpitId(any())).thenReturn(new EnvironmentEntity());
+        final Promotion promotion = getAPromotion();
+        final EnvironmentEntity targetEnvironment = new EnvironmentEntity();
+        targetEnvironment.setId("target-env-id");
 
-        Page<Promotion> promotionPage = new Page<>(singletonList(getAPromotion()), 0, 1, 1);
+        when(objectMapper.readTree(anyString())).thenReturn(mock(ObjectNode.class));
+        when(promotionRepository.findById(any())).thenReturn(Optional.of(promotion));
+        when(environmentService.findByCockpitId(any())).thenReturn(targetEnvironment);
+
+        Page<Promotion> promotionPage = new Page<>(singletonList(promotion), 0, 1, 1);
         when(promotionRepository.search(any(), any(), any())).thenReturn(promotionPage);
 
         CockpitReply<PromotionEntity> cockpitReply = new CockpitReply<>(null, CockpitReplyStatus.SUCCEEDED);
-        when(cockpitPromotionService.processPromotion(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(cockpitReply);
+        when(
+            cockpitPromotionService.processPromotion(
+                argThat(context -> targetEnvironment.getId().equals(context.getEnvironmentId())),
+                any()
+            )
+        )
+            .thenReturn(cockpitReply);
 
-        when(promotionRepository.update(any())).thenReturn(getAPromotion());
+        when(promotionRepository.update(any())).thenReturn(promotion);
 
         promotionService.processPromotion(GraviteeContext.getExecutionContext(), PROMOTION_ID, false);
 
@@ -285,9 +315,13 @@ public class PromotionServiceTest {
 
     @Test(expected = BridgeOperationException.class)
     public void shouldNotProcessPromotionIfCockpitReplyError() throws Exception {
+        final Promotion promotion = getAPromotion();
+        final EnvironmentEntity targetEnvironment = new EnvironmentEntity();
+        targetEnvironment.setId("target-env-id");
+
         when(objectMapper.readTree(anyString())).thenReturn(mock(ObjectNode.class));
         when(promotionRepository.findById(any())).thenReturn(Optional.of(getAPromotion()));
-        when(environmentService.findByCockpitId(any())).thenReturn(new EnvironmentEntity());
+        when(environmentService.findByCockpitId(any())).thenReturn(targetEnvironment);
         when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(true);
 
         Page<Promotion> promotionPage = new Page<>(singletonList(getAPromotion()), 0, 1, 1);
@@ -301,7 +335,14 @@ public class PromotionServiceTest {
         when(apiService.findById(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(existingApi);
 
         CockpitReply<PromotionEntity> cockpitReply = new CockpitReply<>(null, CockpitReplyStatus.ERROR);
-        when(cockpitPromotionService.processPromotion(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(cockpitReply);
+
+        when(
+            cockpitPromotionService.processPromotion(
+                argThat(context -> targetEnvironment.getId().equals(context.getEnvironmentId())),
+                any()
+            )
+        )
+            .thenReturn(cockpitReply);
 
         promotionService.processPromotion(GraviteeContext.getExecutionContext(), PROMOTION_ID, true);
 
@@ -335,6 +376,7 @@ public class PromotionServiceTest {
         );
 
         assertThat(promotionEntity).isNotNull();
+
         verify(auditService)
             .createApiAuditLog(
                 eq(GraviteeContext.getExecutionContext()),


### PR DESCRIPTION
see https://github.com/gravitee-io/issues/issues/7462

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ysxmweredt.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-target-promotion-environment/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
