### PR TITLE
chore: bump elastic reporter to 3.8.6 [ 3.10.x ]

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -103,7 +103,7 @@
         <gravitee-fetcher-gitlab.version>1.11.0</gravitee-fetcher-gitlab.version>
         <gravitee-fetcher-http.version>1.12.0</gravitee-fetcher-http.version>
         <!-- Gateway Only -->
-        <gravitee-reporter-elasticsearch.version>3.8.5</gravitee-reporter-elasticsearch.version>
+        <gravitee-reporter-elasticsearch.version>3.8.6</gravitee-reporter-elasticsearch.version>
         <gravitee-reporter-file.version>2.4.3</gravitee-reporter-file.version>
         <gravitee-reporter-kafka.version>1.3.0</gravitee-reporter-kafka.version>
         <gravitee-reporter-tcp.version>1.3.3</gravitee-reporter-tcp.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7094

**Description**

Linked to this PR https://github.com/gravitee-io/gravitee-reporter-elasticsearch/pull/16

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-bump-gravitee-reporter-elasticsearch/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
