### PR TITLE
feat: add mongoDb retryWrites configuration

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -85,6 +85,7 @@ management:
 #    username:                    # mongodb username (default null)
 #    password:                    # mongodb password (default null)
 #    authSource:                  # mongodb authentication source (when at least a user or a password is defined, default gravitee)
+#    retryWrites:                 # mongodb retriable writes (default true)
 #    readPreference:              # possible values are 'nearest', 'primary', 'primaryPreferred', 'secondary', 'secondaryPreferred'
 #    readPreferenceTags:          # list of read preference tags (https://docs.mongodb.com/manual/core/read-preference-tags/#std-label-replica-set-read-preference-tag-sets)
 ### Write concern

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/common/MongoFactory.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/common/MongoFactory.java
@@ -247,6 +247,9 @@ public class MongoFactory implements FactoryBean<MongoClient> {
             builder.credential(credentials);
         }
 
+        Boolean retryWritesPreference = readPropertyValue(propertyPrefix + "retryWrites", Boolean.class, true);
+        builder.retryWrites(retryWritesPreference);
+
         if (!isReactive) {
             String readPreference = readPropertyValue(propertyPrefix + "readPreference", String.class);
             String readPreferenceTags = readPropertyValue(propertyPrefix + "readPreferenceTags", String.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -111,6 +111,7 @@ management:
 #    username:                    # mongodb username (default null)
 #    password:                    # mongodb password (default null)
 #    authSource:                  # mongodb authentication source (when at least a user or a password is defined, default gravitee)
+#    retryWrites:                 # mongodb retriable writes (default true)
 #    readPreference:              # possible values are 'nearest', 'primary', 'primaryPreferred', 'secondary', 'secondaryPreferred'
 #    readPreferenceTags:          # list of read preference tags (https://docs.mongodb.com/manual/core/read-preference-tags/#std-label-replica-set-read-preference-tag-sets)
 ### Write concern


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7539

**Description**

This PR allows to change the default configuration of mongoDB retryWrites. This is required to connect via SSL to AWS DocumentDB since retryWrites should be disabled there (See: https://docs.aws.amazon.com/documentdb/latest/developerguide/functional-differences.html#functional-differences.retryable-writes)

**Additional context**

Graviteesource Ticket: https://graviteesource.zendesk.com/hc/en-us/requests/4018
