### PR TITLE
fix(debug): stop policy chain if doesn't have stream

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/policy/impl/PolicyDebugDecorator.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/policy/impl/PolicyDebugDecorator.java
@@ -81,6 +81,7 @@ public class PolicyDebugDecorator implements Policy {
 
             if (stream == null) {
                 debugContext.saveNoTransformationDebugStep(debugStep);
+                return null;
             }
 
             return new DebugReadWriteStream(debugContext, stream, debugStep);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/policy/impl/PolicyDebugDecoratorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/policy/impl/PolicyDebugDecoratorTest.java
@@ -217,7 +217,7 @@ public class PolicyDebugDecoratorTest {
         verify(noTransformationPolicy, never()).onResponseContent(policyChain, request, response);
         verify(debugPolicy, atLeastOnce()).stream(policyChain, context);
 
-        verify(context, times(1)).saveNoTransformationDebugStep(any());
+        verify(context, atLeastOnce()).saveNoTransformationDebugStep(any());
         assertThat(chainCaptor.getValue()).isInstanceOf(DebugStreamablePolicyChain.class);
     }
 
@@ -274,7 +274,7 @@ public class PolicyDebugDecoratorTest {
         verify(noTransformationPolicy, atLeastOnce()).onResponseContent(chainCaptor.capture(), eq(request), eq(response));
         verify(debugPolicy, atLeastOnce()).stream(policyChain, context);
 
-        verify(context, times(1)).saveNoTransformationDebugStep(any());
+        verify(context, atLeastOnce()).saveNoTransformationDebugStep(any());
         assertThat(chainCaptor.getValue()).isInstanceOf(DebugStreamablePolicyChain.class);
     }
 


### PR DESCRIPTION
gravitee-io/issues#7499

Reg after https://github.com/gravitee-io/gravitee-api-management/commit/b7f985f849bcd297d52a9d0a474f403820ba9cc4
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7499-debug-mode/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
