### PR TITLE
fix(rest-api): use repository to get Metadata to avoid EnvironmentNotFoundException

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/TaskServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/TaskServiceTest.java
@@ -61,9 +61,6 @@ public class TaskServiceTest {
     private final TaskService taskService = new TaskServiceImpl();
 
     @Mock
-    private ApiService apiService;
-
-    @Mock
     private SubscriptionService subscriptionService;
 
     @Mock
@@ -92,6 +89,9 @@ public class TaskServiceTest {
 
     @Mock
     private ApiRepository apiRepository;
+
+    @Mock
+    private EnvironmentService environmentService;
 
     @Before
     public void setUp() {
@@ -164,6 +164,11 @@ public class TaskServiceTest {
         authorities.add(admin);
         when(authentication.getAuthorities()).thenReturn(authorities);
         SecurityContextHolder.setContext(new SecurityContextImpl(authentication));
+
+        final EnvironmentEntity environment = new EnvironmentEntity();
+        environment.setId(GraviteeContext.getCurrentEnvironment());
+
+        when(environmentService.findByOrganization(GraviteeContext.getCurrentOrganization())).thenReturn(List.of(environment));
 
         taskService.findAll(GraviteeContext.getExecutionContext(), "admin");
 


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7635

**Description**

use repository to get Metadata for task to avoid EnvironmentNotFoundException.

We don’t need to check permission fro metadata, i think, because it's done before to calculate tasks. 

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6070-multi-env-tasks/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
