### PR TITLE
ARCH-115        add execution mode on Api definition

### DIFF
--- a/gravitee-apim-console-webui/src/entities/consoleSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/consoleSettings.ts
@@ -26,6 +26,7 @@ export interface ConsoleSettings {
   management?: ConsoleSettingsManagement;
   newsletter?: ConsoleSettingsNewsletter;
   theme?: ConsoleSettingsTheme;
+  jupiterMode?: ConsoleSettingsJupiterMode;
 }
 
 export interface ConsoleSettingsEmail {
@@ -126,4 +127,9 @@ export interface ConsoleSettingsTheme {
   logo?: string;
   loader?: string;
   css?: string;
+}
+
+export interface ConsoleSettingsJupiterMode {
+  enabled?: boolean;
+  isDefault?: string;
 }

--- a/gravitee-apim-console-webui/src/management/api/creation/steps/api-creation.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/steps/api-creation.controller.ts
@@ -42,6 +42,7 @@ interface Api {
   tags: any[];
   groups: any[];
   lifecycle_state?: string;
+  execution_mode?: string;
 }
 
 class ApiCreationController {
@@ -111,6 +112,12 @@ class ApiCreationController {
       tags: [],
       groups: [],
     };
+
+    if (this.Constants.org.settings.jupiterMode.enabled && this.Constants.org.settings.jupiterMode.isDefault !== 'never') {
+      this.api.execution_mode = 'jupiter';
+    } else {
+      this.api.execution_mode = 'v3';
+    }
 
     this.contextPathInvalid = true;
     this.plan = {

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/ApiDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/ApiDeserializer.java
@@ -75,6 +75,7 @@ public class ApiDeserializer extends StdScalarDeserializer<Api> {
         } else {
             api.setVersion(versionNode.asText());
         }
+        api.setExecutionMode(ExecutionMode.fromLabel(node.path("execution_mode").asText()));
 
         JsonNode proxyNode = node.get("proxy");
         if (proxyNode != null) {

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/ser/ApiSerializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/ser/ApiSerializer.java
@@ -49,6 +49,9 @@ public class ApiSerializer extends StdScalarSerializer<Api> {
         if (api.getDefinitionVersion() != null) {
             jgen.writeObjectField("gravitee", api.getDefinitionVersion().getLabel());
         }
+        if (api.getExecutionMode() != null) {
+            jgen.writeObjectField("execution_mode", api.getExecutionMode().getLabel());
+        }
 
         if (api.getFlowMode() != null) {
             jgen.writeObjectField("flow_mode", api.getFlowMode().toString().toUpperCase());

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
@@ -637,21 +637,21 @@ public class ApiDeserializerTest extends AbstractTest {
     }
 
     @Test
-    public void should_default_definition_executionMode_equal_v3_when_json_contains_null() throws Exception {
+    public void shouldDefaultDefinitionExecutionModeEqualV3WhenJsonContainsNull() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-default-executionmode.json", Api.class);
 
         assertEquals(api.getExecutionMode(), ExecutionMode.V3);
     }
 
     @Test
-    public void should_definition_executionMode_equal_v3_when_json_contains_v3() throws Exception {
+    public void shouldDefinitionExecutionModeEqualV3WhenJsonContainsV3() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-executionmode-v3.json", Api.class);
 
         assertEquals(ExecutionMode.V3, api.getExecutionMode());
     }
 
     @Test
-    public void should_definition_executionMode_equal_jupiter_when_json_contains_jupiter() throws Exception {
+    public void shouldDefinitionExecutionModeEqualJupiterWhenJsonContainsJupiter() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-executionmode-jupiter.json", Api.class);
 
         assertEquals(ExecutionMode.JUPITER, api.getExecutionMode());

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.definition.jackson.api;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -633,5 +634,26 @@ public class ApiDeserializerTest extends AbstractTest {
     @Test(expected = JsonMappingException.class)
     public void definition_v1_withFlow() throws Exception {
         load("/io/gravitee/definition/jackson/api-v1-withflow.json", Api.class);
+    }
+
+    @Test
+    public void should_default_definition_executionMode_equal_v3_when_json_contains_null() throws Exception {
+        Api api = load("/io/gravitee/definition/jackson/api-default-executionmode.json", Api.class);
+
+        assertEquals(api.getExecutionMode(), ExecutionMode.V3);
+    }
+
+    @Test
+    public void should_definition_executionMode_equal_v3_when_json_contains_v3() throws Exception {
+        Api api = load("/io/gravitee/definition/jackson/api-executionmode-v3.json", Api.class);
+
+        assertEquals(ExecutionMode.V3, api.getExecutionMode());
+    }
+
+    @Test
+    public void should_definition_executionMode_equal_jupiter_when_json_contains_jupiter() throws Exception {
+        Api api = load("/io/gravitee/definition/jackson/api-executionmode-jupiter.json", Api.class);
+
+        assertEquals(ExecutionMode.JUPITER, api.getExecutionMode());
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiSerializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiSerializerTest.java
@@ -664,7 +664,7 @@ public class ApiSerializerTest extends AbstractTest {
     }
 
     @Test
-    public void should_default_definition_executionMode_equal_v3_when_api_contains_null() throws Exception {
+    public void shouldDefaultDefinitionExecutionModeEqualV3WhenApiContainsNull() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-default-executionmode.json", Api.class);
         String expectedDefinition = "/io/gravitee/definition/jackson/api-default-executionmode-expected.json";
 
@@ -680,7 +680,7 @@ public class ApiSerializerTest extends AbstractTest {
     }
 
     @Test
-    public void should_definition_executionMode_equal_v3_when_api_contains_v3() throws Exception {
+    public void shouldDefinitionExecutionModeEqualV3WhenApiContainsV3() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-executionmode-v3.json", Api.class);
         String expectedDefinition = "/io/gravitee/definition/jackson/api-executionmode-v3-expected.json";
 
@@ -696,7 +696,7 @@ public class ApiSerializerTest extends AbstractTest {
     }
 
     @Test
-    public void should_definition_executionMode_equal_jupiter_when_api_contains_jupiter() throws Exception {
+    public void shouldDefinitionExecutionModeEqualJupiterWhenApiContainsJupiter() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-executionmode-jupiter.json", Api.class);
         String expectedDefinition = "/io/gravitee/definition/jackson/api-executionmode-jupiter-expected.json";
 

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiSerializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiSerializerTest.java
@@ -662,4 +662,52 @@ public class ApiSerializerTest extends AbstractTest {
             objectMapper().readTree(generatedJsonDefinition.getBytes())
         );
     }
+
+    @Test
+    public void should_default_definition_executionMode_equal_v3_when_api_contains_null() throws Exception {
+        Api api = load("/io/gravitee/definition/jackson/api-default-executionmode.json", Api.class);
+        String expectedDefinition = "/io/gravitee/definition/jackson/api-default-executionmode-expected.json";
+
+        String generatedJsonDefinition = objectMapper().writeValueAsString(api);
+        String expectedGeneratedJsonDefinition = IOUtils.toString(read(expectedDefinition));
+
+        Assert.assertNotNull(generatedJsonDefinition);
+
+        Assert.assertEquals(
+            objectMapper().readTree(expectedGeneratedJsonDefinition.getBytes()),
+            objectMapper().readTree(generatedJsonDefinition.getBytes())
+        );
+    }
+
+    @Test
+    public void should_definition_executionMode_equal_v3_when_api_contains_v3() throws Exception {
+        Api api = load("/io/gravitee/definition/jackson/api-executionmode-v3.json", Api.class);
+        String expectedDefinition = "/io/gravitee/definition/jackson/api-executionmode-v3-expected.json";
+
+        String generatedJsonDefinition = objectMapper().writeValueAsString(api);
+        String expectedGeneratedJsonDefinition = IOUtils.toString(read(expectedDefinition));
+
+        Assert.assertNotNull(generatedJsonDefinition);
+
+        Assert.assertEquals(
+            objectMapper().readTree(expectedGeneratedJsonDefinition.getBytes()),
+            objectMapper().readTree(generatedJsonDefinition.getBytes())
+        );
+    }
+
+    @Test
+    public void should_definition_executionMode_equal_jupiter_when_api_contains_jupiter() throws Exception {
+        Api api = load("/io/gravitee/definition/jackson/api-executionmode-jupiter.json", Api.class);
+        String expectedDefinition = "/io/gravitee/definition/jackson/api-executionmode-jupiter-expected.json";
+
+        String generatedJsonDefinition = objectMapper().writeValueAsString(api);
+        String expectedGeneratedJsonDefinition = IOUtils.toString(read(expectedDefinition));
+
+        Assert.assertNotNull(generatedJsonDefinition);
+
+        Assert.assertEquals(
+            objectMapper().readTree(expectedGeneratedJsonDefinition.getBytes()),
+            objectMapper().readTree(generatedJsonDefinition.getBytes())
+        );
+    }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-default-executionmode-expected.json
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-default-executionmode-expected.json
@@ -1,0 +1,16 @@
+{
+  "id" : "my-api",
+  "name" : "my-api",
+  "version" : "undefined",
+  "gravitee" : "1.0.0",
+  "execution_mode" : "v3",
+  "flow_mode" : "DEFAULT",
+  "proxy" : {
+    "virtual_hosts" : [ {
+      "path" : "/my-api"
+    } ],
+    "strip_context_path" : false,
+    "preserve_host" : false
+  },
+  "properties" : [ ]
+}

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-default-executionmode.json
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-default-executionmode.json
@@ -1,0 +1,11 @@
+{
+  "id" : "my-api",
+  "name" : "my-api",
+  "version" : "undefined",
+  "gravitee" : "1.0.0",
+  "proxy": {
+    "context_path": "/my-api",
+    "endpoint": "http://localhost:1234",
+    "strip_context_path": false
+  }
+}

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-executionmode-jupiter-expected.json
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-executionmode-jupiter-expected.json
@@ -1,0 +1,16 @@
+{
+  "id" : "my-api",
+  "name" : "my-api",
+  "version" : "undefined",
+  "gravitee" : "1.0.0",
+  "execution_mode" : "jupiter",
+  "flow_mode" : "DEFAULT",
+  "proxy" : {
+    "virtual_hosts" : [ {
+      "path" : "/my-api"
+    } ],
+    "strip_context_path" : false,
+    "preserve_host" : false
+  },
+  "properties" : [ ]
+}

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-executionmode-jupiter.json
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-executionmode-jupiter.json
@@ -1,0 +1,12 @@
+{
+  "id" : "my-api",
+  "name" : "my-api",
+  "version" : "undefined",
+  "gravitee" : "1.0.0",
+  "execution_mode" : "jupiter",
+  "proxy": {
+    "context_path": "/my-api",
+    "endpoint": "http://localhost:1234",
+    "strip_context_path": false
+  }
+}

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-executionmode-v3-expected.json
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-executionmode-v3-expected.json
@@ -1,0 +1,16 @@
+{
+  "id" : "my-api",
+  "name" : "my-api",
+  "version" : "undefined",
+  "gravitee" : "1.0.0",
+  "execution_mode" : "v3",
+  "flow_mode" : "DEFAULT",
+  "proxy" : {
+    "virtual_hosts" : [ {
+      "path" : "/my-api"
+    } ],
+    "strip_context_path" : false,
+    "preserve_host" : false
+  },
+  "properties" : [ ]
+}

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-executionmode-v3.json
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-executionmode-v3.json
@@ -1,0 +1,12 @@
+{
+  "id" : "my-api",
+  "name" : "my-api",
+  "version" : "undefined",
+  "gravitee" : "1.0.0",
+  "execution_mode" : "v3",
+  "proxy": {
+    "context_path": "/my-api",
+    "endpoint": "http://localhost:1234",
+    "strip_context_path": false
+  }
+}

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Api.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Api.java
@@ -75,7 +75,7 @@ public class Api implements Serializable {
     @JsonProperty("plans")
     private Map<String, Plan> plans = new HashMap<>();
 
-    @JsonProperty("executionMode")
+    @JsonProperty("execution_mode")
     private ExecutionMode executionMode;
 
     public Api() {}

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/ExecutionMode.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/ExecutionMode.java
@@ -40,11 +40,7 @@ public enum ExecutionMode {
 
     @JsonCreator
     public static ExecutionMode fromLabel(final String label) {
-        if (label != null) {
-            return BY_LABEL.get(label);
-        } else {
-            return null;
-        }
+        return BY_LABEL.getOrDefault(label, V3);
     }
 
     public String getLabel() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandlerFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandlerFactory.java
@@ -84,6 +84,7 @@ public class ApiReactorHandlerFactory implements ReactorHandlerFactory<Api> {
     public static final String REPORTERS_LOGGING_MAX_SIZE_PROPERTY = "reporters.logging.max_size";
     public static final String HANDLERS_REQUEST_HEADERS_X_FORWARDED_PREFIX_PROPERTY = "handlers.request.headers.x-forwarded-prefix";
     public static final String REPORTERS_LOGGING_EXCLUDED_RESPONSE_TYPES_PROPERTY = "reporters.logging.excluded_response_types";
+    public static final String API_JUPITER_MODE_ENABLED = "api.jupiterMode.enabled";
     private final Logger logger = LoggerFactory.getLogger(ApiReactorHandlerFactory.class);
 
     private ApplicationContext applicationContext;
@@ -157,7 +158,11 @@ public class ApiReactorHandlerFactory implements ReactorHandlerFactory<Api> {
                     apiComponentProvider
                 );
 
-                if (api.getExecutionMode() == null || api.getExecutionMode() == ExecutionMode.V3) {
+                if (
+                    !configuration.getProperty(API_JUPITER_MODE_ENABLED, Boolean.class, false) ||
+                    api.getExecutionMode() == null ||
+                    api.getExecutionMode() == ExecutionMode.V3
+                ) {
                     final ApiReactorHandler v3ApiReactor = getApiReactorHandler(api);
 
                     final FlowPolicyResolverFactory flowPolicyResolverFactory = new FlowPolicyResolverFactory();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/definition/Api.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/definition/Api.java
@@ -66,6 +66,7 @@ public class Api extends io.gravitee.definition.model.Api implements Reactable, 
         this.setDefinitionVersion(definition.getDefinitionVersion());
         this.setFlows(definition.getFlows());
         this.setFlowMode(definition.getFlowMode());
+        this.setExecutionMode(definition.getExecutionMode());
     }
 
     public Api(final Api definition) {
@@ -89,6 +90,7 @@ public class Api extends io.gravitee.definition.model.Api implements Reactable, 
         this.setEnvironmentHrid(definition.getEnvironmentHrid());
         this.setOrganizationId(definition.getOrganizationId());
         this.setOrganizationHrid(definition.getOrganizationHrid());
+        this.setExecutionMode(definition.getExecutionMode());
     }
 
     public DefinitionContext getDefinitionContext() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -406,8 +406,12 @@ ds:
 #      cache:
 #        capacity: 8200  #if null defaults to 4096
 
-# Encrypt API properties using this secret
 api:
+  # Jupiter's execution mode allows strict respect of the policy execution order, as it defines in the policy studio whereas, in "v3" mode, execution order may differ depending on policy REQUEST_CONTENT or RESPONSE_CONTENT scope.
+  # jupiterMode:
+    # Enable jupiter mode
+    # enabled: false
+  # Encrypt API properties using this secret
   properties:
     encryption:
       secret: vvLJ4Q8Khvv9tm2tIPdkGEdmgKUruAL6

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
@@ -141,7 +141,6 @@ public class ApisResource extends AbstractResource {
         apiQuery.setContextPath(apisParam.getContextPath());
         apiQuery.setLabel(apisParam.getLabel());
         apiQuery.setVersion(apisParam.getVersion());
-        apiQuery.setExecutionMode(apisParam.getExecutionMode());
         apiQuery.setName(apisParam.getName());
         apiQuery.setTag(apisParam.getTag());
         apiQuery.setState(apisParam.getState());
@@ -423,7 +422,6 @@ public class ApisResource extends AbstractResource {
         apiItem.setName(api.getName());
         apiItem.setVersion(api.getVersion());
         apiItem.setDescription(api.getDescription());
-        apiItem.setExecutionMode(api.getExecutionMode());
 
         final UriBuilder ub = uriInfo.getBaseUriBuilder();
         final UriBuilder uriBuilder = ub

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
@@ -141,6 +141,7 @@ public class ApisResource extends AbstractResource {
         apiQuery.setContextPath(apisParam.getContextPath());
         apiQuery.setLabel(apisParam.getLabel());
         apiQuery.setVersion(apisParam.getVersion());
+        apiQuery.setExecutionMode(apisParam.getExecutionMode());
         apiQuery.setName(apisParam.getName());
         apiQuery.setTag(apisParam.getTag());
         apiQuery.setState(apisParam.getState());
@@ -422,6 +423,7 @@ public class ApisResource extends AbstractResource {
         apiItem.setName(api.getName());
         apiItem.setVersion(api.getVersion());
         apiItem.setDescription(api.getDescription());
+        apiItem.setExecutionMode(api.getExecutionMode());
 
         final UriBuilder ub = uriInfo.getBaseUriBuilder();
         final UriBuilder uriBuilder = ub

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/param/ApisParam.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/param/ApisParam.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.management.rest.resource.param;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.gravitee.definition.model.ExecutionMode;
 import io.swagger.v3.oas.annotations.Parameter;
 import javax.ws.rs.QueryParam;
 
@@ -56,6 +57,10 @@ public class ApisParam {
     @Parameter(description = "filter by version")
     @QueryParam("version")
     private String version;
+
+    @Parameter(description = "filter by execution mode")
+    @QueryParam("executionMode")
+    private ExecutionMode executionMode;
 
     @Parameter(description = "filter by full API Name")
     @QueryParam("name")
@@ -181,5 +186,13 @@ public class ApisParam {
 
     public void setCrossId(String crossId) {
         this.crossId = crossId;
+    }
+
+    public ExecutionMode getExecutionMode() {
+        return executionMode;
+    }
+
+    public void setExecutionMode(final ExecutionMode executionMode) {
+        this.executionMode = executionMode;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/ApiModelEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/ApiModelEntity.java
@@ -15,12 +15,15 @@
  */
 package io.gravitee.rest.api.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.common.component.Lifecycle;
+import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.definition.model.Properties;
 import io.gravitee.definition.model.Rule;
 import io.gravitee.definition.model.plugins.resources.Resource;
 import io.gravitee.definition.model.services.Services;
 import io.gravitee.rest.api.model.api.ApiLifecycleState;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.*;
 
 /**
@@ -34,6 +37,7 @@ public class ApiModelEntity {
     private String name;
     private String version;
     private String description;
+    private ExecutionMode executionMode;
     private Set<String> groups;
     private ProxyModelEntity proxy;
     private Map<String, List<Rule>> paths = new HashMap<>();
@@ -285,5 +289,13 @@ public class ApiModelEntity {
             disableMembershipNotifications +
             '}'
         );
+    }
+
+    public ExecutionMode getExecutionMode() {
+        return executionMode;
+    }
+
+    public void setExecutionMode(final ExecutionMode executionMode) {
+        this.executionMode = executionMode;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiEntity.java
@@ -62,6 +62,11 @@ public class ApiEntity implements Indexable {
     )
     private String description;
 
+    @Schema(description = "Api's execution mode. Define if the execution mode should use v3 or jupiter mode.", example = "v3")
+    @DeploymentRequired
+    @JsonProperty(value = "execution_mode")
+    private ExecutionMode executionMode;
+
     @Schema(description = "API's groups. Used to add team in your API.", example = "['MY_GROUP1', 'MY_GROUP2']")
     private Set<String> groups;
 
@@ -527,6 +532,14 @@ public class ApiEntity implements Indexable {
         this.crossId = crossId;
     }
 
+    public ExecutionMode getExecutionMode() {
+        return executionMode;
+    }
+
+    public void setExecutionMode(final ExecutionMode executionMode) {
+        this.executionMode = executionMode;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -590,6 +603,8 @@ public class ApiEntity implements Indexable {
             graviteeDefinitionVersion +
             ", flowMode=" +
             flowMode +
+            ", executionMode=" +
+            executionMode +
             '}'
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiListItem.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiListItem.java
@@ -345,5 +345,4 @@ public class ApiListItem {
             '}'
         );
     }
-
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiListItem.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiListItem.java
@@ -48,10 +48,6 @@ public class ApiListItem {
     @Schema(description = "Api's version. It's a simple string only used in the portal.", example = "v1.0")
     private String description;
 
-    @Schema(description = "Api's execution mode. Define if the execution mode should use v3 or jupiter mode.", example = "v3")
-    @JsonProperty(value = "execution_mode")
-    private ExecutionMode executionMode;
-
     @JsonProperty("created_at")
     @Schema(description = "The date (as a timestamp) when the API was created.", example = "1581256457163")
     private Date createdAt;
@@ -350,11 +346,4 @@ public class ApiListItem {
         );
     }
 
-    public ExecutionMode getExecutionMode() {
-        return executionMode;
-    }
-
-    public void setExecutionMode(final ExecutionMode executionMode) {
-        this.executionMode = executionMode;
-    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiListItem.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiListItem.java
@@ -17,7 +17,9 @@ package io.gravitee.rest.api.model.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.common.component.Lifecycle;
+import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.definition.model.VirtualHost;
+import io.gravitee.rest.api.model.DeploymentRequired;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.Visibility;
 import io.gravitee.rest.api.model.WorkflowState;
@@ -45,6 +47,10 @@ public class ApiListItem {
 
     @Schema(description = "Api's version. It's a simple string only used in the portal.", example = "v1.0")
     private String description;
+
+    @Schema(description = "Api's execution mode. Define if the execution mode should use v3 or jupiter mode.", example = "v3")
+    @JsonProperty(value = "execution_mode")
+    private ExecutionMode executionMode;
 
     @JsonProperty("created_at")
     @Schema(description = "The date (as a timestamp) when the API was created.", example = "1581256457163")
@@ -342,5 +348,13 @@ public class ApiListItem {
             '\'' +
             '}'
         );
+    }
+
+    public ExecutionMode getExecutionMode() {
+        return executionMode;
+    }
+
+    public void setExecutionMode(final ExecutionMode executionMode) {
+        this.executionMode = executionMode;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiQuery.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiQuery.java
@@ -34,7 +34,6 @@ public class ApiQuery {
     private String label;
     private String state;
     private Visibility visibility;
-    private ExecutionMode executionMode;
     private String version;
     private String name;
     private String tag;
@@ -201,13 +200,5 @@ public class ApiQuery {
             crossId +
             '}'
         );
-    }
-
-    public ExecutionMode getExecutionMode() {
-        return executionMode;
-    }
-
-    public void setExecutionMode(final ExecutionMode executionMode) {
-        this.executionMode = executionMode;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiQuery.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiQuery.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.model.api;
 
+import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.rest.api.model.Visibility;
 import java.util.Collection;
 import java.util.List;
@@ -33,6 +34,7 @@ public class ApiQuery {
     private String label;
     private String state;
     private Visibility visibility;
+    private ExecutionMode executionMode;
     private String version;
     private String name;
     private String tag;
@@ -199,5 +201,13 @@ public class ApiQuery {
             crossId +
             '}'
         );
+    }
+
+    public ExecutionMode getExecutionMode() {
+        return executionMode;
+    }
+
+    public void setExecutionMode(final ExecutionMode executionMode) {
+        this.executionMode = executionMode;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/NewApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/NewApiEntity.java
@@ -170,5 +170,4 @@ public class NewApiEntity {
             '}'
         );
     }
-
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/NewApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/NewApiEntity.java
@@ -49,11 +49,6 @@ public class NewApiEntity {
     )
     private String description;
 
-    @Schema(description = "Api's execution mode. Define if the execution mode should use v3 or jupiter mode.", example = "v3")
-    @DeploymentRequired
-    @JsonProperty(value = "execution_mode")
-    private ExecutionMode executionMode;
-
     @NotNull
     @Schema(description = "API's context path.", example = "/my-awesome-api")
     private String contextPath;
@@ -176,11 +171,4 @@ public class NewApiEntity {
         );
     }
 
-    public ExecutionMode getExecutionMode() {
-        return executionMode;
-    }
-
-    public void setExecutionMode(final ExecutionMode executionMode) {
-        this.executionMode = executionMode;
-    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/NewApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/NewApiEntity.java
@@ -16,8 +16,10 @@
 package io.gravitee.rest.api.model.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.definition.model.FlowMode;
 import io.gravitee.definition.model.flow.Flow;
+import io.gravitee.rest.api.model.DeploymentRequired;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import java.util.Set;
@@ -46,6 +48,11 @@ public class NewApiEntity {
         example = "I can use a hundred characters to describe this API."
     )
     private String description;
+
+    @Schema(description = "Api's execution mode. Define if the execution mode should use v3 or jupiter mode.", example = "v3")
+    @DeploymentRequired
+    @JsonProperty(value = "execution_mode")
+    private ExecutionMode executionMode;
 
     @NotNull
     @Schema(description = "API's context path.", example = "/my-awesome-api")
@@ -167,5 +174,13 @@ public class NewApiEntity {
             '\'' +
             '}'
         );
+    }
+
+    public ExecutionMode getExecutionMode() {
+        return executionMode;
+    }
+
+    public void setExecutionMode(final ExecutionMode executionMode) {
+        this.executionMode = executionMode;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/UpdateApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/UpdateApiEntity.java
@@ -54,6 +54,11 @@ public class UpdateApiEntity {
     )
     private String description;
 
+    @Schema(description = "Api's execution mode. Define if the execution mode should use v3 or jupiter mode.", example = "v3")
+    @DeploymentRequired
+    @JsonProperty(value = "execution_mode")
+    private ExecutionMode executionMode;
+
     @NotNull
     @JsonProperty(value = "proxy", required = true)
     @Schema(description = "API's definition.")
@@ -374,5 +379,13 @@ public class UpdateApiEntity {
 
     public void setCrossId(String crossId) {
         this.crossId = crossId;
+    }
+
+    public ExecutionMode getExecutionMode() {
+        return executionMode;
+    }
+
+    public void setExecutionMode(final ExecutionMode executionMode) {
+        this.executionMode = executionMode;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -301,7 +301,9 @@ public enum Key {
         "true",
         new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))
     ),
-    CONSOLE_PATH_BASED_API_CREATION_ENABLED("console.pathBasedApiCreation.enabled", "false", Set.of(ORGANIZATION, SYSTEM));
+    CONSOLE_PATH_BASED_API_CREATION_ENABLED("console.pathBasedApiCreation.enabled", "false", Set.of(ORGANIZATION, SYSTEM)),
+    JUPITER_MODE_ENABLED("api.jupiterMode.enabled", "false", Set.of(SYSTEM)),
+    JUPITER_MODE_DEFAULT("api.jupiterMode.default", "always", Set.of(SYSTEM));
 
     String key;
     String defaultValue;
@@ -340,6 +342,15 @@ public enum Key {
         this.scopes = scopes;
     }
 
+    public static Key findByKey(String value) {
+        for (Key key : Key.values()) {
+            if (key.key.equals(value)) {
+                return key;
+            }
+        }
+        throw new IllegalArgumentException(value + " is not a valid Key");
+    }
+
     public String key() {
         return key;
     }
@@ -358,14 +369,5 @@ public enum Key {
 
     public Set<KeyScope> scopes() {
         return scopes;
-    }
-
-    public static Key findByKey(String value) {
-        for (Key key : Key.values()) {
-            if (key.key.equals(value)) {
-                return key;
-            }
-        }
-        throw new IllegalArgumentException(value + " is not a valid Key");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ConsoleConfigEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ConsoleConfigEntity.java
@@ -30,6 +30,7 @@ public class ConsoleConfigEntity {
     private Management management;
     private Newsletter newsletter;
     private Theme theme;
+    private JupiterMode jupiterMode;
 
     public ConsoleConfigEntity() {
         super();
@@ -42,6 +43,7 @@ public class ConsoleConfigEntity {
         reCaptcha = new ConsoleReCaptcha();
         scheduler = new ConsoleScheduler();
         theme = new Theme();
+        jupiterMode = new JupiterMode();
     }
 
     // Getters & setters
@@ -115,5 +117,13 @@ public class ConsoleConfigEntity {
 
     public void setTheme(Theme theme) {
         this.theme = theme;
+    }
+
+    public JupiterMode getJupiterMode() {
+        return jupiterMode;
+    }
+
+    public void setJupiterMode(JupiterMode jupiterMode) {
+        this.jupiterMode = jupiterMode;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ConsoleSettingsEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ConsoleSettingsEntity.java
@@ -36,6 +36,7 @@ public class ConsoleSettingsEntity extends AbstractCommonSettingsEntity {
     private Management management;
     private Newsletter newsletter;
     private Theme theme;
+    private JupiterMode jupiterMode;
 
     public ConsoleSettingsEntity() {
         super();
@@ -49,6 +50,7 @@ public class ConsoleSettingsEntity extends AbstractCommonSettingsEntity {
         reCaptcha = new ConsoleReCaptcha();
         scheduler = new ConsoleScheduler();
         theme = new Theme();
+        jupiterMode = new JupiterMode();
     }
 
     // Getters & setters
@@ -130,6 +132,14 @@ public class ConsoleSettingsEntity extends AbstractCommonSettingsEntity {
 
     public void setTheme(Theme theme) {
         this.theme = theme;
+    }
+
+    public JupiterMode getJupiterMode() {
+        return jupiterMode;
+    }
+
+    public void setJupiterMode(JupiterMode jupiterMode) {
+        this.jupiterMode = jupiterMode;
     }
 
     //Classes

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/JupiterMode.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/JupiterMode.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.settings;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.gravitee.rest.api.model.annotations.ParameterKey;
+import io.gravitee.rest.api.model.parameters.Key;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class JupiterMode {
+
+    @ParameterKey(Key.JUPITER_MODE_ENABLED)
+    private Boolean enabled;
+
+    @ParameterKey(Key.JUPITER_MODE_DEFAULT)
+    private String isDefault;
+
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getIsDefault() {
+        return isDefault;
+    }
+
+    public void setIsDefault(String isDefault) {
+        this.isDefault = isDefault;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/JupiterModeService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/JupiterModeService.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.definition.model.ExecutionMode;
+import java.util.Map;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface JupiterModeService {
+    /**
+     * @return <code>true</code> if the jupiter execution mode is enabled, <code>false</code> otherwise
+     */
+    boolean isEnabled();
+
+    /**
+     * Return when the jupiter mode should use by default.
+     * <ul>
+     * <li>always: jupiter mode will be used for creation and import</li>
+     * <li>creation_only: jupiter mode will be used only while creating a new api, not for import</li>
+     * <li>never: jupiter mode won't be used, v3 mode is the default mode</li>
+     * </ul>
+     *
+     * @return default mode set
+     */
+    DefaultMode defaultMode();
+
+    /**
+     * Return the appropriate {@link ExecutionMode} to use regarding the given api defintion and configuration
+     *
+     * @return the {@link ExecutionMode} to use
+     * @param apiDefinition
+     */
+    ExecutionMode getExecutionModeFor(final JsonNode apiDefinition);
+
+    /**
+     * <ul>
+     * <li>always: jupiter mode will be used for creation and import</li>
+     * <li>creation_only: jupiter mode will be used only while creating a new api, not for import</li>
+     * <li>never: jupiter mode won't be used, v3 mode is the default mode</li>
+     * </ul>
+     */
+    enum DefaultMode {
+        ALWAYS("always"),
+        CREATION_ONLY("creation_only"),
+        NEVER("never");
+
+        private static final Map<String, DefaultMode> BY_LABEL = Map.of(
+            ALWAYS.label,
+            ALWAYS,
+            CREATION_ONLY.label,
+            CREATION_ONLY,
+            NEVER.label,
+            NEVER
+        );
+        private final String label;
+
+        DefaultMode(final String label) {
+            this.label = label;
+        }
+
+        public static DefaultMode fromLabel(final String label) {
+            return BY_LABEL.getOrDefault(label, ALWAYS);
+        }
+
+        public String getLabel() {
+            return label;
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/ApiConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/ApiConverter.java
@@ -80,6 +80,9 @@ public class ApiConverter {
                 if (apiDefinition.getDefinitionVersion() != null) {
                     apiEntity.setGraviteeDefinitionVersion(apiDefinition.getDefinitionVersion().getLabel());
                 }
+                if (apiDefinition.getExecutionMode() != null) {
+                    apiEntity.setExecutionMode(apiDefinition.getExecutionMode());
+                }
                 if (apiDefinition.getFlowMode() != null) {
                     apiEntity.setFlowMode(apiDefinition.getFlowMode());
                 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -263,6 +263,9 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     @Autowired
     private ResourceService resourceService;
 
+    @Autowired
+    private JupiterModeService jupiterModeService;
+
     @Value("${configuration.default-api-icon:}")
     private String defaultApiIcon;
 
@@ -418,6 +421,9 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
             if (apiDefinition != null) {
                 apiDefinition = ((ObjectNode) apiDefinition).put("id", id);
+            }
+            if (api.getExecutionMode() == null) {
+                api.setExecutionMode(jupiterModeService.getExecutionModeFor(apiDefinition));
             }
 
             Api repoApi = convert(executionContext, id, api, apiDefinition != null ? apiDefinition.toString() : null);
@@ -1712,7 +1718,6 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             if (apiDefinition == null || apiDefinition.isEmpty()) {
                 updateApiDefinition = new io.gravitee.definition.model.Api();
                 updateApiDefinition.setDefinitionVersion(DefinitionVersion.valueOfLabel(updateApiEntity.getGraviteeDefinitionVersion()));
-                updateApiDefinition.setExecutionMode(ExecutionMode.JUPITER);
             } else {
                 updateApiDefinition = objectMapper.readValue(apiDefinition, io.gravitee.definition.model.Api.class);
             }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -331,6 +331,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         apiEntity.setName(newApiEntity.getName());
         apiEntity.setDescription(newApiEntity.getDescription());
         apiEntity.setVersion(newApiEntity.getVersion());
+        apiEntity.setExecutionMode(newApiEntity.getExecutionMode());
 
         Set<String> groups = newApiEntity.getGroups();
         if (groups != null && !groups.isEmpty()) {
@@ -1713,6 +1714,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             if (apiDefinition == null || apiDefinition.isEmpty()) {
                 updateApiDefinition = new io.gravitee.definition.model.Api();
                 updateApiDefinition.setDefinitionVersion(DefinitionVersion.valueOfLabel(updateApiEntity.getGraviteeDefinitionVersion()));
+                updateApiDefinition.setExecutionMode(ExecutionMode.JUPITER);
             } else {
                 updateApiDefinition = objectMapper.readValue(apiDefinition, io.gravitee.definition.model.Api.class);
             }
@@ -1720,6 +1722,10 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             updateApiDefinition.setName(updateApiEntity.getName());
             updateApiDefinition.setVersion(updateApiEntity.getVersion());
             updateApiDefinition.setProxy(updateApiEntity.getProxy());
+
+            if (updateApiEntity.getExecutionMode() != null) {
+                updateApiDefinition.setExecutionMode(updateApiEntity.getExecutionMode());
+            }
 
             if (StringUtils.isNotEmpty(updateApiEntity.getGraviteeDefinitionVersion())) {
                 updateApiDefinition.setDefinitionVersion(DefinitionVersion.valueOfLabel(updateApiEntity.getGraviteeDefinitionVersion()));
@@ -2258,8 +2264,9 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
     /**
      * Allows to deploy the last published API
-     * @param apiId the API id
-     * @param userId the user id
+     *
+     * @param apiId     the API id
+     * @param userId    the user id
      * @param eventType the event type
      * @return The persisted API or null
      * @throws TechnicalException if an exception occurs while saving the API
@@ -2445,6 +2452,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         apiModelEntity.setVisibility(apiEntity.getVisibility());
         apiModelEntity.setCategories(apiEntity.getCategories());
         apiModelEntity.setVersion(apiEntity.getVersion());
+        apiModelEntity.setExecutionMode(apiEntity.getExecutionMode());
         apiModelEntity.setState(apiEntity.getState());
         apiModelEntity.setTags(apiEntity.getTags());
         apiModelEntity.setServices(apiEntity.getServices());
@@ -2642,6 +2650,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
     /**
      * This method use ApiQuery to search in indexer for fields in api definition
+     *
      * @param executionContext
      * @param apiQuery
      * @return Optional<List < String>> an optional list of api ids and Optional.empty()
@@ -2686,13 +2695,14 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             searchEngineQuery.setFilters(filters);
         }
 
-        if (!isBlank(query.getContextPath()) || !isBlank(query.getTag())) {
-            if (!isBlank(query.getContextPath())) {
-                searchEngineQuery.addExplicitFilter("paths", query.getContextPath());
-            }
-            if (!isBlank(query.getTag())) {
-                searchEngineQuery.addExplicitFilter("tag", query.getTag());
-            }
+        if (!isBlank(query.getContextPath())) {
+            searchEngineQuery.addExplicitFilter("paths", query.getContextPath());
+        }
+        if (!isBlank(query.getTag())) {
+            searchEngineQuery.addExplicitFilter("tag", query.getTag());
+        }
+        if (query.getExecutionMode() != null) {
+            searchEngineQuery.addExplicitFilter("executionMode", query.getExecutionMode().getLabel());
         }
         return searchEngineQuery;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -331,8 +331,6 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         apiEntity.setName(newApiEntity.getName());
         apiEntity.setDescription(newApiEntity.getDescription());
         apiEntity.setVersion(newApiEntity.getVersion());
-        apiEntity.setExecutionMode(newApiEntity.getExecutionMode());
-
         Set<String> groups = newApiEntity.getGroups();
         if (groups != null && !groups.isEmpty()) {
             checkGroupExistence(groups);
@@ -2701,9 +2699,6 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         if (!isBlank(query.getTag())) {
             searchEngineQuery.addExplicitFilter("tag", query.getTag());
         }
-        if (query.getExecutionMode() != null) {
-            searchEngineQuery.addExplicitFilter("executionMode", query.getExecutionMode().getLabel());
-        }
         return searchEngineQuery;
     }
 
@@ -3339,7 +3334,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 lifecycleState = LifecycleState.STOPPED;
                 break;
             default:
-                throw new IllegalArgumentException("Unknown EventType " + eventType.toString() + " to convert EventType into Lifecycle");
+                throw new IllegalArgumentException("Unknown EventType " + eventType + " to convert EventType into Lifecycle");
         }
         return lifecycleState;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
@@ -26,10 +26,7 @@ import io.gravitee.rest.api.model.annotations.ParameterKey;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.model.settings.*;
-import io.gravitee.rest.api.service.ConfigService;
-import io.gravitee.rest.api.service.NewsletterService;
-import io.gravitee.rest.api.service.ParameterService;
-import io.gravitee.rest.api.service.ReCaptchaService;
+import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -64,6 +61,9 @@ public class ConfigServiceImpl extends AbstractService implements ConfigService 
 
     @Autowired
     private ReCaptchaService reCaptchaService;
+
+    @Autowired
+    private JupiterModeService jupiterModeService;
 
     private static final String SENSITIVE_VALUE = "********";
 
@@ -396,6 +396,7 @@ public class ConfigServiceImpl extends AbstractService implements ConfigService 
             consoleConfigEntity.getManagement(),
             consoleConfigEntity.getNewsletter(),
             consoleConfigEntity.getTheme(),
+            consoleConfigEntity.getJupiterMode(),
         };
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/JupiterModeServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/JupiterModeServiceImpl.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static io.gravitee.rest.api.service.JupiterModeService.DefaultMode.CREATION_ONLY;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.definition.model.ExecutionMode;
+import io.gravitee.rest.api.service.JupiterModeService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Component
+public class JupiterModeServiceImpl implements JupiterModeService {
+
+    private final boolean enabled;
+    private final DefaultMode defaultMode;
+
+    @Autowired
+    public JupiterModeServiceImpl(
+        @Value("${api.jupiterMode.enabled:false}") boolean enabled,
+        @Value("${api.jupiterMode.default:always}") String defaultMode
+    ) {
+        this.enabled = enabled;
+        this.defaultMode = DefaultMode.fromLabel(defaultMode);
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public DefaultMode defaultMode() {
+        return defaultMode;
+    }
+
+    @Override
+    public ExecutionMode getExecutionModeFor(final JsonNode apiDefinition) {
+        // When apiDefinition is null, that means it is not an import
+        if (enabled && ((defaultMode == DefaultMode.ALWAYS) || (apiDefinition == null && defaultMode == DefaultMode.CREATION_ONLY))) {
+            return ExecutionMode.JUPITER;
+        }
+        return ExecutionMode.V3;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/api/ApiSerializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/api/ApiSerializer.java
@@ -20,6 +20,7 @@ import static java.util.Collections.emptyList;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.definition.model.Rule;
 import io.gravitee.definition.model.plugins.resources.Resource;
 import io.gravitee.rest.api.model.*;
@@ -69,6 +70,11 @@ public abstract class ApiSerializer extends StdSerializer<ApiEntity> {
 
         if (apiEntity.getVersion() != null) {
             jsonGenerator.writeObjectField("version", apiEntity.getVersion());
+        }
+        if (apiEntity.getExecutionMode() != null) {
+            jsonGenerator.writeObjectField("execution_mode", apiEntity.getExecutionMode().getLabel());
+        } else {
+            jsonGenerator.writeObjectField("execution_mode", ExecutionMode.V3.getLabel());
         }
         if (apiEntity.getDescription() != null) {
             jsonGenerator.writeObjectField("description", apiEntity.getDescription());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_ExportAsJsonTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_ExportAsJsonTest.java
@@ -251,4 +251,19 @@ public class ApiExportService_ExportAsJsonTest extends ApiExportService_ExportAs
     public void shouldConvertAsJsonWithoutMetadata_1_25() throws IOException {
         shouldConvertAsJsonWithoutMetadata(ApiSerializer.Version.V_1_25, "1_25");
     }
+
+    @Test
+    public void shouldConvertAsJsonForExportWithExecutionMode() throws IOException {
+        shouldConvertAsJsonForExportWithExecutionMode(ApiSerializer.Version.DEFAULT, null);
+    }
+
+    @Test
+    public void shouldConvertAsJsonForExportWithExecutionMode_v3() throws IOException {
+        shouldConvertAsJsonForExportWithExecutionMode(ApiSerializer.Version.DEFAULT, ExecutionMode.V3);
+    }
+
+    @Test
+    public void shouldConvertAsJsonForExportWithExecutionMode_jupiter() throws IOException {
+        shouldConvertAsJsonForExportWithExecutionMode(ApiSerializer.Version.DEFAULT, ExecutionMode.JUPITER);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_CreateTest.java
@@ -15,13 +15,13 @@
  */
 package io.gravitee.rest.api.service.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
+import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.model.Api;
@@ -52,6 +52,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.security.core.Authentication;
@@ -132,8 +133,8 @@ public class ApiService_CreateTest {
     @Mock
     private ConnectorService connectorService;
 
-    @Spy
-    private ApiConverter apiConverter;
+    @InjectMocks
+    private ApiConverter apiConverter = Mockito.spy(new ApiConverter());
 
     @AfterClass
     public static void cleanSecurityContextHolder() {
@@ -157,6 +158,7 @@ public class ApiService_CreateTest {
             .thenReturn("toDecode=decoded-value");
         when(parameterService.find(GraviteeContext.getExecutionContext(), Key.API_PRIMARY_OWNER_MODE, ParameterReferenceType.ENVIRONMENT))
             .thenReturn("USER");
+        when(virtualHostService.sanitizeAndValidate(any(), any())).thenAnswer(invocation -> invocation.getArgument(1));
         reset(searchEngineService);
     }
 
@@ -335,5 +337,64 @@ public class ApiService_CreateTest {
                 new MembershipService.MembershipMember(USER_NAME, null, MembershipMemberType.USER),
                 new MembershipService.MembershipRole(RoleScope.API, SystemRole.PRIMARY_OWNER.name())
             );
+    }
+
+    @Test
+    public void shouldCreateWithNoExecutionMode() throws TechnicalException {
+        when(apiRepository.findById(anyString())).thenReturn(Optional.empty());
+        when(apiRepository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        UserEntity admin = new UserEntity();
+        admin.setId(USER_NAME);
+        when(userService.findById(GraviteeContext.getExecutionContext(), admin.getId())).thenReturn(admin);
+
+        NewApiEntity apiToCreate = new NewApiEntity();
+        apiToCreate.setName(API_NAME);
+        apiToCreate.setVersion("v1");
+        apiToCreate.setDescription("Ma description");
+        apiToCreate.setContextPath("/context");
+
+        ApiEntity apiEntity = apiService.create(GraviteeContext.getExecutionContext(), apiToCreate, USER_NAME);
+
+        assertEquals(ExecutionMode.JUPITER, apiEntity.getExecutionMode());
+    }
+
+    @Test
+    public void shouldCreateWithJupiterExecutionMode() throws TechnicalException {
+        when(apiRepository.findById(anyString())).thenReturn(Optional.empty());
+        when(apiRepository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        UserEntity admin = new UserEntity();
+        admin.setId(USER_NAME);
+        when(userService.findById(GraviteeContext.getExecutionContext(), admin.getId())).thenReturn(admin);
+
+        NewApiEntity apiToCreate = new NewApiEntity();
+        apiToCreate.setName(API_NAME);
+        apiToCreate.setVersion("v1");
+        apiToCreate.setDescription("Ma description");
+        apiToCreate.setContextPath("/context");
+        apiToCreate.setExecutionMode(ExecutionMode.JUPITER);
+
+        ApiEntity apiEntity = apiService.create(GraviteeContext.getExecutionContext(), apiToCreate, USER_NAME);
+
+        assertEquals(ExecutionMode.JUPITER, apiEntity.getExecutionMode());
+    }
+
+    @Test
+    public void shouldCreateWithV3ExecutionMode() throws TechnicalException {
+        when(apiRepository.findById(anyString())).thenReturn(Optional.empty());
+        when(apiRepository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        UserEntity admin = new UserEntity();
+        admin.setId(USER_NAME);
+        when(userService.findById(GraviteeContext.getExecutionContext(), admin.getId())).thenReturn(admin);
+
+        NewApiEntity apiToCreate = new NewApiEntity();
+        apiToCreate.setName(API_NAME);
+        apiToCreate.setVersion("v1");
+        apiToCreate.setDescription("Ma description");
+        apiToCreate.setContextPath("/context");
+        apiToCreate.setExecutionMode(ExecutionMode.V3);
+
+        ApiEntity apiEntity = apiService.create(GraviteeContext.getExecutionContext(), apiToCreate, USER_NAME);
+
+        assertEquals(ExecutionMode.V3, apiEntity.getExecutionMode());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_CreateTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.service.impl;
 
+import static io.gravitee.rest.api.service.JupiterModeService.DefaultMode.ALWAYS;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -135,6 +136,9 @@ public class ApiService_CreateTest {
 
     @InjectMocks
     private ApiConverter apiConverter = Mockito.spy(new ApiConverter());
+
+    @Spy
+    private JupiterModeService jupiterModeService = new JupiterModeServiceImpl(true, ALWAYS.getLabel());
 
     @AfterClass
     public static void cleanSecurityContextHolder() {
@@ -356,45 +360,5 @@ public class ApiService_CreateTest {
         ApiEntity apiEntity = apiService.create(GraviteeContext.getExecutionContext(), apiToCreate, USER_NAME);
 
         assertEquals(ExecutionMode.JUPITER, apiEntity.getExecutionMode());
-    }
-
-    @Test
-    public void shouldCreateWithJupiterExecutionMode() throws TechnicalException {
-        when(apiRepository.findById(anyString())).thenReturn(Optional.empty());
-        when(apiRepository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
-        UserEntity admin = new UserEntity();
-        admin.setId(USER_NAME);
-        when(userService.findById(GraviteeContext.getExecutionContext(), admin.getId())).thenReturn(admin);
-
-        NewApiEntity apiToCreate = new NewApiEntity();
-        apiToCreate.setName(API_NAME);
-        apiToCreate.setVersion("v1");
-        apiToCreate.setDescription("Ma description");
-        apiToCreate.setContextPath("/context");
-        apiToCreate.setExecutionMode(ExecutionMode.JUPITER);
-
-        ApiEntity apiEntity = apiService.create(GraviteeContext.getExecutionContext(), apiToCreate, USER_NAME);
-
-        assertEquals(ExecutionMode.JUPITER, apiEntity.getExecutionMode());
-    }
-
-    @Test
-    public void shouldCreateWithV3ExecutionMode() throws TechnicalException {
-        when(apiRepository.findById(anyString())).thenReturn(Optional.empty());
-        when(apiRepository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
-        UserEntity admin = new UserEntity();
-        admin.setId(USER_NAME);
-        when(userService.findById(GraviteeContext.getExecutionContext(), admin.getId())).thenReturn(admin);
-
-        NewApiEntity apiToCreate = new NewApiEntity();
-        apiToCreate.setName(API_NAME);
-        apiToCreate.setVersion("v1");
-        apiToCreate.setDescription("Ma description");
-        apiToCreate.setContextPath("/context");
-        apiToCreate.setExecutionMode(ExecutionMode.V3);
-
-        ApiEntity apiEntity = apiService.create(GraviteeContext.getExecutionContext(), apiToCreate, USER_NAME);
-
-        assertEquals(ExecutionMode.V3, apiEntity.getExecutionMode());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/JupiterModeServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/JupiterModeServiceImplTest.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static io.gravitee.rest.api.service.JupiterModeService.DefaultMode.*;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.definition.jackson.datatype.GraviteeMapper;
+import io.gravitee.definition.model.ExecutionMode;
+import org.junit.Test;
+
+/**
+ * @author Guillaume Guillaume (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class JupiterModeServiceImplTest {
+
+    private final ObjectMapper objectMapper = new GraviteeMapper();
+
+    @Test
+    public void shouldSetDefault() {
+        JupiterModeServiceImpl jupiterModeService = new JupiterModeServiceImpl(false, ALWAYS.getLabel());
+        assertFalse(jupiterModeService.isEnabled());
+        assertEquals(ALWAYS, jupiterModeService.defaultMode());
+    }
+
+    @Test
+    public void shouldReturnJupiterWithoutApiDefWhenEnabledAndDefaultAlways() {
+        JupiterModeServiceImpl jupiterModeService = new JupiterModeServiceImpl(true, ALWAYS.getLabel());
+        assertTrue(jupiterModeService.isEnabled());
+        assertEquals(ALWAYS, jupiterModeService.defaultMode());
+        assertEquals(ExecutionMode.JUPITER, jupiterModeService.getExecutionModeFor(null));
+    }
+
+    @Test
+    public void shouldReturnJupiterWithoutApiDefWhenEnabledAndDefaultCreationOnly() {
+        JupiterModeServiceImpl jupiterModeService = new JupiterModeServiceImpl(true, CREATION_ONLY.getLabel());
+        assertTrue(jupiterModeService.isEnabled());
+        assertEquals(CREATION_ONLY, jupiterModeService.defaultMode());
+        assertEquals(ExecutionMode.JUPITER, jupiterModeService.getExecutionModeFor(null));
+    }
+
+    @Test
+    public void shouldReturnV3WithoutApiDefWhenEnabledAndDefaultNever() {
+        JupiterModeServiceImpl jupiterModeService = new JupiterModeServiceImpl(true, NEVER.getLabel());
+        assertTrue(jupiterModeService.isEnabled());
+        assertEquals(NEVER, jupiterModeService.defaultMode());
+        assertEquals(ExecutionMode.V3, jupiterModeService.getExecutionModeFor(null));
+    }
+
+    @Test
+    public void shouldReturnV3WithoutApiDefWhenDisabledAndDefaultAlways() {
+        JupiterModeServiceImpl jupiterModeService = new JupiterModeServiceImpl(false, ALWAYS.getLabel());
+        assertFalse(jupiterModeService.isEnabled());
+        assertEquals(ALWAYS, jupiterModeService.defaultMode());
+        assertEquals(ExecutionMode.V3, jupiterModeService.getExecutionModeFor(null));
+    }
+
+    @Test
+    public void shouldReturnV3WithoutApiDefWhenDisabledAndDefaultCreationOnly() {
+        JupiterModeServiceImpl jupiterModeService = new JupiterModeServiceImpl(false, CREATION_ONLY.getLabel());
+        assertFalse(jupiterModeService.isEnabled());
+        assertEquals(CREATION_ONLY, jupiterModeService.defaultMode());
+        assertEquals(ExecutionMode.V3, jupiterModeService.getExecutionModeFor(null));
+    }
+
+    @Test
+    public void shouldReturnJupiterWithApiDefWhenEnabledAndDefaultAlways() {
+        JupiterModeServiceImpl jupiterModeService = new JupiterModeServiceImpl(true, ALWAYS.getLabel());
+        assertTrue(jupiterModeService.isEnabled());
+        assertEquals(ALWAYS, jupiterModeService.defaultMode());
+        assertEquals(ExecutionMode.JUPITER, jupiterModeService.getExecutionModeFor(objectMapper.createObjectNode()));
+    }
+
+    @Test
+    public void shouldReturnV3WithApiDefWhenEnabledAndDefaultCreationOnly() {
+        JupiterModeServiceImpl jupiterModeService = new JupiterModeServiceImpl(true, CREATION_ONLY.getLabel());
+        assertTrue(jupiterModeService.isEnabled());
+        assertEquals(CREATION_ONLY, jupiterModeService.defaultMode());
+        assertEquals(ExecutionMode.V3, jupiterModeService.getExecutionModeFor(objectMapper.createObjectNode()));
+    }
+
+    @Test
+    public void shouldReturnV3WithApiDefWhenEnabledAndDefaultNever() {
+        JupiterModeServiceImpl jupiterModeService = new JupiterModeServiceImpl(true, NEVER.getLabel());
+        assertTrue(jupiterModeService.isEnabled());
+        assertEquals(NEVER, jupiterModeService.defaultMode());
+        assertEquals(ExecutionMode.V3, jupiterModeService.getExecutionModeFor(objectMapper.createObjectNode()));
+    }
+
+    @Test
+    public void shouldReturnV3WithApiDefWhenDisabledAndDefaultAlways() {
+        JupiterModeServiceImpl jupiterModeService = new JupiterModeServiceImpl(false, ALWAYS.getLabel());
+        assertFalse(jupiterModeService.isEnabled());
+        assertEquals(ALWAYS, jupiterModeService.defaultMode());
+        assertEquals(ExecutionMode.V3, jupiterModeService.getExecutionModeFor(objectMapper.createObjectNode()));
+    }
+
+    @Test
+    public void shouldReturnV3WithApiDefWhenDisabledAndDefaultCreationOnly() {
+        JupiterModeServiceImpl jupiterModeService = new JupiterModeServiceImpl(false, CREATION_ONLY.getLabel());
+        assertFalse(jupiterModeService.isEnabled());
+        assertEquals(CREATION_ONLY, jupiterModeService.defaultMode());
+        assertEquals(ExecutionMode.V3, jupiterModeService.getExecutionModeFor(objectMapper.createObjectNode()));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithExecutionMode-jupiter.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithExecutionMode-jupiter.json
@@ -1,0 +1,200 @@
+{
+  "crossId": "test-api-cross-id",
+  "description": "Gravitee.io",
+  "gravitee": "1.0.0",
+  "execution_mode": "jupiter",
+  "resources": [],
+  "properties": [],
+  "flow_mode": "DEFAULT",
+  "primaryOwner": {
+    "id": "johndoe",
+    "displayName": "johndoe-sourceId",
+    "type": "USER"
+  },
+  "groups": [
+    "My Group"
+  ],
+  "members": [
+    {
+      "source": "johndoe-source",
+      "sourceId": "johndoe-sourceId",
+      "roles": [
+        "API_PRIMARY_OWNER"
+      ]
+    }
+  ],
+  "pages" : [
+    {
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "Aside",
+      "type": "SYSTEM_FOLDER",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": true,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Link",
+      "type": "LINK",
+      "content" : "Read the doc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Translation",
+      "type": "TRANSLATION",
+      "content" : "Lire la documentation",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Template",
+      "type": "MARKDOWN_TEMPLATE",
+      "content" : "Read the doc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My asciidoc",
+      "type": "ASCIIDOC",
+      "content" : "Read the asciidoc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    }
+  ],
+  "plans": [
+    {
+      "id": "plan-id",
+      "crossId": "test-plan-cross-id",
+      "description": "free plan",
+      "validation": "AUTO",
+      "security": "API_KEY",
+      "type": "API",
+      "status": "PUBLISHED",
+      "api": "id-api",
+      "order": 0,
+      "paths": {
+        "/": [
+          {
+            "methods": [
+              "GET"
+            ],
+            "rate-limit": {
+              "rate": {
+                "limit": 1,
+                "periodTime": 1,
+                "periodTimeUnit": "SECONDS"
+              }
+            },
+            "enabled": true
+          }
+        ]
+      },
+      "flows": [],
+      "comment_required": false
+    }
+  ],
+  "metadata": [
+    {
+      "key": "metadata-key",
+      "name": "metadata-name",
+      "format": "STRING",
+      "value": "metadata-value",
+      "defaultValue": "metadata-default-value",
+      "apiId": "id-api"
+    }
+  ],
+  "id": "id-api",
+  "path_mappings": [],
+  "proxy": {
+    "virtual_hosts": [
+      {
+        "path": "/test"
+      }
+    ],
+    "strip_context_path": false,
+    "preserve_host": false,
+    "logging": {
+      "mode": "CLIENT_PROXY",
+      "condition": "condition",
+      "content":"NONE",
+      "scope":"NONE"
+    },
+    "groups": [
+      {
+        "name": "default-group",
+        "endpoints": [
+          {
+            "name": "default",
+            "target": "http://test",
+            "weight": 1,
+            "backup": false,
+            "type": "http"
+          }
+        ],
+        "load_balancing": {
+          "type": "ROUND_ROBIN"
+        },
+        "http": {
+          "connectTimeout": 5000,
+          "idleTimeout": 60000,
+          "keepAlive": true,
+          "readTimeout": 10000,
+          "pipelining": false,
+          "maxConcurrentConnections": 100,
+          "useCompression": true,
+          "followRedirects": false
+        }
+      }
+    ]
+  },
+  "response_templates": {
+    "API_KEY_MISSING": {
+      "*/*": {
+        "status": 400,
+        "body": "{\"bad\":\"news\"}"
+      }
+    }
+  }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithExecutionMode-v3.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithExecutionMode-v3.json
@@ -1,0 +1,200 @@
+{
+  "crossId": "test-api-cross-id",
+  "description": "Gravitee.io",
+  "gravitee": "1.0.0",
+  "execution_mode": "v3",
+  "resources": [],
+  "properties": [],
+  "flow_mode": "DEFAULT",
+  "primaryOwner": {
+    "id": "johndoe",
+    "displayName": "johndoe-sourceId",
+    "type": "USER"
+  },
+  "groups": [
+    "My Group"
+  ],
+  "members": [
+    {
+      "source": "johndoe-source",
+      "sourceId": "johndoe-sourceId",
+      "roles": [
+        "API_PRIMARY_OWNER"
+      ]
+    }
+  ],
+  "pages" : [
+    {
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "Aside",
+      "type": "SYSTEM_FOLDER",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": true,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Link",
+      "type": "LINK",
+      "content" : "Read the doc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Translation",
+      "type": "TRANSLATION",
+      "content" : "Lire la documentation",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Template",
+      "type": "MARKDOWN_TEMPLATE",
+      "content" : "Read the doc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My asciidoc",
+      "type": "ASCIIDOC",
+      "content" : "Read the asciidoc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    }
+  ],
+  "plans": [
+    {
+      "id": "plan-id",
+      "crossId": "test-plan-cross-id",
+      "description": "free plan",
+      "validation": "AUTO",
+      "security": "API_KEY",
+      "type": "API",
+      "status": "PUBLISHED",
+      "api": "id-api",
+      "order": 0,
+      "paths": {
+        "/": [
+          {
+            "methods": [
+              "GET"
+            ],
+            "rate-limit": {
+              "rate": {
+                "limit": 1,
+                "periodTime": 1,
+                "periodTimeUnit": "SECONDS"
+              }
+            },
+            "enabled": true
+          }
+        ]
+      },
+      "flows": [],
+      "comment_required": false
+    }
+  ],
+  "metadata": [
+    {
+      "key": "metadata-key",
+      "name": "metadata-name",
+      "format": "STRING",
+      "value": "metadata-value",
+      "defaultValue": "metadata-default-value",
+      "apiId": "id-api"
+    }
+  ],
+  "id": "id-api",
+  "path_mappings": [],
+  "proxy": {
+    "virtual_hosts": [
+      {
+        "path": "/test"
+      }
+    ],
+    "strip_context_path": false,
+    "preserve_host": false,
+    "logging": {
+      "mode": "CLIENT_PROXY",
+      "condition": "condition",
+      "content":"NONE",
+      "scope":"NONE"
+    },
+    "groups": [
+      {
+        "name": "default-group",
+        "endpoints": [
+          {
+            "name": "default",
+            "target": "http://test",
+            "weight": 1,
+            "backup": false,
+            "type": "http"
+          }
+        ],
+        "load_balancing": {
+          "type": "ROUND_ROBIN"
+        },
+        "http": {
+          "connectTimeout": 5000,
+          "idleTimeout": 60000,
+          "keepAlive": true,
+          "readTimeout": 10000,
+          "pipelining": false,
+          "maxConcurrentConnections": 100,
+          "useCompression": true,
+          "followRedirects": false
+        }
+      }
+    ]
+  },
+  "response_templates": {
+    "API_KEY_MISSING": {
+      "*/*": {
+        "status": 400,
+        "body": "{\"bad\":\"news\"}"
+      }
+    }
+  }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithExecutionMode.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithExecutionMode.json
@@ -1,0 +1,200 @@
+{
+  "crossId": "test-api-cross-id",
+  "description": "Gravitee.io",
+  "gravitee": "1.0.0",
+  "execution_mode": "v3",
+  "resources": [],
+  "properties": [],
+  "flow_mode": "DEFAULT",
+  "primaryOwner": {
+    "id": "johndoe",
+    "displayName": "johndoe-sourceId",
+    "type": "USER"
+  },
+  "groups": [
+    "My Group"
+  ],
+  "members": [
+    {
+      "source": "johndoe-source",
+      "sourceId": "johndoe-sourceId",
+      "roles": [
+        "API_PRIMARY_OWNER"
+      ]
+    }
+  ],
+  "pages" : [
+    {
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "Aside",
+      "type": "SYSTEM_FOLDER",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": true,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Link",
+      "type": "LINK",
+      "content" : "Read the doc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Translation",
+      "type": "TRANSLATION",
+      "content" : "Lire la documentation",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Template",
+      "type": "MARKDOWN_TEMPLATE",
+      "content" : "Read the doc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My asciidoc",
+      "type": "ASCIIDOC",
+      "content" : "Read the asciidoc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    }
+  ],
+  "plans": [
+    {
+      "id": "plan-id",
+      "crossId": "test-plan-cross-id",
+      "description": "free plan",
+      "validation": "AUTO",
+      "security": "API_KEY",
+      "type": "API",
+      "status": "PUBLISHED",
+      "api": "id-api",
+      "order": 0,
+      "paths": {
+        "/": [
+          {
+            "methods": [
+              "GET"
+            ],
+            "rate-limit": {
+              "rate": {
+                "limit": 1,
+                "periodTime": 1,
+                "periodTimeUnit": "SECONDS"
+              }
+            },
+            "enabled": true
+          }
+        ]
+      },
+      "flows": [],
+      "comment_required": false
+    }
+  ],
+  "metadata": [
+    {
+      "key": "metadata-key",
+      "name": "metadata-name",
+      "format": "STRING",
+      "value": "metadata-value",
+      "defaultValue": "metadata-default-value",
+      "apiId": "id-api"
+    }
+  ],
+  "id": "id-api",
+  "path_mappings": [],
+  "proxy": {
+    "virtual_hosts": [
+      {
+        "path": "/test"
+      }
+    ],
+    "strip_context_path": false,
+    "preserve_host": false,
+    "logging": {
+      "mode": "CLIENT_PROXY",
+      "condition": "condition",
+      "content":"NONE",
+      "scope":"NONE"
+    },
+    "groups": [
+      {
+        "name": "default-group",
+        "endpoints": [
+          {
+            "name": "default",
+            "target": "http://test",
+            "weight": 1,
+            "backup": false,
+            "type": "http"
+          }
+        ],
+        "load_balancing": {
+          "type": "ROUND_ROBIN"
+        },
+        "http": {
+          "connectTimeout": 5000,
+          "idleTimeout": 60000,
+          "keepAlive": true,
+          "readTimeout": 10000,
+          "pipelining": false,
+          "maxConcurrentConnections": 100,
+          "useCompression": true,
+          "followRedirects": false
+        }
+      }
+    ]
+  },
+  "response_templates": {
+    "API_KEY_MISSING": {
+      "*/*": {
+        "status": 400,
+        "body": "{\"bad\":\"news\"}"
+      }
+    }
+  }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -546,8 +546,14 @@ notifiers:
 #cockpit:
 #  url: https://cockpit.gravitee.io
 
-# Encrypt API properties using this secret
 api:
+  # Jupiter's execution mode allows strict respect of the policy execution order, as it defines it the policy studio whereas, in "v3" mode, execution order may differ depending on policy REQUEST_CONTENT or RESPONSE_CONTENT scope.
+  # jupiterMode:
+    # Enable jupiter mode
+    # enabled: false
+    # Allow to use the jupiter mode by default when no execution mode is specified on an api
+    # default: always | creation_only | never
+  # Encrypt API properties using this secret
   properties:
     encryption:
       secret: vvLJ4Q8Khvv9tm2tIPdkGEdmgKUruAL6

--- a/gravitee-apim-rest-api/postman/test/gio_apis.json
+++ b/gravitee-apim-rest-api/postman/test/gio_apis.json
@@ -2145,6 +2145,9 @@
 													"    pm.expect(jsonData.visibility).to.eql(\"PRIVATE\");",
 													"    pm.expect(jsonData.lifecycle_state).to.eql(\"CREATED\");",
 													"});",
+													"pm.test(\"API uses jupiter execution mode\", function() {",
+													"    pm.expect(jsonData.execution_mode).to.eql(\"jupiter\");",
+													"});",
 													"",
 													"pm.collectionVariables.set(\"created_api_id\", jsonData.id);",
 													"pm.collectionVariables.set(\"created_api\", JSON.stringify(jsonData));"
@@ -2173,7 +2176,7 @@
 										],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n\t\"contextPath\": \"/api{{random_uid}}\",\n\t\"description\": \"The API {{random_uid}}\",\n\t\"endpoint\": \"http://api/{{random_uid}}\",\n\t\"name\": \"API {{random_uid}}\",\n\t\"version\": \"{{random_uid}}\"\n}"
+											"raw": "{\n\t\"contextPath\": \"/api{{random_uid}}\",\n\t\"description\": \"The API {{random_uid}}\",\n\t\"endpoint\": \"http://api/{{random_uid}}\",\n\t\"name\": \"API {{random_uid}}\",\n\t\"version\": \"{{random_uid}}\",\n    \"state\": \"STARTED\"\n}"
 										},
 										"url": {
 											"raw": "{{GRAVITEEIO_MGMT_URL}}/apis",
@@ -14943,7 +14946,6 @@
 											"    pm.expect(jsonData).to.be.an('array');",
 											"    pm.expect(jsonData.length).to.equal(1);",
 											"    pm.expect(jsonData[0].name).to.contains(\"search_API1\");",
-											"    pm.expect(jsonData[0].execution_mode).to.eql(\"jupiter\");",
 											"});"
 										],
 										"type": "text/javascript"
@@ -15023,7 +15025,6 @@
 											"    pm.expect(jsonData).to.be.an('array');",
 											"    pm.expect(jsonData.length).to.equal(1);",
 											"    pm.expect(jsonData[0].name).to.contains(\"search_ADMIN\");",
-											"    pm.expect(jsonData[0].execution_mode).to.eql(\"jupiter\");",
 											"});"
 										],
 										"type": "text/javascript"

--- a/gravitee-apim-rest-api/postman/test/gio_apis.json
+++ b/gravitee-apim-rest-api/postman/test/gio_apis.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "f111e935-c2b6-4ffe-96d6-ac57b50fd553",
+		"_postman_id": "23d96be0-4990-404e-ba58-59ed8fa69cfd",
 		"name": "APIs",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -32,6 +32,10 @@
 													"    pm.expect(jsonData.visibility).to.eql(\"PRIVATE\");",
 													"    pm.expect(jsonData.lifecycle_state).to.eql(\"CREATED\");",
 													"});",
+													"pm.test(\"API uses jupiter execution mode\", function() {",
+													"    pm.expect(jsonData.execution_mode).to.eql(\"jupiter\");",
+													"});",
+													"",
 													"",
 													"pm.collectionVariables.set(\"created_api_id\", jsonData.id);",
 													"pm.collectionVariables.set(\"created_api\", JSON.stringify(jsonData));"
@@ -1023,6 +1027,9 @@
 													"    pm.expect(jsonData.state).to.eql(\"STOPPED\");",
 													"    pm.expect(jsonData.visibility).to.eql(\"PRIVATE\");",
 													"    pm.expect(jsonData.lifecycle_state).to.eql(\"CREATED\");",
+													"});",
+													"pm.test(\"API uses jupiter execution mode\", function() {",
+													"    pm.expect(jsonData.execution_mode).to.eql(\"jupiter\");",
 													"});",
 													"",
 													"pm.collectionVariables.set(\"created_api_id\", jsonData.id);",
@@ -2216,6 +2223,10 @@
 													"    pm.expect(jsonData.state).to.eql(\"STOPPED\");",
 													"    pm.expect(jsonData.visibility).to.eql(\"PRIVATE\");",
 													"    pm.expect(jsonData.lifecycle_state).to.eql(\"PUBLISHED\");",
+													"});",
+													"",
+													"pm.test(\"API uses jupiter execution mode\", function() {",
+													"    pm.expect(jsonData.execution_mode).to.eql(\"jupiter\");",
 													"});"
 												],
 												"type": "text/javascript"
@@ -3431,6 +3442,10 @@
 													"    pm.expect(jsonData.lifecycle_state).to.eql(\"CREATED\");",
 													"});",
 													"",
+													"pm.test(\"API uses jupiter execution mode\", function() {",
+													"    pm.expect(jsonData.execution_mode).to.eql(\"jupiter\");",
+													"});",
+													"",
 													"pm.collectionVariables.set(\"created_api_id\", jsonData.id);",
 													"pm.collectionVariables.set(\"created_api\", JSON.stringify(jsonData));"
 												],
@@ -3508,6 +3523,10 @@
 													"    pm.expect(jsonData.state).to.eql(\"STOPPED\");",
 													"    pm.expect(jsonData.visibility).to.eql(\"PRIVATE\");",
 													"    pm.expect(jsonData.lifecycle_state).to.eql(\"PUBLISHED\");",
+													"});",
+													"",
+													"pm.test(\"API uses jupiter execution mode\", function() {",
+													"    pm.expect(jsonData.execution_mode).to.eql(\"jupiter\");",
 													"});"
 												],
 												"type": "text/javascript"
@@ -5185,6 +5204,10 @@
 											"    pm.expect(jsonData.lifecycle_state).to.eql(\"CREATED\");",
 											"});",
 											"",
+											"pm.test(\"API uses v3 execution mode\", function() {",
+											"    pm.expect(jsonData.execution_mode).to.eql(\"v3\");",
+											"});",
+											"",
 											"var jsonData = pm.response.json();",
 											"pm.collectionVariables.set(\"created_api\", JSON.stringify(jsonData));",
 											"pm.collectionVariables.set(\"created_api_id\", jsonData.id);"
@@ -5255,6 +5278,10 @@
 											"pm.test(\"Should contain label\", function () {",
 											"    pm.expect(jsonData.labels).to.be.not.empty;",
 											"    pm.expect(jsonData.labels).to.include(\"quality\");",
+											"});",
+											"",
+											"pm.test(\"API uses v3 execution mode\", function() {",
+											"    pm.expect(jsonData.execution_mode).to.eql(\"v3\");",
 											"});"
 										],
 										"type": "text/javascript"
@@ -7086,7 +7113,7 @@
 									"query": [
 										{
 											"key": "ruleId",
-											"value": null,
+											"value": "",
 											"disabled": true
 										}
 									],
@@ -7261,6 +7288,10 @@
 											"",
 											"pm.test(\"API must be created\", function () {",
 											"    pm.expect(jsonData.lifecycle_state).to.eql(\"CREATED\");",
+											"});",
+											"",
+											"pm.test(\"API uses v3 execution mode\", function() {",
+											"    pm.expect(jsonData.execution_mode).to.eql(\"v3\");",
 											"});",
 											"",
 											"var jsonData = pm.response.json();",
@@ -8214,6 +8245,10 @@
 											"    pm.expect(jsonData.lifecycle_state).to.eql(\"CREATED\");",
 											"});",
 											"",
+											"pm.test(\"API uses v3 execution mode\", function() {",
+											"    pm.expect(jsonData.execution_mode).to.eql(\"v3\");",
+											"});",
+											"",
 											"var jsonData = pm.response.json();",
 											"pm.collectionVariables.set(\"created_api\", JSON.stringify(jsonData));",
 											"pm.collectionVariables.set(\"created_api_id\", jsonData.id);"
@@ -8306,6 +8341,10 @@
 											"    pm.expect(jsonData.state).to.eql(\"STOPPED\");",
 											"    pm.expect(jsonData.visibility).to.eql(\"PRIVATE\");",
 											"    pm.expect(jsonData.lifecycle_state).to.eql(\"PUBLISHED\");",
+											"});",
+											"",
+											"pm.test(\"API uses v3 execution mode\", function() {",
+											"    pm.expect(jsonData.execution_mode).to.eql(\"v3\");",
 											"});"
 										],
 										"type": "text/javascript"
@@ -8398,6 +8437,10 @@
 											"    pm.expect(jsonData.state).to.eql(\"STOPPED\");",
 											"    pm.expect(jsonData.visibility).to.eql(\"PUBLIC\");",
 											"    pm.expect(jsonData.lifecycle_state).to.eql(\"PUBLISHED\");",
+											"});",
+											"",
+											"pm.test(\"API uses v3 execution mode\", function() {",
+											"    pm.expect(jsonData.execution_mode).to.eql(\"v3\");",
 											"});"
 										],
 										"type": "text/javascript"
@@ -11694,6 +11737,10 @@
 											"    pm.expect(jsonData.lifecycle_state).to.eql(\"CREATED\");",
 											"});",
 											"",
+											"pm.test(\"API uses jupiter execution mode\", function() {",
+											"    pm.expect(jsonData.execution_mode).to.eql(\"jupiter\");",
+											"});",
+											"",
 											"pm.collectionVariables.set(\"created_api_id\", jsonData.id);",
 											"pm.collectionVariables.set(\"created_api\", JSON.stringify(jsonData));"
 										],
@@ -11776,6 +11823,10 @@
 											"    pm.expect(jsonData.state).to.eql(\"STOPPED\");",
 											"    pm.expect(jsonData.visibility).to.eql(\"PUBLIC\");",
 											"    pm.expect(jsonData.lifecycle_state).to.eql(\"PUBLISHED\");",
+											"});",
+											"",
+											"pm.test(\"API uses jupiter execution mode\", function() {",
+											"    pm.expect(jsonData.execution_mode).to.eql(\"jupiter\");",
 											"});"
 										],
 										"type": "text/javascript"
@@ -13934,6 +13985,10 @@
 													"        pm.expect(jsonData.visibility).to.eql(\"PRIVATE\");",
 													"        pm.expect(jsonData.state).to.eql(\"STOPPED\");",
 													"    });",
+													"",
+													"    pm.test(\"Should use jupiter execution mode\", function() {",
+													"        pm.expect(jsonData.execution_mode).to.eql(\"jupiter\");",
+													"    });",
 													"} else {",
 													"    pm.test(\"API already imported, assertions skipped\");",
 													"}",
@@ -14009,6 +14064,10 @@
 													"",
 													"    pm.test(\"API must be private\", function () {",
 													"        pm.expect(jsonData.visibility).to.eql(\"PRIVATE\");",
+													"    });",
+													"",
+													"    pm.test(\"Should use jupiter execution mode\", function() {",
+													"        pm.expect(jsonData.execution_mode).to.eql(\"jupiter\");",
 													"    });",
 													"} else {",
 													"    pm.test(\"API already imported, assertions skipped\");",
@@ -14248,6 +14307,10 @@
 													"        pm.expect(jsonData.visibility).to.eql(\"PRIVATE\");",
 													"        pm.expect(jsonData.state).to.eql(\"STOPPED\");",
 													"    });",
+													"",
+													"    pm.test(\"Should use jupiter execution mode\", function() {",
+													"        pm.expect(jsonData.execution_mode).to.eql(\"jupiter\");",
+													"    });",
 													"} else {",
 													"    pm.test(\"API already imported, assertions skipped\");",
 													"}",
@@ -14323,6 +14386,10 @@
 													"",
 													"    pm.test(\"API must be private\", function () {",
 													"        pm.expect(jsonData.visibility).to.eql(\"PRIVATE\");",
+													"    });",
+													"",
+													"    pm.test(\"Should use jupiter execution mode\", function() {",
+													"        pm.expect(jsonData.execution_mode).to.eql(\"jupiter\");",
 													"    });",
 													"} else {",
 													"    pm.test(\"API already imported, assertions skipped\");",
@@ -14463,6 +14530,10 @@
 													"    pm.expect(jsonData.visibility).to.eql(\"PRIVATE\");",
 													"});",
 													"",
+													"pm.test(\"Should use v3 execution mode\", function() {",
+													"    pm.expect(jsonData.execution_mode).to.eql(\"v3\");",
+													"});",
+													"",
 													"pm.test(\"API must be created\", function () {",
 													"    pm.expect(jsonData.lifecycle_state).to.eql(\"CREATED\");",
 													"});",
@@ -14548,6 +14619,10 @@
 													"",
 													"pm.test(\"API must be private\", function () {",
 													"    pm.expect(jsonData.visibility).to.eql(\"PRIVATE\");",
+													"});",
+													"",
+													"pm.test(\"Should use v3 execution mode\", function() {",
+													"    pm.expect(jsonData.execution_mode).to.eql(\"v3\");",
 													"});",
 													""
 												],
@@ -14642,7 +14717,7 @@
 											"variable": [
 												{
 													"key": "apiId",
-													"value": "{{created_api_id}}"
+													"value": null
 												}
 											]
 										}
@@ -14678,6 +14753,10 @@
 											"    pm.expect(jsonData.state).to.eql(\"STOPPED\");",
 											"    pm.expect(jsonData.visibility).to.eql(\"PRIVATE\");",
 											"    pm.expect(jsonData.lifecycle_state).to.eql(\"CREATED\");",
+											"});",
+											"",
+											"pm.test(\"API uses jupiter execution mode\", function() {",
+											"    pm.expect(jsonData.execution_mode).to.eql(\"jupiter\");",
 											"});",
 											"",
 											"pm.collectionVariables.set(\"created_api_api1_id\", jsonData.id);",
@@ -14757,6 +14836,10 @@
 											"    pm.expect(jsonData.state).to.eql(\"STOPPED\");",
 											"    pm.expect(jsonData.visibility).to.eql(\"PRIVATE\");",
 											"    pm.expect(jsonData.lifecycle_state).to.eql(\"CREATED\");",
+											"});",
+											"",
+											"pm.test(\"API uses jupiter execution mode\", function() {",
+											"    pm.expect(jsonData.execution_mode).to.eql(\"jupiter\");",
 											"});",
 											"",
 											"pm.collectionVariables.set(\"created_api_admin_id\", jsonData.id);",
@@ -14860,6 +14943,7 @@
 											"    pm.expect(jsonData).to.be.an('array');",
 											"    pm.expect(jsonData.length).to.equal(1);",
 											"    pm.expect(jsonData[0].name).to.contains(\"search_API1\");",
+											"    pm.expect(jsonData[0].execution_mode).to.eql(\"jupiter\");",
 											"});"
 										],
 										"type": "text/javascript"
@@ -14904,7 +14988,7 @@
 									"raw": ""
 								},
 								"url": {
-									"raw": "{{GRAVITEEIO_MGMT_URL}}/apis/_search?q=search_API1",
+									"raw": "{{GRAVITEEIO_MGMT_URL}}/apis/_search?q=search_API1             ",
 									"host": [
 										"{{GRAVITEEIO_MGMT_URL}}"
 									],
@@ -14915,7 +14999,7 @@
 									"query": [
 										{
 											"key": "q",
-											"value": "search_API1"
+											"value": "search_API1             "
 										}
 									]
 								}
@@ -14939,6 +15023,7 @@
 											"    pm.expect(jsonData).to.be.an('array');",
 											"    pm.expect(jsonData.length).to.equal(1);",
 											"    pm.expect(jsonData[0].name).to.contains(\"search_ADMIN\");",
+											"    pm.expect(jsonData[0].execution_mode).to.eql(\"jupiter\");",
 											"});"
 										],
 										"type": "text/javascript"
@@ -15095,6 +15180,7 @@
 											"pm.test(\"search_API1 is found\", function () {",
 											"    pm.expect(jsonData.length).to.equals == 3;",
 											"    pm.expect(jsonData[0].name).to.contains(\"search_API1\");",
+											"    pm.expect(jsonData[0].execution_mode).to.eql(\"jupiter\");",
 											"});"
 										],
 										"type": "text/javascript"


### PR DESCRIPTION
**Description**

Add execution mode to api definition and all related object used by both management api or the gateway.
Unit tests have been created for it.
Postman collections have been updated to test it


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/prototype-reactive-execution-mode/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
