### PR TITLE
fix: do not notify on dynamic property updates

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-api/src/main/java/io/gravitee/rest/api/idp/api/authentication/UserDetails.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-api/src/main/java/io/gravitee/rest/api/idp/api/authentication/UserDetails.java
@@ -42,6 +42,7 @@ public class UserDetails extends User implements org.springframework.security.co
     private boolean firstLogin;
     private boolean displayNewsletterSubscription;
     private Map<String, Object> customFields;
+    private boolean isSystem;
 
     /**
      * The user creation date
@@ -69,6 +70,17 @@ public class UserDetails extends User implements org.springframework.security.co
     public UserDetails(String username, String password, String email, Collection<? extends GrantedAuthority> authorities) {
         this(username, password, authorities);
         this.email = email;
+    }
+
+    public UserDetails(
+        String username,
+        String password,
+        String email,
+        Collection<? extends GrantedAuthority> authorities,
+        boolean isSystem
+    ) {
+        this(username, password, email, authorities);
+        this.isSystem = isSystem;
     }
 
     public String getId() {
@@ -283,5 +295,13 @@ public class UserDetails extends User implements org.springframework.security.co
 
     public void setPrimaryOwner(boolean primaryOwner) {
         isPrimaryOwner = primaryOwner;
+    }
+
+    public boolean isSystem() {
+        return isSystem;
+    }
+
+    public void setSystem(boolean system) {
+        isSystem = system;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/SecurityContextHelper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/SecurityContextHelper.java
@@ -35,6 +35,17 @@ public class SecurityContextHelper {
     private SecurityContextHelper() {}
 
     public static void authenticateAs(UserEntity user) {
+        authenticateAs(user, false);
+    }
+
+    public static void authenticateAsSystem(String userId, Set<UserRoleEntity> userRoles) {
+        UserEntity user = new UserEntity();
+        user.setId(userId);
+        user.setRoles(userRoles);
+        authenticateAs(user, true);
+    }
+
+    private static void authenticateAs(UserEntity user, boolean isSystem) {
         SecurityContextHolder.setContext(
             new SecurityContext() {
                 @Override
@@ -57,7 +68,7 @@ public class SecurityContextHelper {
 
                         @Override
                         public Object getPrincipal() {
-                            return new UserDetails(user.getId(), "", user.getEmail(), getAuthorities());
+                            return new UserDetails(user.getId(), "", user.getEmail(), getAuthorities(), isSystem);
                         }
 
                         @Override
@@ -67,7 +78,7 @@ public class SecurityContextHelper {
 
                         @Override
                         public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
-                            throw new UnsupportedOperationException("Not implemented");
+                            /* noop */
                         }
 
                         @Override
@@ -79,17 +90,10 @@ public class SecurityContextHelper {
 
                 @Override
                 public void setAuthentication(Authentication authentication) {
-                    throw new UnsupportedOperationException("Not implemented");
+                    /* noop */
                 }
             }
         );
-    }
-
-    public static void authenticateAsSystem(String userId, Set<UserRoleEntity> userRoles) {
-        UserEntity user = new UserEntity();
-        user.setId(userId);
-        user.setRoles(userRoles);
-        authenticateAs(user);
     }
 
     private static String[] computeAuthorities(UserEntity user) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -2252,7 +2252,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
         final ApiEntity deployed = convert(executionContext, singletonList(api)).iterator().next();
 
-        if (userId != null) {
+        if (!getAuthenticatedUser().isSystem()) {
             notifierService.trigger(
                 executionContext,
                 ApiHook.API_DEPLOYED,
@@ -3590,7 +3590,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     private void triggerNotification(ExecutionContext executionContext, String apiId, ApiHook hook, ApiEntity apiEntity) {
         String userId = getAuthenticatedUsername();
 
-        if (userId != null) {
+        if (userId != null && !getAuthenticatedUser().isSystem()) {
             notifierService.trigger(
                 executionContext,
                 hook,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/common/SecurityContextHelperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/common/SecurityContextHelperTest.java
@@ -64,6 +64,12 @@ public class SecurityContextHelperTest {
         authenticateAsSystem("SYSTEM", USER_ROLES);
 
         assertContextMatches("SYSTEM", null, "ENVIRONMENT:ADMIN", "ORGANIZATION:ADMIN");
+
+        final SecurityContext securityContext = SecurityContextHolder.getContext();
+        final Object principal = securityContext.getAuthentication().getPrincipal();
+        final UserDetails userDetails = (UserDetails) principal;
+
+        assertThat(userDetails.isSystem()).isTrue();
     }
 
     private void assertContextMatches(String userName, String userEmail, String... authorities) {


### PR DESCRIPTION
Adds a flag to user detail to be able to check if the user was authenticated programmatically and should not be notified

see https://github.com/gravitee-io/issues/issues/7269
see https://github.com/gravitee-io/issues/issues/5245
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-dynamic-property-notifier/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kgbyffwuuh.chromatic.com)
<!-- Storybook placeholder end -->
