### PR TITLE
Add a manual approval step before running Chromatic to save money

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1247,10 +1247,14 @@ workflows:
                   name: Build Console Storybook
                   requires:
                       - setup
+            - trigger-chromatic:
+                  type: approval
+                  requires:
+                      - Build Console Storybook
             - console-webui-chromatic-deployment:
                   context: cicd-orchestrator
                   requires:
-                      - Build Console Storybook
+                      - trigger-chromatic
             - webui-build:
                   name: Build APIM Console
                   apim-ui-project: gravitee-apim-console-webui


### PR DESCRIPTION
**Issue**

NA

**Description**

Add a manual approval step before running Chromatic to save money.

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/add-manual-approval-before-running-chromatic/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
