### PR TITLE
fix: Avoid storing an empty policy configuration for two different po…

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/CachedPolicyConfigurationFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/CachedPolicyConfigurationFactory.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.policy.impl;
 
 import io.gravitee.policy.api.PolicyConfiguration;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -33,7 +34,7 @@ public class CachedPolicyConfigurationFactory extends PolicyConfigurationFactory
             return null;
         }
 
-        Integer hash = configuration.hashCode();
+        Integer hash = Objects.hash(policyConfigurationClass, configuration);
         PolicyConfiguration config = cachedPolicyConfiguration.get(hash);
         if (config == null) {
             config = super.create(policyConfigurationClass, configuration);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/policy/CachedPolicyConfigurationFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/policy/CachedPolicyConfigurationFactoryTest.java
@@ -78,4 +78,16 @@ public class CachedPolicyConfigurationFactoryTest {
         PolicyConfiguration policyConfiguration1 = policyConfigurationFactory.create(null, null);
         Assert.assertNull(policyConfiguration1);
     }
+
+    @Test
+    public void createEmptyPolicyConfigurationDifferentPolicy() {
+        String configuration = "{}";
+        DummyPolicyConfiguration policyConfiguration = policyConfigurationFactory.create(DummyPolicyConfiguration.class, configuration);
+        Dummy2PolicyConfiguration policyConfiguration2 = policyConfigurationFactory.create(Dummy2PolicyConfiguration.class, configuration);
+
+        Assert.assertNotNull(policyConfiguration);
+        Assert.assertNotNull(policyConfiguration2);
+
+        Assert.assertNotEquals(policyConfiguration, policyConfiguration2);
+    }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/policy/Dummy2PolicyConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/policy/Dummy2PolicyConfiguration.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.policy;
+
+import io.gravitee.policy.api.PolicyConfiguration;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class Dummy2PolicyConfiguration implements PolicyConfiguration {
+
+    private int value;
+
+    public int getValue() {
+        return value;
+    }
+
+    public void setValue(int value) {
+        this.value = value;
+    }
+}


### PR DESCRIPTION
…licy configuration class

closes gravitee-io/issues#7751

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issue-7751-policy-cache/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
