### PR TITLE
Chore/fix ee ebuild

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
         <gravitee-expression-language.version>1.9.2</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>1.33.0</gravitee-gateway-api.version>
+        <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>1.24.2</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>
         <gravitee-plugin.version>1.24.1</gravitee-plugin.version>
@@ -295,6 +296,12 @@
                 <groupId>io.gravitee.plugin</groupId>
                 <artifactId>gravitee-plugin-resource</artifactId>
                 <version>${gravitee-plugin.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.graviteesource.license</groupId>
+                <artifactId>gravitee-license-node</artifactId>
+                <version>${gravitee-license-node.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Building APIM with maven ee profile activated causes this error :
'dependencies.dependency.version' for com.graviteesource.license:gravitee-license-node:jar is missing.

So, restored the gravitee-license-node in dependencyManagement section of pom
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/chore-fixeebuild-master/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kiinsuswzw.chromatic.com)
<!-- Storybook placeholder end -->
