### PR TITLE
Bump gravitee-node to 1.24.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <gravitee-expression-language.version>1.9.2</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>1.32.2</gravitee-gateway-api.version>
-        <gravitee-node.version>1.24.1</gravitee-node.version>
+        <gravitee-node.version>1.24.2</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>
         <gravitee-plugin.version>1.23.2</gravitee-plugin.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7740

**Description**

Bump gravitee-node to 1.24.2
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/7740-bump-gravitee-node-master/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wzpouwbqtg.chromatic.com)
<!-- Storybook placeholder end -->
