### PR TITLE
fix: filter disabled api flows and flows steps

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/definition/Api.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/definition/Api.java
@@ -164,13 +164,12 @@ public class Api extends io.gravitee.definition.model.Api implements Reactable, 
                     if (plan.getFlows() != null) {
                         plan
                             .getFlows()
+                            .stream()
+                            .filter(Flow::isEnabled)
                             .forEach(
-                                new Consumer<Flow>() {
-                                    @Override
-                                    public void accept(Flow flow) {
-                                        policies.addAll(getPolicies(flow.getPre()));
-                                        policies.addAll(getPolicies(flow.getPost()));
-                                    }
+                                flow -> {
+                                    policies.addAll(getPolicies(flow.getPre()));
+                                    policies.addAll(getPolicies(flow.getPost()));
                                 }
                             );
                     }
@@ -180,13 +179,12 @@ public class Api extends io.gravitee.definition.model.Api implements Reactable, 
         // Load policies from flows
         if (getFlows() != null) {
             getFlows()
+                .stream()
+                .filter(Flow::isEnabled)
                 .forEach(
-                    new Consumer<Flow>() {
-                        @Override
-                        public void accept(Flow flow) {
-                            policies.addAll(getPolicies(flow.getPre()));
-                            policies.addAll(getPolicies(flow.getPost()));
-                        }
+                    flow -> {
+                        policies.addAll(getPolicies(flow.getPre()));
+                        policies.addAll(getPolicies(flow.getPost()));
                     }
                 );
         }
@@ -222,15 +220,13 @@ public class Api extends io.gravitee.definition.model.Api implements Reactable, 
 
         return flowStep
             .stream()
+            .filter(Step::isEnabled)
             .map(
-                new Function<Step, Policy>() {
-                    @Override
-                    public Policy apply(Step step) {
-                        Policy policy = new Policy();
-                        policy.setName(step.getPolicy());
-                        policy.setConfiguration(step.getConfiguration());
-                        return policy;
-                    }
+                step -> {
+                    Policy policy = new Policy();
+                    policy.setName(step.getPolicy());
+                    policy.setConfiguration(step.getConfiguration());
+                    return policy;
                 }
             )
             .collect(Collectors.toList());

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/definition/ApiTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/definition/ApiTest.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.definition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.definition.model.Plan;
+import io.gravitee.definition.model.Policy;
+import io.gravitee.definition.model.flow.Flow;
+import io.gravitee.definition.model.flow.Step;
+import java.util.List;
+import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ApiTest {
+
+    @Test
+    public void shoudFilterDisabledFlowPreStep() {
+        Api api = new Api();
+        Flow flow = new Flow();
+        flow.setPre(aStepList());
+        api.setFlows(List.of(flow));
+
+        Set<Policy> result = api.dependencies(Policy.class);
+
+        assertThat(result).hasSize(1).extracting(Policy::getName).containsExactly("enabledPolicy");
+    }
+
+    @Test
+    public void shoudFilterDisabledFlowPostStep() {
+        Api api = new Api();
+        Flow flow = new Flow();
+        flow.setPost(aStepList());
+        api.setFlows(List.of(flow));
+
+        Set<Policy> result = api.dependencies(Policy.class);
+
+        assertThat(result).hasSize(1).extracting(Policy::getName).containsExactly("enabledPolicy");
+    }
+
+    @Test
+    public void shoudFilterDisabledPlanFlowPreStep() {
+        Api api = new Api();
+        Flow flow = new Flow();
+        flow.setPre(aStepList());
+        Plan plan = aPlan(List.of(flow));
+        api.setPlans(List.of(plan));
+
+        Set<Policy> result = api.dependencies(Policy.class);
+
+        assertThat(result).hasSize(2).extracting(Policy::getName).containsExactlyInAnyOrder("enabledPolicy", "key-less");
+    }
+
+    @Test
+    public void shoudFilterDisabledPlanFlowPostStep() {
+        Api api = new Api();
+        Flow flow = new Flow();
+        flow.setPost(aStepList());
+        Plan plan = aPlan(List.of(flow));
+        api.setPlans(List.of(plan));
+
+        Set<Policy> result = api.dependencies(Policy.class);
+
+        assertThat(result).hasSize(2).extracting(Policy::getName).containsExactlyInAnyOrder("enabledPolicy", "key-less");
+    }
+
+    @Test
+    public void shouldFilterDisabledFlows() {
+        Api api = new Api();
+        api.setFlows(aFlowList());
+
+        Set<Policy> result = api.dependencies(Policy.class);
+
+        assertThat(result).hasSize(0);
+    }
+
+    @Test
+    public void shouldFilterDisabledPlanFlows() {
+        Api api = new Api();
+        Plan plan = aPlan(aFlowList());
+        api.setPlans(List.of(plan));
+
+        Set<Policy> result = api.dependencies(Policy.class);
+
+        assertThat(result).hasSize(1).extracting(Policy::getName).containsExactlyInAnyOrder("key-less");
+    }
+
+    private List<Step> aStepList() {
+        Step enabledPreStep = new Step();
+        enabledPreStep.setPolicy("enabledPolicy");
+        enabledPreStep.setEnabled(true);
+        Step disabledPreStep = new Step();
+        disabledPreStep.setName("disabledPolicy");
+        disabledPreStep.setEnabled(false);
+        return List.of(enabledPreStep, disabledPreStep);
+    }
+
+    private Plan aPlan(List<Flow> flowList) {
+        Plan plan = new Plan();
+        plan.setPaths(null);
+        plan.setSecurity("KEY_LESS");
+        plan.setFlows(flowList);
+        return plan;
+    }
+
+    private List<Flow> aFlowList() {
+        Flow enabledFlow = new Flow();
+        enabledFlow.setEnabled(true);
+        Flow disabledFlow = new Flow();
+        disabledFlow.setPre(aStepList());
+        disabledFlow.setEnabled(false);
+        return List.of(enabledFlow, disabledFlow);
+    }
+}


### PR DESCRIPTION
**Description**

In the api definition ``API`` class when we load the dependencies we don't check if the flow steps are disabled or not. Or should consider it and filter it.

Here is an example:
<img width="1788" alt="Screenshot 2022-06-02 at 15 39 08" src="https://user-images.githubusercontent.com/25704259/171642277-e5356dc2-23ac-4ba2-b63d-9a659164c726.png">

I don't have the java script policy. However, I disabled it so I should not have an exception saying ``"Policy toto can not be found in policy registry`` when I deploy it and try to call it using postman or even the debug mode in the next versions.

Same for the ``Flows`` if a flow is disabled I should not consider it.
