### PR TITLE
chore: gateway test sdk : chainable testObserver calls after awaitTerminalEvent

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/AbstractGatewayTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/AbstractGatewayTest.java
@@ -96,10 +96,11 @@ public abstract class AbstractGatewayTest implements PluginRegister, ApiConfigur
      * Proxy for {@link TestObserver#awaitTerminalEvent(long, TimeUnit)} with a default of 30 seconds.
      * It awaits 30 seconds or until this TestObserver/TestSubscriber receives an onError or onComplete events, whichever happens first.
      * @param obs is the observer to await
-     * @return true if the TestObserver/TestSubscriber terminated, false if timeout or interrupt happened
+     * @return the observer after wait
      */
-    protected boolean awaitTerminalEvent(TestObserver<?> obs) {
-        return obs.awaitTerminalEvent(30, TimeUnit.SECONDS);
+    protected <T> TestObserver<T> awaitTerminalEvent(TestObserver<T> obs) {
+        obs.awaitTerminalEvent(30, TimeUnit.SECONDS);
+        return obs;
     }
 
     /**

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/ClientAuthenticationPEMInlineTestCase.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/ClientAuthenticationPEMInlineTestCase.java
@@ -75,8 +75,7 @@ public class ClientAuthenticationPEMInlineTestCase extends AbstractGatewayTest {
         // First call is calling an HTTPS endpoint without ssl configuration => 502
         TestObserver<HttpResponse<Buffer>> obs = client.get(API_ENTRYPOINT).rxSend().test();
 
-        awaitTerminalEvent(obs);
-        obs
+        awaitTerminalEvent(obs)
             .assertComplete()
             .assertValue(
                 response -> {
@@ -89,8 +88,7 @@ public class ClientAuthenticationPEMInlineTestCase extends AbstractGatewayTest {
         // Second call is calling an endpoint where trustAll = false, without keystore => 502
         obs = client.get(API_ENTRYPOINT).rxSend().test();
 
-        awaitTerminalEvent(obs);
-        obs
+        awaitTerminalEvent(obs)
             .assertComplete()
             .assertValue(
                 response -> {
@@ -103,8 +101,7 @@ public class ClientAuthenticationPEMInlineTestCase extends AbstractGatewayTest {
         // Third call is calling an endpoint where trustAll = true, with keystore => 200
         obs = client.get(API_ENTRYPOINT).rxSend().test();
 
-        awaitTerminalEvent(obs);
-        obs
+        awaitTerminalEvent(obs)
             .assertComplete()
             .assertValue(
                 response -> {
@@ -117,8 +114,7 @@ public class ClientAuthenticationPEMInlineTestCase extends AbstractGatewayTest {
         // Fourth call is calling an endpoint where trustAll = false, with truststore and keystore => 200
         obs = client.get(API_ENTRYPOINT).rxSend().test();
 
-        awaitTerminalEvent(obs);
-        obs
+        awaitTerminalEvent(obs)
             .assertComplete()
             .assertValue(
                 response -> {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/ConditionalPolicyTestCase.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/ConditionalPolicyTestCase.java
@@ -61,19 +61,19 @@ public class ConditionalPolicyTestCase extends AbstractGatewayTest {
 
         final TestObserver<HttpResponse<Buffer>> obs = webClient.get(ENDPOINT).putHeader(CONDITION_HEADER, "condition-ok").rxSend().test();
 
-        awaitTerminalEvent(obs);
-        obs.assertComplete();
-        obs.assertValue(
-            response -> {
-                final String content = response.bodyAsString();
+        awaitTerminalEvent(obs)
+            .assertComplete()
+            .assertValue(
+                response -> {
+                    final String content = response.bodyAsString();
 
-                assertThat(response.statusCode()).isEqualTo(200);
-                assertThat(response.headers().contains(X_GRAVITEE_POLICY)).isFalse();
-                assertThat(content).isEqualTo("OnResponseContent2Policy");
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    assertThat(response.headers().contains(X_GRAVITEE_POLICY)).isFalse();
+                    assertThat(content).isEqualTo("OnResponseContent2Policy");
 
-                return true;
-            }
-        );
+                    return true;
+                }
+            );
         obs.assertNoErrors();
         wiremock.verify(
             getRequestedFor(urlPathEqualTo(API_ENTRYPOINT))

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/Http2HeadersTestCase.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/Http2HeadersTestCase.java
@@ -54,20 +54,20 @@ public class Http2HeadersTestCase extends AbstractHttp2GatewayTest {
 
         final TestObserver<HttpResponse<Buffer>> obs = webClient.get("/test/my_team").rxSend().test();
 
-        awaitTerminalEvent(obs);
-        obs.assertComplete();
-        obs.assertValue(
-            response -> {
-                assertThat(response.statusCode()).isEqualTo(200);
+        awaitTerminalEvent(obs)
+            .assertComplete()
+            .assertValue(
+                response -> {
+                    assertThat(response.statusCode()).isEqualTo(200);
 
-                List<String> cookieHeaders = response.headers().getAll(HttpHeaderNames.SET_COOKIE);
-                assertThat(cookieHeaders).hasSize(2);
-                assertThat(cookieHeaders.get(0)).isEqualTo(cookie1);
-                assertThat(cookieHeaders.get(1)).isEqualTo(cookie2);
+                    List<String> cookieHeaders = response.headers().getAll(HttpHeaderNames.SET_COOKIE);
+                    assertThat(cookieHeaders).hasSize(2);
+                    assertThat(cookieHeaders.get(0)).isEqualTo(cookie1);
+                    assertThat(cookieHeaders.get(1)).isEqualTo(cookie2);
 
-                return true;
-            }
-        );
+                    return true;
+                }
+            );
         obs.assertNoErrors();
         wiremock.verify(getRequestedFor(urlPathEqualTo(ENDPOINT)));
     }
@@ -78,16 +78,16 @@ public class Http2HeadersTestCase extends AbstractHttp2GatewayTest {
 
         final TestObserver<HttpResponse<Buffer>> obs = webClient.get("/test/my_team").rxSend().test();
 
-        awaitTerminalEvent(obs);
-        obs.assertComplete();
-        obs.assertValue(
-            response -> {
-                assertThat(response.statusCode()).isEqualTo(200);
-                assertThat(response.headers().contains("custom")).isTrue();
+        awaitTerminalEvent(obs)
+            .assertComplete()
+            .assertValue(
+                response -> {
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    assertThat(response.headers().contains("custom")).isTrue();
 
-                return true;
-            }
-        );
+                    return true;
+                }
+            );
         obs.assertNoErrors();
         wiremock.verify(getRequestedFor(urlPathEqualTo(ENDPOINT)));
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/SuccessTestCase.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/SuccessTestCase.java
@@ -55,19 +55,19 @@ public class SuccessTestCase extends AbstractGatewayTest {
 
         final TestObserver<HttpResponse<Buffer>> obs = webClient.get("/test/my_team").rxSend().test();
 
-        awaitTerminalEvent(obs);
-        obs.assertComplete();
-        obs.assertValue(
-            response -> {
-                final String content = response.bodyAsString();
+        awaitTerminalEvent(obs)
+            .assertComplete()
+            .assertValue(
+                response -> {
+                    final String content = response.bodyAsString();
 
-                assertThat(response.statusCode()).isEqualTo(200);
-                assertThat(response.headers().contains("X-Gravitee-Policy")).isFalse();
-                assertThat(content).isEqualTo("OnResponseContent2Policy");
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    assertThat(response.headers().contains("X-Gravitee-Policy")).isFalse();
+                    assertThat(content).isEqualTo("OnResponseContent2Policy");
 
-                return true;
-            }
-        );
+                    return true;
+                }
+            );
         obs.assertNoErrors();
         wiremock.verify(
             getRequestedFor(urlPathEqualTo("/team/my_team"))


### PR DESCRIPTION
**Description**

chore: gateway test sdk : chainable testObserver calls after awaitTerminalEvent

This is a minor improvment in gateway test SDK, to simplify tests syntax.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/refactor-minortestsdkimprovment/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hrvnrzhtib.chromatic.com)
<!-- Storybook placeholder end -->
