### PR TITLE
Bump `@gravitee/ui-components` to 3.35.3

### DIFF
--- a/gravitee-apim-console-webui/package-lock.json
+++ b/gravitee-apim-console-webui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gravitee-apim-console-webui",
-  "version": "3.10.13",
+  "version": "3.10.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1284,9 +1284,9 @@
       "dev": true
     },
     "@codemirror/autocomplete": {
-      "version": "0.19.13",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.13.tgz",
-      "integrity": "sha512-fI6lgTH2PlyTQqF2eWKDRBRUC+9MqvS2TfvE7aJ4Pu1oHM1w8JI16J9Qvwrd0iabJeF/QodU51Clok98c7fpCQ==",
+      "version": "0.19.15",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.15.tgz",
+      "integrity": "sha512-GQWzvvuXxNUyaEk+5gawbAD8s51/v2Chb++nx0e2eGWrphWk42isBtzOMdc3DxrxrZtPZ55q2ldNp+6G8KJLIQ==",
       "requires": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/state": "^0.19.4",
@@ -1297,9 +1297,9 @@
       }
     },
     "@codemirror/basic-setup": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/basic-setup/-/basic-setup-0.19.1.tgz",
-      "integrity": "sha512-gLjD7YgZU/we6BzS/ecCmD3viw83dsgv5ZUaSydYbYx9X4w4w9RqYnckcJ+0GDyHfNr5Jtfv2Z5ZtFQnBj0UDA==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/basic-setup/-/basic-setup-0.19.3.tgz",
+      "integrity": "sha512-2hfO+QDk/HTpQzeYk1NyL1G9D5L7Sj78dtaQP8xBU42DKU9+OBPF5MdjLYnxP0jKzm6IfQfsLd89fnqW3rBVfQ==",
       "requires": {
         "@codemirror/autocomplete": "^0.19.0",
         "@codemirror/closebrackets": "^0.19.0",
@@ -1312,16 +1312,16 @@
         "@codemirror/language": "^0.19.0",
         "@codemirror/lint": "^0.19.0",
         "@codemirror/matchbrackets": "^0.19.0",
-        "@codemirror/rectangular-selection": "^0.19.0",
+        "@codemirror/rectangular-selection": "^0.19.2",
         "@codemirror/search": "^0.19.0",
         "@codemirror/state": "^0.19.0",
         "@codemirror/view": "^0.19.31"
       }
     },
     "@codemirror/closebrackets": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/closebrackets/-/closebrackets-0.19.1.tgz",
-      "integrity": "sha512-ZiLXT6u+VuBK5QnfBbt/Vmfd9Pg6449wn1DIOWFZHUOldg5eFn3VGGjYY2XWuHQz5WuK+7dXamV2KE885O1gyA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/closebrackets/-/closebrackets-0.19.2.tgz",
+      "integrity": "sha512-ClMPzPcPP0eQiDcVjtVPl6OLxgdtZSYDazsvT0AKl70V1OJva0eHgl4/6kCW3RZ0pb2n34i9nJz4eXCmK+TYDA==",
       "requires": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/rangeset": "^0.19.0",
@@ -1354,9 +1354,9 @@
       }
     },
     "@codemirror/fold": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/fold/-/fold-0.19.3.tgz",
-      "integrity": "sha512-8hT+Eq2G68mL0yPRvSD2ewhnLQAX6sbUJmtGVKFcj8oAXtfpYCX8LIcfXsuI19Qs7gZkOSpqZvn+KKj8IhZoAw==",
+      "version": "0.19.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/fold/-/fold-0.19.4.tgz",
+      "integrity": "sha512-0SNSkRSOa6gymD6GauHa3sxiysjPhUC0SRVyTlvL52o0gz9GHdc8kNqNQskm3fBtGGOiSriGwF/kAsajRiGhVw==",
       "requires": {
         "@codemirror/gutter": "^0.19.0",
         "@codemirror/language": "^0.19.0",
@@ -1376,14 +1376,14 @@
       }
     },
     "@codemirror/highlight": {
-      "version": "0.19.7",
-      "resolved": "https://registry.npmjs.org/@codemirror/highlight/-/highlight-0.19.7.tgz",
-      "integrity": "sha512-3W32hBCY0pbbv/xidismw+RDMKuIag+fo4kZIbD7WoRj+Ttcaxjf+vP6RttRHXLaaqbWh031lTeON8kMlDhMYw==",
+      "version": "0.19.8",
+      "resolved": "https://registry.npmjs.org/@codemirror/highlight/-/highlight-0.19.8.tgz",
+      "integrity": "sha512-v/lzuHjrYR8MN2mEJcUD6fHSTXXli9C1XGYpr+ElV6fLBIUhMTNKR3qThp611xuWfXfwDxeL7ppcbkM/MzPV3A==",
       "requires": {
         "@codemirror/language": "^0.19.0",
         "@codemirror/rangeset": "^0.19.0",
         "@codemirror/state": "^0.19.3",
-        "@codemirror/view": "^0.19.0",
+        "@codemirror/view": "^0.19.39",
         "@lezer/common": "^0.15.0",
         "style-mod": "^4.0.0"
       }
@@ -1496,9 +1496,9 @@
       }
     },
     "@codemirror/lang-python": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-0.19.4.tgz",
