### PR TITLE
fix: move http protocol verticle to full rx

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactor.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.handlers.api;
 
 import static io.reactivex.Completable.defer;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/context/ExecutionContextAdapter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/context/ExecutionContextAdapter.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.handlers.api.adapter.context;
 
 import static io.gravitee.gateway.reactive.api.context.ExecutionContext.ATTR_ADAPTED_CONTEXT;
@@ -19,8 +34,6 @@ public class ExecutionContextAdapter implements io.gravitee.gateway.api.Executio
     private final ExecutionContext<?, ?> ctx;
     private RequestAdapter adaptedRequest;
     private ResponseAdapter adaptedResponse;
-
-
 
     /**
      * Creates an {@link ExecutionContextAdapter} from a {@link ExecutionContext}.
@@ -47,7 +60,6 @@ public class ExecutionContextAdapter implements io.gravitee.gateway.api.Executio
     public <T extends ExecutionContext<?, ?>> T getDelegate() {
         return (T) ctx;
     }
-
 
     @Override
     public RequestAdapter request() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/context/RequestAdapter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/context/RequestAdapter.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.handlers.api.adapter.context;
 
 import io.gravitee.common.http.HttpMethod;
@@ -11,7 +26,6 @@ import io.gravitee.gateway.api.stream.ReadStream;
 import io.gravitee.gateway.api.ws.WebSocket;
 import io.gravitee.gateway.reactive.api.context.Request;
 import io.gravitee.reporter.api.http.Metrics;
-
 import javax.net.ssl.SSLSession;
 
 /**
@@ -31,7 +45,6 @@ public class RequestAdapter implements io.gravitee.gateway.api.Request {
     public void onResume(Runnable onResume) {
         this.onResumeHandler = onResume;
     }
-
 
     @Override
     public ReadStream<Buffer> resume() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/context/ResponseAdapter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/context/ResponseAdapter.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.handlers.api.adapter.context;
 
 import io.gravitee.gateway.api.buffer.Buffer;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/invoker/ConnectionHandlerAdapter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/invoker/ConnectionHandlerAdapter.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.handlers.api.adapter.invoker;
 
 import io.gravitee.gateway.api.buffer.Buffer;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/invoker/FlowableProxyResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/invoker/FlowableProxyResponse.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.handlers.api.adapter.invoker;
 
 import io.gravitee.gateway.api.buffer.Buffer;
@@ -6,13 +21,12 @@ import io.gravitee.gateway.api.proxy.ProxyResponse;
 import io.gravitee.gateway.reactive.api.context.sync.SyncExecutionContext;
 import io.reactivex.Flowable;
 import io.reactivex.internal.subscriptions.EmptySubscription;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 
 public class FlowableProxyResponse extends Flowable<Buffer> {
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/invoker/InvokerAdapter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/invoker/InvokerAdapter.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.handlers.api.adapter.invoker;
 
 import io.gravitee.gateway.reactive.api.context.sync.SyncExecutionContext;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/invoker/ReadWriteStreamAdapter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/invoker/ReadWriteStreamAdapter.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.handlers.api.adapter.invoker;
 
 import io.gravitee.gateway.api.ExecutionContext;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/policy/PolicyAdapter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/policy/PolicyAdapter.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.handlers.api.adapter.policy;
 
 import io.gravitee.gateway.api.buffer.Buffer;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/policy/PolicyChainAdapter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/policy/PolicyChainAdapter.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.handlers.api.adapter.policy;
 
 import io.gravitee.gateway.api.Request;
@@ -35,7 +50,7 @@ public class PolicyChainAdapter implements io.gravitee.policy.api.PolicyChain {
         // TODO: ExecutionFailure.
         ctx.response().status(policyResult.statusCode());
 
-       // ctx.response().content(Buffer.buffer(policyResult.message()));
+        // ctx.response().content(Buffer.buffer(policyResult.message()));
         ctx.interrupt();
         emitter.onComplete();
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/resolver/FlowResolverAdapter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/adapter/resolver/FlowResolverAdapter.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.handlers.api.adapter.resolver;
 
 import io.gravitee.definition.model.flow.Flow;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/condition/FlowConditionEvaluator.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/condition/FlowConditionEvaluator.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.handlers.api.condition;
 
 import io.gravitee.definition.model.flow.Flow;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/flow/FlowChain.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/flow/FlowChain.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.handlers.api.flow;
 
 import static io.gravitee.gateway.policy.StreamType.ON_REQUEST;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/flow/resolver/ApiFlowResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/flow/resolver/ApiFlowResolver.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.handlers.api.flow.resolver;
 
 import io.gravitee.definition.model.Api;
@@ -5,7 +20,6 @@ import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.gateway.reactive.api.context.ExecutionContext;
 import io.gravitee.gateway.reactive.handlers.api.condition.ConditionEvaluator;
 import io.reactivex.Flowable;
-
 import java.util.stream.Collectors;
 
 /**

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/flow/resolver/AsbtractFlowResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/flow/resolver/AsbtractFlowResolver.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.handlers.api.flow.resolver;
 
 import io.gravitee.definition.model.flow.Flow;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/flow/resolver/FlowResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/flow/resolver/FlowResolver.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.handlers.api.flow.resolver;
 
 import io.gravitee.definition.model.flow.Flow;
@@ -18,7 +33,7 @@ public interface FlowResolver {
      * @param ctx the current context.
      * @return a {@link Flowable} of {@link Flow} that have passed the filter step.
      */
