### PR TITLE
fix: use the same node version in jest-e2e as .nvmrc

### DIFF
--- a/docker/test/api-tests/docker-compose-api-tests.yml
+++ b/docker/test/api-tests/docker-compose-api-tests.yml
@@ -18,7 +18,7 @@ version: '3.8'
 
 services:
   jest-e2e:
-    image: cimg/node:lts
+    image: cimg/node:16.10
     working_dir: /test
     volumes:
       - ./gravitee-apim-e2e:/test


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7597

**Description**

fix ci cimg node image as it looks like the lts one is broken
