### PR TITLE
tests: testing sdk improvments

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/AbstractHttp2GatewayTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/AbstractHttp2GatewayTest.java
@@ -35,6 +35,6 @@ public abstract class AbstractHttp2GatewayTest extends AbstractGatewayTest {
 
     @Override
     protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
-        gatewayConfigurationBuilder.set("http.secured", "true").set("http.alpn", "true").set("http.ssl.keystore.type", "self-signed");
+        gatewayConfigurationBuilder.set("http.secured", true).set("http.alpn", true).set("http.ssl.keystore.type", "self-signed");
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/GatewayTestingExtension.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/GatewayTestingExtension.java
@@ -138,6 +138,7 @@ public class GatewayTestingExtension implements BeforeAllCallback, BeforeEachCal
         if (testInstance instanceof AbstractGatewayTest) {
             gatewayTest = (AbstractGatewayTest) testInstance;
             final GatewayConfigurationBuilder gatewayConfigurationBuilder = GatewayConfigurationBuilder.emptyConfiguration();
+            gatewayConfigurationBuilder.set("http.instances", 1);
             gatewayTest.configureGateway(gatewayConfigurationBuilder);
             gatewayRunner = new GatewayRunner(gatewayConfigurationBuilder, gatewayTest);
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/runner/GatewayRunner.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/runner/GatewayRunner.java
@@ -162,7 +162,7 @@ public class GatewayRunner {
         System.setProperty("gravitee.home", graviteeHome);
         System.setProperty("gravitee.conf", graviteeHome + File.separator + "config" + File.separator + "gravitee.yml");
 
-        gatewayConfigurationBuilder.build().forEach((k, v) -> System.setProperty((String) k, (String) v));
+        gatewayConfigurationBuilder.build().forEach((k, v) -> System.setProperty(String.valueOf(k), String.valueOf(v)));
         System.setProperty("http.port", String.valueOf(gatewayPort));
         System.setProperty("services.core.http.port", String.valueOf(technicalApiPort));
         System.setProperty("services.core.http.enabled", String.valueOf(false));


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7600

**Description**

- define only one http instance for gateway instance for testing sdk instead of being cpu based
- allow to configure gateway with objects instead of strings only
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/issues-7600-sdk-defaut-instance-non-string-properties/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jvjpaqcvkf.chromatic.com)
<!-- Storybook placeholder end -->