-      "integrity": "sha512-eSH1JXbf0D30y+f3nWy/+bTLAIV8RmcQbbVD8DsBxkxOHMVKcILgxFRHCovba8YEMtmq45I1DoWcNt1CeKnrYQ==",
+      "version": "0.19.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-0.19.5.tgz",
+      "integrity": "sha512-MQf7t0k6+i9KCzlFCI8EY+jjwyXLy5AwjmXsMyMCMbOw/97j70jFZYrs7Mm7RJakNE2rypWhnLGlyBTSYMqR5g==",
       "requires": {
         "@codemirror/highlight": "^0.19.7",
         "@codemirror/language": "^0.19.0",
@@ -1506,11 +1506,11 @@
       }
     },
     "@codemirror/lang-rust": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-rust/-/lang-rust-0.19.1.tgz",
-      "integrity": "sha512-T/LzRC5bMPvkMg11kr/jnpScqsE68B+F0SYqjyQTzQ+666RhHJICDCSlk7wbIrJi/fagpBwvuAmo2LgQ8dcGsQ==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-rust/-/lang-rust-0.19.2.tgz",
+      "integrity": "sha512-SEXsO7Qf2gktRvVhHMc0Mq4HzPBpFcQlrlcinafy6VFXavWs+QAIB8UAuLG/igOc3PrIHbZFlyEhVUIGstox8w==",
       "requires": {
-        "@codemirror/highlight": "^0.19.0",
+        "@codemirror/highlight": "^0.19.7",
         "@codemirror/language": "^0.19.0",
         "@lezer/rust": "^0.15.0"
       }
@@ -1551,9 +1551,9 @@
       }
     },
     "@codemirror/language": {
-      "version": "0.19.7",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.7.tgz",
-      "integrity": "sha512-pNNUtYWMIMG0lUSKyUXJr8U0rFiCKsKFXbA2Oj17PC+S1FY99hV0z1vcntW67ekAIZw9DMEUQnLsKBuIbAUX7Q==",
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.10.tgz",
+      "integrity": "sha512-yA0DZ3RYn2CqAAGW62VrU8c4YxscMQn45y/I9sjBlqB1e2OTQLg4CCkMBuMSLXk4xaqjlsgazeOQWaJQOKfV8Q==",
       "requires": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/text": "^0.19.0",
@@ -1586,24 +1586,24 @@
       }
     },
     "@codemirror/legacy-modes": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-0.19.0.tgz",
-      "integrity": "sha512-GSPdBNUeyF3nxJ2lztXGp2UoQjn+ggK5z+Kd4tflziecCG1+8mcdudDgFvxDuaTGWyM34S7Ldb4Xv7/XodZtBA==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-0.19.1.tgz",
+      "integrity": "sha512-vYPLsD/ON+3SXhlGj9Qb3fpFNNU3Ya/AtDiv/g3OyqVzhh5vs5rAnOvk8xopGWRwppdhlNPD9VyXjiOmZUQtmQ==",
       "requires": {
         "@codemirror/stream-parser": "^0.19.0"
       }
     },
     "@codemirror/lint": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-0.19.3.tgz",
