### PR TITLE
ci: deploy locally before "sync" on private artifactory and OSS nexus

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,14 +116,7 @@ commands:
 parameters:
     gio_action:
         type: enum
-        enum:
-          [
-              release,
-              package_bundle,
-              nexus_staging,
-              pull_requests,
-              build_rpm_&_docker_images,
-          ]
+        enum: [release, package_bundle, nexus_staging, pull_requests, build_rpm_&_docker_images]
         default: pull_requests
     dry_run:
         type: boolean
@@ -451,7 +444,7 @@ jobs:
                       if [ "<< parameters.enterprise_edition >>" == "true" ]; then
                         dockerTag=$(echo $dockerTag | sed 's/-/-ee-/')
                       fi
-                      
+
                       export REST_API_PRIVATE_IMAGE_TAG=graviteeio.azurecr.io/apim-management-api:${dockerTag}
                       export GATEWAY_PRIVATE_IMAGE_TAG=graviteeio.azurecr.io/apim-gateway:${dockerTag}
 
@@ -977,15 +970,15 @@ jobs:
                   command: |
                       export GIT_GRAVITEE_PACKAGES_REPO=$(mktemp -d)
                       git clone git@github.com:gravitee-io/packages.git ${GIT_GRAVITEE_PACKAGES_REPO}
-                      
+
                       cd ${GIT_GRAVITEE_PACKAGES_REPO}/apim/3.x
                       ./build.sh -v << parameters.graviteeio_version >>
