### PR TITLE
add missing javascript policy in bundle - 3.16.x

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -597,6 +597,7 @@
                 <gravitee-policy-basic-authentication.version>1.2.0</gravitee-policy-basic-authentication.version>
                 <gravitee-policy-circuit-breaker.version>1.0.1</gravitee-policy-circuit-breaker.version>
                 <gravitee-policy-geoip-filtering.version>1.1.0</gravitee-policy-geoip-filtering.version>
+                <gravitee-policy-javascript.version>1.1.1</gravitee-policy-javascript.version>
                 <gravitee-policy-wssecurity-authentication.version>1.0.0</gravitee-policy-wssecurity-authentication.version>
                 <gravitee-resource-auth-provider-http.version>1.1.0</gravitee-resource-auth-provider-http.version>
                 <gravitee-resource-auth-provider-inline.version>1.1.0</gravitee-resource-auth-provider-inline.version>
@@ -646,6 +647,13 @@
                     <groupId>io.gravitee.policy</groupId>
                     <artifactId>gravitee-policy-geoip-filtering</artifactId>
                     <version>${gravitee-policy-geoip-filtering.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>io.gravitee.policy</groupId>
+                    <artifactId>gravitee-policy-javascript</artifactId>
+                    <version>${gravitee-policy-javascript.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
                 </dependency>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7598

**Description**

add missing javascript policy in bundle
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7598-add-missing-policies-in-bundle-3-16-x/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