-      "integrity": "sha512-+c39s05ybD2NjghxkPFsUbH/qBL0cdzKmtHbzUm0RVspeL2OiP7uHYJ6J5+Qr9RjMIPWzcqSauRqxfmCrctUfg==",
+      "version": "0.19.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-0.19.6.tgz",
+      "integrity": "sha512-Pbw1Y5kHVs2J+itQ0uez3dI4qY9ApYVap7eNfV81x1/3/BXgBkKfadaw0gqJ4h4FDG7OnJwb0VbPsjJQllHjaA==",
       "requires": {
         "@codemirror/gutter": "^0.19.4",
         "@codemirror/panel": "^0.19.0",
         "@codemirror/rangeset": "^0.19.1",
         "@codemirror/state": "^0.19.4",
-        "@codemirror/tooltip": "^0.19.5",
-        "@codemirror/view": "^0.19.0",
+        "@codemirror/tooltip": "^0.19.16",
+        "@codemirror/view": "^0.19.22",
         "crelt": "^1.0.5"
       }
     },
@@ -1628,27 +1628,27 @@
       }
     },
     "@codemirror/rangeset": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.8.tgz",
-      "integrity": "sha512-1vusIkxSD0vK5KQ22JO/4Ejfww5268PgM/CpKNBSpTpWZEFlZbmOPyRiY4HXO2oEzOpypbA/walMiNInWnrT0Q==",
+      "version": "0.19.9",
+      "resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.9.tgz",
+      "integrity": "sha512-V8YUuOvK+ew87Xem+71nKcqu1SXd5QROMRLMS/ljT5/3MCxtgrRie1Cvild0G/Z2f1fpWxzX78V0U4jjXBorBQ==",
       "requires": {
         "@codemirror/state": "^0.19.0"
       }
     },
     "@codemirror/rectangular-selection": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/rectangular-selection/-/rectangular-selection-0.19.1.tgz",
-      "integrity": "sha512-9ElnqOg3mpZIWe0prPRd1SZ48Q9QB3bR8Aocq8UtjboJSUG8ABhRrbuTZMW/rMqpBPSjVpCe9xkCCkEQMYQVmw==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/rectangular-selection/-/rectangular-selection-0.19.2.tgz",
+      "integrity": "sha512-AXK/p5eGwFJ9GJcLfntqN4dgY+XiIF7eHfXNQJX5HhQLSped2wJE6WuC1rMEaOlcpOqlb9mrNi/ZdUjSIj9mbA==",
       "requires": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/text": "^0.19.4",
-        "@codemirror/view": "^0.19.0"
+        "@codemirror/view": "^0.19.48"
       }
     },
     "@codemirror/search": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-0.19.8.tgz",
-      "integrity": "sha512-mMHx60bzbcbSI8Fu2WbxsGAZ2FCGkzslISsvyJXOxVoB7E+y1LDTBv0HUJ+srmfIsak6ceMxKgyI6RldRPMu5A==",
+      "version": "0.19.10",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-0.19.10.tgz",
+      "integrity": "sha512-qjubm69HJixPBWzI6HeEghTWOOD8NXiHOTRNvdizqs8xWRuFChq9zkjD3XiAJ7GXSTzCuQJnAP9DBBGCLq4ZIA==",
       "requires": {
         "@codemirror/panel": "^0.19.0",
         "@codemirror/rangeset": "^0.19.0",
@@ -1667,9 +1667,9 @@
       }
     },
     "@codemirror/stream-parser": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/stream-parser/-/stream-parser-0.19.6.tgz",
