### PR TITLE
3.10.x 6044 dynamic dictionary illegal argument exception

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ commands:
     notify-on-failure:
         steps:
             - slack/notify:
-                  branch_pattern: master
+                  branch_pattern: master, /^\d+\.\d+\.x$/
                   event: fail
                   template: basic_fail_1
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/DictionarySynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/DictionarySynchronizer.java
@@ -66,9 +66,7 @@ public class DictionarySynchronizer extends AbstractSynchronizer {
                         DICTIONARY_ID,
                         environments,
                         EventType.PUBLISH_DICTIONARY,
-                        EventType.START_DICTIONARY,
-                        EventType.UNPUBLISH_DICTIONARY,
-                        EventType.STOP_DICTIONARY
+                        EventType.UNPUBLISH_DICTIONARY
                     )
                     .compose(this::processDictionaryEvents)
                     .count()
@@ -83,6 +81,7 @@ public class DictionarySynchronizer extends AbstractSynchronizer {
     }
 
     private long initialSynchronizeDictionaries(long nextLastRefreshAt, List<String> environments) {
+        // We look only for the latest PUBLISH or UNPUBLISH events for dictionaries...
         return this.searchLatestEvents(
                 bulkItems,
                 null,
@@ -91,8 +90,9 @@ public class DictionarySynchronizer extends AbstractSynchronizer {
                 DICTIONARY_ID,
                 environments,
                 EventType.PUBLISH_DICTIONARY,
-                EventType.START_DICTIONARY
+                EventType.UNPUBLISH_DICTIONARY
             )
+            .filter(e -> e.getType().equals(EventType.PUBLISH_DICTIONARY)) // ... but if the latest event of a dictionary is UNPUBLISH, it must not be loaded
             .compose(this::processDictionaryDeployEvents)
             .count()
             .blockingGet();
@@ -104,11 +104,9 @@ public class DictionarySynchronizer extends AbstractSynchronizer {
             .groupBy(Event::getType)
             .flatMap(
                 eventsByType -> {
-                    if (eventsByType.getKey() == EventType.PUBLISH_DICTIONARY || eventsByType.getKey() == EventType.START_DICTIONARY) {
+                    if (eventsByType.getKey() == EventType.PUBLISH_DICTIONARY) {
                         return eventsByType.compose(this::processDictionaryDeployEvents);
-                    } else if (
-                        eventsByType.getKey() == EventType.UNPUBLISH_DICTIONARY || eventsByType.getKey() == EventType.STOP_DICTIONARY
-                    ) {
+                    } else if (eventsByType.getKey() == EventType.UNPUBLISH_DICTIONARY) {
                         return eventsByType.compose(this::processDictionaryUndeployEvents);
                     } else {
                         return Flowable.empty();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/DictionarySynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/DictionarySynchronizerTest.java
@@ -70,7 +70,7 @@ public class DictionarySynchronizerTest extends TestCase {
                 argThat(
                     criteria ->
                         criteria != null &&
-                        criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.START_DICTIONARY)) &&
+                        criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.UNPUBLISH_DICTIONARY)) &&
                         criteria.getEnvironments().containsAll(ENVIRONMENTS)
                 ),
                 eq(Event.EventProperties.DICTIONARY_ID),
@@ -97,16 +97,7 @@ public class DictionarySynchronizerTest extends TestCase {
                 argThat(
                     criteria ->
                         criteria != null &&
-                        criteria
-                            .getTypes()
-                            .containsAll(
-                                Arrays.asList(
-                                    EventType.PUBLISH_DICTIONARY,
-                                    EventType.START_DICTIONARY,
-                                    EventType.UNPUBLISH_DICTIONARY,
-                                    EventType.STOP_DICTIONARY
-                                )
-                            ) &&
+                        criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.UNPUBLISH_DICTIONARY)) &&
                         criteria.getEnvironments().containsAll(ENVIRONMENTS)
                 ),
                 eq(Event.EventProperties.DICTIONARY_ID),
@@ -140,16 +131,7 @@ public class DictionarySynchronizerTest extends TestCase {
                 argThat(
                     criteria ->
                         criteria != null &&
-                        criteria
-                            .getTypes()
-                            .containsAll(
-                                Arrays.asList(
-                                    EventType.PUBLISH_DICTIONARY,
-                                    EventType.START_DICTIONARY,
-                                    EventType.UNPUBLISH_DICTIONARY,
-                                    EventType.STOP_DICTIONARY
-                                )
-                            ) &&
+                        criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.UNPUBLISH_DICTIONARY)) &&
                         criteria.getEnvironments().containsAll(ENVIRONMENTS)
                 ),
                 eq(Event.EventProperties.DICTIONARY_ID),
@@ -164,16 +146,7 @@ public class DictionarySynchronizerTest extends TestCase {
                 argThat(
                     criteria ->
                         criteria != null &&
-                        criteria
-                            .getTypes()
-                            .containsAll(
-                                Arrays.asList(
-                                    EventType.PUBLISH_DICTIONARY,
-                                    EventType.START_DICTIONARY,
-                                    EventType.UNPUBLISH_DICTIONARY,
-                                    EventType.STOP_DICTIONARY
-                                )
-                            ) &&
+                        criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.UNPUBLISH_DICTIONARY)) &&
                         criteria.getEnvironments().containsAll(ENVIRONMENTS)
                 ),
                 eq(Event.EventProperties.DICTIONARY_ID),
@@ -201,16 +174,7 @@ public class DictionarySynchronizerTest extends TestCase {
                 argThat(
                     criteria ->
                         criteria != null &&
-                        criteria
-                            .getTypes()
-                            .containsAll(
-                                Arrays.asList(
-                                    EventType.PUBLISH_DICTIONARY,
-                                    EventType.START_DICTIONARY,
-                                    EventType.UNPUBLISH_DICTIONARY,
-                                    EventType.STOP_DICTIONARY
-                                )
-                            ) &&
+                        criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.UNPUBLISH_DICTIONARY)) &&
                         criteria.getEnvironments().containsAll(ENVIRONMENTS)
                 ),
                 eq(Event.EventProperties.DICTIONARY_ID),
