### PR TITLE
Add e2e to test api redeploy with pending request

### DIFF
--- a/gravitee-apim-e2e/README.md
+++ b/gravitee-apim-e2e/README.md
@@ -7,10 +7,11 @@ They are based on Cypress and Jest and can be run against a locally running APIM
 
 ## Getting Started
 
-First you need to install the dependencies:
+First you need to install the dependencies & build test:
 
 ```shell
 npm install
+npm run build
 ```
 
 Then, the following NPM scripts are available:
@@ -18,7 +19,8 @@ Then, the following NPM scripts are available:
  - `npm run test:ui:dev`: Run the cypress UI tests against a locally running APIM
  - `npm run test:api`: Run the APIM stack and the jest API tests in docker ([more details](./docker/api-tests/README.md))
  - `npm run test:api:dev`: Run the jest API tests against a locally running APIM
- - `npm run apim:serve`: Run the APIM stack in docker in order to run tests locally from your IDE
+ - `npm run apim:serve`: Run the APIM stack in docker with last apim release by default in order to run tests locally from your IDE.  
+   To run with latest master use this env-var `APIM_REGISTRY=graviteeio.azurecr.io APIM_TAG=master-latest npm run apim:serve`
  - `npm run apim:clean`: Stop and remove the containers & volumes.
  - `npm run bulk`: Run jest bulk scripts to create data to local environment
    - You can pass some options like `npm run bulk -- --apis=50 --applications=5`, available options:

--- a/gravitee-apim-e2e/api-test/resources/wiremock/mappings/whattimeisit.json
+++ b/gravitee-apim-e2e/api-test/resources/wiremock/mappings/whattimeisit.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "GET",
-    "url": "/whattimeisit"
+    "urlPath": "/whattimeisit"
   },
   "response": {
     "status": 200,

--- a/gravitee-apim-e2e/api-test/src/gateway/redeploy-api.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/gateway/redeploy-api.spec.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect } from '@jest/globals';
+import { APIsApi } from '@management-apis/APIsApi';
+import { forManagementAsApiUser } from '@client-conf/*';
+import { ApisFaker } from '@management-fakers/ApisFaker';
+import { ApiEntity } from '@management-models/ApiEntity';
+import { PlansFaker } from '@management-fakers/PlansFaker';
+import { PlanEntity } from '@management-models/PlanEntity';
+import { noContent, succeed } from '@lib/jest-utils';
+import { LifecycleAction } from '@management-models/LifecycleAction';
+import { fetchGatewaySuccess } from '@lib/gateway';
+import { PathOperatorOperatorEnum } from '@management-models/PathOperator';
+import { PlanStatus } from '@management-models/PlanStatus';
+import { UpdatePlanEntityFromJSON } from '@management-models/UpdatePlanEntity';
+
+const apiManagementApiAsApiUser = new APIsApi(forManagementAsApiUser());
+const orgId = 'DEFAULT';
+const envId = 'DEFAULT';
+let createdApi: ApiEntity;
+let createdPlan: PlanEntity;
+
+describe('Redeploy Api', () => {
+  describe('On api deployed with latency policy', () => {
+    beforeAll(async () => {
+      const newPlanEntity = PlansFaker.newPlan({ status: PlanStatus.PUBLISHED });
+
+      createdApi = await apiManagementApiAsApiUser.createApi({
+        orgId,
+        envId,
+        newApiEntity: ApisFaker.newApi({
+          gravitee: '2.0.0',
+          flows: [
+            {
+              name: '',
+              path_operator: {
+                path: '/',
+                operator: PathOperatorOperatorEnum.STARTSWITH,
+              },
+              condition: '',
+              consumers: [],
+              methods: [],
+              pre: [
+                {
+                  name: 'Latency',
+                  description: 'This latency policy was created by a test',
+                  enabled: true,
+                  policy: 'latency',
+                  configuration: {
+                    time: 8,
+                    timeUnit: 'SECONDS',
+                  },
+                  condition: "{#request.params['activeLatency'] != null && #request.params['activeLatency'][0] == 'true'}",
+                },
+              ],
+              post: [],
+              enabled: true,
+            },
+          ],
+        }),
+      });
+
+      createdPlan = await apiManagementApiAsApiUser.createApiPlan({ orgId, envId, api: createdApi.id, newPlanEntity });
+
+      await noContent(
+        apiManagementApiAsApiUser.doApiLifecycleActionRaw({ orgId, envId, api: createdApi.id, action: LifecycleAction.START }),
+      );
+      await succeed(apiManagementApiAsApiUser.deployApiRaw({ orgId, envId, api: createdApi.id }));
+    });
+
+    afterAll(async () => {
+      await apiManagementApiAsApiUser.doApiLifecycleAction({ orgId, envId, api: createdApi.id, action: LifecycleAction.STOP });
+      await apiManagementApiAsApiUser.deleteApiPlan({ orgId, envId, api: createdApi.id, plan: createdPlan.id });
+      await apiManagementApiAsApiUser.deleteApi({ orgId, envId, api: createdApi.id });
+    });
+
+    test('should redeploy with active request', async () => {
+      // Fist fetch Gateway to be sure api is deployed
+      await fetchGatewaySuccess({ contextPath: createdApi.context_path + '?activeLatency=false' });
+
+      // Update a Plan to desynchronize Api definition
+      await apiManagementApiAsApiUser.updateApiPlan({
+        envId,
+        orgId,
+        api: createdApi.id,
+        plan: createdPlan.id,
+        updatePlanEntity: UpdatePlanEntityFromJSON({
+          ...createdPlan,
+          publishedAt: null,
+          needRedeployAt: null,
+          selection_rule: 'true',
+        }),
+      });
+
+      // Execute a request during which we will redeploy the api (only one try, no delay before call)
+      const fetchUniqueGatewayCall = fetchGatewaySuccess({
+        contextPath: createdApi.context_path + '?activeLatency=true',
+        failAfterMs: 0,
+        timeout: 0,
+      });
+
+      // Redeploy the api
+      await succeed(apiManagementApiAsApiUser.deployApiRaw({ orgId, envId, api: createdApi.id }));
+
+      // Expect request success
+      await fetchUniqueGatewayCall
+        .then((res) => res.json())
+        .then((json) => {
+          expect(json.date).toBe('11/05/2022 13:19:44.009');
+          expect(json.timestamp).toBe(1652275184009);
+        });
+    });
+  });
+});

--- a/gravitee-apim-e2e/lib/fixtures/management/ApisFaker.ts
+++ b/gravitee-apim-e2e/lib/fixtures/management/ApisFaker.ts
@@ -91,7 +91,7 @@ export class ApisFaker {
       name,
       description,
       version,
-      endpoint: `${process.env.WIREMOCK_BASE_PATH}/echo`,
+      endpoint: `${process.env.WIREMOCK_BASE_PATH}/whattimeisit`,
       ...attributes,
     };
   }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6948

**Description**

Add e2e to test api redeploy with pending request

⚠️ To merge after [this](https://github.com/gravitee-io/gravitee-api-management/pull/1895) and the backport into master 

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/6948-gw-redeploy/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tfkwnngrhh.chromatic.com)
<!-- Storybook placeholder end -->
