### PR TITLE
chore: do not refer to a queue in hazelcast configuration

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-heartbeat/src/main/java/io/gravitee/gateway/services/heartbeat/HeartbeatService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-heartbeat/src/main/java/io/gravitee/gateway/services/heartbeat/HeartbeatService.java
@@ -166,6 +166,11 @@ public class HeartbeatService extends AbstractService<HeartbeatService> implemen
                 // We make the assumption that an IllegalStateException is thrown when trying to update the event while it is not existing in the database anymore.
                 // This can be cause, for instance, by a db event cleanup without taking care of the heartbeat event.
                 event.getProperties().put(EVENT_STATE_PROPERTY, "recreate");
+                LOGGER.warn(
+                    "An error occurred while trying to update the event id[{}] type[{}] while it is not existing anymore",
+                    event.getId(),
+                    event.getType()
+                );
                 topic.publish(event);
             } catch (Exception ex) {
                 // We assume to loose the event if something goes wrong and not republish it to avoid infinite loop and cpu starving. It will be overridden by the next heartbeat event.

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/hazelcast.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/hazelcast.xml
@@ -23,12 +23,6 @@
         <eviction eviction-policy="NONE" size="0"></eviction>
     </map>
 
-    <queue name="heartbeats">
-        <!-- By default, gateway emits one event every 5 seconds-->
-        <!-- Keep 1 hour of events -->
-        <max-size>720</max-size>
-    </queue>
-
     <map name="apis">
         <!-- Eviction is managed programmatically-->
         <eviction eviction-policy="NONE" size="0"></eviction>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7681

**Description**

Not sure it resolves the issue.
We add a WARN log entry in an exception catching block which is republishing the event. Theoretically, we should pass only once in this block, but this log entry will help if the problem occurs again (as discussed with @jhaeyaert)

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-7681-hazelcast-configuration/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
