### PR TITLE
build: no more distinction between CE and EE bundle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,18 +138,6 @@ commands:
             - run:
                 name: Build rest api and gateway docker images
                 command: |
-                    ## Clean rest api
-                    rm rest-api-docker-context/distribution/lib/gravitee-license-node-enterprise*.jar
-                    rm rest-api-docker-context/distribution/plugins/gravitee-ae-connectors-ws*.zip
-                    rm rest-api-docker-context/distribution/plugins/gravitee-notifier-*.zip
-                    rm rest-api-docker-context/distribution/plugins/gravitee-policy-assign-metrics-*.zip
-                    rm rest-api-docker-context/distribution/plugins/gravitee-policy-data-logging-masking-*.zip
-                    ## Clean Gateway
-                    rm gateway-docker-context/distribution/lib/gravitee-license-node-enterprise*.jar
-                    rm gateway-docker-context/distribution/plugins/gravitee-ae-connectors-ws*.zip
-                    rm gateway-docker-context/distribution/plugins/gravitee-policy-assign-metrics-*.zip
-                    rm gateway-docker-context/distribution/plugins/gravitee-policy-data-logging-masking-*.zip
-                    
                     export REST_API_PRIVATE_IMAGE_TAG=graviteeio.azurecr.io/apim-management-api:$APIM_VERSION
                     export GATEWAY_PRIVATE_IMAGE_TAG=graviteeio.azurecr.io/apim-gateway:$APIM_VERSION
                     
@@ -352,7 +340,7 @@ jobs:
             - run:
                   name: "Build project"
                   command: |
-                      mvn -s .gravitee.settings.xml clean package --no-transfer-progress -DskipTests -Dskip.validation=true -T 2C -P distribution-dev,distribution-ee
+                      mvn -s .gravitee.settings.xml clean package --no-transfer-progress -DskipTests -Dskip.validation=true -T 2C -P distribution-dev
                       mkdir -p ./rest-api-docker-context/distribution && cp -r ./gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target/distribution ./rest-api-docker-context/.
                       mkdir -p ./gateway-docker-context/distribution && cp -r ./gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target/distribution ./gateway-docker-context/.
 
@@ -479,10 +467,6 @@ jobs:
             - notify-on-failure
 
     publish-images-azure-registry:
-        parameters:
-            enterprise_edition:
-                default: false
-                type: boolean
         docker:
             - image: cimg/openjdk:11.0
         resource_class: small
@@ -499,34 +483,11 @@ jobs:
             - keeper/env-export:
                   secret-url: keeper://Q721P2LSOPJ9qiXLuf5AHQ/field/password
                   var-name: AZURE_DOCKER_REGISTRY_PASSWORD
-            - when:
-                  condition:
-                      not: << parameters.enterprise_edition>>
-                  steps:
-                      - run:
-                            name: Prepare the CE image by removing EE lib & plugins
-                            command: |
-                                ## Clean rest api
-                                rm rest-api-docker-context/distribution/lib/gravitee-license-node-enterprise*.jar
-                                rm rest-api-docker-context/distribution/plugins/gravitee-ae-connectors-ws*.zip
-                                rm rest-api-docker-context/distribution/plugins/gravitee-notifier-*.zip
-                                rm rest-api-docker-context/distribution/plugins/gravitee-policy-assign-metrics-*.zip
-                                rm rest-api-docker-context/distribution/plugins/gravitee-policy-data-logging-masking-*.zip
-                                ## Clean Gateway
-                                rm gateway-docker-context/distribution/lib/gravitee-license-node-enterprise*.jar
-                                rm gateway-docker-context/distribution/plugins/gravitee-ae-connectors-ws*.zip
-                                rm gateway-docker-context/distribution/plugins/gravitee-policy-assign-metrics-*.zip
-                                rm gateway-docker-context/distribution/plugins/gravitee-policy-data-logging-masking-*.zip
             - run:
-                  name: Build & publish dev docker image <<# parameters.enterprise_edition >>- Enterprise edition<</ parameters.enterprise_edition >>
+                  name: Build & publish dev docker image
                   command: |
