### PR TITLE
chore: exclude json-path from policy to avoid conflict

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -771,6 +771,12 @@
                     <version>${gravitee-policy-data-logging-masking.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>com.jayway.jsonpath</groupId>
+                            <artifactId>json-path</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
             </dependencies>
         </profile>


### PR DESCRIPTION
The gw depends on gravitee-expression-language which depends on json-path (with scope compile).
When we activate the 'distribution-ee' profile, new dependencies are added in the pom.xml. Among them, there is policy-data-logging-masking. And it has also the json-path lib as a 'compile' dependency.
For an unknown reason, when this policy (in scope runtime) is added in final pom, the dependency from expression-language is omitted.

As a consequence, when we build the target (with assembly plugin), as we exclude runtime dependencies, we loose json-path.

This commit excludes the json-path from the data-logging policy.

(cherry picked from commit 512275a6168726215d9efe94588f479660ef6a14)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/3-15-x-json-path-exclusion-ee-env/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
