### PR TITLE
fix: don't override UrlParams for Google and Github IdentityProvider

### DIFF
--- a/gravitee-apim-console-webui/src/entities/identity-provider/identityProvider.ts
+++ b/gravitee-apim-console-webui/src/entities/identity-provider/identityProvider.ts
@@ -82,6 +82,8 @@ export interface IdentityProvider {
   userProfileMapping?: IdentityProviderUserProfileMapping;
   emailRequired?: boolean;
   syncMappings?: boolean;
+  requiredUrlParams?: string[];
+  optionalUrlParams?: string[];
   // @deprecated
   scopes?: any;
   // @deprecated

--- a/gravitee-apim-console-webui/src/services/authentication.service.ts
+++ b/gravitee-apim-console-webui/src/services/authentication.service.ts
@@ -41,12 +41,18 @@ class AuthenticationService {
   authenticate(provider: IdentityProvider, state?: string) {
     let satellizerProvider = this.SatellizerConfig.providers[provider.id];
     if (!satellizerProvider) {
-      satellizerProvider = _.merge(provider, {
+      const newSatellizerProviderConfig: any = {
         oauthType: '2.0',
-        requiredUrlParams: ['scope', 'state'],
-        scopeDelimiter: ' ',
         scope: provider.scopes,
-      });
+      };
+      if (provider.type === 'GOOGLE' || provider.type === 'GITHUB') {
+        newSatellizerProviderConfig.requiredUrlParams = provider.requiredUrlParams;
+        newSatellizerProviderConfig.optionalUrlParams = provider.optionalUrlParams;
+      } else {
+        newSatellizerProviderConfig.requiredUrlParams = ['scope', 'state'];
+      }
+
+      satellizerProvider = _.merge(provider, newSatellizerProviderConfig);
     } else {
       provider.scope = provider.scopes;
       _.merge(satellizerProvider, provider);


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7743

**Description**

APIM Console uses Satellizer to handle different OAuth2 Client configurations (like google, github, facebook, etc..).
When a user defines is own IDP, this IDP has to be added in Satellizer configuration. For that we first look into Satellizer available providers by id. If found, we override this config with the one in the IDP + some default values.

For google & github, there are a specific configurations for URL params (required & optional). If by chance, the user's IDP is called `google` or `github`, then the search into Satellizer providers will find a well-formed existing configuration. Otherwise, we will create a new provider configuration with wrong default values for Google and Github.

The goal of this PR is to create a new Satellizer provider with the right configuration from the IDP.

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/3-15-x-7743-fix-google-idp-on-console/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
