### PR TITLE
Chore/fix ee ebuild

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,6 +293,12 @@
             </dependency>
 
             <dependency>
+                <groupId>com.graviteesource.license</groupId>
+                <artifactId>gravitee-license-node</artifactId>
+                <version>${gravitee-license-node.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>io.gravitee.plugin</groupId>
                 <artifactId>gravitee-plugin-service-discovery</artifactId>
                 <version>${gravitee-plugin.version}</version>


### PR DESCRIPTION
Building APIM with maven ee profile activated causes this error :
'dependencies.dependency.version' for com.graviteesource.license:gravitee-license-node:jar is missing.

So, restored the gravitee-license-node in dependencyManagement section of pom
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-evzcshtvhh.chromatic.com)
<!-- Storybook placeholder end -->
