### PR TITLE
test: fix wiremock dynamic port

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ClientRegistrationService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ClientRegistrationService_UpdateTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.verify;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.Options;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ClientRegistrationProviderRepository;
 import io.gravitee.repository.management.model.ClientRegistrationProvider;
@@ -58,7 +59,7 @@ public class ClientRegistrationService_UpdateTest {
     @Mock
     private AuditService mockAuditService;
 
-    private WireMockServer wireMockServer = new WireMockServer();
+    private final WireMockServer wireMockServer = new WireMockServer(Options.DYNAMIC_PORT);
 
     @Before
     public void setup() {
@@ -74,14 +75,14 @@ public class ClientRegistrationService_UpdateTest {
     public void shouldUpdateProvider() throws TechnicalException {
         UpdateClientRegistrationProviderEntity providerPayload = new UpdateClientRegistrationProviderEntity();
         providerPayload.setName("name");
-        providerPayload.setDiscoveryEndpoint("http://localhost:8080/am");
+        providerPayload.setDiscoveryEndpoint("http://localhost:" + wireMockServer.port() + "/am");
 
         ClientRegistrationProvider existingPayload = new ClientRegistrationProvider();
         existingPayload.setId("CRP_ID");
 
         when(mockClientRegistrationProviderRepository.findById(eq(existingPayload.getId()))).thenReturn(Optional.of(existingPayload));
 
-        stubFor(
+        wireMockServer.stubFor(
             get(urlEqualTo("/am"))
                 .willReturn(aResponse().withBody("{\"token_endpoint\": \"tokenEp\",\"registration_endpoint\": \"registrationEp\"}"))
         );


### PR DESCRIPTION
**Description**

Make sure wiremock uses a dynamic port instead of 8080 that could already be in use and crash the tests.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-wiremock-test-port/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-eslnlvcldd.chromatic.com)
<!-- Storybook placeholder end -->
