### PR TITLE
fix: bump gravitee-resource-oauth2-provider-generic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,7 +267,7 @@ jobs:
             - run:
                   name: "Build project"
                   command: |
-                      mvn -pl '!gravitee-apim-console-webui, !gravitee-apim-portal-webui' -s .gravitee.settings.xml clean install --no-transfer-progress -DskipTests -Dskip.validation=true -T 2C -P distribution-dev,distribution-ee
+                      mvn -pl '!gravitee-apim-console-webui, !gravitee-apim-portal-webui' -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -T 2C -P distribution-dev,distribution-ee
                       mkdir -p ./rest-api-docker-context/distribution && cp -r ./gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target/distribution ./rest-api-docker-context/.
                       mkdir -p ./gateway-docker-context/distribution && cp -r ./gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target/distribution ./gateway-docker-context/.
 

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -93,7 +93,7 @@
         <gravitee-policy-xslt.version>1.6.1</gravitee-policy-xslt.version>
         <gravitee-resource-cache.version>1.6.2</gravitee-resource-cache.version>
         <gravitee-resource-oauth2-provider-am.version>1.14.2</gravitee-resource-oauth2-provider-am.version>
-        <gravitee-resource-oauth2-provider-generic.version>1.16.1</gravitee-resource-oauth2-provider-generic.version>
+        <gravitee-resource-oauth2-provider-generic.version>1.16.2</gravitee-resource-oauth2-provider-generic.version>
         <gravitee-service-discovery-consul.version>1.3.0</gravitee-service-discovery-consul.version>
         <!-- Management API Only -->
         <gravitee-cockpit-connectors-ws.version>2.0.1</gravitee-cockpit-connectors-ws.version>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,7 @@
         <wiremock.version>2.19.0</wiremock.version>
         <wiremock-jre8.version>2.28.0</wiremock-jre8.version>
         <wsdl4j.version>1.6.3</wsdl4j.version>
+
         <!-- Plugins version -->
         <gatling-maven-plugin.version>3.1.1</gatling-maven-plugin.version>
         <maven-assembly-plugin.version>2.6</maven-assembly-plugin.version>


### PR DESCRIPTION
**Issue**

gravitee-io/issues#7258

**Description**

Bump version of `gravitee-resource-oauth2-provider-generic`
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7258-fix-system-proxy-support/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