-      "integrity": "sha512-dmPtoz/MR3IphxAsgywEyvSjOJCb2ikAgqp6BGIlwBEJVRiap0wFK4b3f/3DKIHUG4GezWRYQumXNyb3GNQevw==",
+      "version": "0.19.9",
+      "resolved": "https://registry.npmjs.org/@codemirror/stream-parser/-/stream-parser-0.19.9.tgz",
+      "integrity": "sha512-WTmkEFSRCetpk8xIOvV2yyXdZs3DgYckM0IP7eFi4ewlxWnJO/H4BeJZLs4wQaydWsAqTQoDyIwNH1BCzK5LUQ==",
       "requires": {
         "@codemirror/highlight": "^0.19.0",
         "@codemirror/language": "^0.19.0",
@@ -1685,18 +1685,18 @@
       "integrity": "sha512-T9jnREMIygx+TPC1bOuepz18maGq/92q2a+n4qTqObKwvNMg+8cMTslb8yxeEDEq7S3kpgGWxgO1UWbQRij0dA=="
     },
     "@codemirror/tooltip": {
-      "version": "0.19.15",
-      "resolved": "https://registry.npmjs.org/@codemirror/tooltip/-/tooltip-0.19.15.tgz",
-      "integrity": "sha512-Fb4fKgVziUNSOAhclsvsqHw+1bCfh5po8xT/hw2UQW0UV41t73tJqX5AiqSwmtaDHExN7DFyzG8VQa05d/7g3Q==",
+      "version": "0.19.16",
+      "resolved": "https://registry.npmjs.org/@codemirror/tooltip/-/tooltip-0.19.16.tgz",
+      "integrity": "sha512-zxKDHryUV5/RS45AQL+wOeN+i7/l81wK56OMnUPoTSzCWNITfxHn7BToDsjtrRKbzHqUxKYmBnn/4hPjpZ4WJQ==",
       "requires": {
         "@codemirror/state": "^0.19.0",
         "@codemirror/view": "^0.19.0"
       }
     },
     "@codemirror/view": {
-      "version": "0.19.44",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.44.tgz",
-      "integrity": "sha512-vahNUE6hSXdjzs1gcztKPJQhZu+ZIwRpK4ZGZTSD81/CZUVqtlF75W3RCYVgEdjTI1l6ogJmIL6FM2Xj7ltn7Q==",
+      "version": "0.19.48",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.48.tgz",
+      "integrity": "sha512-0eg7D2Nz4S8/caetCTz61rK0tkHI17V/d15Jy0kLOT8dTLGGNJUponDnW28h2B6bERmPlVHKh8MJIr5OCp1nGw==",
       "requires": {
         "@codemirror/rangeset": "^0.19.5",
         "@codemirror/state": "^0.19.3",
@@ -1778,65 +1778,65 @@
       "integrity": "sha512-svwnzu0KKVpMEuRU1G58xp1BNrho5qki/bxpF/y1tOjAOoM357Avw8Gc8xw40pbN5B1QNyT3wuZQ/nMwSbjh9w=="
     },
     "@formatjs/ecma402-abstract": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.3.tgz",
-      "integrity": "sha512-kP/Buv5vVFMAYLHNvvUzr0lwRTU0u2WTy44Tqwku1X3C3lJ5dKqDCYVqA8wL+Y19Bq+MwHgxqd5FZJRCIsLRyQ==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.4.tgz",
+      "integrity": "sha512-EBikYFp2JCdIfGEb5G9dyCkTGDmC57KSHhRQOC3aYxoPWVZvfWCDjZwkGYHN7Lis/fmuWl906bnNTJifDQ3sXw==",
       "requires": {
-        "@formatjs/intl-localematcher": "0.2.24",
+        "@formatjs/intl-localematcher": "0.2.25",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
     "@formatjs/intl-getcanonicallocales": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-getcanonicallocales/-/intl-getcanonicallocales-1.9.0.tgz",
-      "integrity": "sha512-5f/5oX0lYw4SOPT6KEOJn/TFKY2GRemrxNuvi/+xdyb3kQhsQlUU0vbcSJhnP+sBcrZFOfoL7OVRkw/vFl9KOA==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-getcanonicallocales/-/intl-getcanonicallocales-1.9.2.tgz",
+      "integrity": "sha512-69WTStIJI2ikErOU1Il4NQKLVV8f2x6awr7+/dZz0uihuI7uQRcZtI6k/BBt4EtYaEl6w65YjUF93VuE015C0w==",
       "requires": {
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
     "@formatjs/intl-locale": {
-      "version": "2.4.45",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-locale/-/intl-locale-2.4.45.tgz",
-      "integrity": "sha512-qNaAFJ1dTfDM03YMajntB885JZL0UekjL2Iv9yK27iwIE6BKzOK350d9P/xuw75eI6tcpcvcndb0UhZ7IZxaWA==",
+      "version": "2.4.47",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-locale/-/intl-locale-2.4.47.tgz",
+      "integrity": "sha512-yEpjx6RgVVG3pPsxb/jydhnq/A02KmjMste5U/wWxscRK0sny8LPIoBwgkOQycRoMRLNlLemJaQB7VbHZJ9OVg==",
       "requires": {
-        "@formatjs/ecma402-abstract": "1.11.3",
-        "@formatjs/intl-getcanonicallocales": "1.9.0",
+        "@formatjs/ecma402-abstract": "1.11.4",
+        "@formatjs/intl-getcanonicallocales": "1.9.2",
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
     "@formatjs/intl-localematcher": {
-      "version": "0.2.24",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.24.tgz",
-      "integrity": "sha512-K/HRGo6EMnCbhpth/y3u4rW4aXkmQNqRe1L2G+Y5jNr3v0gYhvaucV8WixNju/INAMbPBlbsRBRo/nfjnoOnxQ==",
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.25.tgz",
+      "integrity": "sha512-YmLcX70BxoSopLFdLr1Ds99NdlTI2oWoLbaUW2M406lxOIPzE1KQhRz2fPUkq34xVZQaihCoU29h0KK7An3bhA==",
       "requires": {
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
@@ -1850,17 +1850,34 @@
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "@formatjs/ecma402-abstract": {
+          "version": "1.11.3",
+          "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.3.tgz",
+          "integrity": "sha512-kP/Buv5vVFMAYLHNvvUzr0lwRTU0u2WTy44Tqwku1X3C3lJ5dKqDCYVqA8wL+Y19Bq+MwHgxqd5FZJRCIsLRyQ==",
+          "requires": {
+            "@formatjs/intl-localematcher": "0.2.24",
+            "tslib": "^2.1.0"
+          }
+        },
+        "@formatjs/intl-localematcher": {
+          "version": "0.2.24",
+          "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.24.tgz",
+          "integrity": "sha512-K/HRGo6EMnCbhpth/y3u4rW4aXkmQNqRe1L2G+Y5jNr3v0gYhvaucV8WixNju/INAMbPBlbsRBRo/nfjnoOnxQ==",
+          "requires": {
+            "tslib": "^2.1.0"
+          }
+        },
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
     },
     "@gravitee/ui-components": {
-      "version": "3.30.1",
-      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.30.1.tgz",
-      "integrity": "sha512-mI2J172M+uKU2ty/cLjOyDwqyt/63/FXzEj/63PwYGrFr52Bmg0qXA2m0uRvCH/wnSr/ZjBH3fY9vSmyoOf+bQ==",
+      "version": "3.35.3",
+      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.35.3.tgz",
+      "integrity": "sha512-6BNEQKzTBCM0zzae5SjlUjp15Eg6HGTycAwO9iTmxar/n9GnxSeqcs3wxfcEibRygGSD/QsNLeHtO8ISkomkbw==",
       "requires": {
         "@codemirror/basic-setup": "^0.19.1",
         "@codemirror/language-data": "^0.19.1",
@@ -2610,14 +2627,14 @@
       }
     },
     "@lezer/common": {
-      "version": "0.15.11",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.11.tgz",
-      "integrity": "sha512-vv0nSdIaVCRcJ8rPuDdsrNVfBOYe/4Szr/LhF929XyDmBndLDuWiCCHooGlGlJfzELyO608AyDhVsuX/ZG36NA=="
+      "version": "0.15.12",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.12.tgz",
+      "integrity": "sha512-edfwCxNLnzq5pBA/yaIhwJ3U3Kz8VAUOTRg0hhxaizaI1N+qxV7EXDv/kLCkLeq2RzSFvxexlaj5Mzfn2kY0Ig=="
     },
     "@lezer/cpp": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@lezer/cpp/-/cpp-0.15.2.tgz",
-      "integrity": "sha512-4Ve5LIRCE+VF+XE/cfSSOg6VuTOfh1pU2oxLKJu3XbyYzmSp9IjSZcW/UNcSRtMxM05MQ4/3AR5tUwp9PL4ExA==",
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/@lezer/cpp/-/cpp-0.15.3.tgz",
+      "integrity": "sha512-QE5YxhnoQ4eJH9G2h5r+m4Zq7d/0NmA0eAnZmiOVggI7a3jpODIXZeJbkUPf4U2yzNCSWAGpZVk8XxkA+cTZvA==",
       "requires": {
         "@lezer/lr": "^0.15.0"
       }
@@ -2671,9 +2688,9 @@
       }
     },
     "@lezer/markdown": {
-      "version": "0.15.5",
-      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-0.15.5.tgz",
-      "integrity": "sha512-ZWCZn1FTQFw70RZFmyWRKHsKYTw8OTPc1SmYWMf6xwz83SNd/MIlXcOoyLLwE3/THfUMmnnSjj2ozfPtqA3mFg==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-0.15.6.tgz",
+      "integrity": "sha512-1XXLa4q0ZthryUEfO47ipvZHxNb+sCKoQIMM9dKs5vXZOBbgF2Vah/GL3g26BFIAEc2uCv4VQnI+lSrv58BT3g==",
       "requires": {
         "@lezer/common": "^0.15.0"
       }
@@ -2687,17 +2704,17 @@
       }
     },
     "@lezer/python": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lezer/python/-/python-0.15.0.tgz",
-      "integrity": "sha512-KkbNfjLZCs/Ibx+3mekGu31qz+zCVkXHL+oNftRxB/lsINlz25SURR5z6wb94JpJt0yDFCEtn/2siAUybLOXiA==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@lezer/python/-/python-0.15.1.tgz",
+      "integrity": "sha512-Xdb2nh+FoxR8ssEADGsroDtsnP+EDhiPpW9zhER3h+6cpGtZ2e9Oq/Rwn9nFQRiKCfMT+AQaqC3ZgAbhbnumyQ==",
       "requires": {
         "@lezer/lr": "^0.15.0"
       }
     },
     "@lezer/rust": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@lezer/rust/-/rust-0.15.0.tgz",
-      "integrity": "sha512-vq7P0P9478Y4J0cKuwChNJjoZBNERyqBJ4wG94gYORKqXmUei/GtIAxu1Ei24BJRPrVHrg0NmC6daFd+i1re1Q==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@lezer/rust/-/rust-0.15.1.tgz",
+      "integrity": "sha512-9R7Mcfe/XWodpT7bYNKoOmEAN+AOHHfma9QUTdEhqduzd1G4qsdQkGSMPfsqt24sZCkQ1EREbE/lmEp4YxTlcA==",
       "requires": {
         "@lezer/lr": "^0.15.0"
       }
@@ -2711,9 +2728,9 @@
       }
     },
     "@lit/reactive-element": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.3.0.tgz",
