### PR TITLE
fix: build correct URL for cockpit login

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/CockpitAuthenticationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/auth/CockpitAuthenticationResource.java
@@ -166,7 +166,7 @@ public class CockpitAuthenticationResource extends AbstractAuthenticationResourc
             );
 
             // Redirect the user.
-            return Response.temporaryRedirect(new URI(URLEncoder.encode(url, "UTF-8"))).build();
+            return Response.temporaryRedirect(new URI(url)).build();
         } catch (Exception e) {
             LOGGER.error("Error occurred when trying to log user using cockpit.", e);
             return Response.serverError().build();


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/gravitee-cockpit/issues/2571

**Description**

Build correct URL for redirection after login from Cockpit

**Additional context**

Url.encode has been added to make Snyk happy (if I remember correctly), but here it messes up the URL. 
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-cockpit-login-issue/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
