### PR TITLE
ci: run e2e api tests using docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,55 @@ commands:
                   paths:
                       - ./<< parameters.apim-ui-project >>/node_modules
 
+    build-backend-images:
+        steps:
+            - run:
+                name: Build rest api and gateway docker images
+                command: |
+                    ## Clean rest api
+                    rm rest-api-docker-context/distribution/lib/gravitee-license-node-enterprise*.jar
+                    rm rest-api-docker-context/distribution/plugins/gravitee-ae-connectors-ws*.zip
+                    rm rest-api-docker-context/distribution/plugins/gravitee-notifier-*.zip
+                    rm rest-api-docker-context/distribution/plugins/gravitee-policy-assign-metrics-*.zip
+                    rm rest-api-docker-context/distribution/plugins/gravitee-policy-data-logging-masking-*.zip
+                    ## Clean Gateway
+                    rm gateway-docker-context/distribution/lib/gravitee-license-node-enterprise*.jar
+                    rm gateway-docker-context/distribution/plugins/gravitee-ae-connectors-ws*.zip
+                    rm gateway-docker-context/distribution/plugins/gravitee-policy-assign-metrics-*.zip
+                    rm gateway-docker-context/distribution/plugins/gravitee-policy-data-logging-masking-*.zip
+                    
+                    export REST_API_PRIVATE_IMAGE_TAG=graviteeio.azurecr.io/apim-management-api:$APIM_VERSION
+                    export GATEWAY_PRIVATE_IMAGE_TAG=graviteeio.azurecr.io/apim-gateway:$APIM_VERSION
+                    
+                    docker build -f gravitee-apim-rest-api/docker/Dockerfile-dev \
+                    --build-arg GRAVITEEIO_VERSION=${APIM_VERSION} \
+                    -t ${REST_API_PRIVATE_IMAGE_TAG} \
+                    rest-api-docker-context
+                    
+                    docker build -f gravitee-apim-gateway/docker/Dockerfile-dev \
+                    --build-arg GRAVITEEIO_VERSION=${APIM_VERSION} \
+                    -t ${GATEWAY_PRIVATE_IMAGE_TAG} \
+                    gateway-docker-context
+
+    save-backend-images-in-workspace:
+        steps:
+            - run:
+                name: Save Image in Docker Cache
+                command: |
+                    mkdir -p ./docker-cache
+                    export REST_API_PRIVATE_IMAGE_TAG=graviteeio.azurecr.io/apim-management-api:$APIM_VERSION
+                    export GATEWAY_PRIVATE_IMAGE_TAG=graviteeio.azurecr.io/apim-gateway:$APIM_VERSION
+                    docker save -o ./docker-cache/apim-management-api.tar ${REST_API_PRIVATE_IMAGE_TAG}
+                    docker save -o ./docker-cache/apim-gateway.tar ${GATEWAY_PRIVATE_IMAGE_TAG}
+
+    load-backend-images-from-workspace:
+        steps:
+            - run:
+                name: Load Image from Docker Cache
+                command: |
+                  docker load < ./docker-cache/apim-management-api.tar
+                  docker load < ./docker-cache/apim-gateway.tar
+
 parameters:
     gio_action:
         type: enum
@@ -276,6 +325,24 @@ jobs:
                   paths:
                       - ./rest-api-docker-context
                       - ./gateway-docker-context
+
+    build-images:
+        docker:
+            - image: cimg/openjdk:11.0
+        resource_class: medium
+        steps:
+          - checkout
+          - attach_workspace:
+              at: .
+          - prepare-env-var
+          - get-apim-version
+          - setup_remote_docker
+          - build-backend-images
+          - save-backend-images-in-workspace
+          - persist_to_workspace:
+              root: ./
+              paths:
+                - ./docker-cache
 
     test:
         docker:
@@ -1193,55 +1260,23 @@ jobs:
             - notify-on-failure
 
     e2e-test:
