### PR TITLE
fix: upgrade tcp and file reporter fixes http headers reporting

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -111,8 +111,8 @@
         <gravitee-reporter-elasticsearch.version>3.11.0</gravitee-reporter-elasticsearch.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->
         <!--    <gravitee-gateway-services-ratelimit.version>1.15.0</gravitee-gateway-services-ratelimit.version>    -->
-        <gravitee-reporter-file.version>2.5.0</gravitee-reporter-file.version>
-        <gravitee-reporter-tcp.version>1.4.0</gravitee-reporter-tcp.version>
+        <gravitee-reporter-file.version>2.5.2-SNAPSHOT</gravitee-reporter-file.version>
+        <gravitee-reporter-tcp.version>1.4.2-SNAPSHOT</gravitee-reporter-tcp.version>
         <gravitee-tracer-jaeger.version>1.1.0</gravitee-tracer-jaeger.version>
     </properties>
 


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7741

**Description**

fix: upgrade tcp and file reporter fixes http headers reporting
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-httpheadersserialization/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
