### PR TITLE
fix: fix a regression on API import when no plan imported

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
@@ -572,7 +572,7 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
     }
 
     protected void createOrUpdatePlans(String apiId, ImportApiJsonNode apiJsonNode, String environmentId) throws IOException {
-        if (apiJsonNode.hasPlans() && !apiJsonNode.getPlans().isEmpty()) {
+        if (apiJsonNode.hasPlans()) {
             Map<String, PlanEntity> existingPlans = planService
                 .findByApi(apiId)
                 .stream()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
@@ -51,7 +51,6 @@ import io.vertx.core.buffer.Buffer;
 import java.io.IOException;
 import java.util.*;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -375,7 +374,7 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
                 MemberToImport memberToImport = objectMapper.readValue(memberNode.toString(), MemberToImport.class);
                 boolean presentWithSameRole = isPresentWithSameRole(membersAlreadyPresent, memberToImport);
 
-                List<String> rolesToImport = getRolesToImport(memberToImport);
+                List<String> roleIdsToImport = getRoleIdsToImport(memberToImport);
                 addOrUpdateMembers(
                     apiId,
                     organizationId,
@@ -383,7 +382,7 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
                     poRoleId,
                     currentPo,
                     memberToImport,
-                    rolesToImport,
+                    roleIdsToImport,
                     presentWithSameRole
                 );
 
@@ -391,12 +390,12 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
                 if (
                     currentPo.getSourceId().equals(memberToImport.getSourceId()) &&
                     currentPo.getSource().equals(memberToImport.getSource()) &&
-                    !rolesToImport.contains(poRoleId)
+                    !roleIdsToImport.contains(poRoleId)
                 ) {
-                    roleUsedInTransfert = rolesToImport;
+                    roleUsedInTransfert = roleIdsToImport;
                 }
 
-                if (rolesToImport.contains(poRoleId)) {
+                if (roleIdsToImport.contains(poRoleId)) {
                     futurePo = memberToImport;
                 }
             }
@@ -444,37 +443,29 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
         );
     }
 
-    protected List<String> getRolesToImport(MemberToImport memberToImport) {
-        List<String> rolesToImport = memberToImport.getRoles();
-        if (rolesToImport == null) {
-            rolesToImport = new ArrayList<>();
-            memberToImport.setRoles(rolesToImport);
+    protected List<String> getRoleIdsToImport(MemberToImport memberToImport) {
+        // Starting with v3, multiple roles per member can be imported and it is a list of role Ids.
+        List<String> roleIdsToImport = memberToImport.getRoles();
+        if (roleIdsToImport == null) {
+            roleIdsToImport = new ArrayList<>();
+            memberToImport.setRoles(roleIdsToImport);
         } else {
-            rolesToImport = new ArrayList<>(rolesToImport);
+            roleIdsToImport = new ArrayList<>(roleIdsToImport);
         }
 
-        // Before v3, only one role per member could be imported
-        String roleToAdd = memberToImport.getRole();
-        if (roleToAdd != null && !roleToAdd.isEmpty()) {
-            rolesToImport.add(roleToAdd);
+        // Before v3, only one role per member could be imported and it was a role name.
+        String roleNameToAdd = memberToImport.getRole();
+        if (roleNameToAdd != null && !roleNameToAdd.isEmpty()) {
+            Optional<RoleEntity> optRoleToAddEntity = roleService.findByScopeAndName(RoleScope.API, roleNameToAdd);
+            if (optRoleToAddEntity.isPresent()) {
+                roleIdsToImport.add(optRoleToAddEntity.get().getId());
+            } else {
+                LOGGER.warn("Role {} does not exist", roleNameToAdd);
+            }
         }
+        roleIdsToImport.sort(Comparator.naturalOrder());
 
-        return rolesToImport
-            .stream()
-            .map(
-                role -> {
-                    final Optional<RoleEntity> optRoleToAddEntity = roleService.findByScopeAndName(RoleScope.API, role);
-                    if (optRoleToAddEntity.isPresent()) {
-                        return role;
-                    } else {
-                        LOGGER.warn("Role {} does not exist", roleToAdd);
-                        return null;
-                    }
-                }
-            )
-            .filter(Objects::nonNull)
-            .sorted(Comparator.naturalOrder())
-            .collect(Collectors.toList());
+        return roleIdsToImport;
     }
 
     private void addOrUpdateMembers(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImplTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.service.impl;
 
+import static java.util.Collections.singleton;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -253,11 +254,16 @@ public class ApiDuplicatorServiceImplTest {
     }
 
     @Test
-    public void shouldNotUpdatePlansIfEmptyPlan() throws IOException {
+    public void shouldDeleteAllExistingPlansIfEmptyPlan() throws IOException {
         ImportApiJsonNode emptyPlansNode = loadTestNode(IMPORT_FILES_FOLDER + "import-api.plans.empty.json");
+        PlanEntity planEntity = new PlanEntity();
+        planEntity.setId("existing-plan-id");
+        when(planService.findByApi(API_ID)).thenReturn(singleton(planEntity));
         apiDuplicatorService.createOrUpdatePlans(API_ID, emptyPlansNode, ENVIRONMENT_ID);
 
-        verifyNoInteractions(planService);
+        verify(planService, times(1)).findByApi(API_ID);
+        verify(planService, times(1)).delete("existing-plan-id");
+        verify(planService, never()).createOrUpdatePlan(any(), any());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_CreateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_CreateWithDefinitionTest.java
@@ -150,11 +150,9 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         RoleEntity poRoleEntity = new RoleEntity();
         poRoleEntity.setId("API_PRIMARY_OWNER");
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), eq(RoleScope.API))).thenReturn(poRoleEntity);
-        when(roleService.findByScopeAndName(RoleScope.API, "API_PRIMARY_OWNER")).thenReturn(Optional.of(poRoleEntity));
 
         RoleEntity ownerRoleEntity = new RoleEntity();
         ownerRoleEntity.setId("API_OWNER");
-        when(roleService.findByScopeAndName(RoleScope.API, "API_OWNER")).thenReturn(Optional.of(ownerRoleEntity));
 
         MemberEntity po = new MemberEntity();
         po.setId("admin");
@@ -230,11 +228,9 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         RoleEntity poRoleEntity = new RoleEntity();
         poRoleEntity.setId("API_PRIMARY_OWNER");
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), eq(RoleScope.API))).thenReturn(poRoleEntity);
-        when(roleService.findByScopeAndName(RoleScope.API, "API_PRIMARY_OWNER")).thenReturn(Optional.of(poRoleEntity));
 
         RoleEntity ownerRoleEntity = new RoleEntity();
         ownerRoleEntity.setId("API_OWNER");
-        when(roleService.findByScopeAndName(RoleScope.API, "API_OWNER")).thenReturn(Optional.of(ownerRoleEntity));
 
         MemberEntity po = new MemberEntity();
         po.setId("admin");
@@ -529,7 +525,6 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
 
         RoleEntity ownerRoleEntity = new RoleEntity();
         ownerRoleEntity.setId("API_OWNER");
-        when(roleService.findByScopeAndName(RoleScope.API, "API_OWNER")).thenReturn(Optional.of(ownerRoleEntity));
 
         MemberEntity po = new MemberEntity();
         po.setId("admin");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_UpdateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_UpdateWithDefinitionTest.java
@@ -158,11 +158,9 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         RoleEntity poRoleEntity = new RoleEntity();
         poRoleEntity.setId("API_PRIMARY_OWNER");
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), eq(RoleScope.API))).thenReturn(poRoleEntity);
-        when(roleService.findByScopeAndName(RoleScope.API, "API_PRIMARY_OWNER")).thenReturn(Optional.of(poRoleEntity));
 
         RoleEntity ownerRoleEntity = new RoleEntity();
         ownerRoleEntity.setId("API_OWNER");
-        when(roleService.findByScopeAndName(RoleScope.API, "API_OWNER")).thenReturn(Optional.of(ownerRoleEntity));
 
         MemberEntity po = new MemberEntity();
         po.setId("admin");
@@ -254,11 +252,9 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         RoleEntity poRole = new RoleEntity();
         poRole.setId("API_PRIMARY_OWNER");
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), any())).thenReturn(poRole);
-        when(roleService.findByScopeAndName(RoleScope.API, "API_PRIMARY_OWNER")).thenReturn(Optional.of(poRole));
 
         RoleEntity ownerRole = new RoleEntity();
         ownerRole.setId("API_OWNER");
-        when(roleService.findByScopeAndName(RoleScope.API, "API_OWNER")).thenReturn(Optional.of(ownerRole));
 
         MemberEntity po = new MemberEntity();
         po.setId("admin");


### PR DESCRIPTION
**Issue**

linked to https://github.com/gravitee-io/issues/issues/7807

**Description**

fix regressions introduced in 3.10.15
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-api-import-regressions/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jtzgexccut.chromatic.com)
<!-- Storybook placeholder end -->
