### PR TITLE
test: add a jest util method to check success status codes

### DIFF
--- a/gravitee-apim-e2e/api-test/apis/gateway-instances.spec.ts
+++ b/gravitee-apim-e2e/api-test/apis/gateway-instances.spec.ts
@@ -17,7 +17,7 @@
 import { beforeAll, describe, expect, test } from '@jest/globals';
 import { GatewayApi } from '@management-apis/GatewayApi';
 import { forManagementAsAdminUser, forManagementAsApiUser } from '@client-conf/*';
-import { fail } from '../../lib/jest-utils';
+import { fail, succeed } from '../../lib/jest-utils';
 
 const orgId = 'DEFAULT';
 const envId = 'DEFAULT';
@@ -27,10 +27,7 @@ const gatewayApiAsUser = new GatewayApi(forManagementAsApiUser());
 describe('GatewayApi', () => {
   describe('Get all gateway instances', () => {
     test('should get a list of gateways as response that complies with response schema', async () => {
-      const response = await gatewayApiAsAdmin.getInstancesRaw({ envId, orgId });
-      expect(response.raw.status).toBe(200);
-
-      const gatewayInstances = await response.value();
+      const gatewayInstances = await succeed(gatewayApiAsAdmin.getInstancesRaw({ envId, orgId }));
       expect(gatewayInstances).toHaveProperty('content');
       expect(gatewayInstances).toHaveProperty('pageElements');
       expect(gatewayInstances).toHaveProperty('pageNumber');

--- a/gravitee-apim-e2e/lib/jest-utils.ts
+++ b/gravitee-apim-e2e/lib/jest-utils.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { expect } from '@jest/globals';
+import { ApiResponse } from 'lib/management-webclient-sdk/src/lib/runtime';
 
 export async function fail(promise, expectedStatus: number, expectedMessage?: string) {
   try {
@@ -26,4 +27,10 @@ export async function fail(promise, expectedStatus: number, expectedMessage?: st
       expect(message).toEqual(expectedMessage);
     }
   }
+}
+
+export async function succeed(promise: Promise<ApiResponse<any>>, expectedStatus: number = 200) {
+  const response = await promise;
+  expect(response.raw.status).toEqual(expectedStatus);
+  return await response.value();
 }


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/7624

test: add a jest util method to check success status codes
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/test-jeste2e-httpstatustest/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
