### PR TITLE
feat: add setting to differentiate apim trial instances

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/producer/HelloCommandProducer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/producer/HelloCommandProducer.java
@@ -27,7 +27,6 @@ import io.gravitee.rest.api.service.InstallationService;
 import io.gravitee.rest.api.service.OrganizationService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.reactivex.Single;
-import java.util.HashMap;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -41,12 +40,16 @@ public class HelloCommandProducer implements CommandProducer<HelloCommand, Hello
 
     private static final String UI_URL = "UI_URL";
     private static final String API_URL = "API_URL";
+    private static final String INSTALLATION_TYPE = "INSTALLATION_TYPE";
 
     @Value("${console.ui.url:http://localhost:3000}")
     private String uiURL;
 
     @Value("${console.api.url:http://localhost:8083/management}")
     private String apiURL;
+
+    @Value("${installation.type:onprem}")
+    private String installationType;
 
     private final Node node;
     private final InstallationService installationService;
@@ -79,6 +82,7 @@ public class HelloCommandProducer implements CommandProducer<HelloCommand, Hello
         command.getPayload().getAdditionalInformation().putAll(installation.getAdditionalInformation());
         command.getPayload().getAdditionalInformation().put(UI_URL, uiURL);
         command.getPayload().getAdditionalInformation().put(API_URL, apiURL);
+        command.getPayload().getAdditionalInformation().put(INSTALLATION_TYPE, installationType);
         command.getPayload().setDefaultOrganizationId(GraviteeContext.getDefaultOrganization());
         command.getPayload().setDefaultEnvironmentId(GraviteeContext.getDefaultEnvironment());
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/producer/HelloCommandProducerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/producer/HelloCommandProducerTest.java
@@ -105,6 +105,7 @@ public class HelloCommandProducerTest {
                 assertEquals(CUSTOM_VALUE, helloCommand.getPayload().getAdditionalInformation().get(CUSTOM_KEY));
                 assertTrue(helloCommand.getPayload().getAdditionalInformation().containsKey("UI_URL"));
                 assertTrue(helloCommand.getPayload().getAdditionalInformation().containsKey("API_URL"));
+                assertTrue(helloCommand.getPayload().getAdditionalInformation().containsKey("INSTALLATION_TYPE"));
 
                 assertEquals(HOSTNAME, helloCommand.getPayload().getNode().getHostname());
                 assertEquals(GraviteeContext.getDefaultOrganization(), helloCommand.getPayload().getDefaultOrganizationId());


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/gravitee-cockpit/issues/2512

**Description**

Cherry-pick commit already on master on the 3.17.x branch

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/317-2512-add-setting-to-differentiate-apim-trial/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
