### PR TITLE
Fix/search index upgrader fix

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/SearchIndexUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/SearchIndexUpgrader.java
@@ -136,7 +136,7 @@ public class SearchIndexUpgrader implements Upgrader, Ordered {
         return true;
     }
 
-    private List<CompletableFuture<?>> runApisIndexationAsync(ExecutorService executorService) throws TechnicalException {
+    protected List<CompletableFuture<?>> runApisIndexationAsync(ExecutorService executorService) throws TechnicalException {
         return apiRepository.findAll().stream().map(api -> runApiIndexationAsync(executorService, api)).collect(toList());
     }
 
@@ -197,7 +197,7 @@ public class SearchIndexUpgrader implements Upgrader, Ordered {
         );
     }
 
-    private List<CompletableFuture<?>> runUsersIndexationAsync(ExecutorService executorService) throws TechnicalException {
+    protected List<CompletableFuture<?>> runUsersIndexationAsync(ExecutorService executorService) throws TechnicalException {
         return userRepository
             .search(
                 new UserCriteria.Builder().statuses(UserStatus.ACTIVE).build(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/SearchIndexUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/SearchIndexUpgraderTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.service.impl.upgrade;
 
 import static io.gravitee.repository.management.model.UserStatus.ACTIVE;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
@@ -35,6 +36,8 @@ import io.gravitee.rest.api.service.search.SearchEngineService;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -77,11 +80,14 @@ public class SearchIndexUpgraderTest {
     }
 
     @Test
-    public void upgrade_should_retrieve_environment_of_each_api() throws Exception {
+    public void runApisIndexationAsync_should_retrieve_environment_of_each_api() throws Exception {
         mockTestApis();
         mockTestUsers();
 
-        upgrader.upgrade();
+        List<CompletableFuture<?>> futures = upgrader.runApisIndexationAsync(Executors.newSingleThreadExecutor());
+        assertEquals(futures.size(), 4);
+
+        futures.forEach(CompletableFuture::join);
 
         verify(environmentRepository, times(1)).findById("env1");
         verify(environmentRepository, times(1)).findById("env2");
@@ -90,11 +96,14 @@ public class SearchIndexUpgraderTest {
     }
 
     @Test
-    public void upgrade_should_index_every_api() throws Exception {
+    public void runApisIndexationAsync_should_index_every_api() throws Exception {
         mockTestApis();
         mockTestUsers();
 
-        upgrader.upgrade();
+        List<CompletableFuture<?>> futures = upgrader.runApisIndexationAsync(Executors.newSingleThreadExecutor());
+        assertEquals(futures.size(), 4);
+
+        futures.forEach(CompletableFuture::join);
 
         verify(searchEngineService, times(1))
             .index(
@@ -127,11 +136,14 @@ public class SearchIndexUpgraderTest {
     }
 
     @Test
-    public void upgrade_should_index_every_user() throws Exception {
+    public void runUsersIndexationAsync_should_index_every_user() throws Exception {
         mockTestApis();
         mockTestUsers();
 
-        upgrader.upgrade();
+        List<CompletableFuture<?>> futures = upgrader.runUsersIndexationAsync(Executors.newSingleThreadExecutor());
+        assertEquals(futures.size(), 4);
+
+        futures.forEach(CompletableFuture::join);
 
         verify(searchEngineService, times(1))
             .index(


### PR DESCRIPTION
fix: use the same ExecutorService for users and api indexation

test: fix SearchIndexUpgrader flaky test
SearchIndexUpgraderTest was flaky, cause verifiy could be executed before completions of indexations futures.
Tests are now done calling internal functions, and waiting for all futures to complete.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-searchindexupgrader-fix/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pkeraxdwoh.chromatic.com)
<!-- Storybook placeholder end -->