-                      
+
                       if [ "<< parameters.dry_run >>" == "false" ]; then
                           docker run --rm -v "${GIT_GRAVITEE_PACKAGES_REPO}/apim/3.x:/packages" -e PACKAGECLOUD_TOKEN=${GIO_PACKAGECLOUD_TOKEN} digitalocean/packagecloud push --yes --skip-errors --verbose graviteeio/rpms/el/7 /packages/*.rpm
                       else
                           echo "This is just a DRY RUN, no RPMs will be published"
-                      fi;                    
+                      fi;
 
     package-bundle:
         docker:
@@ -1019,7 +1012,7 @@ jobs:
                   name: "Prepare bundles for uploading"
                   command: |
                       workingDir=$(pwd)
-                      
+
                       ####################
                       #Distribution - Full                                            
                       ####################
@@ -1047,7 +1040,7 @@ jobs:
                       sha1sum gravitee-apim-gateway-${RELEASE_VERSION}.zip > gravitee-apim-gateway-${RELEASE_VERSION}.zip.sha1
 
                       cd $workingDir
-                      
+
                       ######################
                       #Components - Rest API
                       ######################
@@ -1081,13 +1074,13 @@ jobs:
                       ####################
                       mkdir -p graviteeio-apim/components/gravitee-portal-webui
                       cp ./tmp/${RELEASE_VERSION}/portals/gravitee-apim-portal-webui-${RELEASE_VERSION}.zip graviteeio-apim/components/gravitee-portal-webui/
-                      
+
                       cd graviteeio-apim/components/gravitee-portal-webui
 
                       md5sum gravitee-apim-portal-webui-${RELEASE_VERSION}.zip > gravitee-apim-portal-webui-${RELEASE_VERSION}.zip.md5
                       sha512sum gravitee-apim-portal-webui-${RELEASE_VERSION}.zip > gravitee-apim-portal-webui-${RELEASE_VERSION}.zip.sha512sum
                       sha1sum gravitee-apim-portal-webui-${RELEASE_VERSION}.zip > gravitee-apim-portal-webui-${RELEASE_VERSION}.zip.sha1
-                      
+
                       cd $workingDir
 
                       #############
@@ -1126,38 +1119,38 @@ jobs:
                   command: |
                       workingDir=$(pwd)
                       eeWorkingDir=./tmp/${RELEASE_VERSION}/ee
-                      
+
                       mkdir -p graviteeio-ee/apim/distributions
                       mkdir -p $eeWorkingDir
                       unzip ./tmp/${RELEASE_VERSION}/dist/graviteeio-full-${RELEASE_VERSION}.zip -d $eeWorkingDir
                       cd $eeWorkingDir
-                      
+
                       # move to EE node
                       wget https://download.gravitee.io/graviteeio-ee/license/gravitee-license-node-enterprise-${LICENSE_VERSION}.jar --no-check-certificate
                       cp gravitee-license-node-enterprise-${LICENSE_VERSION}.jar graviteeio-full-${RELEASE_VERSION}/graviteeio-apim-rest-api-${RELEASE_VERSION}/lib/
                       cp gravitee-license-node-enterprise-${LICENSE_VERSION}.jar graviteeio-full-${RELEASE_VERSION}/graviteeio-apim-gateway-${RELEASE_VERSION}/lib/
-                      
+
                       # add the WS connector
                       wget https://download.gravitee.io/graviteeio-ae/plugins/connectors/gravitee-ae-connectors-ws/gravitee-ae-connectors-ws-${AE_VERSION}.zip --no-check-certificate
                       cp gravitee-ae-connectors-ws-${AE_VERSION}.zip graviteeio-full-${RELEASE_VERSION}/graviteeio-apim-rest-api-${RELEASE_VERSION}/plugins/
                       cp gravitee-ae-connectors-ws-${AE_VERSION}.zip graviteeio-full-${RELEASE_VERSION}/graviteeio-apim-gateway-${RELEASE_VERSION}/plugins/
-                      
+
                       # add the notifiers
                       wget https://download.gravitee.io/plugins/notifiers/gravitee-notifier-email/gravitee-notifier-email-${NOTIFIER_EMAIL_VERSION}.zip --no-check-certificate -P graviteeio-full-${RELEASE_VERSION}/graviteeio-apim-rest-api-${RELEASE_VERSION}/plugins
                       wget https://download.gravitee.io/plugins/notifiers/gravitee-notifier-slack/gravitee-notifier-slack-${NOTIFIER_SLACK_VERSION}.zip --no-check-certificate -P graviteeio-full-${RELEASE_VERSION}/graviteeio-apim-rest-api-${RELEASE_VERSION}/plugins
                       wget https://download.gravitee.io/plugins/notifiers/gravitee-notifier-webhook/gravitee-notifier-webhook-${NOTIFIER_WEBHOOK_VERSION}.zip --no-check-certificate -P graviteeio-full-${RELEASE_VERSION}/graviteeio-apim-rest-api-${RELEASE_VERSION}/plugins
-                      
+
                       # Prepare license directory
                       mkdir graviteeio-full-${RELEASE_VERSION}/graviteeio-apim-rest-api-${RELEASE_VERSION}/license
                       mkdir graviteeio-full-${RELEASE_VERSION}/graviteeio-apim-gateway-${RELEASE_VERSION}/license
-                      
+
                       # rezip
                       zip -r -9 graviteeio-ee-full-${RELEASE_VERSION}.zip graviteeio-full-${RELEASE_VERSION} release.json
                       cd $workingDir
-                      
+
                       cp $eeWorkingDir/graviteeio-ee-full-${RELEASE_VERSION}.zip graviteeio-ee/apim/distributions
                       cd graviteeio-ee/apim/distributions
-                      
+
                       md5sum graviteeio-ee-full-${RELEASE_VERSION}.zip > graviteeio-ee-full-${RELEASE_VERSION}.zip.md5
                       sha512sum graviteeio-ee-full-${RELEASE_VERSION}.zip > graviteeio-ee-full-${RELEASE_VERSION}.zip.sha512sum
                       sha1sum graviteeio-ee-full-${RELEASE_VERSION}.zip > graviteeio-ee-full-${RELEASE_VERSION}.zip.sha1
@@ -1238,18 +1231,18 @@ workflows:
                           only:
                               - master
                               - /^\d+\.\d+\.x$/
-            -   publish-images-azure-registry:
-                    name: Publish ce images on azure registry
-                    context: cicd-orchestrator
-                    enterprise_edition: false
-                    requires:
-                        - test
-                        - test-repository
-                    filters:
-                        branches:
-                            only:
-                                - master
-                                - /^\d+\.\d+\.x$/
+            - publish-images-azure-registry:
+                  name: Publish ce images on azure registry
+                  context: cicd-orchestrator
+                  enterprise_edition: false
+                  requires:
+                      - test
+                      - test-repository
+                  filters:
+                      branches:
+                          only:
+                              - master
+                              - /^\d+\.\d+\.x$/
             - webui-install:
                   name: Install APIM Console
                   apim-ui-project: gravitee-apim-console-webui

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,7 +267,7 @@ jobs:
             - run:
                   name: "Build project"
                   command: |
-                      mvn -pl '!gravitee-apim-console-webui, !gravitee-apim-portal-webui' -s .gravitee.settings.xml clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -T 2C -P distribution-dev,distribution-ee
+                      mvn -pl '!gravitee-apim-console-webui, !gravitee-apim-portal-webui' -s .gravitee.settings.xml clean deploy -DaltDeploymentRepository=local::default::file:./target/staging-deploy --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -T 2C -P distribution-dev,distribution-ee
                       mkdir -p ./rest-api-docker-context/distribution && cp -r ./gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target/distribution ./rest-api-docker-context/.
                       mkdir -p ./gateway-docker-context/distribution && cp -r ./gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target/distribution ./gateway-docker-context/.
 
@@ -276,6 +276,11 @@ jobs:
                   paths:
                       - ~/.m2/repository/io/gravitee/apim
                   key: gravitee-api-management-v6-build-apim-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+                  when: on_success
+            - save_cache:
+                  paths:
+                      - ./target/staging-deploy
+                  key: gravitee-api-management-v6-artefact-deploy-apim-{{ .Environment.CIRCLE_WORKFLOW_ID }}
                   when: on_success
             - run:
                   name: "Exclude APIM artefacts from build cache"
@@ -360,17 +365,21 @@ jobs:
             - image: cimg/openjdk:11.0
         resource_class: large
         environment:
-            ALT_DEPLOYMENT_REPOSITORY: "artifactory-gravitee::default::https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots"
+            REPOSITORY_URL: "https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots"
+            REPOSITORY_ID: "artifactory-gravitee"
         steps:
             - checkout
             - attach_workspace:
                   at: .
             - restore-maven-job-cache:
                   jobName: publish-on-artifactory
+            - restore_cache:
+                  keys:
+                      - gravitee-api-management-v6-artefact-deploy-apim-{{ .Environment.CIRCLE_WORKFLOW_ID }}
             - run:
-                  name: "Maven Package and deploy to Artifactory ([gravitee-snapshots] repository)"
+                  name: "Maven deploy to Artifactory from local staging ([gravitee-snapshots] repository)"
                   command: |
-                      mvn deploy --no-transfer-progress -DskipTests -Dskip.validation=true -T 2C -pl '!gravitee-apim-console-webui, !gravitee-apim-portal-webui' -s .gravitee.settings.xml   -DaltDeploymentRepository=${ALT_DEPLOYMENT_REPOSITORY}
+                      mvn org.codehaus.mojo:wagon-maven-plugin:3.0.0-M2:merge-maven-repos -Dwagon.source=file:./target/staging-deploy -Dwagon.target=${REPOSITORY_URL} -Dwagon.targetId=${REPOSITORY_ID} --no-transfer-progress -s .gravitee.settings.xml
             - notify-on-failure
             - save-maven-job-cache:
                   jobName: publish-on-artifactory
@@ -385,10 +394,13 @@ jobs:
                   at: .
             - restore-maven-job-cache:
                   jobName: publish-on-nexus
+            - restore_cache:
+                  keys:
+                      - gravitee-api-management-v6-artefact-deploy-apim-{{ .Environment.CIRCLE_WORKFLOW_ID }}
             - run:
-                  name: "Maven Package and deploy to Nexus Snapshots"
+                  name: "Maven deploy to Nexus Snapshots from local staging"
                   command: |
-                      mvn deploy --no-transfer-progress -DskipTests -Dskip.validation=true -T 2C -pl '!gravitee-apim-console-webui, !gravitee-apim-portal-webui' -s .gravitee.settings.xml
+                      mvn org.sonatype.plugins:nexus-staging:1.6.13:deploy-staged-repository -DserverId=sonatype-nexus-snapshots -DnexusUrl=https://oss.sonatype.org/content/repositories/snapshots -DrepositoryDirectory=./target/staging-deploy --no-transfer-progress -s .gravitee.settings.xml
             - notify-on-failure
             - save-maven-job-cache:
                   jobName: publish-on-nexus

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1178,166 +1178,170 @@ workflows:
                   context: gravitee-qa
                   requires:
                       - validate
-            - test:
-                  requires:
-                      - build
-            - sonarcloud-analysis:
-                  name: Sonar - << matrix.working_directory >>
-                  matrix:
-                      parameters:
-                          working_directory:
-                              - gravitee-apim-rest-api
-                              - gravitee-apim-gateway
-                              - gravitee-apim-definition
-                  context: cicd-orchestrator
-                  requires:
-                      - test
-            - test-repository:
-                  requires:
-                      - build
-            - sonarcloud-analysis:
-                  name: Sonar - gravitee-apim-repository
-                  working_directory: gravitee-apim-repository
-                  context: cicd-orchestrator
-                  requires:
-                      - test-repository
+#            - test:
+#                  requires:
+#                      - build
+#            - sonarcloud-analysis:
+#                  name: Sonar - << matrix.working_directory >>
+#                  matrix:
+#                      parameters:
+#                          working_directory:
+#                              - gravitee-apim-rest-api
+#                              - gravitee-apim-gateway
+#                              - gravitee-apim-definition
+#                  context: cicd-orchestrator
+#                  requires:
+#                      - test
+#            - test-repository:
+#                  requires:
+#                      - build
+#            - sonarcloud-analysis:
+#                  name: Sonar - gravitee-apim-repository
+#                  working_directory: gravitee-apim-repository
+#                  context: cicd-orchestrator
+#                  requires:
+#                      - test-repository
             - publish-on-artifactory:
                   filters:
                       branches:
                           only:
                               - master
                               - /^\d+\.\d+\.x$/
+                              - improve-artefacts-deployment
                   requires:
-                      - test
-                      - test-repository
+#                      - test
+#                      - test-repository
+                      - build
             - publish-on-nexus:
                   filters:
                       branches:
                           only:
                               - master
                               - /^\d+\.\d+\.x$/
+                              - improve-artefacts-deployment
                   requires:
-                      - test
-                      - test-repository
-            - publish-images-azure-registry:
-                  name: Publish ee images on azure registry
-                  context: cicd-orchestrator
-                  enterprise_edition: true
-                  requires:
-                      - test
-                      - test-repository
-                  filters:
-                      branches:
-                          only:
-                              - master
-                              - /^\d+\.\d+\.x$/
-            - publish-images-azure-registry:
-                  name: Publish ce images on azure registry
-                  context: cicd-orchestrator
-                  enterprise_edition: false
-                  requires:
-                      - test
-                      - test-repository
-                  filters:
-                      branches:
-                          only:
-                              - master
-                              - /^\d+\.\d+\.x$/
-            - webui-install:
-                  name: Install APIM Console
-                  apim-ui-project: gravitee-apim-console-webui
-                  requires:
-                      - setup
-            - webui-lint-test:
-                  name: Lint & test APIM Console
-                  apim-ui-project: gravitee-apim-console-webui
-                  requires:
-                      - Install APIM Console
-            - sonarcloud-analysis:
-                  name: Sonar - << matrix.working_directory >>
-                  matrix:
-                      parameters:
-                          working_directory:
-                              - gravitee-apim-console-webui
-                  context: cicd-orchestrator
-                  requires:
-                      - Lint & test APIM Console
-            - webui-build:
-                  name: Build APIM Console
-                  apim-ui-project: gravitee-apim-console-webui
-                  requires:
-                      - Install APIM Console
-            - console-webui-deploy-on-azure-storage:
-                  context: cicd-orchestrator
-                  requires:
-                      - Build APIM Console
-            - console-webui-comment-pr-after-deployment:
-                  context: cicd-orchestrator
-                  requires:
-                      - console-webui-deploy-on-azure-storage
-            - webui-publish-images-azure-registry:
-                  name: Build and publish APIM Console docker image
-                  apim-ui-project: gravitee-apim-console-webui
-                  docker-image-name: apim-management-ui
-                  context: cicd-orchestrator
-                  requires:
-                      - Build APIM Console
-                      - setup
-                  filters:
-                      branches:
-                          only:
-                              - master
-                              - /^\d+\.\d+\.x$/
-            - webui-install:
-                  name: Install APIM Portal
-                  apim-ui-project: gravitee-apim-portal-webui
-                  requires:
-                      - setup
-            - webui-lint-test:
-                  name: Lint & test APIM Portal
-                  apim-ui-project: gravitee-apim-portal-webui
-                  resource-class: large
-                  requires:
-                      - Install APIM Portal
-            - sonarcloud-analysis:
-                  name: Sonar - << matrix.working_directory >>
-                  matrix:
-                      parameters:
-                          working_directory:
-                              - gravitee-apim-portal-webui
-                  context: cicd-orchestrator
-                  requires:
-                      - Lint & test APIM Portal
-            - webui-build:
-                  name: Build APIM Portal
-                  apim-ui-project: gravitee-apim-portal-webui
-                  requires:
-                      - Install APIM Portal
-            - webui-publish-images-azure-registry:
-                  name: Build and publish APIM Portal docker image
-                  apim-ui-project: gravitee-apim-portal-webui
-                  docker-image-name: apim-portal-ui
-                  context: cicd-orchestrator
-                  requires:
-                      - Build APIM Portal
-                      - setup
-                  filters:
-                      branches:
-                          only:
-                              - master
-                              - /^\d+\.\d+\.x$/
-            - deploy-on-azure-cluster:
-                  context: cicd-orchestrator
-                  requires:
-                      - Publish ee images on azure registry
-                      - Publish ce images on azure registry
-                      - Build and publish APIM Console docker image
-                      - Build and publish APIM Portal docker image
-                  filters:
-                      branches:
-                          only:
-                              - master
-                              - /^\d+\.\d+\.x$/
+#                      - test
+#                      - test-repository
+                      - build
+#            - publish-images-azure-registry:
+#                  name: Publish ee images on azure registry
+#                  context: cicd-orchestrator
+#                  enterprise_edition: true
+#                  requires:
+#                      - test
+#                      - test-repository
+#                  filters:
+#                      branches:
+#                          only:
+#                              - master
+#                              - /^\d+\.\d+\.x$/
+#            - publish-images-azure-registry:
+#                  name: Publish ce images on azure registry
+#                  context: cicd-orchestrator
+#                  enterprise_edition: false
+#                  requires:
+#                      - test
+#                      - test-repository
+#                  filters:
+#                      branches:
+#                          only:
+#                              - master
+#                              - /^\d+\.\d+\.x$/
+#            - webui-install:
+#                  name: Install APIM Console
+#                  apim-ui-project: gravitee-apim-console-webui
+#                  requires:
+#                      - setup
+#            - webui-lint-test:
+#                  name: Lint & test APIM Console
+#                  apim-ui-project: gravitee-apim-console-webui
+#                  requires:
+#                      - Install APIM Console
+#            - sonarcloud-analysis:
+#                  name: Sonar - << matrix.working_directory >>
+#                  matrix:
+#                      parameters:
+#                          working_directory:
+#                              - gravitee-apim-console-webui
+#                  context: cicd-orchestrator
+#                  requires:
+#                      - Lint & test APIM Console
+#            - webui-build:
+#                  name: Build APIM Console
+#                  apim-ui-project: gravitee-apim-console-webui
+#                  requires:
+#                      - Install APIM Console
+#            - console-webui-deploy-on-azure-storage:
+#                  context: cicd-orchestrator
+#                  requires:
+#                      - Build APIM Console
+#            - console-webui-comment-pr-after-deployment:
+#                  context: cicd-orchestrator
+#                  requires:
+#                      - console-webui-deploy-on-azure-storage
+#            - webui-publish-images-azure-registry:
+#                  name: Build and publish APIM Console docker image
+#                  apim-ui-project: gravitee-apim-console-webui
+#                  docker-image-name: apim-management-ui
+#                  context: cicd-orchestrator
+#                  requires:
+#                      - Build APIM Console
+#                      - setup
+#                  filters:
+#                      branches:
+#                          only:
+#                              - master
+#                              - /^\d+\.\d+\.x$/
+#            - webui-install:
+#                  name: Install APIM Portal
+#                  apim-ui-project: gravitee-apim-portal-webui
+#                  requires:
+#                      - setup
+#            - webui-lint-test:
+#                  name: Lint & test APIM Portal
+#                  apim-ui-project: gravitee-apim-portal-webui
+#                  resource-class: large
+#                  requires:
+#                      - Install APIM Portal
+#            - sonarcloud-analysis:
+#                  name: Sonar - << matrix.working_directory >>
+#                  matrix:
+#                      parameters:
+#                          working_directory:
+#                              - gravitee-apim-portal-webui
+#                  context: cicd-orchestrator
+#                  requires:
+#                      - Lint & test APIM Portal
+#            - webui-build:
+#                  name: Build APIM Portal
+#                  apim-ui-project: gravitee-apim-portal-webui
+#                  requires:
+#                      - Install APIM Portal
+#            - webui-publish-images-azure-registry:
+#                  name: Build and publish APIM Portal docker image
+#                  apim-ui-project: gravitee-apim-portal-webui
+#                  docker-image-name: apim-portal-ui
+#                  context: cicd-orchestrator
+#                  requires:
+#                      - Build APIM Portal
+#                      - setup
+#                  filters:
+#                      branches:
+#                          only:
+#                              - master
+#                              - /^\d+\.\d+\.x$/
+#            - deploy-on-azure-cluster:
+#                  context: cicd-orchestrator
+#                  requires:
+#                      - Publish ee images on azure registry
+#                      - Publish ce images on azure registry
+#                      - Build and publish APIM Console docker image
+#                      - Build and publish APIM Portal docker image
+#                  filters:
+#                      branches:
+#                          only:
+#                              - master
+#                              - /^\d+\.\d+\.x$/
 
     build_rpm_&_docker_images:
         when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,7 +372,7 @@ jobs:
             - run:
                   name: "Maven deploy to Artifactory from local staging ([gravitee-snapshots] repository)"
                   command: |
-                      mvn org.codehaus.mojo:wagon-maven-plugin:3.0.0-M2:merge-maven-repos -Dwagon.source=file:./target/staging-deploy -Dwagon.target=${REPOSITORY_URL} -Dwagon.targetId=${REPOSITORY_ID} --no-transfer-progress -s .gravitee.settings.xml
+                      mvn org.codehaus.mojo:wagon-maven-plugin:2.0.2:merge-maven-repos -Dwagon.source=file:./target/staging-deploy -Dwagon.target=${REPOSITORY_URL} -Dwagon.targetId=${REPOSITORY_ID} --no-transfer-progress -s .gravitee.settings.xml
             - notify-on-failure
             - save-maven-job-cache:
                   jobName: publish-on-artifactory
@@ -393,7 +393,7 @@ jobs:
             - run:
                   name: "Maven deploy to Nexus Snapshots from local staging"
                   command: |
-                      mvn org.sonatype.plugins:nexus-staging:1.6.13:deploy-staged-repository -DserverId=sonatype-nexus-snapshots -DnexusUrl=https://oss.sonatype.org/content/repositories/snapshots -DrepositoryDirectory=./target/staging-deploy --no-transfer-progress -s .gravitee.settings.xml
+                      mvn org.sonatype.plugins:nexus-staging-maven-plugin:1.6.6:deploy-staged-repository -DserverId=sonatype-nexus-snapshots -DnexusUrl=https://oss.sonatype.org/content/repositories/snapshots -DstagingProfileId=${STAGING_PROFILE_ID} -DrepositoryDirectory=./target/staging-deploy --no-transfer-progress -s .gravitee.settings.xml
             - notify-on-failure
             - save-maven-job-cache:
                   jobName: publish-on-nexus
@@ -1170,14 +1170,15 @@ workflows:
         jobs:
             - setup:
                   context: cicd-orchestrator
-            - validate:
-                  context: gravitee-qa
-                  requires:
-                      - setup
+#            - validate:
+#                  context: gravitee-qa
+#                  requires:
+#                      - setup
             - build:
                   context: gravitee-qa
                   requires:
-                      - validate
+#                      - validate
+                      - setup
 #            - test:
 #                  requires:
 #                      - build
@@ -1213,6 +1214,7 @@ workflows:
 #                      - test-repository
                       - build
             - publish-on-nexus:
+                  context: sonatype
                   filters:
                       branches:
                           only:


### PR DESCRIPTION
**Issue**

N/A

**Description**

Use this article to save time while deploying on artifactory and nexus:
https://maven.apache.org/plugins/maven-deploy-plugin/examples/deploy-network-issues.html

The main purpose is to deploy first in a local folder, and then sync from this folder to remotes repositories.
By doing this, we can expect publication to artifactory and nexus to be faster as the packaging phase will be done
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/improve-artefacts-deployment/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
