### PR TITLE
fix: use logger instead of printing stack trace

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoMediaRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoMediaRepository.java
@@ -36,6 +36,8 @@ import java.util.function.Consumer;
 import org.bson.BsonString;
 import org.bson.Document;
 import org.bson.conversions.Bson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.MongoDbFactory;
@@ -46,6 +48,8 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class MongoMediaRepository implements MediaRepository {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MongoMediaRepository.class);
 
     @Autowired
     private MongoDatabaseFactory mongoFactory;
@@ -168,7 +172,7 @@ public class MongoMediaRepository implements MediaRepository {
                     result = bos.toByteArray();
                     bos.close();
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    LOGGER.error("An error as occurred while converting GridFs file to media", e);
                 }
                 imageData.setData(result);
             }


### PR DESCRIPTION
see https://github.com/gravitee-io/issues/issues/7768
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/7768-sonar-repository-security/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fxmtvherpw.chromatic.com)
<!-- Storybook placeholder end -->
