### PR TITLE
fix: handle client side connection close

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -46,7 +46,7 @@
     <properties>
         <!-- Versions of the plugins for the full distribution -->
         <!-- Management API & Gateway -->
-        <gravitee-connector-http.version>1.1.3</gravitee-connector-http.version>
+        <gravitee-connector-http.version>1.1.4</gravitee-connector-http.version>
         <gravitee-policy-apikey.version>2.4.0</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>1.5.0</gravitee-policy-assign-attributes.version>
         <gravitee-policy-assign-content.version>1.7.0</gravitee-policy-assign-content.version>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/flow/benchmark/BestMatchFlowResolverBenchmark.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/flow/benchmark/BestMatchFlowResolverBenchmark.java
@@ -264,6 +264,11 @@ public class BestMatchFlowResolverBenchmark {
         }
 
         @Override
+        public Request closeHandler(Handler<Void> closeHandler) {
+            return null;
+        }
+
+        @Override
         public ReadStream<Buffer> bodyHandler(Handler<Buffer> handler) {
             return null;
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParametersProcessorBenchmark.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParametersProcessorBenchmark.java
@@ -217,6 +217,11 @@ public class PathParametersProcessorBenchmark {
         }
 
         @Override
+        public Request closeHandler(Handler<Void> closeHandler) {
+            return null;
+        }
+
+        @Override
         public ReadStream<Buffer> bodyHandler(Handler<Buffer> bodyHandler) {
             return null;
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpServerRequest.java
@@ -255,6 +255,12 @@ public class VertxHttpServerRequest implements Request {
         return this.serverRequest.host();
     }
 
+    @Override
+    public Request closeHandler(Handler<Void> closeHandler) {
+        serverRequest.connection().closeHandler(closeHandler::handle);
+        return this;
+    }
+
     public HttpServerRequest getNativeServerRequest() {
         return serverRequest;
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/policy/impl/SimpleRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/policy/impl/SimpleRequest.java
@@ -155,6 +155,11 @@ class SimpleRequest implements Request {
     }
 
     @Override
+    public Request closeHandler(Handler<Void> closeHandler) {
+        return null;
+    }
+
+    @Override
     public ReadStream<Buffer> bodyHandler(Handler<Buffer> bodyHandler) {
         return null;
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <jetty94.wiremock.version>9.4.44.v20210927</jetty94.wiremock.version>
-        <gravitee-connector-http.version>1.1.3</gravitee-connector-http.version>
+        <gravitee-connector-http.version>1.1.4</gravitee-connector-http.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <gravitee-connector-api.version>1.1.0</gravitee-connector-api.version>
         <gravitee-expression-language.version>1.9.1</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>1.31.1</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.31.2</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>1.20.3</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>


### PR DESCRIPTION
see https://github.com/gravitee-io/issues/issues/7573

📝 On 3-15-x the log issue reported for 3-10 is gone 🎉 
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cnpsplhbot.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-handle-client-side-connnection-close-3-15/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