-                      export dockerTag=$TAG
-                      if [ "<< parameters.enterprise_edition >>" == "true" ]; then
-                        dockerTag=$(echo $dockerTag | sed 's/-/-ee-/')
-                      fi
-
-                      export REST_API_PRIVATE_IMAGE_TAG=graviteeio.azurecr.io/apim-management-api:${dockerTag}
-                      export GATEWAY_PRIVATE_IMAGE_TAG=graviteeio.azurecr.io/apim-gateway:${dockerTag}
+                      export REST_API_PRIVATE_IMAGE_TAG=graviteeio.azurecr.io/apim-management-api:${TAG}
+                      export GATEWAY_PRIVATE_IMAGE_TAG=graviteeio.azurecr.io/apim-gateway:${TAG}
 
                       docker build -f gravitee-apim-rest-api/docker/Dockerfile \
                       --build-arg GRAVITEEIO_VERSION=${APIM_VERSION} \
@@ -1064,9 +1025,6 @@ jobs:
             docker_tag_as_latest:
                 default: false
                 type: boolean
-            enterprise_edition:
-                default: false
-                type: boolean
             graviteeio_version:
                 default: ""
                 type: string
@@ -1095,36 +1053,23 @@ jobs:
                       export GRAVITEEIO_VERSION_PATCH=$(echo "${GRAVITEEIO_VERSION}" | awk -F '.' '{print $3}')
                       echo "export GRAVITEEIO_VERSION_PATCH=${GRAVITEEIO_VERSION_PATCH}" >> $BASH_ENV
             - run:
-                  name: "Build & Publish Gravitee.io APIM Docker images <<# parameters.enterprise_edition >>- Enterprise Edition<</ parameters.enterprise_edition >>"
+                  name: "Build & Publish Gravitee.io APIM Docker images"
                   command: |
-                      if [ "<< parameters.enterprise_edition >>" == "false" ]; then
-                        export DOCKER_TAG_SUFFIX=""
-                        export DOCKER_BUILD_ARGS="--build-arg GRAVITEEIO_VERSION=${GRAVITEEIO_VERSION} --build-arg GRAVITEEIO_DOWNLOAD_URL=https://download.gravitee.io/graviteeio-apim/distributions"
-                      else
-                        export DOCKER_TAG_SUFFIX="-ee"
-                        export DOCKER_BUILD_ARGS="--build-arg GRAVITEEIO_VERSION=${GRAVITEEIO_VERSION} --build-arg GRAVITEEIO_DOWNLOAD_URL=https://download.gravitee.io/graviteeio-ee/apim/distributions --build-arg GRAVITEEIO_PACKAGE_NAME=graviteeio-ee-full"
-                      fi
+                      export DOCKER_TAG_SUFFIX=""
+                      export DOCKER_BUILD_ARGS="--build-arg GRAVITEEIO_VERSION=${GRAVITEEIO_VERSION} --build-arg GRAVITEEIO_DOWNLOAD_URL=https://download.gravitee.io/graviteeio-apim/distributions"
 
