### PR TITLE
Revert to gravitee-node 1.21 & bump ae version to 1.6.1

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -709,7 +709,7 @@
             <properties>
                 <!-- Versions of the plugins for the full distribution on dev environment-->
                 <!-- Management API & Gateway -->
-                <gravitee-ae-connectors-ws.version>1.5.4</gravitee-ae-connectors-ws.version>
+                <gravitee-ae-connectors-ws.version>1.6.1</gravitee-ae-connectors-ws.version>
                 <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
                 <gravitee-policy-assign-metrics.version>1.0.1</gravitee-policy-assign-metrics.version>
                 <gravitee-policy-data-logging-masking.version>1.1.1</gravitee-policy-data-logging-masking.version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,9 @@
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>1.32.2</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
-        <gravitee-node.version>1.24.0</gravitee-node.version>
+        <gravitee-node.version>1.21.0</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>
-        <gravitee-plugin.version>1.23.1</gravitee-plugin.version>
+        <gravitee-plugin.version>1.22.0</gravitee-plugin.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>1.22.0</gravitee-reporter-api.version>
         <gravitee-resource-auth-provider-api.version>1.3.0</gravitee-resource-auth-provider-api.version>


### PR DESCRIPTION
**Issue**
na

**Description**

Fix ae on master 
- bump ae to 1.6.1
- revert gravitee-node version incompatible with the current version of some plugins

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-iowmgvzolw.chromatic.com)
<!-- Storybook placeholder end -->
