### PR TITLE
fix(console): add mat font icon with FontSource

### DIFF
--- a/gravitee-apim-console-webui/package-lock.json
+++ b/gravitee-apim-console-webui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gravitee-apim-console-webui",
-  "version": "3.15.6",
+  "version": "3.15.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9089,6 +9089,11 @@
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/@fontsource/libre-franklin/-/libre-franklin-4.4.5.tgz",
       "integrity": "sha512-svwnzu0KKVpMEuRU1G58xp1BNrho5qki/bxpF/y1tOjAOoM357Avw8Gc8xw40pbN5B1QNyT3wuZQ/nMwSbjh9w=="
+    },
+    "@fontsource/material-icons": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/@fontsource/material-icons/-/material-icons-4.5.4.tgz",
+      "integrity": "sha512-YGmXkkEdu6EIgpFKNmB/nIXzZocwSmbI01Ninpmml8x8BT0M6RR++V1KqOfpzZ6Cw/FQ2/KYonQ3x4IY/4VRRA=="
     },
     "@formatjs/ecma402-abstract": {
       "version": "1.11.3",

--- a/gravitee-apim-console-webui/package.json
+++ b/gravitee-apim-console-webui/package.json
@@ -15,6 +15,7 @@
     "@angular/upgrade": "12.2.3",
     "@asyncapi/web-component": "1.0.0-next.15",
     "@fontsource/libre-franklin": "4.4.5",
+    "@fontsource/material-icons": "^4.5.4",
     "@gravitee/ui-components": "3.31.2",
     "@gravitee/ui-particles-angular": "1.4.0",
     "@highcharts/map-collection": "1.1.3",

--- a/gravitee-apim-console-webui/src/index.html
+++ b/gravitee-apim-console-webui/src/index.html
@@ -23,7 +23,6 @@
     <meta name="description" content="" />
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" href="favicon.ico" />
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
     <style type="text/css">
       [ng\:cloak],
       [ng-cloak],

--- a/gravitee-apim-console-webui/src/index.scss
+++ b/gravitee-apim-console-webui/src/index.scss
@@ -67,6 +67,7 @@
 @import 'user/login/login';
 
 @import '../node_modules/@fontsource/libre-franklin/scss/mixins';
+@import '../node_modules/@fontsource/material-icons/400.css';
 
 @import './scss/material-layout-compatibility.scss';
 


### PR DESCRIPTION
**Issue**

na
**Description**

Use FontSource to add mat font icon locally 

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/3-15-x-fix-mat-icon/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
