### PR TITLE
only consider USER while updating members

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
@@ -384,11 +384,12 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
     ) throws JsonProcessingException {
         // Members
         final JsonNode membersToImport = jsonNode.path("members");
-        if (membersToImport != null && membersToImport.isArray()) {
+        if (membersToImport != null && membersToImport.isArray() && membersToImport.size() > 0) {
             // get current members of the api
             Set<MemberToImport> membersAlreadyPresent = membershipService
                 .getMembersByReference(MembershipReferenceType.API, createdOrUpdatedApiEntity.getId())
                 .stream()
+                .filter(member -> member.getType() == MembershipMemberType.USER)
                 .map(
                     member -> {
                         UserEntity userEntity = userService.findById(member.getId());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_CreateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_CreateWithDefinitionTest.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Optional;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
@@ -143,8 +144,11 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         RoleEntity poRoleEntity = new RoleEntity();
         poRoleEntity.setId("API_PRIMARY_OWNER");
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), eq(RoleScope.API))).thenReturn(poRoleEntity);
+        when(roleService.findByScopeAndName(RoleScope.API, "API_PRIMARY_OWNER")).thenReturn(Optional.of(poRoleEntity));
+
         RoleEntity ownerRoleEntity = new RoleEntity();
         ownerRoleEntity.setId("API_OWNER");
+        when(roleService.findByScopeAndName(RoleScope.API, "API_OWNER")).thenReturn(Optional.of(ownerRoleEntity));
 
         MemberEntity po = new MemberEntity();
         po.setId("admin");
@@ -221,8 +225,11 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         RoleEntity poRoleEntity = new RoleEntity();
         poRoleEntity.setId("API_PRIMARY_OWNER");
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), eq(RoleScope.API))).thenReturn(poRoleEntity);
+        when(roleService.findByScopeAndName(RoleScope.API, "API_PRIMARY_OWNER")).thenReturn(Optional.of(poRoleEntity));
+
         RoleEntity ownerRoleEntity = new RoleEntity();
         ownerRoleEntity.setId("API_OWNER");
+        when(roleService.findByScopeAndName(RoleScope.API, "API_OWNER")).thenReturn(Optional.of(ownerRoleEntity));
 
         MemberEntity po = new MemberEntity();
         po.setId("admin");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_CreateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_CreateWithDefinitionTest.java
@@ -151,11 +151,13 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         po.setReferenceId(API_ID);
         po.setReferenceType(MembershipReferenceType.API);
         po.setRoles(Arrays.asList(poRoleEntity));
+        po.setType(MembershipMemberType.USER);
         MemberEntity owner = new MemberEntity();
         owner.setId("user");
         owner.setReferenceId(API_ID);
         owner.setReferenceType(MembershipReferenceType.API);
         owner.setRoles(Arrays.asList(ownerRoleEntity));
+        owner.setType(MembershipMemberType.USER);
         when(membershipService.getMembersByReference(any(), any())).thenReturn(Collections.singleton(po));
 
         UserEntity admin = new UserEntity();
@@ -227,10 +229,12 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         po.setReferenceId(API_ID);
         po.setReferenceType(MembershipReferenceType.API);
         po.setRoles(Arrays.asList(poRoleEntity));
+        po.setType(MembershipMemberType.USER);
         MemberEntity owner = new MemberEntity();
         owner.setId("user");
         owner.setReferenceId(API_ID);
         owner.setReferenceType(MembershipReferenceType.API);
+        owner.setType(MembershipMemberType.USER);
         owner.setRoles(Arrays.asList(ownerRoleEntity));
         when(membershipService.getMembersByReference(any(), any())).thenReturn(Collections.singleton(po));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_UpdateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_UpdateWithDefinitionTest.java
@@ -146,8 +146,11 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         RoleEntity poRoleEntity = new RoleEntity();
         poRoleEntity.setId("API_PRIMARY_OWNER");
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), eq(RoleScope.API))).thenReturn(poRoleEntity);
+        when(roleService.findByScopeAndName(RoleScope.API, "API_PRIMARY_OWNER")).thenReturn(Optional.of(poRoleEntity));
+
         RoleEntity ownerRoleEntity = new RoleEntity();
         ownerRoleEntity.setId("API_OWNER");
