### PR TITLE
ci: add steps to build both ee and ce version of our docker dev images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,7 +265,7 @@ jobs:
             - run:
                   name: "Build project"
                   command: |
-                      mvn -s .gravitee.settings.xml clean package --no-transfer-progress -DskipTests -Dskip.validation=true -T 2C -P distribution-dev
+                      mvn -s .gravitee.settings.xml clean package --no-transfer-progress -DskipTests -Dskip.validation=true -T 2C -P distribution-dev,distribution-ee
                       mkdir -p ./rest-api-docker-context/distribution && cp -r ./gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target/distribution ./rest-api-docker-context/.
                       mkdir -p ./gateway-docker-context/distribution && cp -r ./gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target/distribution ./gateway-docker-context/.
 
@@ -371,6 +371,10 @@ jobs:
             - notify-on-failure
 
     publish-images-azure-registry:
+        parameters:
+            enterprise_edition:
+                default: false
+                type: boolean
         docker:
             - image: cimg/openjdk:11.0
         resource_class: small
@@ -387,11 +391,34 @@ jobs:
             - keeper/env-export:
                   secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
                   var-name: AZURE_DOCKER_REGISTRY_PASSWORD
+            - when:
+                  condition:
+                      not: << parameters.enterprise_edition>>
+                  steps:
+                      - run:
+                            name: Prepare the CE image by removing EE lib & plugins
+                            command: |
+                                ## Clean rest api
+                                rm rest-api-docker-context/distribution/lib/gravitee-license-node-enterprise*.jar
+                                rm rest-api-docker-context/distribution/plugins/gravitee-ae-connectors-ws*.zip
+                                rm rest-api-docker-context/distribution/plugins/gravitee-notifier-*.zip
+                                rm rest-api-docker-context/distribution/plugins/gravitee-policy-assign-metrics-*.zip
+                                rm rest-api-docker-context/distribution/plugins/gravitee-policy-data-logging-masking-*.zip
+                                ## Clean Gateway
+                                rm gateway-docker-context/distribution/lib/gravitee-license-node-enterprise*.jar
+                                rm gateway-docker-context/distribution/plugins/gravitee-ae-connectors-ws*.zip
+                                rm gateway-docker-context/distribution/plugins/gravitee-policy-assign-metrics-*.zip
+                                rm gateway-docker-context/distribution/plugins/gravitee-policy-data-logging-masking-*.zip
             - run:
-                  name: Build & Publish Management API and Gateway Docker Image to Azure Registry
+                  name: Build & publish dev docker image <<# parameters.enterprise_edition >>- Enterprise edition<</ parameters.enterprise_edition >>
                   command: |
-                      export REST_API_PRIVATE_IMAGE_TAG=graviteeio.azurecr.io/apim-management-api:${TAG}
-                      export GATEWAY_PRIVATE_IMAGE_TAG=graviteeio.azurecr.io/apim-gateway:${TAG}
+                      export dockerTag=$TAG
+                      if [ "<< parameters.enterprise_edition >>" == "true" ]; then
+                        dockerTag=$(echo $dockerTag | sed 's/-/-ee-/')
+                      fi
+                      
+                      export REST_API_PRIVATE_IMAGE_TAG=graviteeio.azurecr.io/apim-management-api:${dockerTag}
+                      export GATEWAY_PRIVATE_IMAGE_TAG=graviteeio.azurecr.io/apim-gateway:${dockerTag}
 
                       docker build -f gravitee-apim-rest-api/docker/Dockerfile-dev \
                       --build-arg GRAVITEEIO_VERSION=${APIM_VERSION} \
@@ -402,12 +429,11 @@ jobs:
                       --build-arg GRAVITEEIO_VERSION=${APIM_VERSION} \
                       -t ${GATEWAY_PRIVATE_IMAGE_TAG} \
                       gateway-docker-context
-
+                      
                       echo $AZURE_DOCKER_REGISTRY_PASSWORD | docker login --username $AZURE_DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
                       docker push ${REST_API_PRIVATE_IMAGE_TAG}
                       docker push ${GATEWAY_PRIVATE_IMAGE_TAG}
                       docker logout graviteeio.azurecr.io
-
             - notify-on-failure
 
     cypress-install:
@@ -1229,7 +1255,9 @@ workflows:
                       - test
                       - test-repository
             - publish-images-azure-registry:
+                  name: Publish ee images on azure registry
                   context: cicd-orchestrator
+                  enterprise_edition: true
                   requires:
                       - test
                       - test-repository
@@ -1238,6 +1266,18 @@ workflows:
                           only:
                               - master
                               - /^\d+\.\d+\.x$/
+            -   publish-images-azure-registry:
+                    name: Publish ce images on azure registry
+                    context: cicd-orchestrator
+                    enterprise_edition: false
+                    requires:
+                        - test
+                        - test-repository
+                    filters:
+                        branches:
+                            only:
+                                - master
+                                - /^\d+\.\d+\.x$/
             - webui-lint-test:
                   name: Lint & Test APIM Console
                   apim-ui-project: gravitee-apim-console-webui
@@ -1319,7 +1359,8 @@ workflows:
             - deploy-on-azure-cluster:
                   context: cicd-orchestrator
                   requires:
-                      - publish-images-azure-registry
+                      - Publish ee images on azure registry
+                      - Publish ce images on azure registry
                       - Build and publish APIM Console docker image
                       - Build and publish APIM Portal docker image
                   filters:

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -771,6 +771,12 @@
                     <version>${gravitee-policy-data-logging-masking.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>com.jayway.jsonpath</groupId>
+                            <artifactId>json-path</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
             </dependencies>
         </profile>


### PR DESCRIPTION
**Issue**

Try to avec EE env into apim cloud

**Description**

Try to finish this draft https://github.com/gravitee-io/gravitee-api-management/pull/1496


To avoid building twice APIM and doubling the size of files stored in the circleci workspace, we build first an EE APIM version, then we removed EE lib and EE plugins to build a CE version.

**Additional context**
https://github.com/gravitee-io/cloud-apim/pull/11

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hqsmhxvnut.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/ci-test-buile-ee-images/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