-                      # always create x.y(-ee)?, x.y.z(-ee)? tags
-                      export DOCKER_BUILD_GATEWAY_TAG="       -t graviteeio/apim-gateway:${GRAVITEEIO_VERSION_MAJOR}.${GRAVITEEIO_VERSION_MINOR}${DOCKER_TAG_SUFFIX}        -t graviteeio/apim-gateway:${GRAVITEEIO_VERSION}${DOCKER_TAG_SUFFIX}"
-                      export DOCKER_BUILD_MANAGEMENT_API_TAG="-t graviteeio/apim-management-api:${GRAVITEEIO_VERSION_MAJOR}.${GRAVITEEIO_VERSION_MINOR}${DOCKER_TAG_SUFFIX} -t graviteeio/apim-management-api:${GRAVITEEIO_VERSION}${DOCKER_TAG_SUFFIX}"
-                      export DOCKER_BUILD_MANAGEMENT_UI_TAG=" -t graviteeio/apim-management-ui:${GRAVITEEIO_VERSION_MAJOR}.${GRAVITEEIO_VERSION_MINOR}${DOCKER_TAG_SUFFIX}  -t graviteeio/apim-management-ui:${GRAVITEEIO_VERSION}${DOCKER_TAG_SUFFIX}"
-                      export DOCKER_BUILD_PORTAL_UI_TAG="     -t graviteeio/apim-portal-ui:${GRAVITEEIO_VERSION_MAJOR}.${GRAVITEEIO_VERSION_MINOR}${DOCKER_TAG_SUFFIX}      -t graviteeio/apim-portal-ui:${GRAVITEEIO_VERSION}${DOCKER_TAG_SUFFIX}"
+                      # always create x.y, x.y.z, x.y-ee, x.y.z-ee tags
+                      export DOCKER_BUILD_GATEWAY_TAG="       -t graviteeio/apim-gateway:${GRAVITEEIO_VERSION_MAJOR}.${GRAVITEEIO_VERSION_MINOR}        -t graviteeio/apim-gateway:${GRAVITEEIO_VERSION}        -t graviteeio/apim-gateway:${GRAVITEEIO_VERSION_MAJOR}.${GRAVITEEIO_VERSION_MINOR}-ee        -t graviteeio/apim-gateway:${GRAVITEEIO_VERSION}-ee"
+                      export DOCKER_BUILD_MANAGEMENT_API_TAG="-t graviteeio/apim-management-api:${GRAVITEEIO_VERSION_MAJOR}.${GRAVITEEIO_VERSION_MINOR} -t graviteeio/apim-management-api:${GRAVITEEIO_VERSION} -t graviteeio/apim-management-api:${GRAVITEEIO_VERSION_MAJOR}.${GRAVITEEIO_VERSION_MINOR}-ee -t graviteeio/apim-management-api:${GRAVITEEIO_VERSION}-ee"
+                      export DOCKER_BUILD_MANAGEMENT_UI_TAG=" -t graviteeio/apim-management-ui:${GRAVITEEIO_VERSION_MAJOR}.${GRAVITEEIO_VERSION_MINOR}  -t graviteeio/apim-management-ui:${GRAVITEEIO_VERSION}  -t graviteeio/apim-management-ui:${GRAVITEEIO_VERSION_MAJOR}.${GRAVITEEIO_VERSION_MINOR}-ee  -t graviteeio/apim-management-ui:${GRAVITEEIO_VERSION}-ee"
+                      export DOCKER_BUILD_PORTAL_UI_TAG="     -t graviteeio/apim-portal-ui:${GRAVITEEIO_VERSION_MAJOR}.${GRAVITEEIO_VERSION_MINOR}      -t graviteeio/apim-portal-ui:${GRAVITEEIO_VERSION}      -t graviteeio/apim-portal-ui:${GRAVITEEIO_VERSION_MAJOR}.${GRAVITEEIO_VERSION_MINOR}-ee      -t graviteeio/apim-portal-ui:${GRAVITEEIO_VERSION}-ee"
 
-                      # only create x(-ee)? tag if it's the latest version
+                      # only create x, x-ee and latest tags if it's the latest version
                       if [ "<< parameters.docker_tag_as_latest >>" == "true" ]; then
