### PR TITLE
Fix packaging with elastic repository + use latest version of reporter-elassticsearch

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -119,7 +119,7 @@
         <gravitee-notifier-email.version>1.3.2</gravitee-notifier-email.version>
         <gravitee-notifier-slack.version>1.2.1</gravitee-notifier-slack.version>
         <gravitee-notifier-webhook.version>1.1.0</gravitee-notifier-webhook.version>
-        <gravitee-reporter-elasticsearch.version>3.8.4</gravitee-reporter-elasticsearch.version>
+        <gravitee-reporter-elasticsearch.version>3.8.5</gravitee-reporter-elasticsearch.version>
         <gravitee-reporter-file.version>2.4.3</gravitee-reporter-file.version>
         <gravitee-reporter-kafka.version>1.3.0</gravitee-reporter-kafka.version>
         <gravitee-reporter-tcp.version>1.3.3</gravitee-reporter-tcp.version>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/assembly/plugin-assembly.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/assembly/plugin-assembly.xml
@@ -167,6 +167,7 @@
             <includes>
                 <include>io.gravitee.*:*:jar</include>
             </includes>
+            <scope>compile</scope>
             <useProjectArtifact>false</useProjectArtifact>
         </dependencySet>
         <dependencySet>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/assembly/plugin-assembly.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/assembly/plugin-assembly.xml
@@ -168,6 +168,7 @@
             <includes>
                 <include>io.gravitee.*:*:jar</include>
             </includes>
+            <scope>compile</scope>
             <useProjectArtifact>false</useProjectArtifact>
         </dependencySet>
         <dependencySet>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7110

**Description**

 * when computing dependencies of the rest-api, `gravitee-apim-repositoty-elasticsearch` which is a runtime dependency, is taken into account. As a consequence, `gravitee-common-elasticsearch` is put in the `/lib` folder.
To avoid this, we must add the **compile** scope in the assembly descriptor.
* use the fixed version of `gravitee-reporter-elasticsearch`
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/3-10-x-7110-fix-ilm-support/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
