### PR TITLE
perf: replace truncate with delete

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1088,6 +1088,7 @@ jobs:
                 default: ""
         machine:
             image: ubuntu-2004:current
+            docker_layer_caching: true
         resource_class: large
         steps:
             - when:

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
@@ -536,34 +536,29 @@ public class JdbcApiRepository extends JdbcAbstractPageableRepository<Api> imple
     @Override
     public Optional<Api> findByEnvironmentIdAndCrossId(String environmentId, String crossId) throws TechnicalException {
         LOGGER.debug("JdbcApiRepository.findByEnvironmentIdAndCrossId({}, {})", environmentId, crossId);
-        try {
-            JdbcHelper.CollatingRowMapper<Api> rowMapper = new JdbcHelper.CollatingRowMapper<>(getOrm().getRowMapper(), CHILD_ADDER, "id");
-            jdbcTemplate.query(
-                getOrm().getSelectAllSql() +
-                " a left join " +
-                API_CATEGORIES +
-                " ac on a.id = ac.api_id where a.environment_id = ? and a.cross_id = ?",
-                rowMapper,
-                environmentId,
-                crossId
-            );
+        JdbcHelper.CollatingRowMapper<Api> rowMapper = new JdbcHelper.CollatingRowMapper<>(getOrm().getRowMapper(), CHILD_ADDER, "id");
+        jdbcTemplate.query(
+            getOrm().getSelectAllSql() +
+            " a left join " +
+            API_CATEGORIES +
+            " ac on a.id = ac.api_id where a.environment_id = ? and a.cross_id = ?",
+            rowMapper,
+            environmentId,
+            crossId
+        );
 
-            if (rowMapper.getRows().size() > 1) {
-                throw new TechnicalException("More than one API was found for environmentId " + environmentId + " and crossId " + crossId);
-            }
-
-            Optional<Api> result = rowMapper.getRows().stream().findFirst();
-
-            if (result.isPresent()) {
-                addLabels(result.get());
-                addGroups(result.get());
-            }
-
-            LOGGER.debug("JdbcApiRepository.findByEnvironmentIdAndCrossId({}, {}) = {}", environmentId, crossId, result);
-            return result;
-        } catch (final Exception ex) {
-            LOGGER.error("Failed to find api by environment and crossId", ex);
-            throw new TechnicalException("Failed to find api by environment and crossId", ex);
+        if (rowMapper.getRows().size() > 1) {
+            throw new TechnicalException("More than one API was found for environmentId " + environmentId + " and crossId " + crossId);
         }
+
+        Optional<Api> result = rowMapper.getRows().stream().findFirst();
+
+        if (result.isPresent()) {
+            addLabels(result.get());
+            addGroups(result.get());
+        }
+
+        LOGGER.debug("JdbcApiRepository.findByEnvironmentIdAndCrossId({}, {}) = {}", environmentId, crossId, result);
+        return result;
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryConfiguration.java
@@ -73,13 +73,13 @@ public class JdbcTestRepositoryConfiguration {
                 // It appears that the limitation is not entirely due to the DB engine configuration, but also in the way I/O are managed between container and host.
                 // I let this configuration for documentation purpose, but it does not solve our performance issue.
                 // See --> https://dev.mysql.com/doc/refman/8.0/en/innodb-parameters.html
-                containerBean = new MySQLContainer<>(dockerImageName).withCommand("mysqld --innodb-buffer-pool-size=1G");
+                containerBean = new MySQLContainer<>(dockerImageName);
                 break;
             case MARIADB:
                 // It appears that the limitation is not entirely due to the DB engine configuration, but also in the way I/O are managed between container and host.
                 // I let this configuration for documentation purpose, but it does not solve our performance issue.
                 // See --> https://mariadb.com/kb/en/innodb-system-variables/
-                containerBean = new MariaDBContainer<>(dockerImageName).withCommand("mysqld --innodb-buffer-pool-size=1G");
+                containerBean = new MariaDBContainer<>(dockerImageName);
                 break;
             case SQLSERVER:
                 containerBean = new MSSQLServerContainer<>(dockerImageName);

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
@@ -192,14 +192,9 @@ public class JdbcTestRepositoryInitializer implements TestRepositoryInitializer 
         System.clearProperty("liquibase.databaseChangeLogTableName");
         System.clearProperty("liquibase.databaseChangeLogLockTableName");
         System.clearProperty("gravitee_prefix");
-        jt.execute(
-            (Connection con) -> {
-                for (final String table : tablesToTruncate) {
-                    jt.execute("truncate table " + escapeReservedWord(prefix + table));
-                }
-                jt.execute("truncate table " + escapeReservedWord(rateLimitPrefix + "ratelimit"));
-                return null;
-            }
-        );
+        for (final String table : tablesToTruncate) {
+            jt.update("delete from " + escapeReservedWord(prefix + table));
+        }
+        jt.update("delete from " + escapeReservedWord(rateLimitPrefix + "ratelimit"));
     }
 }


### PR DESCRIPTION
**Description**

Weird, but it seems that in our case, delete is more performant than truncate.

An explanation could be that TRUNCATE can be rolled back in a transaction for MySQL > 8.0. https://dba.stackexchange.com/a/292081
But I don't understand why it also improves others DB.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-jdbc-testcontainer-performance-issue/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
