### PR TITLE
test: added basic tests for portal applications

### DIFF
--- a/gravitee-apim-e2e/api-test/src/portal/portal-applications.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/portal/portal-applications.spec.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterAll, beforeAll, describe } from '@jest/globals';
+import { ANONYMOUS, forPortal, forPortalAsAdminUser, forPortalAsApiUser, forPortalAsAppUser, forPortalAsSimpleUser } from '@client-conf/*';
+import { created, noContent, unauthorized } from '@lib/jest-utils';
+import { ApplicationApi } from '@portal-apis/ApplicationApi';
+import { Application } from '@portal-models/Application';
+import { PortalApplicationFaker } from '@portal-fakers/PortalApplicationFaker';
+
+const portalApplicationApiAsAdminUser = new ApplicationApi(forPortalAsAdminUser());
+const portalApplicationApiAsAppUser = new ApplicationApi(forPortalAsAppUser());
+const portalApplicationApiAsApiUser = new ApplicationApi(forPortalAsApiUser());
+const portalApplicationApiAsSimpleUser = new ApplicationApi(forPortalAsSimpleUser());
+const portalApplicationApiAsAnonymous = new ApplicationApi(forPortal({ auth: ANONYMOUS }));
+
+describe('Portal application tests', () => {
+  describe('Portal application tests with authorized users', () => {
+    let application: Application;
+
+    describe.each`
+      user             | applicationResource
+      ${'ADMIN'}       | ${portalApplicationApiAsAdminUser}
+      ${'api_user'}    | ${portalApplicationApiAsApiUser}
+      ${'app_user'}    | ${portalApplicationApiAsAppUser}
+      ${'simple_user'} | ${portalApplicationApiAsSimpleUser}
+    `('As $user user', ({ applicationResource }) => {
+      test('should create an application', async () => {
+        application = await created(
+          applicationResource.createApplicationRaw({
+            applicationInput: PortalApplicationFaker.newApplicationInput(),
+          }),
+        );
+      });
+
+      test('should delete an application', async () => {
+        await noContent(
+          applicationResource.deleteApplicationByApplicationIdRaw({
+            applicationId: application.id,
+          }),
+        );
+      });
+    });
+  });
+
+  describe('Portal application tests with unauthorized users', () => {
+    let application: Application;
+
+    beforeAll(async () => {
+      application = await portalApplicationApiAsAdminUser.createApplication({
+        applicationInput: PortalApplicationFaker.newApplicationInput(),
+      });
+    });
+
+    test('should fail to create an application as an unauthorized user', async () => {
+      await unauthorized(
+        portalApplicationApiAsAnonymous.createApplicationRaw({
+          applicationInput: PortalApplicationFaker.newApplicationInput(),
+        }),
+      );
+    });
+
+    test('should fail to delete an application as an unauthorized user', async () => {
+      await unauthorized(
+        portalApplicationApiAsAnonymous.deleteApplicationByApplicationIdRaw({
+          applicationId: application.id,
+        }),
+      );
+    });
+
+    afterAll(async () => {
+      await portalApplicationApiAsAdminUser.deleteApplicationByApplicationId({
+        applicationId: application.id,
+      });
+    });
+  });
+});

--- a/gravitee-apim-e2e/jest.config.ci.js
+++ b/gravitee-apim-e2e/jest.config.ci.js
@@ -10,6 +10,7 @@ module.exports = {
     '@management-models/(.*)': '<rootDir>/dist/lib/management-webclient-sdk/src/lib/models/$1',
     '@portal-apis/(.*)': '<rootDir>/dist/lib/portal-webclient-sdk/src/lib/apis/$1',
     '@portal-models/(.*)': '<rootDir>/dist/lib/portal-webclient-sdk/src/lib/models/$1',
+    '@portal-fakers/(.*)': '<rootDir>/dist/lib/fixtures/portal/$1',
     '@api-test-resources/(.*)': '<rootDir>/api-test/resources/$1',
     '@lib/jest-utils': '<rootDir>/dist/lib/jest-utils',
     '@lib/gateway': '<rootDir>/dist/lib/gateway',

--- a/gravitee-apim-e2e/jest.config.js
+++ b/gravitee-apim-e2e/jest.config.js
@@ -84,6 +84,7 @@ module.exports = {
     '@management-models/(.*)': '<rootDir>/lib/management-webclient-sdk/src/lib/models/$1',
     '@portal-apis/(.*)': '<rootDir>/lib/portal-webclient-sdk/src/lib/apis/$1',
     '@portal-models/(.*)': '<rootDir>/lib/portal-webclient-sdk/src/lib/models/$1',
+    '@portal-fakers/(.*)': '<rootDir>/lib/fixtures/portal/$1',
     '@api-test-resources/(.*)': '<rootDir>/api-test/resources/$1',
     '@lib/jest-utils': '<rootDir>/lib/jest-utils',
     '@lib/gateway': '<rootDir>/lib/gateway',

--- a/gravitee-apim-e2e/lib/fixtures/portal/PortalApplicationFaker.ts
+++ b/gravitee-apim-e2e/lib/fixtures/portal/PortalApplicationFaker.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import faker from '@faker-js/faker';
+import { ApplicationInput } from '@portal-models/ApplicationInput';
+
+export class PortalApplicationFaker {
+  static newApplicationInput(attributes?: Partial<ApplicationInput>): ApplicationInput {
+    const name = faker.commerce.productName();
+    const description = faker.commerce.productDescription();
+    return {
+      name,
+      description,
+      settings: {
+        app: {
+          type: 'test',
+          client_id: faker.random.alphaNumeric(10),
+        },
+      },
+      ...attributes,
+    };
+  }
+}

--- a/gravitee-apim-e2e/tsconfig.json
+++ b/gravitee-apim-e2e/tsconfig.json
@@ -20,7 +20,8 @@
       "@portal-models/*": ["lib/portal-webclient-sdk/src/lib/models/*"],
       "@api-test-resources/*": ["<rootDir>/api-test/resources/$1"],
       "@lib/jest-utils": ["lib/jest-utils"],
-      "@lib/gateway": ["lib/gateway"]
+      "@lib/gateway": ["lib/gateway"],
+      "@portal-fakers/*": ["lib/fixtures/portal/*"]
     }
   },
   "include": ["**/*.ts"]


### PR DESCRIPTION
added basic test for portal applications
- create and delete portal applications for authorised and unauthorised users

gravitee-io/issues#7701
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/test-7701-portal-application-tests-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vkrfcdkrvu.chromatic.com)
<!-- Storybook placeholder end -->
