### PR TITLE
feat: allow test inheritance with gateway sdk

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/AbstractGatewayTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/AbstractGatewayTest.java
@@ -70,7 +70,7 @@ public abstract class AbstractGatewayTest implements PluginRegister, ApiConfigur
     private int technicalApiPort = -1;
     private Map<String, Api> deployedForTestClass;
     private boolean areClassApisPrepared = false;
-    private ApplicationContext applicationContext;
+    protected ApplicationContext applicationContext;
 
     /**
      * The wiremock used by the deployed apis as a backend.

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/annotations/DeployApi.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/annotations/DeployApi.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.gateway.tests.sdk.annotations;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -40,11 +41,15 @@ import java.lang.annotation.Target;
  * You can modify a deployed method level api with {@link AbstractGatewayTest#deployedApis}.
  * For example, it can be useful if you want to modify a {@link io.gravitee.definition.model.Endpoint.Status} and check how the api behaves if the backend is down.
  *</pre>
+ *
+ * This annotation is flagged with {@link Inherited}. Subclasses do not have to reuse it explicitly if they want to use the same one from parent class.
+ *
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
 @Target({ ElementType.TYPE, ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
+@Inherited
 public @interface DeployApi {
     String[] value();
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/annotations/GatewayTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/annotations/GatewayTest.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.gateway.tests.sdk.annotations;
 import io.gravitee.apim.gateway.tests.sdk.GatewayTestingExtension;
 import io.vertx.junit5.VertxExtension;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -41,7 +42,13 @@ import org.junit.jupiter.api.parallel.Resources;
  * Avoid flaky tests by adding a lock identified by 'SYSTEM_PROPERTY'
  * It allows to avoid race condition of writing and then writing the same JVM System Property
  * </pre>
+ *
  * @see <a htref="https://junit.org/junit5/docs/snapshot/user-guide/#writing-tests-parallel-execution-synchronization">Junit5 Documentation - Synchronization</a>
+ *
+ * This annotation is flagged with {@link Inherited}. Subclasses do not have to reuse it explicitly if they want to use the same one from parent class.
+ *
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
  */
 @Target({ ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
@@ -49,6 +56,7 @@ import org.junit.jupiter.api.parallel.Resources;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ResourceLock(value = Resources.SYSTEM_PROPERTIES, mode = ResourceAccessMode.READ_WRITE)
 @Order(Integer.MAX_VALUE)
+@Inherited
 public @interface GatewayTest {
     /**
      * Define where to find the configuration folder of the gateway used by {@code gravitee.home}.

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/plugin/PluginManifestLoader.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/plugin/PluginManifestLoader.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.gateway.tests.sdk.plugin;
+
+import io.gravitee.plugin.core.api.PluginManifest;
+import io.gravitee.plugin.core.api.PluginManifestFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Properties;
+import org.junit.platform.commons.PreconditionViolationException;
+
+/**
+ * Load {@link PluginManifest} from file "plugin.properties"
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class PluginManifestLoader {
+
+    private PluginManifestLoader() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static PluginManifest readManifest() {
+        try {
+            final Path resources = Path.of("src/main/resources");
+            final PluginManifestVisitor visitor = new PluginManifestVisitor();
+            Files.walkFileTree(resources, visitor);
+
+            Path pluginManifestPath = visitor.getPluginManifest();
+            if (pluginManifestPath != null) {
+                try (InputStream manifestInputStream = Files.newInputStream(pluginManifestPath)) {
+                    Properties properties = new Properties();
+                    properties.load(manifestInputStream);
+
+                    return PluginManifestFactory.create(properties);
+                }
+            }
+        } catch (IOException e) {
+            throw new PreconditionViolationException("Unable to find a 'plugin.properties' file in src/main/resources folder", e);
+        }
+
+        return null;
+    }
+
+    /**
+     * This {@link java.nio.file.FileVisitor<Path>} will be used to visit the file tree until it finds the "plugin.properties" file.
+     */
+    static class PluginManifestVisitor extends SimpleFileVisitor<Path> {
+
+        private Path pluginManifest = null;
+
+        @Override
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+            if (file.getFileName().toString().equals("plugin.properties")) {
+                pluginManifest = file;
+                return FileVisitResult.TERMINATE;
+            }
+
+            return super.visitFile(file, attrs);
+        }
+
+        public Path getPluginManifest() {
+            return pluginManifest;
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/plugin/PluginRegister.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/plugin/PluginRegister.java
@@ -15,7 +15,9 @@
  */
 package io.gravitee.apim.gateway.tests.sdk.plugin;
 
+import io.gravitee.gateway.policy.PolicyManifest;
 import io.gravitee.plugin.connector.ConnectorPlugin;
+import io.gravitee.plugin.core.api.PluginManifest;
 import io.gravitee.plugin.policy.PolicyPlugin;
 import io.gravitee.plugin.resource.ResourcePlugin;
 import io.gravitee.reporter.api.Reporter;
@@ -44,6 +46,14 @@ public interface PluginRegister {
      * @param policies is the map containing policies to deploy
      */
     default void configurePolicies(Map<String, PolicyPlugin> policies) {}
+
+    /**
+     * Override this method to load the policy into the Gateway as a regular plugin.
+     * This method differs from {@link PluginRegister#configurePolicies(Map)} in the way that it will initialize and register the policy as a regular plugin in the gateway.
+     * Useful for policies with initializers inherited from {@link io.gravitee.policy.api.PolicyContext}.
+     * @param policies is the map containing policies to deploy
+     */
+    default void loadPolicy(PluginManifest manifest, Map<String, PolicyPlugin> policies) {}
 
     /**
      * Override this method to register a connector to be used by the gateway.

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/io/gravitee/apim/gateway/tests/sdk/AbstractPolicyTestTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/io/gravitee/apim/gateway/tests/sdk/AbstractPolicyTestTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.gateway.tests.sdk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.policy.api.PolicyConfiguration;
+import java.lang.reflect.Type;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class AbstractPolicyTestTest {
+
+    @Test
+    @DisplayName("Should register policy for first child")
+    void shouldRegisterPolicyForFirstChild() {
+        final ChildFirstLevel childFirstLevel = new ChildFirstLevel();
+        final Type[] types = childFirstLevel.getClassGenericTypes();
+        assertThat(types).hasSize(2);
+        assertThat((Class<?>) types[0]).isEqualTo(FakePolicy.class);
+        assertThat((Class<?>) types[1]).isEqualTo(FakePolicyConfiguration.class);
+    }
+
+    @Test
+    @DisplayName("Should register policy for second child")
+    void shouldRegisterPolicyForSecondChild() {
+        final ChildSecondLevel childSecondLevel = new ChildSecondLevel();
+        final Type[] types = childSecondLevel.getClassGenericTypes();
+        assertThat(types).hasSize(2);
+        assertThat((Class<?>) types[0]).isEqualTo(FakePolicy.class);
+        assertThat((Class<?>) types[1]).isEqualTo(FakePolicyConfiguration.class);
+    }
+
+    class ChildFirstLevel extends AbstractPolicyTest<FakePolicy, FakePolicyConfiguration> {
+
+        @Override
+        protected String policyName() {
+            return "first";
+        }
+    }
+
+    class ChildSecondLevel extends ChildFirstLevel {
+
+        @Override
+        protected String policyName() {
+            return "second";
+        }
+    }
+
+    class FakePolicy {}
+
+    class FakePolicyConfiguration implements PolicyConfiguration {}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <gravitee-gateway-api.version>1.32.2</gravitee-gateway-api.version>
         <gravitee-node.version>1.24.1</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>
-        <gravitee-plugin.version>1.23.1</gravitee-plugin.version>
+        <gravitee-plugin.version>1.23.2</gravitee-plugin.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>1.22.0</gravitee-reporter-api.version>
         <gravitee-resource-auth-provider-api.version>1.3.0</gravitee-resource-auth-provider-api.version>


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/7600

## Description

In some cases, it would be interesting to write a test class with all of our test cases, and to inherit from it to run the same tests, with a different configuration.

A good example is the project Jupiter. We could have a `MyPolicyIntegrationTest` testing the policy in a classical way, and a `MyPolicyJupiterIntegrationTest` just inheriting from it, and configuring the api (with `configureApi(Api)`) and configuring the gateway (with `configureGateway(configuration)`) to check that the same behavior occurs.


## Bonus

This PR also marks `@GatewayTest` and `@DeployApi` as `@Inherited`.
This means that you don't have to add them explicitly on a subclass if you want to keep the same configuration as in the parent

## Policy Loading

The second commit: [a1c22e7](https://github.com/gravitee-io/gravitee-api-management/pull/1908/commits/a1c22e7884b1bc74746f84b64936eb21d80875e7), allows to load the policy as the gateway would do for a real plugin, with `PolicyContext` resolution. This is particularly useful for policies such as `JavascriptPolicy` or `GroovyPolicy` which uses an initialization phase thanks to `PolicyContext.onActivation()`

🚨 DO NOT MERGE TILL https://github.com/gravitee-io/gravitee-plugin/pull/86 has not been merged. Do not forget to update pom for `gravitee-plugin`

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/issues-7600-it-test-subclasses/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jbyowrvhmo.chromatic.com)
<!-- Storybook placeholder end -->
