### PR TITLE
fix: add mongodb clean up script for API keys

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.17.0/api-keys-cleanup.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.17.0/api-keys-cleanup.js
@@ -1,0 +1,25 @@
+/**
+ * This script should be run before upgrading in order to avoid any issue
+ * linked to https://github.com/spring-projects/spring-data-mongodb/issues/2350$
+ * while running the ApiKeySubscriptionUpgrader
+ */
+
+// Override this variable if you use prefix
+const prefix = '';
+
+function unsetUndefined(doc) {
+    return Object.keys(doc).some((k, i) => {
+        if (doc[k] === undefined) {
+            print('found an undefined field on API key', doc._id, k, 'will be unset');
+            delete doc[k];
+            return true;
+        }
+    });
+}
+
+db.getCollection(`${prefix}keys`).find({}).forEach(doc => {
+    const changed = unsetUndefined(doc);
+    if (changed) {
+        db.getCollection(`${prefix}keys`).replaceOne(doc);
+    }
+});


### PR DESCRIPTION
The ApiKeySubscription upgrader may fail in case of an API key field
being set to undefined (eg `api`), leading corrupted data.

see https://github.com/gravitee-io/issues/issues/7610
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-add-upgrade-script-for-3-17/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
