### PR TITLE
fix(rest-api): fix organization permission combined with environment permission

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/filter/PermissionsFilter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/filter/PermissionsFilter.java
@@ -17,7 +17,7 @@ package io.gravitee.rest.api.management.rest.filter;
 
 import io.gravitee.rest.api.management.rest.security.Permission;
 import io.gravitee.rest.api.management.rest.security.Permissions;
-import io.gravitee.rest.api.service.*;
+import io.gravitee.rest.api.service.PermissionService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
@@ -77,7 +77,9 @@ public class PermissionsFilter implements ContainerRequestFilter {
             case ORGANIZATION:
                 return hasPermission(executionContext, permission, executionContext.getOrganizationId());
             case ENVIRONMENT:
-                return hasPermission(executionContext, permission, executionContext.getEnvironmentId());
+                return (
+                    executionContext.hasEnvironmentId() && hasPermission(executionContext, permission, executionContext.getEnvironmentId())
+                );
             case APPLICATION:
                 return hasPermission(executionContext, permission, getApplicationId(requestContext));
             case API:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/filter/PermissionsFilter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/filter/PermissionsFilter.java
@@ -87,7 +87,9 @@ public class PermissionsFilter implements ContainerRequestFilter {
             case ORGANIZATION:
                 return hasPermission(executionContext, permission, executionContext.getOrganizationId());
             case ENVIRONMENT:
-                return hasPermission(executionContext, permission, executionContext.getEnvironmentId());
+                return (
+                    executionContext.hasEnvironmentId() && hasPermission(executionContext, permission, executionContext.getEnvironmentId())
+                );
             case APPLICATION:
                 return hasPermission(executionContext, permission, getApplicationId(requestContext));
             case API:


### PR DESCRIPTION
**Issue**
na

**Description**

in the case where a resource is subject to 2 permissions, one organization and one environment like :

```
@Permissions(
        {
            @Permission(value = RolePermission.ENVIRONMENT_TENANT, acls = RolePermissionAction.UPDATE),
            @Permission(value = RolePermission.ORGANIZATION_TENANT, acls = RolePermissionAction.UPDATE),
        }
    )
```
the environment id does not necessarily exist the permission and the permission should be rejected without error



**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ldutilznbk.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-permissions/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
