### PR TITLE
fix: let OneShotUpgraders handle multi-organization and multi-environ…

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/Upgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/Upgrader.java
@@ -15,18 +15,12 @@
  */
 package io.gravitee.rest.api.service;
 
-import io.gravitee.rest.api.service.common.ExecutionContext;
-
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface Upgrader {
-    // FIXME : executionContext parameter has to be removed
-    //  Upgrader.upgrade() is run with the default environment ExecutionContext as parameter
-    //  But most upgraders have to process every environment, not only the default one
-    //  Related issue : https://github.com/gravitee-io/issues/issues/7407
-    boolean upgrade(ExecutionContext executionContext);
+    boolean upgrade();
 
     int getOrder();
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UpgraderServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UpgraderServiceImpl.java
@@ -18,7 +18,6 @@ package io.gravitee.rest.api.service.impl;
 import io.gravitee.common.service.AbstractService;
 import io.gravitee.rest.api.service.InitializerService;
 import io.gravitee.rest.api.service.Upgrader;
-import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.Comparator;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -54,7 +53,7 @@ public class UpgraderServiceImpl extends AbstractService<UpgraderServiceImpl> im
             .forEach(
                 upgrader -> {
                     logger.info("Running upgrader {}", upgrader.getClass().getName());
-                    upgrader.upgrade(GraviteeContext.getExecutionContext());
+                    upgrader.upgrade();
                 }
             );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/AlertsEnvironmentUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/AlertsEnvironmentUpgrader.java
@@ -25,7 +25,6 @@ import io.gravitee.repository.management.model.Application;
 import io.gravitee.rest.api.model.alert.AlertReferenceType;
 import io.gravitee.rest.api.model.alert.AlertTriggerEntity;
 import io.gravitee.rest.api.service.InstallationService;
-import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.converter.AlertTriggerConverter;
 import io.gravitee.rest.api.service.exceptions.AbstractNotFoundException;
@@ -84,7 +83,7 @@ public class AlertsEnvironmentUpgrader extends OneShotUpgrader {
     }
 
     @Override
-    protected void processOneShotUpgrade(ExecutionContext executionContext) throws TechnicalException {
+    protected void processOneShotUpgrade() throws TechnicalException {
         alertTriggerRepository
             .findAll()
             .forEach(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/ApiKeySubscriptionsUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/ApiKeySubscriptionsUpgrader.java
@@ -19,8 +19,8 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.model.ApiKey;
 import io.gravitee.rest.api.service.InstallationService;
-import io.gravitee.rest.api.service.common.ExecutionContext;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,7 +48,7 @@ public class ApiKeySubscriptionsUpgrader extends OneShotUpgrader {
     }
 
     @Override
-    protected void processOneShotUpgrade(ExecutionContext executionContext) throws TechnicalException {
+    protected void processOneShotUpgrade() throws TechnicalException {
         apiKeyRepository.findAll().forEach(this::updateApiKeySubscriptions);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/ApiLoggingConditionUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/ApiLoggingConditionUpgrader.java
@@ -23,7 +23,6 @@ import io.gravitee.repository.management.model.Api;
 import io.gravitee.rest.api.model.InstallationEntity;
 import io.gravitee.rest.api.service.InstallationService;
 import io.gravitee.rest.api.service.Upgrader;
-import io.gravitee.rest.api.service.common.ExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,7 +44,7 @@ public class ApiLoggingConditionUpgrader implements Upgrader, Ordered {
     private ObjectMapper objectMapper;
 
     @Override
-    public boolean upgrade(ExecutionContext executionContext) {
+    public boolean upgrade() {
         InstallationEntity installation = installationService.getOrInitialize();
         if (isStatus(installation, SUCCESS)) {
             LOGGER.info("Skipping {} execution cause it has already been successfully executed", this.getClass().getSimpleName());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/ApplicationApiKeyModeUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/ApplicationApiKeyModeUpgrader.java
@@ -29,7 +29,6 @@ import io.gravitee.repository.management.model.Application;
 import io.gravitee.repository.management.model.Plan;
 import io.gravitee.repository.management.model.Subscription;
 import io.gravitee.rest.api.service.InstallationService;
-import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -68,7 +67,7 @@ public class ApplicationApiKeyModeUpgrader extends OneShotUpgrader {
     }
 
     @Override
-    protected void processOneShotUpgrade(ExecutionContext executionContext) throws Exception {
+    protected void processOneShotUpgrade() throws Exception {
         List<String> apiKeyPlansIds = findAllApiKeyPlansId();
         Map<String, Long> apiKeySubscriptionsCountByApplication = countApiKeySubscriptionsByApplication(apiKeyPlansIds);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/CockpitIdUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/CockpitIdUpgrader.java
@@ -38,7 +38,10 @@ public class CockpitIdUpgrader implements Upgrader, Ordered {
     private EnvironmentService environmentService;
 
     @Override
-    public boolean upgrade(ExecutionContext executionContext) {
+    public boolean upgrade() {
+        // FIXME : this upgrader uses the default ExecutionContext, but should handle all environments/organizations
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+
         Collection<OrganizationEntity> organizations = organizationService.findAll();
 
         organizations

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DefaultCategoryUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DefaultCategoryUpgrader.java
@@ -21,7 +21,6 @@ import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.CategoryRepository;
 import io.gravitee.repository.management.model.Category;
 import io.gravitee.rest.api.service.Upgrader;
-import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.Date;
 import java.util.Optional;
 import java.util.Set;
@@ -51,7 +50,7 @@ public class DefaultCategoryUpgrader implements Upgrader, Ordered {
     private ApiRepository apiRepository;
 
     @Override
-    public boolean upgrade(ExecutionContext executionContext) {
+    public boolean upgrade() {
         // Initialize default category
         final Set<Category> categories;
         try {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DefaultDashboardsUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DefaultDashboardsUpgrader.java
@@ -25,6 +25,7 @@ import io.gravitee.rest.api.model.NewDashboardEntity;
 import io.gravitee.rest.api.service.DashboardService;
 import io.gravitee.rest.api.service.Upgrader;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.List;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
@@ -46,7 +47,10 @@ public class DefaultDashboardsUpgrader implements Upgrader, Ordered {
     private DashboardService dashboardService;
 
     @Override
-    public boolean upgrade(ExecutionContext executionContext) {
+    public boolean upgrade() {
+        // FIXME : this upgrader uses the default ExecutionContext, but should handle all environments/organizations
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+
         final List<DashboardEntity> dashboards = dashboardService.findAll();
         if (dashboards == null || dashboards.isEmpty()) {
             checkAndCreateDashboard(executionContext, PLATFORM);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DefaultEnvironmentUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DefaultEnvironmentUpgrader.java
@@ -17,7 +17,6 @@ package io.gravitee.rest.api.service.impl.upgrade;
 
 import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.Upgrader;
-import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,7 +40,7 @@ public class DefaultEnvironmentUpgrader implements Upgrader, Ordered {
     private EnvironmentService environmentService;
 
     @Override
-    public boolean upgrade(ExecutionContext executionContext) {
+    public boolean upgrade() {
         // initialize roles.
         if (environmentService.findByOrganization(GraviteeContext.getDefaultOrganization()).isEmpty()) {
             logger.info("    No environment found. Add default one.");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DefaultInstallationUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DefaultInstallationUpgrader.java
@@ -18,7 +18,6 @@ package io.gravitee.rest.api.service.impl.upgrade;
 import io.gravitee.rest.api.model.InstallationEntity;
 import io.gravitee.rest.api.service.InstallationService;
 import io.gravitee.rest.api.service.Upgrader;
-import io.gravitee.rest.api.service.common.ExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,7 +37,7 @@ public class DefaultInstallationUpgrader implements Upgrader, Ordered {
     private InstallationService installationService;
 
     @Override
-    public boolean upgrade(ExecutionContext executionContext) {
+    public boolean upgrade() {
         final InstallationEntity installation = installationService.getOrInitialize();
         logger.info("Current installation id is [{}]", installation.getId());
         return true;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DefaultMetadataUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DefaultMetadataUpgrader.java
@@ -21,6 +21,7 @@ import io.gravitee.rest.api.model.NewMetadataEntity;
 import io.gravitee.rest.api.service.MetadataService;
 import io.gravitee.rest.api.service.Upgrader;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,7 +48,10 @@ public class DefaultMetadataUpgrader implements Upgrader, Ordered {
     private MetadataService metadataService;
 
     @Override
-    public boolean upgrade(ExecutionContext executionContext) {
+    public boolean upgrade() {
+        // FIXME : this upgrader uses the default ExecutionContext, but should handle all environments/organizations
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+
         // initialize default metadata
         final MetadataEntity defaultEmailSupportMetadata = metadataService.findDefaultByKey(METADATA_EMAIL_SUPPORT_KEY);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DefaultOrganizationUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DefaultOrganizationUpgrader.java
@@ -17,7 +17,6 @@ package io.gravitee.rest.api.service.impl.upgrade;
 
 import io.gravitee.rest.api.service.OrganizationService;
 import io.gravitee.rest.api.service.Upgrader;
-import io.gravitee.rest.api.service.common.ExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,7 +39,7 @@ public class DefaultOrganizationUpgrader implements Upgrader, Ordered {
     private OrganizationService organizationService;
 
     @Override
-    public boolean upgrade(ExecutionContext executionContext) {
+    public boolean upgrade() {
         // initialize default organization.
         if (organizationService.count().equals(0L)) {
             logger.info("    No organization found. Add default one.");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DefaultPageRevisionUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DefaultPageRevisionUpgrader.java
@@ -23,7 +23,6 @@ import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.service.PageRevisionService;
 import io.gravitee.rest.api.service.PageService;
 import io.gravitee.rest.api.service.Upgrader;
-import io.gravitee.rest.api.service.common.ExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,7 +48,7 @@ public class DefaultPageRevisionUpgrader implements Upgrader, Ordered {
     private PageRevisionService pageRevisionService;
 
     @Override
-    public boolean upgrade(ExecutionContext executionContext) {
+    public boolean upgrade() {
         if (hasNoRevisions()) {
             logger.info("No page revisions found. Create a default revision based on pages.");
             final int pageSize = 100;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DefaultParameterUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DefaultParameterUpgrader.java
@@ -21,7 +21,6 @@ import io.gravitee.repository.management.model.Parameter;
 import io.gravitee.repository.management.model.ParameterReferenceType;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.service.Upgrader;
-import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
@@ -51,7 +50,7 @@ public class DefaultParameterUpgrader implements Upgrader, Ordered {
     private ConfigurableEnvironment environment;
 
     @Override
-    public boolean upgrade(ExecutionContext executionContext) {
+    public boolean upgrade() {
         try {
             String envPortalURL = environment.getProperty("portalURL", Key.MANAGEMENT_URL.defaultValue());
             if (envPortalURL != null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/EnvironmentUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/EnvironmentUpgrader.java
@@ -40,7 +40,7 @@ public abstract class EnvironmentUpgrader implements Upgrader, Ordered {
     protected abstract void upgradeEnvironment(ExecutionContext executionContext);
 
     @Override
-    public final boolean upgrade(ExecutionContext defaultExecutionContext) {
+    public final boolean upgrade() {
         try {
             environmentRepository
                 .findAll()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/IdentityProviderActivationUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/IdentityProviderActivationUpgrader.java
@@ -40,7 +40,10 @@ public class IdentityProviderActivationUpgrader implements Upgrader, Ordered {
     private IdentityProviderActivationService identityProviderActivationService;
 
     @Override
-    public boolean upgrade(ExecutionContext executionContext) {
+    public boolean upgrade() {
+        // FIXME : this upgrader uses the default ExecutionContext, but should handle all environments/organizations
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+
         // initialize roles.
         final ActivationTarget defaultEnvTarget = new ActivationTarget(
             GraviteeContext.getDefaultEnvironment(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/IdentityProviderUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/IdentityProviderUpgrader.java
@@ -67,7 +67,10 @@ public class IdentityProviderUpgrader implements Upgrader, Ordered {
     private IdentityProviderActivationService identityProviderActivationService;
 
     @Override
-    public boolean upgrade(ExecutionContext executionContext) {
+    public boolean upgrade() {
+        // FIXME : this upgrader uses the default ExecutionContext, but should handle all environments/organizations
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+
         boolean found = true;
         int idx = 0;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/OneShotUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/OneShotUpgrader.java
@@ -20,7 +20,6 @@ import static io.gravitee.rest.api.service.impl.upgrade.UpgradeStatus.*;
 import io.gravitee.rest.api.model.InstallationEntity;
 import io.gravitee.rest.api.service.InstallationService;
 import io.gravitee.rest.api.service.Upgrader;
-import io.gravitee.rest.api.service.common.ExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,7 +54,7 @@ public abstract class OneShotUpgrader implements Upgrader, Ordered {
     }
 
     @Override
-    public final boolean upgrade(ExecutionContext executionContext) {
+    public final boolean upgrade() {
         if (!isEnabled()) {
             LOGGER.info("Skipping {} execution cause it's not enabled in configuration", this.getClass().getSimpleName());
             return false;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/OneShotUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/OneShotUpgrader.java
@@ -47,7 +47,7 @@ public abstract class OneShotUpgrader implements Upgrader, Ordered {
 
     private String installationStatusKey;
 
-    protected abstract void processOneShotUpgrade(ExecutionContext executionContext) throws Exception;
+    protected abstract void processOneShotUpgrade() throws Exception;
 
     public OneShotUpgrader(String installationStatusKey) {
         super();
@@ -81,7 +81,7 @@ public abstract class OneShotUpgrader implements Upgrader, Ordered {
         try {
             LOGGER.info("Starting {} execution with dry-run {}", this.getClass().getSimpleName(), isDryRun() ? "enabled" : "disabled");
             setExecutionStatus(installation, RUNNING);
-            processOneShotUpgrade(executionContext);
+            processOneShotUpgrade();
             setExecutionStatus(installation, isDryRun() ? DRY_SUCCESS : SUCCESS);
         } catch (Throwable e) {
             LOGGER.error("{} execution failed", this.getClass().getSimpleName(), e);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/OrganizationUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/OrganizationUpgrader.java
@@ -40,7 +40,7 @@ public abstract class OrganizationUpgrader implements Upgrader, Ordered {
     protected abstract void upgradeOrganization(ExecutionContext executionContext);
 
     @Override
-    public final boolean upgrade(ExecutionContext defaultExecutionContext) {
+    public final boolean upgrade() {
         try {
             organizationRepository
                 .findAll()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/OrphanCategoryUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/OrphanCategoryUpgrader.java
@@ -21,7 +21,6 @@ import io.gravitee.repository.management.api.CategoryRepository;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.Category;
 import io.gravitee.rest.api.service.InstallationService;
-import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -52,7 +51,7 @@ public class OrphanCategoryUpgrader extends OneShotUpgrader {
     }
 
     @Override
-    protected void processOneShotUpgrade(ExecutionContext executionContext) throws TechnicalException {
+    protected void processOneShotUpgrade() throws TechnicalException {
         Set<Api> updatedApis = findAndFixApisWithOrphanCategories();
         for (Api api : updatedApis) {
             LOGGER.info("Removing orphan categories for API [{}]", api.getId());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/SearchIndexUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/SearchIndexUpgrader.java
@@ -95,7 +95,7 @@ public class SearchIndexUpgrader implements Upgrader, Ordered {
     }
 
     @Override
-    public boolean upgrade(ExecutionContext executionContext) {
+    public boolean upgrade() {
         ExecutorService executorService = Executors.newFixedThreadPool(
             Runtime.getRuntime().availableProcessors() * 2,
             new ThreadFactory() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/AlertsEnvironmentUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/AlertsEnvironmentUpgraderTest.java
@@ -26,7 +26,6 @@ import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.repository.management.model.AlertTrigger;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.Application;
-import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.converter.AlertTriggerConverter;
 import java.util.Optional;
 import java.util.Set;
@@ -83,7 +82,7 @@ public class AlertsEnvironmentUpgraderTest {
         api3.setEnvironmentId("env-id-2");
         when(apiRepository.findById("api-id-3")).thenReturn(Optional.of(api3));
 
-        upgrader.processOneShotUpgrade(GraviteeContext.getExecutionContext());
+        upgrader.processOneShotUpgrade();
 
         // 2 alerts have been updated with API environment
         verify(alertTriggerRepository, times(1))
@@ -116,7 +115,7 @@ public class AlertsEnvironmentUpgraderTest {
         application3.setEnvironmentId("env-id-2");
         when(applicationRepository.findById("app-id-3")).thenReturn(Optional.of(application3));
 
-        upgrader.processOneShotUpgrade(GraviteeContext.getExecutionContext());
+        upgrader.processOneShotUpgrade();
 
         // 2 alerts have been updated with applications environment
         verify(alertTriggerRepository, times(1))
@@ -135,7 +134,7 @@ public class AlertsEnvironmentUpgraderTest {
                 Set.of(buildTestAlert("alert-id-2", "alert-name-2", "PLATFORM"), buildTestAlert("alert-id-4", "alert-name-4", "PLATFORM"))
             );
 
-        upgrader.processOneShotUpgrade(GraviteeContext.getExecutionContext());
+        upgrader.processOneShotUpgrade();
 
         // existing platform alert have been updated and linked to DEFAULT env
         verify(alertTriggerRepository, times(1))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/ApiKeySubscriptionsUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/ApiKeySubscriptionsUpgraderTest.java
@@ -15,13 +15,12 @@
  */
 package io.gravitee.rest.api.service.impl.upgrade;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.model.ApiKey;
-import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import java.util.ArrayList;
 import java.util.List;
@@ -59,7 +58,7 @@ public class ApiKeySubscriptionsUpgraderTest {
 
         when(apiKeyRepository.findAll()).thenReturn(keys);
 
-        upgrader.processOneShotUpgrade(GraviteeContext.getExecutionContext());
+        upgrader.processOneShotUpgrade();
 
         verify(apiKeyRepository, times(1)).findAll();
         verify(apiKeyRepository, times(8)).update(argThat(keys::contains));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/ApiLoggingConditionUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/ApiLoggingConditionUpgraderTest.java
@@ -15,7 +15,8 @@
  */
 package io.gravitee.rest.api.service.impl.upgrade;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -26,8 +27,8 @@ import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.rest.api.model.InstallationEntity;
 import io.gravitee.rest.api.service.InstallationService;
-import io.gravitee.rest.api.service.common.GraviteeContext;
-import java.util.*;
+import java.util.Map;
+import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -53,7 +54,7 @@ public class ApiLoggingConditionUpgraderTest {
     public void upgrade_should_not_run_cause_already_executed_successfull() {
         mockInstallationWithExecutionStatus("SUCCESS");
 
-        boolean success = upgrader.upgrade(GraviteeContext.getExecutionContext());
+        boolean success = upgrader.upgrade();
 
         assertFalse(success);
         verify(installationService, never()).setAdditionalInformation(any());
@@ -63,7 +64,7 @@ public class ApiLoggingConditionUpgraderTest {
     public void upgrade_should_not_run_cause_already_running() {
         mockInstallationWithExecutionStatus("RUNNING");
 
-        boolean success = upgrader.upgrade(GraviteeContext.getExecutionContext());
+        boolean success = upgrader.upgrade();
 
         assertFalse(success);
         verify(installationService, never()).setAdditionalInformation(any());
@@ -74,7 +75,7 @@ public class ApiLoggingConditionUpgraderTest {
         InstallationEntity installation = mockInstallationWithExecutionStatus(null);
         doThrow(new Exception("test exception")).when(upgrader).fixApis();
 
-        boolean success = upgrader.upgrade(GraviteeContext.getExecutionContext());
+        boolean success = upgrader.upgrade();
 
         assertFalse(success);
         verify(installation.getAdditionalInformation(), times(1)).put(InstallationService.API_LOGGING_CONDITION_UPGRADER, "RUNNING");
@@ -87,7 +88,7 @@ public class ApiLoggingConditionUpgraderTest {
         InstallationEntity installation = mockInstallationWithExecutionStatus(null);
         doNothing().when(upgrader).fixApis();
 
-        boolean success = upgrader.upgrade(GraviteeContext.getExecutionContext());
+        boolean success = upgrader.upgrade();
 
         assertTrue(success);
         verify(installation.getAdditionalInformation(), times(1)).put(InstallationService.API_LOGGING_CONDITION_UPGRADER, "RUNNING");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/ApplicationApiKeyModeUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/ApplicationApiKeyModeUpgraderTest.java
@@ -26,7 +26,6 @@ import io.gravitee.repository.management.model.ApiKeyMode;
 import io.gravitee.repository.management.model.Application;
 import io.gravitee.repository.management.model.Plan;
 import io.gravitee.repository.management.model.Subscription;
-import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -95,7 +94,7 @@ public class ApplicationApiKeyModeUpgraderTest {
                 )
             );
 
-        upgrader.processOneShotUpgrade(GraviteeContext.getExecutionContext());
+        upgrader.processOneShotUpgrade();
 
         // all applications have been searched
         verify(applicationRepository, times(1)).findAll();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/EnvironmentUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/EnvironmentUpgraderTest.java
@@ -49,7 +49,7 @@ public class EnvironmentUpgraderTest {
 
     @Test
     public void upgrade_should_read_all_environments() throws Exception {
-        upgrader.upgrade(null);
+        upgrader.upgrade();
 
         verify(environmentRepository, times(1)).findAll();
     }
@@ -66,7 +66,7 @@ public class EnvironmentUpgraderTest {
                 )
             );
 
-        upgrader.upgrade(null);
+        upgrader.upgrade();
 
         verify(upgrader, times(1))
             .upgradeEnvironment(argThat(e -> e.getEnvironmentId().equals("env1") && e.getOrganizationId().equals("org1")));
@@ -80,7 +80,7 @@ public class EnvironmentUpgraderTest {
 
     @Test
     public void upgrade_should_return_true_when_no_technicalException() throws Exception {
-        boolean result = upgrader.upgrade(null);
+        boolean result = upgrader.upgrade();
 
         assertTrue(result);
     }
@@ -89,7 +89,7 @@ public class EnvironmentUpgraderTest {
     public void upgrade_should_return_false_when_technicalException() throws Exception {
         when(environmentRepository.findAll()).thenThrow(new TechnicalException("this is a test exception"));
 
-        boolean result = upgrader.upgrade(null);
+        boolean result = upgrader.upgrade();
 
         assertFalse(result);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/OrganizationUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/OrganizationUpgraderTest.java
@@ -49,7 +49,7 @@ public class OrganizationUpgraderTest {
 
     @Test
     public void upgrade_should_read_all_organizations() throws Exception {
-        upgrader.upgrade(null);
+        upgrader.upgrade();
 
         verify(organizationRepository, times(1)).findAll();
     }
@@ -59,7 +59,7 @@ public class OrganizationUpgraderTest {
         when(organizationRepository.findAll())
             .thenReturn(Set.of(buildTestOrganization("org1"), buildTestOrganization("org2"), buildTestOrganization("org3")));
 
-        upgrader.upgrade(null);
+        upgrader.upgrade();
 
         verify(upgrader, times(1)).upgradeOrganization(argThat(e -> !e.hasEnvironmentId() && e.getOrganizationId().equals("org1")));
         verify(upgrader, times(1)).upgradeOrganization(argThat(e -> !e.hasEnvironmentId() && e.getOrganizationId().equals("org2")));
@@ -69,7 +69,7 @@ public class OrganizationUpgraderTest {
 
     @Test
     public void upgrade_should_return_true_when_no_technicalException() throws Exception {
-        boolean result = upgrader.upgrade(null);
+        boolean result = upgrader.upgrade();
 
         assertTrue(result);
     }
@@ -78,7 +78,7 @@ public class OrganizationUpgraderTest {
     public void upgrade_should_return_false_when_technicalException() throws Exception {
         when(organizationRepository.findAll()).thenThrow(new TechnicalException("this is a test exception"));
 
-        boolean result = upgrader.upgrade(null);
+        boolean result = upgrader.upgrade();
 
         assertFalse(result);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/OrphanCategoryUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/OrphanCategoryUpgraderTest.java
@@ -26,7 +26,6 @@ import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.Category;
 import io.gravitee.rest.api.model.InstallationEntity;
 import io.gravitee.rest.api.service.InstallationService;
-import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import java.util.HashMap;
 import java.util.Map;
@@ -57,21 +56,21 @@ public class OrphanCategoryUpgraderTest {
     @Test
     public void upgrade_should_not_run_cause_already_executed_with_success() {
         setUpgradeStatus(UpgradeStatus.SUCCESS);
-        assertFalse(upgrader.upgrade(GraviteeContext.getExecutionContext()));
+        assertFalse(upgrader.upgrade());
         verify(installationService, never()).setAdditionalInformation(any());
     }
 
     @Test
     public void upgrade_should_not_run_because_already_running() {
         setUpgradeStatus(UpgradeStatus.RUNNING);
-        assertFalse(upgrader.upgrade(GraviteeContext.getExecutionContext()));
+        assertFalse(upgrader.upgrade());
         verify(installationService, never()).setAdditionalInformation(any());
     }
 
     @Test
     public void upgrade_should_run_because_already_executed_but_failed() {
         setUpgradeStatus(UpgradeStatus.FAILURE);
-        assertTrue(upgrader.upgrade(GraviteeContext.getExecutionContext()));
+        assertTrue(upgrader.upgrade());
         verify(installationService, times(2)).setAdditionalInformation(any());
     }
 
@@ -88,7 +87,7 @@ public class OrphanCategoryUpgraderTest {
         when(apiRepository.findAll()).thenReturn(Set.of(apiWithOrphanCategory));
 
         setUpgradeStatus(null);
-        assertTrue(upgrader.upgrade(GraviteeContext.getExecutionContext()));
+        assertTrue(upgrader.upgrade());
 
         assertEquals(1, apiWithOrphanCategory.getCategories().size());
         assertFalse(apiWithOrphanCategory.getCategories().contains(orphanCategoryId));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/PlansDataFixUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/PlansDataFixUpgraderTest.java
@@ -70,7 +70,7 @@ public class PlansDataFixUpgraderTest {
     public void upgrade_should_not_run_cause_not_enabled() {
         ReflectionTestUtils.setField(upgrader, "enabled", false);
 
-        boolean success = upgrader.upgrade(null);
+        boolean success = upgrader.upgrade();
 
         assertFalse(success);
         verifyNoInteractions(installationService);
@@ -81,7 +81,7 @@ public class PlansDataFixUpgraderTest {
         ReflectionTestUtils.setField(upgrader, "enabled", true);
         mockInstallationWithExecutionStatus("SUCCESS");
 
-        boolean success = upgrader.upgrade(null);
+        boolean success = upgrader.upgrade();
 
         assertFalse(success);
         verify(installationService, never()).setAdditionalInformation(any());
@@ -92,7 +92,7 @@ public class PlansDataFixUpgraderTest {
         ReflectionTestUtils.setField(upgrader, "enabled", true);
         mockInstallationWithExecutionStatus("RUNNING");
 
-        boolean success = upgrader.upgrade(null);
+        boolean success = upgrader.upgrade();
 
         assertFalse(success);
         verify(installationService, never()).setAdditionalInformation(any());
@@ -104,7 +104,7 @@ public class PlansDataFixUpgraderTest {
         InstallationEntity installation = mockInstallationWithExecutionStatus(null);
         doThrow(new Exception("test exception")).when(upgrader).processOneShotUpgrade();
 
-        boolean success = upgrader.upgrade(null);
+        boolean success = upgrader.upgrade();
 
         assertFalse(success);
         verify(installation.getAdditionalInformation(), times(1)).put(InstallationService.PLANS_DATA_UPGRADER_STATUS, "RUNNING");
@@ -118,7 +118,7 @@ public class PlansDataFixUpgraderTest {
         InstallationEntity installation = mockInstallationWithExecutionStatus(null);
         doNothing().when(upgrader).processOneShotUpgrade();
 
-        boolean success = upgrader.upgrade(null);
+        boolean success = upgrader.upgrade();
 
         assertTrue(success);
         verify(installation.getAdditionalInformation(), times(1)).put(InstallationService.PLANS_DATA_UPGRADER_STATUS, "RUNNING");
@@ -133,7 +133,7 @@ public class PlansDataFixUpgraderTest {
         InstallationEntity installation = mockInstallationWithExecutionStatus(null);
         doNothing().when(upgrader).processOneShotUpgrade();
 
-        boolean success = upgrader.upgrade(null);
+        boolean success = upgrader.upgrade();
 
         assertTrue(success);
         verify(installation.getAdditionalInformation(), times(1)).put(InstallationService.PLANS_DATA_UPGRADER_STATUS, "RUNNING");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/SearchIndexUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/SearchIndexUpgraderTest.java
@@ -29,7 +29,6 @@ import io.gravitee.repository.management.model.User;
 import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.service.PageService;
-import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.converter.UserConverter;
 import io.gravitee.rest.api.service.search.SearchEngineService;
@@ -82,7 +81,7 @@ public class SearchIndexUpgraderTest {
         mockTestApis();
         mockTestUsers();
 
-        upgrader.upgrade(GraviteeContext.getExecutionContext());
+        upgrader.upgrade();
 
         verify(environmentRepository, times(1)).findById("env1");
         verify(environmentRepository, times(1)).findById("env2");
@@ -95,7 +94,7 @@ public class SearchIndexUpgraderTest {
         mockTestApis();
         mockTestUsers();
 
-        upgrader.upgrade(GraviteeContext.getExecutionContext());
+        upgrader.upgrade();
 
         verify(searchEngineService, times(1))
             .index(
@@ -132,7 +131,7 @@ public class SearchIndexUpgraderTest {
         mockTestApis();
         mockTestUsers();
 
-        upgrader.upgrade(GraviteeContext.getExecutionContext());
+        upgrader.upgrade();
 
         verify(searchEngineService, times(1))
             .index(


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7518

**Description**

fix: let OneShotUpgraders handle multi-organization and multi-environment

Before this change, OneShotUpgrader.processOneShotUpgrade() was called with the default environment execution context as parameter.

But upgraders should consider every organization/environment, and not run only against the default one.

So, this parameter has been removed.
And the PlanDataFixUpgrader has been fixed, in order to handle multi-organization and multi-environment.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-oneshotupgradermultienv/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
