### PR TITLE
fix(apim-repository): improve audit set env & org id script

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.18.0/audit-set-environmentId-organizationId.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.18.0/audit-set-environmentId-organizationId.js
@@ -5,42 +5,9 @@ print(`Add 'environmentId' and 'organizationId' columns in 'audits' table`);
 
 const audits = db.getCollection(`${prefix}audits`);
 const environments = db.getCollection(`${prefix}environments`);
+const organizations = db.getCollection(`${prefix}organizations`);
 const applications = db.getCollection(`${prefix}applications`);
 const apis = db.getCollection(`${prefix}apis`);
-
-function handleApiAudit(audit) {
-    const envId = getEnvIdByApiId(audit.referenceId);
-    const orgId = getOrgIdByEnvId(envId);
-
-    audit.organizationId = orgId || "DEFAULT";
-    audit.environmentId = envId || "DEFAULT";
-    audits.replaceOne({ _id: audit._id }, audit);
-}
-
-function handleApplicationAudit(audit) {
-    const envId = getEnvIdByAppId(audit.referenceId);
-    const orgId = getOrgIdByEnvId(envId);
-
-    audit.organizationId = orgId || "DEFAULT";
-    audit.environmentId = envId || "DEFAULT";
-    audits.replaceOne({ _id: audit._id }, audit);
-}
-
-function handleEnvironmentAudit(audit) {
-    const envId = audit.referenceId;
-    const orgId = getOrgIdByEnvId(envId);
-
-    audit.organizationId = orgId || "DEFAULT";
-    audit.environmentId = envId || "DEFAULT";
-    audits.replaceOne({ _id: audit._id }, audit);
-}
-
-function handleOrganizationAudit(audit) {
-    const orgId = getOrgIdByEnvId(audit.referenceId);
-
-    audit.organizationId = orgId || "DEFAULT";
-    audits.replaceOne({ _id: audit._id }, audit);
-}
 
 const environmentIdByApiIdMap = {};
 function getEnvIdByApiId(apiId) {
@@ -75,24 +42,120 @@ function getOrgIdByEnvId(envId) {
     return orgId;
 }
 
-audits.find({ organizationId: null }).forEach((audit) => {
-    switch (audit.referenceType) {
-        case "API":
-            handleApiAudit(audit);
-            break;
-        case "APPLICATION":
-            handleApplicationAudit(audit);
-            break;
-        case "ENVIRONMENT":
-            handleEnvironmentAudit(audit);
-            break;
-        case "ORGANIZATION":
-            handleOrganizationAudit(audit);
-            break;
+function handleApiAudit(audit) {
+    const envId = getEnvIdByApiId(audit.referenceId);
+    const orgId = getOrgIdByEnvId(envId);
+
+    const organizationId = orgId || "DEFAULT";
+    const environmentId = envId || "DEFAULT";
+    return {
+        updateOne: {
+            filter: { _id: audit._id },
+            update: { $set: { organizationId, environmentId } },
+        },
+    };
+}
+
+function handleApplicationAudit(audit) {
+    const envId = getEnvIdByAppId(audit.referenceId);
+    const orgId = getOrgIdByEnvId(envId);
+
+    const organizationId = orgId || "DEFAULT";
+    const environmentId = envId || "DEFAULT";
+    return {
+        updateOne: {
+            filter: { _id: audit._id },
+            update: { $set: { organizationId, environmentId } },
+        },
+    };
+}
+
+function handleEnvironmentAudit(audit) {
+    const envId = audit.referenceId;
+    const orgId = getOrgIdByEnvId(envId);
+
+    const organizationId = orgId || "DEFAULT";
+    const environmentId = envId || "DEFAULT";
+    return {
+        updateOne: {
+            filter: { _id: audit._id },
+            update: { $set: { organizationId, environmentId } },
+        },
+    };
+}
+
+function handleOrganizationAudit(audit) {
+    const orgId = getOrgIdByEnvId(audit.referenceId);
+
+    const organizationId = orgId || "DEFAULT";
+    return {
+        updateOne: {
+            filter: { _id: audit._id },
+            update: { $set: { organizationId } },
+        },
+    };
+}
+
+function updateForMultipleOrgEnv() {
+    print(`Run update for multiple one org & env`);
+    let bulkUpdate = [];
+    let bulkUpdateLimit = 1000;
+    audits.find({ organizationId: null }).forEach((audit) => {
+        if (!audit.referenceId) {
+            audit.referenceId = "DEFAULT";
+        }
+        switch (audit.referenceType) {
+            case "API":
+                bulkUpdate.push(handleApiAudit(audit));
+                break;
+            case "APPLICATION":
+                bulkUpdate.push(handleApplicationAudit(audit));
+                break;
+            case "ENVIRONMENT":
+                bulkUpdate.push(handleEnvironmentAudit(audit));
+                break;
+            case "ORGANIZATION":
+                bulkUpdate.push(handleOrganizationAudit(audit));
+                break;
+        }
+
+        // Write update each bulkUpdateLimit
+        if (bulkUpdate.length >= bulkUpdateLimit) {
+            audits.bulkWrite(bulkUpdate);
+            print(`Update ${bulkUpdate.length} audit`);
+            bulkUpdate = [];
+        }
+    });
+
+    // Write last bulkUpdate
+    if (bulkUpdate.length > 0) {
+        audits.bulkWrite(bulkUpdate);
+        print(`Update ${bulkUpdate.length} audit`);
     }
-});
+}
+
+function updateForOnlyOneOrgEnv() {
+    const envLength = environments.count();
+    const orgLength = organizations.count();
+
+    if (envLength === 1 && orgLength === 1) {
+        print(`Run update for only one org & env`);
+        const env = environments.findOne();
+        const org = organizations.findOne();
+
+        audits.updateMany({}, { $set: { organizationId: env._id, environmentId: org._id } });
+        return true;
+    }
+    return false;
+}
+
+const hasExecutedUpdateForOnlyOneOrgEnv = updateForOnlyOneOrgEnv();
+if (!hasExecutedUpdateForOnlyOneOrgEnv) {
+    updateForMultipleOrgEnv();
+}
+
 print(`Create new indexes in 'audits' table`);
 
-audits.createIndex({ organizationId: 1 });
-audits.createIndex({ organizationId: 1, environmentId: 1 });
+audits.createIndex({ organizationId: 1 }, { name: "o1" });
+audits.createIndex({ organizationId: 1, environmentId: 1 }, { name: "o1e1" });
 audits.reIndex();


### PR DESCRIPTION
**Issue**
https://github.com/gravitee-io/issues/issues/7521

**Description**

Improvement : 
- only use updateMany if client have only one env and one org
> useful because the majority of our client don't have a cockpit and therefore have only one env/org (normally)
- use bulkWrite to group db update by "batches" in order to improve script performances


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/improve-audit-script/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
