### PR TITLE
chore(ci): split steps 'build repo models' and 'run tests'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -288,11 +288,12 @@ jobs:
                   at: .
             - restore-maven-cache
             - run:
+                  name: Build repository models
+                  command: |
+                      mvn clean install -s .gravitee.settings.xml -f gravitee-apim-repository/gravitee-apim-repository-api -Dskip.validation=true -DskipTests
+            - run:
                   name: Run tests
                   command: |
-                      cd gravitee-apim-repository/gravitee-apim-repository-api
-                      mvn -s ../../.gravitee.settings.xml clean install -DskipTests
-                      cd ../..
                       mvn -pl 'gravitee-apim-definition, gravitee-apim-rest-api, gravitee-apim-gateway' -amd --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dskip.validation=true -T 2C
             - run:
                   name: Save test results


### PR DESCRIPTION
chore(ci): split steps 'build repo models' and 'run tests'
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/refactor-improvecirclecisyntax/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
