### PR TITLE
feat(jupiter): support jupiter and v3 execution modes

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/GatewayConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/GatewayConfiguration.java
@@ -30,6 +30,9 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 public class GatewayConfiguration implements InitializingBean {
 
+    public static final boolean JUPITER_MODE_ENABLED_BY_DEFAULT = false;
+    public static final String JUPITER_MODE_ENABLED_KEY = "api.jupiterMode.enabled";
+
     static final String SHARDING_TAGS_SYSTEM_PROPERTY = "tags";
     private static final String SHARDING_TAGS_SEPARATOR = ",";
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactor.java
@@ -20,6 +20,7 @@ import static io.gravitee.gateway.reactive.api.ExecutionPhase.RESPONSE;
 import static io.reactivex.Completable.defer;
 
 import io.gravitee.common.component.AbstractLifecycleComponent;
+import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.gateway.api.handler.Handler;
 import io.gravitee.gateway.core.endpoint.lifecycle.GroupLifecycleManager;
 import io.gravitee.gateway.handlers.api.definition.Api;
@@ -88,6 +89,11 @@ public class SyncApiReactor extends AbstractLifecycleComponent<ReactorHandler> i
             new FlowChain("Platform", FlowResolverFactory.forPlatform(api, organizationManager), platformPolicyChainFactory);
         this.apiPlanFlowChain = new FlowChain("Api Plan", FlowResolverFactory.forApiPlan(api), policyChainFactory);
         this.apiFlowChain = new FlowChain("Api", FlowResolverFactory.forApi(api), policyChainFactory);
+    }
+
+    @Override
+    public ExecutionMode executionMode() {
+        return ExecutionMode.JUPITER;
     }
 
     @Override
@@ -237,13 +243,6 @@ public class SyncApiReactor extends AbstractLifecycleComponent<ReactorHandler> i
     }
 
     @Override
-    public SyncApiReactor handler(Handler<io.gravitee.gateway.api.ExecutionContext> handler) {
-        throw new RuntimeException(
-            "Handler method is here for compatibility only byt must not be called. Invoke handle(SyncRequest, SyncResponse) instead."
-        );
-    }
-
-    @Override
     protected void doStart() throws Exception {
         log.debug("API handler is now starting, preparing API context...");
         long startTime = System.currentTimeMillis(); // Get the start Time
@@ -294,7 +293,7 @@ public class SyncApiReactor extends AbstractLifecycleComponent<ReactorHandler> i
     }
 
     @Override
