### PR TITLE
fix: handle client side sse connection close

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/flow/benchmark/BestMatchFlowResolverBenchmark.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/flow/benchmark/BestMatchFlowResolverBenchmark.java
@@ -269,6 +269,11 @@ public class BestMatchFlowResolverBenchmark {
         }
 
         @Override
+        public Request closeHandler(Handler<Void> closeHandler) {
+            return null;
+        }
+
+        @Override
         public ReadStream<Buffer> bodyHandler(Handler<Buffer> handler) {
             return null;
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParametersProcessorBenchmark.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParametersProcessorBenchmark.java
@@ -212,6 +212,11 @@ public class PathParametersProcessorBenchmark {
         }
 
         @Override
+        public Request closeHandler(Handler<Void> closeHandler) {
+            return null;
+        }
+
+        @Override
         public ReadStream<Buffer> bodyHandler(Handler<Buffer> bodyHandler) {
             return null;
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxHttpServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxHttpServerRequest.java
@@ -251,6 +251,12 @@ public class VertxHttpServerRequest implements Request {
         return this;
     }
 
+    @Override
+    public Request closeHandler(Handler<Void> closeHandler) {
+        serverRequest.connection().closeHandler(closeHandler::handle);
+        return this;
+    }
+
     public HttpServerRequest getNativeServerRequest() {
         return serverRequest;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <gravitee-common.version>1.20.5</gravitee-common.version>
         <gravitee-expression-language.version>1.6.3</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>1.27.3</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.27.4</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>1.16.5</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>


### PR DESCRIPTION
see https://github.com/gravitee-io/issues/issues/7093

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-handle-client-side-connnection-close/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
