### PR TITLE
[Management] Audit event are not scoped by env

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/AuditCriteria.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/AuditCriteria.java
@@ -33,6 +33,10 @@ public class AuditCriteria {
 
     private long from, to;
 
+    private List<String> environmentIds;
+
+    private String organizationId;
+
     AuditCriteria(AuditCriteria.Builder builder) {
         this.from = builder.from;
         this.to = builder.to;
@@ -41,6 +45,8 @@ public class AuditCriteria {
         if (builder.events != null) {
             this.events = builder.events;
         }
+        this.environmentIds = builder.environmentIds;
+        this.organizationId = builder.organizationId;
     }
 
     public Map<Audit.AuditReferenceType, List<String>> getReferences() {
@@ -83,6 +89,14 @@ public class AuditCriteria {
         this.events = events;
     }
 
+    public List<String> getEnvironmentIds() {
+        return environmentIds;
+    }
+
+    public String getOrganizationId() {
+        return organizationId;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -93,6 +107,8 @@ public class AuditCriteria {
         if (from != that.from) return false;
         if (to != that.to) return false;
         if (references != null ? !references.equals(that.references) : that.references != null) return false;
+        if (environmentIds != null ? !environmentIds.equals(that.environmentIds) : that.environmentIds != null) return false;
+        if (organizationId != that.organizationId) return false;
         return properties != null ? properties.equals(that.properties) : that.properties == null;
     }
 
@@ -116,6 +132,10 @@ public class AuditCriteria {
         private long to;
 
         private List<String> events;
+
+        private List<String> environmentIds;
+
+        private String organizationId;
 
         public Builder from(long from) {
             this.from = from;
@@ -145,6 +165,16 @@ public class AuditCriteria {
 
         public AuditCriteria build() {
             return new AuditCriteria(this);
+        }
+
+        public AuditCriteria.Builder environmentIds(final List<String> environmentIds) {
+            this.environmentIds = environmentIds;
+            return this;
+        }
+
+        public AuditCriteria.Builder organizationId(final String organizationId) {
+            this.organizationId = organizationId;
+            return this;
         }
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Audit.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Audit.java
@@ -68,6 +68,8 @@ public class Audit {
     }
 
     private String id;
+    private String organizationId;
+    private String environmentId;
     private String referenceId;
     private AuditReferenceType referenceType;
     private String user;
@@ -82,6 +84,22 @@ public class Audit {
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    public String getOrganizationId() {
+        return organizationId;
+    }
+
+    public void setOrganizationId(String organizationId) {
+        this.organizationId = organizationId;
+    }
+
+    public String getEnvironmentId() {
+        return environmentId;
+    }
+
+    public void setEnvironmentId(String environmentId) {
+        this.environmentId = environmentId;
     }
 
     public String getReferenceId() {

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAuditRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAuditRepository.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.jdbc.management;
 import static io.gravitee.repository.jdbc.common.AbstractJdbcRepositoryConfiguration.escapeReservedWord;
 import static io.gravitee.repository.jdbc.management.JdbcHelper.*;
 import static java.lang.String.format;
+import static org.springframework.util.CollectionUtils.isEmpty;
 
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
@@ -183,6 +184,12 @@ public class JdbcAuditRepository extends JdbcAbstractPageableRepository<Audit> i
             ", " +
             "events: " +
             filter.getEvents() +
+            ", " +
+            "environmentIds: " +
+            filter.getEnvironmentIds() +
+            ", " +
+            "organizationId: " +
+            filter.getOrganizationId() +
             " }"
         );
     }
@@ -209,6 +216,21 @@ public class JdbcAuditRepository extends JdbcAbstractPageableRepository<Audit> i
             argsList.add(new Date(filter.getTo()));
             started = true;
         }
+
+        if (!isEmpty(filter.getEnvironmentIds())) {
+            builder.append(started ? AND_CLAUSE : WHERE_CLAUSE);
+            builder.append("a.environment_id in (").append(getOrm().buildInClause(filter.getEnvironmentIds())).append(")");
+            argsList.addAll(filter.getEnvironmentIds());
+            started = true;
+        }
+
+        if (filter.getOrganizationId() != null) {
+            builder.append(started ? AND_CLAUSE : WHERE_CLAUSE);
+            builder.append("a.organization_id = ?");
+            argsList.add(filter.getOrganizationId());
+            started = true;
+        }
+
         started = addPropertiesWhereClause(filter, argsList, builder, started);
         started = addReferencesWhereClause(filter, argsList, builder, started);
         addStringsWhereClause(filter.getEvents(), "event", argsList, builder, started);

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAuditRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAuditRepository.java
@@ -58,6 +58,8 @@ public class JdbcAuditRepository extends JdbcAbstractPageableRepository<Audit> i
         return JdbcObjectMapper
             .builder(Audit.class, this.tableName, "id")
             .addColumn("id", Types.NVARCHAR, String.class)
+            .addColumn("organization_id", Types.NVARCHAR, String.class)
+            .addColumn("environment_id", Types.NVARCHAR, String.class)
             .addColumn("reference_id", Types.NVARCHAR, String.class)
             .addColumn("reference_type", Types.NVARCHAR, Audit.AuditReferenceType.class)
             .addColumn("user", Types.NVARCHAR, String.class)

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_18_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_18_0/schema.yml
@@ -1,20 +1,123 @@
 databaseChangeLog:
-  - changeSet:
-      id: 3.18.0
-      author: GraviteeSource Team
-      changes:
-        - addColumn:
-            tableName: ${gravitee_prefix}alert_triggers
-            columns:
-              - column:
-                  name: environment_id
-                  type: nvarchar(64)
-        - addColumn:
-              tableName: ${gravitee_prefix}audits
-              columns:
-                  - column:
-                        name: organization_id
-                        type: nvarchar(64)
-                  - column:
-                        name: environment_id
-                        type: nvarchar(64)
+    -   changeSet:
+            id: 3.18.0
+            author: GraviteeSource Team
+            changes:
+                -   addColumn:
+                        tableName: ${gravitee_prefix}alert_triggers
+                        columns:
+                            -   column:
+                                    name: environment_id
+                                    type: nvarchar(64)
+                                    constraints:
+                                        nullable: true
+                -   addColumn:
+                        tableName: ${gravitee_prefix}audits
+                        columns:
+                            -   column:
+                                    name: organization_id
+                                    type: nvarchar(64)
+                                    constraints:
+                                        nullable: true
+                            -   column:
+                                    name: environment_id
+                                    type: nvarchar(64)
+                                    constraints:
+                                        nullable: true
+                -   createIndex:
+                        tableName: ${gravitee_prefix}audits
+                        indexName: idx_${gravitee_prefix}organization_environment
+                        columns:
+                            -   column:
+                                    name: organization_id
+                                    type: nvarchar(64)
+                            -   column:
+                                    name: environment_id
+                                    type: nvarchar(64)
+                # mssql
+                -   sql:
+                        dbms: mssql
+                        sql: UPDATE ${gravitee_prefix}audits SET organization_id = reference_id WHERE reference_type = 'ORGANIZATION';
+                -   sql:
+                        dbms: mssql
+                        sql: |
+                            UPDATE a
+                            SET organization_id = coalesce(e.organization_id, 'DEFAULT'), environment_id = coalesce(e.id, 'DEFAULT')
+                            FROM ${gravitee_prefix}audits a
+                            LEFT JOIN ${gravitee_prefix}environments e on e.id = a.reference_id
+                            WHERE a.reference_type = 'ENVIRONMENT';
+                -   sql:
+                        dbms: mssql
+                        sql: |
+                            UPDATE a
+                            SET organization_id = coalesce(e.organization_id, 'DEFAULT'), environment_id = coalesce(e.id, 'DEFAULT')
+                            FROM ${gravitee_prefix}audits a
+                            LEFT JOIN ${gravitee_prefix}apis apis on a.reference_id = apis.id
+                            LEFT JOIN ${gravitee_prefix}environments e on e.id = apis.environment_id
+                            WHERE a.reference_type = 'API';
+                -   sql:
+                        dbms: mssql
+                        sql: |
+                            UPDATE a
+                            SET organization_id = coalesce(e.organization_id, 'DEFAULT'), environment_id = coalesce(e.id, 'DEFAULT')
+                            FROM ${gravitee_prefix}audits a
+                            LEFT JOIN ${gravitee_prefix}applications app on a.reference_id = app.id
+                            LEFT JOIN ${gravitee_prefix}environments e on e.id = app.environment_id
+                            WHERE a.reference_type = 'APPLICATION';
+                # postgresql
+                -   sql:
+                        dbms: postgresql
+                        sql: UPDATE ${gravitee_prefix}audits SET organization_id = reference_id WHERE reference_type = 'ORGANIZATION';
+                -   sql:
+                        dbms: postgresql
+                        sql: |
+                            UPDATE ${gravitee_prefix}audits ua
+                            SET organization_id = coalesce(e.organization_id, 'DEFAULT'), environment_id = coalesce(e.id, 'DEFAULT')
+                            FROM ${gravitee_prefix}audits a
+                            LEFT JOIN ${gravitee_prefix}environments e on e.id = a.reference_id
+                            WHERE ua.id = a.id AND a.reference_type = 'ENVIRONMENT';
+                -   sql:
+                        dbms: postgresql
+                        sql: |
+                            UPDATE ${gravitee_prefix}audits ua
+                            SET organization_id = coalesce(e.organization_id, 'DEFAULT'), environment_id = coalesce(e.id, 'DEFAULT')
+                            FROM ${gravitee_prefix}audits a
+                            LEFT JOIN ${gravitee_prefix}apis apis on a.reference_id = apis.id
+                            LEFT JOIN ${gravitee_prefix}environments e on e.id = apis.environment_id
+                            WHERE ua.id = a.id AND a.reference_type = 'API';
+                -   sql:
+                        dbms: postgresql
+                        sql: |
+                            UPDATE ${gravitee_prefix}audits ua
+                            SET organization_id = coalesce(e.organization_id, 'DEFAULT'), environment_id = coalesce(e.id, 'DEFAULT')
+                            FROM ${gravitee_prefix}audits a
+                            LEFT JOIN ${gravitee_prefix}applications app on a.reference_id = app.id
+                            LEFT JOIN ${gravitee_prefix}environments e on e.id = app.environment_id
+                            WHERE ua.id = a.id AND a.reference_type = 'APPLICATION';
+                # mariadb, mysql
+                -   sql:
+                        dbms: mariadb, mysql
+                        sql: UPDATE ${gravitee_prefix}audits SET organization_id = reference_id WHERE reference_type = 'ORGANIZATION';
+                -   sql:
+                        dbms: mariadb, mysql
+                        sql: |
+                            UPDATE ${gravitee_prefix}audits a
+                            LEFT JOIN ${gravitee_prefix}environments e on e.id = a.reference_id
+                            SET a.organization_id = coalesce(e.organization_id, 'DEFAULT'), environment_id = coalesce(e.id, 'DEFAULT')
+                            WHERE a.reference_type = 'ENVIRONMENT';
+                -   sql:
+                        dbms: mariadb, mysql
+                        sql: |
+                            UPDATE ${gravitee_prefix}audits a
+                            LEFT JOIN ${gravitee_prefix}apis apis on a.reference_id = apis.id
+                            LEFT JOIN ${gravitee_prefix}environments e on e.id = apis.environment_id
+                            SET a.organization_id = coalesce(e.organization_id, 'DEFAULT'), a.environment_id = coalesce(e.id, 'DEFAULT')
+                            WHERE a.reference_type = 'API';
+                -   sql:
+                        dbms: mariadb, mysql
+                        sql: |
+                            UPDATE ${gravitee_prefix}audits a
+                            LEFT JOIN ${gravitee_prefix}applications app on a.reference_id = app.id
+                            LEFT JOIN ${gravitee_prefix}environments e on e.id = app.environment_id
+                            SET a.organization_id = coalesce(e.organization_id, 'DEFAULT'), a.environment_id = coalesce(e.id, 'DEFAULT')
+                            WHERE a.reference_type = 'APPLICATION';

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_18_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_18_0/schema.yml
@@ -9,3 +9,12 @@ databaseChangeLog:
               - column:
                   name: environment_id
                   type: nvarchar(64)
+        - addColumn:
+              tableName: ${gravitee_prefix}audits
+              columns:
+                  - column:
+                        name: organization_id
+                        type: nvarchar(64)
+                  - column:
+                        name: environment_id
+                        type: nvarchar(64)

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/audit/AuditMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/audit/AuditMongoRepositoryImpl.java
@@ -65,6 +65,14 @@ public class AuditMongoRepositoryImpl implements AuditMongoRepositoryCustom {
             query.addCriteria(where("event").in(filter.getEvents()));
         }
 
+        if (filter.getEnvironmentIds() != null && !filter.getEnvironmentIds().isEmpty()) {
+            query.addCriteria(where("environmentId").in(filter.getEnvironmentIds()));
+        }
+
+        if (filter.getOrganizationId() != null) {
+            query.addCriteria(where("organizationId").is(filter.getOrganizationId()));
+        }
+
         long total = mongoTemplate.count(query, AuditMongo.class);
 
         query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize(), Sort.by(Sort.Direction.DESC, "createdAt")));

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/AuditMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/AuditMongo.java
@@ -30,6 +30,8 @@ public class AuditMongo extends Auditable {
     @Id
     private String id;
 
+    private String organizationId;
+    private String environmentId;
     private String referenceId;
     private String referenceType;
     private String user;
@@ -43,6 +45,22 @@ public class AuditMongo extends Auditable {
 
     public void setId(String id) {
         this.id = id;
+    }
+
+    public String getOrganizationId() {
+        return organizationId;
+    }
+
+    public void setOrganizationId(String organizationId) {
+        this.organizationId = organizationId;
+    }
+
+    public String getEnvironmentId() {
+        return environmentId;
+    }
+
+    public void setEnvironmentId(String environmentId) {
+        this.environmentId = environmentId;
     }
 
     public String getReferenceId() {

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.18.0/audit-set-environmentId-organizationId.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.18.0/audit-set-environmentId-organizationId.js
@@ -1,0 +1,98 @@
+// Override this variable if you use prefix
+const prefix = "";
+
+print(`Add 'environmentId' and 'organizationId' columns in 'audits' table`);
+
+const audits = db.getCollection(`${prefix}audits`);
+const environments = db.getCollection(`${prefix}environments`);
+const applications = db.getCollection(`${prefix}applications`);
+const apis = db.getCollection(`${prefix}apis`);
+
+function handleApiAudit(audit) {
+    const envId = getEnvIdByApiId(audit.referenceId);
+    const orgId = getOrgIdByEnvId(envId);
+
+    audit.organizationId = orgId || "DEFAULT";
+    audit.environmentId = envId || "DEFAULT";
+    audits.replaceOne({ _id: audit._id }, audit);
+}
+
+function handleApplicationAudit(audit) {
+    const envId = getEnvIdByAppId(audit.referenceId);
+    const orgId = getOrgIdByEnvId(envId);
+
+    audit.organizationId = orgId || "DEFAULT";
+    audit.environmentId = envId || "DEFAULT";
+    audits.replaceOne({ _id: audit._id }, audit);
+}
+
+function handleEnvironmentAudit(audit) {
+    const envId = audit.referenceId;
+    const orgId = getOrgIdByEnvId(envId);
+
+    audit.organizationId = orgId || "DEFAULT";
+    audit.environmentId = envId || "DEFAULT";
+    audits.replaceOne({ _id: audit._id }, audit);
+}
+
+function handleOrganizationAudit(audit) {
+    const orgId = getOrgIdByEnvId(audit.referenceId);
+
+    audit.organizationId = orgId || "DEFAULT";
+    audits.replaceOne({ _id: audit._id }, audit);
+}
+
+const environmentIdByApiIdMap = {};
+function getEnvIdByApiId(apiId) {
+    let envId = environmentIdByApiIdMap[apiId];
+    if (!envId) {
+        const api = apis.findOne({ _id: apiId });
+        envId = api ? api.environmentId || null : null;
+        environmentIdByApiIdMap[apiId] = envId;
+    }
+    return envId;
+}
+
+const environmentIdByAppIdMap = {};
+function getEnvIdByAppId(appId) {
+    let envId = environmentIdByAppIdMap[appId];
+    if (!envId) {
+        const app = applications.findOne({ _id: appId });
+        envId = app ? app.environmentId || null : null;
+        environmentIdByAppIdMap[appId] = envId;
+    }
+    return envId;
+}
+
+const organizationIdByEnvironmentIdMap = {};
+function getOrgIdByEnvId(envId) {
+    let orgId = organizationIdByEnvironmentIdMap[envId];
+    if (!orgId) {
+        const env = environments.findOne({ _id: envId });
+        orgId = env ? env.organizationId || null : null;
+        organizationIdByEnvironmentIdMap[envId] = orgId;
+    }
+    return orgId;
+}
+
+audits.find({ organizationId: null }).forEach((audit) => {
+    switch (audit.referenceType) {
+        case "API":
+            handleApiAudit(audit);
+            break;
+        case "APPLICATION":
+            handleApplicationAudit(audit);
+            break;
+        case "ENVIRONMENT":
+            handleEnvironmentAudit(audit);
+            break;
+        case "ORGANIZATION":
+            handleOrganizationAudit(audit);
+            break;
+    }
+});
+print(`Create new indexes in 'audits' table`);
+
+audits.createIndex({ organizationId: 1 });
+audits.createIndex({ organizationId: 1, environmentId: 1 });
+audits.reIndex();

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/create-index.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/create-index.js
@@ -78,6 +78,8 @@ db.getCollection(`${prefix}roles`).reIndex();
 db.getCollection(`${prefix}audits`).dropIndexes();
 db.getCollection(`${prefix}audits`).createIndex( { "referenceType": 1, "referenceId": 1 }, { "name": "rt1ri1" } );
 db.getCollection(`${prefix}audits`).createIndex( { "createdAt": 1 }, { "name": "c1" } );
+db.getCollection(`${prefix}audits`).createIndex({ organizationId: 1 }, { name: "o1" });
+db.getCollection(`${prefix}audits`).createIndex({ organizationId: 1, environmentId: 1 }, { name: "o1e1" });
 db.getCollection(`${prefix}audits`).reIndex();
 
 // "rating" collection

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/AuditRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/AuditRepositoryTest.java
@@ -17,6 +17,7 @@ package io.gravitee.repository;
 
 import static io.gravitee.repository.utils.DateUtils.compareDate;
 import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static org.junit.Assert.*;
 
 import io.gravitee.common.data.domain.Page;
@@ -27,9 +28,8 @@ import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.model.Audit;
 import io.gravitee.repository.management.model.Plan;
-import java.util.Collections;
-import java.util.Date;
-import java.util.Optional;
+import java.util.*;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class AuditRepositoryTest extends AbstractRepositoryTest {
@@ -40,12 +40,47 @@ public class AuditRepositoryTest extends AbstractRepositoryTest {
     }
 
     @Test
+    public void shouldCreate() throws Exception {
+        final Audit audit = new Audit();
+        audit.setId("createdAudit");
+        audit.setOrganizationId("DEFAULT");
+        audit.setEnvironmentId("DEFAULT");
+        audit.setReferenceType(Audit.AuditReferenceType.API);
+        audit.setReferenceId("1");
+        audit.setEvent(Plan.AuditEvent.PLAN_CREATED.name());
+        final Map<String, String> properties = new HashMap<>();
+        properties.put(Audit.AuditProperties.PLAN.name(), "123");
+        audit.setProperties(properties);
+        audit.setUser("JohnDoe");
+        audit.setPatch("diff");
+        audit.setCreatedAt(new Date(1486771200000L));
+
+        final Audit createdAudit = auditRepository.create(audit);
+        assertEquals("id", createdAudit.getId(), audit.getId());
+        assertEquals("organizationId", createdAudit.getOrganizationId(), audit.getOrganizationId());
+        assertEquals("environmentId", createdAudit.getEnvironmentId(), audit.getEnvironmentId());
+        assertEquals("referenceId", createdAudit.getReferenceId(), audit.getReferenceId());
+        assertEquals("referenceType", createdAudit.getReferenceType(), audit.getReferenceType());
+        assertEquals("event", createdAudit.getEvent(), audit.getEvent());
+        assertEquals("properties", createdAudit.getProperties(), audit.getProperties());
+        assertEquals("user", createdAudit.getUser(), audit.getUser());
+        assertEquals("createdAt", createdAudit.getCreatedAt(), audit.getCreatedAt());
+        assertEquals("patch", createdAudit.getPatch(), audit.getPatch());
+
+        Optional<Audit> optionalAudit = auditRepository.findById("createdAudit");
+        Assert.assertTrue("Audit saved not found", optionalAudit.isPresent());
+        assertEquals("id", optionalAudit.get().getId(), audit.getId());
+    }
+
+    @Test
     public void shouldFindById() throws TechnicalException {
         Optional<Audit> auditOptional = auditRepository.findById("new");
 
         assertTrue(auditOptional.isPresent());
         Audit audit = auditOptional.get();
         assertEquals("id", "new", audit.getId());
+        assertEquals("organizationId", "DEFAULT", audit.getOrganizationId());
+        assertEquals("environmentId", "DEFAULT", audit.getEnvironmentId());
         assertEquals("referenceId", "1", audit.getReferenceId());
         assertEquals("referenceType", Audit.AuditReferenceType.API, audit.getReferenceType());
         assertEquals("event", Plan.AuditEvent.PLAN_CREATED.name(), audit.getEvent());

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/AuditRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/AuditRepositoryTest.java
@@ -179,4 +179,32 @@ public class AuditRepositoryTest extends AbstractRepositoryTest {
         assertEquals("page elements", 1, auditPage.getPageElements());
         assertEquals("page number", 0, auditPage.getPageNumber());
     }
+
+    @Test
+    public void shouldSearchWithEnvironmentIds() throws TechnicalException {
+        AuditCriteria auditCriteria = new AuditCriteria.Builder().environmentIds(singletonList("DEFAULT")).build();
+        Pageable page = new PageableBuilder().pageNumber(0).pageSize(10).build();
+
+        Page<Audit> auditPage = auditRepository.search(auditCriteria, page);
+
+        assertNotNull(auditPage);
+        assertEquals("total elements", 1, auditPage.getTotalElements());
+        assertEquals("page elements", 1, auditPage.getPageElements());
+        assertEquals("page number", 0, auditPage.getPageNumber());
+        assertEquals("find audit with id 'new'", "new", auditPage.getContent().get(0).getId());
+    }
+
+    @Test
+    public void shouldSearchWithOrganizationId() throws TechnicalException {
+        AuditCriteria auditCriteria = new AuditCriteria.Builder().organizationId("DEFAULT").build();
+        Pageable page = new PageableBuilder().pageNumber(0).pageSize(10).build();
+
+        Page<Audit> auditPage = auditRepository.search(auditCriteria, page);
+
+        assertNotNull(auditPage);
+        assertEquals("total elements", 1, auditPage.getTotalElements());
+        assertEquals("page elements", 1, auditPage.getPageElements());
+        assertEquals("page number", 0, auditPage.getPageNumber());
+        assertEquals("find audit with id 'new'", "new", auditPage.getContent().get(0).getId());
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/AuditRepositoryMock.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/AuditRepositoryMock.java
@@ -26,6 +26,8 @@ import static org.mockito.Mockito.when;
 
 import io.gravitee.repository.management.api.AuditRepository;
 import io.gravitee.repository.management.model.Audit;
+import io.gravitee.repository.management.model.Entrypoint;
+import io.gravitee.repository.management.model.Environment;
 import io.gravitee.repository.management.model.Plan;
 import java.util.Date;
 
@@ -43,6 +45,8 @@ public class AuditRepositoryMock extends AbstractRepositoryMock<AuditRepository>
     void prepare(AuditRepository auditRepository) throws Exception {
         final Audit newAudit = mock(Audit.class);
         when(newAudit.getId()).thenReturn("new");
+        when(newAudit.getOrganizationId()).thenReturn("DEFAULT");
+        when(newAudit.getEnvironmentId()).thenReturn("DEFAULT");
         when(newAudit.getReferenceType()).thenReturn(Audit.AuditReferenceType.API);
         when(newAudit.getReferenceId()).thenReturn("1");
         when(newAudit.getEvent()).thenReturn(Plan.AuditEvent.PLAN_CREATED.name());
@@ -52,11 +56,27 @@ public class AuditRepositoryMock extends AbstractRepositoryMock<AuditRepository>
         when(newAudit.getCreatedAt()).thenReturn(new Date(1486771200000L));
         when(auditRepository.findById("new")).thenReturn(of(newAudit));
 
+        final Audit createdAudit = mock(Audit.class);
+        when(createdAudit.getId()).thenReturn("createdAudit");
+        when(createdAudit.getOrganizationId()).thenReturn("DEFAULT");
+        when(createdAudit.getEnvironmentId()).thenReturn("DEFAULT");
+        when(createdAudit.getReferenceType()).thenReturn(Audit.AuditReferenceType.API);
+        when(createdAudit.getReferenceId()).thenReturn("1");
+        when(createdAudit.getEvent()).thenReturn(Plan.AuditEvent.PLAN_CREATED.name());
+        when(createdAudit.getProperties()).thenReturn(singletonMap(Audit.AuditProperties.PLAN.name(), "123"));
+        when(createdAudit.getUser()).thenReturn("JohnDoe");
+        when(createdAudit.getPatch()).thenReturn("diff");
+        when(createdAudit.getCreatedAt()).thenReturn(new Date(1486771200000L));
+        when(auditRepository.create(any(Audit.class))).thenReturn(createdAudit);
+        when(auditRepository.findById("createdAudit")).thenReturn(of(createdAudit));
+
         final Audit searchable1 = mock(Audit.class);
         when(searchable1.getId()).thenReturn("searchable1");
+        when(searchable1.getOrganizationId()).thenReturn("DEFAULT");
 
         final Audit searchable2 = mock(Audit.class);
         when(searchable2.getId()).thenReturn("searchable2");
+        when(searchable2.getOrganizationId()).thenReturn("DEFAULT");
         //shouldSearchWithPagination
         when(auditRepository.search(argThat(o -> o != null && o.getReferences() != null && !o.getReferences().isEmpty()), any()))
             .thenReturn(new io.gravitee.common.data.domain.Page<>(singletonList(searchable2), 0, 1, 2));

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/AuditRepositoryMock.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/AuditRepositoryMock.java
@@ -23,6 +23,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.internal.util.collections.Sets.newSet;
 
 import io.gravitee.repository.management.api.AuditRepository;
 import io.gravitee.repository.management.model.Audit;
@@ -113,5 +114,21 @@ public class AuditRepositoryMock extends AbstractRepositoryMock<AuditRepository>
         //shouldSearchTo
         when(auditRepository.search(argThat(o -> o != null && o.getFrom() == 0 && o.getTo() > 0), any()))
             .thenReturn(new io.gravitee.common.data.domain.Page<>(singletonList(mock(Audit.class)), 0, 1, 1));
+        //shouldSearchWithEnvironmentIds
+        when(
+            auditRepository.search(
+                argThat(o -> o != null && o.getEnvironmentIds() != null && o.getEnvironmentIds().get(0).equals("DEFAULT")),
+                any()
+            )
+        )
+            .thenReturn(new io.gravitee.common.data.domain.Page<>(asList(newAudit), 0, 1, 1));
+        //shouldSearchWithOrganizationId
+        when(
+            auditRepository.search(
+                argThat(o -> o != null && o.getOrganizationId() != null && o.getOrganizationId().equals("DEFAULT")),
+                any()
+            )
+        )
+            .thenReturn(new io.gravitee.common.data.domain.Page<>(asList(newAudit), 0, 1, 1));
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/audit-tests/audits.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/audit-tests/audits.json
@@ -1,6 +1,8 @@
 [
   {
     "id": "new",
+    "organizationId": "DEFAULT",
+    "environmentId": "DEFAULT",
     "referenceId": "1",
     "referenceType": "API",
     "event": "PLAN_CREATED",

--- a/gravitee-apim-repository/sonar-project.properties
+++ b/gravitee-apim-repository/sonar-project.properties
@@ -16,6 +16,9 @@ sonar.exclusions=gravitee-apim-repository-coverage/**, **/target/**
 # Source encoding
 sonar.language=java
 
+# Duplication
+sonar.cpd.exclusions=gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/** 
+
 # Test
 sonar.test=.
 sonar.test.inclusions=**/*Test.java

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AuditServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AuditServiceImpl.java
@@ -364,6 +364,10 @@ public class AuditServiceImpl extends AbstractService implements AuditService {
     ) {
         Audit audit = new Audit();
         audit.setId(UuidString.generateRandom());
+        audit.setOrganizationId(executionContext.getOrganizationId());
+        if (executionContext.hasEnvironmentId() && !referenceType.equals(Audit.AuditReferenceType.ORGANIZATION)) {
+            audit.setEnvironmentId(executionContext.getEnvironmentId());
+        }
         audit.setCreatedAt(createdAt == null ? new Date() : createdAt);
 
         final UserDetails authenticatedUser = getAuthenticatedUser();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AuditServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AuditServiceImpl.java
@@ -88,6 +88,11 @@ public class AuditServiceImpl extends AbstractService implements AuditService {
     public MetadataPage<AuditEntity> search(final ExecutionContext executionContext, AuditQuery query) {
         Builder criteria = new Builder().from(query.getFrom()).to(query.getTo());
 
+        criteria.organizationId(executionContext.getOrganizationId());
+        if (executionContext.hasEnvironmentId()) {
+            criteria.environmentIds(Collections.singletonList(executionContext.getEnvironmentId()));
+        }
+
         if (query.isCurrentEnvironmentLogsOnly()) {
             criteria.references(Audit.AuditReferenceType.ENVIRONMENT, Collections.singletonList(executionContext.getEnvironmentId()));
         } else if (query.isCurrentOrganizationLogsOnly()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AuditService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AuditService_CreateTest.java
@@ -1,0 +1,187 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static java.util.Collections.singletonMap;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.definition.jackson.datatype.GraviteeMapper;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.AuditRepository;
+import io.gravitee.repository.management.model.Audit;
+import io.gravitee.repository.management.model.Plan;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.util.Collections;
+import java.util.Date;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AuditService_CreateTest {
+
+    @InjectMocks
+    private AuditServiceImpl auditService = new AuditServiceImpl();
+
+    @Spy
+    private ObjectMapper objectMapper = new GraviteeMapper();
+
+    @Mock
+    private AuditRepository auditRepository;
+
+    @Test
+    public void should_createApiAuditLog() throws TechnicalException {
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        String apiId = "apiId";
+        Date createdAt = new Date(1486771200000L);
+
+        when(auditRepository.create(any())).thenReturn(new Audit());
+
+        auditService.createApiAuditLog(
+            executionContext,
+            apiId,
+            Collections.singletonMap(Audit.AuditProperties.PLAN, "123"),
+            Plan.AuditEvent.PLAN_CREATED,
+            createdAt,
+            singletonMap("name", "Joe"),
+            singletonMap("name", "Bar")
+        );
+
+        verify(auditRepository, times(1))
+            .create(
+                argThat(
+                    arg ->
+                        arg != null &&
+                        !arg.getId().isEmpty() &&
+                        arg.getOrganizationId().equals("DEFAULT") &&
+                        arg.getEnvironmentId().equals("DEFAULT") &&
+                        arg.getReferenceType().equals(Audit.AuditReferenceType.API) &&
+                        arg.getReferenceId().equals(apiId) &&
+                        arg.getCreatedAt().equals(createdAt) &&
+                        arg.getProperties().equals(Collections.singletonMap(Audit.AuditProperties.PLAN.name(), "123")) &&
+                        arg.getPatch().toString().equals("[{\"op\":\"replace\",\"path\":\"/name\",\"value\":\"Bar\"}]")
+                )
+            );
+    }
+
+    @Test
+    public void should_createApplicationAuditLog() throws TechnicalException {
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        String applicationId = "applicationId";
+        Date createdAt = new Date(1486771200000L);
+
+        when(auditRepository.create(any())).thenReturn(new Audit());
+
+        auditService.createApplicationAuditLog(
+            executionContext,
+            applicationId,
+            Collections.singletonMap(Audit.AuditProperties.PLAN, "123"),
+            Plan.AuditEvent.PLAN_CREATED,
+            createdAt,
+            singletonMap("name", "Joe"),
+            singletonMap("name", "Bar")
+        );
+
+        verify(auditRepository, times(1))
+            .create(
+                argThat(
+                    arg ->
+                        arg != null &&
+                        !arg.getId().isEmpty() &&
+                        arg.getOrganizationId().equals("DEFAULT") &&
+                        arg.getEnvironmentId().equals("DEFAULT") &&
+                        arg.getReferenceType().equals(Audit.AuditReferenceType.APPLICATION) &&
+                        arg.getReferenceId().equals(applicationId) &&
+                        arg.getCreatedAt().equals(createdAt) &&
+                        arg.getProperties().equals(Collections.singletonMap(Audit.AuditProperties.PLAN.name(), "123")) &&
+                        arg.getPatch().toString().equals("[{\"op\":\"replace\",\"path\":\"/name\",\"value\":\"Bar\"}]")
+                )
+            );
+    }
+
+    @Test
+    public void should_createAuditLog_with_AuditReferenceType_ENVIRONMENT() throws TechnicalException {
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        Date createdAt = new Date(1486771200000L);
+
+        when(auditRepository.create(any())).thenReturn(new Audit());
+
+        auditService.createAuditLog(
+            executionContext,
+            Collections.singletonMap(Audit.AuditProperties.PLAN, "123"),
+            Plan.AuditEvent.PLAN_CREATED,
+            createdAt,
+            singletonMap("name", "Joe"),
+            singletonMap("name", "Bar")
+        );
+
+        verify(auditRepository, times(1))
+            .create(
+                argThat(
+                    arg ->
+                        arg != null &&
+                        !arg.getId().isEmpty() &&
+                        arg.getOrganizationId().equals("DEFAULT") &&
+                        arg.getEnvironmentId().equals("DEFAULT") &&
+                        arg.getReferenceType().equals(Audit.AuditReferenceType.ENVIRONMENT) &&
+                        arg.getReferenceId().equals(executionContext.getEnvironmentId()) &&
+                        arg.getCreatedAt().equals(createdAt) &&
+                        arg.getProperties().equals(Collections.singletonMap(Audit.AuditProperties.PLAN.name(), "123")) &&
+                        arg.getPatch().toString().equals("[{\"op\":\"replace\",\"path\":\"/name\",\"value\":\"Bar\"}]")
+                )
+            );
+    }
+
+    @Test
+    public void should_createAuditLog_with_AuditReferenceType_ORGANIZATION() throws TechnicalException {
+        ExecutionContext executionContext = new ExecutionContext("organizationId", null);
+        Date createdAt = new Date(1486771200000L);
+
+        when(auditRepository.create(any())).thenReturn(new Audit());
+
+        auditService.createAuditLog(
+            executionContext,
+            Collections.singletonMap(Audit.AuditProperties.PLAN, "123"),
+            Plan.AuditEvent.PLAN_CREATED,
+            createdAt,
+            singletonMap("name", "Joe"),
+            singletonMap("name", "Bar")
+        );
+
+        verify(auditRepository, times(1))
+            .create(
+                argThat(
+                    arg ->
+                        arg != null &&
+                        !arg.getId().isEmpty() &&
+                        arg.getOrganizationId().equals(executionContext.getOrganizationId()) &&
+                        arg.getEnvironmentId() == null &&
+                        arg.getReferenceType().equals(Audit.AuditReferenceType.ORGANIZATION) &&
+                        arg.getReferenceId().equals(executionContext.getOrganizationId()) &&
+                        arg.getCreatedAt().equals(createdAt) &&
+                        arg.getProperties().equals(Collections.singletonMap(Audit.AuditProperties.PLAN.name(), "123")) &&
+                        arg.getPatch().toString().equals("[{\"op\":\"replace\",\"path\":\"/name\",\"value\":\"Bar\"}]")
+                )
+            );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AuditService_SearchTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AuditService_SearchTest.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.definition.jackson.datatype.GraviteeMapper;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.api.AuditRepository;
+import io.gravitee.repository.management.api.search.AuditCriteria;
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.repository.management.model.Audit;
+import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.model.audit.AuditEntity;
+import io.gravitee.rest.api.model.audit.AuditQuery;
+import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.util.Arrays;
+import java.util.Optional;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AuditService_SearchTest {
+
+    private static final String USER_NAME = "myUser";
+    private static final String API_ID = "id-api";
+
+    @InjectMocks
+    private AuditServiceImpl auditService = new AuditServiceImpl();
+
+    @Spy
+    private ObjectMapper objectMapper = new GraviteeMapper();
+
+    @Mock
+    private AuditRepository auditRepository;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private ApiRepository apiRepository;
+
+    @Mock
+    private Api api;
+
+    @Test
+    public void should_search() throws TechnicalException {
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        Audit auditFound = new Audit();
+        auditFound.setId("auditId");
+        auditFound.setUser(USER_NAME);
+        auditFound.setReferenceType(Audit.AuditReferenceType.API);
+        auditFound.setReferenceId(API_ID);
+
+        Page<Audit> pageFound = new Page<>(Arrays.asList(auditFound), 2, 1, 2);
+
+        when(
+            auditRepository.search(
+                eq(
+                    new AuditCriteria.Builder()
+                        .organizationId(executionContext.getOrganizationId())
+                        .environmentIds(singletonList(executionContext.getEnvironmentId()))
+                        .build()
+                ),
+                any()
+            )
+        )
+            .thenReturn(pageFound);
+        when(userService.findById(GraviteeContext.getExecutionContext(), USER_NAME)).thenReturn(new UserEntity());
+        when(apiRepository.findById(API_ID)).thenReturn(Optional.of(api));
+
+        AuditQuery query = new AuditQuery();
+        query.setPage(2);
+        query.setSize(1);
+        final Page<AuditEntity> auditPage = auditService.search(executionContext, query);
+
+        assertNotNull(auditPage);
+        assertEquals(1, auditPage.getContent().size());
+        assertEquals(auditFound.getId(), auditPage.getContent().get(0).getId());
+        assertEquals(2, auditPage.getPageNumber());
+        assertEquals(1, auditPage.getPageElements());
+        assertEquals(2, auditPage.getTotalElements());
+    }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7521

**Description**

Add 2 new field fo audit logs (environmentId and organizationId) to be able to display audit with right scope

In next PR :
- Add new Screen in organization settings for organization lvl and lower
- Migrate environment lvl audit page to Angular (same for API lvl)
- Clean some unused filter about ORG & ENV  

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zzxijeknpx.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7509-add-env-and-org-for-audit/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
