### PR TITLE
Fix deletion of properties of a manual dictionary

### DIFF
--- a/gravitee-apim-console-webui/src/services/dictionary.service.ts
+++ b/gravitee-apim-console-webui/src/services/dictionary.service.ts
@@ -30,14 +30,12 @@ class DictionaryService {
     return this.$http.post(`${this.Constants.env.baseURL}/configuration/dictionaries`, dictionary);
   }
 
-  async update(dictionary) {
-    const { data } = await this.get(dictionary.id);
-
+  update(dictionary) {
     return this.$http.put([`${this.Constants.env.baseURL}/configuration/dictionaries`, dictionary.id].join('/'), {
       name: dictionary.name,
       description: dictionary.description,
       type: dictionary.type,
-      properties: { ...data.properties, ...dictionary.properties },
+      properties: dictionary.properties,
       provider: dictionary.provider,
       trigger: dictionary.trigger,
     });

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoDictionaryRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoDictionaryRepository.java
@@ -57,7 +57,7 @@ public class MongoDictionaryRepository implements DictionaryRepository {
         Dictionary res = mapper.map(page, Dictionary.class);
 
         // Convert properties
-        if (res != null && res.getProperties() != null && !res.getProperties().isEmpty()) {
+        if (res != null && res.getProperties() != null) {
             final Map<String, String> properties = new HashMap<>(res.getProperties().size());
             res.getProperties().forEach((key, value) -> properties.put(key.replaceAll(DOT_REPLACEMENT, "."), value));
             res.setProperties(properties);
@@ -74,7 +74,7 @@ public class MongoDictionaryRepository implements DictionaryRepository {
         DictionaryMongo dictionaryMongo = mapper.map(dictionary, DictionaryMongo.class);
 
         // Convert properties to avoid dots in the key / value
-        if (dictionaryMongo.getProperties() != null && !dictionaryMongo.getProperties().isEmpty()) {
+        if (dictionaryMongo.getProperties() != null) {
             final Map<String, String> properties = new HashMap<>(dictionaryMongo.getProperties().size());
             dictionaryMongo.getProperties().forEach((key, value) -> properties.put(key.replaceAll("\\.", DOT_REPLACEMENT), value));
             dictionaryMongo.setProperties(properties);
@@ -85,7 +85,7 @@ public class MongoDictionaryRepository implements DictionaryRepository {
         Dictionary res = mapper.map(createdDictionaryMongo, Dictionary.class);
 
         // Convert properties
-        if (res != null && res.getProperties() != null && !res.getProperties().isEmpty()) {
+        if (res != null && res.getProperties() != null) {
             final Map<String, String> properties = new HashMap<>(res.getProperties().size());
             res.getProperties().forEach((key, value) -> properties.put(key.replaceAll(DOT_REPLACEMENT, "."), value));
             res.setProperties(properties);
@@ -115,7 +115,7 @@ public class MongoDictionaryRepository implements DictionaryRepository {
             dictionaryMongo.setDeployedAt(dictionary.getDeployedAt());
 
             // Convert properties to avoid dots in the key / value
-            if (dictionary.getProperties() != null && !dictionary.getProperties().isEmpty()) {
+            if (dictionary.getProperties() != null) {
                 final Map<String, String> properties = new HashMap<>(dictionary.getProperties().size());
                 dictionary.getProperties().forEach((key, value) -> properties.put(key.replaceAll("\\.", DOT_REPLACEMENT), value));
                 dictionaryMongo.setProperties(properties);
@@ -142,7 +142,7 @@ public class MongoDictionaryRepository implements DictionaryRepository {
             final Dictionary res = mapper.map(dictionaryMongoUpdated, Dictionary.class);
 
             // Convert properties
-            if (res != null && res.getProperties() != null && !res.getProperties().isEmpty()) {
+            if (res != null && res.getProperties() != null) {
                 final Map<String, String> properties = new HashMap<>(res.getProperties().size());
                 res.getProperties().forEach((key, value) -> properties.put(key.replaceAll(DOT_REPLACEMENT, "."), value));
                 res.setProperties(properties);

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/DictionaryRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/DictionaryRepositoryTest.java
@@ -16,7 +16,10 @@
 package io.gravitee.repository;
 
 import static io.gravitee.repository.utils.DateUtils.compareDate;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import io.gravitee.repository.config.AbstractRepositoryTest;
 import io.gravitee.repository.management.model.Dictionary;
@@ -24,7 +27,6 @@ import io.gravitee.repository.management.model.DictionaryType;
 import java.util.*;
 import org.junit.Assert;
 import org.junit.Test;
-import org.mockito.internal.util.collections.Sets;
 
 public class DictionaryRepositoryTest extends AbstractRepositoryTest {
 
@@ -119,6 +121,7 @@ public class DictionaryRepositoryTest extends AbstractRepositoryTest {
         Assert.assertEquals("Invalid saved dictionary name.", "My dic 1", optional.get().getName());
 
         final Dictionary dictionary = optional.get();
+        dictionary.setId("dic-1");
         dictionary.setName("My dic 1");
         dictionary.setEnvironmentId("new_DEFAULT");
         dictionary.setDescription("Description for my dic 1");
@@ -136,6 +139,35 @@ public class DictionaryRepositoryTest extends AbstractRepositoryTest {
         int nbDictionariesAfterUpdate = dictionaryRepository.findAll().size();
 
         Assert.assertEquals(nbDictionariesBeforeUpdate, nbDictionariesAfterUpdate);
+
+        Optional<Dictionary> optionalUpdated = dictionaryRepository.findById("dic-1");
+        Assert.assertTrue("Dictionary to update not found", optionalUpdated.isPresent());
+
+        final Dictionary dictionaryUpdated = optionalUpdated.get();
+        Assert.assertEquals("Invalid saved environment id.", dictionary.getEnvironmentId(), dictionaryUpdated.getEnvironmentId());
+        Assert.assertEquals("Invalid saved dictionary name.", dictionary.getName(), dictionaryUpdated.getName());
+        Assert.assertEquals("Invalid dictionary description.", dictionary.getDescription(), dictionaryUpdated.getDescription());
+        Assert.assertTrue("Invalid dictionary createdAt.", compareDate(dictionary.getCreatedAt(), dictionaryUpdated.getCreatedAt()));
+        Assert.assertTrue("Invalid dictionary updatedAt.", compareDate(dictionary.getUpdatedAt(), dictionaryUpdated.getUpdatedAt()));
+        Assert.assertEquals("Invalid dictionary type.", dictionary.getType(), dictionaryUpdated.getType());
+        Assert.assertEquals("Invalid dictionary properties.", dictionary.getProperties(), dictionaryUpdated.getProperties());
+    }
+
+    @Test
+    public void shouldUpdateWithEmptyProperties() throws Exception {
+        Optional<Dictionary> optional = dictionaryRepository.findById("dic-1");
+
+        final Dictionary dictionary = optional.get();
+        dictionary.setId("dic-1");
+        dictionary.setName("My dic 1");
+        dictionary.setEnvironmentId("new_DEFAULT");
+        dictionary.setDescription("Description for my dic 1");
+        dictionary.setCreatedAt(new Date(1000000000000L));
+        dictionary.setUpdatedAt(new Date(1486771200000L));
+        dictionary.setType(DictionaryType.DYNAMIC);
+        dictionary.setProperties(new HashMap<>());
+
+        dictionaryRepository.update(dictionary);
 
         Optional<Dictionary> optionalUpdated = dictionaryRepository.findById("dic-1");
         Assert.assertTrue("Dictionary to update not found", optionalUpdated.isPresent());

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/DictionaryRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/DictionaryRepositoryTest.java
@@ -95,6 +95,11 @@ public class DictionaryRepositoryTest extends AbstractRepositoryTest {
         dictionary.setCreatedAt(new Date(1000000000000L));
         dictionary.setUpdatedAt(new Date(1439032010883L));
         dictionary.setType(DictionaryType.MANUAL);
+        final Map<String, String> properties = new HashMap<>();
+        properties.put("localhost", "localhost");
+        properties.put("localhost:8082", "localhost:8082");
+        properties.put("127.0.0.1:8082", "127.0.0.1:8082");
+        dictionary.setProperties(properties);
 
         int nbDictionariesBeforeCreation = dictionaryRepository.findAll().size();
         dictionaryRepository.create(dictionary);
@@ -112,6 +117,7 @@ public class DictionaryRepositoryTest extends AbstractRepositoryTest {
         Assert.assertTrue("Invalid dictionary createdAt.", compareDate(dictionary.getCreatedAt(), dictionarySaved.getCreatedAt()));
         Assert.assertTrue("Invalid dictionary updatedAt.", compareDate(dictionary.getUpdatedAt(), dictionarySaved.getUpdatedAt()));
         Assert.assertEquals("Invalid dictionary type.", dictionary.getType(), dictionarySaved.getType());
+        Assert.assertEquals("Invalid dictionary properties.", dictionary.getProperties(), dictionarySaved.getProperties());
     }
 
     @Test
@@ -144,6 +150,7 @@ public class DictionaryRepositoryTest extends AbstractRepositoryTest {
         Assert.assertTrue("Dictionary to update not found", optionalUpdated.isPresent());
 
         final Dictionary dictionaryUpdated = optionalUpdated.get();
+
         Assert.assertEquals("Invalid saved environment id.", dictionary.getEnvironmentId(), dictionaryUpdated.getEnvironmentId());
         Assert.assertEquals("Invalid saved dictionary name.", dictionary.getName(), dictionaryUpdated.getName());
         Assert.assertEquals("Invalid dictionary description.", dictionary.getDescription(), dictionaryUpdated.getDescription());

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/DictionaryRepositoryMock.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/DictionaryRepositoryMock.java
@@ -108,6 +108,6 @@ public class DictionaryRepositoryMock extends AbstractRepositoryMock<DictionaryR
         when(dictionaryRepository.findById("unknown")).thenReturn(empty());
         when(dictionaryRepository.findById("dic-1")).thenReturn(of(dic1), of(dic1), of(dictionaryUpdated));
 
-        when(dictionaryRepository.update(argThat(o -> o == null || o.getId().equals("unknown")))).thenThrow(new IllegalStateException());
+        when(dictionaryRepository.update(argThat(o -> o == null || "unknown".equals(o.getId())))).thenThrow(new IllegalStateException());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/DictionaryRepositoryMock.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/DictionaryRepositoryMock.java
@@ -42,13 +42,17 @@ public class DictionaryRepositoryMock extends AbstractRepositoryMock<DictionaryR
 
     @Override
     void prepare(DictionaryRepository dictionaryRepository) throws Exception {
-        final Dictionary newDictionary = mock(Dictionary.class);
-        when(newDictionary.getName()).thenReturn("My dic 1");
-        when(newDictionary.getEnvironmentId()).thenReturn("DEFAULT");
-        when(newDictionary.getDescription()).thenReturn("Description for my dic 1");
-        when(newDictionary.getCreatedAt()).thenReturn(new Date(1000000000000L));
-        when(newDictionary.getUpdatedAt()).thenReturn(new Date(1439032010883L));
-        when(newDictionary.getType()).thenReturn(DictionaryType.MANUAL);
+        final Dictionary newDictionary = new Dictionary();
+        newDictionary.setId("new-dictionary");
+        newDictionary.setEnvironmentId("DEFAULT");
+        newDictionary.setName("My dic 1");
+        newDictionary.setDescription("Description for my dic 1");
+        newDictionary.setCreatedAt(new Date(1000000000000L));
+        newDictionary.setUpdatedAt(new Date(1439032010883L));
+        newDictionary.setType(DictionaryType.MANUAL);
+        newDictionary.setProperties(
+            Map.of("localhost", "localhost", "localhost:8082", "localhost:8082", "127.0.0.1:8082", "127.0.0.1:8082")
+        );
 
         final Dictionary dic1 = new Dictionary();
         dic1.setId("dic-1");

--- a/gravitee-apim-repository/sonar-project.properties
+++ b/gravitee-apim-repository/sonar-project.properties
@@ -11,7 +11,7 @@ sonar.sources=.
 sonar.java.binaries=**/target/**
 
 # Exclude the whole coverage module as it is needed only for code coverage purpose
-sonar.exclusions=gravitee-apim-repository-coverage/**, **/target/**
+sonar.exclusions=gravitee-apim-repository-coverage/**, **/target/**, gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/**
 
 # Source encoding
 sonar.language=java


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6996

**Description**

 - Revert "fix: merge dictionary properties with new fetch before update" - commit a0badb3
 - Allow deletion of the last property of a dictionary with MongoDB
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6996-fix-dictionnary-property-deletion/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