+        when(roleService.findByScopeAndName(RoleScope.API, "API_OWNER")).thenReturn(Optional.of(ownerRoleEntity));
 
         MemberEntity po = new MemberEntity();
         po.setId("admin");
@@ -240,8 +243,11 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         RoleEntity poRole = new RoleEntity();
         poRole.setId("API_PRIMARY_OWNER");
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), any())).thenReturn(poRole);
+        when(roleService.findByScopeAndName(RoleScope.API, "API_PRIMARY_OWNER")).thenReturn(Optional.of(poRole));
+
         RoleEntity ownerRole = new RoleEntity();
         ownerRole.setId("API_OWNER");
+        when(roleService.findByScopeAndName(RoleScope.API, "API_OWNER")).thenReturn(Optional.of(ownerRole));
 
         MemberEntity po = new MemberEntity();
         po.setId("admin");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_UpdateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_UpdateWithDefinitionTest.java
@@ -154,12 +154,14 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         po.setReferenceId("ref-admin");
         po.setReferenceType(MembershipReferenceType.API);
         po.setRoles(Collections.singletonList(poRoleEntity));
+        po.setType(MembershipMemberType.USER);
 
         MemberEntity owner = new MemberEntity();
         owner.setId("owner");
         owner.setReferenceId("ref-user");
         owner.setReferenceType(MembershipReferenceType.API);
         owner.setRoles(Collections.singletonList(ownerRoleEntity));
+        owner.setType(MembershipMemberType.USER);
 
         when(membershipService.getMembersByReference(MembershipReferenceType.API, API_ID)).thenReturn(Collections.singleton(po));
 
@@ -246,12 +248,14 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         po.setReferenceId("ref-admin");
         po.setReferenceType(MembershipReferenceType.API);
         po.setRoles(Collections.singletonList(poRole));
+        po.setType(MembershipMemberType.USER);
 
         MemberEntity owner = new MemberEntity();
         owner.setId("owner");
         owner.setReferenceId("ref-user");
         owner.setReferenceType(MembershipReferenceType.API);
         owner.setRoles(Collections.singletonList(ownerRole));
+        owner.setType(MembershipMemberType.USER);
 
         when(membershipService.getMembersByReference(MembershipReferenceType.API, API_ID))
             .thenReturn(new HashSet(Arrays.asList(owner, po)));
@@ -286,6 +290,7 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         po.setReferenceId(API_ID);
         po.setReferenceType(MembershipReferenceType.API);
         po.setRoles(Arrays.asList(poRoleEntity));
+        po.setType(MembershipMemberType.USER);
 
         when(membershipService.getMembersByReference(MembershipReferenceType.API, API_ID)).thenReturn(new HashSet(Arrays.asList(po)));
         when(userService.findById(admin.getId())).thenReturn(admin);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImplTest.java
