### PR TITLE
Run Chromatic automatically instead of manually

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1429,16 +1429,12 @@ workflows:
                   name: Build Console Storybook
                   requires:
                       - setup
-            - trigger-chromatic:
-                  type: approval
+            - console-webui-chromatic-deployment:
+                  context: cicd-orchestrator
                   requires:
                       - Build Console Storybook
                       - test-repository
                       - test
-            - console-webui-chromatic-deployment:
-                  context: cicd-orchestrator
-                  requires:
-                      - trigger-chromatic
             - webui-build:
                   name: Build APIM Console
                   apim-ui-project: gravitee-apim-console-webui


### PR DESCRIPTION
**Issue**

NA

**Description**

As we moved to the `Standard` plan on Chromatic a few days ago we can now remove the manual approval, at least on master.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/remove-chromatic-trigger/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bykshwdskt.chromatic.com)
<!-- Storybook placeholder end -->
