### PR TITLE
chore: update faker dependency

### DIFF
--- a/gravitee-apim-e2e/api-test/apis/api-definition.spec.ts
+++ b/gravitee-apim-e2e/api-test/apis/api-definition.spec.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as faker from 'faker';
 import { afterAll, beforeAll, describe, expect, test } from '@jest/globals';
 import { fail } from '../../lib/jest-utils';
 import { APIPlansApi } from '@management-apis/APIPlansApi';
@@ -26,6 +25,7 @@ import { LifecycleAction } from '@management-models/LifecycleAction';
 import { APIPagesApi } from '@management-apis/APIPagesApi';
 import { PagesFaker } from '@management-fakers/PagesFaker';
 import { forManagement } from '@client-conf/*';
+import faker from '@faker-js/faker';
 
 const orgId = 'DEFAULT';
 const envId = 'DEFAULT';

--- a/gravitee-apim-e2e/lib/fixtures/management/ApisFaker.ts
+++ b/gravitee-apim-e2e/lib/fixtures/management/ApisFaker.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as faker from 'faker';
 import { ApiEntity, ApiEntityFlowModeEnum } from '@management-models/ApiEntity';
 import { MemberEntity } from '@management-models/MemberEntity';
 import { PageEntity } from '@management-models/PageEntity';
@@ -21,6 +20,7 @@ import { Visibility } from '@management-models/Visibility';
 import { LoadBalancerTypeEnum } from '@management-models/LoadBalancer';
 import { Proxy } from '@management-models/Proxy';
 import { NewApiEntity } from '@management-models/NewApiEntity';
+import faker from '@faker-js/faker';
 
 export interface ApiImportEntity extends ApiEntity {
   members?: Array<MemberEntity>;

--- a/gravitee-apim-e2e/lib/fixtures/management/PagesFaker.ts
+++ b/gravitee-apim-e2e/lib/fixtures/management/PagesFaker.ts
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as faker from 'faker';
 import { PageEntity } from '@management-models/PageEntity';
 import { Visibility } from '@management-models/Visibility';
+import faker from '@faker-js/faker';
 
 export enum PageType {
   ASCIIDOC = 'ASCIIDOC',

--- a/gravitee-apim-e2e/lib/fixtures/management/PlansFaker.ts
+++ b/gravitee-apim-e2e/lib/fixtures/management/PlansFaker.ts
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as faker from 'faker';
 import { PlanEntity } from '@management-models/PlanEntity';
 import { PlanValidationType } from '@management-models/PlanValidationType';
 import { PlanSecurityType } from '@management-models/PlanSecurityType';
 import { PlanType } from '@management-models/PlanType';
 import { PlanStatus } from '@management-models/PlanStatus';
+import faker from '@faker-js/faker';
 
 export class PlansFaker {
   static plan(attributes?: Partial<PlanEntity>): PlanEntity {

--- a/gravitee-apim-e2e/package-lock.json
+++ b/gravitee-apim-e2e/package-lock.json
@@ -9,12 +9,11 @@
             "version": "3.16.1",
             "license": "MIT License",
             "dependencies": {
-                "@types/jsonwebtoken": "8.5.8",
-                "faker": "5.5.3"
+                "@faker-js/faker": "6.2.0",
+                "@types/jsonwebtoken": "8.5.8"
             },
             "devDependencies": {
                 "@jest/create-cache-key-function": "^28.0.0",
-                "@types/faker": "5.5.9",
                 "@types/jest": "27.4.1",
                 "@types/node": "16.10.9",
                 "@types/node-fetch": "2.6.1",
@@ -639,6 +638,15 @@
                 "ms": "^2.1.1"
             }
         },
+        "node_modules/@faker-js/faker": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-6.2.0.tgz",
+            "integrity": "sha512-3kIcQ+aTr3I+LqDbJwbINFk5oA+a63LH57GPJt9PM8AWqN7nCwnubuSiWosHYQlyf2NicrvpzXQxllyLeEdpyQ==",
+            "engines": {
+                "node": ">=14.0.0",
+                "npm": ">=6.0.0"
+            }
+        },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1176,12 +1184,6 @@
             "dependencies": {
                 "@babel/types": "^7.3.0"
             }
-        },
-        "node_modules/@types/faker": {
-            "version": "5.5.9",
-            "resolved": "https://registry.npmjs.org/@types/faker/-/faker-5.5.9.tgz",
-            "integrity": "sha512-uCx6mP3UY5SIO14XlspxsGjgaemrxpssJI0Ol+GfhxtcKpv9pgRZYsS4eeKeHVLje6Qtc8lGszuBI461+gVZBA==",
-            "dev": true
         },
         "node_modules/@types/glob": {
             "version": "7.2.0",
@@ -2758,11 +2760,6 @@
             "engines": [
                 "node >=0.6.0"
             ]
-        },
-        "node_modules/faker": {
-            "version": "5.5.3",
-            "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
-            "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g=="
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -6932,6 +6929,11 @@
                 }
             }
         },
