### PR TITLE
Use `@Lazy` to avoid issue with circular dependencies in services

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AuditServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AuditServiceImpl.java
@@ -100,6 +100,7 @@ public class AuditServiceImpl extends AbstractService implements AuditService {
     private UserService userService;
 
     @Autowired
+    @Lazy
     private PermissionService permissionService;
 
     @Autowired


### PR DESCRIPTION
**Issue**

NA

**Description**

Use `@Lazy` to avoid issue with circular dependencies in services. The reference to this service has been added in https://github.com/gravitee-io/gravitee-api-management/pull/1659, first PR making the CI fail.

![](https://media.giphy.com/media/gaLd7AlFtjopW/giphy.gif)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-build-circular-dep-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
