### PR TITLE
fix(portal): remove X-Frame-Options inside nginx config

### DIFF
--- a/gravitee-apim-portal-webui/docker/config/templates/default.conf.tmpl
+++ b/gravitee-apim-portal-webui/docker/config/templates/default.conf.tmpl
@@ -3,7 +3,6 @@ server {
     listen {{ getenv "HTTPS_PORT" "8443" }};
     server_name {{ getenv "SERVER_NAME" "_" }};
 
-    add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Content-Type-Options nosniff;
     add_header X-Permitted-Cross-Domain-Policies none;


### PR DESCRIPTION
**Issue**
https://github.com/gravitee-io/issues/issues/7710

**Description**

Remove  because we use iframe to preview the portal theme

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-portal/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jraqkregux.chromatic.com)
<!-- Storybook placeholder end -->