-     Flowable<Flow> resolve(ExecutionContext<?, ?> ctx);
+    Flowable<Flow> resolve(ExecutionContext<?, ?> ctx);
 
     /**
      * Provides the initial list of flows.
@@ -28,5 +43,5 @@ public interface FlowResolver {
      * @param ctx the current context
      * @return a {@link Flowable} of {@link Flow}.
      */
-     Flowable<Flow> provideFlows(ExecutionContext<?, ?> ctx);
+    Flowable<Flow> provideFlows(ExecutionContext<?, ?> ctx);
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/flow/resolver/PlanFlowResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/flow/resolver/PlanFlowResolver.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.handlers.api.flow.resolver;
 
 import io.gravitee.definition.model.Api;
@@ -5,7 +20,6 @@ import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.gateway.reactive.api.context.ExecutionContext;
 import io.gravitee.gateway.reactive.handlers.api.condition.ConditionEvaluator;
 import io.reactivex.Flowable;
-
 import java.util.Objects;
 import java.util.stream.Collectors;
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/flow/resolver/PlatformFlowResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/flow/resolver/PlatformFlowResolver.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.handlers.api.flow.resolver;
 
 import io.gravitee.definition.model.Organization;
@@ -5,7 +20,6 @@ import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.gateway.reactive.api.context.ExecutionContext;
 import io.gravitee.gateway.reactive.handlers.api.condition.ConditionEvaluator;
 import io.reactivex.Flowable;
