### PR TITLE
improve 3.10.x workflows execution (cache + split)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,12 +47,35 @@ commands:
                       echo "export BUILD_NUMBER=$BUILD_NUMBER" >> $BASH_ENV
                       echo "export GIT_COMMIT=$GIT_COMMIT" >> $BASH_ENV
 
-    restore-maven-cache:
-        description: Restore Maven cache
+
+    restore-maven-job-cache:
+        description: Restore Maven cache for a dedicated job
+        parameters:
+            jobName:
+                description: The job name
+                type: string
+                default: ""
         steps:
             - restore_cache:
                   keys:
-                      - gravitee-api-management-v5-{{ .Branch }}-{{ checksum "pom.xml" }}
+                      - gravitee-api-management-v6-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+                      - gravitee-api-management-v6-<< parameters.jobName >>-{{ .Branch }}-
+                      - gravitee-api-management-v6-<< parameters.jobName >>-
+                      - gravitee-api-management-v6-
+
+    save-maven-job-cache:
+        description: Restore Maven cache for a dedicated job
+        parameters:
+            jobName:
+                description: The job name
+                type: string
+                default: ""
+        steps:
+            - save_cache:
+                  paths:
+                      - ~/.m2
+                  key: gravitee-api-management-v6-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+                  when: always
 
     notify-on-failure:
         steps:
@@ -212,12 +235,14 @@ jobs:
             - checkout
             - attach_workspace:
                   at: .
-            - restore-maven-cache
+            - restore-maven-job-cache:
+                  jobName: validate
             - run:
                   name: "validate project"
                   command: |
                       mvn -pl '!gravitee-apim-console-webui, !gravitee-apim-portal-webui' -s .gravitee.settings.xml validate --no-transfer-progress -T 2C
-
+            - save-maven-job-cache:
+                  jobName: validate
             - notify-on-failure
 
     build:
@@ -228,21 +253,28 @@ jobs:
             - checkout
             - attach_workspace:
                   at: .
-            - restore-maven-cache
+            - restore-maven-job-cache:
+                  jobName: build
             - prepare-env-var
             - run:
                   name: "Build project"
                   command: |
-                      mvn -pl '!gravitee-apim-console-webui, !gravitee-apim-portal-webui' -s .gravitee.settings.xml clean package --no-transfer-progress -DskipTests -Dskip.validation=true -T 2C
+                      mvn -pl '!gravitee-apim-console-webui, !gravitee-apim-portal-webui' -s .gravitee.settings.xml clean install --no-transfer-progress -DskipTests -Dskip.validation=true -T 2C
                       cp ./gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/gravitee-apim-rest-api-standalone-distribution-zip/target/gravitee-apim-rest-api-distribution-*.tar.gz ./
                       cp ./gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/gravitee-apim-gateway-standalone-distribution-zip/target/gravitee-apim-gateway-distribution-*.tar.gz ./
 
             - notify-on-failure
             - save_cache:
                   paths:
-                      - ~/.m2
-                  key: gravitee-api-management-v5-{{ .Branch }}-{{ checksum "pom.xml" }}
-                  when: always
+                      - ~/.m2/repository/io/gravitee/apim
+                  key: gravitee-api-management-v6-build-apim-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+                  when: on_success
+            - run:
+                  name: "Exclude APIM artefacts from build cache"
+                  command: |
+                      rm -rf ~/.m2/repository/io/gravitee/apim
+            - save-maven-job-cache:
+                  jobName: build
             - persist_to_workspace:
                   root: ./
                   paths:
@@ -258,7 +290,11 @@ jobs:
             - checkout
             - attach_workspace:
                   at: .
-            - restore-maven-cache
+            - restore-maven-job-cache:
+                  jobName: test
+            - restore_cache:
+                  keys:
+                      - gravitee-api-management-v6-build-apim-{{ .Environment.CIRCLE_WORKFLOW_ID }}
             - run:
                   name: Run tests
                   command: |
@@ -271,6 +307,8 @@ jobs:
                       find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
                   when: always
             - notify-on-failure
+            - save-maven-job-cache:
+                  jobName: test
             - store_test_results:
                   path: ~/test-results
 
@@ -284,12 +322,15 @@ jobs:
             - checkout
             - attach_workspace:
                   at: .
-            - restore-maven-cache
+            - restore-maven-job-cache:
+                  jobName: publish-on-artifactory
             - run:
                   name: "Maven Package and deploy to Artifactory ([gravitee-snapshots] repository)"
                   command: |
                       mvn deploy --no-transfer-progress -DskipTests -Dskip.validation=true -T 2C -pl '!gravitee-apim-console-webui, !gravitee-apim-portal-webui' -s .gravitee.settings.xml   -DaltDeploymentRepository=${ALT_DEPLOYMENT_REPOSITORY}
             - notify-on-failure
+            - save-maven-job-cache:
+                  jobName: publish-on-artifactory
 
     publish-on-nexus:
         docker:
@@ -299,12 +340,15 @@ jobs:
             - checkout
             - attach_workspace:
                   at: .
