### PR TITLE
Update `gravitee-bom` to 2.4

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/services/discovery/EndpointDiscoveryModule.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/services/discovery/EndpointDiscoveryModule.java
@@ -19,19 +19,13 @@ import io.gravitee.definition.jackson.datatype.GraviteeModule;
 import io.gravitee.definition.jackson.datatype.services.discovery.deser.EndpointDiscoveryDeserializer;
 import io.gravitee.definition.jackson.datatype.services.discovery.ser.EndpointDiscoverySerializer;
 import io.gravitee.definition.model.services.discovery.EndpointDiscoveryService;
-import io.gravitee.definition.model.services.dynamicproperty.DynamicPropertyService;
 
-/**
- * @author David BRASSELY (david.brassely at graviteesource.com)
- * @author GraviteeSource Team
- */
 public class EndpointDiscoveryModule extends GraviteeModule {
 
     private static final long serialVersionUID = 1L;
 
-    @SuppressWarnings("unchecked")
     public EndpointDiscoveryModule() {
-        super(DynamicPropertyService.SERVICE_KEY);
+        super(EndpointDiscoveryService.SERVICE_KEY);
         // first deserializers
         addDeserializer(EndpointDiscoveryService.class, new EndpointDiscoveryDeserializer(EndpointDiscoveryService.class));
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,9 +56,9 @@
 
     <properties>
         <!-- Vert.X version is mandatory for vertx-grpc-protoc-plugin in gravitee-gateway-standalone-container -->
-        <vertx.version>4.2.4</vertx.version>
+        <vertx.version>4.2.6</vertx.version>
         <!-- Gravitee dependencies version -->
-        <gravitee-bom.version>2.1</gravitee-bom.version>
+        <gravitee-bom.version>2.4</gravitee-bom.version>
         <gravitee-alert-api.version>1.9.0</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>1.10.0</gravitee-cockpit-api.version>
         <gravitee-common.version>1.25.0</gravitee-common.version>


### PR DESCRIPTION
**Issue**

NA

**Description**

Update `gravitee-bom` to 2.4 and fix key used in `EndpointDiscoveryModule`
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/update-bom/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bbyjuwbgvn.chromatic.com)
<!-- Storybook placeholder end -->
