### PR TITLE
Test/jest test plans deploy run e2e

### DIFF
--- a/gravitee-apim-e2e/api-test/src/gateway/api-key.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/gateway/api-key.spec.ts
@@ -29,7 +29,7 @@ import { ApplicationsFaker } from '@management-fakers/ApplicationsFaker';
 import { LifecycleAction } from '@management-models/LifecycleAction';
 import { ApplicationsApi } from '@management-apis/ApplicationsApi';
 import { ApplicationSubscriptionsApi } from '@management-apis/ApplicationSubscriptionsApi';
-import { fetchGateway } from '@lib/gateway';
+import { fetchGatewaySuccess, fetchGatewayUnauthorized } from '@lib/gateway';
 
 const orgId = 'DEFAULT';
 const envId = 'DEFAULT';
@@ -97,15 +97,13 @@ describe('Gateway - Api Key', () => {
       ${'wrong X-Gravitee-Api-Key header'} | ${{ 'X-Gravitee-Api-Key': 'wrong key' }}
     `('Gateway call with $case', ({ headers }) => {
       test('Should return 401 unauthorized', async () => {
-        await fetchGateway(createdApi.context_path, 'GET', null, headers).then((response) => expect(response.status).toBe(401));
+        await fetchGatewayUnauthorized({ contextPath: createdApi.context_path, headers });
       });
     });
 
     describe('Gateway call with correct X-Gravitee-Api-Key header', () => {
       test('Should return 200 OK', async () => {
-        await fetchGateway(createdApi.context_path, 'GET', null, { 'X-Gravitee-Api-Key': createdApiKey.key }).then((response) =>
-          expect(response.status).toBe(200),
-        );
+        await fetchGatewaySuccess({ contextPath: createdApi.context_path, headers: { 'X-Gravitee-Api-Key': createdApiKey.key } });
       });
     });
   });
@@ -118,17 +116,13 @@ describe('Gateway - Api Key', () => {
       ${'wrong api-key query param'} | ${{ 'api-key': 'wrong key' }}
     `('Gateway call with $case', ({ queryParams }) => {
       test('Should return 401 unauthorized', async () => {
-        await fetchGateway(`${createdApi.context_path}?${new URLSearchParams(queryParams)}`).then((response) =>
-          expect(response.status).toBe(401),
-        );
+        await fetchGatewayUnauthorized({ contextPath: `${createdApi.context_path}?${new URLSearchParams(queryParams)}` });
       });
     });
 
     describe('Gateway call with correct api-key query param', () => {
       test('Should return 200 OK', async () => {
-        await fetchGateway(`${createdApi.context_path}?${new URLSearchParams({ 'api-key': createdApiKey.key })}`).then((response) =>
-          expect(response.status).toBe(200),
-        );
+        await fetchGatewaySuccess({ contextPath: `${createdApi.context_path}?${new URLSearchParams({ 'api-key': createdApiKey.key })}` });
       });
     });
   });

