### PR TITLE
fix(rest-api): use right ENVIRONMENT_DICTIONARY permission on deleteDictionary

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/configuration/dictionary/DictionaryResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/configuration/dictionary/DictionaryResource.java
@@ -150,7 +150,7 @@ public class DictionaryResource extends AbstractResource {
             @ApiResponse(code = 500, message = "Internal server error"),
         }
     )
-    @Permissions({ @Permission(value = RolePermission.APPLICATION_DEFINITION, acls = RolePermissionAction.DELETE) })
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DICTIONARY, acls = RolePermissionAction.DELETE) })
     public Response deleteDictionary(@PathParam("dictionary") String dictionary) {
         dictionaryService.delete(dictionary);
         return Response.noContent().build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/DictionaryResource_DeleteTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/DictionaryResource_DeleteTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.common.http.HttpStatusCode;
+import javax.ws.rs.core.Response;
+import org.junit.Test;
+
+public class DictionaryResource_DeleteTest extends AbstractResourceTest {
+
+    private static final String DICTIONARY_ID = "dictionaryId";
+
+    protected String contextPath() {
+        return "configuration/dictionaries/";
+    }
+
+    @Test
+    public void shouldDeleteDictionary() {
+        final Response response = envTarget(DICTIONARY_ID).request().delete();
+        assertEquals(HttpStatusCode.NO_CONTENT_204, response.getStatus());
+
+        verify(dictionaryService, times(1)).delete(eq(DICTIONARY_ID));
+    }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6556

**Description**

use right ENVIRONMENT_DICTIONARY permission on deleteDictionary

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/3-10-x-6556-delete-a-dictionary/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
