### PR TITLE
fix: set cookie secure by default

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-security/src/main/java/io/gravitee/rest/api/management/security/SecurityManagementConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-security/src/main/java/io/gravitee/rest/api/management/security/SecurityManagementConfiguration.java
@@ -24,6 +24,7 @@ import io.gravitee.rest.api.service.MembershipService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.env.Environment;
 import org.springframework.security.config.annotation.authentication.configuration.GlobalAuthenticationConfigurerAdapter;
 
 /**
@@ -36,8 +37,8 @@ import org.springframework.security.config.annotation.authentication.configurati
 public class SecurityManagementConfiguration extends GlobalAuthenticationConfigurerAdapter {
 
     @Bean
-    public CookieGenerator jwtCookieGenerator() {
-        return new CookieGenerator();
+    public CookieGenerator jwtCookieGenerator(Environment environment) {
+        return new CookieGenerator(environment);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-security/src/main/java/io/gravitee/rest/api/portal/security/SecurityPortalConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-security/src/main/java/io/gravitee/rest/api/portal/security/SecurityPortalConfiguration.java
@@ -24,6 +24,7 @@ import io.gravitee.rest.api.service.MembershipService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.env.Environment;
 import org.springframework.security.config.annotation.authentication.configuration.GlobalAuthenticationConfigurerAdapter;
 
 /**
@@ -36,8 +37,8 @@ import org.springframework.security.config.annotation.authentication.configurati
 public class SecurityPortalConfiguration extends GlobalAuthenticationConfigurerAdapter {
 
     @Bean
-    public CookieGenerator jwtCookieGenerator() {
-        return new CookieGenerator();
+    public CookieGenerator jwtCookieGenerator(Environment environment) {
+        return new CookieGenerator(environment);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/cookies/CookieGenerator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/cookies/CookieGenerator.java
@@ -28,12 +28,15 @@ import org.springframework.core.env.Environment;
  */
 public class CookieGenerator {
 
-    private static final boolean DEFAULT_JWT_COOKIE_SECURE = false;
+    private static final boolean DEFAULT_JWT_COOKIE_SECURE = true;
     private static final String DEFAULT_JWT_COOKIE_PATH = "/";
     private static final String DEFAULT_JWT_COOKIE_DOMAIN = "";
 
-    @Autowired
-    private Environment environment;
+    private final Environment environment;
+
+    public CookieGenerator(Environment environment) {
+        this.environment = environment;
+    }
 
     public Cookie generate(final String name, final String value, final boolean httpOnly) {
         final Cookie cookie = new Cookie(name, value);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/cookies/CookieGeneratorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/cookies/CookieGeneratorTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.security.cookies;
+
+import static org.junit.Assert.*;
+
+import javax.servlet.http.Cookie;
+import org.junit.Test;
+import org.springframework.core.env.Environment;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class CookieGeneratorTest {
+
+    @Test
+    public void shouldSetDefaultCookieOptions() {
+        final Environment environment = new MockEnvironment();
+        final CookieGenerator cookieGenerator = new CookieGenerator(environment);
+        final Cookie cookie = cookieGenerator.generate("test");
+        assertTrue(cookie.getSecure());
+        assertTrue(cookie.isHttpOnly());
+        assertEquals("", cookie.getDomain());
+        assertEquals("/", cookie.getPath());
+        assertEquals(604800, cookie.getMaxAge());
+    }
+
+    @Test
+    public void shouldSetCookieOptionsFromEnvironment() {
+        final Environment environment = new MockEnvironment()
+            .withProperty("jwt.cookie-secure", "false")
+            .withProperty("jwt.cookie-path", "/test")
+            .withProperty("jwt.cookie-domain", "gravitee.io")
+            .withProperty("jwt.expire-after", "1");
+
+        final CookieGenerator cookieGenerator = new CookieGenerator(environment);
+        final Cookie cookie = cookieGenerator.generate("test");
+        assertEquals("test", cookie.getValue());
+        assertFalse(cookie.getSecure());
+        assertTrue(cookie.isHttpOnly());
+        assertEquals("gravitee.io", cookie.getDomain());
+        assertEquals("/test", cookie.getPath());
+        assertEquals(1, cookie.getMaxAge());
+    }
+
+    @Test
+    public void shouldRevokeCookie() {
+        final Environment environment = new MockEnvironment();
+
+        final CookieGenerator cookieGenerator = new CookieGenerator(environment);
+        final Cookie cookie = cookieGenerator.generate(null);
+        assertNull(cookie.getValue());
+        assertEquals(0, cookie.getMaxAge());
+    }
+}


### PR DESCRIPTION
see https://github.com/gravitee-io/issues/issues/7725
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7725-cookie-secure-by-default/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