--- a/gravitee-apim-e2e/api-test/src/gateway/plans-deployment.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/gateway/plans-deployment.spec.ts
@@ -1,0 +1,260 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { forManagementAsApiUser, forManagementAsAppUser } from '@client-conf/*';
+import { afterAll, beforeAll, describe, test } from '@jest/globals';
+import { APIsApi } from '@management-apis/APIsApi';
+import { ApiEntity } from '@management-models/ApiEntity';
+import { ApisFaker } from '@management-fakers/ApisFaker';
+import { ApplicationsApi } from '@management-apis/ApplicationsApi';
+import { ApplicationsFaker } from '@management-fakers/ApplicationsFaker';
+import { ApplicationEntity } from '@management-models/ApplicationEntity';
+import { succeed } from '@lib/jest-utils';
+import { PlansFaker } from '@management-fakers/PlansFaker';
+import { PlanEntity } from '@management-models/PlanEntity';
+import { APIPlansApi } from '@management-apis/APIPlansApi';
+import { PlanStatus } from '@management-models/PlanStatus';
+import { PlanSecurityType } from '@management-models/PlanSecurityType';
+import { LifecycleAction } from '@management-models/LifecycleAction';
+import { fetchGatewaySuccess, fetchGatewayUnauthorized } from '@lib/gateway';
+import { ApplicationSubscriptionsApi } from '@management-apis/ApplicationSubscriptionsApi';
+import { Subscription } from '@management-models/Subscription';
+import { ApiKeyEntity } from '@management-models/ApiKeyEntity';
+
+const orgId = 'DEFAULT';
+const envId = 'DEFAULT';
+
+const apisResource = new APIsApi(forManagementAsApiUser());
+const apiPlansResource = new APIPlansApi(forManagementAsApiUser());
+const applicationSubscriptionsResource = new ApplicationSubscriptionsApi(forManagementAsAppUser());
+const applicationsResource = new ApplicationsApi(forManagementAsAppUser());
+
+let createdApi: ApiEntity;
+let createdApiKeyPlan: PlanEntity;
+let createdFreePlan: PlanEntity;
+let createdApiKey: ApiKeyEntity;
+let createdApplication: ApplicationEntity;
+let createdSubscription: Subscription;
+
+describe('Gateway - Plans deployment', () => {
+  beforeAll(async () => {
+    // create an API with a published API key plan
+    createdApi = await apisResource.importApiDefinition({
+      envId,
+      orgId,
+      body: ApisFaker.apiImport({ plans: [PlansFaker.plan({ security: PlanSecurityType.APIKEY, status: PlanStatus.PUBLISHED })] }),
+    });
+
+    // start it
+    await apisResource.doApiLifecycleAction({
+      envId,
+      orgId,
+      api: createdApi.id,
+      action: LifecycleAction.START,
+    });
+  });
+
+  describe('Without free plan', () => {
+    test('Gateway should return HTTP 401', async () => {
+      await fetchGatewayUnauthorized({ contextPath: createdApi.context_path });
+    });
+  });
+
+  describe('With 1 free plan', () => {
+    beforeAll(async () => {
+      createdFreePlan = await apisResource.createApiPlan({
+        envId,
+        orgId,
+        api: createdApi.id,
+        newPlanEntity: PlansFaker.newPlan(),
+      });
+    });
+
+    test('gateway should return HTTP 401 cause plan is not published', async () => {
+      await fetchGatewayUnauthorized({ contextPath: createdApi.context_path });
+    });
+
+    test('should deploy the API', async () => {
+      await succeed(apisResource.deployApiRaw({ orgId, envId, api: createdApi.id }));
+    });
+
+    test('gateway should return HTTP 401 cause plan is still not published', async () => {
+      await fetchGatewayUnauthorized({ contextPath: createdApi.context_path });
+    });
+
+    test('should publish plan', async () => {
+      await succeed(apiPlansResource.publishApiPlanRaw({ envId, orgId, plan: createdFreePlan.id, api: createdApi.id }));
+    });
+
+    test('gateway should return HTTP 401 cause published plan is not deployed', async () => {
+      await fetchGatewayUnauthorized({ contextPath: createdApi.context_path });
+    });
+
+    test('should redeploy the API with published plan', async () => {
+      await succeed(apisResource.deployApiRaw({ orgId, envId, api: createdApi.id }));
+    });
+
+    test('gateway should succeed with HTTP 200', async () => {
+      await fetchGatewaySuccess({ contextPath: createdApi.context_path });
+    });
+
+    test('should close plan', async () => {
+      await succeed(apiPlansResource.closeApiPlanRaw({ envId, orgId, plan: createdFreePlan.id, api: createdApi.id }));
+    });
+
+    test('gateway should still succeed with HTTP 200 cause closed plan not deployed', async () => {
+      await fetchGatewaySuccess({ contextPath: createdApi.context_path });
+    });
+
+    test('should redeploy the API with closed plan', async () => {
+      await succeed(apisResource.deployApiRaw({ orgId, envId, api: createdApi.id }));
+    });
+
+    test('gateway should return HTTP 401 cause free plan is closed', async () => {
+      await fetchGatewayUnauthorized({ contextPath: createdApi.context_path });
+    });
+  });
+
+  describe('With 1 additional API key plan', () => {
+    beforeAll(async () => {
+      createdApiKeyPlan = await apisResource.createApiPlan({
+        envId,
+        orgId,
+        api: createdApi.id,
+        newPlanEntity: PlansFaker.newPlan({ security: PlanSecurityType.APIKEY, status: PlanStatus.PUBLISHED }),
+      });
+
+      // create an application
+      createdApplication = await applicationsResource.createApplication({
+        envId,
+        orgId,
+        newApplicationEntity: ApplicationsFaker.newApplication(),
+      });
+
+      // subscribe application to plan
+      createdSubscription = await applicationSubscriptionsResource.createSubscriptionWithApplication({
+        envId,
+        orgId,
+        plan: createdApiKeyPlan.id,
+        application: createdApplication.id,
+      });
+
+      // get the subscription api key
+      createdApiKey = (
+        await applicationSubscriptionsResource.getApiKeysForApplicationSubscription({
+          envId,
+          orgId,
+          application: createdApplication.id,
+          subscription: createdSubscription.id,
+        })
+      )[0];
+    });
+
+    test('gateway should return HTTP 401 cause published api key plan is not deployed', async () => {
+      await fetchGatewayUnauthorized({ contextPath: createdApi.context_path, headers: { 'X-Gravitee-Api-Key': createdApiKey.key } });
+      await fetchGatewayUnauthorized({ contextPath: createdApi.context_path });
+    });
+
+    test('should redeploy the API with published API key plan', async () => {
+      await succeed(apisResource.deployApiRaw({ orgId, envId, api: createdApi.id }));
+    });
+
+    test('gateway should succeed with HTTP 200 on API key plan, but still not authorized on free plan', async () => {
+      await fetchGatewaySuccess({ contextPath: createdApi.context_path, headers: { 'X-Gravitee-Api-Key': createdApiKey.key } });
+      await fetchGatewayUnauthorized({ contextPath: createdApi.context_path });
+    });
+
+    test('should recreate 1 published free plan', async () => {
+      createdFreePlan = await apisResource.createApiPlan({
+        envId,
+        orgId,
+        api: createdApi.id,
+        newPlanEntity: PlansFaker.newPlan({ status: PlanStatus.PUBLISHED }),
+      });
+    });
+
+    test('should redeploy the API with published API key plan and free plan', async () => {
+      await succeed(apisResource.deployApiRaw({ orgId, envId, api: createdApi.id }));
+    });
+
+    test('gateway should succeed with HTTP 200 on API key plan, and on free plan', async () => {
+      await fetchGatewaySuccess({ contextPath: createdApi.context_path, headers: { 'X-Gravitee-Api-Key': createdApiKey.key } });
+      await fetchGatewaySuccess({ contextPath: createdApi.context_path });
+    });
+
+    test('should close free plan', async () => {
+      await succeed(apiPlansResource.closeApiPlanRaw({ envId, orgId, plan: createdFreePlan.id, api: createdApi.id }));
+    });
+
+    test('should redeploy the API with closed API key plan and free plan', async () => {
+      await succeed(apisResource.deployApiRaw({ orgId, envId, api: createdApi.id }));
+    });
+
+    test('gateway should succeed with HTTP 200 on apikey plan, but no more on free plan', async () => {
+      await fetchGatewaySuccess({ contextPath: createdApi.context_path, headers: { 'X-Gravitee-Api-Key': createdApiKey.key } });
+      await fetchGatewayUnauthorized({ contextPath: createdApi.context_path });
+    });
+
+    test('should close apikey plan', async () => {
+      await succeed(apiPlansResource.closeApiPlanRaw({ envId, orgId, plan: createdApiKeyPlan.id, api: createdApi.id }));
+    });
+
+    test('should redeploy the API with closed API key plan and closed free plan', async () => {
+      await succeed(apisResource.deployApiRaw({ orgId, envId, api: createdApi.id }));
+    });
+
+    test('gateway should fail with HTTP 401 on both plans', async () => {
+      await fetchGatewayUnauthorized({ contextPath: createdApi.context_path, headers: { 'X-Gravitee-Api-Key': createdApiKey.key } });
+      await fetchGatewayUnauthorized({ contextPath: createdApi.context_path });
+    });
+
+    afterAll(async () => {
+      if (createdApplication) {
+        await applicationsResource.deleteApplication({
+          envId,
+          orgId,
+          application: createdApplication.id,
+        });
+      }
+    });
+  });
+
+  afterAll(async () => {
+    if (createdApi) {
+      // stop API
+      await apisResource.doApiLifecycleAction({
+        envId,
+        orgId,
+        api: createdApi.id,
+        action: LifecycleAction.STOP,
+      });
+
+      // close plan
+      await apisResource.closeApiPlan({
+        envId,
+        orgId,
+        plan: createdApi.plans[0].id,
+        api: createdApi.id,
+      });
+
+      // delete API
+      await apisResource.deleteApi({
+        envId,
+        orgId,
+        api: createdApi.id,
+      });
+    }
+  });
+});

