### PR TITLE
test: enable tearDownApi() helper to deal with multiple plans

### DIFF
--- a/gravitee-apim-cypress/cypress/support/common/api.commands.ts
+++ b/gravitee-apim-cypress/cypress/support/common/api.commands.ts
@@ -43,7 +43,7 @@ Cypress.Commands.add('teardownApi', (api) => {
   cy.log(`----- Removing API "${api.name}" -----`);
   cy.log(`Number of plans: ${api.plans.length}`);
   if (api.plans.length > 0) {
-    closePlan(ADMIN_USER, api.id, api.plans[0].id).ok();
+    api.plans.forEach((plan) => closePlan(ADMIN_USER, api.id, plan.id).ok())
   }
   stopApi(ADMIN_USER, api.id).noContent();
   deleteApi(ADMIN_USER, api.id).noContent();


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/7293

The helper function to tear down an API (stop plan, stop API, delete API) wasn't able to deal with multiple plans yet, so that was changed.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/test-improve-teardownapi-function/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
