### PR TITLE
Add an attribute to specify the version of TLS to use in MongoFactory

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -114,6 +114,7 @@ management:
 
 ## SSL settings
 #    sslEnabled:                  # mongodb ssl mode (default false)
+#    tlsProtocol:                 # protocol to use when connecting to the mongodb instance (when sslEnabled is true, default TLS)
 #    keystore:
 #      path:                      # Path to the keystore (when sslEnabled is true, default null)
 #      type:                      # Type of the keystore, supports jks, pem, pkcs12 (when sslEnabled is true, default null)

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/common/MongoFactory.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/common/MongoFactory.java
@@ -144,7 +144,8 @@ public class MongoFactory implements FactoryBean<MongoClient> {
 
         if (sslEnabled) {
             try {
-                SSLContext sslContext = SSLContext.getInstance("TLS");
+                String tlsProtocol = readPropertyValue(propertyPrefix + "tlsProtocol", String.class, "TLS");
+                SSLContext sslContext = SSLContext.getInstance(tlsProtocol);
                 sslContext.init(getKeyManagers(), getTrustManagers(), null);
                 sslBuilder.context(sslContext);
             } catch (NoSuchAlgorithmException | KeyManagementException e) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -153,6 +153,7 @@ management:
 
 ## SSL settings
 #    sslEnabled:                  # mongodb ssl mode (default false)
+#    tlsProtocol:                 # protocol to use when connecting to the mongodb instance (when sslEnabled is true, default TLS)
 #    keystore:
 #      path:                      # Path to the keystore (when sslEnabled is true, default null)
 #      type:                      # Type of the keystore, supports jks, pem, pkcs12 (when sslEnabled is true, default null)


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7212

**Description**

Add an attribute to specify the version of TLS to use in MongoFactory

TODO: 
 - [x] Find a way to test it properly, I didn't succeed in running a local APIM configured with a MongoDB + SSL with autosign certificate
 - [x] Add a note in the docs: https://github.com/gravitee-io/gravitee-docs/pull/754
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/7212-use-tls1-2-in-mongo-factory/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lmgnurxhqm.chromatic.com)
<!-- Storybook placeholder end -->
