### PR TITLE
fix: debug mode - encrypted api properties are not interpreted

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/ApiDeploymentPreProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/ApiDeploymentPreProcessor.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.manager;
+
+import io.gravitee.common.util.DataEncryptor;
+import io.gravitee.definition.model.Plan;
+import io.gravitee.definition.model.Properties;
+import io.gravitee.definition.model.Property;
+import io.gravitee.gateway.env.GatewayConfiguration;
+import io.gravitee.gateway.handlers.api.definition.Api;
+import java.security.GeneralSecurityException;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ApiDeploymentPreProcessor {
+
+    public static final Logger logger = LoggerFactory.getLogger(ApiDeploymentPreProcessor.class);
+
+    private final DataEncryptor dataEncryptor;
+    private final GatewayConfiguration gatewayConfiguration;
+
+    public ApiDeploymentPreProcessor(DataEncryptor dataEncryptor, GatewayConfiguration gatewayConfiguration) {
+        this.dataEncryptor = dataEncryptor;
+        this.gatewayConfiguration = gatewayConfiguration;
+    }
+
+    public void prepareApi(Api api) {
+        api.setPlans(getPlansMatchingShardingTag(api));
+        decryptProperties(api.getProperties());
+    }
+
+    private List<Plan> getPlansMatchingShardingTag(io.gravitee.gateway.handlers.api.definition.Api api) {
+        return api
+            .getPlans()
+            .stream()
+            .filter(
+                plan -> {
+                    if (plan.getTags() != null && !plan.getTags().isEmpty()) {
+                        boolean hasMatchingTags = gatewayConfiguration.hasMatchingTags(plan.getTags());
+                        if (!hasMatchingTags) {
+                            logger.debug(
+                                "Plan name[{}] api[{}] has been ignored because not in configured sharding tags",
+                                plan.getName(),
+                                api.getName()
+                            );
+                        }
+                        return hasMatchingTags;
+                    }
+                    return true;
+                }
+            )
+            .collect(Collectors.toList());
+    }
+
+    private void decryptProperties(Properties properties) {
+        if (properties != null) {
+            for (Property property : properties.getProperties()) {
+                if (property.isEncrypted()) {
+                    try {
+                        property.setValue(dataEncryptor.decrypt(property.getValue()));
+                        property.setEncrypted(false);
+                        properties.getValues().put(property.getKey(), property.getValue());
+                    } catch (GeneralSecurityException e) {
+                        logger.error("Error decrypting API property value for key {}", property.getKey(), e);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
@@ -20,8 +20,10 @@ import io.gravitee.gateway.core.classloader.DefaultClassLoader;
 import io.gravitee.gateway.core.component.ComponentProvider;
 import io.gravitee.gateway.core.component.spring.SpringComponentProvider;
 import io.gravitee.gateway.core.condition.ExpressionLanguageStringConditionEvaluator;
+import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.handlers.api.ApiContextHandlerFactory;
 import io.gravitee.gateway.handlers.api.definition.Api;
+import io.gravitee.gateway.handlers.api.manager.ApiDeploymentPreProcessor;
 import io.gravitee.gateway.handlers.api.manager.ApiManager;
 import io.gravitee.gateway.handlers.api.manager.endpoint.ApiManagementEndpoint;
 import io.gravitee.gateway.handlers.api.manager.endpoint.ApisManagementEndpoint;
@@ -58,10 +60,18 @@ public class ApiHandlerConfiguration {
     private Node node;
 
     @Autowired
+    private GatewayConfiguration gatewayConfiguration;
+
+    @Autowired
     private io.gravitee.node.api.configuration.Configuration configuration;
 
     @Bean
-    public ApiManager apiManager() {
+    public ApiDeploymentPreProcessor apiDeploymentPreProcessor(DataEncryptor apiPropertiesEncryptor) {
+        return new ApiDeploymentPreProcessor(apiPropertiesEncryptor, gatewayConfiguration);
+    }
+
+    @Bean
+    public ApiManager apiManager() throws Exception {
         return new ApiManagerImpl();
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/manager/ApiBuilder.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/manager/ApiBuilder.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.manager;
+
+import static java.util.Collections.singletonList;
+import static org.mockito.Mockito.mock;
+
+import io.gravitee.definition.model.Proxy;
+import io.gravitee.definition.model.VirtualHost;
+import io.gravitee.gateway.handlers.api.definition.Api;
+import java.util.Date;
+
+class ApiBuilder {
+
+    private final Api api = new Api();
+
+    public ApiBuilder id(String id) {
+        this.api.setId(id);
+        return this;
+    }
+
+    public ApiBuilder name(String name) {
+        this.api.setName(name);
+        return this;
+    }
+
+    public ApiBuilder proxy(Proxy proxy) {
+        this.api.setProxy(proxy);
+        return this;
+    }
+
+    public ApiBuilder deployedAt(Date updatedAt) {
+        this.api.setDeployedAt(updatedAt);
+        return this;
+    }
+
+    public ApiBuilder mockProxy() {
+        Proxy proxy = new Proxy();
+        proxy.setVirtualHosts(singletonList(mock(VirtualHost.class)));
+        return proxy(proxy);
+    }
+
+    public Api build() {
+        api.setEnabled(true);
+
+        return this.api;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/manager/ApiDeploymentPreProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/manager/ApiDeploymentPreProcessorTest.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.manager;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.util.DataEncryptor;
+import io.gravitee.definition.model.Plan;
+import io.gravitee.definition.model.Properties;
+import io.gravitee.definition.model.Property;
+import io.gravitee.gateway.env.GatewayConfiguration;
+import io.gravitee.gateway.handlers.api.definition.Api;
+import io.gravitee.gateway.reactor.ReactorEvent;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ApiDeploymentPreProcessorTest {
+
+    @Mock
+    private GatewayConfiguration gatewayConfiguration;
+
+    @Mock
+    private DataEncryptor dataEncryptor;
+
+    private ApiDeploymentPreProcessor cut;
+
+    @Before
+    public void setUp() {
+        cut = new ApiDeploymentPreProcessor(dataEncryptor, gatewayConfiguration);
+    }
+
+    @Test
+    public void shouldNotFilterPlanWithoutMatchingTag() throws Exception {
+        final Api api = buildTestApi();
+
+        final Plan mockedPlan = mock(Plan.class);
+        when(mockedPlan.getTags()).thenReturn(new HashSet<>());
+        api.setPlans(singletonList(mockedPlan));
+
+        cut.prepareApi(api);
+
+        assertTrue(api.getPlans().contains(mockedPlan));
+    }
+
+    @Test
+    public void shouldFilterPlanWithoutConfiguredTag() throws Exception {
+        final Api api = buildTestApi();
+
+        final Plan mockedPlan = mock(Plan.class);
+        when(mockedPlan.getTags()).thenReturn(new HashSet<>(List.of("tag")));
+        api.setPlans(singletonList(mockedPlan));
+
+        when(gatewayConfiguration.hasMatchingTags(any())).thenReturn(false);
+
+        cut.prepareApi(api);
+
+        assertTrue(api.getPlans().isEmpty());
+    }
+
+    @Test
+    public void shouldNotFilterPlanWithConfiguredTag() throws Exception {
+        final Api api = buildTestApi();
+
+        final Plan mockedPlan = mock(Plan.class);
+        when(mockedPlan.getTags()).thenReturn(new HashSet<>(List.of("tag")));
+        api.setPlans(singletonList(mockedPlan));
+
+        when(gatewayConfiguration.hasMatchingTags(any())).thenReturn(true);
+
+        cut.prepareApi(api);
+
+        assertTrue(api.getPlans().contains(mockedPlan));
+    }
+
+    @Test
+    public void shouldDecryptApiPropertiesOnDeployment() throws Exception {
+        final Api api = buildTestApi();
+
+        Properties properties = new Properties();
+        properties.setProperties(
+            List.of(
+                new Property("key1", "plain value 1", false),
+                new Property("key2", "value2Base64encrypted", true),
+                new Property("key3", "value3Base64encrypted", true)
+            )
+        );
+        api.setProperties(properties);
+
+        when(dataEncryptor.decrypt("value2Base64encrypted")).thenReturn("plain value 2");
+        when(dataEncryptor.decrypt("value3Base64encrypted")).thenReturn("plain value 3");
+
+        cut.prepareApi(api);
+
+        verify(dataEncryptor, times(2)).decrypt(any());
+        assertEquals(Map.of("key1", "plain value 1", "key2", "plain value 2", "key3", "plain value 3"), api.getProperties().getValues());
+    }
+
+    private Api buildTestApi() {
+        return new ApiBuilder().id("api-test").name("api-name-test").deployedAt(new Date()).build();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/DebugReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/DebugReactor.java
@@ -22,6 +22,7 @@ import io.gravitee.definition.model.HttpRequest;
 import io.gravitee.definition.model.HttpResponse;
 import io.gravitee.gateway.debug.definition.DebugApi;
 import io.gravitee.gateway.debug.vertx.VertxDebugHttpClientConfiguration;
+import io.gravitee.gateway.handlers.api.manager.ApiDeploymentPreProcessor;
 import io.gravitee.gateway.reactor.Reactable;
 import io.gravitee.gateway.reactor.ReactorEvent;
 import io.gravitee.gateway.reactor.handler.ReactorHandlerRegistry;
@@ -62,6 +63,9 @@ public class DebugReactor extends DefaultReactor {
     @Qualifier("debugReactorHandlerRegistry")
     private ReactorHandlerRegistry reactorHandlerRegistry;
 
+    @Autowired
+    private ApiDeploymentPreProcessor apiDeploymentPreProcessor;
+
     @Override
     public void onEvent(Event<ReactorEvent, Reactable> reactorEvent) {
         if (reactorEvent.type() == ReactorEvent.DEBUG) {
@@ -74,6 +78,7 @@ public class DebugReactor extends DefaultReactor {
                     logger.debug("Reactable already deployed. No need to do it again.");
                     return;
                 }
+                apiDeploymentPreProcessor.prepareApi(reactableDebugApi);
                 logger.info("Deploy api for debug...");
 
                 logger.debug("Creating ReactorHandler");

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/reactor/DebugReactorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/reactor/DebugReactorTest.java
@@ -23,6 +23,7 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -33,6 +34,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.HttpRequest;
 import io.gravitee.gateway.debug.definition.DebugApi;
 import io.gravitee.gateway.debug.vertx.VertxDebugHttpClientConfiguration;
+import io.gravitee.gateway.handlers.api.manager.ApiDeploymentPreProcessor;
 import io.gravitee.gateway.reactor.ReactorEvent;
 import io.gravitee.gateway.reactor.handler.ReactorHandlerRegistry;
 import io.gravitee.gateway.reactor.impl.ReactableWrapper;
@@ -51,6 +53,7 @@ import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -88,8 +91,16 @@ public class DebugReactorTest {
     @Mock
     private VertxDebugHttpClientConfiguration debugHttpClientConfiguration;
 
+    @Mock
+    private ApiDeploymentPreProcessor apiDeploymentPreProcessor;
+
     @Captor
     ArgumentCaptor<io.gravitee.repository.management.model.Event> eventCaptor;
+
+    @Before
+    public void setUp() {
+        doNothing().when(apiDeploymentPreProcessor).prepareApi(any());
+    }
 
     @Test
     public void shouldDebugApiSuccessfully() throws TechnicalException, JsonProcessingException {


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/7629

## 💥 Cause of the bug 

`ApiManagerImpl` was not only responsible of managing the lifecycle of the api (`deploy`/`undeploy`) but also of transforming it on two aspects:
- filters plans matching gateway configuration tags
- loop over api properties to decrypt them if their were encrypted

Debug Mode is not relying on `ApiManagerImpl` to deploy an  `api`, so we lose the api preparation step.

## 🛠 How is it resolved

In this fix, I extracted the api preparation logic into a dedicated class: `ApiDeploymentPreProcessor` (if you have a better name, do not hesitate)

This allow to move the responsibility in this class, which is now used by `ApiManagerImpl` and `DebugReactor`.
So now, all the new "pre-transformation" of the api will be done in this dedicated class

## 🎁 Bonus

It also fixes the plan filtering on sharding tag criteria

## ⁉️ Why not moving the call to api preparation method away from ApiManagerImpl ?

I decided to let the call to the preparation step at this place because it makes sense to me to do this kind of processing just before the deployment (moreover for decrypting data)

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-7629-debug-decrypt-api-properties/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
