### PR TITLE
fix: change permission scope for GroupsResource

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/GroupsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/GroupsResource.java
@@ -62,7 +62,7 @@ public class GroupsResource extends AbstractResource {
         )
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
-    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_GROUP, acls = RolePermissionAction.READ) })
+    @Permissions({ @Permission(value = RolePermission.ORGANIZATION_TAG, acls = RolePermissionAction.READ) })
     public Response getGroups() {
         return Response.ok(groupService.findAllByOrganization(GraviteeContext.getCurrentOrganization())).build();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/OrganizationGroupsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/OrganizationGroupsResource.java
@@ -39,8 +39,8 @@ import javax.ws.rs.core.Response;
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Tag(name = "Groups")
-public class GroupsResource extends AbstractResource {
+@Tag(name = "Organization Groups")
+public class OrganizationGroupsResource extends AbstractResource {
 
     @Inject
     private GroupService groupService;
@@ -49,9 +49,7 @@ public class GroupsResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
         summary = "Find groups",
-        description = "Find all groups for current organization" +
-        "Only administrators could see all groups." +
-        "Only users with MANAGE_API permissions could see API groups."
+        description = "Find all groups for current organization" + "Only users with ORGANIZATION_TAG permissions could see API groups."
     )
     @ApiResponse(
         responseCode = "200",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/OrganizationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/OrganizationResource.java
@@ -212,8 +212,8 @@ public class OrganizationResource extends AbstractResource {
     }
 
     @Path("groups")
-    public GroupsResource getGroupsResource() {
-        return resourceContext.getResource(GroupsResource.class);
+    public OrganizationGroupsResource getGroupsResource() {
+        return resourceContext.getResource(OrganizationGroupsResource.class);
     }
 
     @Path("promotions")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/OrganizationGroupsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/OrganizationGroupsResourceTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class GroupsResourceTest extends AbstractResourceTest {
+public class OrganizationGroupsResourceTest extends AbstractResourceTest {
 
     @Override
     protected String contextPath() {


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7776
https://github.com/gravitee-io/issues/issues/7369

**Description**

Resource was using an ENVIRONMENT scoped permission (`ENVIRONMENT_GROUPS`).

Thanks to this commit (65e1ff77c75071e1f3c7b31a808d3ab3fa1f9d18), `PermissionFilter` changed the way it validates `ENVIRONMENT` permissions: an environment id should exist, and on Organization settings we do not have it.

Since this resource is only used by `Sharding Tags ` screen, I choose this permission (`ORGANIZATION_TAG`).
It's not perfect, but it fixes the problem

⚠️ It needs a discussion with product team (@mouligno) about group exclusion for sharding tags. For the moment, groups are fetched for the whole organization. If we do that, we at least need to improve the UI to have a group list grouped by ENVIRONMENT, wdyt ?

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/issues-7776-sharding-tag-permission/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wqvymkfsqi.chromatic.com)
<!-- Storybook placeholder end -->
