### PR TITLE
fix: restore system role creation on startup

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DefaultRolesUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DefaultRolesUpgrader.java
@@ -58,6 +58,7 @@ public class DefaultRolesUpgrader extends OneShotUpgrader {
                 organization -> {
                     ExecutionContext executionContext = new ExecutionContext(organization);
                     initializeDefaultRoles(executionContext);
+                    roleService.createOrUpdateSystemRoles(executionContext, executionContext.getOrganizationId());
                 }
             );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/DefaultRoleUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/DefaultRoleUpgraderTest.java
@@ -62,6 +62,7 @@ public class DefaultRoleUpgraderTest {
         upgrader.processOneShotUpgrade();
         verify(roleService, times(1)).findAllByOrganization(expectedExecutionContext.getOrganizationId());
         verify(roleService, times(1)).initialize(expectedExecutionContext, expectedExecutionContext.getOrganizationId());
+        verify(roleService, times(1)).createOrUpdateSystemRoles(expectedExecutionContext, organization.getId());
     }
 
     @Test
@@ -82,5 +83,6 @@ public class DefaultRoleUpgraderTest {
         verify(roleService, never()).initialize(expectedExecutionContext, expectedExecutionContext.getOrganizationId());
         verify(roleService).findByScopeAndName(API, ROLE_API_REVIEWER.getName(), expectedExecutionContext.getOrganizationId());
         verify(roleService).create(expectedExecutionContext, ROLE_API_REVIEWER);
+        verify(roleService, times(1)).createOrUpdateSystemRoles(expectedExecutionContext, organization.getId());
     }
 }


### PR DESCRIPTION

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-create-system-roles/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
