### PR TITLE
Upgrade MongoDB driver and use MongoDB 5 as default version in docker setups

### DIFF
--- a/docker/quick-setup/ee-with-alert-engine/docker-compose.yml
+++ b/docker/quick-setup/ee-with-alert-engine/docker-compose.yml
@@ -28,7 +28,7 @@ volumes:
 
 services:
   mongodb:
-    image: mongo:${MONGODB_VERSION:-3.6}
+    image: mongo:${MONGODB_VERSION:-5}
     container_name: gio_apim_mongodb
     restart: always
     volumes:

--- a/docker/quick-setup/gateway-http-bridge-repository/docker-compose.yml
+++ b/docker/quick-setup/gateway-http-bridge-repository/docker-compose.yml
@@ -28,7 +28,7 @@ volumes:
 
 services:
   mongodb:
-    image: mongo:${MONGODB_VERSION:-3.6}
+    image: mongo:${MONGODB_VERSION:-5}
     container_name: gio_apim_mongodb
     restart: always
     volumes:

--- a/docker/quick-setup/https-gateway/docker-compose.yml
+++ b/docker/quick-setup/https-gateway/docker-compose.yml
@@ -28,7 +28,7 @@ volumes:
 
 services:
   mongodb:
-    image: mongo:${MONGODB_VERSION:-3.6}
+    image: mongo:${MONGODB_VERSION:-5}
     container_name: gio_apim_mongodb
     restart: always
     volumes:

--- a/docker/quick-setup/keycloak/docker-compose.yml
+++ b/docker/quick-setup/keycloak/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - frontend
 
   mongodb:
-    image: mongo:${MONGODB_VERSION:-3.6}
+    image: mongo:${MONGODB_VERSION:-5}
     container_name: gio_apim_mongodb
     restart: always
     volumes:

--- a/docker/quick-setup/mongodb/docker-compose.yml
+++ b/docker/quick-setup/mongodb/docker-compose.yml
@@ -28,7 +28,7 @@ volumes:
 
 services:
   mongodb:
-    image: mongo:${MONGODB_VERSION:-3.6}
+    image: mongo:${MONGODB_VERSION:-5}
     container_name: gio_apim_mongodb
     restart: always
     volumes:

--- a/docker/quick-setup/nginx/docker-compose.yml
+++ b/docker/quick-setup/nginx/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     networks:
       - frontend
   mongodb:
-    image: mongo:${MONGODB_VERSION:-3.6}
+    image: mongo:${MONGODB_VERSION:-5}
     container_name: gio_apim_mongodb
     restart: always
     volumes:

--- a/docker/quick-setup/opensearch/docker-compose.yml
+++ b/docker/quick-setup/opensearch/docker-compose.yml
@@ -28,7 +28,7 @@ volumes:
 
 services:
   mongodb:
-    image: mongo:${MONGODB_VERSION:-3.6}
+    image: mongo:${MONGODB_VERSION:-5}
     container_name: gio_apim_mongodb
     restart: always
     volumes:

--- a/docker/quick-setup/redis-rate-limit/docker-compose.yml
+++ b/docker/quick-setup/redis-rate-limit/docker-compose.yml
@@ -30,7 +30,7 @@ volumes:
 
 services:
   mongodb:
-    image: mongo:${MONGODB_VERSION:-3.6}
+    image: mongo:${MONGODB_VERSION:-5}
     container_name: gio_apim_mongodb
     restart: always
     volumes:

--- a/docker/quick-setup/tags-internal-external/docker-compose.yml
+++ b/docker/quick-setup/tags-internal-external/docker-compose.yml
@@ -28,7 +28,7 @@ volumes:
 
 services:
   mongodb:
-    image: mongo:${MONGODB_VERSION:-3.6}
+    image: mongo:${MONGODB_VERSION:-5}
     container_name: gio_apim_mongodb
     restart: always
     volumes:

--- a/gravitee-apim-e2e/docker/common/docker-compose-apis.yml
+++ b/gravitee-apim-e2e/docker/common/docker-compose-apis.yml
@@ -28,7 +28,7 @@ volumes:
 
 services:
   mongodb:
-    image: circleci/mongo:${MONGODB_VERSION:-4}
+    image: circleci/mongo:${MONGODB_VERSION:-5}
     container_name: gio_apim_mongodb
     restart: always
     ports:

--- a/gravitee-apim-e2e/docker/common/docker-compose-apis.yml
+++ b/gravitee-apim-e2e/docker/common/docker-compose-apis.yml
@@ -92,6 +92,8 @@ services:
       - gravitee_management_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
       - gravitee_analytics_elasticsearch_endpoints_0=http://elasticsearch:9200
       - gravitee_newsletter_enabled=false
+      - gravitee_security_providers[0].users[0].email=user@gravitee.io
+      - gravitee_security_providers[0].users[1].email=admin@gravitee.io
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://admin:adminadmin@localhost:18083/_node" ]
       interval: 2s

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/pom.xml
@@ -33,9 +33,9 @@
 	<properties>
         <!--
             According to https://docs.spring.io/spring-data/mongodb/docs/current/reference/html/#compatibility.matrix
-            spring data 3.2.x is compatible with mongo driver 4.1.x
+            spring data 3.4.x is compatible with mongo driver 4.6.x
         -->
-        <mongo.version>4.1.2</mongo.version>
+        <mongo.version>4.6.0</mongo.version>
         <spring.data.mongodb.version>3.4.0</spring.data.mongodb.version>
     </properties>
 

--- a/gravitee-apim-rest-api/docker/compose/docker-compose-dev.yml
+++ b/gravitee-apim-rest-api/docker/compose/docker-compose-dev.yml
@@ -22,7 +22,7 @@ volumes:
 
 services:
   mongodb:
-    image: mongo:${MONGODB_VERSION:-3.6}
+    image: mongo:${MONGODB_VERSION:-5}
     container_name: gio_apim_mongodb
     volumes:
       - ./logs/apim-mongodb:/var/log/mongodb


### PR DESCRIPTION
**Issue**

NA

**Description**

 - move from Mongo 3.6 to Mongo 5 as the default value in docker quick setup
 - move from Mongo 4 to Mongo 5 as the default value in e2e docker compose
 - bump mongodb driver to 3.4.0
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/update-mongodb-version-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-aenudmrszv.chromatic.com)
<!-- Storybook placeholder end -->
