### PR TITLE
feat: configure system role edition

### DIFF
--- a/gravitee-apim-console-webui/src/entities/consoleSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/consoleSettings.ts
@@ -115,6 +115,9 @@ export interface ConsoleSettingsManagement {
   automaticValidation?: {
     enabled?: boolean;
   };
+  systemRoleEdition?: {
+    enabled?: boolean;
+  };
 }
 
 export interface ConsoleSettingsNewsletter {

--- a/gravitee-apim-console-webui/src/organization/configuration/roles/org-settings-roles.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/roles/org-settings-roles.component.ts
@@ -28,12 +28,14 @@ import {
   GioConfirmDialogData,
 } from '../../../shared/components/gio-confirm-dialog/gio-confirm-dialog.component';
 import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+import { Constants } from '../../../entities/Constants';
 
 interface RoleVM {
   name: string;
   description: string;
   isDefault: boolean;
   isSystem: boolean;
+  isReadOnly: boolean;
   canBeDeleted: boolean;
   icon: string;
   hasUserRoleManagement: boolean;
@@ -53,6 +55,7 @@ export class OrgSettingsRolesComponent implements OnInit, OnDestroy {
     @Inject(UIRouterState) private readonly ajsState: StateService,
     private readonly matDialog: MatDialog,
     private readonly snackBarService: SnackBarService,
+    @Inject('Constants') private readonly constants: Constants,
   ) {}
 
   private readonly unsubscribe$ = new Subject<boolean>();
@@ -130,9 +133,20 @@ export class OrgSettingsRolesComponent implements OnInit, OnDestroy {
       isSystem: role.system,
       hasUserRoleManagement: role.scope === 'ORGANIZATION',
       canBeDeleted: !role.default && !role.system,
-      isReadOnly: role.scope === 'ORGANIZATION' && role.name === 'ADMIN',
+      isReadOnly: this.isReadOnly(role),
       icon: OrgSettingsRolesComponent.getScopeIcon(role.scope),
     }));
+  }
+
+  private isReadOnly(role: Role) {
+    if (this.hasSystemRoleEditionEnabled()) {
+      return role.scope === 'ORGANIZATION' && role.name === 'ADMIN';
+    }
+    return role.system;
+  }
+
+  private hasSystemRoleEditionEnabled(): boolean {
+    return this.constants?.org?.settings?.management?.systemRoleEdition?.enabled;
   }
 
   private static getScopeIcon(scope: RoleScope): string {

--- a/gravitee-apim-console-webui/src/organization/configuration/roles/role/org-settings-role.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/roles/role/org-settings-role.component.ts
@@ -25,6 +25,7 @@ import { UIRouterState, UIRouterStateParams } from '../../../../ajs-upgraded-pro
 import { Role } from '../../../../entities/role/role';
 import { RoleService } from '../../../../services-ngx/role.service';
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+import { Constants } from '../../../../entities/Constants';
 
 type RolePermissionsTableDM = {
   permissionName: string;
@@ -65,6 +66,7 @@ export class OrgSettingsRoleComponent implements OnInit, OnDestroy {
   constructor(
     @Inject(UIRouterState) private readonly ajsState: StateService,
     @Inject(UIRouterStateParams) private readonly ajsStateParams: { roleScope: string; role: string },
+    @Inject('Constants') private readonly constants: Constants,
     private readonly roleService: RoleService,
     private readonly snackBarService: SnackBarService,
   ) {}
@@ -207,7 +209,14 @@ export class OrgSettingsRoleComponent implements OnInit, OnDestroy {
   }
 
   public get isReadOnly(): boolean {
-    return this.role?.scope === 'ORGANIZATION' && this.role?.name === 'ADMIN';
+    if (this.hasSystemRoleEditionEnabled()) {
+      return this.role.scope === 'ORGANIZATION' && this.role.name === 'ADMIN';
+    }
+    return this.role.system;
+  }
+
+  private hasSystemRoleEditionEnabled(): boolean {
+    return this.constants?.org?.settings?.management?.systemRoleEdition?.enabled;
   }
 }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -301,7 +301,9 @@ public enum Key {
         "true",
         new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))
     ),
