### PR TITLE
fix: Do not try to redeliver updated heartbeat event, only the creati…

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-heartbeat/src/main/java/io/gravitee/gateway/services/heartbeat/HeartbeatService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-heartbeat/src/main/java/io/gravitee/gateway/services/heartbeat/HeartbeatService.java
@@ -155,31 +155,37 @@ public class HeartbeatService extends AbstractService<HeartbeatService> implemen
         // Writing event to the repository is the responsibility of the master node
         if (clusterManager.isMasterNode()) {
             Event event = message.getMessageObject();
-            try {
-                String state = event.getProperties().get(EVENT_STATE_PROPERTY);
-                if (state != null) {
+
+            String state = event.getProperties().get(EVENT_STATE_PROPERTY);
+            if (state != null) {
+                try {
                     eventRepository.create(event);
-                } else {
-                    eventRepository.update(event);
+                } catch (Exception ex) {
+                    // We make the assumption that an IllegalStateException is thrown when trying to update the
+                    // event while it is not existing in the database anymore.
+                    // This can be caused, for instance, by a db event cleanup without taking care of the heartbeat event.
+                    event.getProperties().put(EVENT_STATE_PROPERTY, "recreate");
+                    LOGGER.error(
+                        "An error occurred while trying to create the heartbeat event id[{}] type[{}] while it is not existing anymore",
+                        event.getId(),
+                        event.getType(),
+                        ex
+                    );
+                    topic.publish(event);
                 }
-            } catch (IllegalStateException isex) {
-                // We make the assumption that an IllegalStateException is thrown when trying to update the event while it is not existing in the database anymore.
-                // This can be cause, for instance, by a db event cleanup without taking care of the heartbeat event.
-                event.getProperties().put(EVENT_STATE_PROPERTY, "recreate");
-                LOGGER.warn(
-                    "An error occurred while trying to update the event id[{}] type[{}] while it is not existing anymore",
-                    event.getId(),
-                    event.getType()
-                );
-                topic.publish(event);
-            } catch (Exception ex) {
-                // We assume to loose the event if something goes wrong and not republish it to avoid infinite loop and cpu starving. It will be overridden by the next heartbeat event.
-                LOGGER.warn(
-                    "An error occurred while pushing heartbeat event id[{}] type[{}]. Message is: {}",
-                    event.getId(),
-                    event.getType(),
-                    ex.getMessage()
-                );
+            } else {
+                try {
+                    eventRepository.update(event);
+                } catch (Exception ex) {
+                    // We assume to lose the event if something goes wrong and not republish it to avoid infinite
+                    // loop and cpu starving. It will be overridden by the next heartbeat event.
+                    LOGGER.warn(
+                        "An error occurred while trying to update the heartbeat event id[{}] type[{}], skipping it...",
+                        event.getId(),
+                        event.getType(),
+                        ex
+                    );
+                }
             }
         }
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-heartbeat/src/test/java/io/gravitee/gateway/services/heartbeat/HeartbeatServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-heartbeat/src/test/java/io/gravitee/gateway/services/heartbeat/HeartbeatServiceTest.java
@@ -86,7 +86,7 @@ public class HeartbeatServiceTest {
     }
 
     @Test
-    public void shouldRepublishEventWhenIllegalArgumentExceptionIsThrown() throws TechnicalException {
+    public void shouldNotRepublishEventWhenIllegalArgumentExceptionIsThrown() throws TechnicalException {
         Event event = new Event();
         event.setId(UUID.toString(UUID.random()));
         event.setProperties(new HashMap<>());
@@ -97,8 +97,8 @@ public class HeartbeatServiceTest {
             .thenThrow(new IllegalStateException(String.format("No event found with id [%s]", event.getId())));
         cut.onMessage(message);
 
-        verify(topic).publish(event);
-        assertEquals("recreate", event.getProperties().get(EVENT_STATE_PROPERTY));
+        verifyNoInteractions(topic);
+        assertTrue(event.getProperties().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
…on of the event must be ensured

**Issue**

https://github.com/gravitee-io/issues/issues/7806

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-7806-heartbeat-event/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