@@ -244,16 +208,7 @@ public class DictionarySynchronizerTest extends TestCase {
                 argThat(
                     criteria ->
                         criteria != null &&
-                        criteria
-                            .getTypes()
-                            .containsAll(
-                                Arrays.asList(
-                                    EventType.PUBLISH_DICTIONARY,
-                                    EventType.START_DICTIONARY,
-                                    EventType.UNPUBLISH_DICTIONARY,
-                                    EventType.STOP_DICTIONARY
-                                )
-                            ) &&
+                        criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.UNPUBLISH_DICTIONARY)) &&
                         criteria.getEnvironments().containsAll(ENVIRONMENTS)
                 ),
                 eq(Event.EventProperties.DICTIONARY_ID),
@@ -268,16 +223,7 @@ public class DictionarySynchronizerTest extends TestCase {
                 argThat(
                     criteria ->
                         criteria != null &&
-                        criteria
-                            .getTypes()
-                            .containsAll(
-                                Arrays.asList(
-                                    EventType.PUBLISH_DICTIONARY,
-                                    EventType.START_DICTIONARY,
-                                    EventType.UNPUBLISH_DICTIONARY,
-                                    EventType.STOP_DICTIONARY
-                                )
-                            ) &&
+                        criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.UNPUBLISH_DICTIONARY)) &&
                         criteria.getEnvironments().containsAll(ENVIRONMENTS)
                 ),
                 eq(Event.EventProperties.DICTIONARY_ID),
@@ -304,9 +250,9 @@ public class DictionarySynchronizerTest extends TestCase {
             dictionary.setId("dictionary" + i + "-test");
 
             if (i % 2 == 0) {
-                eventAccumulator.add(mockEvent(dictionary, EventType.START_DICTIONARY));
+                eventAccumulator.add(mockEvent(dictionary, EventType.PUBLISH_DICTIONARY));
             } else {
-                eventAccumulator.add(mockEvent(dictionary, EventType.STOP_DICTIONARY));
+                eventAccumulator.add(mockEvent(dictionary, EventType.UNPUBLISH_DICTIONARY));
             }
 
             if (i % 100 == 0) {
@@ -317,14 +263,7 @@ public class DictionarySynchronizerTest extends TestCase {
                                 criteria != null &&
                                 criteria
                                     .getTypes()
-                                    .containsAll(
-                                        Arrays.asList(
-                                            EventType.PUBLISH_DICTIONARY,
-                                            EventType.START_DICTIONARY,
-                                            EventType.UNPUBLISH_DICTIONARY,
-                                            EventType.STOP_DICTIONARY
-                                        )
-                                    ) &&
+                                    .containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.UNPUBLISH_DICTIONARY)) &&
                                 criteria.getEnvironments().containsAll(ENVIRONMENTS)
                         ),
                         eq(Event.EventProperties.DICTIONARY_ID),
