### PR TITLE
Handle connection to MongoDB with self-signed SSL certificate

### DIFF
--- a/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-string.component.spec.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/triggers/conditions/trigger-condition-string.component.spec.ts
@@ -15,10 +15,6 @@
  */
 import { IComponentControllerService } from 'angular';
 
-import { setupAngularJsTesting } from '../../../../../../jest.setup';
-
-setupAngularJsTesting();
-
 describe('AlertTriggerConditionStringComponent', () => {
   let $componentController: IComponentControllerService;
   let alertTriggerConditionStringComponent: any;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -113,9 +113,11 @@ management:
 
 ## SSL settings
 #    sslEnabled:                  # mongodb ssl mode (default false)
-#    keystore:                    # path to KeyStore (when sslEnabled is true, default null)
-#    keystorePassword:            # KeyStore password (when sslEnabled is true, default null)
-#    keyPassword:                 # password for recovering keys in the KeyStore (when sslEnabled is true, default null)
+#    keystore:
+#      path:                      # Path to the keystore (when sslEnabled is true, default null)
+#      type:                      # Type of the keystore, supports jks, pem, pkcs12 (when sslEnabled is true, default null)
+#      password:                  # KeyStore password (when sslEnabled is true, default null)
+#      keyPassword:               # Password for recovering keys in the KeyStore (when sslEnabled is true, default null)
 #    truststore:
 #      path:                      # Path to the truststore (when sslEnabled is true, default null)
 #      type:                      # Type of the truststore, supports jks, pem, pkcs12 (when sslEnabled is true, default null)

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -116,7 +116,10 @@ management:
 #    keystore:                    # path to KeyStore (when sslEnabled is true, default null)
 #    keystorePassword:            # KeyStore password (when sslEnabled is true, default null)
 #    keyPassword:                 # password for recovering keys in the KeyStore (when sslEnabled is true, default null)
-
+#    truststore:
+#      path:                      # Path to the truststore (when sslEnabled is true, default null)
+#      type:                      # Type of the truststore, supports jks, pem, pkcs12 (when sslEnabled is true, default null)
+#      password:                  # Truststore password (when sslEnabled is true, default null)
 # Management repository: single MongoDB using URI
 # For more information about MongoDB configuration using URI, please have a look to:
 # - http://mongodb.github.io/mongo-java-driver/4.1/apidocs/mongodb-driver-core/com/mongodb/ConnectionString.html

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -139,9 +139,11 @@ management:
 
 ## SSL settings
 #    sslEnabled:                  # mongodb ssl mode (default false)
-#    keystore:                    # path to KeyStore (when sslEnabled is true, default null)
-#    keystorePassword:            # KeyStore password (when sslEnabled is true, default null)
-#    keyPassword:                 # password for recovering keys in the KeyStore (when sslEnabled is true, default null)
+#    keystore:
+#      path:                      # Path to the keystore (when sslEnabled is true, default null)
+#      type:                      # Type of the keystore, supports jks, pem, pkcs12 (when sslEnabled is true, default null)
+#      password:                  # KeyStore password (when sslEnabled is true, default null)
+#      keyPassword:               # Password for recovering keys in the KeyStore (when sslEnabled is true, default null)
 #    truststore:
 #      path:                      # Path to the truststore (when sslEnabled is true, default null)
 #      type:                      # Type of the truststore, supports jks, pem, pkcs12 (when sslEnabled is true, default null)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -142,7 +142,10 @@ management:
 #    keystore:                    # path to KeyStore (when sslEnabled is true, default null)
 #    keystorePassword:            # KeyStore password (when sslEnabled is true, default null)
 #    keyPassword:                 # password for recovering keys in the KeyStore (when sslEnabled is true, default null)
-
+#    truststore:
+#      path:                      # Path to the truststore (when sslEnabled is true, default null)
+#      type:                      # Type of the truststore, supports jks, pem, pkcs12 (when sslEnabled is true, default null)
+#      password:                  # Truststore password (when sslEnabled is true, default null)
 # Management repository: single MongoDB using URI
 # For more information about MongoDB configuration using URI, please have a look to:
 # - http://mongodb.github.io/mongo-java-driver/4.1/apidocs/mongodb-driver-core/com/mongodb/ConnectionString.html


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/_support_team/issues/151
https://github.com/gravitee-io/issues/issues/7539

**Description**

 - Add new attributes to handle Truststore in MongoFactory
 - Handle connection to MongoDB with self-signed SSL certificate

**To test**

See section below ⬇️  

----

# APIM + Mongo with SSL 

## Prerequisites

To follow this tutorial, you will need to have the following:
- Docker installed and running
- `openssl` command is available
- `keytool` command is available 

For convenience, you can create a folder to store all the certificates and keys at the same place: 
```shell
mkdir mongo-ssl
cd mongo-ssl
```

## Create the certificates

First, we need to create an SSL certificate, signed by itself, that will be used as root certificate:
```shell
openssl req -newkey rsa:4096 -keyform PEM -keyout ca.key -x509 -days 3650 -subj "/emailAddress=contact@graviteesource.com/CN=mongo.gravitee.io/OU=GraviteeSource/O=GraviteeSource/L=Lille/ST=France/C=FR" -passout pass:ca-secret -outform PEM -out ca.pem
```

It will create a file named `ca.pem` containing the certificate and a file named `ca.key` containing the private key.

Then, we need to create a certificate that we will use on the MongoDB side that needs to be signed by the root certificate:
```shell
# First, create a private key
openssl genrsa -out mongo.key 4096

# Then, create a certificate request
openssl req -new -key mongo.key -out mongo.csr -sha256 -subj "/emailAddress=contact@graviteesource.com/CN=localhost/OU=Mongo/O=GraviteeSource/L=Lille/ST=France/C=FR"

# Finally, sign the certificate request with the root certificate
openssl x509 -req -in mongo.csr -CA ca.pem -CAkey ca.key -set_serial 100 -extensions server -days 1460 -outform PEM -out mongo.cer -sha256 -passin pass:ca-secret

# Create .pem file
cat mongo.key mongo.cer > mongo.pem

# Create a keystore with the root certificate
keytool -import -file ca.pem -storetype PKCS12 -keystore ca-truststore.p12 -storepass truststore-secret -noprompt -alias mongo-ca
```

## Configure and Start MongoDB

Create a `mongod.conf` file with the following content:
```yaml
net:
  bindIp: 0.0.0.0
  port: 27017
  tls:
    certificateKeyFile: /etc/mongo/mongo.pem
    mode: requireTLS
```

Start a MongoDB instance with Docker with the following command:
```shell
# Start MongoDB container with host binding to port 27017
docker run --rm -p 27017:27017 --name mongo-with-ssl -v $(pwd):/etc/mongo mongo:5 --config /etc/mongo/mongod.conf
```

## Configure and start Gravitee APIM

As of 3.15.x, Gravitee APIM can be configured to use Mongo + SSL with a self-signed certificate. 
To do so you need to add the following configuration to the `gravitee.yml` file (both on Management API and Gateway):
```yaml
# In the management.mongodb section
    truststore:
      type: pkcs12                                                              # Supports jks, pem, pkcs12
      path: <<path to your certificate folder>>/mongo-ssl/ca-truststore.p12     # path to KeyStore (when sslEnabled is true, default null)
      password: truststore-secret                                               # KeyStore password (when sslEnabled is true, default null)
```

Et voilà, you are ready to start Gravitee APIM! 🚀
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-krekrcggxy.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/151-mongo-self-signed-certificate/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
