### PR TITLE
fix: fix API search with crossId criteria

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
@@ -136,6 +136,7 @@ public class ApisResource extends AbstractResource {
         apiQuery.setName(apisParam.getName());
         apiQuery.setTag(apisParam.getTag());
         apiQuery.setState(apisParam.getState());
+        apiQuery.setCrossId(apisParam.getCrossId());
         if (apisParam.getCategory() != null) {
             apiQuery.setCategory(categoryService.findById(apisParam.getCategory(), GraviteeContext.getCurrentEnvironment()).getId());
         }


### PR DESCRIPTION
fix: fix API search with crossId criteria

**Issue**
https://github.com/gravitee-io/issues/issues/7660
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-searchapibycrossid/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
