### PR TITLE
Fix build since elasticsearch repo has been introduced - 3.10.x

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/pom.xml
@@ -120,6 +120,14 @@
             <scope>runtime</scope>
             <type>zip</type>
         </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-elasticsearch</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+            <type>zip</type>
+        </dependency>
     </dependencies>
 
     <build>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/pom.xml
@@ -163,6 +163,14 @@
 			<scope>runtime</scope>
 			<type>zip</type>
 		</dependency>
+
+		<dependency>
+			<groupId>io.gravitee.apim.repository</groupId>
+			<artifactId>gravitee-apim-repository-elasticsearch</artifactId>
+			<version>${project.version}</version>
+			<scope>runtime</scope>
+			<type>zip</type>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
**Issue**

N/A

**Description**

Declare repository-elasticsearch as a dependency of the distribution, so the builds can be made in the right order
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-build-since-elastic-repository/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
