### PR TITLE
test: added Cypress UI-tests for gateway instances information

### DIFF
--- a/gravitee-apim-console-webui/src/management/instances/details/monitoring/instance-monitoring.html
+++ b/gravitee-apim-console-webui/src/management/instances/details/monitoring/instance-monitoring.html
@@ -51,7 +51,7 @@
       </md-card-content>
     </md-card>
   </div>
-  <md-card>
+  <md-card data-testid="instance-monitoring_jvm-box">
     <md-card-content>
       <div layout="row">
         <ng-md-icon class="gravitee-monitoring-icon-title" icon="memory"></ng-md-icon>
@@ -227,7 +227,7 @@
     </md-card-content>
   </md-card>
   <div layout="row">
-    <md-card flex="50">
+    <md-card flex="50" data-testid="instance-monitoring_cpu-box">
       <md-card-content layout="column">
         <div layout="row">
           <ng-md-icon class="gravitee-monitoring-icon-title" icon="memory"></ng-md-icon>
@@ -248,7 +248,7 @@
         </div>
       </md-card-content>
     </md-card>
-    <md-card flex="50">
+    <md-card flex="50" data-testid="instance-monitoring_process-box">
       <md-card-content layout="column">
         <div layout="row">
           <ng-md-icon class="gravitee-monitoring-icon-title" icon="memory"></ng-md-icon>
@@ -266,7 +266,7 @@
     </md-card>
   </div>
   <div layout="row">
-    <md-card flex="50">
+    <md-card flex="50" data-testid="instance-monitoring_thread-box">
       <md-card-content layout="column">
         <div layout="row">
           <ng-md-icon class="gravitee-monitoring-icon-title" icon="memory"></ng-md-icon>
@@ -282,7 +282,7 @@
         </div>
       </md-card-content>
     </md-card>
-    <md-card flex="50">
+    <md-card flex="50" data-testid="instance-monitoring_gc-box">
       <md-card-content layout="column">
         <div layout="row">
           <ng-md-icon class="gravitee-monitoring-icon-title" icon="memory"></ng-md-icon>

--- a/gravitee-apim-console-webui/src/management/instances/instances.html
+++ b/gravitee-apim-console-webui/src/management/instances/instances.html
@@ -19,7 +19,14 @@
   <div class="gv-forms gv-forms-fluid" layout="column">
     <div>
       <h1>API Gateway</h1>
-      <md-switch style="margin: 0 auto" ng-model="$ctrl.showHistory" ng-change="switchDisplayInstances()"> Show history </md-switch>
+      <md-switch
+        style="margin: 0 auto"
+        ng-model="$ctrl.showHistory"
+        ng-change="switchDisplayInstances()"
+        data-testid="instances_show-history-switch"
+      >
+        Show history
+      </md-switch>
     </div>
 
     <div class="gv-form-content">
@@ -34,6 +41,7 @@
                   ng-model="$ctrl.searchGatewayInstances"
                   placeholder="Search Gateway instances..."
                   autofocus
+                  data-testid="instances_search-gateway-textfield"
                 />
               </div>
             </md-card-header-text>
@@ -43,6 +51,7 @@
               <div
                 class="gravitee-instances-box"
                 ng-repeat="instance in $ctrl.instances.content | filter:$ctrl.searchGatewayInstances | orderBy:'-started_at'"
+                data-testid="instances_instances-box"
               >
                 <a ui-sref="management.instances.detail.environment({instanceId: instance.event})">
                   <md-card class="gravitee-instances-box gravitee-card gravitee-api-card">
@@ -84,7 +93,7 @@
             <md-table-container>
               <table md-table class="gv-table-dense">
                 <thead md-head>
-                  <tr md-row>
+                  <tr md-row data-testid="instances_history-table-head">
                     <th md-column>Host</th>
                     <th md-column>Status</th>
                     <th md-column>Tags</th>