-            - restore-maven-cache
+            - restore-maven-job-cache:
+                  jobName: publish-on-nexus
             - run:
                   name: "Maven Package and deploy to Nexus Snapshots"
                   command: |
                       mvn deploy --no-transfer-progress -DskipTests -Dskip.validation=true -T 2C -pl '!gravitee-apim-console-webui, !gravitee-apim-portal-webui' -s .gravitee.settings.xml
             - notify-on-failure
+            - save-maven-job-cache:
+                  jobName: publish-on-nexus
 
     publish-images-azure-registry:
         docker:
@@ -623,9 +667,8 @@ jobs:
             DRY_RUN: << pipeline.parameters.dry_run >>
         steps:
             - checkout
-            - restore_cache:
-                  keys:
-                      - gio-gravitee-release-dependencies-{{ .Branch }}
+            - restore-maven-job-cache:
+                  jobName: release
             - attach_workspace:
                   at: /tmp
             - keeper/env-export:
@@ -648,6 +691,9 @@ jobs:
                   name: Maven deploy to Gravitee's private Artifactory
                   command: |
                       mvn -Duser.home=${HOME} -s /tmp/.gravitee.settings.xml -B -U -P gio-artifactory-release,gio-release clean deploy -DskipTests=true -Dskip.validation -T 4 --no-transfer-progress
+            - save-maven-job-cache:
+                  jobName: release
+
             - add_ssh_keys:
                   fingerprints:
                       - "ac:88:23:8f:c6:0f:7d:f0:fc:df:73:20:34:56:02:6c"
@@ -709,6 +755,7 @@ jobs:
                       else
                         echo "# --->>> THIS IS A DRY RUN"
                       fi;
+
 
     publish_prod_docker_images:
         parameters:
@@ -817,7 +864,9 @@ jobs:
                   command: |
                       # the previous cache key was computed with the SNAPSHOT version of the release. 
                       echo "<< pipeline.parameters.graviteeio_version >>-SNAPSHOT" > .apim-version.txt
-            - restore-maven-cache
+            - restore-maven-job-cache:
+                  jobName: nexus-staging
+
             - attach_workspace:
                   at: .
             - prepare-gpg
@@ -825,6 +874,8 @@ jobs:
                   name: Release on Nexus
                   command: |
                       mvn clean deploy --activate-profiles gravitee-release --batch-mode -DskipTests -Dskip.validation=true --settings .gravitee.settings.xml --update-snapshots
+            - save-maven-job-cache:
+                  jobName: nexus-staging
 
     publish_rpm_packages:
       parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1154,20 +1154,24 @@ workflows:
             - test:
                   requires:
                       - build
-            - test-repository:
-                  requires:
-                      - build
             - sonarcloud-analysis:
                   name: Sonar - << matrix.working_directory >>
                   matrix:
                       parameters:
                           working_directory:
                               - gravitee-apim-rest-api
-                              - gravitee-apim-repository
                               - gravitee-apim-gateway
                   context: cicd-orchestrator
                   requires:
                       - test
+            - test-repository:
+                  requires:
+                      - build
+            - sonarcloud-analysis:
+                  name: Sonar - gravitee-apim-repository
+                  working_directory: gravitee-apim-repository
+                  context: cicd-orchestrator
+                  requires:
                       - test-repository
             - publish-on-artifactory:
                   filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,6 @@ commands:
                       - gravitee-api-management-v6-<< parameters.jobName >>-{{ .Branch }}-
                       - gravitee-api-management-v6-<< parameters.jobName >>-
                       - gravitee-api-management-v6-
-
     save-maven-job-cache:
         description: Restore Maven cache for a dedicated job
         parameters:
@@ -217,6 +216,11 @@ jobs:
             - checkout
             - attach_workspace:
                   at: .
+            - restore_cache:
+                  keys:
+                      - gravitee-api-management-v6-sonarcloud-analysis-{{ .Branch }}-{{ checksum "pom.xml" }}
+                      - gravitee-api-management-v6-sonarcloud-analysis-{{ .Branch }}-
+                      - gravitee-api-management-v6-sonarcloud-analysis-
             - keeper/env-export:
                   secret-url: keeper://9x9YgyU6DWzux4DPoHAzDQ/field/password
                   var-name: SONAR_TOKEN
@@ -226,6 +230,11 @@ jobs:
                   command: sonar-scanner -Dsonar.projectVersion=${APIM_VERSION}
                   working_directory: << parameters.working_directory >>
             - notify-on-failure
+            - save_cache:
+                  paths:
+                      - /opt/sonar-scanner/.sonar/cache
+                  key: gravitee-api-management-v6-sonarcloud-analysis-{{ .Branch }}-{{ checksum "pom.xml" }}
+                  when: always
 
     validate:
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,9 +283,9 @@ jobs:
                       - ./gravitee-apim-gateway-distribution-*.tar.gz
 
     test:
