### PR TITLE
fix(portal): do not use `innerHTML` with user data provided by users

### DIFF
--- a/gravitee-apim-portal-webui/src/app/pages/application/application-creation/application-creation-step5/application-creation-step5.component.html
+++ b/gravitee-apim-portal-webui/src/app/pages/application/application-creation/application-creation-step5/application-creation-step5.component.html
@@ -93,12 +93,9 @@
         </li>
       </ul>
     </div>
-    <gv-button
-      link
-      outlined
-      [routerLink]="['/applications/', createdApplication.id]"
-      [innerHTML]="'applicationCreation.validation.confirm' | translate: { name: createdApplication.name }"
-    ></gv-button>
+    <gv-button link outlined [routerLink]="['/applications/', createdApplication.id]">{{
+      'applicationCreation.validation.confirm' | translate: { name: createdApplication.name }
+    }}</gv-button>
   </div>
 
   <div class="message message-full message-error" *ngIf="creationError">


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/_support_team/issues/126

**Description**

Do not use `innerHTML` with user data provided by users

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/126-portal-fix-css/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