-    public void handle(io.gravitee.gateway.api.ExecutionContext result) {
+    public void handle(io.gravitee.gateway.api.ExecutionContext ctx, Handler<io.gravitee.gateway.api.ExecutionContext> endHandler) {
         throw new RuntimeException(new IllegalAccessException("Handle method can be called on SyncApiReactor"));
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/adapter/condition/ConditionEvaluatorAdapterTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/adapter/condition/ConditionEvaluatorAdapterTest.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.gateway.reactive.handlers.api.adapter.condition;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/utils/WebSocketUtils.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/utils/WebSocketUtils.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.gateway.standalone.vertx.ws.utils;
+package io.gravitee.gateway.http.utils;
 
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.vertx.core.http.HttpMethod;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/ws/VertxWebSocket.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/ws/VertxWebSocket.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.gateway.standalone.vertx.ws;
+package io.gravitee.gateway.http.vertx.ws;
 
 import io.gravitee.gateway.api.handler.Handler;
 import io.gravitee.gateway.api.ws.WebSocket;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/ws/VertxWebSocketFrame.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/ws/VertxWebSocketFrame.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.gateway.standalone.vertx.ws;
+package io.gravitee.gateway.http.vertx.ws;
 
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.ws.WebSocketFrame;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/ws/VertxWebSocketServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/ws/VertxWebSocketServerRequest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.gateway.standalone.vertx.ws;
+package io.gravitee.gateway.http.vertx.ws;
 
 import io.gravitee.common.http.IdGenerator;
 import io.gravitee.gateway.api.Request;
@@ -30,7 +30,7 @@ public class VertxWebSocketServerRequest extends VertxHttpServerRequest {
 
     private final VertxWebSocket vertxWebSocket;
 
-    VertxWebSocketServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator) {
+    public VertxWebSocketServerRequest(HttpServerRequest httpServerRequest, IdGenerator idGenerator) {
         super(httpServerRequest, idGenerator);
         this.vertxWebSocket = new VertxWebSocket(httpServerRequest);
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/ws/VertxWebSocketServerResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/ws/VertxWebSocketServerResponse.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.gateway.standalone.vertx.ws;
+package io.gravitee.gateway.http.vertx.ws;
 
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.ws.WebSocket;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/reactive/http/vertx/VertxHttpServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/reactive/http/vertx/VertxHttpServerRequest.java
@@ -72,6 +72,10 @@ public class VertxHttpServerRequest implements Request {
                 .cache();
     }
 
+    public VertxHttpServerResponse response() {
+        return new VertxHttpServerResponse(this);
+    }
+
     @Override
     public String id() {
         return id;
@@ -197,7 +201,10 @@ public class VertxHttpServerRequest implements Request {
 
     @Override
     public Maybe<Buffer> body() {
-        return chunks.reduce(Buffer::appendBuffer);
+        // Reduce all the chunks to create a unique buffer containing all the content.
+        final Maybe<Buffer> buffer = chunks().reduce(Buffer::appendBuffer);
+        this.chunks = buffer.toFlowable();
+        return buffer;
     }
 
     @Override
@@ -234,11 +241,11 @@ public class VertxHttpServerRequest implements Request {
     }
 
     @Override
-    public synchronized Completable chunks(final Flowable<Buffer> chunks) {
+    public Completable chunks(final Flowable<Buffer> chunks) {
         return setChunks(chunks);
     }
 
-    private synchronized Completable setChunks(Flowable<Buffer> chunks) {
+    private Completable setChunks(Flowable<Buffer> chunks) {
         return onChunk(upstream -> chunks);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/DefaultPolicyChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/DefaultPolicyChainFactory.java
@@ -29,6 +29,7 @@ import io.gravitee.node.cache.standalone.StandaloneCache;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -76,6 +77,7 @@ public class DefaultPolicyChainFactory implements PolicyChainFactory {
                 .filter(Step::isEnabled)
                 .map(step -> new PolicyMetadata(step.getPolicy(), step.getConfiguration(), step.getCondition()))
                 .map(policyMetadata -> policyManager.create(phase, policyMetadata))
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
 
             policyChain = new PolicyChain(flow.getName() + " " + phase.name(), policies, phase);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/reactive/policy/PolicyChainTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/reactive/policy/PolicyChainTest.java
@@ -18,10 +18,9 @@ package io.gravitee.gateway.reactive.policy;
 import static java.util.Arrays.asList;
 import static org.mockito.Mockito.*;
 
+import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.gateway.reactive.api.ExecutionPhase;
-import io.gravitee.gateway.reactive.api.context.ExecutionContext;
-import io.gravitee.gateway.reactive.api.context.MessageExecutionContext;
-import io.gravitee.gateway.reactive.api.context.RequestExecutionContext;
+import io.gravitee.gateway.reactive.api.context.*;
 import io.gravitee.gateway.reactive.api.policy.Policy;
 import io.gravitee.gateway.reactive.reactor.handler.message.DefaultMessageFlow;
 import io.reactivex.Completable;
@@ -39,11 +38,12 @@ class PolicyChainTest {
 
     protected static final String CHAIN_ID = "unit-test";
     protected static final String MOCK_ERROR_MESSAGE = "Mock error";
+    protected static final String MOCK_STATUS_ERROR_MESSAGE = "Mock error on status";
 
     @Test
     public void shouldExecuteNothingWithEmptyPolicyList() {
         PolicyChain cut = new PolicyChain(CHAIN_ID, new ArrayList<>(), ExecutionPhase.REQUEST);
-        final ExecutionContext ctx = mock(ExecutionContext.class);
+        final RequestExecutionContext ctx = mock(RequestExecutionContext.class);
         final TestObserver<Void> obs = cut.execute(ctx).test();
 
         obs.assertComplete();
@@ -184,21 +184,49 @@ class PolicyChainTest {
     }
 
     @Test
-    public void shouldExecuteOnlyPolicy1IfError() {
+    public void shouldExecuteOnlyPolicy1AndInterruptWhenPolicy1Error() {
         final Policy policy1 = mock(Policy.class);
         final Policy policy2 = mock(Policy.class);
         final RequestExecutionContext ctx = mock(RequestExecutionContext.class);
 
         final PolicyChain cut = new PolicyChain(CHAIN_ID, asList(policy1, policy2), ExecutionPhase.REQUEST);
 
+        final Response response = mock(Response.class);
+        when(ctx.response()).thenReturn(response);
         when(policy1.onRequest(ctx)).thenReturn(Completable.error(new RuntimeException(MOCK_ERROR_MESSAGE)));
 
         final TestObserver<Void> obs = cut.execute(ctx).test();
-        obs.assertErrorMessage(MOCK_ERROR_MESSAGE);
+        obs.assertResult();
 
         verify(policy1).onRequest(ctx);
         verify(policy1).getId();
-
         verifyNoMoreInteractions(policy1, policy2);
+
+        verify(ctx).interrupt();
+        verify(response).status(HttpStatusCode.INTERNAL_SERVER_ERROR_500);
+    }
+
+    @Test
+    public void shouldErrorWhenUnableToSetStatusWhileHandlingInterruptionOnPolicyError() {
+        final Policy policy1 = mock(Policy.class);
+        final Policy policy2 = mock(Policy.class);
+        final RequestExecutionContext ctx = mock(RequestExecutionContext.class);
+
+        final PolicyChain cut = new PolicyChain(CHAIN_ID, asList(policy1, policy2), ExecutionPhase.REQUEST);
+
+        final Response response = mock(Response.class);
+        when(ctx.response()).thenReturn(response);
+        when(response.status(HttpStatusCode.INTERNAL_SERVER_ERROR_500)).thenThrow(new RuntimeException(MOCK_STATUS_ERROR_MESSAGE));
+
+        when(policy1.onRequest(ctx)).thenReturn(Completable.error(new RuntimeException(MOCK_ERROR_MESSAGE)));
+
+        final TestObserver<Void> obs = cut.execute(ctx).test();
+        obs.assertErrorMessage(MOCK_STATUS_ERROR_MESSAGE);
+
+        verify(policy1).onRequest(ctx);
+        verify(policy1).getId();
+        verifyNoMoreInteractions(policy1, policy2);
+
+        verify(ctx).interrupt();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
@@ -18,26 +18,41 @@ package io.gravitee.gateway.reactive.reactor;
 import io.gravitee.common.event.Event;
 import io.gravitee.common.event.EventListener;
 import io.gravitee.common.event.EventManager;
+import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.http.IdGenerator;
+import io.gravitee.common.http.MediaType;
 import io.gravitee.common.service.AbstractService;
+import io.gravitee.definition.model.ExecutionMode;
+import io.gravitee.gateway.api.context.SimpleExecutionContext;
 import io.gravitee.gateway.env.GatewayConfiguration;
-import io.gravitee.gateway.reactive.api.context.Request;
-import io.gravitee.gateway.reactive.api.context.Response;
+import io.gravitee.gateway.http.utils.WebSocketUtils;
+import io.gravitee.gateway.http.vertx.VertxHttp2ServerRequest;
+import io.gravitee.gateway.http.vertx.grpc.VertxGrpcServerRequest;
+import io.gravitee.gateway.http.vertx.ws.VertxWebSocketServerRequest;
+import io.gravitee.gateway.reactive.api.context.ExecutionContext;
 import io.gravitee.gateway.reactive.http.vertx.VertxHttpServerRequest;
-import io.gravitee.gateway.reactive.http.vertx.VertxHttpServerResponse;
 import io.gravitee.gateway.reactive.reactor.handler.EntrypointResolver;
 import io.gravitee.gateway.reactor.Reactable;
 import io.gravitee.gateway.reactor.ReactorEvent;
+import io.gravitee.gateway.reactor.handler.HandlerEntrypoint;
 import io.gravitee.gateway.reactor.handler.ReactorHandler;
 import io.gravitee.gateway.reactor.handler.ReactorHandlerRegistry;
+import io.gravitee.reporter.api.http.Metrics;
 import io.reactivex.Completable;
-import io.reactivex.Maybe;
+import io.vertx.core.http.HttpVersion;
+import io.vertx.reactivex.core.http.HttpHeaders;
 import io.vertx.reactivex.core.http.HttpServerRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
+ * Request dispatcher responsible to dispatch any HTTP request to the appropriate {@link io.gravitee.gateway.reactor.handler.ReactorHandler}.
+ * The execution mode depends on the entrypoint resolved and the associated handler:
+ * <ul>
+ *     <li>{@link ExecutionMode#JUPITER}: request is handled by an instance of {@link ApiReactor}</li>
+ *     <li>{@link ExecutionMode#V3}: request is handled by an instance of {@link ReactorHandler}</li>
+ * </ul>
+ *
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
@@ -46,57 +61,157 @@ public class DefaultHttpRequestDispatcher
     implements HttpRequestDispatcher, EventListener<ReactorEvent, Reactable> {
 
     private final Logger log = LoggerFactory.getLogger(DefaultHttpRequestDispatcher.class);
+    public static final String ATTR_ENTRYPOINT = ExecutionContext.ATTR_PREFIX + "entrypoint";
+
+    private final EventManager eventManager;
+    private final GatewayConfiguration gatewayConfiguration;
+    private final ReactorHandlerRegistry reactorHandlerRegistry;
+    private final EntrypointResolver entrypointResolver;
     private final IdGenerator idGenerator;
 
-    @Autowired
-    protected EventManager eventManager;
-
-    @Autowired
-    protected GatewayConfiguration gatewayConfiguration;
-
-    @Autowired
-    private ReactorHandlerRegistry reactorHandlerRegistry;
-
-    @Autowired
-    private EntrypointResolver entrypointResolver;
-
-    public DefaultHttpRequestDispatcher(IdGenerator idGenerator) {
+    public DefaultHttpRequestDispatcher(
+        EventManager eventManager,
+        GatewayConfiguration gatewayConfiguration,
+        ReactorHandlerRegistry reactorHandlerRegistry,
+        EntrypointResolver entrypointResolver,
+        IdGenerator idGenerator
+    ) {
+        this.eventManager = eventManager;
+        this.gatewayConfiguration = gatewayConfiguration;
+        this.reactorHandlerRegistry = reactorHandlerRegistry;
+        this.entrypointResolver = entrypointResolver;
         this.idGenerator = idGenerator;
     }
 
+    /**
+     * {@inheritDoc}
+     * Each incoming request is dispatched respecting the following step order:
+     * <ul>
+     *     <li>Pre-processors: executes all global pre-processors (transactionId, ...).</li>
+     *     <li>Api resolution: resolves the {@link ReactorHandler} that is able to handle the request based on the request host path.</li>
+     *     <li>Api request: invokes the V3 or Jupiter {@link ReactorHandler} to handle the api request. Eventually, handle not found if no handler has been resolved.</li>
+     *     <li>Post-processors: executes all global post-processors (reporters, ...).
+     * </ul>
+     */
     @Override
     public Completable dispatch(HttpServerRequest httpServerRequest) {
+        // FIXME: run global pre-processors.
         log.debug("Dispatching request on host {} and path {}", httpServerRequest.host(), httpServerRequest.path());
-        return Maybe
-            .fromCallable(() -> entrypointResolver.resolve(httpServerRequest.host(), httpServerRequest.path()))
-            .flatMapCompletable(
-                handlerEntrypoint -> {
-                    final ReactorHandler target = handlerEntrypoint.target();
 
-                    // TODO: NotFoundHandler to make it work like an api and avoid creating a NotFoundProcessor;
+        final HandlerEntrypoint handlerEntrypoint = entrypointResolver.resolve(httpServerRequest.host(), httpServerRequest.path());
 
-                    if (target instanceof ApiReactor) {
-                        // For now, supports only sync requests.
-                        VertxHttpServerRequest request = new VertxHttpServerRequest(
-                            httpServerRequest,
-                            handlerEntrypoint.path(),
-                            idGenerator
-                        );
-                        VertxHttpServerResponse response = new VertxHttpServerResponse(request);
+        Completable dispatchObs;
 
-                        // Set gateway tenant
-                        gatewayConfiguration.tenant().ifPresent(tenant -> request.metrics().setTenant(tenant));
+        if (handlerEntrypoint == null || handlerEntrypoint.target() == null) {
+            // FIXME: Handle Not Found when no api has been resolved for the targeted host and path.
+            dispatchObs = handleNotFound(httpServerRequest);
+        } else if (handlerEntrypoint.executionMode() == ExecutionMode.JUPITER) {
+            // Jupiter execution mode.
+            dispatchObs = handleJupiterRequest(httpServerRequest, handlerEntrypoint);
+        } else {
+            // V3 execution mode.
+            dispatchObs = handleV3Request(httpServerRequest, handlerEntrypoint);
+        }
 
-                        // Set gateway zone
-                        gatewayConfiguration.zone().ifPresent(zone -> request.metrics().setZone(zone));
+        return dispatchObs;
+        // FIXME: run global post-processors.
+    }
 
-                        return ((ApiReactor) target).handle(request, response);
-                    } else {
-                        // TODO: Handle v3 compatibility.
-                        return httpServerRequest.response().rxEnd();
+    private Completable handleJupiterRequest(HttpServerRequest httpServerRequest, HandlerEntrypoint handlerEntrypoint) {
+        final ApiReactor apiReactor = handlerEntrypoint.target();
+
+        // For now, supports only sync requests.
+        VertxHttpServerRequest request = new VertxHttpServerRequest(httpServerRequest, handlerEntrypoint.path(), idGenerator);
+
+        // Set gateway tenants and zones in request metrics.
+        prepareMetrics(request.metrics());
+
+        return apiReactor.handle(request, request.response());
+    }
+
+    private Completable handleV3Request(HttpServerRequest httpServerRequest, HandlerEntrypoint handlerEntrypoint) {
+        final ReactorHandler reactorHandler = handlerEntrypoint.target();
+
+        io.gravitee.gateway.http.vertx.VertxHttpServerRequest request = createV3Request(httpServerRequest);
+
+        // Prepare invocation execution context.
+        SimpleExecutionContext ctx = new SimpleExecutionContext(request, request.create());
+
+        // Required by the v3 execution mode.
+        ctx.setAttribute(ATTR_ENTRYPOINT, handlerEntrypoint);
+
+        // Set gateway tenants and zones in request metrics.
+        prepareMetrics(request.metrics());
+
+        // Must catch the end of the v3 request handling to complete the reactive chain.
+        return Completable.create(
+            emitter ->
+                reactorHandler.handle(
+                    ctx,
+                    context -> {
+                        if (context.response().ended()) {
+                            emitter.onComplete();
+                        } else {
+                            httpServerRequest.response().rxEnd().subscribe(emitter::onComplete, emitter::onError);
+                        }
                     }
+                )
+        );
+    }
+
+    /**
+     * Prepare some global metrics for the current request (tenants, zones, ...).
+     *
+     * @param metrics the {@link Metrics} object to add information on.
+     */
+    private void prepareMetrics(Metrics metrics) {
+        // Set gateway tenant
+        gatewayConfiguration.tenant().ifPresent(metrics::setTenant);
+
+        // Set gateway zone
+        gatewayConfiguration.zone().ifPresent(metrics::setZone);
+    }
+
+    private Completable handleNotFound(HttpServerRequest httpServerRequest) {
+        // FIXME: properly handle not found.
+        httpServerRequest.response().setStatusCode(HttpStatusCode.NOT_FOUND_404);
+        return httpServerRequest.response().rxEnd();
+    }
+
+    private io.gravitee.gateway.http.vertx.VertxHttpServerRequest createV3Request(HttpServerRequest httpServerRequest) {
+        io.gravitee.gateway.http.vertx.VertxHttpServerRequest request;
+
+        if (isV3WebSocket(httpServerRequest)) {
+            request = new VertxWebSocketServerRequest(httpServerRequest.getDelegate(), idGenerator);
+        } else {
+            if (httpServerRequest.version() == HttpVersion.HTTP_2) {
+                if (MediaType.APPLICATION_GRPC.equals(httpServerRequest.getHeader(HttpHeaders.CONTENT_TYPE))) {
+                    request = new VertxGrpcServerRequest(httpServerRequest.getDelegate(), idGenerator);
+                } else {
+                    request = new VertxHttp2ServerRequest(httpServerRequest.getDelegate(), idGenerator);
                 }
-            );
+            } else {
+                request = new io.gravitee.gateway.http.vertx.VertxHttpServerRequest(httpServerRequest.getDelegate(), idGenerator);
+            }
+        }
+
+        return request;
+    }
+
+    /**
+     * We are only considering HTTP_1.x requests for now.
+     * There is a dedicated RFC to support WebSockets over HTTP2: https://tools.ietf.org/html/rfc8441
+     *
+     * @param httpServerRequest
+     * @return
+     */
+    private boolean isV3WebSocket(HttpServerRequest httpServerRequest) {
+        String connectionHeader = httpServerRequest.getHeader(HttpHeaders.CONNECTION);
+        String upgradeHeader = httpServerRequest.getHeader(HttpHeaders.UPGRADE);
+        return (
+            (httpServerRequest.version() == HttpVersion.HTTP_1_0 || httpServerRequest.version() == HttpVersion.HTTP_1_1) &&
+            WebSocketUtils.isWebSocket(httpServerRequest.method().name(), connectionHeader, upgradeHeader)
+        );
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/HttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/HttpRequestDispatcher.java
@@ -20,9 +20,18 @@ import io.reactivex.Completable;
 import io.vertx.reactivex.core.http.HttpServerRequest;
 
 /**
+ * Request dispatcher responsible to dispatch any HTTP request to the appropriate {@link io.gravitee.gateway.reactor.handler.ReactorHandler}.
+ *
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface HttpRequestDispatcher extends Service<HttpRequestDispatcher> {
+    /**
+     * Dispatches the incoming request to the right {@link io.gravitee.gateway.reactor.handler.ReactorHandler}.
+     *
+     * @param httpServerRequest the vertx http request.
+     *
+     * @return a {@link Completable} that completes when the request has been fully dispatched and completed.
+     */
     Completable dispatch(HttpServerRequest httpServerRequest);
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/handler/DefaultEntrypointResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/handler/DefaultEntrypointResolver.java
@@ -38,8 +38,6 @@ import javax.net.ssl.SSLSession;
  */
 public class DefaultEntrypointResolver implements EntrypointResolver {
 
-    public static final String ATTR_ENTRYPOINT = ExecutionContext.ATTR_PREFIX + "entrypoint";
-
     private final ReactorHandlerRegistry handlerRegistry;
 
     public DefaultEntrypointResolver(ReactorHandlerRegistry handlerRegistry) {
@@ -48,162 +46,12 @@ public class DefaultEntrypointResolver implements EntrypointResolver {
 
     @Override
     public HandlerEntrypoint resolve(String host, String path) {
-        Request request = new EntrypointRequest(path, host);
         for (HandlerEntrypoint entrypoint : handlerRegistry.getEntrypoints()) {
-            if (entrypoint.accept(request)) {
+            if (entrypoint.accept(host, path)) {
                 return entrypoint;
             }
         }
 
         return null;
-    }
-
-    /**
-     * FIXME: quick & dirty solution to make current entry point resolution working.
-     */
-    private static class EntrypointRequest implements Request {
-
-        private final String path;
-        private final String host;
-
-        public EntrypointRequest(String path, String host) {
-            this.path = path;
-            this.host = host;
-        }
-
-        @Override
-        public String id() {
-            return null;
-        }
-
-        @Override
-        public String transactionId() {
-            return null;
-        }
-
-        @Override
-        public String uri() {
-            return null;
-        }
-
-        @Override
-        public String path() {
-            return path;
-        }
-
-        @Override
-        public String pathInfo() {
-            return null;
-        }
-
-        @Override
-        public String contextPath() {
-            return null;
-        }
-
-        @Override
-        public MultiValueMap<String, String> parameters() {
-            return null;
-        }
-
-        @Override
-        public MultiValueMap<String, String> pathParameters() {
-            return null;
-        }
-
-        @Override
-        public HttpHeaders headers() {
-            return null;
-        }
-
-        @Override
-        public HttpMethod method() {
-            return null;
-        }
-
-        @Override
-        public String scheme() {
-            return null;
-        }
-
-        @Override
-        public HttpVersion version() {
-            return null;
-        }
-
-        @Override
-        public long timestamp() {
-            return 0;
-        }
-
-        @Override
-        public String remoteAddress() {
-            return null;
-        }
-
-        @Override
-        public String localAddress() {
-            return null;
-        }
-
-        @Override
-        public SSLSession sslSession() {
-            return null;
-        }
-
-        @Override
-        public Metrics metrics() {
-            return null;
-        }
-
-        @Override
-        public boolean ended() {
-            return false;
-        }
-
-        @Override
-        public Request timeoutHandler(Handler<Long> timeoutHandler) {
-            return null;
-        }
-
-        @Override
-        public Handler<Long> timeoutHandler() {
-            return null;
-        }
-
-        @Override
-        public boolean isWebSocket() {
-            return false;
-        }
-
-        @Override
-        public WebSocket websocket() {
-            return null;
-        }
-
-        @Override
-        public Request customFrameHandler(Handler<HttpFrame> frameHandler) {
-            return null;
-        }
-
-        @Override
-        public Request closeHandler(Handler<Void> closeHandler) {
-            return null;
-        }
-
-        @Override
-        public String host() {
-            return host;
-        }
-
-        @Override
-        public ReadStream<Buffer> bodyHandler(Handler<Buffer> bodyHandler) {
-            return null;
-        }
-
-        @Override
-        public ReadStream<Buffer> endHandler(Handler<Void> endHandler) {
-            return null;
-        }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/Entrypoint.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/Entrypoint.java
@@ -25,29 +25,33 @@ import io.gravitee.gateway.api.Request;
  */
 public interface Entrypoint {
     /**
-     * Listening path.
-     *
-     * @return
+     * @return the listening path of this entrypoint.
      */
     String path();
 
     /**
-     * The optional listening host (can be null).
+     * @return the optional listening host (can be <code>null</code>).
      */
     String host();
 
     /**
-     * Priority of the entrypoint.
-     *
-     * @return
+     * @return the priority of the this entrypoint.
      */
     int priority();
 
     /**
-     * Does the entrypoint accepts the incoming request ?
-     *
-     * @param request
-     * @return
+     * @deprecated see {@link #accept(String, String)} instead.
      */
+    @Deprecated(forRemoval = true)
     boolean accept(Request request);
+
+    /**
+     * Allows to test the entrypoint against the specified <code>host</code> and <code>path</code> to check if it can handle the request or not.
+     *
+     * @param host the request's host.
+     * @param path the request's path.
+     *
+     * @return <code>true</code> if the entrypoint is able to accept the request, <code>false</code> else.
+     */
+    boolean accept(String host, String path);
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/HandlerEntrypoint.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/HandlerEntrypoint.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.gateway.reactor.handler;
 
+import io.gravitee.definition.model.ExecutionMode;
+
 /**
  * This class represents a listening entrypoint link to a {@link ReactorHandler}.
  *
@@ -22,5 +24,7 @@ package io.gravitee.gateway.reactor.handler;
  * @author GraviteeSource Team
  */
 public interface HandlerEntrypoint extends Entrypoint {
-    ReactorHandler target();
+    <T extends ReactorHandler> T target();
+
+    ExecutionMode executionMode();
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/ReactorHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/ReactorHandler.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.reactor.handler;
 
 import io.gravitee.common.component.LifecycleComponent;
+import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.handler.Handler;
 import io.gravitee.gateway.reactor.Reactable;
@@ -24,16 +25,15 @@ import io.gravitee.gateway.reactor.Reactable;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface ReactorHandler extends LifecycleComponent<ReactorHandler>, Handler<ExecutionContext> {
+public interface ReactorHandler extends LifecycleComponent<ReactorHandler> {
     /**
      * A reactable element associated to the current handler.
      */
     Reactable reactable();
 
-    /**
-     * Response handler.
-     *
-     * @param handler Handler called when the response is processed.
-     */
-    ReactorHandler handler(Handler<ExecutionContext> handler);
+    default ExecutionMode executionMode() {
+        return ExecutionMode.V3;
+    }
+
+    void handle(ExecutionContext context, Handler<ExecutionContext> endHandler);
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/VirtualHost.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/VirtualHost.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.reactor.handler;
 
 import io.gravitee.gateway.api.Request;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 /**
@@ -84,11 +85,20 @@ public class VirtualHost implements Entrypoint {
 
     @Override
     public boolean accept(Request request) {
-        String host = request.host();
+        return accept(request.host(), request.path());
+    }
 
-        return (this.host != null)
-            ? this.host.equalsIgnoreCase(host) && (request.path().startsWith(this.path) || request.path().equals(pathWithoutTrailingSlash))
-            : (request.path().startsWith(this.path) || request.path().equals(pathWithoutTrailingSlash));
+    @Override
+    public boolean accept(String host, String path) {
+        return matchHost(host) && matchPath(path);
+    }
+
+    private boolean matchHost(String host) {
+        return this.host == null || this.host.equalsIgnoreCase(host);
+    }
+
+    private boolean matchPath(String path) {
+        return path.startsWith(this.path) || path.equals(pathWithoutTrailingSlash);
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/impl/DefaultReactorHandlerRegistry.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/impl/DefaultReactorHandlerRegistry.java
@@ -15,7 +15,9 @@
  */
 package io.gravitee.gateway.reactor.handler.impl;
 
+import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.reactive.reactor.ApiReactor;
 import io.gravitee.gateway.reactor.Reactable;
 import io.gravitee.gateway.reactor.handler.*;
 import java.util.*;
@@ -187,6 +189,11 @@ public class DefaultReactorHandlerRegistry implements ReactorHandlerRegistry {
         }
 
         @Override
+        public ExecutionMode executionMode() {
+            return handler.executionMode();
+        }
+
+        @Override
         public String path() {
             return entrypoint.path();
         }
@@ -204,6 +211,11 @@ public class DefaultReactorHandlerRegistry implements ReactorHandlerRegistry {
         @Override
         public boolean accept(Request request) {
             return entrypoint.accept(request);
+        }
+
+        @Override
+        public boolean accept(String host, String path) {
+            return entrypoint.accept(host, path);
         }
 
         @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/impl/DefaultReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/impl/DefaultReactor.java
@@ -90,13 +90,13 @@ public class DefaultReactor extends AbstractService<Reactor> implements Reactor,
                     if (entrypoint != null) {
                         entrypoint
                             .target()
-                            .handler(
+                            .handle(
+                                ctx,
                                 context1 -> {
                                     // Ensure that response has been ended before going further
                                     context1.response().endHandler(avoid -> processResponse(context1, handler)).end();
                                 }
-                            )
-                            .handle(ctx);
+                            );
                     } else {
                         processNotFound(ctx, handler);
                     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcherTest.java
@@ -1,0 +1,361 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.reactor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.common.event.Event;
+import io.gravitee.common.event.EventManager;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.common.http.IdGenerator;
+import io.gravitee.definition.model.ExecutionMode;
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.gateway.env.GatewayConfiguration;
+import io.gravitee.gateway.reactive.api.context.Request;
+import io.gravitee.gateway.reactive.api.context.Response;
+import io.gravitee.gateway.reactive.reactor.handler.EntrypointResolver;
+import io.gravitee.gateway.reactor.Reactable;
+import io.gravitee.gateway.reactor.ReactorEvent;
+import io.gravitee.gateway.reactor.handler.HandlerEntrypoint;
+import io.gravitee.gateway.reactor.handler.ReactorHandler;
+import io.gravitee.gateway.reactor.handler.ReactorHandlerRegistry;
+import io.reactivex.Completable;
+import io.reactivex.Flowable;
+import io.reactivex.observers.TestObserver;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.reactivex.core.MultiMap;
+import io.vertx.reactivex.core.http.HttpServerRequest;
+import io.vertx.reactivex.core.http.HttpServerResponse;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class DefaultHttpRequestDispatcherTest {
+
+    protected static final String HOST = "gravitee.io";
+    protected static final String PATH = "/path";
+    protected static final String MOCK_ERROR_MESSAGE = "Mock error";
+
+    @Mock
+    private EventManager eventManager;
+
+    @Mock
+    private GatewayConfiguration gatewayConfiguration;
+
+    @Mock
+    private ReactorHandlerRegistry reactorHandlerRegistry;
+
+    @Mock
+    private EntrypointResolver entrypointResolver;
+
+    @Mock
+    private IdGenerator idGenerator;
+
+    @Mock
+    private HttpServerRequest rxRequest;
+
+    @Mock
+    private HttpServerResponse rxResponse;
+
+    @Mock
+    private io.vertx.core.http.HttpServerRequest request;
+
+    @Mock
+    private io.vertx.core.http.HttpServerResponse response;
+
+    @Mock
+    private HandlerEntrypoint handlerEntrypoint;
+
+    private DefaultHttpRequestDispatcher cut;
+
+    @BeforeEach
+    public void init() {
+        // Mock vertx request behavior.
+        lenient().when(rxRequest.host()).thenReturn(HOST);
+        lenient().when(rxRequest.path()).thenReturn(PATH);
+        lenient().when(rxRequest.method()).thenReturn(HttpMethod.GET);
+        lenient().when(rxRequest.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+        lenient().when(rxRequest.toFlowable()).thenReturn(Flowable.empty());
+        lenient().when(rxRequest.response()).thenReturn(rxResponse);
+        lenient().when(rxRequest.getDelegate()).thenReturn(request);
+
+        lenient().when(request.host()).thenReturn(HOST);
+        lenient().when(request.path()).thenReturn(PATH);
+        lenient().when(request.method()).thenReturn(HttpMethod.GET);
+        lenient().when(request.headers()).thenReturn(io.vertx.core.MultiMap.caseInsensitiveMultiMap());
+        lenient().when(request.response()).thenReturn(response);
+
+        // Mock vertx response behavior.
+        lenient().when(rxResponse.headers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+        lenient().when(rxResponse.trailers()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+        lenient().when(rxResponse.getDelegate()).thenReturn(response);
+
+        lenient().when(response.headers()).thenReturn(io.vertx.core.MultiMap.caseInsensitiveMultiMap());
+        lenient().when(response.trailers()).thenReturn(io.vertx.core.MultiMap.caseInsensitiveMultiMap());
+
+        cut = new DefaultHttpRequestDispatcher(eventManager, gatewayConfiguration, reactorHandlerRegistry, entrypointResolver, idGenerator);
+    }
+
+    @Test
+    public void shouldHandleJupiterRequest() {
+        final ApiReactor apiReactor = mock(ApiReactor.class, withSettings().extraInterfaces(ReactorHandler.class));
+
+        this.prepareJupiterMock(handlerEntrypoint, apiReactor);
+
+        when(apiReactor.handle(any(Request.class), any(Response.class))).thenReturn(Completable.complete());
+
+        final TestObserver<Void> obs = cut.dispatch(rxRequest).test();
+
+        obs.assertResult();
+    }
+
+    @Test
+    public void shouldSetMetricsWhenHandlingJupiterRequest() {
+        final ApiReactor apiReactor = mock(ApiReactor.class, withSettings().extraInterfaces(ReactorHandler.class));
+        final ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+
+        this.prepareJupiterMock(handlerEntrypoint, apiReactor);
+
+        when(gatewayConfiguration.tenant()).thenReturn(Optional.of("TENANT"));
+        when(gatewayConfiguration.zone()).thenReturn(Optional.of("ZONE"));
+        when(apiReactor.handle(requestCaptor.capture(), any(Response.class))).thenReturn(Completable.complete());
+
+        final TestObserver<Void> obs = cut.dispatch(rxRequest).test();
+
+        obs.assertResult();
+
+        final Request jupiterRequest = requestCaptor.getValue();
+        assertEquals("TENANT", jupiterRequest.metrics().getTenant());
+        assertEquals("ZONE", jupiterRequest.metrics().getZone());
+    }
+
+    @Test
+    public void shouldPropagateErrorWhenErrorWithJupiterRequest() {
+        final ApiReactor apiReactor = mock(ApiReactor.class, withSettings().extraInterfaces(ReactorHandler.class));
+
+        this.prepareJupiterMock(handlerEntrypoint, apiReactor);
+
+        when(apiReactor.handle(any(Request.class), any(Response.class)))
+            .thenReturn(Completable.error(new RuntimeException(MOCK_ERROR_MESSAGE)));
+
+        final TestObserver<Void> obs = cut.dispatch(rxRequest).test();
+
+        obs.assertErrorMessage(MOCK_ERROR_MESSAGE);
+    }
+
+    @Test
+    public void shouldHandleV3Request() {
+        final ReactorHandler apiReactor = mock(ReactorHandler.class);
+
+        this.prepareV3Mock(handlerEntrypoint, apiReactor);
+        when(response.ended()).thenReturn(true);
+
+        doAnswer(
+                i -> {
+                    simulateEndHandlerCall(i);
+                    return null;
+                }
+            )
+            .when(apiReactor)
+            .handle(any(ExecutionContext.class), any(Handler.class));
+
+        final TestObserver<Void> obs = cut.dispatch(rxRequest).test();
+
+        obs.assertResult();
+    }
+
+    @Test
+    public void shouldSetMetricsWhenHandlingV3Request() {
+        final ReactorHandler apiReactor = mock(ReactorHandler.class);
+
+        this.prepareV3Mock(handlerEntrypoint, apiReactor);
+        when(gatewayConfiguration.tenant()).thenReturn(Optional.of("TENANT"));
+        when(gatewayConfiguration.zone()).thenReturn(Optional.of("ZONE"));
+        when(response.ended()).thenReturn(true);
+
+        doAnswer(
+                i -> {
+                    final ExecutionContext ctx = i.getArgument(0, ExecutionContext.class);
+
+                    assertEquals("TENANT", ctx.request().metrics().getTenant());
+                    assertEquals("ZONE", ctx.request().metrics().getZone());
+                    simulateEndHandlerCall(i);
+                    return null;
+                }
+            )
+            .when(apiReactor)
+            .handle(any(ExecutionContext.class), any(Handler.class));
+
+        final TestObserver<Void> obs = cut.dispatch(rxRequest).test();
+
+        obs.assertResult();
+    }
+
+    @Test
+    public void shouldEndResponseWhenNotAlreadyEndedByV3Handler() {
+        final ReactorHandler apiReactor = mock(ReactorHandler.class);
+
+        this.prepareV3Mock(handlerEntrypoint, apiReactor);
+        when(gatewayConfiguration.tenant()).thenReturn(Optional.of("TENANT"));
+        when(gatewayConfiguration.zone()).thenReturn(Optional.of("ZONE"));
+        when(response.ended()).thenReturn(false);
+        when(rxResponse.rxEnd()).thenReturn(Completable.complete());
+
+        doAnswer(
+                i -> {
+                    final ExecutionContext ctx = i.getArgument(0, ExecutionContext.class);
+
+                    assertEquals("TENANT", ctx.request().metrics().getTenant());
+                    assertEquals("ZONE", ctx.request().metrics().getZone());
+                    simulateEndHandlerCall(i);
+                    return null;
+                }
+            )
+            .when(apiReactor)
+            .handle(any(ExecutionContext.class), any(Handler.class));
+
+        final TestObserver<Void> obs = cut.dispatch(rxRequest).test();
+
+        obs.assertResult();
+    }
+
+    @Test
+    public void shouldPropagateErrorWhenExceptionWithV3Request() {
+        final ReactorHandler apiReactor = mock(ReactorHandler.class);
+
+        this.prepareV3Mock(handlerEntrypoint, apiReactor);
+
+        doThrow(new RuntimeException(MOCK_ERROR_MESSAGE)).when(apiReactor).handle(any(ExecutionContext.class), any(Handler.class));
+
+        final TestObserver<Void> obs = cut.dispatch(rxRequest).test();
+
+        obs.assertErrorMessage(MOCK_ERROR_MESSAGE);
+    }
+
+    @Test
+    public void shouldHandleNotFoundWhenNoHandlerResolved() {
+        // FIXME: subjects to change with full support of NotFound.
+        when(entrypointResolver.resolve(HOST, PATH)).thenReturn(null);
+        when(rxResponse.rxEnd()).thenReturn(Completable.complete());
+
+        final TestObserver<Void> obs = cut.dispatch(rxRequest).test();
+
+        obs.assertResult();
+
+        verify(rxResponse).setStatusCode(HttpStatusCode.NOT_FOUND_404);
+    }
+
+    @Test
+    public void shouldHandleNotFoundWhenNoTargetOnResolvedHandler() {
+        // FIXME: subjects to change with full support of NotFound.
+        this.prepareV3Mock(handlerEntrypoint, null);
+
+        when(entrypointResolver.resolve(HOST, PATH)).thenReturn(null);
+        when(rxResponse.rxEnd()).thenReturn(Completable.complete());
+
+        final TestObserver<Void> obs = cut.dispatch(rxRequest).test();
+
+        obs.assertResult();
+
+        verify(rxResponse).setStatusCode(HttpStatusCode.NOT_FOUND_404);
+    }
+
+    @Test
+    public void shouldCreateToHandlerRegistryWhenDeployApiEvent() {
+        final Event<ReactorEvent, Reactable> event = mock(Event.class);
+        final Reactable api = mock(Reactable.class);
+
+        when(event.type()).thenReturn(ReactorEvent.DEPLOY);
+        when(event.content()).thenReturn(api);
+        cut.onEvent(event);
+
+        verify(reactorHandlerRegistry).create(api);
+        verifyNoMoreInteractions(reactorHandlerRegistry);
+    }
+
+    @Test
+    public void shouldUpdateToHandlerRegistryWhenUpdateApiEvent() {
+        final Event<ReactorEvent, Reactable> event = mock(Event.class);
+        final Reactable api = mock(Reactable.class);
+
+        when(event.type()).thenReturn(ReactorEvent.UPDATE);
+        when(event.content()).thenReturn(api);
+        cut.onEvent(event);
+
+        verify(reactorHandlerRegistry).update(api);
+        verifyNoMoreInteractions(reactorHandlerRegistry);
+    }
+
+    @Test
+    public void shouldRemoveToHandlerRegistryWhenUpdateApiEvent() {
+        final Event<ReactorEvent, Reactable> event = mock(Event.class);
+        final Reactable api = mock(Reactable.class);
+
+        when(event.type()).thenReturn(ReactorEvent.UNDEPLOY);
+        when(event.content()).thenReturn(api);
+        cut.onEvent(event);
+
+        verify(reactorHandlerRegistry).remove(api);
+        verifyNoMoreInteractions(reactorHandlerRegistry);
+    }
+
+    @Test
+    public void shouldSubscribeToEventsWhenStarting() throws Exception {
+        cut.start();
+        verify(eventManager).subscribeForEvents(cut, ReactorEvent.class);
+    }
+
+    @Test
+    public void shouldClearHandlerRegistryWhenStopping() throws Exception {
+        cut.stop();
+        verify(reactorHandlerRegistry).clear();
+    }
+
+    private void prepareJupiterMock(HandlerEntrypoint handlerEntrypoint, ApiReactor apiReactor) {
+        when(entrypointResolver.resolve(HOST, PATH)).thenReturn(handlerEntrypoint);
+        when(handlerEntrypoint.executionMode()).thenReturn(ExecutionMode.JUPITER);
+        when(handlerEntrypoint.path()).thenReturn(PATH);
+        when(handlerEntrypoint.target()).thenReturn(apiReactor);
+    }
+
+    private void prepareV3Mock(HandlerEntrypoint handlerEntrypoint, ReactorHandler apiReactor) {
+        when(entrypointResolver.resolve(HOST, PATH)).thenReturn(handlerEntrypoint);
+
+        if (apiReactor != null) {
+            when(handlerEntrypoint.executionMode()).thenReturn(ExecutionMode.V3);
+            when(handlerEntrypoint.target()).thenReturn(apiReactor);
+        }
+    }
+
+    private void simulateEndHandlerCall(InvocationOnMock i) {
+        final ExecutionContext ctx = i.getArgument(0);
+        final Handler<ExecutionContext> endHandler = i.getArgument(1, Handler.class);
+        endHandler.handle(ctx);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/handler/DefaultEntrypointResolverTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/handler/DefaultEntrypointResolverTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.reactor.handler;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.gateway.reactor.handler.HandlerEntrypoint;
+import io.gravitee.gateway.reactor.handler.ReactorHandlerRegistry;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class DefaultEntrypointResolverTest {
+
+    protected static final String HOST = "gravitee.io";
+    protected static final String PATH = "/path";
+
+    @Mock
+    private ReactorHandlerRegistry handlerRegistry;
+
+    private DefaultEntrypointResolver cut;
+
+    @BeforeEach
+    public void init() {
+        cut = new DefaultEntrypointResolver(handlerRegistry);
+    }
+
+    @Test
+    public void shouldIteratorOverEntrypointToResolveHandler() {
+        final HandlerEntrypoint handler1 = mock(HandlerEntrypoint.class);
+        final HandlerEntrypoint handler2 = mock(HandlerEntrypoint.class);
+        final HandlerEntrypoint handler3 = mock(HandlerEntrypoint.class);
+
+        when(handler1.accept(HOST, PATH)).thenReturn(false);
+        when(handler2.accept(HOST, PATH)).thenReturn(false);
+        when(handler3.accept(HOST, PATH)).thenReturn(true);
+
+        when(handlerRegistry.getEntrypoints()).thenReturn(List.of(handler1, handler2, handler3));
+
+        final HandlerEntrypoint resolvedHandler = cut.resolve(HOST, PATH);
+
+        assertEquals(handler3, resolvedHandler);
+    }
+
+    @Test
+    public void shouldReturnNullHanlderWhenNoHandlerCanHandleTheRequest() {
+        final HandlerEntrypoint handler1 = mock(HandlerEntrypoint.class);
+        final HandlerEntrypoint handler2 = mock(HandlerEntrypoint.class);
+        final HandlerEntrypoint handler3 = mock(HandlerEntrypoint.class);
+
+        when(handler1.accept(HOST, PATH)).thenReturn(false);
+        when(handler2.accept(HOST, PATH)).thenReturn(false);
+        when(handler3.accept(HOST, PATH)).thenReturn(false);
+
+        when(handlerRegistry.getEntrypoints()).thenReturn(List.of(handler1, handler2, handler3));
+
+        final HandlerEntrypoint resolvedHandler = cut.resolve(HOST, PATH);
+
+        assertNull(resolvedHandler);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/DummyReactorHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/DummyReactorHandler.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.api.handler.Handler;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.reactor.Reactable;
 import java.util.List;
@@ -53,12 +54,12 @@ public class DummyReactorHandler extends AbstractReactorHandler<Reactable> {
     }
 
     @Override
-    public void handle(ExecutionContext context) {
-        doHandle(context);
+    public void handle(ExecutionContext context, Handler<ExecutionContext> endHandler) {
+        doHandle(context, endHandler);
     }
 
     @Override
-    protected void doHandle(ExecutionContext executionContext) {
+    protected void doHandle(ExecutionContext executionContext, Handler<ExecutionContext> endHandler) {
         Response proxyResponse = mock(Response.class);
         when(proxyResponse.headers()).thenReturn(HttpHeaders.create());
         when(proxyResponse.status()).thenReturn(HttpStatusCode.OK_200);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/EntrypointResolverTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/EntrypointResolverTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.*;
 
+import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.http.HttpHeaders;
@@ -335,7 +336,12 @@ public class EntrypointResolverTest {
         }
 
         @Override
-        public ReactorHandler target() {
+        public <T extends ReactorHandler> T target() {
+            return null;
+        }
+
+        @Override
+        public ExecutionMode executionMode() {
             return null;
         }
 
@@ -357,6 +363,11 @@ public class EntrypointResolverTest {
         @Override
         public boolean accept(Request request) {
             return entrypoint.accept(request);
+        }
+
+        @Override
+        public boolean accept(String host, String path) {
+            return entrypoint.accept(host, path);
         }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -421,6 +421,57 @@
 
         <plugins>
             <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <environmentVariables>
+                        <gravitee.http.instances>1</gravitee.http.instances>
+                    </environmentVariables>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>jupiter-v3-mode-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <reportsDirectory>${project.build.directory}/surefire-reports-jupiter-v3-mode</reportsDirectory>
+                            <environmentVariables>
+                                <gravitee.api.jupiterMode.enabled>true</gravitee.api.jupiterMode.enabled>
+                            </environmentVariables>
+                            <excludes>
+                                <!-- FIXME: the following tests has been temporarily excluded because they concern feature not yet implemented on Jupiter. -->
+                                <!-- FIXME: Do not forget to re-include the test after implementing the feature -->
+                                <exclude>**/LoggableClientResponseWithRequestTimeoutTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>jupiter-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <reportsDirectory>${project.build.directory}/surefire-reports-jupiter</reportsDirectory>
+                            <environmentVariables>
+                                <gravitee.api.jupiterMode.enabled>true</gravitee.api.jupiterMode.enabled>
+                                <gravitee.api.jupiterMode.default>always</gravitee.api.jupiterMode.default>
+                            </environmentVariables>
+                            <excludes>
+                                <!-- FIXME: the following tests has been temporarily excluded because they concern feature not yet implemented on Jupiter. -->
+                                <!-- FIXME: Do not forget to re-include the test after implementing the feature -->
+                                <exclude>**/LoggableClientResponseWithRequestTimeoutTest.java</exclude>
+                                <exclude>**/PlanFlowTest.java</exclude>
+                                <exclude>**/CorsWithPoliciesFlowTest.java</exclude>
+                                <exclude>**/CorsPoliciesFlowTest.java</exclude>
+                                <!-- This test is no more valid with Jupiter because flow condition is now evaluated once for the whole flow
+                                    (EL based on a param suppressed during request policy chain and re-evaluated at response phase). -->
+                                <exclude>**/ExpressionLanguageConditionFlowTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>0.6.1</version>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/node/GatewayNode.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/node/GatewayNode.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.gateway.standalone.node;
 
+import static io.gravitee.gateway.env.GatewayConfiguration.JUPITER_MODE_ENABLED_BY_DEFAULT;
+import static io.gravitee.gateway.env.GatewayConfiguration.JUPITER_MODE_ENABLED_KEY;
+
 import io.gravitee.common.component.LifecycleComponent;
 import io.gravitee.gateway.reactive.reactor.HttpRequestDispatcher;
 import io.gravitee.gateway.reactor.Reactor;
@@ -28,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -37,6 +41,9 @@ public class GatewayNode extends AbstractNode {
 
     @Autowired
     private NodeMetadataResolver nodeMetadataResolver;
+
+    @Value("${" + JUPITER_MODE_ENABLED_KEY + ":" + JUPITER_MODE_ENABLED_BY_DEFAULT + "}")
+    private boolean jupiterMode;
 
     private Map<String, Object> metadata = null;
 
@@ -64,7 +71,13 @@ public class GatewayNode extends AbstractNode {
         final List<Class<? extends LifecycleComponent>> components = new ArrayList<>();
 
         components.add(NodeMonitoringReporterService.class);
-        components.add(HttpRequestDispatcher.class);
+
+        if (jupiterMode) {
+            components.add(HttpRequestDispatcher.class);
+        } else {
+            components.add(Reactor.class);
+        }
+
         components.add(VertxEmbeddedContainer.class);
         components.add(ClusterService.class);
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxReactorConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxReactorConfiguration.java
@@ -42,13 +42,19 @@ public class VertxReactorConfiguration {
     }
 
     @Bean("gatewayHttpServer")
-    //    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
     public VertxHttpServerFactory vertxHttpServerFactory(
         Vertx vertx,
         @Qualifier("httpServerConfiguration") HttpServerConfiguration httpServerConfiguration,
         KeyStoreLoaderManager keyStoreLoaderManager
     ) {
         return new VertxHttpServerFactory(vertx, httpServerConfiguration, keyStoreLoaderManager);
+    }
+
+    @Bean
+    @Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+    public ReactorVerticle v3GraviteeVerticle() {
+        // V3 ReactorVerticle bean must be kept while we are still supporting v3 execution mode.
+        return new ReactorVerticle();
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/ws/VertxWebSocketReactorHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/ws/VertxWebSocketReactorHandler.java
@@ -17,10 +17,11 @@ package io.gravitee.gateway.standalone.vertx.ws;
 
 import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.IdGenerator;
+import io.gravitee.gateway.http.utils.WebSocketUtils;
 import io.gravitee.gateway.http.vertx.VertxHttpServerRequest;
+import io.gravitee.gateway.http.vertx.ws.VertxWebSocketServerRequest;
 import io.gravitee.gateway.reactor.Reactor;
 import io.gravitee.gateway.standalone.vertx.VertxReactorHandler;
-import io.gravitee.gateway.standalone.vertx.ws.utils.WebSocketUtils;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpVersion;
 


### PR DESCRIPTION

**Description**

Gateway is now able to start without Jupiter to keep the current V3 behavior.
With Jupiter enabled, Gateway can handle requests for apis configured either with `JUPITER` either with `V3` execution mode.

Gateway container tests have been reactivated 🥳. Tests are run 3 times by Maven:

1. With Jupiter disabled: tests the current V3 behavior as today
2. With Jupiter enabled and `V3` execution mode: tests that the same tests are running well when requests are handled by Jupiter but in V3 execution compatibility mode.
3. With Jupiter enabled and `JUPITER` execution mode: tests that the same tests are running well when requests are handled by Jupiter with the new `JUPITER` compatibility mode.

**Note**: because all the features are not developed yet or some of them will not be compatible, some tests have been excluded . You can find the list of tests that have been excluded directly in the `pom.xml` of `gravitee-apim-gateway-standalone-container`.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/prototype-reactive-http-dispatcher/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