-      docker:
-        - image: cimg/openjdk:11.0-node
-          environment:
-            - tcp.port: 8083
-        - image: mongo:4.4
-        - image: docker.elastic.co/elasticsearch/elasticsearch:7.10.1
-          environment:
-            - transport.host: localhost #2
-            - network.host: 127.0.0.1 #3
-            - http.port: 9200 #4
-            - cluster.name: es-cluster #5
-            - discovery.type: single-node #6
-            - xpack.security.enabled: false #7
-            - ES_JAVA_OPTS: "-Xms256m -Xmx256m" #8
-      resource_class: medium
-      executor:
-        name: node-lts
-        class: medium
-      steps:
-        - checkout
-        - attach_workspace:
-            at: .
-        - run:
-            name: Wait for Mongo to be up and running
-            command: timeout 15s bash -c 'until nc -vz localhost 27017; do sleep 2; done'
-        - run:
-            name: Run API & e2e tests
-            command: |
-              # Remove Enterprise edition features
-              # FIXME: add a licence to be able to run Enterprise edition
-              rm rest-api-docker-context/distribution/lib/gravitee-license-node-enterprise*.jar
-              rm rest-api-docker-context/distribution/plugins/gravitee-ae-connectors-ws*.zip
-              rm rest-api-docker-context/distribution/plugins/gravitee-notifier-*.zip
-              rm rest-api-docker-context/distribution/plugins/gravitee-policy-assign-metrics-*.zip
-              rm rest-api-docker-context/distribution/plugins/gravitee-policy-data-logging-masking-*.zip
-              rm gateway-docker-context/distribution/lib/gravitee-license-node-enterprise*.jar
-              rm gateway-docker-context/distribution/plugins/gravitee-ae-connectors-ws*.zip
-              rm gateway-docker-context/distribution/plugins/gravitee-policy-assign-metrics-*.zip
-              rm gateway-docker-context/distribution/plugins/gravitee-policy-data-logging-masking-*.zip
-              # Start APIM in background
-              GIO_MAX_MEM=1024m rest-api-docker-context/distribution/bin/gravitee &
-              GIO_MAX_MEM=1024m gateway-docker-context/distribution/bin/gravitee &
-              echo "Gravitee rest-api started ! Waiting for a connection..."
-              # Wait for APIM to be up and running
-              timeout 60s bash -c 'until nc -vz localhost 8083; do sleep 2; done'
-              # Run e2e tests
-              cd gravitee-apim-e2e
-              npm run test:ci
-        - notify-on-failure
+        machine:
+            image: ubuntu-2004:202101-01
+        resource_class: medium
+        steps:
+            - checkout
+            - attach_workspace:
+                at: .
+            - get-apim-version
+            - load-backend-images-from-workspace
+            - run:
+                name: Run API & e2e tests
+                command: |
+                    APIM_REGISTRY=graviteeio.azurecr.io \
+                    APIM_TAG=$APIM_VERSION \
+                    docker-compose -f ./docker/test/common/docker-compose-apis.yml -f ./docker/test/api-tests/docker-compose-api-tests.yml \
+                      -p api-integration-test up --no-build --abort-on-container-exit --exit-code-from jest-e2e
+            - notify-on-failure
 
     publish_rpm_packages:
         parameters:
@@ -1288,6 +1323,9 @@ workflows:
                   context: gravitee-qa
                   requires:
                       - validate
+            - build-images:
+                requires:
+                  - build
             - test:
                   requires:
                       - build
@@ -1457,7 +1495,7 @@ workflows:
                   name: Test APIM e2e
                   requires:
                       - Lint & Build APIM e2e
-                      - build
+                      - build-images
                   filters:
                     branches:
                       only:

--- a/docker/test/api-tests/README.md
+++ b/docker/test/api-tests/README.md
@@ -1,0 +1,14 @@
+# MongoDB
+
+Here is a docker-compose to run APIM jest api e2e tests with MongoDB as database.
+
+---
+> For more information, please read :
+> https://docs.gravitee.io/apim/3.x/apim_installguide_repositories_mongodb.html
+---
+
+## How to run ?
+
+```bash
+APIM_REGISTRY={APIM_REGISTRY} APIM_TAG={APIM_TAG} docker-compose -f ./docker/test/common/docker-compose-apis.yml -f ./docker/test/api-tests/docker-compose-api-tests.yml -p api-integration-test up --abort-on-container-exit --exit-code-from jest-e2e
+```

