### PR TITLE
fix regression in API imports

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
@@ -411,7 +411,7 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
                 MemberToImport memberToImport = objectMapper.readValue(memberNode.toString(), MemberToImport.class);
                 boolean presentWithSameRole = isPresentWithSameRole(membersAlreadyPresent, memberToImport);
 
-                List<String> rolesToImport = getRolesToImport(memberToImport);
+                List<String> roleIdsToImport = getRoleIdsToImport(memberToImport);
                 addOrUpdateMembers(
                     apiId,
                     organizationId,
@@ -419,7 +419,7 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
                     poRoleId,
                     currentPo,
                     memberToImport,
-                    rolesToImport,
+                    roleIdsToImport,
                     presentWithSameRole
                 );
 
@@ -427,12 +427,12 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
                 if (
                     currentPo.getSourceId().equals(memberToImport.getSourceId()) &&
                     currentPo.getSource().equals(memberToImport.getSource()) &&
-                    !rolesToImport.contains(poRoleId)
+                    !roleIdsToImport.contains(poRoleId)
                 ) {
-                    roleUsedInTransfert = rolesToImport;
+                    roleUsedInTransfert = roleIdsToImport;
                 }
 
-                if (rolesToImport.contains(poRoleId)) {
+                if (roleIdsToImport.contains(poRoleId)) {
                     futurePo = memberToImport;
                 }
             }
@@ -460,37 +460,30 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
         );
     }
 
-    protected List<String> getRolesToImport(MemberToImport memberToImport) {
-        List<String> rolesToImport = memberToImport.getRoles();
-        if (rolesToImport == null) {
-            rolesToImport = new ArrayList<>();
-            memberToImport.setRoles(rolesToImport);
+    protected List<String> getRoleIdsToImport(MemberToImport memberToImport) {
+        // Starting with v3, multiple roles per member can be imported and it is a list of role Ids.
+        List<String> roleIdsToImport = memberToImport.getRoles();
+        if (roleIdsToImport == null) {
+            roleIdsToImport = new ArrayList<>();
+            memberToImport.setRoles(roleIdsToImport);
         } else {
-            rolesToImport = new ArrayList<>(rolesToImport);
+            roleIdsToImport = new ArrayList<>(roleIdsToImport);
         }
 
-        // Before v3, only one role per member could be imported
-        String roleToAdd = memberToImport.getRole();
-        if (roleToAdd != null && !roleToAdd.isEmpty()) {
-            rolesToImport.add(roleToAdd);
+        // Before v3, only one role per member could be imported and it was a role name.
+        String roleNameToAdd = memberToImport.getRole();
+        if (roleNameToAdd != null && !roleNameToAdd.isEmpty()) {
+            Optional<RoleEntity> optRoleToAddEntity = roleService.findByScopeAndName(RoleScope.API, roleNameToAdd);
+            if (optRoleToAddEntity.isPresent()) {
+                roleIdsToImport.add(optRoleToAddEntity.get().getId());
+            } else {
+                LOGGER.warn("Role {} does not exist", roleNameToAdd);
+            }
         }
 
-        return rolesToImport
-            .stream()
-            .map(
-                role -> {
-                    final Optional<RoleEntity> optRoleToAddEntity = roleService.findByScopeAndName(RoleScope.API, role);
-                    if (optRoleToAddEntity.isPresent()) {
-                        return role;
-                    } else {
-                        LOGGER.warn("Role {} does not exist", roleToAdd);
-                        return null;
-                    }
-                }
-            )
-            .filter(Objects::nonNull)
-            .sorted(Comparator.naturalOrder())
-            .collect(Collectors.toList());
+        roleIdsToImport.sort(Comparator.naturalOrder());
+
+        return roleIdsToImport;
     }
 
     private void addOrUpdateMembers(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
@@ -596,7 +596,7 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
 
     protected void updatePlans(String apiId, JsonNode jsonNode, String environmentId, boolean isUpdate) throws JsonProcessingException {
         final JsonNode plansDefinition = jsonNode.path(API_DEFINITION_FIELD_PLANS);
-        if (plansDefinition != null && plansDefinition.isArray() && plansDefinition.size() > 0) {
+        if (plansDefinition != null && plansDefinition.isArray()) {
             List<PlanEntity> plansToImport = objectMapper.readValue(
                 plansDefinition.toString(),
                 objectMapper.getTypeFactory().constructCollectionType(List.class, PlanEntity.class)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_CreateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_CreateWithDefinitionTest.java
@@ -144,11 +144,9 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         RoleEntity poRoleEntity = new RoleEntity();
         poRoleEntity.setId("API_PRIMARY_OWNER");
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), eq(RoleScope.API))).thenReturn(poRoleEntity);
-        when(roleService.findByScopeAndName(RoleScope.API, "API_PRIMARY_OWNER")).thenReturn(Optional.of(poRoleEntity));
 
         RoleEntity ownerRoleEntity = new RoleEntity();
         ownerRoleEntity.setId("API_OWNER");
-        when(roleService.findByScopeAndName(RoleScope.API, "API_OWNER")).thenReturn(Optional.of(ownerRoleEntity));
 
         MemberEntity po = new MemberEntity();
         po.setId("admin");
@@ -225,11 +223,9 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         RoleEntity poRoleEntity = new RoleEntity();
         poRoleEntity.setId("API_PRIMARY_OWNER");
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), eq(RoleScope.API))).thenReturn(poRoleEntity);
-        when(roleService.findByScopeAndName(RoleScope.API, "API_PRIMARY_OWNER")).thenReturn(Optional.of(poRoleEntity));
 
         RoleEntity ownerRoleEntity = new RoleEntity();
         ownerRoleEntity.setId("API_OWNER");
-        when(roleService.findByScopeAndName(RoleScope.API, "API_OWNER")).thenReturn(Optional.of(ownerRoleEntity));
 
         MemberEntity po = new MemberEntity();
         po.setId("admin");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_UpdateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_UpdateWithDefinitionTest.java
@@ -146,11 +146,9 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         RoleEntity poRoleEntity = new RoleEntity();
         poRoleEntity.setId("API_PRIMARY_OWNER");
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), eq(RoleScope.API))).thenReturn(poRoleEntity);
-        when(roleService.findByScopeAndName(RoleScope.API, "API_PRIMARY_OWNER")).thenReturn(Optional.of(poRoleEntity));
 
         RoleEntity ownerRoleEntity = new RoleEntity();
         ownerRoleEntity.setId("API_OWNER");
