### PR TITLE
fix(rest-api): calculate getHealthRatio only if 1w globalAvailability is not null

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiMetricsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiMetricsResource.java
@@ -92,7 +92,7 @@ public class ApiMetricsResource extends AbstractResource {
         );
         if (apiAvailability != null) {
             Map<String, Double> globalAvailability = apiAvailability.getGlobal();
-            if (globalAvailability != null) {
+            if (globalAvailability != null && globalAvailability.get("1w") != null) {
                 try {
                     return BigDecimal.valueOf(globalAvailability.get("1w")).divide(BigDecimal.valueOf(100), 4, RoundingMode.DOWN);
                 } catch (NumberFormatException nfe) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiMetricsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiMetricsResourceTest.java
@@ -170,5 +170,21 @@ public class ApiMetricsResourceTest extends AbstractResourceTest {
         assertNull(apiMetrics.getHits());
         assertNull(apiMetrics.getHealth());
         assertNull(apiMetrics.getSubscribers());
+
+        // Case 3 - with null globalAvailability 1w
+        doReturn(null).when(analyticsService).execute(any(StatsQuery.class));
+        doReturn(null).when(subscriptionService).search(any());
+        io.gravitee.rest.api.model.healthcheck.ApiMetrics<Number> mockedMetrics3 = new io.gravitee.rest.api.model.healthcheck.ApiMetrics<>();
+        mockedMetrics.setGlobal(Collections.singletonMap("1w", null));
+        doReturn(mockedMetrics3).when(healthCheckService).getAvailability(any(), any());
+
+        response = target(API).path("metrics").request().get();
+        assertEquals(OK_200, response.getStatus());
+
+        apiMetrics = response.readEntity(ApiMetrics.class);
+        assertNotNull(apiMetrics);
+        assertNull(apiMetrics.getHits());
+        assertNull(apiMetrics.getHealth());
+        assertNull(apiMetrics.getSubscribers());
     }
 }


### PR DESCRIPTION
**Issue**
https://github.com/gravitee-io/issues/issues/7231
https://graviteesource.zendesk.com/agent/tickets/3691
https://graviteesource.zendesk.com/agent/tickets/4027

**Description**

⚠️ I've not reproduce this error. but with the trace of this two issue i think this fix correct this bug. 

I tried (a little) to understand  why this value is null at times but without success. 
but in any case I think that this part must be resilient to these errors ( considering the existing try/catch)

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wfnnzlxhko.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7231/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
