### PR TITLE
fix: do not join multi value headers as a unique coma separated string

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/DebugReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/DebugReactor.java
@@ -33,6 +33,7 @@ import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.*;
+import io.vertx.core.http.impl.headers.HeadersAdaptor;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import io.vertx.core.net.*;
 import java.util.*;
@@ -232,7 +233,7 @@ public class DebugReactor extends DefaultReactor {
     MultiMap convertHeaders(Map<String, List<String>> headers) {
         final HeadersMultiMap headersMultiMap = new HeadersMultiMap();
         if (headers != null) {
-            headers.forEach((key, value) -> headersMultiMap.add(key, String.join(", ", value)));
+            headers.forEach(headersMultiMap::set);
         }
         return headersMultiMap;
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/reactor/DebugReactorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/reactor/DebugReactorTest.java
@@ -383,6 +383,8 @@ public class DebugReactorTest {
         assertThat(result.get("X-Gravitee-Transaction-Id")).contains("transaction-id");
         assertThat(result.get("content-type")).contains("application/json");
         assertThat(result.get("X-Gravitee-Request-Id")).contains("request-id");
-        assertThat(result.get("accept-encoding")).contains("deflate", "gzip", "compress");
+        assertThat(result.getAll("accept-encoding")).containsAll(List.of("deflate", "gzip", "compress"));
+        // Implementation returned by convertHeaders(headers) will return the first value when using get(key)
+        assertThat(result.get("accept-encoding")).contains("deflate");
     }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7809

**Description**

We were joining multi value headers with a `,` to have a single string.

It is a modification of the customer request, meaning it could falsify the debug session of a user.

Let's say, in a groovy policy, the user wants to access the header value arrays to join these on one string, then it's not possible.

This fix just add the header entry as a `key: String, value: List<String>` instead of `key: String, value:String`
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-7809-debugmode-multivalue-header/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