-      "integrity": "sha512-0TKSIuJHXNLM0k98fi0AdMIdUoHIYlDHTP+0Vruc2SOs4T6vU1FinXgSvYd8mSrkt+8R+qdRAXvjpqrMXMyBgw=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.3.2.tgz",
+      "integrity": "sha512-A2e18XzPMrIh35nhIdE4uoqRzoIpEU5vZYuQN4S3Ee1zkGdYC27DP12pewbw/RLgPHzaE4kx/YqxMzebOpm0dA=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
@@ -11080,9 +11097,9 @@
       }
     },
     "jsonschema": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.0.tgz",
-      "integrity": "sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
+      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ=="
     },
     "killable": {
       "version": "1.0.1",
@@ -11314,9 +11331,9 @@
       "dev": true
     },
     "lit": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.2.0.tgz",
-      "integrity": "sha512-FDyxUuczo6cJJY/2Bkgfh1872U4ikUvmK1Cb6+lYC1CW+QOo8CaWXCpvPKFzYsz0ojUxoruBLVrECc7VI2f1dQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.2.4.tgz",
+      "integrity": "sha512-O7t+uizo1/Br0y+5RaWRzPkd4MsoL4XY2eq7n2wrESyCCjeagq4ERZKsyKX40jbmsz4bAAs7/0qNRX11TuXzoA==",
       "requires": {
         "@lit/reactive-element": "^1.3.0",
         "lit-element": "^3.2.0",
@@ -11333,9 +11350,9 @@
       }
     },
     "lit-html": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.0.tgz",
