### PR TITLE
fix: update data when a platform flow is saved

### DIFF
--- a/gravitee-apim-console-webui/src/organization/configuration/policies/org-settings-platform-policies.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/org-settings-platform-policies.component.spec.ts
@@ -178,6 +178,13 @@ describe('OrgSettingsPlatformPoliciesComponent', () => {
       });
       req.flush(organization);
 
+      httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/configuration/flows/flow-schema`).flush(platformFlowSchema);
+
+      httpTestingController
+        .expectOne(`${CONSTANTS_TESTING.env.baseURL}/policies?expand=schema&expand=icon&withResource=false`)
+        .flush(policies);
+
+      httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}`).flush(organization);
       // This one is send by the GioPolicyStudioWrapperComponent
       httpTestingController
         .expectOne(`${CONSTANTS_TESTING.org.baseURL}/configuration/flows/configuration-schema`)

--- a/gravitee-apim-console-webui/src/organization/configuration/policies/org-settings-platform-policies.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/org-settings-platform-policies.component.ts
@@ -135,7 +135,7 @@ export class OrgSettingsPlatformPoliciesComponent implements OnInit, OnDestroy {
         }),
       )
       .subscribe(() => {
-        this.definition = { ...this.definition };
+        this.ngOnInit();
       });
   }
 }


### PR DESCRIPTION
Fixing  https://github.com/gravitee-io/issues/issues/7651 introduced
a regression, as when saving the platform flow, the UI was getting updated
to its pre update data state.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-plaform-flow-data/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