--- a/docker/test/api-tests/docker-compose-api-tests.yml
+++ b/docker/test/api-tests/docker-compose-api-tests.yml
@@ -1,0 +1,35 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: '3.8'
+
+services:
+  jest-e2e:
+    image: cimg/node:lts
+    working_dir: /test
+    volumes:
+      - ../../../gravitee-apim-e2e:/test
+    command: npm run test:ci
+    environment:
+      - MANAGEMENT_BASE_PATH=http://management_api:8083/management
+      - PORTAL_BASE_PATH=http://management_api:8083/portal/environments
+    depends_on:
+      management_api:
+        condition: service_healthy
+      gateway:
+        condition: service_healthy
+    networks:
+      - apim

--- a/docker/test/common/docker-compose-apis.yml
+++ b/docker/test/common/docker-compose-apis.yml
@@ -1,0 +1,130 @@
+#
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: '3.8'
+
+networks:
+  apim:
+    name: apim
+  storage:
+    name: storage
+
+volumes:
+  data-elasticsearch:
+  data-mongo:
+
+services:
+  mongodb:
+    image: circleci/mongo:${MONGODB_VERSION:-4}
+    container_name: gio_apim_mongodb
+    restart: always
+    ports:
+      - "30017:27017"
+    volumes:
+      - data-mongo:/data/db
+      - ./.logs/apim-mongodb:/var/log/mongodb
+    healthcheck:
+      test: echo 'db.runCommand({serverStatus:1}).ok' | mongo admin --quiet | grep 1
+      interval: 10s
+      timeout: 10s
+      retries: 5
+    networks:
+      - storage
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.7.0}
+    container_name: gio_apim_elasticsearch
+    restart: always
+    volumes:
+      - data-elasticsearch:/usr/share/elasticsearch/data
+    environment:
+      - http.host=0.0.0.0
+      - transport.host=0.0.0.0
+      - xpack.security.enabled=false
+      - xpack.monitoring.enabled=false
+      - cluster.name=elasticsearch
+      - bootstrap.memory_lock=true
+      - discovery.type=single-node
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile: 65536
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9200/_cat/health?h=st" ]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+    networks:
+      - storage
+
+  management_api:
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-api:${APIM_TAG:-3}
+    container_name: gio_apim_management_api
+    restart: always
+    links:
+      - mongodb
+      - elasticsearch
+    depends_on:
+      mongodb:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
+    ports:
+      - "8083:8083"
+    volumes:
+      - ./.logs/apim-management-api:/opt/graviteeio-management-api/logs
+    environment:
+      - gravitee_management_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
+      - gravitee_analytics_elasticsearch_endpoints_0=http://elasticsearch:9200
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://admin:adminadmin@localhost:18083/_node" ]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+    networks:
+      - storage
+      - apim
+
+  gateway:
+    image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_TAG:-3}
+    container_name: gio_apim_gateway
+    restart: always
+    links:
+      - mongodb
+      - elasticsearch
+    depends_on:
+      mongodb:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
+    ports:
+      - "8082:8082"
+    volumes:
+      - ./.logs/apim-gateway:/opt/graviteeio-gateway/logs
+    environment:
+      - gravitee_management_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
+      - gravitee_ratelimit_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
+      - gravitee_reporters_elasticsearch_endpoints_0=http://elasticsearch:9200
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://admin:adminadmin@localhost:18082/_node" ]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+    networks:
+      - storage
+      - apim


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7597

**Description**

- [x] Add a step in the CI to build avec cache the backend docker images
- [x] Add tests docker compose to be able to use health check and rerun tests locally exactly as they are run in the CI
- [x] Run jest tests using docker compose.


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/ci-e2e-using-docker-compose-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
