### PR TITLE
fix: switch monitoring db calls to IO thread

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/NodeMonitoringRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/NodeMonitoringRepositoryTest.java
@@ -20,6 +20,7 @@ import io.gravitee.repository.config.AbstractRepositoryTest;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.subscribers.TestSubscriber;
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
 /**
@@ -42,6 +43,7 @@ public class NodeMonitoringRepositoryTest extends AbstractRepositoryTest {
     public void shouldFindByNodeIdAndType() {
         final TestObserver<Monitoring> testObserver = nodeMonitoringRepository.findByNodeIdAndType("nodeId1", Monitoring.NODE_INFOS).test();
 
+        awaitTerminalEvent(testObserver);
         testObserver.assertComplete();
         testObserver.assertNoErrors();
         testObserver.assertValue(monitoring -> monitoring.getNodeId().equals("nodeId1"));
@@ -51,6 +53,7 @@ public class NodeMonitoringRepositoryTest extends AbstractRepositoryTest {
     public void shouldFindByUnknownNodeId() {
         final TestObserver<Monitoring> testObserver = nodeMonitoringRepository.findByNodeIdAndType("unknown", Monitoring.NODE_INFOS).test();
 
+        awaitTerminalEvent(testObserver);
         testObserver.assertComplete();
         testObserver.assertNoErrors();
         testObserver.assertResult();
@@ -62,6 +65,7 @@ public class NodeMonitoringRepositoryTest extends AbstractRepositoryTest {
             .findByTypeAndTimeFrame(Monitoring.HEALTH_CHECK, 1617753600000L, 1617926400000L)
             .test();
 
+        testObserver.awaitTerminalEvent(15, TimeUnit.SECONDS);
         testObserver.assertComplete();
         testObserver.assertNoErrors();
         testObserver.assertValueCount(1);
@@ -80,6 +84,7 @@ public class NodeMonitoringRepositoryTest extends AbstractRepositoryTest {
 
         final TestObserver<Monitoring> testObserver = nodeMonitoringRepository.create(monitoring).test();
 
+        awaitTerminalEvent(testObserver);
         testObserver.assertComplete();
         testObserver.assertNoErrors();
         testObserver.assertValue(createdMonitoring -> createdMonitoring.getNodeId().equals("nodeId1"));
@@ -98,6 +103,7 @@ public class NodeMonitoringRepositoryTest extends AbstractRepositoryTest {
 
         final TestObserver<Monitoring> testObserver = nodeMonitoringRepository.update(monitoring).test();
 
+        awaitTerminalEvent(testObserver);
         testObserver.assertComplete();
         testObserver.assertNoErrors();
         testObserver.assertValue(createdMonitoring -> createdMonitoring.getNodeId().equals("nodeId2"));
@@ -110,7 +116,12 @@ public class NodeMonitoringRepositoryTest extends AbstractRepositoryTest {
 
         final TestObserver<Monitoring> testObserver = nodeMonitoringRepository.update(monitoring).test();
 
+        awaitTerminalEvent(testObserver);
         testObserver.assertNotComplete();
         testObserver.assertError(IllegalStateException.class);
+    }
+
+    private void awaitTerminalEvent(TestObserver<Monitoring> testObserver) {
+        testObserver.awaitTerminalEvent(15, TimeUnit.SECONDS);
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/AbstractRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/AbstractRepositoryTest.java
@@ -28,6 +28,7 @@ import io.gravitee.repository.management.model.flow.Flow;
 import io.gravitee.repository.media.api.MediaRepository;
 import java.io.File;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.apache.commons.io.FilenameUtils;
@@ -328,7 +329,7 @@ public abstract class AbstractRepositoryTest {
         } else if (object instanceof Installation) {
             installationRepository.create((Installation) object);
         } else if (object instanceof Monitoring) {
-            nodeMonitoringRepository.create((Monitoring) object);
+            nodeMonitoringRepository.create((Monitoring) object).test().awaitTerminalEvent(15, TimeUnit.SECONDS);
         } else if (object instanceof Flow) {
             flowRepository.create((Flow) object);
         } else if (object instanceof Promotion) {


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7682

**Description**

NodeMonitoringService (in `gravitee-node`) consumes DB in a reactive way.
On APIM side, we are **not** reactive.

The problem was that the calls to DB in the repository where done on Vertx event loop, and then wrapped to a Reactive object (`Single`, `Maybe` or `Flowable`).  So the blocking call was also blocking the event loop.

This PR resolves this problem by encapsulating the DB call inside the `Single` | `Maybe` | `Flowable` creation and using `subscribeOn(Schedulers.io())` to use the IO thread.

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-7682-iothread/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