-                        DOCKER_BUILD_GATEWAY_TAG+="        -t graviteeio/apim-gateway:${GRAVITEEIO_VERSION_MAJOR}${DOCKER_TAG_SUFFIX}"
-                        DOCKER_BUILD_MANAGEMENT_API_TAG+=" -t graviteeio/apim-management-api:${GRAVITEEIO_VERSION_MAJOR}${DOCKER_TAG_SUFFIX}"
-                        DOCKER_BUILD_MANAGEMENT_UI_TAG+="  -t graviteeio/apim-management-ui:${GRAVITEEIO_VERSION_MAJOR}${DOCKER_TAG_SUFFIX}"
-                        DOCKER_BUILD_PORTAL_UI_TAG+="      -t graviteeio/apim-portal-ui:${GRAVITEEIO_VERSION_MAJOR}${DOCKER_TAG_SUFFIX}"
-
-                        # only create "latest" tag for Community Edition and if it's the latest version (obviously)
-                        if [ "<< parameters.enterprise_edition >>" == "false" ]; then
-                          DOCKER_BUILD_GATEWAY_TAG+="        -t graviteeio/apim-gateway:latest"
-                          DOCKER_BUILD_MANAGEMENT_API_TAG+=" -t graviteeio/apim-management-api:latest"
-                          DOCKER_BUILD_MANAGEMENT_UI_TAG+="  -t graviteeio/apim-management-ui:latest"
-                          DOCKER_BUILD_PORTAL_UI_TAG+="      -t graviteeio/apim-portal-ui:latest"
-                        fi
+                        DOCKER_BUILD_GATEWAY_TAG+="        -t graviteeio/apim-gateway:${GRAVITEEIO_VERSION_MAJOR}           -t graviteeio/apim-gateway:${GRAVITEEIO_VERSION_MAJOR}-ee           -t graviteeio/apim-gateway:latest"
+                        DOCKER_BUILD_MANAGEMENT_API_TAG+=" -t graviteeio/apim-management-api:${GRAVITEEIO_VERSION_MAJOR}    -t graviteeio/apim-management-api:${GRAVITEEIO_VERSION_MAJOR}-ee    -t graviteeio/apim-management-api:latest"
+                        DOCKER_BUILD_MANAGEMENT_UI_TAG+="  -t graviteeio/apim-management-ui:${GRAVITEEIO_VERSION_MAJOR}     -t graviteeio/apim-management-ui:${GRAVITEEIO_VERSION_MAJOR}-ee     -t graviteeio/apim-management-ui:latest"
+                        DOCKER_BUILD_PORTAL_UI_TAG+="      -t graviteeio/apim-portal-ui:${GRAVITEEIO_VERSION_MAJOR}         -t graviteeio/apim-portal-ui:${GRAVITEEIO_VERSION_MAJOR}-ee         -t graviteeio/apim-portal-ui:latest"
                       fi
 
                       docker build ${DOCKER_BUILD_ARGS} --quiet ${DOCKER_BUILD_GATEWAY_TAG}         -f ./gravitee-apim-gateway/docker/Dockerfile-from-download ./gravitee-apim-gateway/docker
@@ -1393,21 +1338,8 @@ workflows:
                       - test
                       - test-repository
             - publish-images-azure-registry:
-                  name: Publish ee images on azure registry
+                  name: Publish images on azure registry
                   context: cicd-orchestrator
-                  enterprise_edition: true
-                  requires:
-                      - test
-                      - test-repository
-                  filters:
-                      branches:
-                          only:
-                              - master
-                              - /^\d+\.\d+\.x$/
-            - publish-images-azure-registry:
-                  name: Publish ce images on azure registry
-                  context: cicd-orchestrator
-                  enterprise_edition: false
                   requires:
                       - test
                       - test-repository
@@ -1458,7 +1390,6 @@ workflows:
                           only:
                               - master
                               - /^\d+\.\d+\.x$/
-                              - fix-ui-azure-publish
             - webui-lint-test:
                   name: Lint & Test APIM Portal
                   apim-ui-project: gravitee-apim-portal-webui
@@ -1498,8 +1429,7 @@ workflows:
             - deploy-on-azure-cluster:
                   context: cicd-orchestrator
                   requires:
-                      - Publish ee images on azure registry
-                      - Publish ce images on azure registry
+                      - Publish images on azure registry
                       - Build and publish APIM Console docker image
                       - Build and publish APIM Portal docker image
                   filters:
@@ -1543,21 +1473,13 @@ workflows:
                   graviteeio_version: << pipeline.parameters.graviteeio_version >>
                   docker_tag_as_latest: << pipeline.parameters.docker_tag_as_latest >>
                   dry_run: << pipeline.parameters.dry_run >>
-                  enterprise_edition: false
                   context: cicd-orchestrator