--- a/gravitee-apim-e2e/api-test/src/gateway/simple-proxy.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/gateway/simple-proxy.spec.ts
@@ -22,7 +22,7 @@ import { ApiEntity } from '@management-models/ApiEntity';
 import { PlansFaker } from '@management-fakers/PlansFaker';
 import { LifecycleAction } from '@management-models/LifecycleAction';
 import { PlanStatus } from '@management-models/PlanStatus';
-import { fetchGateway } from '@lib/gateway';
+import { fetchGatewaySuccess } from '@lib/gateway';
 import { APIPlansApi } from '@management-apis/APIPlansApi';
 
 const orgId = 'DEFAULT';
@@ -57,7 +57,7 @@ describe('Gateway - Simple proxy', () => {
 
   describe('Gateway call', () => {
     test('Gateway call should return backend response', async () => {
-      await fetchGateway(createdApi.context_path)
+      await fetchGatewaySuccess({ contextPath: createdApi.context_path })
         .then((res) => res.json())
         .then((json) => {
           expect(json.date).toBe('11/05/2022 13:19:44.009');

--- a/gravitee-apim-e2e/api-test/src/policies/mock-policy.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/policies/mock-policy.spec.ts
@@ -24,7 +24,7 @@ import { PlanEntity } from '@management-models/PlanEntity';
 import { RuleMethodsEnum } from '@management-models/Rule';
 import { noContent, succeed } from '@lib/jest-utils';
 import { LifecycleAction } from '@management-models/LifecycleAction';
-import { fetchGateway } from '@lib/gateway';
+import { fetchGatewaySuccess } from '@lib/gateway';
 import { PathOperatorOperatorEnum } from '@management-models/PathOperator';
 import { PlanStatus } from '@management-models/PlanStatus';
 
@@ -92,7 +92,7 @@ describe('Mock policy', () => {
       );
       await succeed(apiManagementApiAsApiUser.deployApiRaw({ orgId, envId, api: createdApi.id }));
 
-      await fetchGateway(createdApi.context_path)
+      await fetchGatewaySuccess({ contextPath: createdApi.context_path })
         .then((res) => res.json())
         .then((body) => {
           expect(body).toEqual(JSON.parse(mockContent));
@@ -158,7 +158,7 @@ describe('Mock policy', () => {
     test('should create, deploy and call a mock policy', async () => {
       await succeed(apiManagementApiAsApiUser.deployApiRaw({ orgId, envId, api: createdApi.id }));
 
-      await fetchGateway(createdApi.context_path)
+      await fetchGatewaySuccess({ contextPath: createdApi.context_path })
         .then((res) => res.json())
         .then((json) => {
           expect(json).toEqual(JSON.parse(mockContent));


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7693

**Description**

**test(e2e): jest e2e gateway calls checks expected status**

When calling the gateway during an e2e test,
Waiting for a response other than 404 in not enough for most usecases.

For example, when testing a plan closure, you want the gateway to return a 200 with your published plan, and then, a 401 after plan closure.

So, a expectedResultCode has been added to the parameters, and parameters were refactored to make it simpler to use.

2 implementations for now :
- fetchGatewaySuccess expecting a 200 return code
- fetchGatewayUnauthorized expecting a 401 return code

Looks like the jest-utils APIM calls.

**test(e2e): add jest tests for plans deployment by gateway**
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/test-jesttestplansdeploy-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dirtnmkupk.chromatic.com)
<!-- Storybook placeholder end -->
