### PR TITLE
feat: bump ui-components dependency to v3.35.0

### DIFF
--- a/gravitee-apim-console-webui/package-lock.json
+++ b/gravitee-apim-console-webui/package-lock.json
@@ -21,7 +21,7 @@
         "@angular/upgrade": "12.2.3",
         "@asyncapi/web-component": "1.0.0-next.15",
         "@fontsource/libre-franklin": "4.4.5",
-        "@gravitee/ui-components": "3.33.1",
+        "@gravitee/ui-components": "3.35.0",
         "@gravitee/ui-particles-angular": "3.4.0",
         "@gravitee/ui-policy-studio-angular": "3.0.1",
         "@highcharts/map-collection": "1.1.4",
@@ -11159,9 +11159,9 @@
       "dev": true
     },
     "node_modules/@gravitee/ui-components": {
-      "version": "3.33.1",
-      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.33.1.tgz",
-      "integrity": "sha512-Lkh2f+OsfDgEc8US2vxAe7SsFyG5k2D1GGSEddG3gZIHUwEnUi0ylrWIyJB1u5nGoAvDT6VnlsJLGWLbksCyAA==",
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.35.0.tgz",
+      "integrity": "sha512-YuQbXY+xYSSt3eXgigYx5jdu92C+PBmPoxu/VkGc2zngytBFGQG7wpBObGZEt53MfQ7nNNzaaTTsxb9dvdNiqg==",
       "dependencies": {
         "@codemirror/basic-setup": "^0.19.1",
         "@codemirror/language-data": "^0.19.1",
@@ -56454,9 +56454,9 @@
       "dev": true
     },
     "@gravitee/ui-components": {
-      "version": "3.33.1",
-      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.33.1.tgz",
-      "integrity": "sha512-Lkh2f+OsfDgEc8US2vxAe7SsFyG5k2D1GGSEddG3gZIHUwEnUi0ylrWIyJB1u5nGoAvDT6VnlsJLGWLbksCyAA==",
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.35.0.tgz",
+      "integrity": "sha512-YuQbXY+xYSSt3eXgigYx5jdu92C+PBmPoxu/VkGc2zngytBFGQG7wpBObGZEt53MfQ7nNNzaaTTsxb9dvdNiqg==",
       "requires": {
         "@codemirror/basic-setup": "^0.19.1",
         "@codemirror/language-data": "^0.19.1",

--- a/gravitee-apim-console-webui/package.json
+++ b/gravitee-apim-console-webui/package.json
@@ -15,7 +15,7 @@
     "@angular/upgrade": "12.2.3",
     "@asyncapi/web-component": "1.0.0-next.15",
     "@fontsource/libre-franklin": "4.4.5",
-    "@gravitee/ui-components": "3.33.1",
+    "@gravitee/ui-components": "3.35.0",
     "@gravitee/ui-particles-angular": "3.4.0",
     "@gravitee/ui-policy-studio-angular": "3.0.1",
     "@highcharts/map-collection": "1.1.4",


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6065
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/feat-apipropertiestitle/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