@@ -15,14 +15,32 @@
  */
 package io.gravitee.rest.api.service.impl;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import io.gravitee.rest.api.model.*;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.service.*;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import io.gravitee.rest.api.service.spring.ServiceConfiguration;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
 /**
@@ -31,9 +49,36 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class ApiDuplicatorServiceImplTest {
 
+    private static final String API_ID = "id-api";
+    public static final String ENVIRONMENT_ID = "DEFAULT";
+
     @InjectMocks
     protected ApiDuplicatorServiceImpl apiDuplicatorService;
 
+    @Mock
+    private ApiMetadataService apiMetadataService;
+
+    @Mock
+    private MembershipService membershipService;
+
+    @Mock
+    private PageService pageService;
+
+    @Mock
+    private PlanService planService;
+
+    @Mock
+    private RoleService roleService;
+
+    @Mock
+    private UserService userService;
+
+    @Spy
+    private ObjectMapper objectMapper = (new ServiceConfiguration()).objectMapper();
+
+    /*
+     * Test helper methods
+     */
     @Test
     public void preprocessApiDefinitionUpdatingIds_should_regenerate_plans_id() throws JsonProcessingException {
         JsonNode jsonNode = new ObjectMapper()
@@ -48,5 +93,295 @@ public class ApiDuplicatorServiceImplTest {
             "{\"id\":\"my-api-id\",\"plans\":[{\"id\":\"b53f77ba-380a-34e2-8c5d-5c60847f0de4\"},{\"id\":\"1b552fa9-bb70-3bbc-b925-9e0b6dd4a35d\"}]}",
             newApiDefinition
         );
+    }
+
+    @Test
+    public void shouldGetOnlyUserMembers() {
+        MemberEntity userMember = new MemberEntity();
+        userMember.setId("user-id");
+        userMember.setType(MembershipMemberType.USER);
+        userMember.setRoles(Collections.singletonList(new RoleEntity()));
+
+        MemberEntity groupMember = new MemberEntity();
+        groupMember.setId("group-id");
+        groupMember.setType(MembershipMemberType.GROUP);
+        groupMember.setRoles(Collections.singletonList(new RoleEntity()));
+
+        when(membershipService.getMembersByReference(MembershipReferenceType.API, API_ID)).thenReturn(Set.of(userMember, groupMember));
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setId("user-id");
+        userEntity.setSource("user-source");
+        userEntity.setSourceId("user-source-id");
+
+        when(userService.findById("user-id")).thenReturn(userEntity);
+
+        final Set<ApiDuplicatorServiceImpl.MemberToImport> apiCurrentMembers = apiDuplicatorService.getAPICurrentMembers(API_ID);
+
+        assertEquals(1, apiCurrentMembers.size());
+        final ApiDuplicatorServiceImpl.MemberToImport memberToImport = apiCurrentMembers.iterator().next();
+        assertEquals("user-source", memberToImport.getSource());
+        assertEquals("user-source-id", memberToImport.getSourceId());
+        assertNull(memberToImport.getRole());
+        assertEquals(1, memberToImport.getRoles().size());
+    }
+
+    @Test
+    public void shouldFindExistingMemberWithSameRole() {
+        ApiDuplicatorServiceImpl.MemberToImport existingMember = new ApiDuplicatorServiceImpl.MemberToImport();
+        existingMember.setSource("user-source");
+        existingMember.setSourceId("user-sourceId");
+        existingMember.setRoles(Collections.singletonList("user-role"));
+
+        assertTrue(apiDuplicatorService.isPresentWithSameRole(Set.of(existingMember), existingMember));
+    }
+
+    @Test
+    public void shouldNotFindExistingMemberWithSameRole_no_existing_member() {
+        ApiDuplicatorServiceImpl.MemberToImport existingMember = new ApiDuplicatorServiceImpl.MemberToImport();
+        existingMember.setSource("user-source");
+        existingMember.setSourceId("user-sourceId");
+        existingMember.setRoles(Collections.singletonList("user-role"));
+
+        ApiDuplicatorServiceImpl.MemberToImport memberToImportWithNoRole = new ApiDuplicatorServiceImpl.MemberToImport();
+        memberToImportWithNoRole.setSource("user-source");
+        memberToImportWithNoRole.setSourceId("user-sourceId");
+
+        ApiDuplicatorServiceImpl.MemberToImport memberToImportWithEmptyRole = new ApiDuplicatorServiceImpl.MemberToImport();
+        memberToImportWithNoRole.setSource("user-source");
+        memberToImportWithNoRole.setSourceId("user-sourceId");
+        memberToImportWithNoRole.setRoles(Collections.emptyList());
+
+        ApiDuplicatorServiceImpl.MemberToImport anotherMember = new ApiDuplicatorServiceImpl.MemberToImport();
+        anotherMember.setSource("another-user-source");
+        anotherMember.setSourceId("another-user-sourceId");
+        anotherMember.setRoles(Collections.singletonList("user-role"));
+
+        assertFalse(apiDuplicatorService.isPresentWithSameRole(Set.of(existingMember), memberToImportWithNoRole));
+        assertFalse(apiDuplicatorService.isPresentWithSameRole(Set.of(existingMember), memberToImportWithEmptyRole));
+        assertFalse(apiDuplicatorService.isPresentWithSameRole(Set.of(existingMember), anotherMember));
+    }
+
+    @Test
+    public void shouldGetRolesToImport_fromRoles() {
+        RoleEntity userRoleEntity = new RoleEntity();
+        userRoleEntity.setId("user-role");
+
+        ApiDuplicatorServiceImpl.MemberToImport memberToImport = new ApiDuplicatorServiceImpl.MemberToImport();
+        memberToImport.setSource("user-source");
+        memberToImport.setSourceId("user-sourceId");
+        memberToImport.setRoles(Collections.singletonList(userRoleEntity.getId()));
+
+        when(roleService.findByScopeAndName(RoleScope.API, "user-role")).thenReturn(Optional.of(userRoleEntity));
+
+        final List<String> rolesToImport = apiDuplicatorService.getRolesToImport(memberToImport);
+
+        assertNotNull(rolesToImport);
+        assertEquals(1, rolesToImport.size());
+        assertEquals("user-role", rolesToImport.get(0));
+    }
+
+    @Test
+    public void shouldGetRolesToImport_fromRole() {
+        RoleEntity userRoleEntity = new RoleEntity();
+        userRoleEntity.setId("user-role");
+
+        ApiDuplicatorServiceImpl.MemberToImport memberToImport = new ApiDuplicatorServiceImpl.MemberToImport();
+        memberToImport.setSource("user-source");
+        memberToImport.setSourceId("user-sourceId");
+        memberToImport.setRole(userRoleEntity.getId());
+
+        when(roleService.findByScopeAndName(RoleScope.API, "user-role")).thenReturn(Optional.of(userRoleEntity));
+
+        final List<String> rolesToImport = apiDuplicatorService.getRolesToImport(memberToImport);
+
+        assertNotNull(rolesToImport);
+        assertEquals(1, rolesToImport.size());
+        assertEquals("user-role", rolesToImport.get(0));
+    }
+
+    @Test
+    public void shouldGetRolesToImport_fromRolesAndRole() {
+        RoleEntity userRoleEntity1 = new RoleEntity();
+        userRoleEntity1.setId("user-role-1");
+        RoleEntity userRoleEntity2 = new RoleEntity();
+        userRoleEntity2.setId("user-role-2");
+
+        when(roleService.findByScopeAndName(RoleScope.API, "user-role-1")).thenReturn(Optional.of(userRoleEntity1));
+        when(roleService.findByScopeAndName(RoleScope.API, "user-role-2")).thenReturn(Optional.of(userRoleEntity2));
+        when(roleService.findByScopeAndName(RoleScope.API, "unexisting_role")).thenReturn(Optional.empty());
+
+        ApiDuplicatorServiceImpl.MemberToImport memberToImport = new ApiDuplicatorServiceImpl.MemberToImport();
+        memberToImport.setSource("user-source");
+        memberToImport.setSourceId("user-sourceId");
+        memberToImport.setRoles(List.of(userRoleEntity2.getId(), "unexisting_role"));
+        memberToImport.setRole(userRoleEntity1.getId());
+
+        final List<String> rolesToImport = apiDuplicatorService.getRolesToImport(memberToImport);
+
+        assertNotNull(rolesToImport);
+        assertEquals(2, rolesToImport.size());
+        assertEquals("user-role-1", rolesToImport.get(0));
+        assertEquals("user-role-2", rolesToImport.get(1));
+    }
+
+    /*
+     * Test update methods
+     */
+    private static final String IMPORT_FILES_FOLDER = "io/gravitee/rest/api/management/service/import/";
+
+    // Pages
+
+    @Test
+    public void shouldNotUpdatePagesIfNoPage_APIcreationMode() throws IOException {
+        JsonNode noPagesNode = loadTestNode(IMPORT_FILES_FOLDER + "import-api.pages.null.json");
+        apiDuplicatorService.updatePlans(API_ID, noPagesNode, ENVIRONMENT_ID, false);
+
+        verifyNoInteractions(pageService);
+    }
+
+    @Test
+    public void shouldNotUpdatePagesIfNoPlan_APIUpdateMode() throws IOException {
+        JsonNode noPagesNode = loadTestNode(IMPORT_FILES_FOLDER + "import-api.pages.null.json");
+        apiDuplicatorService.updatePages(API_ID, noPagesNode, ENVIRONMENT_ID, true);
+
+        verifyNoInteractions(pageService);
+    }
+
+    @Test
+    public void shouldNotUpdatePagesIfEmptyPlan_APIcreationMode() throws IOException {
+        JsonNode emptyPagesNode = loadTestNode(IMPORT_FILES_FOLDER + "import-api.pages.empty.json");
+        apiDuplicatorService.updatePages(API_ID, emptyPagesNode, ENVIRONMENT_ID, false);
+
+        verifyNoInteractions(pageService);
+    }
+
+    @Test
+    public void shouldNotUpdatePagesIfEmptyPlan_APIupdateMode() throws IOException {
+        JsonNode emptyPagesNode = loadTestNode(IMPORT_FILES_FOLDER + "import-api.pages.empty.json");
+        apiDuplicatorService.updatePages(API_ID, emptyPagesNode, ENVIRONMENT_ID, true);
+
+        verifyNoInteractions(pageService);
+    }
+
+    @Test
+    public void shouldUpdatePages_APIcreationMode() throws IOException {
+        JsonNode pagesNode = loadTestNode(IMPORT_FILES_FOLDER + "import-api.pages.default.json");
+        apiDuplicatorService.updatePages(API_ID, pagesNode, ENVIRONMENT_ID, false);
+
+        verify(pageService, never()).createOrUpdatePages(any(), eq(ENVIRONMENT_ID), eq(API_ID));
+        verify(pageService, times(1)).duplicatePages(argThat(pageEntities -> pageEntities.size() == 2), eq(ENVIRONMENT_ID), eq(API_ID));
+    }
+
+    @Test
+    public void shouldUpdatePages_APIUpdateMode() throws IOException {
+        JsonNode pagesNode = loadTestNode(IMPORT_FILES_FOLDER + "import-api.pages.default.json");
+        apiDuplicatorService.updatePages(API_ID, pagesNode, ENVIRONMENT_ID, true);
+
+        verify(pageService, times(1))
+            .createOrUpdatePages(argThat(pageEntities -> pageEntities.size() == 2), eq(ENVIRONMENT_ID), eq(API_ID));
+        verify(pageService, never()).duplicatePages(any(), eq(ENVIRONMENT_ID), eq(API_ID));
+    }
+
+    // Plans
+    @Test
+    public void shouldNotUpdatePlansIfNoPlan_APIcreationMode() throws IOException {
+        JsonNode noPlansNode = loadTestNode(IMPORT_FILES_FOLDER + "import-api.plans.null.json");
+        apiDuplicatorService.updatePlans(API_ID, noPlansNode, ENVIRONMENT_ID, false);
+
+        verifyNoInteractions(planService);
+    }
+
+    @Test
+    public void shouldNotUpdatePlansIfNoPlan_APIUpdateMode() throws IOException {
+        JsonNode noPlansNode = loadTestNode(IMPORT_FILES_FOLDER + "import-api.plans.null.json");
+        apiDuplicatorService.updatePlans(API_ID, noPlansNode, ENVIRONMENT_ID, true);
+
+        verifyNoInteractions(planService);
+    }
+
+    @Test
+    public void shouldNotUpdatePlansIfEmptyPlan_APIcreationMode() throws IOException {
+        JsonNode emptyPlansNode = loadTestNode(IMPORT_FILES_FOLDER + "import-api.plans.empty.json");
+        apiDuplicatorService.updatePlans(API_ID, emptyPlansNode, ENVIRONMENT_ID, false);
+
+        verifyNoInteractions(planService);
+    }
+
+    @Test
+    public void shouldNotUpdatePlansIfEmptyPlan_APIupdateMode() throws IOException {
+        JsonNode emptyPlansNode = loadTestNode(IMPORT_FILES_FOLDER + "import-api.plans.empty.json");
+        apiDuplicatorService.updatePlans(API_ID, emptyPlansNode, ENVIRONMENT_ID, true);
+
+        verifyNoInteractions(planService);
+    }
+
+    @Test
+    public void shouldUpdatePlans_APIcreationMode() throws IOException {
+        JsonNode plansNode = loadTestNode(IMPORT_FILES_FOLDER + "import-api.plans.default.json");
+        apiDuplicatorService.updatePlans(API_ID, plansNode, ENVIRONMENT_ID, false);
+
+        verify(planService, never()).findByApi(API_ID);
+        verify(planService, never()).delete(any());
+        verify(planService, times(2)).createOrUpdatePlan(any(PlanEntity.class), eq(ENVIRONMENT_ID));
+    }
+
+    @Test
+    public void shouldUpdatePlans_APIUpdateMode() throws IOException {
+        JsonNode plansNode = loadTestNode(IMPORT_FILES_FOLDER + "import-api.plans.default.json");
+        PlanEntity existingPlanInImport = new PlanEntity();
+        existingPlanInImport.setId("plan-id");
+        PlanEntity unExistingPlanInImport = new PlanEntity();
+        unExistingPlanInImport.setId("another-plan-id");
+        when(planService.findByApi(API_ID)).thenReturn(Set.of(existingPlanInImport, unExistingPlanInImport));
+
+        apiDuplicatorService.updatePlans(API_ID, plansNode, ENVIRONMENT_ID, true);
+
+        verify(planService, times(1)).findByApi(API_ID);
+        verify(planService, times(1)).delete(any());
+        verify(planService, times(2)).createOrUpdatePlan(any(PlanEntity.class), eq(ENVIRONMENT_ID));
+    }
+
+    // Metadata
+    @Test
+    public void shouldNotUpdateMetadataIfNoMetadata() throws IOException {
+        JsonNode noMetadataNode = loadTestNode(IMPORT_FILES_FOLDER + "import-api.metadata.null.json");
+        apiDuplicatorService.updateMetadata(API_ID, noMetadataNode);
+
+        verifyNoInteractions(apiMetadataService);
+    }
+
+    @Test
+    public void shouldNotUpdateMetadataIfEmptyMetadata() throws IOException {
+        JsonNode emptyMetadataNode = loadTestNode(IMPORT_FILES_FOLDER + "import-api.metadata.empty.json");
+        apiDuplicatorService.updateMetadata(API_ID, emptyMetadataNode);
+
+        verifyNoInteractions(apiMetadataService);
+    }
+
+    @Test
+    public void shouldUpdateMetadata() throws IOException {
+        JsonNode metadataNode = loadTestNode(IMPORT_FILES_FOLDER + "import-api.metadata.default.json");
+        apiDuplicatorService.updateMetadata(API_ID, metadataNode);
+
+        verify(apiMetadataService, times(2)).update(any(UpdateApiMetadataEntity.class));
+    }
+
+    @Test(expected = TechnicalManagementException.class)
+    public void shouldThrowTechnicalManagementExceptionWithMetadata() throws IOException {
+        JsonNode metadataNode = loadTestNode(IMPORT_FILES_FOLDER + "import-api.metadata.default.json");
+        when(apiMetadataService.update(any())).thenThrow(new RuntimeException("fake exception"));
+
+        apiDuplicatorService.updateMetadata(API_ID, metadataNode);
+    }
+
+    /*
+     * Util methods
+     */
+    private JsonNode loadTestNode(String resourceName) throws IOException {
+        URL url = Resources.getResource(resourceName);
+        String toBeImport = Resources.toString(url, Charsets.UTF_8);
+
+        return objectMapper.readTree(toBeImport);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import/import-api.metadata.default.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import/import-api.metadata.default.json
@@ -1,0 +1,21 @@
+{
+    "name": "with-metadata",
+    "metadata": [
+        {
+            "key": "metadata-key",
+            "name": "metadata-name",
+            "format": "STRING",
+            "value": "metadata-value",
+            "defaultValue": "metadata-default-value",
+            "apiId": "id-api"
+        },
+        {
+            "key": "metadata-key-2",
+            "name": "metadata-name-2",
+            "format": "STRING",
+            "value": "metadata-value-2",
+            "defaultValue": "metadata-default-value-2",
+            "apiId": "id-api"
+        }
+    ]
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import/import-api.metadata.empty.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import/import-api.metadata.empty.json
@@ -1,0 +1,4 @@
+{
+    "name": "empty-metadata",
+    "metadata": []
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import/import-api.metadata.null.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import/import-api.metadata.null.json
@@ -1,0 +1,3 @@
+{
+    "name": "no-metadata"
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import/import-api.pages.default.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import/import-api.pages.default.json
@@ -1,0 +1,27 @@
+{
+    "name": "with-pages",
+    "pages": [
+        {
+            "name": "toto",
+            "type": "MARKDOWN",
+            "order": 1,
+            "lastContributor": "admin",
+            "published": false,
+            "visibility": "PUBLIC",
+            "source": {
+                "type": "http-fetcher",
+                "configuration": {
+                    "url": "https://github.com/jenkinsci/workflow-cps-global-lib-plugin/blob/master/README.md"
+                }
+            }
+        },
+        {
+            "name": "petstore",
+            "type": "SWAGGER",
+            "order": 2,
+            "visibility": "PUBLIC",
+            "lastContributor": "admin",
+            "published": false
+        }
+    ]
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import/import-api.pages.empty.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import/import-api.pages.empty.json
@@ -1,0 +1,4 @@
+{
+    "name": "empty-pages",
+    "pages": []
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import/import-api.pages.null.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import/import-api.pages.null.json
@@ -1,0 +1,3 @@
+{
+    "name": "no-pages"
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import/import-api.plans.default.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import/import-api.plans.default.json
@@ -1,0 +1,57 @@
+{
+    "name": "with-plans",
+    "plans": [
+        {
+            "id": "plan-id",
+            "name": "free plan",
+            "description": "free plan",
+            "validation": "AUTO",
+            "security": "API_KEY",
+            "type": "API",
+            "status": "PUBLISHED",
+            "api": "id-api",
+            "order": 0,
+            "paths": {
+                "/": [
+                    {
+                        "methods": ["GET"],
+                        "rate-limit": {
+                            "rate": {
+                                "limit": 1,
+                                "periodTime": 1,
+                                "periodTimeUnit": "SECONDS"
+                            }
+                        },
+                        "enabled": true
+                    }
+                ]
+            }
+        },
+        {
+            "id": "plan-id2",
+            "name": "keyless plan",
+            "description": "keyless plan",
+            "validation": "AUTO",
+            "security": "KEY_LESS",
+            "type": "API",
+            "status": "PUBLISHED",
+            "api": "id-api",
+            "order": 0,
+            "paths": {
+                "/": [
+                    {
+                        "methods": ["GET"],
+                        "rate-limit": {
+                            "rate": {
+                                "limit": 1,
+                                "periodTime": 1,
+                                "periodTimeUnit": "SECONDS"
+                            }
+                        },
+                        "enabled": true
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import/import-api.plans.empty.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import/import-api.plans.empty.json
@@ -1,0 +1,4 @@
+{
+    "name": "empty-plans",
+    "plans": []
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import/import-api.plans.null.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import/import-api.plans.null.json
@@ -1,0 +1,3 @@
+{
+    "name": "no-plans"
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6808

**Description**

After having created or updated an API from a definition, we update the members of the API. This PR fixes 2 things:
 - we should process members only if there is at least one member to process (obviously 😉 )
 - we should only consider `USER` memberships when looking for existing members, since we will compare existing users with those in the `members` section of the API definition
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/3-10-x-6808-import-with-empty-list-of-members/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