-      "integrity": "sha512-dJnevgV8VkCuOXLWrjQopDE8nSy8CzipZ/ATfYQv7z7Dct4abblcKecf50gkIScuwCTzKvRLgvTgV0zzagW4gA==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.4.tgz",
+      "integrity": "sha512-IPY0V0z/QWcTduxb6DlP46Un8n6tG+mHSAijGcPozfXTjVkvFLN4/irPzthtq/eC8RU+7CUqh6h4KB7tnRPJfg==",
       "requires": {
         "@types/trusted-types": "^2.0.2"
       }

--- a/gravitee-apim-console-webui/package.json
+++ b/gravitee-apim-console-webui/package.json
@@ -4,7 +4,7 @@
   "description": "Gravitee.io APIM - UI Console",
   "dependencies": {
     "@fontsource/libre-franklin": "^4.4.5",
-    "@gravitee/ui-components": "3.30.1",
+    "@gravitee/ui-components": "3.35.3",
     "@highcharts/map-collection": "^1.1.3",
     "@toast-ui/editor": "^2.5.2",
     "@toast-ui/editor-plugin-code-syntax-highlight": "^1.0.0",

--- a/gravitee-apim-portal-webui/package-lock.json
+++ b/gravitee-apim-portal-webui/package-lock.json
@@ -2744,9 +2744,9 @@
       "integrity": "sha512-WF3oU6l2WqJjN4OWvnjF9AHyQjHpjcfpyuckM7euFeX6ZGRPpPj+ZCqzf41g81MSksf9aZI4fFCZXWTBusgcWA=="
     },
     "@gravitee/ui-components": {
-      "version": "3.35.2",
-      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.35.2.tgz",
-      "integrity": "sha512-c4mw9s6bgQc4Wejf3yElpLKAnMPx9pI2ScI0YmBIhTyea/9E1cyDsLx+dlEQw2cCEsqNZuCMZub3XRJ4LEjyPA==",
+      "version": "3.35.3",
+      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.35.3.tgz",
+      "integrity": "sha512-6BNEQKzTBCM0zzae5SjlUjp15Eg6HGTycAwO9iTmxar/n9GnxSeqcs3wxfcEibRygGSD/QsNLeHtO8ISkomkbw==",
       "requires": {
         "@codemirror/basic-setup": "^0.19.1",
         "@codemirror/language-data": "^0.19.1",
@@ -11851,9 +11851,9 @@
       "dev": true
     },
     "lit": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.2.3.tgz",
-      "integrity": "sha512-5/v+r9dH3Pw/o0rhp/qYk3ERvOUclNF31bWb0FiW6MPgwdQIr+/KCt/p3zcd8aPl8lIGnxdGrVcZA+gWS6oFOQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.2.4.tgz",
+      "integrity": "sha512-O7t+uizo1/Br0y+5RaWRzPkd4MsoL4XY2eq7n2wrESyCCjeagq4ERZKsyKX40jbmsz4bAAs7/0qNRX11TuXzoA==",
       "requires": {
         "@lit/reactive-element": "^1.3.0",
         "lit-element": "^3.2.0",
@@ -11870,9 +11870,9 @@
       }
     },
     "lit-html": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.3.tgz",