-
 import java.util.stream.Collectors;
 
 /**

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/reactive/http/vertx/VertxSyncHttpServerResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/reactive/http/vertx/VertxSyncHttpServerResponse.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.http.vertx;
 
 import io.gravitee.gateway.api.buffer.Buffer;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/impl/PolicyChain.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/impl/PolicyChain.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.policy.impl;
 
 import io.gravitee.gateway.reactive.api.ExecutionPhase;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/ApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/ApiReactor.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.reactor;
 
 import io.gravitee.gateway.reactive.api.context.Request;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.reactor;
 
 import io.gravitee.common.event.Event;
@@ -27,7 +42,9 @@ import org.springframework.beans.factory.annotation.Autowired;
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class DefaultHttpRequestDispatcher extends AbstractService<HttpRequestDispatcher> implements HttpRequestDispatcher, EventListener<ReactorEvent, Reactable> {
+public class DefaultHttpRequestDispatcher
+    extends AbstractService<HttpRequestDispatcher>
+    implements HttpRequestDispatcher, EventListener<ReactorEvent, Reactable> {
 
     private final Logger log = LoggerFactory.getLogger(DefaultHttpRequestDispatcher.class);
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/HttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/HttpRequestDispatcher.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.reactor;
 
 import io.gravitee.common.service.Service;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/handler/context/AbstractExecutionContext.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/handler/context/AbstractExecutionContext.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.reactor.handler.context;
 
 import io.gravitee.el.TemplateContext;
@@ -11,7 +26,6 @@ import io.gravitee.gateway.reactive.api.context.Response;
 import io.gravitee.gateway.reactive.api.el.EvaluableRequest;
 import io.gravitee.gateway.reactive.api.el.EvaluableResponse;
 import io.gravitee.tracing.api.Tracer;
-
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/handler/context/AsyncExecutionContext.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/handler/context/AsyncExecutionContext.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.reactor.handler.context;
 
 import io.gravitee.gateway.core.component.ComponentProvider;
@@ -9,6 +24,7 @@ import io.gravitee.gateway.reactive.api.context.async.AsyncResponse;
  * @author GraviteeSource Team
  */
 public class AsyncExecutionContext extends AbstractExecutionContext<AsyncRequest, AsyncResponse> {
+
     public AsyncExecutionContext(AsyncRequest request, AsyncResponse response, ComponentProvider componentProvider) {
         super(request, response, componentProvider);
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/handler/context/ExecutionContextFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/handler/context/ExecutionContextFactory.java
@@ -22,7 +22,6 @@ import io.gravitee.gateway.reactive.api.context.Request;
 import io.gravitee.gateway.reactive.api.context.Response;
 import io.gravitee.gateway.reactive.api.context.sync.SyncRequest;
 import io.gravitee.gateway.reactive.api.context.sync.SyncResponse;
-
 import java.util.ArrayList;
 import java.util.List;
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/handler/context/SyncExecutionContext.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/handler/context/SyncExecutionContext.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.reactor.handler.context;
 
 import io.gravitee.gateway.core.component.ComponentProvider;
@@ -8,7 +23,9 @@ import io.gravitee.gateway.reactive.api.context.sync.SyncResponse;
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class SyncExecutionContext extends AbstractExecutionContext<SyncRequest, SyncResponse> implements io.gravitee.gateway.reactive.api.context.sync.SyncExecutionContext {
+public class SyncExecutionContext
+    extends AbstractExecutionContext<SyncRequest, SyncResponse>
+    implements io.gravitee.gateway.reactive.api.context.sync.SyncExecutionContext {
 
     public SyncExecutionContext(SyncRequest request, SyncResponse response, ComponentProvider componentProvider) {
         super(request, response, componentProvider);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/handler/impl/DefaultEntrypointResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/handler/impl/DefaultEntrypointResolver.java
@@ -30,7 +30,6 @@ import io.gravitee.gateway.reactive.reactor.handler.EntrypointResolver;
 import io.gravitee.gateway.reactor.handler.HandlerEntrypoint;
 import io.gravitee.gateway.reactor.handler.ReactorHandlerRegistry;
 import io.gravitee.reporter.api.http.Metrics;
-
 import javax.net.ssl.SSLSession;
 
 /**

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/Processor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/Processor.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.reactor.processor;
 
 import io.gravitee.gateway.reactive.api.context.ExecutionContext;
@@ -8,7 +23,6 @@ import io.reactivex.Completable;
  * @author GraviteeSource Team
  */
 public interface Processor {
-
     String getId();
 
     Completable execute(ExecutionContext<?, ?> ctx);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/ProcessorChain.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/ProcessorChain.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.gravitee.gateway.reactive.reactor.processor;
 
 import io.gravitee.gateway.reactive.api.context.ExecutionContext;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -342,10 +342,14 @@
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>
+            <artifactId>vertx-junit5-rx-java2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
             <artifactId>vertx-grpc</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java-util</artifactId>
@@ -427,7 +431,8 @@
                       protobuf-java version that grpc depends on.
                     -->
                     <protoTestSourceRoot>src/test/resources</protoTestSourceRoot>
-                    <protocArtifact>com.google.protobuf:protoc:${protobuf-java.version}:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${protobuf-java.version}:exe:${os.detected.classifier}
+                    </protocArtifact>
                     <pluginId>grpc-java</pluginId>
                     <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.42.1:exe:${os.detected.classifier}</pluginArtifact>
                     <protocPlugins>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/reactive/standalone/vertx/HttpProtocolVerticle.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/reactive/standalone/vertx/HttpProtocolVerticle.java
@@ -24,6 +24,7 @@ import io.reactivex.plugins.RxJavaPlugins;
 import io.vertx.core.http.HttpServer;
 import io.vertx.reactivex.core.AbstractVerticle;
 import io.vertx.reactivex.core.RxHelper;
+import io.vertx.reactivex.core.http.HttpServerResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -78,11 +79,11 @@ public class HttpProtocolVerticle extends AbstractVerticle {
                             .onErrorResumeNext(
                                 throwable -> {
                                     log.error("An unexpected error occurred while dispatching the incoming request", throwable);
-                                    return request
-                                        .response()
-                                        .setStatusCode(HttpStatusCode.INTERNAL_SERVER_ERROR_500)
-                                        .rxEnd()
-                                        .onErrorResumeNext(endError -> Completable.complete());
+                                    HttpServerResponse response = request.response();
+                                    if (!response.headWritten()) {
+                                        response.setStatusCode(HttpStatusCode.INTERNAL_SERVER_ERROR_500);
+                                    }
+                                    return response.rxEnd().onErrorResumeNext(endError -> Completable.complete());
                                 }
                             )
                 )

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/reactive/standalone/vertx/HttpProtocolVerticle.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/reactive/standalone/vertx/HttpProtocolVerticle.java
@@ -39,16 +39,13 @@ public class HttpProtocolVerticle extends AbstractVerticle {
 
     private final io.vertx.reactivex.core.http.HttpServer rxHttpServer;
     private final HttpRequestDispatcher requestDispatcher;
-    private final HttpServerConfiguration httpServerConfiguration;
     private Disposable requestDisposable;
 
     public HttpProtocolVerticle(
         @Qualifier("gatewayHttpServer") HttpServer httpServer,
-        @Qualifier("httpServerConfiguration") HttpServerConfiguration httpServerConfiguration,
         @Qualifier("httpRequestDispatcher") HttpRequestDispatcher requestDispatcher
     ) {
         this.rxHttpServer = io.vertx.reactivex.core.http.HttpServer.newInstance(httpServer);
-        this.httpServerConfiguration = httpServerConfiguration;
         this.requestDispatcher = requestDispatcher;
     }
 
@@ -94,7 +91,7 @@ public class HttpProtocolVerticle extends AbstractVerticle {
         return rxHttpServer
             .rxListen()
             .ignoreElement()
-            .doOnComplete(() -> log.info("HTTP listener ready to accept requests on port {}", httpServerConfiguration.getPort()))
+            .doOnComplete(() -> log.info("HTTP listener ready to accept requests on port {}", rxHttpServer.actualPort()))
             .doOnError(throwable -> log.error("Unable to start HTTP Server", throwable.getCause()));
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxEmbeddedContainer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxEmbeddedContainer.java
@@ -64,7 +64,7 @@ public class VertxEmbeddedContainer extends AbstractLifecycleComponent<VertxEmbe
 
         DeploymentOptions options = new DeploymentOptions().setInstances(instances);
         vertx.deployVerticle(
-                SpringVerticleFactory.VERTICLE_PREFIX + ':' + HttpProtocolVerticle.class.getName(),
+            SpringVerticleFactory.VERTICLE_PREFIX + ':' + HttpProtocolVerticle.class.getName(),
             options,
             event -> {
                 if (event.failed()) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxReactorConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxReactorConfiguration.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -44,18 +44,20 @@ public class VertxReactorConfiguration {
     @Bean("gatewayHttpServer")
     //    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
     public VertxHttpServerFactory vertxHttpServerFactory(
-            Vertx vertx,
-            @Qualifier("httpServerConfiguration") HttpServerConfiguration httpServerConfiguration,
-            KeyStoreLoaderManager keyStoreLoaderManager
-                                                        ) {
+        Vertx vertx,
+        @Qualifier("httpServerConfiguration") HttpServerConfiguration httpServerConfiguration,
+        KeyStoreLoaderManager keyStoreLoaderManager
+    ) {
         return new VertxHttpServerFactory(vertx, httpServerConfiguration, keyStoreLoaderManager);
     }
 
     @Bean
     @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-    public HttpProtocolVerticle graviteeVerticle(@Qualifier("gatewayHttpServer") HttpServer httpServer,
-                                                 @Qualifier("httpServerConfiguration") HttpServerConfiguration httpServerConfiguration,
-                                                 @Qualifier("httpRequestDispatcher") HttpRequestDispatcher requestDispatcher) {
+    public HttpProtocolVerticle graviteeVerticle(
+        @Qualifier("gatewayHttpServer") HttpServer httpServer,
+        @Qualifier("httpServerConfiguration") HttpServerConfiguration httpServerConfiguration,
+        @Qualifier("httpRequestDispatcher") HttpRequestDispatcher requestDispatcher
+    ) {
         return new HttpProtocolVerticle(httpServer, httpServerConfiguration, requestDispatcher);
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxReactorConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxReactorConfiguration.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,11 +15,13 @@
  */
 package io.gravitee.gateway.standalone.vertx;
 
+import io.gravitee.gateway.reactive.reactor.HttpRequestDispatcher;
 import io.gravitee.gateway.reactive.standalone.vertx.HttpProtocolVerticle;
 import io.gravitee.node.certificates.KeyStoreLoaderManager;
 import io.gravitee.node.vertx.VertxHttpServerFactory;
 import io.gravitee.node.vertx.configuration.HttpServerConfiguration;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServer;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Bean;
@@ -42,17 +44,19 @@ public class VertxReactorConfiguration {
     @Bean("gatewayHttpServer")
     //    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
     public VertxHttpServerFactory vertxHttpServerFactory(
-        Vertx vertx,
-        @Qualifier("httpServerConfiguration") HttpServerConfiguration httpServerConfiguration,
-        KeyStoreLoaderManager keyStoreLoaderManager
-    ) {
+            Vertx vertx,
+            @Qualifier("httpServerConfiguration") HttpServerConfiguration httpServerConfiguration,
+            KeyStoreLoaderManager keyStoreLoaderManager
+                                                        ) {
         return new VertxHttpServerFactory(vertx, httpServerConfiguration, keyStoreLoaderManager);
     }
 
     @Bean
     @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
-    public HttpProtocolVerticle graviteeVerticle() {
-        return new HttpProtocolVerticle();
+    public HttpProtocolVerticle graviteeVerticle(@Qualifier("gatewayHttpServer") HttpServer httpServer,
+                                                 @Qualifier("httpServerConfiguration") HttpServerConfiguration httpServerConfiguration,
+                                                 @Qualifier("httpRequestDispatcher") HttpRequestDispatcher requestDispatcher) {
+        return new HttpProtocolVerticle(httpServer, httpServerConfiguration, requestDispatcher);
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxReactorConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxReactorConfiguration.java
@@ -55,10 +55,9 @@ public class VertxReactorConfiguration {
     @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
     public HttpProtocolVerticle graviteeVerticle(
         @Qualifier("gatewayHttpServer") HttpServer httpServer,
-        @Qualifier("httpServerConfiguration") HttpServerConfiguration httpServerConfiguration,
         @Qualifier("httpRequestDispatcher") HttpRequestDispatcher requestDispatcher
     ) {
-        return new HttpProtocolVerticle(httpServer, httpServerConfiguration, requestDispatcher);
+        return new HttpProtocolVerticle(httpServer, requestDispatcher);
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/reactive/standalone/vertx/HttpProtocolVerticleTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/reactive/standalone/vertx/HttpProtocolVerticleTest.java
@@ -98,14 +98,7 @@ public class HttpProtocolVerticleTest {
         client
             .request(HttpMethod.GET, httpServer.actualPort(), "127.0.0.1", "/")
             .compose(HttpClientRequest::send)
-            .onComplete(
-                testContext.succeeding(
-                    response ->
-                        testContext.verify(
-                            () -> assertThat(response.statusCode()).isEqualTo(500)
-                        )
-                )
-            )
+            .onComplete(testContext.succeeding(response -> testContext.verify(() -> assertThat(response.statusCode()).isEqualTo(500))))
             .compose(httpClientResponse -> client.request(HttpMethod.GET, httpServer.actualPort(), "127.0.0.1", "/"))
             .compose(HttpClientRequest::send)
             .onComplete(

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/reactive/standalone/vertx/HttpProtocolVerticleTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/reactive/standalone/vertx/HttpProtocolVerticleTest.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.standalone.vertx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.gateway.reactive.reactor.HttpRequestDispatcher;
+import io.gravitee.node.vertx.ReactivexVertxHttpServerFactory;
+import io.gravitee.node.vertx.VertxHttpServerFactory;
+import io.gravitee.node.vertx.configuration.HttpServerConfiguration;
+import io.reactivex.Completable;
+import io.reactivex.Flowable;
+import io.reactivex.Single;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.*;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import io.vertx.reactivex.core.http.HttpServerRequest;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.Environment;
+import org.springframework.mock.env.MockEnvironment;
+
+@ExtendWith(VertxExtension.class)
+public class HttpProtocolVerticleTest {
+
+    private HttpRequestDispatcher mockRequestDispatcher;
+    private HttpServer httpServer;
+
+    @BeforeEach
+    @DisplayName("Deploy a new http protocol verticle")
+    void deployVerticle(Vertx vertx, VertxTestContext testContext) throws Exception {
+        HttpServerConfiguration httpServerConfiguration = HttpServerConfiguration.builder().withEnvironment(new MockEnvironment()).build();
+        VertxHttpServerFactory vertxHttpServerFactory = new VertxHttpServerFactory(vertx, httpServerConfiguration, null);
+        httpServer = vertxHttpServerFactory.getObject();
+        mockRequestDispatcher = spy(new MockHttpRequestDispatcher());
+        vertx.deployVerticle(
+            new HttpProtocolVerticle(httpServer, httpServerConfiguration, mockRequestDispatcher),
+            testContext.succeedingThenComplete()
+        );
+    }
+
+    @AfterEach
+    @DisplayName("Check that the verticle is still there")
+    void lastChecks(Vertx vertx) {
+        assertThat(vertx.deploymentIDs()).isNotEmpty().hasSize(1);
+    }
+
+    @Test
+    void verticle_should_be_deployed(Vertx vertx, VertxTestContext testContext) {
+        testContext.completeNow();
+    }
+
+    @Test
+    void http_server_should_listen(Vertx vertx, VertxTestContext testContext) {
+        HttpClient client = vertx.createHttpClient();
+        client
+            .request(HttpMethod.GET, httpServer.actualPort(), "127.0.0.1", "/")
+            .compose(HttpClientRequest::send)
+            .onComplete(
+                testContext.succeeding(
+                    response ->
+                        testContext.verify(
+                            () -> {
+                                assertThat(response.statusCode()).isEqualTo(200);
+                                testContext.completeNow();
+                            }
+                        )
+                )
+            );
+    }
+
+    @Test
+    void http_server_should_close_and_resume_on_error(Vertx vertx, VertxTestContext testContext) {
+        doReturn(Completable.error(new RuntimeException("error"))).doCallRealMethod().when(mockRequestDispatcher).dispatch(any());
+        HttpClient client = vertx.createHttpClient();
+        client
+            .request(HttpMethod.GET, httpServer.actualPort(), "127.0.0.1", "/")
+            .compose(HttpClientRequest::send)
+            .onComplete(
+                testContext.succeeding(
+                    response ->
+                        testContext.verify(
+                            () -> assertThat(response.statusCode()).isEqualTo(500)
+                        )
+                )
+            )
+            .compose(httpClientResponse -> client.request(HttpMethod.GET, httpServer.actualPort(), "127.0.0.1", "/"))
+            .compose(HttpClientRequest::send)
+            .onComplete(
+                testContext.succeeding(
+                    response ->
+                        testContext.verify(
+                            () -> {
+                                assertThat(response.statusCode()).isEqualTo(200);
+                                testContext.completeNow();
+                            }
+                        )
+                )
+            );
+    }
+
+    @Test
+    void http_server_should_dispose_when_connection_closed(Vertx vertx, VertxTestContext testContext) {
+        Completable timer = Completable.timer(2, TimeUnit.SECONDS).doOnDispose(() -> testContext.completeNow());
+        doReturn(timer).when(mockRequestDispatcher).dispatch(any());
+        HttpClient client = vertx.createHttpClient();
+        client
+            .request(HttpMethod.GET, httpServer.actualPort(), "127.0.0.1", "/")
+            .compose(
+                request -> {
+                    request.send().otherwiseEmpty();
+                    return request.connection().close();
+                }
+            );
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/reactive/standalone/vertx/HttpProtocolVerticleTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/reactive/standalone/vertx/HttpProtocolVerticleTest.java
@@ -59,13 +59,9 @@ public class HttpProtocolVerticleTest {
         int randomPort = socket.getLocalPort();
         socket.close();
         httpServer = vertx.createHttpServer(new HttpServerOptions().setPort(randomPort));
-        HttpServerConfiguration httpServerConfiguration = HttpServerConfiguration.builder()
-                                                                                 .withPort(randomPort)
-                                                                                 .withEnvironment(new MockEnvironment())
-                                                                                 .build();
         mockRequestDispatcher = spy(new MockHttpRequestDispatcher());
         vertx.deployVerticle(
-                new HttpProtocolVerticle(httpServer, httpServerConfiguration, mockRequestDispatcher),
+                new HttpProtocolVerticle(httpServer, mockRequestDispatcher),
                 testContext.succeedingThenComplete()
                             );
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/reactive/standalone/vertx/MockHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/reactive/standalone/vertx/MockHttpRequestDispatcher.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.standalone.vertx;
+
+import io.gravitee.common.component.Lifecycle;
+import io.gravitee.gateway.reactive.reactor.HttpRequestDispatcher;
+import io.reactivex.Completable;
+import io.vertx.reactivex.core.http.HttpServerRequest;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class MockHttpRequestDispatcher implements HttpRequestDispatcher {
+
+    @Override
+    public Completable dispatch(HttpServerRequest httpServerRequest) {
+        return httpServerRequest.response().rxEnd();
+    }
+
+    @Override
+    public Lifecycle.State lifecycleState() {
+        return null;
+    }
+
+    @Override
+    public HttpRequestDispatcher start() throws Exception {
+        return this;
+    }
+
+    @Override
+    public HttpRequestDispatcher stop() throws Exception {
+        return this;
+    }
+}


### PR DESCRIPTION

**Description**

  - migrate verticle to full rx
  - properly handle connection close on request to dispose underlying subscription
  - resume when dispatch error is thrown
  - use constructor instead of autowired to easily implements tests
  - remove vertx injection and unused code

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/prototype-reactive-http-verticle/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
