### PR TITLE
feat(console): add Jupiter toggle for api creation & edition

### DIFF
--- a/gravitee-apim-console-webui/src/entities/api/Api.ts
+++ b/gravitee-apim-console-webui/src/entities/api/Api.ts
@@ -41,6 +41,7 @@ export interface Api {
   flows?: Flow[];
   plans?: ApiPlan[];
   gravitee?: string;
+  execution_mode?: 'v3' | 'jupiter';
 
   deployed_at?: number;
   created_at: number;

--- a/gravitee-apim-console-webui/src/entities/flow/configurationSchema.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/flow/configurationSchema.fixture.ts
@@ -36,6 +36,7 @@ export function fakeFlowConfigurationSchema(attributes?: FlowConfigurationSchema
     },
     required: [],
     disabled: [],
+    execution_mode: 'v3',
   };
 
   return { ...base, ...attributes };

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/config/policy-studio-config.component.html
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/config/policy-studio-config.component.html
@@ -15,11 +15,28 @@
     limitations under the License.
 
 -->
-<div class="policy-studio-api-config">
-  <div *ngIf="!this.isLoading" class="policy-studio-api-config__information">
+<div *ngIf="!this.isLoading" class="policy-studio-api-config">
+  <div class="policy-studio-api-config__information">
     <gv-icon class="policy-studio-api-config__information__icon" title="Info" shape="code:info"></gv-icon>
     <blockquote class="policy-studio-api-config__information__blockquote" [innerHtml]="this.information"></blockquote>
   </div>
 
-  <gv-schema-form [schema]="this.schema" [values]="this.apiDefinition" (:gv-schema-form:change)="onChange($event)"> </gv-schema-form>
+  <gv-schema-form
+    class="policy-studio-api-config__schema-form"
+    [schema]="this.schema"
+    [values]="this.apiDefinition"
+    (:gv-schema-form:change)="onChange($event)"
+  >
+  </gv-schema-form>
+
+  <gio-form-slide-toggle *ngIf="displayJupiterToggle" class="policy-studio-api-config__execution_mode" appearance="fill">
+    <gio-form-label>Enable Jupiter mode</gio-form-label>
+    <mat-slide-toggle
+      gioFormSlideToggle
+      aria-label="Enable Jupiter mode"
+      name="execution_mode"
+      [checked]="apiDefinition.execution_mode === 'jupiter'"
+      (change)="toggleJupiterMode($event)"
+    ></mat-slide-toggle>
+  </gio-form-slide-toggle>
 </div>

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/config/policy-studio-config.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/config/policy-studio-config.component.scss
@@ -6,20 +6,32 @@
   flex-direction: column;
   height: var(--gv-policy-studio--h);
 }
