### PR TITLE
Fix JDBC coverage report on 3.10.x

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
@@ -238,7 +238,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine>-Xmx1024m</argLine>
+                    <argLine>@{argLine} -Xmx1024m</argLine>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
**Issue**

NA

**Description**

Fix JDBC coverage report on 3.10.x
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-jdbc-coverage-3-10-x/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