-                  name: Build and push docker images for APIM CE << pipeline.parameters.graviteeio_version >><<# pipeline.parameters.dry_run >> - Dry Run<</ pipeline.parameters.dry_run >>
-            - publish_prod_docker_images:
-                  graviteeio_version: << pipeline.parameters.graviteeio_version >>
-                  docker_tag_as_latest: << pipeline.parameters.docker_tag_as_latest >>
-                  dry_run: << pipeline.parameters.dry_run >>
-                  enterprise_edition: true
-                  context: cicd-orchestrator
-                  name: Build and push docker images for APIM EE << pipeline.parameters.graviteeio_version >><<# pipeline.parameters.dry_run >> - Dry Run<</ pipeline.parameters.dry_run >>
+                  name: Build and push docker images for APIM << pipeline.parameters.graviteeio_version >><<# pipeline.parameters.dry_run >> - Dry Run<</ pipeline.parameters.dry_run >>
             -  publish_rpm_packages:
                   context: cicd-orchestrator
                   graviteeio_version: << pipeline.parameters.graviteeio_version >>
                   dry_run: << pipeline.parameters.dry_run >>
-                  name: Build and push RPM packages for APIM CE & EE << pipeline.parameters.graviteeio_version >><<# pipeline.parameters.dry_run >> - Dry Run<</ pipeline.parameters.dry_run >>
+                  name: Build and push RPM packages for APIM << pipeline.parameters.graviteeio_version >><<# pipeline.parameters.dry_run >> - Dry Run<</ pipeline.parameters.dry_run >>
 
     release:
         when:

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -46,6 +46,7 @@
     <properties>
         <!-- Versions of the plugins for the full distribution -->
         <!-- Management API & Gateway -->
+        <gravitee-alert-engine-connectors-ws.version>1.0.0</gravitee-alert-engine-connectors-ws.version>
         <gravitee-connector-http.version>2.0.0</gravitee-connector-http.version>
         <gravitee-policy-apikey.version>2.4.0</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>1.5.0</gravitee-policy-assign-attributes.version>
@@ -103,6 +104,9 @@
         <gravitee-fetcher-github.version>1.6.0</gravitee-fetcher-github.version>
         <gravitee-fetcher-gitlab.version>1.11.0</gravitee-fetcher-gitlab.version>
         <gravitee-fetcher-http.version>1.12.0</gravitee-fetcher-http.version>
+        <gravitee-notifier-email.version>1.4.1</gravitee-notifier-email.version>
+        <gravitee-notifier-slack.version>1.3.0</gravitee-notifier-slack.version>
+        <gravitee-notifier-webhook.version>1.1.0</gravitee-notifier-webhook.version>
         <!-- Gateway Only -->
         <gravitee-reporter-elasticsearch.version>3.11.0</gravitee-reporter-elasticsearch.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->
@@ -114,6 +118,13 @@
 
     <dependencies>
         <!-- Connectors -->
+        <dependency>
+            <groupId>io.gravitee.ae</groupId>
+            <artifactId>gravitee-alert-engine-connectors-ws</artifactId>
+            <version>${gravitee-alert-engine-connectors-ws.version}</version>
+            <type>zip</type>
+            <scope>runtime</scope>
+        </dependency>
         <dependency>
             <groupId>io.gravitee.cockpit</groupId>
             <artifactId>gravitee-cockpit-connectors-ws</artifactId>
@@ -165,7 +176,28 @@
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>
-
+        <!-- Notifiers -->
+        <dependency>
+            <groupId>io.gravitee.notifier</groupId>
+            <artifactId>gravitee-notifier-email</artifactId>
+            <version>${gravitee-notifier-email.version}</version>
+            <type>zip</type>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.notifier</groupId>
+            <artifactId>gravitee-notifier-slack</artifactId>
+            <version>${gravitee-notifier-slack.version}</version>
+            <type>zip</type>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.notifier</groupId>
+            <artifactId>gravitee-notifier-webhook</artifactId>
+            <version>${gravitee-notifier-webhook.version}</version>
+            <type>zip</type>
+            <scope>runtime</scope>
+        </dependency>
         <!-- Policies -->
         <dependency>
             <groupId>io.gravitee.policy</groupId>