-      "integrity": "sha512-vI4j3eWwtQaR8q/O63juZVliBIFMio716X719/lSsGH4UWPy2/7Qf377jsNs4cx3gCHgIbx8yxFgXFQ/igZyXQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.4.tgz",
+      "integrity": "sha512-IPY0V0z/QWcTduxb6DlP46Un8n6tG+mHSAijGcPozfXTjVkvFLN4/irPzthtq/eC8RU+7CUqh6h4KB7tnRPJfg==",
       "requires": {
         "@types/trusted-types": "^2.0.2"
       }

--- a/gravitee-apim-portal-webui/package.json
+++ b/gravitee-apim-portal-webui/package.json
@@ -34,7 +34,7 @@
     "@angular/platform-browser-dynamic": "^9.1.1",
     "@angular/router": "^9.1.1",
     "@formatjs/intl-relativetimeformat": "^4.5.11",
-    "@gravitee/ui-components": "3.35.2",
+    "@gravitee/ui-components": "3.35.3",
     "@highcharts/map-collection": "^1.1.3",
     "@ibm/plex": "^5.1.0",
     "@ngx-translate/core": "^12.1.2",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/openapi.yaml
@@ -10,7 +10,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0
-  version: "3.10.14"
+  version: "3.10.15-SNAPSHOT"
 servers:
   - url: http://localhost:8083/portal/environments/{envId}
     description: The portal API for a given environment


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6869

**Description**

Bump `@gravitee/ui-components` to 3.35.3
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6869-upgrade-ui-components/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
