### PR TITLE
bump reporters version

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -104,11 +104,11 @@
         <gravitee-fetcher-gitlab.version>1.11.0</gravitee-fetcher-gitlab.version>
         <gravitee-fetcher-http.version>1.12.0</gravitee-fetcher-http.version>
         <!-- Gateway Only -->
-        <gravitee-reporter-elasticsearch.version>3.11.0</gravitee-reporter-elasticsearch.version>
+        <gravitee-reporter-elasticsearch.version>3.12.0</gravitee-reporter-elasticsearch.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->
         <!--    <gravitee-gateway-services-ratelimit.version>1.15.0</gravitee-gateway-services-ratelimit.version>    -->
-        <gravitee-reporter-file.version>2.5.0</gravitee-reporter-file.version>
-        <gravitee-reporter-tcp.version>1.4.0</gravitee-reporter-tcp.version>
+        <gravitee-reporter-file.version>2.5.1</gravitee-reporter-file.version>
+        <gravitee-reporter-tcp.version>1.4.1</gravitee-reporter-tcp.version>
         <gravitee-tracer-jaeger.version>1.1.0</gravitee-tracer-jaeger.version>
     </properties>
 


### PR DESCRIPTION
**Issue**

N/A

**Description**

- File & TCP reporters have been fixed to use the latest version of gravitee-bom (and avoid a -SNAPSHOT dependency)
- Elasticsearch reporter was not the latest available
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/bump-reporters-version/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