+.policy-studio-api-config {
+  &__information {
+    display: flex;
+    align-items: center;
 
-.policy-studio-api-config__information {
-  display: flex;
-  align-items: center;
+    &__icon {
+      --gv-icon--c: var(--gv-theme-color, #5a7684);
+      --gv-icon-opacity--c: var(--gv-theme-color-info-light, #64b5f6);
+    }
 
-  &__icon {
-    --gv-icon--c: var(--gv-theme-color, #5a7684);
-    --gv-icon-opacity--c: var(--gv-theme-color-info-light, #64b5f6);
+    &__blockquote {
+      border-left: 1px solid var(--gv-theme-color, #5a7684);
+      margin: 15px;
+      padding-left: 15px;
+      font-size: 14px;
+    }
+  }
+  &__schema-form {
+    --gv-policy-studio--pb: 0px;
   }
 
-  &__blockquote {
-    border-left: 1px solid var(--gv-theme-color, #5a7684);
-    margin: 15px;
-    padding-left: 15px;
-    font-size: 14px;
+  &__execution_mode {
+    width: 100%;
+  }
+
+  :host-context(.save-bar-opened) {
+    padding-bottom: 84px;
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/config/policy-studio-config.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/config/policy-studio-config.module.ts
@@ -15,11 +15,14 @@
  */
 import { CommonModule } from '@angular/common';
 import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 
 import { PolicyStudioConfigComponent } from './policy-studio-config.component';
 
+import { GioFormSlideToggleModule } from '../../../../shared/components/gio-form-slide-toogle/gio-form-slide-toggle.module';
+
 @NgModule({
-  imports: [CommonModule],
+  imports: [CommonModule, MatSlideToggleModule, GioFormSlideToggleModule],
   declarations: [PolicyStudioConfigComponent],
   exports: [PolicyStudioConfigComponent],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/gio-policy-studio-layout.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/gio-policy-studio-layout.component.spec.ts
@@ -94,6 +94,7 @@ describe('GioPolicyStudioLayoutComponent', () => {
           picture: undefined,
           plans: [],
           flows: api.flows,
+          execution_mode: undefined,
         }),
       );
     });

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/models/ApiDefinition.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/models/ApiDefinition.ts
@@ -36,5 +36,6 @@ export function toApiDefinition(api: Api): ApiDefinition {
     version: api.version,
     properties: api.properties,
     services: api.services,
+    execution_mode: api.execution_mode,
   };
 }

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/models/Definition.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/models/Definition.ts
@@ -21,4 +21,5 @@ export interface Definition {
   version: string;
   flow_mode: 'DEFAULT' | 'BEST_MATCH';
   flows: Flow[];
+  execution_mode?: 'v3' | 'jupiter';
 }

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/properties/policy-studio-properties.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/properties/policy-studio-properties.component.spec.ts
@@ -71,6 +71,7 @@ describe('PolicyStudioPropertiesComponent', () => {
         version: api.version,
         services: api.services,
         properties: api.properties,
+        execution_mode: api.execution_mode,
       });
     });
   });

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/resources/policy-studio-resources.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/resources/policy-studio-resources.component.spec.ts
@@ -75,6 +75,7 @@ describe('PolicyStudioResourcesComponent', () => {
         version: api.version,
         services: api.services,
         properties: api.properties,
+        execution_mode: api.execution_mode,
       });
     });
   });

--- a/gravitee-apim-console-webui/src/management/api/portal/general/apiPortal.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/general/apiPortal.controller.ts
@@ -45,6 +45,7 @@ class ApiPortalController {
   private qualityMetricsDescription: Map<string, string>;
   private isQualityEnabled: boolean;
   private apiLabelsDictionary = [];
+  private displayJupiterToggle: boolean;
 
   constructor(
     private ApiService: ApiService,
@@ -224,6 +225,8 @@ class ApiPortalController {
     _.forEach(this.qualityRules, (qualityRule) => {
       this.qualityMetricsDescription.set(qualityRule.id, qualityRule.description);
     });
+
+    this.displayJupiterToggle = this.Constants.org.settings.jupiterMode.enabled ?? false;
   }
 
   $onInit() {

--- a/gravitee-apim-console-webui/src/management/api/portal/general/apiPortal.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/general/apiPortal.html
@@ -156,8 +156,20 @@
           <label>Portal categories</label>
           <md-chips readonly="true" ng-model="portalCtrl.api.categories"></md-chips>
         </div>
-
-        <div class="md-actions gravitee-api-save-button" layout="row">
+        <div layout="column" ng-if="displayJupiterToggle">
+          <md-input-container permission permission-only="'api-definition-u'" class="flex">
+            <md-switch
+              class="api-portal__jupiter-mode-toggle"
+              ng-model="portalCtrl.api.execution_mode"
+              ng-true-value="'jupiter'"
+              ng-false-value="'v3'"
+              aria-label="Enable Jupiter mode"
+            >
+              Enable Jupiter mode
+            </md-switch>
+          </md-input-container>
+        </div>
+        <div class="md-actions api-portal__actions" layout="row">
           <md-button
             permission
             permission-only="'api-definition-u'"

--- a/gravitee-apim-console-webui/src/management/api/portal/general/apiPortal.scss
+++ b/gravitee-apim-console-webui/src/management/api/portal/general/apiPortal.scss
@@ -4,4 +4,10 @@
   gv-icon {
     --gv-icon--s: 24px;
   }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+  }
 }

--- a/gravitee-apim-console-webui/src/services-ngx/api.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api.service.ts
@@ -66,6 +66,7 @@ export class ApiService {
         disable_membership_notifications: api.disable_membership_notifications,
         flow_mode: api.flow_mode,
         gravitee: api.gravitee,
+        execution_mode: api.execution_mode,
       },
       { headers: new HttpHeaders({ ...(api.etag ? { 'If-Match': api.etag } : {}) }) },
     );

--- a/gravitee-apim-console-webui/src/services/api.service.ts
+++ b/gravitee-apim-console-webui/src/services/api.service.ts
@@ -213,6 +213,7 @@ export class ApiService {
         disable_membership_notifications: api.disable_membership_notifications,
         flow_mode: api.flow_mode,
         gravitee: api.gravitee,
+        execution_mode: api.execution_mode,
       },
       { headers: { 'If-Match': api.etag } },
     );


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7784

**Description**

Add Jupiter toggle for api creation & policy studio configuration

**Additional context**

<img width="1741" alt="image" src="https://user-images.githubusercontent.com/4974420/172575320-48ef15cb-de00-4102-a53a-8f5698917ecd.png">


<img width="1740" alt="image" src="https://user-images.githubusercontent.com/4974420/172170255-2ebd1e40-0c81-4f00-9040-b3445ec2c343.png">

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bvxryqetuj.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/prototype-reactive-security-chain-ui-jupiter-toggle/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