+        "@faker-js/faker": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-6.2.0.tgz",
+            "integrity": "sha512-3kIcQ+aTr3I+LqDbJwbINFk5oA+a63LH57GPJt9PM8AWqN7nCwnubuSiWosHYQlyf2NicrvpzXQxllyLeEdpyQ=="
+        },
         "@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -7373,12 +7375,6 @@
             "requires": {
                 "@babel/types": "^7.3.0"
             }
-        },
-        "@types/faker": {
-            "version": "5.5.9",
-            "resolved": "https://registry.npmjs.org/@types/faker/-/faker-5.5.9.tgz",
-            "integrity": "sha512-uCx6mP3UY5SIO14XlspxsGjgaemrxpssJI0Ol+GfhxtcKpv9pgRZYsS4eeKeHVLje6Qtc8lGszuBI461+gVZBA==",
-            "dev": true
         },
         "@types/glob": {
             "version": "7.2.0",
@@ -8606,11 +8602,6 @@
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
             "dev": true
-        },
-        "faker": {
-            "version": "5.5.3",
-            "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
-            "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g=="
         },
         "fast-deep-equal": {
             "version": "3.1.3",

--- a/gravitee-apim-e2e/package.json
+++ b/gravitee-apim-e2e/package.json
@@ -28,7 +28,6 @@
     "license": "MIT License",
     "devDependencies": {
         "@jest/create-cache-key-function": "^28.0.0",
-        "@types/faker": "5.5.9",
         "@types/jest": "27.4.1",
         "@types/node": "16.10.9",
         "@types/node-fetch": "2.6.1",
@@ -47,6 +46,6 @@
     },
     "dependencies": {
         "@types/jsonwebtoken": "8.5.8",
-        "faker": "5.5.3"
+        "@faker-js/faker": "6.2.0"
     }
 }

