### PR TITLE
[APIM Console] APIs not showing in a selected User when the Group they are in is Updated.

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
@@ -18,8 +18,7 @@ package io.gravitee.rest.api.service.impl;
 import static io.gravitee.repository.management.model.Membership.AuditEvent.MEMBERSHIP_CREATED;
 import static io.gravitee.repository.management.model.Membership.AuditEvent.MEMBERSHIP_DELETED;
 import static io.gravitee.rest.api.model.permissions.SystemRole.PRIMARY_OWNER;
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.singleton;
+import static java.util.Collections.*;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
@@ -28,11 +27,16 @@ import com.google.common.cache.CacheBuilder;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.common.event.EventManager;
 import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiFieldInclusionFilter;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.repository.management.api.MembershipRepository;
 import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldExclusionFilter;
+import io.gravitee.repository.management.api.search.ApplicationCriteria;
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.repository.management.model.ApiLifecycleState;
+import io.gravitee.repository.management.model.Application;
 import io.gravitee.repository.management.model.Audit;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.alert.ApplicationAlertEventType;
@@ -771,22 +775,30 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 );
             Set<UserMembership> userMemberships = new HashSet<>(userMembershipMap.values());
 
+            // Find all application Ids and api Ids liked to all user groups
             if (type.equals(MembershipReferenceType.APPLICATION) || type.equals(MembershipReferenceType.API)) {
-                Set<GroupEntity> userGroups = groupService.findByUser(userId);
-                for (GroupEntity group : userGroups) {
+                String[] groupIds = groupService.findByUser(userId).stream().map(GroupEntity::getId).toArray(String[]::new);
+
+                List<String> resourceIds = new ArrayList<>();
+
+                if (type.equals(MembershipReferenceType.APPLICATION)) {
+                    Set<Application> groupApplications = applicationRepository.findByGroups(List.of(groupIds));
+                    groupApplications.forEach(application -> resourceIds.add(application.getId()));
+                } else if (type.equals(MembershipReferenceType.API)) {
+                    ApiCriteria criteria = new ApiCriteria.Builder().groups(groupIds).build();
+                    Set<Api> groupApis = apiRepository.search(criteria, ApiFieldInclusionFilter.builder().build());
+                    groupApis.forEach(api -> resourceIds.add(api.getId()));
+                }
+
+                if (!resourceIds.isEmpty()) {
                     userMemberships.addAll(
-                        membershipRepository
-                            .findByMemberIdAndMemberTypeAndReferenceType(
-                                group.getId(),
-                                io.gravitee.repository.management.model.MembershipMemberType.GROUP,
-                                convert(type)
-                            )
+                        resourceIds
                             .stream()
                             .map(
-                                membership -> {
+                                id -> {
                                     UserMembership userMembership = new UserMembership();
                                     userMembership.setType(type.name());
-                                    userMembership.setReference(membership.getReferenceId());
+                                    userMembership.setReference(id);
                                     return userMembership;
                                 }
                             )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/GroupService_DeleteTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/GroupService_DeleteTest.java
@@ -1,0 +1,220 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service;
+
+import static io.gravitee.repository.management.model.Group.AuditEvent.GROUP_DELETED;
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.common.event.EventManager;
+import io.gravitee.common.util.Maps;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.api.ApplicationRepository;
+import io.gravitee.repository.management.api.GroupRepository;
+import io.gravitee.repository.management.api.PageRepository;
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.api.search.ApplicationCriteria;
+import io.gravitee.repository.management.api.search.PageCriteria;
+import io.gravitee.repository.management.model.AccessControl;
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.repository.management.model.Group;
+import io.gravitee.repository.management.model.Page;
+import io.gravitee.rest.api.model.*;
+import io.gravitee.rest.api.model.alert.ApplicationAlertEventType;
+import io.gravitee.rest.api.model.alert.ApplicationAlertMembershipEvent;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.model.permissions.SystemRole;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.GroupNotFoundException;
+import io.gravitee.rest.api.service.exceptions.InstallationNotFoundException;
+import io.gravitee.rest.api.service.exceptions.StillPrimaryOwnerException;
+import io.gravitee.rest.api.service.impl.GroupServiceImpl;
+import java.util.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class GroupService_DeleteTest {
+
+    private static final String ENVIRONMENT_ID = "my-group-id";
+    private static final String GROUP_ID = "my-group-id";
+
+    @InjectMocks
+    private final GroupService groupService = new GroupServiceImpl();
+
+    @Mock
+    private GroupRepository groupRepository;
+
+    @Mock
+    private ApiRepository apiRepository;
+
+    @Mock
+    private ApplicationRepository applicationRepository;
+
+    @Mock
+    private PageRepository pageRepository;
+
+    @Mock
+    private MembershipService membershipService;
+
+    @Mock
+    private PermissionService permissionService;
+
+    @Mock
+    private RoleService roleService;
+
+    @Mock
+    private AuditService auditService;
+
+    @Mock
+    private EventManager eventManager;
+
+    @Test(expected = GroupNotFoundException.class)
+    public void throwGroupNotFoundException() throws Exception {
+        when(groupRepository.findById(GROUP_ID)).thenReturn(Optional.empty());
+        groupService.delete(ENVIRONMENT_ID, GROUP_ID);
+    }
+
+    @Test(expected = StillPrimaryOwnerException.class)
+    public void throwStillPrimaryOwnerException() throws Exception {
+        when(groupRepository.findById(GROUP_ID)).thenReturn(Optional.of(Mockito.mock(Group.class)));
+
+        RoleEntity role = new RoleEntity();
+        role.setId("API_PRIMARY_OWNER_ID");
+        when(roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name())).thenReturn(Optional.of(role));
+        when(
+            membershipService.getMembershipsByMemberAndReferenceAndRole(
+                MembershipMemberType.GROUP,
+                GROUP_ID,
+                MembershipReferenceType.API,
+                "API_PRIMARY_OWNER_ID"
+            )
+        )
+            .thenReturn(Set.of(new MembershipEntity()));
+
+        groupService.delete(ENVIRONMENT_ID, GROUP_ID);
+    }
+
+    @Test
+    public void shouldDeleteGroup() throws Exception {
+        when(groupRepository.findById(GROUP_ID)).thenReturn(Optional.of(Mockito.mock(Group.class)));
+
+        RoleEntity role = new RoleEntity();
+        role.setId("API_PRIMARY_OWNER_ID");
+        when(roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name())).thenReturn(Optional.of(role));
+
+        when(
+            membershipService.getMembershipsByMemberAndReferenceAndRole(
+                MembershipMemberType.GROUP,
+                GROUP_ID,
+                MembershipReferenceType.API,
+                "API_PRIMARY_OWNER_ID"
+            )
+        )
+            .thenReturn(Collections.emptySet());
+
+        when(apiRepository.search(new ApiCriteria.Builder().environmentId(ENVIRONMENT_ID).groups(GROUP_ID).build()))
+            .thenReturn(Collections.emptyList());
+
+        when(applicationRepository.findByGroups(Collections.singletonList(GROUP_ID))).thenReturn(Collections.emptySet());
+
+        when(pageRepository.search(new PageCriteria.Builder().build())).thenReturn(Collections.emptyList());
+
+        groupService.delete(ENVIRONMENT_ID, GROUP_ID);
+
+        verify(membershipService, times(1))
+            .deleteReference(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
+                eq(MembershipReferenceType.GROUP),
+                eq(GROUP_ID)
+            );
+
+        verify(membershipService, times(1))
+            .deleteReferenceMember(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
+                eq(MembershipReferenceType.API),
+                eq(null),
+                eq(MembershipMemberType.GROUP),
+                eq(GROUP_ID)
+            );
+
+        verify(membershipService, times(1))
+            .deleteReferenceMember(
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment()),
+                eq(MembershipReferenceType.APPLICATION),
+                eq(null),
+                eq(MembershipMemberType.GROUP),
+                eq(GROUP_ID)
+            );
+
+        verify(eventManager, times(1))
+            .publishEvent(eq(ApplicationAlertEventType.APPLICATION_MEMBERSHIP_UPDATE), any(ApplicationAlertMembershipEvent.class));
+
+        verify(groupRepository, times(1)).delete(eq(GROUP_ID));
+
+        verify(auditService, times(1)).createEnvironmentAuditLog(eq(ENVIRONMENT_ID), any(), eq(GROUP_DELETED), any(), any(), eq(null));
+    }
+
+    @Test
+    public void shouldDeleteGroupWithAccessControl() throws Exception {
+        when(groupRepository.findById(GROUP_ID)).thenReturn(Optional.of(Mockito.mock(Group.class)));
+
+        RoleEntity role = new RoleEntity();
+        role.setId("API_PRIMARY_OWNER_ID");
+        when(roleService.findByScopeAndName(RoleScope.API, SystemRole.PRIMARY_OWNER.name())).thenReturn(Optional.of(role));
+
+        when(
+            membershipService.getMembershipsByMemberAndReferenceAndRole(
+                MembershipMemberType.GROUP,
+                GROUP_ID,
+                MembershipReferenceType.API,
+                "API_PRIMARY_OWNER_ID"
+            )
+        )
+            .thenReturn(Collections.emptySet());
+
+        when(apiRepository.search(new ApiCriteria.Builder().environmentId(ENVIRONMENT_ID).groups(GROUP_ID).build()))
+            .thenReturn(Collections.emptyList());
+
+        when(applicationRepository.findByGroups(Collections.singletonList(GROUP_ID))).thenReturn(Collections.emptySet());
+
+        Page page = new Page();
+        AccessControl accessControlToRemove = new AccessControl();
+        accessControlToRemove.setReferenceType("GROUP");
+        accessControlToRemove.setReferenceId(GROUP_ID);
+        AccessControl accessControlToKeep = new AccessControl();
+        page.setAccessControls(new HashSet<>(Set.of(accessControlToRemove, accessControlToKeep)));
+        when(pageRepository.search(new PageCriteria.Builder().build())).thenReturn(List.of(page));
+
+        groupService.delete(ENVIRONMENT_ID, GROUP_ID);
+
+        verify(pageRepository, times(1)).update(argThat(arg -> arg.getAccessControls().size() == 1));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/MembershipService_FindUserMembershipTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/MembershipService_FindUserMembershipTest.java
@@ -16,15 +16,20 @@
 package io.gravitee.rest.api.service;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import com.google.common.collect.Sets;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.repository.management.api.ApiFieldInclusionFilter;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.repository.management.api.MembershipRepository;
-import io.gravitee.repository.management.model.Membership;
-import io.gravitee.repository.management.model.MembershipMemberType;
-import io.gravitee.repository.management.model.MembershipReferenceType;
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.api.search.ApplicationCriteria;
+import io.gravitee.repository.management.model.*;
 import io.gravitee.rest.api.model.GroupEntity;
 import io.gravitee.rest.api.model.RoleEntity;
 import io.gravitee.rest.api.model.UserMembership;
@@ -55,6 +60,12 @@ public class MembershipService_FindUserMembershipTest {
     private MembershipRepository mockMembershipRepository;
 
     @Mock
+    private ApiRepository mockApiRepository;
+
+    @Mock
+    private ApplicationRepository mockApplicationRepository;
+
+    @Mock
     private GroupService mockGroupService;
 
     @Mock
@@ -71,7 +82,7 @@ public class MembershipService_FindUserMembershipTest {
     }
 
     @Test
-    public void shouldGetEmptyResultIfNoApiNorGroups() throws Exception {
+    public void shouldGetEmptyResultIfNoApiorGroups() throws Exception {
         when(mockRoleService.findByScope(any())).thenReturn(Collections.emptyList());
         when(
             mockMembershipRepository.findByMemberIdAndMemberTypeAndReferenceType(
@@ -127,8 +138,6 @@ public class MembershipService_FindUserMembershipTest {
     @Test
     public void shouldGetApiWithOnlyGroups() throws Exception {
         when(mockRoleService.findByScope(any())).thenReturn(Collections.emptyList());
-        Membership mGroup = mock(Membership.class);
-        when(mGroup.getReferenceId()).thenReturn("api-id2");
 
         when(
             mockMembershipRepository.findByMemberIdAndMemberTypeAndReferenceType(
@@ -139,17 +148,14 @@ public class MembershipService_FindUserMembershipTest {
         )
             .thenReturn(Collections.emptySet());
 
-        when(
-            mockMembershipRepository.findByMemberIdAndMemberTypeAndReferenceType(
-                eq("GROUP"),
-                eq(MembershipMemberType.GROUP),
-                eq(MembershipReferenceType.API)
-            )
-        )
-            .thenReturn(Collections.singleton(mGroup));
-        GroupEntity group1 = mock(GroupEntity.class);
-        doReturn("GROUP").when(group1).getId();
-        doReturn(new HashSet<>(asList(group1))).when(mockGroupService).findByUser(USER_ID);
+        GroupEntity group1 = new GroupEntity();
+        group1.setId("Group1Id");
+        when(mockGroupService.findByUser(eq(USER_ID))).thenReturn(new HashSet<>(asList(group1)));
+
+        Api api = new Api();
+        api.setId("apiGroup1Id");
+        when(mockApiRepository.search(eq(new ApiCriteria.Builder().groups("Group1Id").build()), (ApiFieldInclusionFilter) any()))
+            .thenReturn(new HashSet<>(asList(api)));
 
         List<UserMembership> references = membershipService.findUserMembership(
             io.gravitee.rest.api.model.MembershipReferenceType.API,
@@ -158,7 +164,7 @@ public class MembershipService_FindUserMembershipTest {
 
         assertFalse(references.isEmpty());
         assertEquals(1, references.size());
-        assertEquals("api-id2", references.get(0).getReference());
+        assertEquals("apiGroup1Id", references.get(0).getReference());
         assertEquals("API", references.get(0).getType());
     }
 
@@ -173,10 +179,6 @@ public class MembershipService_FindUserMembershipTest {
         when(mApi.getReferenceId()).thenReturn("api-id1");
         when(mApi.getRoleId()).thenReturn("role");
 
-        Membership mGroup = mock(Membership.class);
-        when(mGroup.getReferenceId()).thenReturn("api-id2");
-        when(mApi.getRoleId()).thenReturn("role");
-
         when(
             mockMembershipRepository.findByMemberIdAndMemberTypeAndReferenceType(
                 eq(USER_ID),
@@ -186,17 +188,14 @@ public class MembershipService_FindUserMembershipTest {
         )
             .thenReturn(Collections.singleton(mApi));
 
-        when(
-            mockMembershipRepository.findByMemberIdAndMemberTypeAndReferenceType(
-                eq("GROUP"),
-                eq(MembershipMemberType.GROUP),
-                eq(MembershipReferenceType.API)
-            )
-        )
-            .thenReturn(Collections.singleton(mGroup));
-        GroupEntity group1 = mock(GroupEntity.class);
-        doReturn("GROUP").when(group1).getId();
-        doReturn(new HashSet<>(asList(group1))).when(mockGroupService).findByUser(USER_ID);
+        GroupEntity group1 = new GroupEntity();
+        group1.setId("Group1Id");
+        when(mockGroupService.findByUser(eq(USER_ID))).thenReturn(new HashSet<>(asList(group1)));
+
+        Api api = new Api();
+        api.setId("apiGroup1Id");
+        when(mockApiRepository.search(eq(new ApiCriteria.Builder().groups("Group1Id").build()), (ApiFieldInclusionFilter) any()))
+            .thenReturn(new HashSet<>(asList(api)));
 
         List<UserMembership> references = membershipService.findUserMembership(
             io.gravitee.rest.api.model.MembershipReferenceType.API,
@@ -206,8 +205,8 @@ public class MembershipService_FindUserMembershipTest {
         assertFalse(references.isEmpty());
         assertEquals(2, references.size());
         assertNotEquals(references.get(0).getReference(), references.get(1).getReference());
-        assertTrue(references.get(0).getReference().equals("api-id1") || references.get(0).getReference().equals("api-id2"));
-        assertTrue(references.get(1).getReference().equals("api-id1") || references.get(1).getReference().equals("api-id2"));
+        assertEquals(references.get(0).getReference(), "api-id1");
+        assertEquals(references.get(1).getReference(), "apiGroup1Id");
         assertEquals("API", references.get(0).getType());
     }
 
@@ -254,5 +253,37 @@ public class MembershipService_FindUserMembershipTest {
         assertNotEquals(references.get(0).getReference(), references.get(1).getReference());
         assertTrue(references.get(0).getReference().equals("api-id1") || references.get(0).getReference().equals("app-id1"));
         assertTrue(references.get(1).getReference().equals("api-id1") || references.get(1).getReference().equals("app-id1"));
+    }
+
+    @Test
+    public void shouldGetApplicationWithOnlyGroups() throws Exception {
+        when(mockRoleService.findByScope(any())).thenReturn(Collections.emptyList());
+
+        when(
+            mockMembershipRepository.findByMemberIdAndMemberTypeAndReferenceType(
+                eq(USER_ID),
+                eq(MembershipMemberType.USER),
+                eq(MembershipReferenceType.APPLICATION)
+            )
+        )
+            .thenReturn(Collections.emptySet());
+
+        GroupEntity group1 = new GroupEntity();
+        group1.setId("Group1Id");
+        when(mockGroupService.findByUser(eq(USER_ID))).thenReturn(new HashSet<>(asList(group1)));
+
+        Application application = new Application();
+        application.setId("applicationGroup1Id");
+        when(mockApplicationRepository.findByGroups(eq(List.of("Group1Id")))).thenReturn(new HashSet<>(asList(application)));
+
+        List<UserMembership> references = membershipService.findUserMembership(
+            io.gravitee.rest.api.model.MembershipReferenceType.APPLICATION,
+            USER_ID
+        );
+
+        assertFalse(references.isEmpty());
+        assertEquals(1, references.size());
+        assertEquals("applicationGroup1Id", references.get(0).getReference());
+        assertEquals("APPLICATION", references.get(0).getType());
     }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7285

**Description**

- Rest-Api:  find all application & api to all user groups correctly

> The previous code has two bad behaviors:
> - find link between api or app inside membership repository -> this link is not made here, this link is made by the group ids inside api or application entity
> - this code return default membership used by setting group to init "Default API Role" & "Default Application Role" on "Add member" -> these are not user roles

- delete default group role & pages accessControls with group 

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7285-user-group-bug/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
