### PR TITLE
feat(jupiter): better handling of request and response body

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/error/AbstractFailureProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/error/AbstractFailureProcessor.java
@@ -112,7 +112,7 @@ public abstract class AbstractFailureProcessor implements Processor {
 
             response.headers().set(HttpHeaderNames.CONTENT_LENGTH, Integer.toString(payload.length()));
             response.headers().set(HttpHeaderNames.CONTENT_TYPE, contentType);
-            return context.response().body(payload);
+            context.response().body(payload);
         }
         return Completable.complete();
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/error/template/ResponseTemplateBasedFailureProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/error/template/ResponseTemplateBasedFailureProcessor.java
@@ -151,7 +151,7 @@ public class ResponseTemplateBasedFailureProcessor extends AbstractFailureProces
             String body = context.getTemplateEngine().getValue(template.getBody(), String.class);
             Buffer payload = Buffer.buffer(body);
             context.response().headers().set(HttpHeaderNames.CONTENT_LENGTH, Integer.toString(payload.length()));
-            return context.response().body(payload);
+            context.response().body(payload);
         }
         return Completable.complete();
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/error/SimpleFailureProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/error/SimpleFailureProcessorTest.java
@@ -55,7 +55,6 @@ class SimpleFailureProcessorTest extends AbstractProcessorTest {
     @BeforeEach
     public void beforeEach() {
         simpleFailureProcessor = SimpleFailureProcessor.instance();
-        lenient().when(mockResponse.body(any(Buffer.class))).thenReturn(Completable.complete());
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/PolicyChain.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/PolicyChain.java
@@ -15,9 +15,7 @@
  */
 package io.gravitee.gateway.reactive.policy;
 
-import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.gateway.reactive.api.ExecutionPhase;
-import io.gravitee.gateway.reactive.api.context.ExecutionContext;
 import io.gravitee.gateway.reactive.api.context.MessageExecutionContext;
 import io.gravitee.gateway.reactive.api.context.RequestExecutionContext;
 import io.gravitee.gateway.reactive.api.policy.Policy;
@@ -32,7 +30,6 @@ import org.slf4j.LoggerFactory;
  * PolicyChain is responsible for executing a given list of policies respecting the original order.
  * Policy execution must occur in an ordered sequence, one by one.
  * It is the responsibility of the chain to handle any policy execution error and stop the entire execution of the policy chain.
- * The PolicyChain should also check the current execution context against the {@link ExecutionContext#isInterrupted()} flag and abort the chain execution accordingly.
  *
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/notfound/NotFoundProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/notfound/NotFoundProcessor.java
@@ -44,21 +44,20 @@ public class NotFoundProcessor implements Processor {
 
     @Override
     public Completable execute(final RequestExecutionContext ctx) {
-        return Completable
-            .defer(
-                () -> {
-                    LOGGER.warn("No handler can be found for request {}, returning NOT_FOUND (404)", ctx.request().path());
-                    // Send a NOT_FOUND HTTP status code (404)
-                    ctx.response().status(HttpStatusCode.NOT_FOUND_404);
-                    String message = environment.getProperty("http.errors[404].message", "No context-path matches the request URI.");
-                    ctx.response().headers().set(HttpHeaderNames.CONTENT_LENGTH, Integer.toString(message.length()));
-                    ctx
-                        .response()
-                        .headers()
-                        .set(HttpHeaderNames.CONTENT_TYPE, environment.getProperty("http.errors[404].contentType", MediaType.TEXT_PLAIN));
-                    return ctx.response().body(Buffer.buffer(message));
-                }
-            )
-            .andThen(ctx.response().end());
+        return Completable.defer(
+            () -> {
+                LOGGER.warn("No handler can be found for request {}, returning NOT_FOUND (404)", ctx.request().path());
+                // Send a NOT_FOUND HTTP status code (404)
+                ctx.response().status(HttpStatusCode.NOT_FOUND_404);
+                String message = environment.getProperty("http.errors[404].message", "No context-path matches the request URI.");
+                ctx.response().headers().set(HttpHeaderNames.CONTENT_LENGTH, Integer.toString(message.length()));
+                ctx
+                    .response()
+                    .headers()
+                    .set(HttpHeaderNames.CONTENT_TYPE, environment.getProperty("http.errors[404].contentType", MediaType.TEXT_PLAIN));
+                ctx.response().body(Buffer.buffer(message));
+                return ctx.response().end();
+            }
+        );
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/NotFoundProcessorChainFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/NotFoundProcessorChainFactoryTest.java
@@ -64,7 +64,6 @@ class NotFoundProcessorChainFactoryTest {
         when(request.metrics()).thenReturn(metrics);
         when(response.end()).thenReturn(Completable.complete());
         when(response.headers()).thenReturn(HttpHeaders.create());
-        when(response.body(any(Buffer.class))).thenReturn(Completable.complete());
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/notfound/NotFoundProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/notfound/NotFoundProcessorTest.java
@@ -58,7 +58,6 @@ class NotFoundProcessorTest {
     @BeforeEach
     public void beforeEach() {
         when(response.headers()).thenReturn(HttpHeaders.create());
-        when(response.body(any(Buffer.class))).thenReturn(Completable.complete());
         when(response.end()).thenReturn(Completable.complete());
         notFoundProcessor = new NotFoundProcessor(new StandardEnvironment());
         ctx = new DefaultRequestExecutionContext(request, response);


### PR DESCRIPTION
When a policy wants to apply transformation on the request or response body, make the `onBody(xxx)` part of the reactive chain to make sure that it will be subscribed and completed before moving to the next policy.

Because the current v3 adapters also subscribe to the request or response body (PolicyAdapter, Invoker adapter), the reactive body chunks are cached only when it is absolutely required (in case on any body transformation).

If no policy manipulate the body, the gateway will simply stream the content from client to backend or backend to client like without loading the body in memory like it is the case in v3.

This enhancement will also allows to prepare the work on the Expression Language with body support.