--- a/gravitee-apim-e2e/ui-test/cypress.json
+++ b/gravitee-apim-e2e/ui-test/cypress.json
@@ -1,4 +1,5 @@
 {
+  "baseUrl": "http://localhost:8083",
   "projectId": "ui-test",
   "integrationFolder": "ui-test/integration",
   "fixturesFolder": "ui-test/fixtures",

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/gateways/ui-gateway-information-spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/gateways/ui-gateway-information-spec.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ADMIN_USER, API_PUBLISHER_USER } from '@fakers/users/users';
+
+describe('Get Gateway instance information as admin', () => {
+  beforeEach(() => {
+    cy.loginInAPIM(ADMIN_USER.username, ADMIN_USER.password);
+    cy.visit(`${Cypress.env('managementUI')}/#!/environments/DEFAULT/instances/`);
+    cy.url().should('contain', 'instances');
+  });
+
+  it('should display all important UI elements', function () {
+    cy.get('h1').contains('API Gateway');
+    cy.getByDataTestId('instances_show-history-switch').should((historySwitch) => {
+      expect(historySwitch).to.have.class('ng-empty');
+      expect(historySwitch).to.contain.text('Show history');
+    });
+    cy.getByDataTestId('instances_search-gateway-textfield').should((textfield) => {
+      expect(textfield).to.have.attr('placeholder', 'Search Gateway instances...');
+      expect(textfield).to.have.attr('type', 'text');
+      expect(textfield).to.have.class('ng-empty');
+    });
+    cy.getByDataTestId('instances_instances-box').should((instancesBox) => {
+      expect(instancesBox).to.have.length.greaterThan(0);
+      expect(instancesBox[0]).to.contain('STARTED');
+    });
+  });
+
+  it('should be able to toggle the show history button', () => {
+    cy.getByDataTestId('instances_show-history-switch').trigger('click');
+    cy.getByDataTestId('instances_instances-box').should('not.exist');
+    const headerList = [];
+    cy.getByDataTestId('instances_history-table-head')
+      .find('th')
+      .should((tableHeadItems) => {
+        expect(tableHeadItems).to.have.length(7);
+        tableHeadItems.each(($headerItem) => {
+          headerList.push(tableHeadItems[$headerItem].innerText);
+        });
+        expect(headerList).to.deep.equal(['Host', 'Status', 'Tags', 'Tenant', 'Started at', 'Last heartbeat', 'Stopped at']);
+      });
+  });
+
+  it('should be able to toggle the hide history button', function () {
+    cy.getByDataTestId('instances_show-history-switch').trigger('click');
+    cy.getByDataTestId('instances_show-history-switch').trigger('click');
+    cy.getByDataTestId('instances_instances-box').should((instancesBox) => {
+      expect(instancesBox).to.have.length.greaterThan(0);
+      expect(instancesBox[0]).to.contain('STARTED');
+    });
+  });
+
+  it('should redirect to instance overview showing information of selected gateway', () => {
+    cy.getByDataTestId('instances_instances-box').its(0).trigger('click');
+    cy.url().should('contain', 'environment');
+    cy.contains('Informations');
+    cy.contains('Plugins');
+    cy.contains('System properties');
+  });
+
+  it('should display monitoring information of selected gateway', () => {
+    cy.getByDataTestId('instances_instances-box').its(0).trigger('click');
+    cy.get('a[title="Monitoring"]').trigger('click');
+    cy.getByDataTestId('instance-monitoring_jvm-box').contains('JVM').should('be.visible');
+    cy.getByDataTestId('instance-monitoring_cpu-box').scrollIntoView().contains('CPU').should('be.visible');
+    cy.getByDataTestId('instance-monitoring_process-box').contains('Process').should('be.visible');
+    cy.getByDataTestId('instance-monitoring_thread-box').scrollIntoView().contains('Thread').should('be.visible');
+    cy.getByDataTestId('instance-monitoring_gc-box').contains('Garbage collector').should('be.visible');
+    cy.url().should('contain', 'monitoring');
+  });
+});
+
+describe('Get Gateway instance information as non-admin', () => {
+  beforeEach(() => {
+    cy.loginInAPIM(API_PUBLISHER_USER.username, API_PUBLISHER_USER.password);
+  });
+
+  it('should not be able to call gateway instances', function () {
+    cy.visit(`${Cypress.env('managementUI')}/#!/environments/DEFAULT/instances/`);
+    cy.url().should('not.contain', 'instances');
+  });
+});


### PR DESCRIPTION
gravitee-io/issues#7586

Created Cypress tests for displaying Gateway information in UI

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/test-7586-gateway-instance-information-ui-tests-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
