### PR TITLE
Refactor/plan flows in plan collection

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Plan.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Plan.java
@@ -117,8 +117,6 @@ public class Plan {
 
     private Set<String> tags = new HashSet<>();
 
-    private String flows;
-
     public Plan() {}
 
     public Plan(Plan cloned) {
@@ -143,7 +141,6 @@ public class Plan {
         this.selectionRule = cloned.getSelectionRule();
         this.tags = cloned.getTags();
         this.generalConditions = cloned.getGeneralConditions();
-        this.flows = cloned.flows;
     }
 
     public String getId() {
@@ -336,14 +333,6 @@ public class Plan {
 
     public void setCrossId(String crossId) {
         this.crossId = crossId;
-    }
-
-    public String getFlows() {
-        return flows;
-    }
-
-    public void setFlows(String flows) {
-        this.flows = flows;
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/flow/FlowReferenceType.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/flow/FlowReferenceType.java
@@ -21,4 +21,5 @@ package io.gravitee.repository.management.model.flow;
  */
 public enum FlowReferenceType {
     ORGANIZATION,
+    PLAN,
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPlanRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPlanRepository.java
@@ -77,7 +77,6 @@ public class JdbcPlanRepository extends JdbcAbstractFindAllRepository<Plan> impl
             .addColumn("comment_message", Types.NVARCHAR, String.class)
             .addColumn("selection_rule", Types.NVARCHAR, String.class)
             .addColumn("general_conditions", Types.NVARCHAR, String.class)
-            .addColumn("flows", Types.NVARCHAR, String.class)
             .build();
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_18_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_18_0/schema.yml
@@ -164,14 +164,3 @@ databaseChangeLog:
                   - column:
                         name: environment_id
                         type: nvarchar(64)
-        # ################
-        # Plans changes : add plans flows in plans table
-        # ################
-        - addColumn:
-            tableName: ${gravitee_prefix}plans
-            columns:
-              - column:
-                  name: flows
-                  type: nclob
-                  constraints:
-                    nullable: true

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PlanMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PlanMongo.java
@@ -92,8 +92,6 @@ public class PlanMongo extends Auditable {
 
     private String selectionRule;
 
-    private String flows;
-
     public String getId() {
         return id;
     }
@@ -268,14 +266,6 @@ public class PlanMongo extends Auditable {
 
     public void setCrossId(String crossId) {
         this.crossId = crossId;
-    }
-
-    public String getFlows() {
-        return flows;
-    }
-
-    public void setFlows(String flows) {
-        this.flows = flows;
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/PlanRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/PlanRepositoryTest.java
@@ -65,7 +65,6 @@ public class PlanRepositoryTest extends AbstractRepositoryTest {
         assertTrue(plan.get().isCommentRequired());
         assertEquals("What is your project code?", plan.get().getCommentMessage());
         assertNull(plan.get().getSelectionRule());
-        assertEquals("test flows", plan.get().getFlows());
     }
 
     @Test
@@ -91,7 +90,6 @@ public class PlanRepositoryTest extends AbstractRepositoryTest {
         assertTrue(compareDate(new Date(1506878460000L), plan.getPublishedAt()));
         assertTrue(compareDate(new Date(1507611600000L), plan.getClosedAt()));
         assertTrue(compareDate(new Date(1507611670000L), plan.getNeedRedeployAt()));
-        assertEquals("test flows", plan.getFlows());
     }
 
     @Test
@@ -183,7 +181,6 @@ public class PlanRepositoryTest extends AbstractRepositoryTest {
         plan.setPublishedAt(parse("13/02/2016"));
         plan.setClosedAt(parse("14/02/2016"));
         plan.setSecurity(Plan.PlanSecurityType.KEY_LESS);
-        plan.setFlows("test flows");
 
         planRepository.create(plan);
 
@@ -203,7 +200,6 @@ public class PlanRepositoryTest extends AbstractRepositoryTest {
         Assert.assertTrue("Invalid plan published date.", compareDate(plan.getPublishedAt(), createdPlan.getPublishedAt()));
         Assert.assertTrue("Invalid plan closed date.", compareDate(plan.getClosedAt(), createdPlan.getClosedAt()));
         Assert.assertEquals("Invalid plan security.", plan.getSecurity(), createdPlan.getSecurity());
-        Assert.assertEquals("Invalid plan flows.", plan.getFlows(), createdPlan.getFlows());
     }
 
     @Test
@@ -260,7 +256,6 @@ public class PlanRepositoryTest extends AbstractRepositoryTest {
         plan.setGeneralConditions("New GCU");
         plan.setStatus(Plan.Status.CLOSED);
         plan.setTags(Collections.singleton("tag1"));
-        plan.setFlows("updated test flows");
 
         planRepository.update(plan);
 
@@ -273,7 +268,6 @@ public class PlanRepositoryTest extends AbstractRepositoryTest {
         Assert.assertEquals("Invalid plan description.", plan.getDescription(), planUpdated.getDescription());
         Assert.assertEquals("Invalid plan status.", plan.getStatus(), planUpdated.getStatus());
         Assert.assertEquals("Invalid plan tags.", plan.getTags().size(), planUpdated.getTags().size());
-        Assert.assertEquals("Invalid plan flows.", plan.getFlows(), planUpdated.getFlows());
     }
 
     @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/PlanRepositoryMock.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/PlanRepositoryMock.java
@@ -55,7 +55,6 @@ public class PlanRepositoryMock extends AbstractRepositoryMock<PlanRepository> {
         when(plan.getStatus()).thenReturn(Plan.Status.STAGING);
         when(plan.getSecurity()).thenReturn(Plan.PlanSecurityType.KEY_LESS);
         when(plan.getGeneralConditions()).thenReturn("general_conditions");
-        when(plan.getFlows()).thenReturn("test flows");
 
         final Plan plan2 = mock(Plan.class);
         when(plan2.getId()).thenReturn("my-plan");
@@ -79,7 +78,6 @@ public class PlanRepositoryMock extends AbstractRepositoryMock<PlanRepository> {
         when(plan2.getCommentMessage()).thenReturn("What is your project code?");
         when(plan2.getSelectionRule()).thenReturn(null);
         when(plan2.getGeneralConditions()).thenReturn("GCU-my-plan");
-        when(plan2.getFlows()).thenReturn("test flows");
 
         final Plan planOAuth2 = mock(Plan.class);
         when(planOAuth2.getName()).thenReturn("Plan oauth2 name");

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/plan-tests/plans.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/plan-tests/plans.json
@@ -22,8 +22,7 @@
       "commentRequired": true,
       "commentMessage": "What is your project code?",
       "generalConditions": "GCU-my-plan",
-      "tags": [ "tag1", "tag2" ],
-      "flows": "test flows"
+      "tags": [ "tag1", "tag2" ]
    },
    {
       "id":"updated-plan",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/PlanConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/PlanConverter.java
@@ -43,11 +43,7 @@ public class PlanConverter {
     @Autowired
     private ObjectMapper objectMapper;
 
-    public PlanEntity toPlanEntity(Plan plan) {
-        return toPlanEntity(plan, null);
-    }
-
-    public PlanEntity toPlanEntity(Plan plan, ApiEntity apiEntity) {
+    public PlanEntity toPlanEntity(Plan plan, List<Flow> flows) {
         PlanEntity entity = new PlanEntity();
 
         entity.setId(plan.getId());
@@ -59,6 +55,7 @@ public class PlanConverter {
         entity.setUpdatedAt(plan.getUpdatedAt());
         entity.setOrder(plan.getOrder());
         entity.setExcludedGroups(plan.getExcludedGroups());
+        entity.setFlows(flows);
 
         if (plan.getDefinition() != null && !plan.getDefinition().isEmpty()) {
             try {
@@ -66,18 +63,6 @@ public class PlanConverter {
                 entity.setPaths(rules);
             } catch (IOException ioe) {
                 LOGGER.error("Unexpected error while generating policy definition", ioe);
-            }
-        }
-
-        if (apiEntity != null) {
-            if (DefinitionVersion.V2.equals(DefinitionVersion.valueOfLabel(apiEntity.getGraviteeDefinitionVersion()))) {
-                Optional<List<Flow>> planFlows = apiEntity
-                    .getPlans()
-                    .stream()
-                    .filter(pl -> plan.getId() != null && plan.getId().equals(pl.getId()))
-                    .map(PlanEntity::getFlows)
-                    .findFirst();
-                planFlows.ifPresent(entity::setFlows);
             }
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/PlanConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/PlanConverter.java
@@ -20,32 +20,34 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.Rule;
+import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.repository.management.model.Plan;
 import io.gravitee.rest.api.model.*;
+import io.gravitee.rest.api.model.api.ApiEntity;
 import java.io.IOException;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
-import lombok.AllArgsConstructor;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /**
  * @author GraviteeSource Team
  */
 @Component
-@AllArgsConstructor
 public class PlanConverter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PlanConverter.class);
 
+    @Autowired
     private ObjectMapper objectMapper;
 
     public PlanEntity toPlanEntity(Plan plan) {
+        return toPlanEntity(plan, null);
+    }
+
+    public PlanEntity toPlanEntity(Plan plan, ApiEntity apiEntity) {
         PlanEntity entity = new PlanEntity();
 
         entity.setId(plan.getId());
@@ -58,7 +60,7 @@ public class PlanConverter {
         entity.setOrder(plan.getOrder());
         entity.setExcludedGroups(plan.getExcludedGroups());
 
-        if (StringUtils.isNotEmpty(plan.getDefinition())) {
+        if (plan.getDefinition() != null && !plan.getDefinition().isEmpty()) {
             try {
                 HashMap<String, List<Rule>> rules = objectMapper.readValue(plan.getDefinition(), new TypeReference<>() {});
                 entity.setPaths(rules);
@@ -67,11 +69,15 @@ public class PlanConverter {
             }
         }
 
-        if (StringUtils.isNotEmpty(plan.getFlows())) {
-            try {
-                entity.setFlows(objectMapper.readValue(plan.getFlows(), new TypeReference<>() {}));
-            } catch (JsonProcessingException e) {
-                LOGGER.error("Unexpected error while converting plan flows to entities", e);
+        if (apiEntity != null) {
+            if (DefinitionVersion.V2.equals(DefinitionVersion.valueOfLabel(apiEntity.getGraviteeDefinitionVersion()))) {
+                Optional<List<Flow>> planFlows = apiEntity
+                    .getPlans()
+                    .stream()
+                    .filter(pl -> plan.getId() != null && plan.getId().equals(pl.getId()))
+                    .map(PlanEntity::getFlows)
+                    .findFirst();
+                planFlows.ifPresent(entity::setFlows);
             }
         }
 
@@ -211,8 +217,6 @@ public class PlanConverter {
             String planPolicies = objectMapper.writeValueAsString(newPlan.getPaths());
             plan.setDefinition(planPolicies);
         }
-
-        plan.setFlows(objectMapper.writeValueAsString(newPlan.getFlows()));
 
         return plan;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/flow/FlowServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/flow/FlowServiceImpl.java
@@ -211,7 +211,11 @@ public class FlowServiceImpl extends AbstractService implements FlowService {
         f.setMethods(flow.getMethods());
         f.setEnabled(flow.isEnabled());
         f.setCondition(flow.getCondition());
-        f.setConsumers(flow.getConsumers().stream().map(this::convertConsumer).collect(Collectors.toList()));
+        f.setConsumers(
+            flow.getConsumers() != null
+                ? flow.getConsumers().stream().map(this::convertConsumer).collect(Collectors.toList())
+                : Collections.emptyList()
+        );
         return f;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/converter/PlanConverterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/converter/PlanConverterTest.java
@@ -17,11 +17,9 @@ package io.gravitee.rest.api.service.converter;
 
 import static org.junit.Assert.*;
 
-import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.repository.management.model.Plan;
 import io.gravitee.rest.api.model.*;
-import io.gravitee.rest.api.model.api.ApiEntity;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -50,7 +48,9 @@ public class PlanConverterTest {
         plan.setGeneralConditions("general_conditions");
         plan.setSecurity(Plan.PlanSecurityType.KEY_LESS);
 
-        PlanEntity planEntity = planConverter.toPlanEntity(plan);
+        List<Flow> flows = new ArrayList<>();
+
+        PlanEntity planEntity = planConverter.toPlanEntity(plan, flows);
 
         assertEquals(plan.getId(), planEntity.getId());
         assertEquals(plan.getName(), planEntity.getName());
@@ -60,41 +60,7 @@ public class PlanConverterTest {
         assertEquals(plan.getApi(), planEntity.getApi());
         assertEquals(plan.getGeneralConditions(), planEntity.getGeneralConditions());
         assertEquals(plan.getSecurity().name(), planEntity.getSecurity().name());
-    }
-
-    @Test
-    public void toPlanEntity_should_get_flows_from_apiEntity_plans() {
-        String planId = "my-test-plan";
-
-        Plan plan = new Plan();
-        plan.setId(planId);
-        plan.setType(Plan.PlanType.API);
-        plan.setValidation(Plan.PlanValidationType.AUTO);
-
-        ApiEntity apiEntity = new ApiEntity();
-        apiEntity.setGraviteeDefinitionVersion(DefinitionVersion.V2.getLabel());
-
-        Flow flow1 = new Flow();
-        Flow flow2 = new Flow();
-        Flow flow3 = new Flow();
-
-        PlanEntity plan1 = new PlanEntity();
-        plan1.setId(planId);
-        plan1.setFlows(List.of(flow1, flow3));
-
-        PlanEntity plan2 = new PlanEntity();
-        plan2.setId("another-plan-id");
-        plan2.setFlows(List.of(flow2));
-
-        apiEntity.getPlans().add(plan1);
-        apiEntity.getPlans().add(plan2);
-
-        PlanEntity planEntity = planConverter.toPlanEntity(plan, apiEntity);
-
-        // should not contains flow 2 cause it belongs to another plan
-        assertEquals(2, planEntity.getFlows().size());
-        assertTrue(planEntity.getFlows().contains(flow1));
-        assertTrue(planEntity.getFlows().contains(flow3));
+        assertSame(flows, planEntity.getFlows());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/DebugApiServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/DebugApiServiceTest.java
@@ -73,8 +73,7 @@ public class DebugApiServiceTest {
 
     @Before
     public void setup() {
-        debugApiService =
-            new DebugApiServiceImpl(apiService, eventService, objectMapper, instanceService, new PlanConverter(new ObjectMapper()));
+        debugApiService = new DebugApiServiceImpl(apiService, eventService, objectMapper, instanceService, new PlanConverter());
 
         ApiEntity apiEntity = mock(ApiEntity.class);
         when(apiEntity.getReferenceId()).thenReturn(ENVIRONMENT_ID);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/EventServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/EventServiceTest.java
@@ -30,7 +30,6 @@ import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.Event;
 import io.gravitee.repository.management.model.EventType;
-import io.gravitee.repository.management.model.Organization;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.service.PlanService;
 import io.gravitee.rest.api.service.UserService;
@@ -568,7 +567,7 @@ public class EventServiceTest {
         throws TechnicalException, JsonProcessingException {
         ObjectMapper realObjectMapper = new ObjectMapper();
         ReflectionTestUtils.setField(eventService, "objectMapper", realObjectMapper);
-        ReflectionTestUtils.setField(eventService, "planConverter", new PlanConverter(realObjectMapper));
+        ReflectionTestUtils.setField(eventService, "planConverter", new PlanConverter());
         when(eventRepository.create(any())).thenAnswer(i -> i.getArguments()[0]);
 
         Api api = new Api();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_CloseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_CloseTest.java
@@ -22,12 +22,11 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.model.Plan;
 import io.gravitee.rest.api.model.SubscriptionEntity;
-import io.gravitee.rest.api.model.api.ApiEntity;
-import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.PlanService;
 import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.configuration.flow.FlowService;
 import io.gravitee.rest.api.service.converter.PlanConverter;
 import io.gravitee.rest.api.service.exceptions.PlanAlreadyClosedException;
 import io.gravitee.rest.api.service.exceptions.PlanNotFoundException;
@@ -72,13 +71,10 @@ public class PlanService_CloseTest {
     private AuditService auditService;
 
     @Mock
-    private ApiService apiService;
-
-    @Mock
-    private ApiEntity api;
-
-    @Mock
     private PlanConverter planConverter;
+
+    @Mock
+    private FlowService flowService;
 
     @Test(expected = PlanNotFoundException.class)
     public void shouldNotCloseBecauseNotFound() throws TechnicalException {
@@ -113,7 +109,6 @@ public class PlanService_CloseTest {
         when(subscriptionService.findByPlan(GraviteeContext.getExecutionContext(), PLAN_ID))
             .thenReturn(Collections.singleton(subscription));
         when(plan.getApi()).thenReturn(API_ID);
-        when(apiService.findById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(api);
         when(planRepository.findByApi(any())).thenReturn(Collections.emptySet());
 
         planService.close(GraviteeContext.getExecutionContext(), PLAN_ID, USER);
@@ -135,7 +130,6 @@ public class PlanService_CloseTest {
         when(subscriptionService.findByPlan(GraviteeContext.getExecutionContext(), PLAN_ID))
             .thenReturn(Collections.singleton(subscription));
         when(plan.getApi()).thenReturn(API_ID);
-        when(apiService.findById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(api);
         when(planRepository.findByApi(any())).thenReturn(Collections.emptySet());
 
         planService.close(GraviteeContext.getExecutionContext(), PLAN_ID, USER);
@@ -157,7 +151,6 @@ public class PlanService_CloseTest {
             .thenReturn(Collections.singleton(subscription));
         when(plan.getApi()).thenReturn(API_ID);
         when(planRepository.findByApi(any())).thenReturn(Collections.emptySet());
-        when(apiService.findById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(api);
 
         planService.close(GraviteeContext.getExecutionContext(), PLAN_ID, USER);
 
@@ -177,7 +170,6 @@ public class PlanService_CloseTest {
         when(subscriptionService.findByPlan(GraviteeContext.getExecutionContext(), PLAN_ID))
             .thenReturn(Collections.singleton(subscription));
         when(plan.getApi()).thenReturn(API_ID);
-        when(apiService.findById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(api);
         when(planRepository.findByApi(any())).thenReturn(Collections.emptySet());
 
         planService.close(GraviteeContext.getExecutionContext(), PLAN_ID, USER);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_CloseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_CloseTest.java
@@ -72,6 +72,12 @@ public class PlanService_CloseTest {
     private AuditService auditService;
 
     @Mock
+    private ApiService apiService;
+
+    @Mock
+    private ApiEntity api;
+
+    @Mock
     private PlanConverter planConverter;
 
     @Test(expected = PlanNotFoundException.class)
@@ -107,6 +113,7 @@ public class PlanService_CloseTest {
         when(subscriptionService.findByPlan(GraviteeContext.getExecutionContext(), PLAN_ID))
             .thenReturn(Collections.singleton(subscription));
         when(plan.getApi()).thenReturn(API_ID);
+        when(apiService.findById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(api);
         when(planRepository.findByApi(any())).thenReturn(Collections.emptySet());
 
         planService.close(GraviteeContext.getExecutionContext(), PLAN_ID, USER);
@@ -128,6 +135,7 @@ public class PlanService_CloseTest {
         when(subscriptionService.findByPlan(GraviteeContext.getExecutionContext(), PLAN_ID))
             .thenReturn(Collections.singleton(subscription));
         when(plan.getApi()).thenReturn(API_ID);
+        when(apiService.findById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(api);
         when(planRepository.findByApi(any())).thenReturn(Collections.emptySet());
 
         planService.close(GraviteeContext.getExecutionContext(), PLAN_ID, USER);
@@ -149,6 +157,7 @@ public class PlanService_CloseTest {
             .thenReturn(Collections.singleton(subscription));
         when(plan.getApi()).thenReturn(API_ID);
         when(planRepository.findByApi(any())).thenReturn(Collections.emptySet());
+        when(apiService.findById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(api);
 
         planService.close(GraviteeContext.getExecutionContext(), PLAN_ID, USER);
 
@@ -168,6 +177,7 @@ public class PlanService_CloseTest {
         when(subscriptionService.findByPlan(GraviteeContext.getExecutionContext(), PLAN_ID))
             .thenReturn(Collections.singleton(subscription));
         when(plan.getApi()).thenReturn(API_ID);
+        when(apiService.findById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(api);
         when(planRepository.findByApi(any())).thenReturn(Collections.emptySet());
 
         planService.close(GraviteeContext.getExecutionContext(), PLAN_ID, USER);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_DeleteTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_DeleteTest.java
@@ -20,11 +20,13 @@ import static org.mockito.Mockito.*;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.model.Plan;
+import io.gravitee.repository.management.model.flow.FlowReferenceType;
 import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.PlanService;
 import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.configuration.flow.FlowService;
 import io.gravitee.rest.api.service.exceptions.PlanWithSubscriptionsException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.Collections;
@@ -64,6 +66,9 @@ public class PlanService_DeleteTest {
     @Mock
     private AuditService auditService;
 
+    @Mock
+    private FlowService flowService;
+
     @Test(expected = PlanWithSubscriptionsException.class)
     public void shouldNotDeleteBecauseSubscriptionsExist() throws TechnicalException {
         when(plan.getStatus()).thenReturn(Plan.Status.PUBLISHED);
@@ -85,6 +90,7 @@ public class PlanService_DeleteTest {
         planService.delete(GraviteeContext.getExecutionContext(), PLAN_ID);
 
         verify(planRepository, times(1)).delete(PLAN_ID);
+        verify(flowService, times(1)).save(FlowReferenceType.PLAN, PLAN_ID, null);
     }
 
     @Test(expected = TechnicalManagementException.class)
@@ -105,6 +111,7 @@ public class PlanService_DeleteTest {
         planService.delete(GraviteeContext.getExecutionContext(), PLAN_ID);
 
         verify(planRepository, times(1)).delete(PLAN_ID);
+        verify(flowService, times(1)).save(FlowReferenceType.PLAN, PLAN_ID, null);
     }
 
     @Test
@@ -118,6 +125,7 @@ public class PlanService_DeleteTest {
         planService.delete(GraviteeContext.getExecutionContext(), PLAN_ID);
 
         verify(planRepository, times(1)).delete(PLAN_ID);
+        verify(flowService, times(1)).save(FlowReferenceType.PLAN, PLAN_ID, null);
     }
 
     @Test
@@ -130,5 +138,6 @@ public class PlanService_DeleteTest {
         planService.delete(GraviteeContext.getExecutionContext(), PLAN_ID);
 
         verify(planRepository, times(1)).delete(PLAN_ID);
+        verify(flowService, times(1)).save(FlowReferenceType.PLAN, PLAN_ID, null);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_DeprecateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_DeprecateTest.java
@@ -69,6 +69,12 @@ public class PlanService_DeprecateTest {
     private AuditService auditService;
 
     @Mock
+    private ApiService apiService;
+
+    @Mock
+    private ApiEntity api;
+
+    @Mock
     private PlanConverter planConverter;
 
     @Test(expected = PlanAlreadyDeprecatedException.class)
@@ -101,6 +107,7 @@ public class PlanService_DeprecateTest {
         when(plan.getType()).thenReturn(Plan.PlanType.API);
         when(plan.getValidation()).thenReturn(Plan.PlanValidationType.AUTO);
         when(plan.getApi()).thenReturn(API_ID);
+        when(apiService.findById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(api);
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
         when(planRepository.update(plan)).thenAnswer(returnsFirstArg());
 
@@ -137,6 +144,7 @@ public class PlanService_DeprecateTest {
         when(plan.getType()).thenReturn(Plan.PlanType.API);
         when(plan.getValidation()).thenReturn(Plan.PlanValidationType.AUTO);
         when(plan.getApi()).thenReturn(API_ID);
+        when(apiService.findById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(api);
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
         when(planRepository.update(plan)).thenAnswer(returnsFirstArg());
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_DeprecateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_DeprecateTest.java
@@ -22,12 +22,11 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.model.Plan;
 import io.gravitee.rest.api.model.SubscriptionEntity;
-import io.gravitee.rest.api.model.api.ApiEntity;
-import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.PlanService;
 import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.configuration.flow.FlowService;
 import io.gravitee.rest.api.service.converter.PlanConverter;
 import io.gravitee.rest.api.service.exceptions.PlanAlreadyClosedException;
 import io.gravitee.rest.api.service.exceptions.PlanAlreadyDeprecatedException;
@@ -69,13 +68,10 @@ public class PlanService_DeprecateTest {
     private AuditService auditService;
 
     @Mock
-    private ApiService apiService;
-
-    @Mock
-    private ApiEntity api;
-
-    @Mock
     private PlanConverter planConverter;
+
+    @Mock
+    private FlowService flowService;
 
     @Test(expected = PlanAlreadyDeprecatedException.class)
     public void shouldNotDepreciateBecauseAlreadyDepreciated() throws TechnicalException {
@@ -107,7 +103,6 @@ public class PlanService_DeprecateTest {
         when(plan.getType()).thenReturn(Plan.PlanType.API);
         when(plan.getValidation()).thenReturn(Plan.PlanValidationType.AUTO);
         when(plan.getApi()).thenReturn(API_ID);
-        when(apiService.findById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(api);
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
         when(planRepository.update(plan)).thenAnswer(returnsFirstArg());
 
@@ -144,7 +139,6 @@ public class PlanService_DeprecateTest {
         when(plan.getType()).thenReturn(Plan.PlanType.API);
         when(plan.getValidation()).thenReturn(Plan.PlanValidationType.AUTO);
         when(plan.getApi()).thenReturn(API_ID);
-        when(apiService.findById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(api);
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
         when(planRepository.update(plan)).thenAnswer(returnsFirstArg());
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_FindByApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_FindByApiTest.java
@@ -55,13 +55,21 @@ public class PlanService_FindByApiTest {
     private PlanRepository planRepository;
 
     @Mock
+    private ApiService apiService;
+
+    @Mock
     private Plan plan;
+
+    @Mock
+    private ApiEntity api;
 
     @Mock
     private PlanConverter planConverter;
 
     @Test
     public void shouldFindByApi() throws TechnicalException {
+        when(plan.getApi()).thenReturn(API_ID);
+        when(apiService.findById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(api);
         when(planRepository.findByApi(API_ID)).thenReturn(Collections.singleton(plan));
 
         final Set<PlanEntity> plans = planService.findByApi(GraviteeContext.getExecutionContext(), API_ID);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_FindByIdTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_FindByIdTest.java
@@ -19,17 +19,19 @@ import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.model.Plan;
+import io.gravitee.repository.management.model.flow.FlowReferenceType;
 import io.gravitee.rest.api.model.PlanEntity;
-import io.gravitee.rest.api.model.api.ApiEntity;
-import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.PlanService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.configuration.flow.FlowService;
 import io.gravitee.rest.api.service.converter.PlanConverter;
 import io.gravitee.rest.api.service.exceptions.PlanNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.util.List;
 import java.util.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -52,28 +54,29 @@ public class PlanService_FindByIdTest {
     private PlanService planService = new PlanServiceImpl();
 
     @Mock
-    private ApiService apiService;
-
-    @Mock
     private PlanRepository planRepository;
 
     @Mock
     private Plan plan;
 
     @Mock
-    private ApiEntity api;
+    private List<Flow> planFlows;
 
     @Mock
     private PlanConverter planConverter;
 
+    @Mock
+    private FlowService flowService;
+
     @Test
     public void shouldFindById() throws TechnicalException {
-        when(plan.getApi()).thenReturn(API_ID);
-        when(apiService.findById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(api);
+        when(plan.getId()).thenReturn(PLAN_ID);
+
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
+        when(flowService.findByReference(FlowReferenceType.PLAN, PLAN_ID)).thenReturn(planFlows);
 
         PlanEntity planEntityFromConverter = mock(PlanEntity.class);
-        when(planConverter.toPlanEntity(plan, api)).thenReturn(planEntityFromConverter);
+        when(planConverter.toPlanEntity(plan, planFlows)).thenReturn(planEntityFromConverter);
 
         final PlanEntity resultPlanEntity = planService.findById(GraviteeContext.getExecutionContext(), PLAN_ID);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_FindByIdTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_FindByIdTest.java
@@ -46,9 +46,13 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class PlanService_FindByIdTest {
 
     private static final String PLAN_ID = "my-plan";
+    private static final String API_ID = "my-api";
 
     @InjectMocks
     private PlanService planService = new PlanServiceImpl();
+
+    @Mock
+    private ApiService apiService;
 
     @Mock
     private PlanRepository planRepository;
@@ -57,14 +61,19 @@ public class PlanService_FindByIdTest {
     private Plan plan;
 
     @Mock
+    private ApiEntity api;
+
+    @Mock
     private PlanConverter planConverter;
 
     @Test
     public void shouldFindById() throws TechnicalException {
+        when(plan.getApi()).thenReturn(API_ID);
+        when(apiService.findById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(api);
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
 
         PlanEntity planEntityFromConverter = mock(PlanEntity.class);
-        when(planConverter.toPlanEntity(plan)).thenReturn(planEntityFromConverter);
+        when(planConverter.toPlanEntity(plan, api)).thenReturn(planEntityFromConverter);
 
         final PlanEntity resultPlanEntity = planService.findById(GraviteeContext.getExecutionContext(), PLAN_ID);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_PublishTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_PublishTest.java
@@ -18,15 +18,17 @@ package io.gravitee.rest.api.service.impl;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.Mockito.*;
 
-import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.model.Plan;
 import io.gravitee.rest.api.model.PageEntity;
 import io.gravitee.rest.api.model.SubscriptionEntity;
-import io.gravitee.rest.api.model.api.ApiEntity;
-import io.gravitee.rest.api.service.*;
+import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.PageService;
+import io.gravitee.rest.api.service.PlanService;
+import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.configuration.flow.FlowService;
 import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.converter.PlanConverter;
 import io.gravitee.rest.api.service.exceptions.*;
@@ -71,16 +73,13 @@ public class PlanService_PublishTest {
     private PageService pageService;
 
     @Mock
-    private ApiService apiService;
-
-    @Mock
-    private ApiEntity apiEntity;
-
-    @Mock
     private PlanConverter planConverter;
 
     @Mock
     private ApiConverter apiConverter;
+
+    @Mock
+    private FlowService flowService;
 
     @Test(expected = PlanAlreadyPublishedException.class)
     public void shouldNotPublishBecauseAlreadyPublished() throws TechnicalException {
@@ -149,7 +148,6 @@ public class PlanService_PublishTest {
         when(plan.getApi()).thenReturn(API_ID);
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
         when(planRepository.update(plan)).thenAnswer(returnsFirstArg());
-        when(apiService.findById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(apiEntity);
 
         planService.publish(GraviteeContext.getExecutionContext(), PLAN_ID);
 
@@ -165,7 +163,6 @@ public class PlanService_PublishTest {
         when(plan.getApi()).thenReturn(API_ID);
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
         when(planRepository.update(plan)).thenAnswer(returnsFirstArg());
-        when(apiService.findById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(apiEntity);
 
         planService.publish(GraviteeContext.getExecutionContext(), PLAN_ID);
 
@@ -183,7 +180,6 @@ public class PlanService_PublishTest {
         when(plan.getGeneralConditions()).thenReturn(GC_PAGE_ID);
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
         when(planRepository.update(plan)).thenAnswer(returnsFirstArg());
-        when(apiService.findById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(apiEntity);
 
         PageEntity page = mock(PageEntity.class);
         when(page.getId()).thenReturn(GC_PAGE_ID);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_PublishTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_PublishTest.java
@@ -71,7 +71,16 @@ public class PlanService_PublishTest {
     private PageService pageService;
 
     @Mock
+    private ApiService apiService;
+
+    @Mock
+    private ApiEntity apiEntity;
+
+    @Mock
     private PlanConverter planConverter;
+
+    @Mock
+    private ApiConverter apiConverter;
 
     @Test(expected = PlanAlreadyPublishedException.class)
     public void shouldNotPublishBecauseAlreadyPublished() throws TechnicalException {
@@ -140,6 +149,7 @@ public class PlanService_PublishTest {
         when(plan.getApi()).thenReturn(API_ID);
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
         when(planRepository.update(plan)).thenAnswer(returnsFirstArg());
+        when(apiService.findById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(apiEntity);
 
         planService.publish(GraviteeContext.getExecutionContext(), PLAN_ID);
 
@@ -155,6 +165,7 @@ public class PlanService_PublishTest {
         when(plan.getApi()).thenReturn(API_ID);
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
         when(planRepository.update(plan)).thenAnswer(returnsFirstArg());
+        when(apiService.findById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(apiEntity);
 
         planService.publish(GraviteeContext.getExecutionContext(), PLAN_ID);
 
@@ -172,6 +183,7 @@ public class PlanService_PublishTest {
         when(plan.getGeneralConditions()).thenReturn(GC_PAGE_ID);
         when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
         when(planRepository.update(plan)).thenAnswer(returnsFirstArg());
+        when(apiService.findById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(apiEntity);
 
         PageEntity page = mock(PageEntity.class);
         when(page.getId()).thenReturn(GC_PAGE_ID);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_UpdateTest.java
@@ -30,6 +30,7 @@ import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.Plan;
+import io.gravitee.repository.management.model.flow.FlowReferenceType;
 import io.gravitee.rest.api.model.PageEntity;
 import io.gravitee.rest.api.model.PlanValidationType;
 import io.gravitee.rest.api.model.SubscriptionEntity;
@@ -37,6 +38,7 @@ import io.gravitee.rest.api.model.UpdatePlanEntity;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.configuration.flow.FlowService;
 import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.converter.PlanConverter;
 import io.gravitee.rest.api.service.exceptions.PlanGeneralConditionStatusException;
@@ -101,6 +103,9 @@ public class PlanService_UpdateTest {
 
     @Mock
     private ApiConverter apiConverter;
+
+    @Mock
+    private FlowService flowService;
 
     @Test
     public void shouldUpdate() throws TechnicalException {
@@ -253,7 +258,7 @@ public class PlanService_UpdateTest {
 
         planService.update(GraviteeContext.getExecutionContext(), updatePlan, true);
 
-        verify(planRepository, times(1)).update(argThat(plan1 -> !plan1.getFlows().isEmpty()));
+        verify(flowService, times(1)).save(FlowReferenceType.PLAN, updatePlan.getId(), updatePlan.getFlows());
     }
 
     @Test(expected = PlanInvalidException.class)
@@ -310,7 +315,7 @@ public class PlanService_UpdateTest {
 
         planService.update(GraviteeContext.getExecutionContext(), updatePlan, true);
 
-        verify(planRepository, times(1)).update(argThat(plan1 -> !plan1.getFlows().isEmpty()));
+        verify(flowService, times(1)).save(FlowReferenceType.PLAN, updatePlan.getId(), updatePlan.getFlows());
     }
 
     @Test


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7693

**Description**

refactor: plans flows are stored in flows collection instead of api definition
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/refactor-planflowsinplancollection/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hamzcapztc.chromatic.com)
<!-- Storybook placeholder end -->
