### PR TITLE
fix(rest-api): add upgrader to update System ADMIN role to add new Audit Perm with CRUD

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/RoleService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/RoleService.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.service;
 
+import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.rest.api.model.MembershipReferenceType;
 import io.gravitee.rest.api.model.NewRoleEntity;
 import io.gravitee.rest.api.model.RoleEntity;
@@ -22,6 +23,7 @@ import io.gravitee.rest.api.model.UpdateRoleEntity;
 import io.gravitee.rest.api.model.permissions.Permission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.*;
 
@@ -32,6 +34,13 @@ import java.util.*;
  */
 public interface RoleService {
     RoleEntity create(ExecutionContext executionContext, final NewRoleEntity roleEntity);
+    void createOrUpdateSystemRole(
+        ExecutionContext executionContext,
+        SystemRole roleName,
+        RoleScope roleScope,
+        Permission[] permissions,
+        String organizationId
+    );
     void createOrUpdateSystemRoles(ExecutionContext executionContext, String organizationId);
     void delete(ExecutionContext executionContext, String roleId);
     List<RoleEntity> findAllByOrganization(String organizationId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DefaultOrganizationAdminRoleUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DefaultOrganizationAdminRoleUpgrader.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade;
+
+import io.gravitee.rest.api.model.permissions.OrganizationPermission;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.model.permissions.SystemRole;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component
+public class DefaultOrganizationAdminRoleUpgrader extends OrganizationUpgrader {
+
+    private final RoleService roleService;
+
+    @Autowired
+    public DefaultOrganizationAdminRoleUpgrader(RoleService roleService) {
+        this.roleService = roleService;
+    }
+
+    @Override
+    protected void upgradeOrganization(ExecutionContext executionContext) {
+        roleService.createOrUpdateSystemRole(
+            executionContext,
+            SystemRole.ADMIN,
+            RoleScope.ORGANIZATION,
+            OrganizationPermission.values(),
+            executionContext.getOrganizationId()
+        );
+    }
+
+    @Override
+    public int getOrder() {
+        return 150;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/RoleService_CreateOrUpdateSystemRolesTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/RoleService_CreateOrUpdateSystemRolesTest.java
@@ -15,8 +15,10 @@
  */
 package io.gravitee.rest.api.service.impl;
 
+import static io.gravitee.rest.api.model.permissions.EnvironmentPermission.DOCUMENTATION;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -25,10 +27,13 @@ import io.gravitee.repository.management.api.RoleRepository;
 import io.gravitee.repository.management.model.Role;
 import io.gravitee.repository.management.model.RoleReferenceType;
 import io.gravitee.repository.management.model.RoleScope;
+import io.gravitee.rest.api.model.NewRoleEntity;
 import io.gravitee.rest.api.model.permissions.EnvironmentPermission;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.Arrays;
+import java.util.Collections;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -186,5 +191,21 @@ public class RoleService_CreateOrUpdateSystemRolesTest {
                         o.getScope().equals(RoleScope.GROUP)
                 )
             );
+    }
+
+    @Test(expected = TechnicalManagementException.class)
+    public void shouldNotCreateBecauseOfTechnicalManagementException() throws TechnicalException {
+        Role mgmtAdminRole = mock(Role.class);
+        when(
+            mockRoleRepository.findByScopeAndNameAndReferenceIdAndReferenceType(
+                RoleScope.ENVIRONMENT,
+                "ADMIN",
+                REFERENCE_ID,
+                REFERENCE_TYPE
+            )
+        )
+            .thenThrow(new TechnicalException());
+
+        roleService.createOrUpdateSystemRoles(GraviteeContext.getExecutionContext(), REFERENCE_ID);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/DefaultOrganizationAdminRoleUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/DefaultOrganizationAdminRoleUpgraderTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade;
+
+import static org.mockito.Mockito.*;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.OrganizationRepository;
+import io.gravitee.repository.management.model.Organization;
+import io.gravitee.rest.api.model.permissions.OrganizationPermission;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.model.permissions.SystemRole;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultOrganizationAdminRoleUpgraderTest {
+
+    @InjectMocks
+    DefaultOrganizationAdminRoleUpgrader upgrader;
+
+    @Mock
+    RoleService roleService;
+
+    @Mock
+    OrganizationRepository organizationRepository;
+
+    @Test
+    public void shouldInitializeDefaultRoles() throws TechnicalException {
+        final Organization organization = mock(Organization.class);
+        when(organization.getId()).thenReturn(GraviteeContext.getDefaultOrganization());
+
+        final ExecutionContext executionContext = new ExecutionContext(organization);
+
+        upgrader.upgradeOrganization(executionContext);
+        verify(roleService, times(1))
+            .createOrUpdateSystemRole(
+                executionContext,
+                SystemRole.ADMIN,
+                RoleScope.ORGANIZATION,
+                OrganizationPermission.values(),
+                organization.getId()
+            );
+    }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7628

**Description**

Update all ADMIN role for each organization (this role are not editable by the user)

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-admin-audit-role/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bckasswigm.chromatic.com)
<!-- Storybook placeholder end -->
