### PR TITLE
add missing javascript policy in bundle - 3.10.x

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -64,6 +64,7 @@
         <gravitee-policy-html-json.version>1.6.0</gravitee-policy-html-json.version>
         <gravitee-policy-http-signature.version>1.3.0</gravitee-policy-http-signature.version>
         <gravitee-policy-ipfiltering.version>1.8.0</gravitee-policy-ipfiltering.version>
+        <gravitee-policy-javascript.version>1.1.1</gravitee-policy-javascript.version>
         <gravitee-policy-json-threat-protection.version>1.2.3</gravitee-policy-json-threat-protection.version>
         <gravitee-policy-json-to-json.version>1.6.1</gravitee-policy-json-to-json.version>
         <gravitee-policy-json-validation.version>1.6.1</gravitee-policy-json-validation.version>
@@ -341,6 +342,12 @@
                                         <groupId>io.gravitee.policy</groupId>
                                         <artifactId>gravitee-policy-ipfiltering</artifactId>
                                         <version>${gravitee-policy-ipfiltering.version}</version>
+                                        <type>zip</type>
+                                    </artifactItem>
+                                    <artifactItem>
+                                        <groupId>io.gravitee.policy</groupId>
+                                        <artifactId>gravitee-policy-javascript</artifactId>
+                                        <version>${gravitee-policy-javascript.version}</version>
                                         <type>zip</type>
                                     </artifactItem>
                                     <artifactItem>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7598

**Description**

add missing javascript policy in bundle
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7598-add-missing-policies-in-bundle-3-10-x/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
