### PR TITLE
chore: remove logger in apim bootstrap

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-bootstrap/src/main/java/io/gravitee/rest/api/standalone/boostrap/Bootstrap.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-bootstrap/src/main/java/io/gravitee/rest/api/standalone/boostrap/Bootstrap.java
@@ -21,16 +21,13 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@SuppressWarnings("java:S4507") // disable printStackTrace warning as we are starting the application
 public class Bootstrap {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(Bootstrap.class);
 
     private static final String GRAVITEE_HOME_PROP = "gravitee.home";
     private static final String CONTAINER_CLASS = "io.gravitee.rest.api.standalone.GraviteeApisContainer";
@@ -74,7 +71,7 @@ public class Bootstrap {
             try {
                 cpList.add(lib.toURI().toURL());
             } catch (java.net.MalformedURLException urlEx) {
-                LOGGER.error("Unable to add lib " + lib.getAbsolutePath(), urlEx);
+                urlEx.printStackTrace();
             }
         }
 
@@ -97,7 +94,7 @@ public class Bootstrap {
                     cpList.add(lib.toURI().toURL());
                 }
             } catch (java.net.MalformedURLException urlEx) {
-                LOGGER.error("Unable to add lib " + libDir.getAbsolutePath(), urlEx);
+                urlEx.printStackTrace();
             }
         }
 


### PR DESCRIPTION

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-bootstrap-logger/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
