### PR TITLE
[rest-api] Organization audit

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAuditRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAuditRepository.java
@@ -273,20 +273,23 @@ public class JdbcAuditRepository extends JdbcAbstractPageableRepository<Audit> i
             builder.append(started ? AND_CLAUSE : WHERE_CLAUSE);
             builder.append("(");
             for (Entry<Audit.AuditReferenceType, List<String>> ref : filter.getReferences().entrySet()) {
-                builder.append("( reference_type = ? and reference_id in (");
+                builder.append("( reference_type = ?");
                 argsList.add(ref.getKey().toString());
                 LOGGER.debug("argsList after ref type = {}", argsList);
-                boolean first = true;
-                for (String id : ref.getValue()) {
-                    if (!first) {
-                        builder.append(", ");
+
+                if (ref.getValue() != null && !ref.getValue().isEmpty()) {
+                    StringJoiner inReferenceIdsQueryString = new StringJoiner(",", "and reference_id in (", ")");
+
+                    for (String id : ref.getValue()) {
+                        inReferenceIdsQueryString.add("?");
+                        argsList.add(id);
+                        LOGGER.debug("argsList after ref id = {}", argsList);
                     }
-                    first = false;
-                    builder.append("?");
-                    argsList.add(id);
-                    LOGGER.debug("argsList after ref id = {}", argsList);
+                    builder.append(inReferenceIdsQueryString);
                 }
-                builder.append(") )");
+
+                builder.append(")");
+
                 started = true;
             }
             builder.append(") ");

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/audit/AuditMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/audit/AuditMongoRepositoryImpl.java
@@ -45,8 +45,13 @@ public class AuditMongoRepositoryImpl implements AuditMongoRepositoryCustom {
             filter
                 .getReferences()
                 .forEach(
-                    (referenceType, referenceIds) ->
-                        query.addCriteria(where("referenceType").is(referenceType).andOperator(where("referenceId").in(referenceIds)))
+                    (referenceType, referenceIds) -> {
+                        if (referenceIds != null && !referenceIds.isEmpty()) {
+                            query.addCriteria(where("referenceType").is(referenceType).andOperator(where("referenceId").in(referenceIds)));
+                        } else {
+                            query.addCriteria(where("referenceType").is(referenceType));
+                        }
+                    }
                 );
         }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/AuditRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/AuditRepositoryTest.java
@@ -207,4 +207,17 @@ public class AuditRepositoryTest extends AbstractRepositoryTest {
         assertEquals("page number", 0, auditPage.getPageNumber());
         assertEquals("find audit with id 'new'", "new", auditPage.getContent().get(0).getId());
     }
+
+    @Test
+    public void shouldSearchWithReferenceTypeOnly() throws TechnicalException {
+        AuditCriteria auditCriteria = new AuditCriteria.Builder().references(Audit.AuditReferenceType.API, null).build();
+        Pageable page = new PageableBuilder().pageNumber(0).pageSize(10).build();
+
+        Page<Audit> auditPage = auditRepository.search(auditCriteria, page);
+
+        assertNotNull(auditPage);
+        assertEquals("total elements", 3, auditPage.getTotalElements());
+        assertEquals("page elements", 3, auditPage.getPageElements());
+        assertEquals("page number", 0, auditPage.getPageNumber());
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/AuditRepositoryMock.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/AuditRepositoryMock.java
@@ -79,7 +79,17 @@ public class AuditRepositoryMock extends AbstractRepositoryMock<AuditRepository>
         when(searchable2.getId()).thenReturn("searchable2");
         when(searchable2.getOrganizationId()).thenReturn("DEFAULT");
         //shouldSearchWithPagination
-        when(auditRepository.search(argThat(o -> o != null && o.getReferences() != null && !o.getReferences().isEmpty()), any()))
+        when(
+            auditRepository.search(
+                argThat(
+                    o ->
+                        o != null &&
+                        o.getReferences() != null &&
+                        o.getReferences().get(Audit.AuditReferenceType.API).equals(singletonList("2"))
+                ),
+                any()
+            )
+        )
             .thenReturn(new io.gravitee.common.data.domain.Page<>(singletonList(searchable2), 0, 1, 2));
         //shouldSearchWithEvent
         when(
@@ -130,5 +140,20 @@ public class AuditRepositoryMock extends AbstractRepositoryMock<AuditRepository>
             )
         )
             .thenReturn(new io.gravitee.common.data.domain.Page<>(asList(newAudit), 0, 1, 1));
+        //shouldSearchWithReferenceTypeOnly
+        when(
+            auditRepository.search(
+                argThat(
+                    o ->
+                        o != null &&
+                        o.getReferences() != null &&
+                        !o.getReferences().isEmpty() &&
+                        o.getReferences().containsKey(Audit.AuditReferenceType.API) &&
+                        o.getReferences().get(Audit.AuditReferenceType.API) == null
+                ),
+                any()
+            )
+        )
+            .thenReturn(new io.gravitee.common.data.domain.Page<>(asList(searchable2, newAudit, searchable1), 0, 3, 3));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiAuditResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiAuditResource.java
@@ -69,8 +69,6 @@ public class ApiAuditResource extends AbstractResource {
         query.setSize(param.getSize());
         query.setApiIds(Collections.singletonList(api));
         query.setApplicationIds(Collections.emptyList());
-        query.setCurrentEnvironmentLogsOnly(false);
-        query.setCurrentOrganizationLogsOnly(false);
 
         if (param.getEvent() != null) {
             query.setEvents(Collections.singletonList(param.getEvent()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/AuditResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/AuditResource.java
@@ -57,8 +57,8 @@ public class AuditResource extends AbstractResource {
 
     @GET
     @Operation(
-        summary = "Retrieve audit logs for the platform",
-        description = "User must have the MANAGEMENT_AUDIT[READ] permission to use this service"
+        summary = "Retrieve audit logs for the environment",
+        description = "User must have the ENVIRONMENT_AUDIT[READ] or ORGANIZATION_AUDIT[READ] permission to use this service"
     )
     @ApiResponse(
         responseCode = "200",
@@ -68,7 +68,12 @@ public class AuditResource extends AbstractResource {
     @ApiResponse(responseCode = "500", description = "Internal server error")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_AUDIT, acls = RolePermissionAction.READ) })
+    @Permissions(
+            {
+                    @Permission(value = RolePermission.ENVIRONMENT_AUDIT, acls = RolePermissionAction.READ),
+                    @Permission(value = RolePermission.ORGANIZATION_AUDIT, acls = RolePermissionAction.READ),
+            }
+    )
     public AuditEntityMetadataPage getAudits(@BeanParam AuditParam param) {
         AuditQuery query = new AuditQuery();
         query.setFrom(param.getFrom());
@@ -99,8 +104,8 @@ public class AuditResource extends AbstractResource {
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
-        summary = "List available audit event type for platform",
-        description = "User must have the MANAGEMENT_AUDIT[READ] permission to use this service"
+        summary = "List available audit event type for the environment",
+        description = "User must have the ENVIRONMENT_AUDIT[READ] or ORGANIZATION_AUDIT[READ] permission to use this service"
     )
     @ApiResponse(
         responseCode = "200",
@@ -111,7 +116,12 @@ public class AuditResource extends AbstractResource {
         )
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
-    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_AUDIT, acls = RolePermissionAction.READ) })
+    @Permissions(
+            {
+                    @Permission(value = RolePermission.ENVIRONMENT_AUDIT, acls = RolePermissionAction.READ),
+                    @Permission(value = RolePermission.ORGANIZATION_AUDIT, acls = RolePermissionAction.READ),
+            }
+    )
     public Response getAuditEvents() {
         if (events.isEmpty()) {
             Set<Class<? extends Audit.AuditEvent>> subTypesOf = new Reflections("io.gravitee.repository.management.model")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/AuditResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/AuditResource.java
@@ -15,13 +15,17 @@
  */
 package io.gravitee.rest.api.management.rest.resource;
 
+import static java.util.Map.entry;
+
 import io.gravitee.common.http.MediaType;
 import io.gravitee.repository.management.model.Audit;
 import io.gravitee.rest.api.management.rest.model.wrapper.AuditEntityMetadataPage;
 import io.gravitee.rest.api.management.rest.resource.param.AuditParam;
+import io.gravitee.rest.api.management.rest.resource.param.AuditType;
 import io.gravitee.rest.api.management.rest.security.Permission;
 import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.model.audit.AuditQuery;
+import io.gravitee.rest.api.model.audit.AuditReferenceType;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.AuditService;
@@ -81,13 +85,18 @@ public class AuditResource extends AbstractResource {
         query.setPage(param.getPage());
         query.setSize(param.getSize());
 
-        if (param.getApiId() != null) {
-            query.setApiIds(Collections.singletonList(param.getApiId()));
+        if (param.getEnvironmentId() != null) {
+            query.setEnvironmentIds(Collections.singletonList(param.getEnvironmentId()));
         }
         if (param.getApplicationId() != null) {
             query.setApplicationIds(Collections.singletonList(param.getApplicationId()));
         }
-
+        if (param.getApiId() != null) {
+            query.setApiIds(Collections.singletonList(param.getApiId()));
+        }
+        if (param.getType() != null) {
+            query.setReferenceType(AuditType.fromAuditType(param.getType()));
+        }
         if (param.getEvent() != null) {
             query.setEvents(Collections.singletonList(param.getEvent()));
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/AuditResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/AuditResource.java
@@ -69,10 +69,10 @@ public class AuditResource extends AbstractResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Permissions(
-            {
-                    @Permission(value = RolePermission.ENVIRONMENT_AUDIT, acls = RolePermissionAction.READ),
-                    @Permission(value = RolePermission.ORGANIZATION_AUDIT, acls = RolePermissionAction.READ),
-            }
+        {
+            @Permission(value = RolePermission.ENVIRONMENT_AUDIT, acls = RolePermissionAction.READ),
+            @Permission(value = RolePermission.ORGANIZATION_AUDIT, acls = RolePermissionAction.READ),
+        }
     )
     public AuditEntityMetadataPage getAudits(@BeanParam AuditParam param) {
         AuditQuery query = new AuditQuery();
@@ -80,17 +80,12 @@ public class AuditResource extends AbstractResource {
         query.setTo(param.getTo());
         query.setPage(param.getPage());
         query.setSize(param.getSize());
-        if (param.isEnvironmentLogsOnly()) {
-            query.setCurrentEnvironmentLogsOnly(true);
-        } else if (param.isOrganizationLogsOnly()) {
-            query.setCurrentOrganizationLogsOnly(true);
-        } else {
-            if (param.getApiId() != null) {
-                query.setApiIds(Collections.singletonList(param.getApiId()));
-            }
-            if (param.getApplicationId() != null) {
-                query.setApplicationIds(Collections.singletonList(param.getApplicationId()));
-            }
+
+        if (param.getApiId() != null) {
+            query.setApiIds(Collections.singletonList(param.getApiId()));
+        }
+        if (param.getApplicationId() != null) {
+            query.setApplicationIds(Collections.singletonList(param.getApplicationId()));
         }
 
         if (param.getEvent() != null) {
@@ -117,10 +112,10 @@ public class AuditResource extends AbstractResource {
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
     @Permissions(
-            {
-                    @Permission(value = RolePermission.ENVIRONMENT_AUDIT, acls = RolePermissionAction.READ),
-                    @Permission(value = RolePermission.ORGANIZATION_AUDIT, acls = RolePermissionAction.READ),
-            }
+        {
+            @Permission(value = RolePermission.ENVIRONMENT_AUDIT, acls = RolePermissionAction.READ),
+            @Permission(value = RolePermission.ORGANIZATION_AUDIT, acls = RolePermissionAction.READ),
+        }
     )
     public Response getAuditEvents() {
         if (events.isEmpty()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/OrganizationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/OrganizationResource.java
@@ -16,9 +16,7 @@
 package io.gravitee.rest.api.management.rest.resource.organization;
 
 import io.gravitee.common.http.MediaType;
-import io.gravitee.rest.api.management.rest.resource.AbstractResource;
-import io.gravitee.rest.api.management.rest.resource.EnvironmentsResource;
-import io.gravitee.rest.api.management.rest.resource.PromotionsResource;
+import io.gravitee.rest.api.management.rest.resource.*;
 import io.gravitee.rest.api.management.rest.resource.auth.OAuth2AuthenticationResource;
 import io.gravitee.rest.api.management.rest.resource.installation.InstallationResource;
 import io.gravitee.rest.api.management.rest.resource.portal.SocialIdentityProvidersResource;
@@ -221,5 +219,10 @@ public class OrganizationResource extends AbstractResource {
     @Path("promotions")
     public PromotionsResource getPromotionsResource() {
         return resourceContext.getResource(PromotionsResource.class);
+    }
+
+    @Path("audit")
+    public AuditResource getAuditResource() {
+        return resourceContext.getResource(AuditResource.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/param/AuditParam.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/param/AuditParam.java
@@ -25,18 +25,6 @@ import javax.ws.rs.QueryParam;
  */
 public class AuditParam {
 
-    @QueryParam("envLog")
-    @Parameter(
-        description = "true if you only want logs from the current environment, false if you also want api, application and organization audit logs"
-    )
-    private boolean environmentLogsOnly;
-
-    @QueryParam("orgLog")
-    @Parameter(
-        description = "true if you only want logs from the current organization, false if you also want api, application and environment audit logs"
-    )
-    private boolean organizationLogsOnly;
-
     @QueryParam("api")
     private String apiId;
 
@@ -63,22 +51,6 @@ public class AuditParam {
     @QueryParam("page")
     @DefaultValue("1")
     private int page;
-
-    public boolean isEnvironmentLogsOnly() {
-        return environmentLogsOnly;
-    }
-
-    public void setEnvironmentLogsOnly(boolean environmentLogsOnly) {
-        this.environmentLogsOnly = environmentLogsOnly;
-    }
-
-    public boolean isOrganizationLogsOnly() {
-        return organizationLogsOnly;
-    }
-
-    public void setOrganizationLogsOnly(boolean organizationLogsOnly) {
-        this.organizationLogsOnly = organizationLogsOnly;
-    }
 
     public String getApiId() {
         return apiId;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/param/AuditParam.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/param/AuditParam.java
@@ -25,11 +25,18 @@ import javax.ws.rs.QueryParam;
  */
 public class AuditParam {
 
+    @QueryParam("environment")
+    private String environmentId;
+
     @QueryParam("api")
     private String apiId;
 
     @QueryParam("application")
     private String applicationId;
+
+    @QueryParam("type")
+    @Parameter(description = "filter on the type of audit")
+    private AuditType type;
 
     @QueryParam("event")
     @Parameter(description = "filter by the name of an event.", example = "APPLICATION_UPDATED, API_CREATED, METADATA_DELETED, ...")
@@ -52,6 +59,14 @@ public class AuditParam {
     @DefaultValue("1")
     private int page;
 
+    public String getEnvironmentId() {
+        return environmentId;
+    }
+
+    public void setEnvironmentId(String environmentId) {
+        this.environmentId = environmentId;
+    }
+
     public String getApiId() {
         return apiId;
     }
@@ -66,6 +81,14 @@ public class AuditParam {
 
     public void setApplicationId(String applicationId) {
         this.applicationId = applicationId;
+    }
+
+    public AuditType getType() {
+        return type;
+    }
+
+    public void setType(AuditType type) {
+        this.type = type;
     }
 
     public String getEvent() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/param/AuditType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/param/AuditType.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource.param;
+
+import static java.util.Map.entry;
+
+import io.gravitee.rest.api.model.audit.AuditReferenceType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Map;
+
+@Schema(enumAsRef = true)
+public enum AuditType {
+    ORGANIZATION,
+    ENVIRONMENT,
+    APPLICATION,
+    API;
+
+    private static final Map<AuditType, AuditReferenceType> AUDIT_TYPE_AUDIT_REFERENCE_TYPE_MAP = Map.ofEntries(
+        entry(AuditType.ORGANIZATION, AuditReferenceType.ORGANIZATION),
+        entry(AuditType.ENVIRONMENT, AuditReferenceType.ENVIRONMENT),
+        entry(AuditType.APPLICATION, AuditReferenceType.APPLICATION),
+        entry(AuditType.API, AuditReferenceType.API)
+    );
+
+    public static AuditReferenceType fromAuditType(AuditType auditType) {
+        return AUDIT_TYPE_AUDIT_REFERENCE_TYPE_MAP.get(auditType);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/AbstractResourceTest.java
@@ -227,6 +227,9 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
     @Autowired
     protected ObjectMapper objectMapper;
 
+    @Autowired
+    protected AuditService auditService;
+
     @Configuration
     @PropertySource("classpath:/io/gravitee/rest/api/management/rest/resource/jwt.properties")
     static class ContextConfiguration {
@@ -529,6 +532,11 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
         @Bean
         public JsonPatchService jsonPatchService() {
             return mock(JsonPatchService.class);
+        }
+
+        @Bean
+        public AuditService auditService() {
+            return mock(AuditService.class);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/AuditResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/AuditResourceTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.common.data.domain.MetadataPage;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.model.audit.AuditEntity;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.core.Response;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class AuditResourceTest extends AbstractResourceTest {
+
+    @Override
+    protected String contextPath() {
+        return "audit/";
+    }
+
+    @Before
+    public void setUp() {
+        when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(true);
+        reset(auditService);
+    }
+
+    private class TestAudit extends AuditEntity {
+
+        protected TestAudit(String id) {
+            super();
+            this.setId(id);
+        }
+    }
+
+    @Test
+    public void should_list_env_audit() {
+        List<AuditEntity> audits = List.of(new TestAudit("audit-1"));
+        Map<String, String> metadata = new HashMap<>();
+        when(auditService.search(any(), argThat(o -> o != null))).thenReturn(new MetadataPage<>(audits, 1, 1, 1, metadata));
+
+        final Response response = envTarget().request().get();
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+    }
+
+    @Test
+    public void should_list_env_audit_with_event() {
+        List<AuditEntity> audits = List.of(new TestAudit("audit-1"));
+        Map<String, String> metadata = new HashMap<>();
+        when(auditService.search(any(), argThat(o -> o != null && o.getEvents().equals(Collections.singletonList("eventId")))))
+            .thenReturn(new MetadataPage<>(audits, 1, 1, 1, metadata));
+
+        final Response response = envTarget().queryParam("event", "eventId").request().get();
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+    }
+
+    @Test
+    public void should_list_org_audit() {
+        List<AuditEntity> audits = List.of(new TestAudit("audit-1"));
+        Map<String, String> metadata = new HashMap<>();
+
+        when(auditService.search(any(), argThat(o -> o != null))).thenReturn(new MetadataPage<>(audits, 1, 1, 1, metadata));
+
+        final Response response = orgTarget().request().get();
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/audit/AuditEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/audit/AuditEntity.java
@@ -27,7 +27,7 @@ public class AuditEntity {
 
     private String id;
     private String referenceId;
-    private String referenceType;
+    private AuditReferenceType referenceType;
     private String user;
     private Date createdAt;
     private String event;
@@ -50,11 +50,11 @@ public class AuditEntity {
         this.referenceId = referenceId;
     }
 
-    public String getReferenceType() {
+    public AuditReferenceType getReferenceType() {
         return referenceType;
     }
 
-    public void setReferenceType(String referenceType) {
+    public void setReferenceType(AuditReferenceType referenceType) {
         this.referenceType = referenceType;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/audit/AuditQuery.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/audit/AuditQuery.java
@@ -23,8 +23,6 @@ import java.util.List;
  */
 public class AuditQuery {
 
-    private boolean currentEnvironmentLogsOnly;
-    private boolean currentOrganizationLogsOnly;
     private List<String> apiIds;
     private List<String> applicationIds;
     private List<String> events;
@@ -32,22 +30,6 @@ public class AuditQuery {
     private long to;
     private int size;
     private int page;
-
-    public boolean isCurrentEnvironmentLogsOnly() {
-        return currentEnvironmentLogsOnly;
-    }
-
-    public void setCurrentEnvironmentLogsOnly(boolean currentEnvironmentLogsOnly) {
-        this.currentEnvironmentLogsOnly = currentEnvironmentLogsOnly;
-    }
-
-    public boolean isCurrentOrganizationLogsOnly() {
-        return currentOrganizationLogsOnly;
-    }
-
-    public void setCurrentOrganizationLogsOnly(boolean currentOrganizationLogsOnly) {
-        this.currentOrganizationLogsOnly = currentOrganizationLogsOnly;
-    }
 
     public List<String> getApiIds() {
         return apiIds;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/audit/AuditQuery.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/audit/AuditQuery.java
@@ -23,13 +23,23 @@ import java.util.List;
  */
 public class AuditQuery {
 
+    private List<String> environmentIds;
     private List<String> apiIds;
     private List<String> applicationIds;
+    private AuditReferenceType referenceType;
     private List<String> events;
     private long from;
     private long to;
     private int size;
     private int page;
+
+    public List<String> getEnvironmentIds() {
+        return environmentIds;
+    }
+
+    public void setEnvironmentIds(List<String> environmentIds) {
+        this.environmentIds = environmentIds;
+    }
 
     public List<String> getApiIds() {
         return apiIds;
@@ -45,6 +55,14 @@ public class AuditQuery {
 
     public void setApplicationIds(List<String> applicationIds) {
         this.applicationIds = applicationIds;
+    }
+
+    public AuditReferenceType getReferenceType() {
+        return referenceType;
+    }
+
+    public void setReferenceType(AuditReferenceType resourceType) {
+        this.referenceType = resourceType;
     }
 
     public List<String> getEvents() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/audit/AuditReferenceType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/audit/AuditReferenceType.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.audit;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Schema(enumAsRef = true)
+public enum AuditReferenceType {
+    ORGANIZATION,
+    ENVIRONMENT,
+    APPLICATION,
+    API,
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/OrganizationPermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/OrganizationPermission.java
@@ -35,7 +35,8 @@ public enum OrganizationPermission implements Permission {
     TAG("TAG", 1900),
     TENANT("TENANT", 2000),
     ENTRYPOINT("ENTRYPOINT", 2100),
-    POLICIES("POLICIES", 2200);
+    POLICIES("POLICIES", 2200),
+    AUDIT("AUDIT", 2300);
 
     String name;
     int mask;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RolePermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RolePermission.java
@@ -93,7 +93,8 @@ public enum RolePermission {
     ORGANIZATION_TAG(RoleScope.ORGANIZATION, OrganizationPermission.TAG),
     ORGANIZATION_TENANT(RoleScope.ORGANIZATION, OrganizationPermission.TENANT),
     ORGANIZATION_ENTRYPOINT(RoleScope.ORGANIZATION, OrganizationPermission.ENTRYPOINT),
-    ORGANIZATION_POLICIES(RoleScope.ORGANIZATION, OrganizationPermission.POLICIES);
+    ORGANIZATION_POLICIES(RoleScope.ORGANIZATION, OrganizationPermission.POLICIES),
+    ORGANIZATION_AUDIT(RoleScope.ORGANIZATION, OrganizationPermission.AUDIT);
 
     RoleScope scope;
     Permission permission;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AuditServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AuditServiceImpl.java
@@ -93,11 +93,7 @@ public class AuditServiceImpl extends AbstractService implements AuditService {
             criteria.environmentIds(Collections.singletonList(executionContext.getEnvironmentId()));
         }
 
-        if (query.isCurrentEnvironmentLogsOnly()) {
-            criteria.references(Audit.AuditReferenceType.ENVIRONMENT, Collections.singletonList(executionContext.getEnvironmentId()));
-        } else if (query.isCurrentOrganizationLogsOnly()) {
-            criteria.references(Audit.AuditReferenceType.ORGANIZATION, Collections.singletonList(executionContext.getOrganizationId()));
-        } else if (query.getApiIds() != null && !query.getApiIds().isEmpty()) {
+        if (query.getApiIds() != null && !query.getApiIds().isEmpty()) {
             criteria.references(Audit.AuditReferenceType.API, query.getApiIds());
         } else if (query.getApplicationIds() != null && !query.getApplicationIds().isEmpty()) {
             criteria.references(Audit.AuditReferenceType.APPLICATION, query.getApplicationIds());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AuditServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AuditServiceImpl.java
@@ -87,6 +87,12 @@ public class AuditServiceImpl extends AbstractService implements AuditService {
     private ApiRepository apiRepository;
 
     @Autowired
+    private EnvironmentRepository environmentRepository;
+
+    @Autowired
+    private OrganizationRepository organizationRepository;
+
+    @Autowired
     private ApplicationRepository applicationRepository;
 
     @Autowired
@@ -173,13 +179,26 @@ public class AuditServiceImpl extends AbstractService implements AuditService {
                 metadata.put(metadataKey, auditEntity.getUser());
             }
 
-            if (Audit.AuditReferenceType.API.name().equals(auditEntity.getReferenceType().name())) {
-                metadataKey = "API:" + auditEntity.getReferenceId() + ":name";
+            if (Audit.AuditReferenceType.ORGANIZATION.name().equals(auditEntity.getReferenceType().name())) {
+                metadataKey = "ORGANIZATION:" + auditEntity.getReferenceId() + ":name";
                 if (!metadata.containsKey(metadataKey)) {
                     try {
-                        Optional<Api> optApi = apiRepository.findById(auditEntity.getReferenceId());
-                        if (optApi.isPresent()) {
-                            metadata.put(metadataKey, optApi.get().getName());
+                        Optional<Organization> optOrganization = organizationRepository.findById(auditEntity.getReferenceId());
+                        if (optOrganization.isPresent()) {
+                            metadata.put(metadataKey, optOrganization.get().getName());
+                        }
+                    } catch (TechnicalException e) {
+                        LOGGER.error("Error finding metadata {}", metadataKey);
+                        metadata.put(metadataKey, auditEntity.getReferenceId());
+                    }
+                }
+            } else if (Audit.AuditReferenceType.ENVIRONMENT.name().equals(auditEntity.getReferenceType().name())) {
+                metadataKey = "ENVIRONMENT:" + auditEntity.getReferenceId() + ":name";
+                if (!metadata.containsKey(metadataKey)) {
+                    try {
+                        Optional<Environment> optEnvironment = environmentRepository.findById(auditEntity.getReferenceId());
+                        if (optEnvironment.isPresent()) {
+                            metadata.put(metadataKey, optEnvironment.get().getName());
                         }
                     } catch (TechnicalException e) {
                         LOGGER.error("Error finding metadata {}", metadataKey);
@@ -193,6 +212,19 @@ public class AuditServiceImpl extends AbstractService implements AuditService {
                         Optional<Application> optApp = applicationRepository.findById(auditEntity.getReferenceId());
                         if (optApp.isPresent()) {
                             metadata.put(metadataKey, optApp.get().getName());
+                        }
+                    } catch (TechnicalException e) {
+                        LOGGER.error("Error finding metadata {}", metadataKey);
+                        metadata.put(metadataKey, auditEntity.getReferenceId());
+                    }
+                }
+            } else if (Audit.AuditReferenceType.API.name().equals(auditEntity.getReferenceType().name())) {
+                metadataKey = "API:" + auditEntity.getReferenceId() + ":name";
+                if (!metadata.containsKey(metadataKey)) {
+                    try {
+                        Optional<Api> optApi = apiRepository.findById(auditEntity.getReferenceId());
+                        if (optApi.isPresent()) {
+                            metadata.put(metadataKey, optApi.get().getName());
                         }
                     } catch (TechnicalException e) {
                         LOGGER.error("Error finding metadata {}", metadataKey);


### PR DESCRIPTION
**Issue**
https://github.com/gravitee-io/issues/issues/7536

**Description**

- Make audits available at the organization level
- Adds the possibility to filter by type
- Allows to filter by environmentId if the audit is of type ENVIRONMENT 


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zzfoacjddv.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7536-organization-audit/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