--- a/gravitee-apim-e2e/ui-test/fixtures/fakers/api-imports.ts
+++ b/gravitee-apim-e2e/ui-test/fixtures/fakers/api-imports.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as faker from 'faker';
 import {
   ApiImport,
   ApiImportMember,
@@ -27,7 +26,8 @@ import { Flow, FlowMode, OperatorType } from '@model/api-flows';
 import { ApiFakers } from './apis';
 import { ApiUser } from '@model/users';
 import { Role } from '@model/roles';
-import { PlanSecurityType, PlanStatus, PlanType, PlanValidation, Step } from '@model/plan';
+import { PlanSecurityType, PlanStatus, PlanType, PlanValidation } from '@model/plan';
+import faker from '@faker-js/faker';
 
 export class ApiImportFakers {
   static api(attributes?: Partial<ApiImport>): ApiImport {

--- a/gravitee-apim-e2e/ui-test/fixtures/fakers/apis.ts
+++ b/gravitee-apim-e2e/ui-test/fixtures/fakers/apis.ts
@@ -13,17 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as faker from 'faker';
 import { Api, ApiDefinition } from '@model/apis';
 import { Plan, PlanSecurityType, PlanStatus, PlanValidation } from '@model/plan';
 
 import { ApiImportFakers } from '@fakers/api-imports';
 import { PolicyFakers } from '@fakers/policies';
 import { ResourceFakers } from '@fakers/resources';
-import { API_PUBLISHER_USER } from '@fakers/users/users';
 import { Step } from '@model/plan';
-import { importCreateApi } from '@commands/management/api-management-commands';
 import { ApiImport } from '@model/api-imports';
+import faker from '@faker-js/faker';
 
 export class ApiFakers {
   static version() {

--- a/gravitee-apim-e2e/ui-test/fixtures/fakers/applications.ts
+++ b/gravitee-apim-e2e/ui-test/fixtures/fakers/applications.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as faker from 'faker';
 import { Application } from '@model/applications';
+import faker from '@faker-js/faker';
 
 export class ApplicationFakers {
   static application(attributes?: Partial<Application>): Application {

--- a/gravitee-apim-e2e/ui-test/fixtures/fakers/groups.ts
+++ b/gravitee-apim-e2e/ui-test/fixtures/fakers/groups.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as faker from 'faker';
 import { Group } from '@model/groups';
+import faker from '@faker-js/faker';
 
 export class GroupFakers {
   static group(attributes?: Partial<Group>): Group {

--- a/gravitee-apim-e2e/ui-test/fixtures/fakers/plans.ts
+++ b/gravitee-apim-e2e/ui-test/fixtures/fakers/plans.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as faker from 'faker';
 import { NewPlanEntity } from '@model/plan';
+import faker from '@faker-js/faker';
 
 export class PlanFakers {
   static plan(attributes?: Partial<NewPlanEntity>): NewPlanEntity {

--- a/gravitee-apim-e2e/ui-test/fixtures/fakers/resources.ts
+++ b/gravitee-apim-e2e/ui-test/fixtures/fakers/resources.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as faker from 'faker';
+import faker from '@faker-js/faker';
 
 export class ResourceFakers {
   static oauth2AmResource(securityDomain: string, clientId: string, clientSecret: string, attributes?: any): any {

--- a/gravitee-apim-e2e/ui-test/integration/apim/rest-api/apis/quality.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/rest-api/apis/quality.spec.ts
@@ -26,9 +26,9 @@ import { Group, GroupEvent } from '@model/groups';
 import { Task, TaskQuality, TaskType, User } from '@model/users';
 import { Member } from '@model/members';
 import { ApiFakers } from '@fakers/apis';
-import * as faker from 'faker';
 import Response = Cypress.Response;
 import { gio } from '@commands/gravitee.commands';
+import faker from '@faker-js/faker';
 
 context('API - Quality', () => {
   let createdQualityRule: QualityRule;

--- a/gravitee-apim-e2e/ui-test/integration/platform/jwt-policy-tests.ts
+++ b/gravitee-apim-e2e/ui-test/integration/platform/jwt-policy-tests.ts
@@ -19,13 +19,13 @@ import { deployApi, importCreateApi, startApi } from '@commands/management/api-m
 import { publishPlan } from '@commands/management/api-plan-management-commands';
 import { ApiImport } from '@model/api-imports';
 import { requestGateway } from 'support/common/http.commands';
-import * as faker from 'faker';
 import { ApiFakers } from '@fakers/apis';
 import { am_createApplication, am_deleteApplication } from '@commands/am_management/am_application-management-commands';
 import { am_createDomain, am_deleteDomain, am_enableDomain } from '@commands/am_management/am_domain-management-commands';
 import { am_getApiToken } from '@commands/am_management/am_token-management-commands';
 import { AM_ADMIN_USER } from '@fakers/users/am_users';
 import { Application } from '@model/applications';
+import faker from '@faker-js/faker';
 
 context('Create and test JWT policy', () => {
   let hs256Api: ApiImport;

--- a/gravitee-apim-e2e/ui-test/support/common/api.commands.ts
+++ b/gravitee-apim-e2e/ui-test/support/common/api.commands.ts
@@ -14,20 +14,12 @@
  * limitations under the License.
  */
 
-import {
-  stopApi,
-  deleteApi,
-  deployApi,
-  importSwaggerApi,
-  startApi,
-  createApi,
-  updateApi,
-} from '@commands/management/api-management-commands';
+import { stopApi, deleteApi, deployApi, importSwaggerApi, startApi, updateApi } from '@commands/management/api-management-commands';
 import { closePlan, createPlan, publishPlan } from '@commands/management/api-plan-management-commands';
 import { ApiImportFakers } from '@fakers/api-imports';
 import { ADMIN_USER, API_PUBLISHER_USER } from '@fakers/users/users';
 import { ApiImport, ImportSwaggerDescriptorEntity, ImportSwaggerDescriptorEntityType } from '@model/api-imports';
-import * as faker from 'faker';
+import faker from '@faker-js/faker';
 
 declare global {
   namespace Cypress {


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7596

**Description**

Replace faker dependency with @faker-js/faker
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/chore-update-faker-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
