### PR TITLE
use latest version of reporter-elasticsearch

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -104,7 +104,7 @@
         <gravitee-fetcher-gitlab.version>1.11.0</gravitee-fetcher-gitlab.version>
         <gravitee-fetcher-http.version>1.12.0</gravitee-fetcher-http.version>
         <!-- Gateway Only -->
-        <gravitee-reporter-elasticsearch.version>3.12.0</gravitee-reporter-elasticsearch.version>
+        <gravitee-reporter-elasticsearch.version>3.12.1</gravitee-reporter-elasticsearch.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->
         <!--    <gravitee-gateway-services-ratelimit.version>1.15.0</gravitee-gateway-services-ratelimit.version>    -->
         <gravitee-reporter-file.version>2.5.1</gravitee-reporter-file.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7110

**Description**

use the fixed version of `gravitee-reporter-elasticsearch`
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/3-15-x-7110-fix-ilm-support/index.html)
_Notes_: The deployed app is linked to the management API of the Element Zero team's environment.
<!-- UI placeholder end -->
