### PR TITLE
fix: synchronize service discovery starts

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-endpoint-discovery/src/main/java/io/gravitee/gateway/services/endpoint/discovery/verticle/EndpointDiscoveryVerticle.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-endpoint-discovery/src/main/java/io/gravitee/gateway/services/endpoint/discovery/verticle/EndpointDiscoveryVerticle.java
@@ -108,7 +108,11 @@ public class EndpointDiscoveryVerticle extends AbstractVerticle implements Event
         }
     }
 
-    private void startServiceDiscovery(final Api api, final EndpointGroup group, final EndpointDiscoveryService discoveryService) {
+    private synchronized void startServiceDiscovery(
+        final Api api,
+        final EndpointGroup group,
+        final EndpointDiscoveryService discoveryService
+    ) {
         LOGGER.info(
             "A discovery service is defined for API id[{}] name[{}] group[{}] type[{}]",
             api.getId(),


### PR DESCRIPTION
Fix https://github.com/gravitee-io/issues/issues/7821

**Description**

We have an issue when we start APIM using the service discovery eureka plugin.

To reproduce the actual behaviour.

1. Run an Eureka Server and register **two** applications. ( you use this basic _hello world_ https://spring.io/guides/gs/service-registration-and-discovery/ ) 

<img width="1792" alt="Screenshot 2022-06-08 at 14 05 38" src="https://user-images.githubusercontent.com/25704259/172612044-b776dc81-2cd1-4385-ace4-8360b3a7becb.png">

2. Start APIM using the gravitee-service-discovery-eureka-1.2.0.zip and the following configuration
```yml
service-discovery:
  eureka:
    client:
      refresh:
        interval: 30
    serviceUrl:
      default: http://localhost:8761/eureka
```

3. Create two application that use the service discovery. ( Go to endpoint the in group settings you should be able to activate the option )

4. Restart the gateway. With the ``synchronized`` you should not have an exception saying that the zip file has been closed.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-sync-service-discovery-start/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
