### PR TITLE
fix: add undefined to null mongo converter

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/ManagementRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/ManagementRepositoryConfiguration.java
@@ -19,6 +19,9 @@ import com.mongodb.client.MongoClient;
 import io.gravitee.repository.Scope;
 import io.gravitee.repository.mongodb.common.AbstractRepositoryConfiguration;
 import io.gravitee.repository.mongodb.common.MongoFactory;
+import io.gravitee.repository.mongodb.management.converters.BsonUndefinedToNullReadingConverter;
+import java.util.List;
+import javax.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -27,6 +30,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
 /**
@@ -42,6 +47,18 @@ public class ManagementRepositoryConfiguration extends AbstractRepositoryConfigu
     @Autowired
     @Qualifier("managementMongo")
     private MongoFactory mongoFactory;
+
+    @Autowired
+    private MappingMongoConverter mappingMongoConverter;
+
+    private static MongoCustomConversions mongoCustomConversions() {
+        return new MongoCustomConversions(List.of(new BsonUndefinedToNullReadingConverter()));
+    }
+
+    @PostConstruct
+    public void addCustomConverters() {
+        mappingMongoConverter.setCustomConversions(mongoCustomConversions());
+    }
 
     @Bean(name = "managementMongo")
     public MongoFactory mongoFactory() {

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/converters/BsonUndefinedToNullReadingConverter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/converters/BsonUndefinedToNullReadingConverter.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.converters;
+
+import org.bson.BsonUndefined;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+
+/**
+ * @author GraviteeSource Team
+ */
+@ReadingConverter
+public class BsonUndefinedToNullReadingConverter implements Converter<BsonUndefined, Object> {
+
+    @Override
+    public Object convert(BsonUndefined source) {
+        return null;
+    }
+}


### PR DESCRIPTION
Register a BsonUndefined to null converter in order to avoid query
failures when encountering a document with a field set to `undefined`

While spring data ignores entirely null fields, this may happen
because of a mongoshell query or if the database has been accessed
using another tool.

see https://github.com/gravitee-io/issues/issues/7610

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-add-undefined-to-null-mongo-converter/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
