### PR TITLE
3.10.x Alert not correctly displayed/saved

### DIFF
--- a/gravitee-apim-console-webui/src/components/alerts/alerts.html
+++ b/gravitee-apim-console-webui/src/components/alerts/alerts.html
@@ -111,15 +111,15 @@
       </div>
     </div>
   </div>
-  <div ng-style="{'text-align': $ctrl.alerts.length == 0 ? 'center' : 'none' }">
-    <md-button
-      ng-if="$ctrl.hasPermissionForCurrentScope('alert-c')"
-      ng-class="{'md-fab-bottom-right': $ctrl.alerts.length > 0}"
-      class="md-fab"
-      aria-label="create-alert"
-      ng-click="$ctrl.goTo('alertnew')"
-    >
-      <ng-md-icon icon="add" style="fill: #fff"></ng-md-icon>
-    </md-button>
-  </div>
+</div>
+<div ng-style="{'text-align': $ctrl.alerts.length == 0 ? 'center' : 'none' }">
+  <md-button
+    ng-if="$ctrl.hasPermissionForCurrentScope('alert-c')"
+    ng-class="{'md-fab-bottom-right': $ctrl.alerts.length > 0}"
+    class="md-fab"
+    aria-label="create-alert"
+    ng-click="$ctrl.goTo('alertnew')"
+  >
+    <ng-md-icon icon="add" style="fill: #fff"></ng-md-icon>
+  </md-button>
 </div>

--- a/gravitee-apim-console-webui/src/entities/alert.ts
+++ b/gravitee-apim-console-webui/src/entities/alert.ts
@@ -237,14 +237,14 @@ export class AggregationCondition extends Condition {
   static OPERATORS: Operator[] = [AggregationCondition.LT, AggregationCondition.LTE, AggregationCondition.GTE, AggregationCondition.GT];
 
   static FUNCTIONS: Function[] = [
-    new Function('count', 'count'),
-    new Function('avg', 'average'),
-    new Function('min', 'min'),
-    new Function('max', 'max'),
-    new Function('p50', '50th percentile'),
-    new Function('p90', '90th percentile'),
-    new Function('p95', '95th percentile'),
-    new Function('p99', '99th percentile'),
+    new Function('COUNT', 'count'),
+    new Function('AVG', 'average'),
+    new Function('MIN', 'min'),
+    new Function('MAX', 'max'),
+    new Function('P50', '50th percentile'),
+    new Function('P90', '90th percentile'),
+    new Function('P95', '95th percentile'),
+    new Function('P99', '99th percentile'),
   ];
 
   constructor() {

--- a/gravitee-apim-console-webui/src/management/api/analytics/alerts/api-alerts-dashboard.html
+++ b/gravitee-apim-console-webui/src/management/api/analytics/alerts/api-alerts-dashboard.html
@@ -16,7 +16,7 @@
 
 -->
 <gv-alert-dashboard
-  reference-type="'api'"
+  reference-type="'API'"
   reference-id="$parent.apiCtrl.api.id"
   has-configured-alerts="$ctrl.hasConfiguredAlerts"
   has-alerting-plugin="$ctrl.hasAlertingPlugin"


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7279
https://github.com/gravitee-io/issues/issues/7086
https://github.com/gravitee-io/issues/issues/6705
https://github.com/gravitee-io/issues/issues/7537
https://github.com/gravitee-io/issues/issues/5334

**Description**


Capitalize the functions id for alert trigger from because it will be done by the backend which prevented the form from selecting the right element on an update

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/3-10-x-alert/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