-        machine:
-            image: ubuntu-2004:202107-02
-        resource_class: xlarge
+        docker:
+            - image: cimg/openjdk:11.0
+        resource_class: medium
         steps:
             - checkout
             - attach_workspace:
@@ -296,10 +296,15 @@ jobs:
                   keys:
                       - gravitee-api-management-v6-build-apim-{{ .Environment.CIRCLE_WORKFLOW_ID }}
             - run:
-                  name: Run tests
+                  name: Run APIM definition tests
                   command: |
-                      # Need to use `package` phase to get repo-test's jar build and shared to mongodb and jdbc repos
-                      mvn -pl '!gravitee-apim-console-webui, !gravitee-apim-portal-webui' -s .gravitee.settings.xml package --no-transfer-progress -T 2C
+                      # workaround because repo mongo and jdbc use it for tests and we don't want the -amd option to add them in maven reactor
+                      mvn -s .gravitee.settings.xml test --no-transfer-progress -Dskip.validation=true -T 2C -f gravitee-apim-definition/pom.xml
+            - run:
+                  name: Run All except APIM definition tests
+                  command: |
+                      # workaround because repo mongo and jdbc use it for tests and we don't want the -amd option to add them in maven reactor
+                      mvn -pl 'gravitee-apim-rest-api, gravitee-apim-gateway' -amd --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dskip.validation=true -T 2C
             - run:
                   name: Save test results
                   command: |
@@ -309,6 +314,37 @@ jobs:
             - notify-on-failure
             - save-maven-job-cache:
                   jobName: test
+            - store_test_results:
+                  path: ~/test-results
+
+    test-repository:
+        machine:
+            image: ubuntu-2004:current
+        resource_class: large
+        steps:
+            - checkout
+            - attach_workspace:
+                  at: .
+            - restore-maven-job-cache:
+                  jobName: test-repository
+            - restore_cache:
+                  keys:
+                      - gravitee-api-management-v6-build-apim-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+            - run:
+                  name: Run tests
+                  command: |
+                      cd gravitee-apim-repository
+                      # Need to use `package` phase to get repo-test's jar build and shared to mongodb and jdbc repos
+                      mvn package -s ../.gravitee.settings.xml --no-transfer-progress -Dskip.validation=true -T 2C
+            - run:
+                  name: Save test results
+                  command: |
+                      mkdir -p ~/test-results/junit/
+                      find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
+                  when: always
+            - notify-on-failure
+            - save-maven-job-cache:
+                  jobName: test-repository
             - store_test_results:
                   path: ~/test-results
 
@@ -1109,6 +1145,9 @@ workflows:
             - test:
                   requires:
                       - build
+            - test-repository:
+                  requires:
+                      - build
             - sonarcloud-analysis:
                   name: Sonar - << matrix.working_directory >>
                   matrix:
@@ -1120,6 +1159,7 @@ workflows:
                   context: cicd-orchestrator
                   requires:
                       - test
+                      - test-repository
             - publish-on-artifactory:
                   filters:
                       branches:
@@ -1128,6 +1168,7 @@ workflows:
                               - /^\d+\.\d+\.x$/
                   requires:
                       - test
+                      - test-repository
             - publish-on-nexus:
                   filters:
                       branches:
@@ -1136,10 +1177,12 @@ workflows:
                               - /^\d+\.\d+\.x$/
                   requires:
                       - test
+                      - test-repository
             - publish-images-azure-registry:
                   context: cicd-orchestrator
                   requires:
                       - test
+                      - test-repository
                   filters:
                       branches:
                           only:

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http/ClientConnectionResponseTemplateTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http/ClientConnectionResponseTemplateTest.java
@@ -34,7 +34,7 @@ public class ClientConnectionResponseTemplateTest extends AbstractWiremockGatewa
 
     @Test
     public void call_unreachable_api_with_response_template() throws Exception {
-        HttpResponse response = Request.Post("http://localhost:8082/unreachable").execute().returnResponse();
+        HttpResponse response = execute(Request.Post("http://localhost:8082/unreachable")).returnResponse();
 
         assertEquals(HttpStatus.SC_BAD_GATEWAY, response.getStatusLine().getStatusCode());
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/MessageService_GetRecipientIdsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/MessageService_GetRecipientIdsTest.java
@@ -33,6 +33,7 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.MessageRecipientFormatException;
 import io.gravitee.rest.api.service.impl.MessageServiceImpl;
 import java.util.*;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -69,6 +70,11 @@ public class MessageService_GetRecipientIdsTest {
 
     @Mock
     SubscriptionService subscriptionService;
+
+    @Before
+    public void init() {
+        GraviteeContext.cleanContext();
+    }
 
     @Test
     public void shouldThrowExceptionIfNull() {


### PR DESCRIPTION
**Issue**

N/A

**Description**

try a new strategy of cache handling
* one cache per job, shared across workflow instances
* one dedicated cache, shared by some jobs, and only for a workflow instance (behave like a workspace)

split services and repositories tests.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/3-10-x-redesign-circleci-cache-strategy/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
