### PR TITLE
fix: use org instead of env when auditing token creation

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TokenServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TokenServiceImpl.java
@@ -85,7 +85,7 @@ public class TokenServiceImpl extends AbstractService implements TokenService {
             final Token token = convert(newToken, TokenReferenceType.USER, user, passwordEncoder.encode(decodedToken));
             auditService.createOrganizationAuditLog(
                 executionContext,
-                executionContext.getEnvironmentId(),
+                executionContext.getOrganizationId(),
                 Collections.singletonMap(TOKEN, token.getId()),
                 TOKEN_CREATED,
                 token.getCreatedAt(),
@@ -114,7 +114,7 @@ public class TokenServiceImpl extends AbstractService implements TokenService {
                 tokenRepository.delete(tokenId);
                 auditService.createOrganizationAuditLog(
                     executionContext,
-                    executionContext.getEnvironmentId(),
+                    executionContext.getOrganizationId(),
                     Collections.singletonMap(TOKEN, tokenId),
                     TOKEN_DELETED,
                     new Date(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/TokenServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/TokenServiceTest.java
@@ -63,6 +63,8 @@ public class TokenServiceTest {
 
     private static final String USER_ID = "user123";
     private static final String TOKEN_ID = "1";
+    private static final String CURRENT_ENVIRONMENT = "test";
+    private static final String CURRENT_ORGANIZATION = "gravitee";
 
     @InjectMocks
     private final TokenService tokenService = new TokenServiceImpl();
@@ -93,6 +95,7 @@ public class TokenServiceTest {
                 public void setAuthentication(Authentication authentication) {}
             }
         );
+        GraviteeContext.cleanContext();
     }
 
     @Before
@@ -152,6 +155,8 @@ public class TokenServiceTest {
                 public void setAuthentication(Authentication authentication) {}
             }
         );
+        GraviteeContext.setCurrentOrganization(CURRENT_ORGANIZATION);
+        GraviteeContext.setCurrentEnvironment(CURRENT_ENVIRONMENT);
     }
 
     @Test
@@ -199,7 +204,7 @@ public class TokenServiceTest {
         verify(auditService)
             .createOrganizationAuditLog(
                 eq(GraviteeContext.getExecutionContext()),
-                eq(GraviteeContext.getCurrentEnvironment()),
+                eq(CURRENT_ORGANIZATION),
                 anyMap(),
                 eq(TOKEN_CREATED),
                 any(Date.class),
@@ -227,7 +232,7 @@ public class TokenServiceTest {
         verify(auditService)
             .createOrganizationAuditLog(
                 eq(GraviteeContext.getExecutionContext()),
-                eq(GraviteeContext.getCurrentEnvironment()),
+                eq(CURRENT_ORGANIZATION),
                 anyMap(),
                 eq(TOKEN_DELETED),
                 any(Date.class),
@@ -246,7 +251,7 @@ public class TokenServiceTest {
         verify(auditService)
             .createOrganizationAuditLog(
                 eq(GraviteeContext.getExecutionContext()),
-                eq(GraviteeContext.getCurrentEnvironment()),
+                eq(CURRENT_ORGANIZATION),
                 anyMap(),
                 eq(TOKEN_DELETED),
                 any(Date.class),


### PR DESCRIPTION
see https://github.com/gravitee-io/issues/issues/7507
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-create-token-context/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