-    CONSOLE_PATH_BASED_API_CREATION_ENABLED("console.pathBasedApiCreation.enabled", "false", Set.of(ORGANIZATION, SYSTEM));
+    CONSOLE_PATH_BASED_API_CREATION_ENABLED("console.pathBasedApiCreation.enabled", "false", Set.of(ORGANIZATION, SYSTEM)),
+
+    CONSOLE_SYSTEM_ROLE_EDITION_ENABLED("console.systemRoleEdition.enabled", "false", Set.of(SYSTEM));
 
     String key;
     String defaultValue;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/Management.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/Management.java
@@ -44,6 +44,9 @@ public class Management {
     @ParameterKey(Key.CONSOLE_USERCREATION_AUTOMATICVALIDATION_ENABLED)
     private Enabled automaticValidation;
 
+    @ParameterKey(Key.CONSOLE_SYSTEM_ROLE_EDITION_ENABLED)
+    private Enabled systemRoleEdition;
+
     public Enabled getSupport() {
         return support;
     }
@@ -90,5 +93,13 @@ public class Management {
 
     public void setAutomaticValidation(Enabled automaticValidation) {
         this.automaticValidation = automaticValidation;
+    }
+
+    public Enabled getSystemRoleEdition() {
+        return systemRoleEdition;
+    }
+
+    public void setSystemRoleEdition(Enabled systemRoleEdition) {
+        this.systemRoleEdition = systemRoleEdition;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
@@ -145,7 +145,7 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
                 null,
                 role
             );
-            if (entity.isDefaultRole()) {
+            if (entity != null && entity.isDefaultRole()) {
                 toggleDefaultRole(executionContext, roleEntity.getScope(), entity.getName());
             }
             return entity;
@@ -181,7 +181,7 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
                 role,
                 updatedRole
             );
-            if (entity.isDefaultRole()) {
+            if (entity != null && entity.isDefaultRole()) {
                 toggleDefaultRole(executionContext, scope, entity.getName());
             }
             return entity;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/RoleService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/RoleService_UpdateTest.java
@@ -30,7 +30,11 @@ import io.gravitee.repository.management.model.RoleScope;
 import io.gravitee.rest.api.model.RoleEntity;
 import io.gravitee.rest.api.model.UpdateRoleEntity;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.model.settings.ConsoleConfigEntity;
+import io.gravitee.rest.api.model.settings.Enabled;
+import io.gravitee.rest.api.model.settings.Management;
 import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.ConfigService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.RoleNotFoundException;
 import java.util.Collections;
@@ -57,6 +61,9 @@ public class RoleService_UpdateTest {
     @Mock
     private AuditService auditService;
 
+    @Mock
+    private ConfigService configService;
+
     @Test
     public void shouldUpdate() throws TechnicalException {
         UpdateRoleEntity updateRoleEntityMock = mock(UpdateRoleEntity.class);
@@ -78,7 +85,14 @@ public class RoleService_UpdateTest {
             )
         )
             .thenReturn(roleMock);
+
         when(mockRoleRepository.findById("updated_mock_role")).thenReturn(Optional.of(roleMock));
+
+        ConsoleConfigEntity consoleConfig = new ConsoleConfigEntity();
+        Management management = new Management();
+        management.setSystemRoleEdition(new Enabled(true));
+        consoleConfig.setManagement(management);
+        when(configService.getConsoleConfig(any())).thenReturn(consoleConfig);
 
         RoleEntity entity = roleService.update(GraviteeContext.getExecutionContext(), updateRoleEntityMock);
 
@@ -101,6 +115,12 @@ public class RoleService_UpdateTest {
         when(updateRoleEntityMock.getScope()).thenReturn(io.gravitee.rest.api.model.permissions.RoleScope.ENVIRONMENT);
 
         when(mockRoleRepository.findById("updated_mock_role")).thenReturn(Optional.empty());
+
+        ConsoleConfigEntity consoleConfig = new ConsoleConfigEntity();
+        Management management = new Management();
+        management.setSystemRoleEdition(new Enabled(true));
+        consoleConfig.setManagement(management);
+        when(configService.getConsoleConfig(any())).thenReturn(consoleConfig);
 
         roleService.update(GraviteeContext.getExecutionContext(), updateRoleEntityMock);
 


### PR DESCRIPTION
System role edition will be enabled only if the following configuration is added to our config file

```yaml
console:
  systemRoleEdition:
    enabled: true
```

see https://github.com/gravitee-io/issues/issues/7659
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/7659-feat-optional-system-role-edition/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qyfktghupb.chromatic.com)
<!-- Storybook placeholder end -->
