### PR TITLE
fix: fix gateway management API access

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Endpoint.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Endpoint.java
@@ -157,6 +157,7 @@ public class Endpoint implements Serializable {
         this.healthCheck = healthCheck;
     }
 
+    @JsonIgnore
     public Set<EndpointStatusListener> getEndpointAvailabilityListeners() {
         return this.listeners;
     }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/EndpointTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/EndpointTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.model;
+
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.definition.model.endpoint.EndpointStatusListener;
+import org.junit.Test;
+
+public class EndpointTest {
+
+    private String expectedJsonString = String.join(
+        ",",
+        "{\"name\":\"my-name\"",
+        "\"target\":\"my-target\"",
+        "\"weight\":1",
+        "\"backup\":false",
+        "\"tenants\":null",
+        "\"type\":\"my-type\"",
+        "\"inherit\":null",
+        "\"healthcheck\":null}"
+    );
+
+    @Test
+    public void shouldSerializeEndpoint() throws JsonProcessingException {
+        Endpoint endpoint = new Endpoint("my-type", "my-name", "my-target");
+
+        String serializedEndpoint = new ObjectMapper().writeValueAsString(endpoint);
+
+        assertEquals(expectedJsonString, serializedEndpoint);
+    }
+
+    @Test
+    public void shouldSerializeEndpoint_withUnserializableStatusListener() throws JsonProcessingException {
+        /* This simulates an EndpointStatusListener that jackson will fail to serialize
+         * For serialization, jackson will call the getter that throws an exception
+         */
+        var unserializableStatusListener = new EndpointStatusListener() {
+            public void onStatusChanged(Endpoint.Status s) {}
+
+            public String getTestData() throws Exception {
+                throw new Exception("Serialization fails");
+            }
+        };
+
+        Endpoint endpoint = new Endpoint("my-type", "my-name", "my-target");
+        endpoint.addEndpointAvailabilityListener(unserializableStatusListener);
+
+        String serializedEndpoint = new ObjectMapper().writeValueAsString(endpoint);
+
+        assertEquals(expectedJsonString, serializedEndpoint);
+    }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7287

**Description**

fix: fix gateway management API access

Commit 7e1ecfec added a getter for Endpoint status listeners.

It introduced a regression when ApiManagementEndpoint tries to serialize the API :
ManagedEndpoint is not serializable cause it doesn't contains any getter, and at all endpointAvailabilityListener couldn't be serialized cause it references himself and would cause an infinite serialization loop.

This commit ignores status listeners during serialization, making behave like before this change.
Junit tests ensure Endpoint can serialize without problem even if having a unserializable endpointAvailabilityListener.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-fixendpointserialization-315/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
