### PR TITLE
chore(ci): build gravitee-apim-repository before launching APIM tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,6 +290,9 @@ jobs:
             - run:
                   name: Run tests
                   command: |
+                      cd gravitee-apim-repository/gravitee-apim-repository-api
+                      mvn -s ../../.gravitee.settings.xml clean install -DskipTests
+                      cd ../..
                       mvn -pl 'gravitee-apim-definition, gravitee-apim-rest-api, gravitee-apim-gateway' -amd --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dskip.validation=true -T 2C
             - run:
                   name: Save test results


### PR DESCRIPTION
APIM tests need repository to be build before cause it uses repository model.
This is a workaround before refactoring the cache system.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/chore-citestsrepoworkaround/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
