### PR TITLE
Fix documentation auto fetch

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -1144,13 +1144,19 @@ public class PageServiceImpl extends AbstractService implements PageService, App
             }
 
             try {
-                if (
-                    pageToUpdate.getSource() != null &&
-                    pageToUpdate.getSource().getConfiguration() != null &&
-                    page.getSource() != null &&
-                    page.getSource().getConfiguration() != null
-                ) {
-                    mergeSensitiveData(this.getFetcher(pageToUpdate.getSource()).getConfiguration(), page);
+                if (page.getSource() != null && page.getSource().getConfiguration() != null) {
+                    final FetcherConfiguration newFetcherConfiguration = this.getFetcher(page.getSource()).getConfiguration();
+                    if (newFetcherConfiguration.isAutoFetch()) {
+                        page.setUseAutoFetch(Boolean.TRUE);
+                    } else {
+                        page.setUseAutoFetch(null);
+                    }
+
+                    if (pageToUpdate.getSource() != null && pageToUpdate.getSource().getConfiguration() != null) {
+                        final FetcherConfiguration originalFetcherConfiguration =
+                            this.getFetcher(pageToUpdate.getSource()).getConfiguration();
+                        mergeSensitiveData(originalFetcherConfiguration, page);
+                    }
                 }
             } catch (FetcherException e) {
                 throw onUpdateFail(pageId, e);
@@ -2126,6 +2132,7 @@ public class PageServiceImpl extends AbstractService implements PageService, App
         }
         page.setContent(updatePageEntity.getContent());
         page.setMetadata(updatePageEntity.getMetadata());
+        page.setUseAutoFetch(updatePageEntity.getUseAutoFetch());
         page.setUpdatedAt(new Date());
         page.setLastContributor(contributor);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_AutoFetchTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_AutoFetchTest.java
@@ -16,18 +16,25 @@
 package io.gravitee.rest.api.service;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.gravitee.plugin.core.api.PluginManager;
 import io.gravitee.plugin.fetcher.FetcherPlugin;
+import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PageRepository;
 import io.gravitee.repository.management.model.Page;
 import io.gravitee.repository.management.model.PageReferenceType;
 import io.gravitee.repository.management.model.PageSource;
 import io.gravitee.rest.api.fetcher.FetcherConfigurationFactory;
+import io.gravitee.rest.api.model.PageSourceEntity;
 import io.gravitee.rest.api.model.PageType;
+import io.gravitee.rest.api.model.UpdatePageEntity;
+import io.gravitee.rest.api.model.Visibility;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.impl.GraviteeDescriptorServiceImpl;
 import io.gravitee.rest.api.service.impl.PageServiceImpl;
@@ -52,6 +59,8 @@ import org.springframework.context.ApplicationContext;
  */
 @RunWith(MockitoJUnitRunner.class)
 public class PageService_AutoFetchTest {
+
+    private static final String PAGE_ID = "ba01aef0-e3da-4499-81ae-f0e3daa4995a";
 
     @InjectMocks
     private PageServiceImpl pageService = new PageServiceImpl();
@@ -158,6 +167,8 @@ public class PageService_AutoFetchTest {
             .thenReturn(fetcherConfiguration);
         AutowireCapableBeanFactory mockAutowireCapableBeanFactory = mock(AutowireCapableBeanFactory.class);
         when(applicationContext.getAutowireCapableBeanFactory()).thenReturn(mockAutowireCapableBeanFactory);
+        PageService_MockSinglePageFetcherConfiguration.forceCronValue("* * * * * *");
+        PageService_MockSinglePageFetcherConfiguration.forceAutoFetchValue(true);
 
         long pages = pageService.execAutoFetch(GraviteeContext.getCurrentEnvironment());
         assertEquals(1, pages);
@@ -187,6 +198,7 @@ public class PageService_AutoFetchTest {
         AutowireCapableBeanFactory mockAutowireCapableBeanFactory = mock(AutowireCapableBeanFactory.class);
         when(applicationContext.getAutowireCapableBeanFactory()).thenReturn(mockAutowireCapableBeanFactory);
         PageService_MockSinglePageFetcherConfiguration.forceCronValue("* 10 * * * *");
+        PageService_MockSinglePageFetcherConfiguration.forceAutoFetchValue(true);
 
         long pages = pageService.execAutoFetch(GraviteeContext.getCurrentEnvironment());
         assertEquals(0, pages);
@@ -236,5 +248,105 @@ public class PageService_AutoFetchTest {
 
         pageService.execAutoFetch(GraviteeContext.getCurrentEnvironment());
         verify(pageRepository, times(11)).update(any());
+    }
+
+    @Test
+    public void shouldSetUseAutoFetch_True() throws TechnicalException {
+        PageSource pageSource = new PageSource();
+        pageSource.setType("type");
+        pageSource.setConfiguration("{\"autoFetch\": true, \"fetchCron\" : \"* 10 * * * *\"}");
+        when(mockPage.getSource()).thenReturn(pageSource);
+        when(mockPage.getOrder()).thenReturn(1);
+        when(mockPage.getReferenceType()).thenReturn(PageReferenceType.ENVIRONMENT);
+        when(mockPage.getVisibility()).thenReturn(Visibility.PUBLIC.name());
+        when(pageRepository.findById(PAGE_ID)).thenReturn(Optional.of(mockPage));
+        when(pageRepository.update(any())).thenAnswer(returnsFirstArg());
+
+        FetcherPlugin fetcherPlugin = mock(FetcherPlugin.class);
+        when(fetcherPlugin.clazz()).thenReturn("io.gravitee.rest.api.service.PageService_ImportSimplePageMockFetcher");
+        when(fetcherPlugin.configuration()).thenReturn(PageService_MockSinglePageFetcherConfiguration.class);
+        when(fetcherPluginManager.get(any())).thenReturn(fetcherPlugin);
+        Class<PageService_ImportSimplePageMockFetcher> mockFetcherClass = PageService_ImportSimplePageMockFetcher.class;
+        when(fetcherPlugin.fetcher()).thenReturn(mockFetcherClass);
+        PageService_MockSinglePageFetcherConfiguration fetcherConfiguration = new PageService_MockSinglePageFetcherConfiguration();
+        when(fetcherConfigurationFactory.create(eq(PageService_MockSinglePageFetcherConfiguration.class), anyString()))
+            .thenReturn(fetcherConfiguration);
+        AutowireCapableBeanFactory mockAutowireCapableBeanFactory = mock(AutowireCapableBeanFactory.class);
+        when(applicationContext.getAutowireCapableBeanFactory()).thenReturn(mockAutowireCapableBeanFactory);
+        PageService_MockSinglePageFetcherConfiguration.forceAutoFetchValue(true);
+
+        ObjectNode node = JsonNodeFactory.instance.objectNode();
+        node.put("autoFetch", true);
+        node.put("fetchCron", "* 5 * * * *");
+
+        PageSourceEntity pageSourceEntity = new PageSourceEntity();
+        pageSourceEntity.setConfiguration(node);
+        pageSourceEntity.setType("type");
+        UpdatePageEntity updatePageEntity = new UpdatePageEntity();
+        updatePageEntity.setSource(pageSourceEntity);
+        updatePageEntity.setContent("existing content");
+        updatePageEntity.setOrder(1);
+
+        pageService.update(PAGE_ID, updatePageEntity);
+
+        verify(pageRepository).update(argThat(page -> page.getUseAutoFetch() != null && page.getUseAutoFetch() == true));
+    }
+
+    @Test
+    public void shouldSetUseAutoFetch_Null() throws TechnicalException {
+        PageSource pageSource = new PageSource();
+        pageSource.setType("type");
+        pageSource.setConfiguration("{\"autoFetch\": true, \"fetchCron\" : \"* 10 * * * *\"}");
+        when(mockPage.getSource()).thenReturn(pageSource);
+        when(mockPage.getOrder()).thenReturn(1);
+        when(mockPage.getReferenceType()).thenReturn(PageReferenceType.ENVIRONMENT);
+        when(mockPage.getVisibility()).thenReturn(Visibility.PUBLIC.name());
+        when(pageRepository.findById(PAGE_ID)).thenReturn(Optional.of(mockPage));
+        when(pageRepository.update(any())).thenAnswer(returnsFirstArg());
+
+        FetcherPlugin fetcherPlugin = mock(FetcherPlugin.class);
+        when(fetcherPlugin.clazz()).thenReturn("io.gravitee.rest.api.service.PageService_ImportSimplePageMockFetcher");
+        when(fetcherPlugin.configuration()).thenReturn(PageService_MockSinglePageFetcherConfiguration.class);
+        when(fetcherPluginManager.get(any())).thenReturn(fetcherPlugin);
+        Class<PageService_ImportSimplePageMockFetcher> mockFetcherClass = PageService_ImportSimplePageMockFetcher.class;
+        when(fetcherPlugin.fetcher()).thenReturn(mockFetcherClass);
+        PageService_MockSinglePageFetcherConfiguration fetcherConfiguration = new PageService_MockSinglePageFetcherConfiguration();
+        when(fetcherConfigurationFactory.create(eq(PageService_MockSinglePageFetcherConfiguration.class), anyString()))
+            .thenReturn(fetcherConfiguration);
+        AutowireCapableBeanFactory mockAutowireCapableBeanFactory = mock(AutowireCapableBeanFactory.class);
+        when(applicationContext.getAutowireCapableBeanFactory()).thenReturn(mockAutowireCapableBeanFactory);
+        PageService_MockSinglePageFetcherConfiguration.forceAutoFetchValue(false);
+
+        ObjectNode node = JsonNodeFactory.instance.objectNode();
+        node.put("autoFetch", false);
+
+        PageSourceEntity pageSourceEntity = new PageSourceEntity();
+        pageSourceEntity.setConfiguration(node);
+        pageSourceEntity.setType("type");
+        UpdatePageEntity updatePageEntity = new UpdatePageEntity();
+        updatePageEntity.setSource(pageSourceEntity);
+        updatePageEntity.setContent("existing content");
+        updatePageEntity.setOrder(1);
+
+        pageService.update(PAGE_ID, updatePageEntity);
+
+        verify(pageRepository).update(argThat(page -> page.getUseAutoFetch() == null));
+    }
+
+    @Test
+    public void shouldNotSetUseAutoFetch() throws TechnicalException {
+        when(mockPage.getOrder()).thenReturn(1);
+        when(mockPage.getReferenceType()).thenReturn(PageReferenceType.ENVIRONMENT);
+        when(mockPage.getVisibility()).thenReturn(Visibility.PUBLIC.name());
+        when(pageRepository.findById(PAGE_ID)).thenReturn(Optional.of(mockPage));
+        when(pageRepository.update(any())).thenAnswer(returnsFirstArg());
+
+        UpdatePageEntity updatePageEntity = new UpdatePageEntity();
+        updatePageEntity.setSource(null);
+        updatePageEntity.setContent("existing content");
+        updatePageEntity.setOrder(1);
+
+        pageService.update(PAGE_ID, updatePageEntity);
+        verify(pageRepository).update(argThat(page -> page.getUseAutoFetch() == null));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_MockSinglePageFetcherConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_MockSinglePageFetcherConfiguration.java
@@ -25,6 +25,7 @@ import io.gravitee.fetcher.api.FilepathAwareFetcherConfiguration;
 public class PageService_MockSinglePageFetcherConfiguration implements FetcherConfiguration, FilepathAwareFetcherConfiguration {
 
     private static String cron = "* * * * * *";
+    private static boolean isAutoFetch = true;
 
     @Override
     public String getFilepath() {
@@ -36,7 +37,7 @@ public class PageService_MockSinglePageFetcherConfiguration implements FetcherCo
 
     @Override
     public boolean isAutoFetch() {
-        return true;
+        return isAutoFetch;
     }
 
     @Override
@@ -46,5 +47,9 @@ public class PageService_MockSinglePageFetcherConfiguration implements FetcherCo
 
     public static void forceCronValue(String value) {
         cron = value;
+    }
+
+    public static void forceAutoFetchValue(boolean value) {
+        isAutoFetch = value;
     }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7589

**Description**

Do determine if a page should be automatically fetch, a boolean is computed and stored in DB: `useAutoFetch`.
This boolean is never send back to the client and stays in the service layer.
To compute it, we need the configuration of the fetcher used to get the content of the page (if it exists). 

Unfortunately, before this PR, this computing was not done when updating a page but only when fetching manually a page.


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7589-fix-autofetch/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
