### PR TITLE
fix(console): add default basehref

### DIFF
--- a/docker/quick-setup/nginx/conf/nginx.conf
+++ b/docker/quick-setup/nginx/conf/nginx.conf
@@ -42,10 +42,14 @@ http {
 
             location /console/ {
                 proxy_pass http://apim-management-ui/;
+                sub_filter_once  on;
+                sub_filter  '<base href="/' '<base href="/console/';
             }
 
             location /portal/ {
                 proxy_pass http://apim-management-api/portal/;
+                sub_filter_once  on;
+                sub_filter  '<base href="/' '<base href="/portal/';
             }
 
             location / {

--- a/gravitee-apim-console-webui/src/index.html
+++ b/gravitee-apim-console-webui/src/index.html
@@ -19,6 +19,7 @@
 <html class="bootstrap">
   <head>
     <meta charset="utf-8" />
+    <base href="/" />
     <title ng-bind="consoleTitle"></title>
     <meta name="description" content="" />
     <meta name="viewport" content="width=device-width" />


### PR DESCRIPTION
And an example how to override with nginx

https://github.com/gravitee-io/issues/issues/7569

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-reverse-proxy-custom-conf/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