@@ -584,6 +616,7 @@
             <properties>
                 <!-- Versions of the plugins for the full distribution on dev environment-->
                 <!-- Management API & Gateway -->
+                <!-- Community plugins -->
                 <gravitee-connector-kafka.version>1.1.0</gravitee-connector-kafka.version>
                 <gravitee-policy-aws-lambda.version>1.1.0</gravitee-policy-aws-lambda.version>
                 <gravitee-policy-basic-authentication.version>1.2.0</gravitee-policy-basic-authentication.version>
@@ -596,10 +629,13 @@
                 <gravitee-resource-auth-provider-ldap.version>1.1.0</gravitee-resource-auth-provider-ldap.version>
                 <gravitee-resource-cache-redis.version>1.0.1</gravitee-resource-cache-redis.version>
                 <gravitee-resource-oauth2-provider-keycloak.version>1.9.1</gravitee-resource-oauth2-provider-keycloak.version>
-
                 <!-- Using service GeoIP requires to adapt Java HeapSpace: https://github.com/gravitee-io/gravitee-service-geoip/blob/master/README.adoc -->
                 <!-- So keep it commented for the moment -->
                 <!-- <gravitee-service-geoip.version>1.1.0</gravitee-service-geoip.version>-->
+
+                <!-- Enterprise plugins -->
+                <gravitee-policy-assign-metrics.version>2.0.1</gravitee-policy-assign-metrics.version>
+                <gravitee-policy-data-logging-masking.version>2.0.1</gravitee-policy-data-logging-masking.version>
 
                 <!-- Management API Only -->
                 <!-- Gateway Only -->
@@ -614,6 +650,13 @@
                     <scope>runtime</scope>
                 </dependency>
                 <!-- Policies -->
