### PR TITLE
fix: sync API on dynamic properties updates

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -2068,11 +2068,13 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
             final ApiEntity deployed = convert(singletonList(apiValue)).iterator().next();
 
-            notifierService.trigger(
-                ApiHook.API_DEPLOYED,
-                apiId,
-                new NotificationParamsBuilder().api(deployed).user(userService.findById(userId)).build()
-            );
+            if (userId != null) {
+                notifierService.trigger(
+                    ApiHook.API_DEPLOYED,
+                    apiId,
+                    new NotificationParamsBuilder().api(deployed).user(userService.findById(userId)).build()
+                );
+            }
 
             return deployed;
         } else {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertiesService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertiesService.java
@@ -25,6 +25,7 @@ import io.gravitee.definition.model.services.dynamicproperty.DynamicPropertyServ
 import io.gravitee.node.api.Node;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.service.ApiService;
+import io.gravitee.rest.api.service.EventService;
 import io.gravitee.rest.api.service.HttpClientService;
 import io.gravitee.rest.api.service.event.ApiEvent;
 import io.gravitee.rest.api.services.dynamicproperties.provider.http.HttpProvider;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertyUpdaterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertyUpdaterTest.java
@@ -15,17 +15,23 @@
  */
 package io.gravitee.rest.api.services.dynamicproperties;
 
+import static org.mockito.Mockito.*;
+
+import io.gravitee.definition.model.Properties;
 import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.model.api.UpdateApiEntity;
+import io.gravitee.rest.api.service.ApiService;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.services.dynamicproperties.DynamicPropertyUpdater;
 import io.gravitee.rest.api.services.dynamicproperties.model.DynamicProperty;
 import io.gravitee.rest.api.services.dynamicproperties.provider.Provider;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 /**
@@ -42,18 +48,22 @@ public class DynamicPropertyUpdaterTest {
     @Mock
     private Provider provider;
 
+    @Mock
+    ApiService apiService;
+
     @Before
     public void setUp() {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         poller = new DynamicPropertyUpdater(apiEntity);
-        Mockito.when(provider.name()).thenReturn("mock");
+        when(provider.name()).thenReturn("mock");
+        reset(provider, apiService);
         poller.setProvider(provider);
+        poller.setApiService(apiService);
     }
 
     @Test
     public void shouldNotUpdatePropertiesBecauseOfProviderException() {
-        Mockito
-            .when(provider.get())
+        when(provider.get())
             .thenReturn(
                 CompletableFuture
                     .completedFuture((Collection<DynamicProperty>) Collections.<DynamicProperty>emptyList())
@@ -69,8 +79,7 @@ public class DynamicPropertyUpdaterTest {
 
     @Test
     public void shouldUpdateProperties() {
-        Mockito
-            .when(provider.get())
+        when(provider.get())
             .thenReturn(
                 CompletableFuture.supplyAsync(
                     () -> {
@@ -80,6 +89,43 @@ public class DynamicPropertyUpdaterTest {
                 )
             );
 
+        ApiEntity api = new ApiEntity();
+        apiEntity.setId("api-id");
+        apiEntity.setProperties(new Properties());
+
+        when(apiService.findById(any())).thenReturn(api);
+        when(apiService.isSynchronized(any())).thenReturn(true);
+        when(apiService.update(eq("api-id"), any(UpdateApiEntity.class))).thenReturn(api);
+
         poller.handle(1L);
+
+        verify(apiService, times(1)).update(any(), any());
+        verify(apiService, times(1)).deploy(any(), eq(null), any(), any());
+    }
+
+    @Test
+    public void shouldNotUpdatePropertyOnUpdateError() {
+        when(provider.get())
+            .thenReturn(
+                CompletableFuture.supplyAsync(
+                    () -> {
+                        DynamicProperty property = new DynamicProperty("my-key", "my-value");
+                        return Collections.singletonList(property);
+                    }
+                )
+            );
+
+        ApiEntity api = new ApiEntity();
+        apiEntity.setId("api-id");
+        apiEntity.setProperties(new Properties());
+
+        when(apiService.findById(any())).thenReturn(api);
+        when(apiService.isSynchronized("api-id")).thenReturn(true);
+        when(apiService.update(eq("api-id"), any())).thenThrow(new TechnicalManagementException());
+
+        poller.handle(1L);
+
+        verify(apiService, times(1)).update(any(), any());
+        verify(apiService, never()).deploy(eq("api-id"), eq(null), any(), any());
     }
 }


### PR DESCRIPTION
Because the actions were taken on behalf of an unknown user (DynamicPropertiesUpdater),
the update of dynamic properties was failing when trying to notify the user with no visible error being logged.

The revision adds a check on null userIds in the update method of ApiService and do not
try to notify for null users. The AuditService will create an event for the user `system`
in that case, instead of using `DynamicPropertiesUpdater` as a user name.

When an update fails the deployment does not occurs and the error is logged.

see 
https://github.com/gravitee-io/issues/issues/7269
https://github.com/gravitee-io/issues/issues/5245

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7269-fix-dynamic-properties-updater/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