@@ -357,7 +296,7 @@ public class DictionarySynchronizerTest extends TestCase {
                 argThat(
                     criteria ->
                         criteria != null &&
-                        criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.START_DICTIONARY))
+                        criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_DICTIONARY, EventType.UNPUBLISH_DICTIONARY))
                 ),
                 eq(Event.EventProperties.DICTIONARY_ID),
                 anyLong(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/src/main/java/io/gravitee/rest/api/services/dictionary/provider/http/mapper/JoltMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/src/main/java/io/gravitee/rest/api/services/dictionary/provider/http/mapper/JoltMapper.java
@@ -64,13 +64,10 @@ public class JoltMapper {
             .stream()
             .map(
                 item -> {
-                    Map<String, String> mapItem = (Map<String, String>) item;
-                    Object key = mapItem.get("key");
-                    if (key instanceof Number) {
-                        return new DynamicProperty(key.toString(), mapItem.get("value"));
-                    } else {
-                        return new DynamicProperty((String) key, mapItem.get("value"));
-                    }
+                    Map<Object, Object> mapItem = (Map<Object, Object>) item;
+                    String key = String.valueOf(mapItem.get("key"));
+                    String value = String.valueOf(mapItem.get("value"));
+                    return new DynamicProperty(key, value);
                 }
             )
             .collect(Collectors.toList());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/src/test/java/io/gravitee/rest/api/services/dictionary/provider/http/HttpProviderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/src/test/java/io/gravitee/rest/api/services/dictionary/provider/http/HttpProviderTest.java
@@ -72,7 +72,8 @@ public class HttpProviderTest {
     @Test
     public void shouldGetProperties() throws IOException {
         when(configuration.getUrl()).thenReturn("http://localhost:" + wireMockRule.port() + "/success");
-        when(configuration.getSpecification()).thenReturn(IOUtils.toString(read("/jolt/specification.json"), Charset.defaultCharset()));
+        when(configuration.getSpecification())
+            .thenReturn(IOUtils.toString(read("/jolt/specification-key-value-simple.json"), Charset.defaultCharset()));
         when(configuration.getMethod()).thenReturn(HttpMethod.GET);
 
         HttpProvider provider = new HttpProvider(configuration);
@@ -90,7 +91,8 @@ public class HttpProviderTest {
     @Test
     public void shouldGetPropertiesWithoutMethod() throws IOException {
         when(configuration.getUrl()).thenReturn("http://localhost:" + wireMockRule.port() + "/success_post");
-        when(configuration.getSpecification()).thenReturn(IOUtils.toString(read("/jolt/specification.json"), Charset.defaultCharset()));
+        when(configuration.getSpecification())
+            .thenReturn(IOUtils.toString(read("/jolt/specification-key-value-simple.json"), Charset.defaultCharset()));
         when(configuration.getBody()).thenReturn("{}");
 
         HttpProvider provider = new HttpProvider(configuration);
@@ -108,7 +110,8 @@ public class HttpProviderTest {
     @Test
     public void shouldGetPropertiesFromPOST() throws IOException {
         when(configuration.getUrl()).thenReturn("http://localhost:" + wireMockRule.port() + "/success_post");
-        when(configuration.getSpecification()).thenReturn(IOUtils.toString(read("/jolt/specification.json"), Charset.defaultCharset()));
+        when(configuration.getSpecification())
+            .thenReturn(IOUtils.toString(read("/jolt/specification-key-value-simple.json"), Charset.defaultCharset()));
         when(configuration.getMethod()).thenReturn(HttpMethod.GET);
         when(configuration.getBody()).thenReturn("{}");
 
@@ -127,7 +130,8 @@ public class HttpProviderTest {
     @Test
     public void shouldGetNullPropertiesBecauseHttpError() throws IOException {
         when(configuration.getUrl()).thenReturn("http://localhost:" + wireMockRule.port() + "/error");
-        when(configuration.getSpecification()).thenReturn(IOUtils.toString(read("/jolt/specification.json"), Charset.defaultCharset()));
+        when(configuration.getSpecification())
+            .thenReturn(IOUtils.toString(read("/jolt/specification-key-value-simple.json"), Charset.defaultCharset()));
         when(configuration.getMethod()).thenReturn(HttpMethod.GET);
 
         HttpProvider provider = new HttpProvider(configuration);
@@ -145,7 +149,8 @@ public class HttpProviderTest {
     @Test(expected = CompletionException.class)
     public void shouldCallUnknownUri() throws IOException {
         when(configuration.getUrl()).thenReturn("http://unknown_host:" + wireMockRule.port());
-        when(configuration.getSpecification()).thenReturn(IOUtils.toString(read("/jolt/specification.json"), Charset.defaultCharset()));
+        when(configuration.getSpecification())
+            .thenReturn(IOUtils.toString(read("/jolt/specification-key-value-simple.json"), Charset.defaultCharset()));
         when(configuration.getMethod()).thenReturn(HttpMethod.GET);
 
         HttpProvider provider = new HttpProvider(configuration);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/src/test/java/io/gravitee/rest/api/services/dictionary/provider/http/mapper/JoltMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/src/test/java/io/gravitee/rest/api/services/dictionary/provider/http/mapper/JoltMapperTest.java
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.services.dynamicproperties.provider.http.mapper;
+package io.gravitee.rest.api.services.dictionary.provider.http.mapper;
 
 import static org.junit.Assert.assertEquals;
 
-import io.gravitee.rest.api.services.dynamicproperties.model.DynamicProperty;
+import io.gravitee.rest.api.services.dictionary.model.DynamicProperty;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/src/test/resources/jolt/custom-response.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/src/test/resources/jolt/custom-response.json
@@ -1,40 +1,14 @@
 {
-  "content": [
-    {
-      "name": "Elysee",
-      "country": "FRANCE",
-      "address": "Avenue des Champs-Élysées",
-      "city": "PARIS",
-      "stores_id": 1,
-      "zip_code": "75000",
-      "gps_x": "48.869729",
-      "gps_y": "2.307784",
-      "phone_number": "01 00 00 00 00",
-      "backend_url": "https://north-europe.company.com/"
-    },
-    {
-      "name": "Montparnasse",
-      "country": "FRANCE",
-      "address": "Boulevard de Vaugirard",
-      "city": "PARIS",
-      "stores_id": 2,
-      "zip_code": "75000",
-      "gps_x": "48.841895",
-      "gps_y": "2.319508",
-      "phone_number": "01 00 00 00 00",
-      "backend_url": "https://north-europe.company.com/"
-    },
-    {
-      "name": "Yu garden",
-      "country": "CHINA",
-      "address": "huanpu qu",
-      "city": "Shanghai",
-      "stores_id": 3,
-      "zip_code": "XXXX",
-      "gps_x": "31.227208",
-      "gps_y": "121.491836",
-      "phone_number": "+351 000 000 000",
-      "backend_url": "https://south-asia.company.com/"
-    }
-  ]
+  "content": {
+    "name": "Elysee",
+    "country": "FRANCE",
+    "address": "Avenue des Champs-Élysées",
+    "city": "PARIS",
+    "stores_id": 1,
+    "zip_code": "75000",
+    "gps_x": "48.869729",
+    "gps_y": "2.307784",
+    "phone_number": "01 00 00 00 00",
+    "backend_url": "https://north-europe.company.com/"
+  }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/src/test/resources/jolt/specification-key-value-simple.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/src/test/resources/jolt/specification-key-value-simple.json
@@ -1,0 +1,13 @@
+[
+  {
+    "operation": "shift",
+    "spec": {
+      "content": {
+        "*": {
+          "$": "[#2].key",
+          "@": "[#2].value"
+        }
+      }
+    }
+  }
+]

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/src/test/resources/jolt/specification-value-as-key.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/src/test/resources/jolt/specification-value-as-key.json
@@ -4,8 +4,8 @@
     "spec": {
       "content": {
         "*": {
-          "stores_id": "[&1].key",
-          "backend_url": "[&1].value"
+          "$": "[#2].value",
+          "@": "[#2].key"
         }
       }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/provider/http/mapper/JoltMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/provider/http/mapper/JoltMapper.java
@@ -73,13 +73,10 @@ public class JoltMapper {
             .stream()
             .map(
                 item -> {
-                    Map<String, String> mapItem = (Map<String, String>) item;
-                    Object key = mapItem.get("key");
-                    if (key instanceof Number) {
-                        return new DynamicProperty(key.toString(), mapItem.get("value"));
-                    } else {
-                        return new DynamicProperty((String) key, mapItem.get("value"));
-                    }
+                    Map<Object, Object> mapItem = (Map<Object, Object>) item;
+                    String key = String.valueOf(mapItem.get("key"));
+                    String value = String.valueOf(mapItem.get("value"));
+                    return new DynamicProperty(key, value);
                 }
             )
             .collect(Collectors.toList());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertiesServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertiesServiceTest.java
@@ -89,7 +89,7 @@ public class DynamicPropertiesServiceTest {
         when(providerConfiguration.getUrl()).thenReturn("http://localhost:" + wireMockRule.port() + "/success");
         when(providerConfiguration.getMethod()).thenReturn(HttpMethod.GET);
         when(providerConfiguration.getSpecification())
-            .thenReturn(IOUtils.toString(read("/jolt/specification.json"), Charset.defaultCharset()));
+            .thenReturn(IOUtils.toString(read("/jolt/specification-value-as-key.json"), Charset.defaultCharset()));
         when(httpClientService.createHttpClient(anyString(), anyBoolean())).thenReturn(Vertx.vertx().createHttpClient());
         cut.onEvent(new SimpleEvent<>(ApiEvent.DEPLOY, apiEntity));
 
@@ -134,7 +134,7 @@ public class DynamicPropertiesServiceTest {
         when(providerConfiguration.getUrl()).thenReturn("http://localhost:" + wireMockRule.port() + "/success");
         when(providerConfiguration.getMethod()).thenReturn(HttpMethod.GET);
         when(providerConfiguration.getSpecification())
-            .thenReturn(IOUtils.toString(read("/jolt/specification.json"), Charset.defaultCharset()));
+            .thenReturn(IOUtils.toString(read("/jolt/specification-value-as-key.json"), Charset.defaultCharset()));
         when(httpClientService.createHttpClient(anyString(), anyBoolean())).thenReturn(Vertx.vertx().createHttpClient());
         cut.onEvent(new SimpleEvent<>(ApiEvent.UPDATE, apiEntity));
 
@@ -149,7 +149,7 @@ public class DynamicPropertiesServiceTest {
         when(providerConfiguration.getUrl()).thenReturn("http://localhost:" + wireMockRule.port() + "/success");
         when(providerConfiguration.getMethod()).thenReturn(HttpMethod.GET);
         when(providerConfiguration.getSpecification())
-            .thenReturn(IOUtils.toString(read("/jolt/specification.json"), Charset.defaultCharset()));
+            .thenReturn(IOUtils.toString(read("/jolt/specification-value-as-key.json"), Charset.defaultCharset()));
         when(httpClientService.createHttpClient(anyString(), anyBoolean())).thenReturn(Vertx.vertx().createHttpClient());
         cut.onEvent(new SimpleEvent<>(ApiEvent.UPDATE, apiEntity));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/java/io/gravitee/rest/api/services/dynamicproperties/provider/http/HttpProviderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/java/io/gravitee/rest/api/services/dynamicproperties/provider/http/HttpProviderTest.java
@@ -78,7 +78,7 @@ public class HttpProviderTest {
         when(dynamicPropertyService.getConfiguration()).thenReturn(providerConfiguration);
         when(providerConfiguration.getUrl()).thenReturn("http://localhost:" + wireMockRule.port() + "/success");
         when(providerConfiguration.getSpecification())
-            .thenReturn(IOUtils.toString(read("/jolt/specification.json"), Charset.defaultCharset()));
+            .thenReturn(IOUtils.toString(read("/jolt/specification-key-value-simple.json"), Charset.defaultCharset()));
         when(providerConfiguration.getMethod()).thenReturn(HttpMethod.GET);
 
         HttpProvider provider = new HttpProvider(dynamicPropertyService);
@@ -98,7 +98,7 @@ public class HttpProviderTest {
         when(dynamicPropertyService.getConfiguration()).thenReturn(providerConfiguration);
         when(providerConfiguration.getUrl()).thenReturn("http://localhost:" + wireMockRule.port() + "/success_post");
         when(providerConfiguration.getSpecification())
-            .thenReturn(IOUtils.toString(read("/jolt/specification.json"), Charset.defaultCharset()));
+            .thenReturn(IOUtils.toString(read("/jolt/specification-key-value-simple.json"), Charset.defaultCharset()));
         when(providerConfiguration.getMethod()).thenReturn(HttpMethod.GET);
         when(providerConfiguration.getBody()).thenReturn("{}");
 
@@ -119,7 +119,7 @@ public class HttpProviderTest {
         when(dynamicPropertyService.getConfiguration()).thenReturn(providerConfiguration);
         when(providerConfiguration.getUrl()).thenReturn("http://localhost:" + wireMockRule.port() + "/error");
         when(providerConfiguration.getSpecification())
-            .thenReturn(IOUtils.toString(read("/jolt/specification.json"), Charset.defaultCharset()));
+            .thenReturn(IOUtils.toString(read("/jolt/specification-key-value-simple.json"), Charset.defaultCharset()));
         when(providerConfiguration.getMethod()).thenReturn(HttpMethod.GET);
 
         HttpProvider provider = new HttpProvider(dynamicPropertyService);
@@ -139,7 +139,7 @@ public class HttpProviderTest {
         when(dynamicPropertyService.getConfiguration()).thenReturn(providerConfiguration);
         when(providerConfiguration.getUrl()).thenReturn("http://unknown_host:" + wireMockRule.port());
         when(providerConfiguration.getSpecification())
-            .thenReturn(IOUtils.toString(read("/jolt/specification.json"), Charset.defaultCharset()));
+            .thenReturn(IOUtils.toString(read("/jolt/specification-key-value-simple.json"), Charset.defaultCharset()));
         when(providerConfiguration.getMethod()).thenReturn(HttpMethod.GET);
 
         HttpProvider provider = new HttpProvider(dynamicPropertyService);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/resources/jolt/custom-response.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/resources/jolt/custom-response.json
@@ -1,5 +1,5 @@
 {
-  "content": [
+  "content":
     {
       "name": "Elysee",
       "country": "FRANCE",
@@ -11,30 +11,4 @@
       "gps_y": "2.307784",
       "phone_number": "01 00 00 00 00",
       "backend_url": "https://north-europe.company.com/"
-    },
-    {
-      "name": "Montparnasse",
-      "country": "FRANCE",
-      "address": "Boulevard de Vaugirard",
-      "city": "PARIS",
-      "stores_id": 2,
-      "zip_code": "75000",
-      "gps_x": "48.841895",
-      "gps_y": "2.319508",
-      "phone_number": "01 00 00 00 00",
-      "backend_url": "https://north-europe.company.com/"
-    },
-    {
-      "name": "Yu garden",
-      "country": "CHINA",
-      "address": "huanpu qu",
-      "city": "Shanghai",
-      "stores_id": 3,
-      "zip_code": "XXXX",
-      "gps_x": "31.227208",
-      "gps_y": "121.491836",
-      "phone_number": "+351 000 000 000",
-      "backend_url": "https://south-asia.company.com/"
-    }
-  ]
-}
+    }}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/resources/jolt/specification-key-value-simple.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/resources/jolt/specification-key-value-simple.json
@@ -1,0 +1,13 @@
+[
+  {
+    "operation": "shift",
+    "spec": {
+      "content": {
+        "*": {
+          "$": "[#2].key",
+          "@": "[#2].value"
+        }
+      }
+    }
+  }
+]

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/resources/jolt/specification-value-as-key.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/resources/jolt/specification-value-as-key.json
@@ -4,8 +4,8 @@
     "spec": {
       "content": {
         "*": {
-          "stores_id": "[&1].key",
-          "backend_url": "[&1].value"
+          "$": "[#2].value",
+          "@": "[#2].key"
         }
       }
     }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6044

https://github.com/gravitee-io/issues/issues/7684

**Description**
- Backport this forgotten stuff 😁 : https://github.com/gravitee-io/gravitee-api-management/pull/1038
- Small fix for Dictionary and Property with jolt transformation  

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/3-10-x-6044-dynamic-dictionary-illegalargumentexception/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
