### PR TITLE
ci: restart also jdbc environments after a build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -821,6 +821,11 @@ jobs:
                       kubectl rollout restart deployment/${K8S_NAME}-apim3-ui -n ${K8S_NAMESPACE}
                       kubectl rollout restart deployment/${K8S_NAME}-apim3-gateway -n ${K8S_NAMESPACE}
 
+                      kubectl rollout restart deployment/${K8S_NAME}-jdbc-apim3-api -n ${K8S_NAMESPACE}-jdbc
+                      kubectl rollout restart deployment/${K8S_NAME}-jdbc-apim3-portal -n ${K8S_NAMESPACE}-jdbc
+                      kubectl rollout restart deployment/${K8S_NAME}-jdbc-apim3-ui -n ${K8S_NAMESPACE}-jdbc
+                      kubectl rollout restart deployment/${K8S_NAME}-jdbc-apim3-gateway -n ${K8S_NAMESPACE}-jdbc
+
             - notify-on-failure
 
     ## Release Jobs


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7054

**Description**

Restart JDBC environments after a build
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7054-add-jdbc-environments/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
