### PR TITLE
refactor: compile x-forwarded-for delimiter pattern only once

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/forward/XForwardForProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/forward/XForwardForProcessor.java
@@ -22,12 +22,18 @@ import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.context.MutableExecutionContext;
 import io.gravitee.gateway.core.processor.AbstractProcessor;
 import java.util.Arrays;
+import java.util.regex.Pattern;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
 public class XForwardForProcessor extends AbstractProcessor<ExecutionContext> {
+
+    /**
+     * {@link java.util.regex.Pattern} for a comma delimited string
+     */
+    private static final Pattern COMMA_SEPARATED_VALUES_PATTERN = Pattern.compile(",");
 
     @Override
     public void handle(ExecutionContext context) {
@@ -64,6 +70,6 @@ public class XForwardForProcessor extends AbstractProcessor<ExecutionContext> {
             return new String[0];
         }
 
-        return Arrays.stream(commaDelimitedStrings.split(",")).map(String::strip).toArray(String[]::new);
+        return Arrays.stream(COMMA_SEPARATED_VALUES_PATTERN.split(commaDelimitedStrings)).map(String::strip).toArray(String[]::new);
     }
 }


### PR DESCRIPTION
see https://github.com/gravitee-io/issues/issues/7765
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/7765-refactor/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-orqkfmzeyy.chromatic.com)
<!-- Storybook placeholder end -->