-        when(roleService.findByScopeAndName(RoleScope.API, "API_OWNER")).thenReturn(Optional.of(ownerRoleEntity));
 
         MemberEntity po = new MemberEntity();
         po.setId("admin");
@@ -243,11 +241,9 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         RoleEntity poRole = new RoleEntity();
         poRole.setId("API_PRIMARY_OWNER");
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), any())).thenReturn(poRole);
-        when(roleService.findByScopeAndName(RoleScope.API, "API_PRIMARY_OWNER")).thenReturn(Optional.of(poRole));
 
         RoleEntity ownerRole = new RoleEntity();
         ownerRole.setId("API_OWNER");
-        when(roleService.findByScopeAndName(RoleScope.API, "API_OWNER")).thenReturn(Optional.of(ownerRole));
 
         MemberEntity po = new MemberEntity();
         po.setId("admin");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImplTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.service.impl;
 
+import static java.util.Collections.singleton;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -309,11 +310,16 @@ public class ApiDuplicatorServiceImplTest {
     }
 
     @Test
-    public void shouldNotUpdatePlansIfEmptyPlan_APIupdateMode() throws IOException {
+    public void shouldDeleteAllExistingPlansIfEmptyPlan_APIupdateMode() throws IOException {
         JsonNode emptyPlansNode = loadTestNode(IMPORT_FILES_FOLDER + "import-api.plans.empty.json");
+        PlanEntity planEntity = new PlanEntity();
+        planEntity.setId("existing-plan-id");
+        when(planService.findByApi(API_ID)).thenReturn(singleton(planEntity));
         apiDuplicatorService.updatePlans(API_ID, emptyPlansNode, ENVIRONMENT_ID, true);
 
-        verifyNoInteractions(planService);
+        verify(planService, times(1)).findByApi(API_ID);
+        verify(planService, times(1)).delete("existing-plan-id");
+        verify(planService, never()).createOrUpdatePlan(any(), any());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImplTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import io.gravitee.rest.api.model.*;
@@ -173,9 +172,7 @@ public class ApiDuplicatorServiceImplTest {
         memberToImport.setSourceId("user-sourceId");
         memberToImport.setRoles(Collections.singletonList(userRoleEntity.getId()));
 
-        when(roleService.findByScopeAndName(RoleScope.API, "user-role")).thenReturn(Optional.of(userRoleEntity));
-
-        final List<String> rolesToImport = apiDuplicatorService.getRolesToImport(memberToImport);
+        final List<String> rolesToImport = apiDuplicatorService.getRoleIdsToImport(memberToImport);
 
         assertNotNull(rolesToImport);
         assertEquals(1, rolesToImport.size());
@@ -194,7 +191,7 @@ public class ApiDuplicatorServiceImplTest {
 
         when(roleService.findByScopeAndName(RoleScope.API, "user-role")).thenReturn(Optional.of(userRoleEntity));
 
-        final List<String> rolesToImport = apiDuplicatorService.getRolesToImport(memberToImport);
+        final List<String> rolesToImport = apiDuplicatorService.getRoleIdsToImport(memberToImport);
 
         assertNotNull(rolesToImport);
         assertEquals(1, rolesToImport.size());
@@ -204,26 +201,28 @@ public class ApiDuplicatorServiceImplTest {
     @Test
     public void shouldGetRolesToImport_fromRolesAndRole() {
         RoleEntity userRoleEntity1 = new RoleEntity();
-        userRoleEntity1.setId("user-role-1");
+        userRoleEntity1.setId("user-role-1-id");
+        userRoleEntity1.setName("user-role-1-name");
         RoleEntity userRoleEntity2 = new RoleEntity();
-        userRoleEntity2.setId("user-role-2");
+        userRoleEntity2.setId("user-role-2-id");
+        userRoleEntity2.setName("user-role-2-name");
 
-        when(roleService.findByScopeAndName(RoleScope.API, "user-role-1")).thenReturn(Optional.of(userRoleEntity1));
-        when(roleService.findByScopeAndName(RoleScope.API, "user-role-2")).thenReturn(Optional.of(userRoleEntity2));
-        when(roleService.findByScopeAndName(RoleScope.API, "unexisting_role")).thenReturn(Optional.empty());
+        when(roleService.findByScopeAndName(RoleScope.API, "user-role-1-name")).thenReturn(Optional.of(userRoleEntity1));
 
         ApiDuplicatorServiceImpl.MemberToImport memberToImport = new ApiDuplicatorServiceImpl.MemberToImport();
         memberToImport.setSource("user-source");
         memberToImport.setSourceId("user-sourceId");
         memberToImport.setRoles(List.of(userRoleEntity2.getId(), "unexisting_role"));
-        memberToImport.setRole(userRoleEntity1.getId());
+        memberToImport.setRole(userRoleEntity1.getName());
 
-        final List<String> rolesToImport = apiDuplicatorService.getRolesToImport(memberToImport);
+        final List<String> rolesToImport = apiDuplicatorService.getRoleIdsToImport(memberToImport);
 
         assertNotNull(rolesToImport);
-        assertEquals(2, rolesToImport.size());
-        assertEquals("user-role-1", rolesToImport.get(0));
-        assertEquals("user-role-2", rolesToImport.get(1));
+        assertEquals(3, rolesToImport.size());
+        assertTrue(rolesToImport.contains("user-role-1-id"));
+        assertTrue(rolesToImport.contains("user-role-2-id"));
+        // The check on role existence will occur when creating the membership. So this method returns every roleId available in the definition.
+        assertTrue(rolesToImport.contains("unexisting_role"));
     }
 
     /*


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7807

**Description**

This [commit](https://github.com/gravitee-io/gravitee-api-management/commit/c0fd2ecbb47cd7e63e227882702b05f6e8e4aa80) made in 3.10.x and merged in upper branches has introduced regressions. This PR fixes them.

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7807-fix-api-import-regressions/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
