### PR TITLE
chore: fix license target directory in maven assembly plugin

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
@@ -69,7 +69,7 @@
 
         <fileSet>
             <directory>src/main/resources/license</directory>
-            <outputDirectory>lib</outputDirectory>
+            <outputDirectory>license</outputDirectory>
             <includes>
                 <include>*.*</include>
             </includes>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
@@ -78,7 +78,7 @@
 
         <fileSet>
             <directory>src/main/resources/license</directory>
-            <outputDirectory>lib</outputDirectory>
+            <outputDirectory>license</outputDirectory>
             <includes>
                 <include>*.*</include>
             </includes>


### PR DESCRIPTION
chore: fix license target directory in maven assembly plugin
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/chore-licensefiletargetdirectory/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ekccskdjwd.chromatic.com)
<!-- Storybook placeholder end -->
