### PR TITLE
fix: fix 'not equals' alert filter condition field type

### DIFF
--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-string.component.spec.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-string.component.spec.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { IComponentControllerService } from 'angular';
+
+import { setupAngularJsTesting } from '../../../../../../jest.setup';
+
+setupAngularJsTesting();
+
+describe('AlertTriggerConditionStringComponent', () => {
+  let $componentController: IComponentControllerService;
+  let alertTriggerConditionStringComponent: any;
+
+  beforeEach(inject((_$componentController_) => {
+    $componentController = _$componentController_;
+    alertTriggerConditionStringComponent = $componentController('gvAlertTriggerConditionString', null, {});
+  }));
+
+  describe('displaySelect', () => {
+    describe('values are set', () => {
+      beforeEach(() => {
+        alertTriggerConditionStringComponent.values = [];
+      });
+
+      it('should return true with NOT_EQUALS operator', () => {
+        alertTriggerConditionStringComponent.condition = { operator: 'NOT_EQUALS' };
+        expect(alertTriggerConditionStringComponent.displaySelect()).toBeTruthy();
+      });
+
+      it('should return true with EQUALS operator', () => {
+        alertTriggerConditionStringComponent.condition = { operator: 'EQUALS' };
+        expect(alertTriggerConditionStringComponent.displaySelect()).toBeTruthy();
+      });
+
+      it('should return false with another operator', () => {
+        alertTriggerConditionStringComponent.condition = { operator: 'ANOTHER' };
+        expect(alertTriggerConditionStringComponent.displaySelect()).toBeFalsy();
+      });
+    });
+
+    describe('values are not set', () => {
+      beforeEach(() => {
+        alertTriggerConditionStringComponent.values = undefined;
+      });
+
+      it('should return false with NOT_EQUALS operator', () => {
+        alertTriggerConditionStringComponent.condition = { operator: 'NOT_EQUALS' };
+        expect(alertTriggerConditionStringComponent.displaySelect()).toBeFalsy();
+      });
+
+      it('should return false with EQUALS operator', () => {
+        alertTriggerConditionStringComponent.condition = { operator: 'EQUALS' };
+        expect(alertTriggerConditionStringComponent.displaySelect()).toBeFalsy();
+      });
+
+      it('should return false with another operator', () => {
+        alertTriggerConditionStringComponent.condition = { operator: 'ANOTHER' };
+        expect(alertTriggerConditionStringComponent.displaySelect()).toBeFalsy();
+      });
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-string.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-string.component.ts
@@ -51,7 +51,7 @@ const AlertTriggerConditionStringComponent: ng.IComponentOptions = {
     };
 
     this.displaySelect = () => {
-      return (this.values !== undefined && this.condition.operator === 'EQUALS') || this.condition.operator === 'NOT_EQUALS';
+      return this.values !== undefined && (this.condition.operator === 'EQUALS' || this.condition.operator === 'NOT_EQUALS');
     };
   },
 };


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7489

**Description**

fix: fix 'not equals' alert filter condition field type

not_equals condition should behave like equals condition :
- When the condition contains values, display a list of values, let the user select one of them
- When the condition doesn't contain any value, display an input field, let the user enter his own value
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-fixalertsconditions/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