+                <dependency>
+                    <groupId>com.graviteesource.policy</groupId>
+                    <artifactId>gravitee-policy-assign-metrics</artifactId>
+                    <version>${gravitee-policy-assign-metrics.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                </dependency>
                 <dependency>
                     <groupId>io.gravitee.policy</groupId>
                     <artifactId>gravitee-policy-aws-lambda</artifactId>
@@ -634,6 +677,19 @@
                     <version>${gravitee-policy-circuit-breaker.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.policy</groupId>
+                    <artifactId>gravitee-policy-data-logging-masking</artifactId>
+                    <version>${gravitee-policy-data-logging-masking.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>com.jayway.jsonpath</groupId>
+                            <artifactId>json-path</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
                 <dependency>
                     <groupId>io.gravitee.policy</groupId>
@@ -702,82 +758,6 @@
                 <!--     <type>zip</type>-->
                 <!--     <scope>runtime</scope>-->
                 <!-- </dependency>-->
-            </dependencies>
-        </profile>
-        <profile>
-            <id>distribution-ee</id>
-            <properties>
-                <!-- Versions of the plugins for the full distribution on dev environment-->
-                <!-- Management API & Gateway -->
-                <gravitee-ae-connectors-ws.version>1.6.1</gravitee-ae-connectors-ws.version>
-                <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
-                <gravitee-policy-assign-metrics.version>1.0.1</gravitee-policy-assign-metrics.version>
-                <gravitee-policy-data-logging-masking.version>1.1.1</gravitee-policy-data-logging-masking.version>
-
-                <!-- Management API Only -->
-                <gravitee-notifier-email.version>1.4.1</gravitee-notifier-email.version>
-                <gravitee-notifier-slack.version>1.2.1</gravitee-notifier-slack.version>
-                <gravitee-notifier-webhook.version>1.1.0</gravitee-notifier-webhook.version>
-                <!-- Gateway Only -->
-            </properties>
-            <dependencies>
-                <!-- License jar to put in /lib -->
-                <dependency>
-                    <groupId>com.graviteesource.license</groupId>
-                    <artifactId>gravitee-license-node-enterprise</artifactId>
-                    <version>${gravitee-license-node.version}</version>
-                </dependency>
-                <!-- Connectors -->
-                <dependency>
-                    <groupId>com.graviteesource.ae.connectors</groupId>
-                    <artifactId>gravitee-ae-connectors-ws</artifactId>
-                    <version>${gravitee-ae-connectors-ws.version}</version>
-                    <type>zip</type>
-                    <scope>runtime</scope>
-                </dependency>
-                <!-- Notifiers -->
-                <dependency>
-                    <groupId>io.gravitee.notifier</groupId>
-                    <artifactId>gravitee-notifier-email</artifactId>
-                    <version>${gravitee-notifier-email.version}</version>
-                    <type>zip</type>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>com.graviteesource.notifier</groupId>
-                    <artifactId>gravitee-notifier-slack</artifactId>
-                    <version>${gravitee-notifier-slack.version}</version>
-                    <type>zip</type>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>io.gravitee.notifier</groupId>
-                    <artifactId>gravitee-notifier-webhook</artifactId>
-                    <version>${gravitee-notifier-webhook.version}</version>
-                    <type>zip</type>
-                    <scope>runtime</scope>
-                </dependency>
-                <!-- Policies -->
-                <dependency>
-                    <groupId>com.graviteesource.policy</groupId>
-                    <artifactId>gravitee-policy-assign-metrics</artifactId>
-                    <version>${gravitee-policy-assign-metrics.version}</version>
-                    <type>zip</type>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>com.graviteesource.policy</groupId>
-                    <artifactId>gravitee-policy-data-logging-masking</artifactId>
-                    <version>${gravitee-policy-data-logging-masking.version}</version>
-                    <type>zip</type>
-                    <scope>runtime</scope>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>com.jayway.jsonpath</groupId>
-                            <artifactId>json-path</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
             </dependencies>
         </profile>
     </profiles>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -95,11 +95,6 @@
         <!-- Gravitee.io -->
         <dependency>
             <groupId>io.gravitee.node</groupId>
-            <artifactId>gravitee-node-container</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
         </dependency>
 
@@ -110,12 +105,22 @@
 
         <dependency>
             <groupId>io.gravitee.node</groupId>
-            <artifactId>gravitee-node-vertx</artifactId>
+            <artifactId>gravitee-node-container</artifactId>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-kubernetes</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-license</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-vertx</artifactId>
         </dependency>
 
         <dependency>
@@ -589,19 +594,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-            <id>ee</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <dependencies>
-                <!-- GraviteeSource dependencies -->
-                <dependency>
-                    <groupId>com.graviteesource.license</groupId>
-                    <artifactId>gravitee-license-node</artifactId>
-                </dependency>
-            </dependencies>
         </profile>
     </profiles>
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
@@ -118,7 +118,6 @@
             <unpack>false</unpack>
             <includes>
                 <include>io.gravitee.*:*:jar</include>
-                <include>com.graviteesource.*:*:jar</include>
             </includes>
             <scope>compile</scope>
             <useProjectArtifact>false</useProjectArtifact>
@@ -143,10 +142,8 @@
                 <exclude>*:*:jar</exclude>
                 <exclude>io.gravitee.fetcher:*:zip</exclude>
                 <exclude>io.gravitee.cockpit:gravitee-cockpit-connectors-ws:zip</exclude>
-                <exclude>io.gravitee.repository:gravitee-apim-repository-elasticsearch:zip</exclude>
-                <!-- for EE version -->
                 <exclude>io.gravitee.notifier:*:zip</exclude>
-                <exclude>com.graviteesource.notifier:*:zip</exclude>
+                <exclude>io.gravitee.repository:gravitee-apim-repository-elasticsearch:zip</exclude>
             </excludes>
             <useProjectArtifact>false</useProjectArtifact>
             <fileMode>755</fileMode>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/pom.xml
@@ -36,12 +36,17 @@
         <!-- Gravitee.io -->
         <dependency>
             <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-container</artifactId>
         </dependency>
 
         <dependency>
             <groupId>io.gravitee.node</groupId>
-            <artifactId>gravitee-node-api</artifactId>
+            <artifactId>gravitee-node-license</artifactId>
         </dependency>
 
         <dependency>
@@ -430,19 +435,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-            <id>ee</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <dependencies>
-                <!-- GraviteeSource dependencies -->
-                <dependency>
-                    <groupId>com.graviteesource.license</groupId>
-                    <artifactId>gravitee-license-node</artifactId>
-                </dependency>
-            </dependencies>
         </profile>
     </profiles>
 </project>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
@@ -136,7 +136,6 @@
             <unpack>false</unpack>
             <includes>
                 <include>io.gravitee.*:*:jar</include>
-                <include>com.graviteesource.*:*:*</include>
             </includes>
             <scope>compile</scope>
             <useProjectArtifact>false</useProjectArtifact>
@@ -162,10 +161,10 @@
             <unpack>false</unpack>
             <excludes>
                 <exclude>*:*:jar</exclude>
-                <exclude>io.gravitee.reporter:*:zip</exclude>
-                <exclude>io.gravitee.tracer:*:zip</exclude>
                 <exclude>io.gravitee.apim.repository.gateway.bridge.http:*:zip</exclude>
                 <exclude>io.gravitee.policy:gravitee-gateway-services-ratelimit:zip</exclude>
+                <exclude>io.gravitee.reporter:*:zip</exclude>
+                <exclude>io.gravitee.tracer:*:zip</exclude>
             </excludes>
             <useProjectArtifact>false</useProjectArtifact>
             <fileMode>755</fileMode>

--- a/pom.xml
+++ b/pom.xml
@@ -67,10 +67,9 @@
         <gravitee-expression-language.version>1.9.2</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>1.32.2</gravitee-gateway-api.version>
-        <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
-        <gravitee-node.version>1.21.0</gravitee-node.version>
+        <gravitee-node.version>1.24.1</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>
-        <gravitee-plugin.version>1.22.0</gravitee-plugin.version>
+        <gravitee-plugin.version>1.23.1</gravitee-plugin.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>1.22.0</gravitee-reporter-api.version>
         <gravitee-resource-auth-provider-api.version>1.3.0</gravitee-resource-auth-provider-api.version>
@@ -197,12 +196,6 @@
             </dependency>
 
             <dependency>
-                <groupId>com.graviteesource.license</groupId>
-                <artifactId>gravitee-license-node</artifactId>
-                <version>${gravitee-license-node.version}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>io.gravitee.node</groupId>
                 <artifactId>gravitee-node-api</artifactId>
                 <version>${gravitee-node.version}</version>
@@ -229,6 +222,12 @@
             <dependency>
                 <groupId>io.gravitee.node</groupId>
                 <artifactId>gravitee-node-cache</artifactId>
+                <version>${gravitee-node.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.gravitee.node</groupId>
+                <artifactId>gravitee-node-license</artifactId>
                 <version>${gravitee-node.version}</version>
             </dependency>
 


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7770

**Description**

- [x] make APIM depending on `gravitee-node:1.24.1` and `gravitee-plugin:1.23.1`
- [x] remove `ee` profile in `gravitee-apim-gateway-standalone-container` and `gravitee-apim-rest-api-standalone-container`
- [x] remove dependency on `gravitee-license`
- [x] remove `distribution-ee` profile in `gravitee-apim-distribution` and dispatch former dependencies
- [x] use the `1.3.0` version of `gravitee-notifier-slack` which is now a public plugin (no longer a EE plugin)
- [x] use the `2.0.1` version of `gravitee-policy-data-logging-masking` which remains a EE plugin but use the new license framework
- [x] use the `2.0.1` version of `gravitee-policy-assign-metrics` which remains a EE plugin but use the new license framework
- [x] use the new version of Alert-Engine connector... 
- [x] adapt the `config.yml`
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/master-7770-remove-distinction-between-ce-ee/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ozqtgpssvt.chromatic.com)
<!-- Storybook placeholder end -->
