### PR TITLE
Copy the original `organizationId` when anonymizing a user while deleting it

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -1233,6 +1233,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
             if (anonymizeOnDelete) {
                 User anonym = new User();
                 anonym.setId(user.getId());
+                anonym.setOrganizationId(user.getOrganizationId());
                 anonym.setCreatedAt(user.getCreatedAt());
                 anonym.setUpdatedAt(user.getUpdatedAt());
                 anonym.setStatus(user.getStatus());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/UserServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/UserServiceTest.java
@@ -995,6 +995,7 @@ public class UserServiceTest {
         setField(userService, "anonymizeOnDelete", true);
 
         String userId = "userId";
+        String organizationId = "DEFAULT";
         String firstName = "first";
         String lastName = "last";
         String email = "email";
@@ -1003,6 +1004,7 @@ public class UserServiceTest {
             .thenReturn(Collections.emptySet());
         User user = new User();
         user.setId(userId);
+        user.setOrganizationId(organizationId);
         user.setSourceId("sourceId");
         Date updatedAt = new Date(1234567890L);
         user.setUpdatedAt(updatedAt);
@@ -1026,6 +1028,7 @@ public class UserServiceTest {
                         public boolean matches(User user) {
                             return (
                                 userId.equals(user.getId()) &&
+                                organizationId.equals(user.getOrganizationId()) &&
                                 UserStatus.ARCHIVED.equals(user.getStatus()) &&
                                 ("deleted-" + userId).equals(user.getSourceId()) &&
                                 !updatedAt.equals(user.getUpdatedAt()) &&

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -433,7 +433,7 @@ user:
       # Must contains 32 chars (256 bits)
       #secret:
   anonymize-on-delete:
-    #enabled: true
+    #enabled: false
 
 # Enable / disable documentation sanitize. Enabled by default.
 documentation:


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7613

**Description**

Also set `false` as the default value in `gravitee.yml` file to be consistent with the code
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7613-delete-user-with-anonymized-data/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
