### PR TITLE
test(e2e): use APPLICATION_CREATE event rule

### DIFF
--- a/gravitee-apim-e2e/api-test/applications/application-membership.spec.ts
+++ b/gravitee-apim-e2e/api-test/applications/application-membership.spec.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import { afterAll, beforeAll, describe, expect } from '@jest/globals';
-import faker from '@faker-js/faker';
 import { ApplicationsApi } from '@management-apis/ApplicationsApi';
 import { forManagementAsAdminUser, forManagementAsAppUser, forPortalAsApiUser, forPortalAsSimpleUser } from '@client-conf/*';
 import { forbidden, succeed } from '../../lib/jest-utils';
@@ -23,9 +22,8 @@ import { UsersApi } from '@management-apis/UsersApi';
 import { RoleScope } from '@management-models/RoleScope';
 import { ApplicationApi } from '@portal-apis/ApplicationApi';
 import { ApplicationEntity } from '@management-models/ApplicationEntity';
-import { UpdateApplicationEntityFromJSON, UpdateApplicationEntityFromJSONTyped } from '@management-models/UpdateApplicationEntity';
+import { UpdateApplicationEntityFromJSON } from '@management-models/UpdateApplicationEntity';
 import { GroupEntity } from '@management-models/GroupEntity';
-import { MemberEntity } from '@management-models/MemberEntity';
 import { SearchableUser } from '@management-models/SearchableUser';
 import { ApplicationsFaker } from '@management-fakers/ApplicationsFaker';
 import { GroupsFaker } from '@management-fakers/GroupsFaker';
@@ -53,7 +51,7 @@ describe('Applications - Membership', () => {
     group = await configurationManagementApiAsAdminUser.createGroup({
       orgId,
       envId,
-      newGroupEntity: GroupsFaker.newGroup({ event_rules: [{ event: 'API_CREATE' }] }),
+      newGroupEntity: GroupsFaker.newGroup({ event_rules: [{ event: 'APPLICATION_CREATE' }] }),
     });
 
     // Get user member


### PR DESCRIPTION
fix gravitee-io/issues#7641
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7641-applications-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
