### PR TITLE
Various fixes and improvements on configure logging dialog

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/analytics/logs/_logs.scss
+++ b/gravitee-apim-console-webui/src/management/api/analytics/logs/_logs.scss
@@ -126,8 +126,19 @@
   margin: 0 5%;
   width: 90%;
 }
-.api-analytics-logging-configuration_form-details_input {
+
+.logging-configuration__input-container {
   width: 100%;
+
+  &__expression-container {
+    display: flex;
+    flex: 1 1 auto;
+
+    &__input {
+      flex-grow: 1;
+      overflow: hidden;
+    }
+  }
 }
 
 .api-analytics-logging-configuration_enabled {

--- a/gravitee-apim-console-webui/src/management/api/analytics/logs/configure-logging.dialog.html
+++ b/gravitee-apim-console-webui/src/management/api/analytics/logs/configure-logging.dialog.html
@@ -42,7 +42,7 @@
             </div>
             <md-input-container flex>
               <label>Plan is </label>
-              <md-select ng-model="condition.value">
+              <md-select ng-model="condition.value" required>
                 <md-option ng-repeat="plan in $ctrl.plans" value="{{plan.id}}"> {{plan.name}} </md-option>
               </md-select>
             </md-input-container>
@@ -55,7 +55,7 @@
             </div>
             <md-input-container flex>
               <label>Application is </label>
-              <md-select ng-model="condition.value">
+              <md-select ng-model="condition.value" required>
                 <md-option ng-repeat="application in $ctrl.subscribers" value="{{application.id}}"> {{application.name}} </md-option>
               </md-select>
             </md-input-container>
@@ -104,8 +104,8 @@
             </div>
             <md-input-container flex>
               <label>HTTP Method is</label>
-              <md-select ng-model="condition.value">
-                <md-option ng-repeat="method in methods" value="{{method}}"> {{method}} </md-option>
+              <md-select ng-model="condition.value" required>
+                <md-option ng-repeat="method in $ctrl.methods" value="{{method}}"> {{method}} </md-option>
               </md-select>
             </md-input-container>
           </div>
@@ -153,6 +153,7 @@
                 format="YYYY-MM-DD HH:mm"
                 ng-model="condition.param1"
                 ng-model-options="{ updateOn: 'blur' }"
+                required
               />
             </md-input-container>
           </div>
@@ -162,7 +163,7 @@
 
     <md-dialog-actions layout="row">
       <md-button ng-click="$ctrl.hide()">Cancel</md-button>
-      <md-button type="submit" class="md-raised md-primary">Save</md-button>
+      <md-button type="submit" class="md-raised md-primary" ng-disabled="!$ctrl.isValid()">Save</md-button>
     </md-dialog-actions>
   </form>
 </md-dialog>

--- a/gravitee-apim-console-webui/src/management/api/analytics/logs/configure-logging.dialog.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/logs/configure-logging.dialog.ts
@@ -15,6 +15,7 @@
  */
 import * as moment from 'moment';
 import { IComponentController } from 'angular';
+import { isNil } from 'lodash';
 
 export class ConditionType {
   title: string;
@@ -54,6 +55,20 @@ export class Condition {
       return `${this.type.statement} ${this.operator} '${this.value}'`;
     } else {
       return `${this.type.statement}['${this.param1}'] != null && ${this.type.statement}['${this.param1}'][0] ${this.operator} '${this.value}'`;
+    }
+  }
+
+  isValid(): boolean {
+    switch (this.type.id) {
+      case 'logging-duration':
+        return !isNil(this.param1) && !isNil(this.param2);
+      case 'logging-end-date':
+        return !isNil(this.param1);
+      case 'request-header':
+      case 'request-param':
+        return !isNil(this.param1) && !isNil(this.value) && this.value !== '' && !isNil(this.operator) && !isNil(this.type.statement);
+      default:
+        return !isNil(this.value) && this.value !== '' && !isNil(this.operator) && !isNil(this.type.statement);
     }
   }
 }
@@ -101,6 +116,10 @@ export class ConfigureLoggingDialogController implements IComponentController {
 
   public hide() {
     this.$mdDialog.hide();
+  }
+
+  public isValid(): boolean {
+    return this.conditions.every((condition) => condition.isValid());
   }
 
   public save() {

--- a/gravitee-apim-console-webui/src/management/api/analytics/logs/logging-configuration.html
+++ b/gravitee-apim-console-webui/src/management/api/analytics/logs/logging-configuration.html
@@ -82,13 +82,13 @@
           </div>
 
           <div layout="row" flex-xs="50">
-            <md-input-container class="md-block" flex-gt-sm>
+            <md-input-container class="logging-configuration__input-container">
               <label class="md-no-float">Condition</label>
-              <div layout="row" flex-xs="50">
+              <div class="logging-configuration__input-container__expression-container">
                 <gv-expression-language
                   rows="1"
                   gv-model
-                  class="api-analytics-logging-configuration_form-details_input"
+                  class="logging-configuration__input-container__expression-container__input"
                   ng-attr-grammar="{{loggingCtrl.spelGrammar}}"
                   ng-model="loggingCtrl.api.proxy.logging.condition"
                   placeholder="{#request.headers['Content-Type'][0] === 'application/json'}"


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7351
Following https://github.com/gravitee-io/issues/issues/7351#issuecomment-1148358617

**Description**

Fixing the following feedback provided by @LiliaEn 
 - When I select condition type HTTP method, I am getting an empty dropdown and there is no method to be selected-> seems to be a bug
 - A condition can be saved with the condition type only, without specifying the actual condition. Is "Save" button enabled on purpose, to allow the users to manually edit the condition, or we should keep it disabled until the fields are filled in? Like in this case (see the last 2 screenshots), I selected Plan condition type, but I didn't select the plan from the dropdown
 - When adding a long condition or multiple conditions, it exceeds the field
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7351-improve-dialog/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lrouskeuee.chromatic.com)
<!-- Storybook placeholder end -->
