### PR TITLE
fix: add mapping for apiPrimaryOwner when updating group

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
@@ -817,6 +817,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         group.setEmailInvitation(entity.isEmailInvitation());
         group.setEnvironmentId(environmentId);
         group.setDisableMembershipNotifications(entity.isDisableMembershipNotifications());
+        group.setApiPrimaryOwner(entity.getApiPrimaryOwner());
 
         return group;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/GroupService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/GroupService_UpdateTest.java
@@ -36,7 +36,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 /**
@@ -76,7 +75,10 @@ public class GroupService_UpdateTest {
         updatedGroupEntity.setRoles(Maps.<RoleScope, String>builder().put(RoleScope.API, "OWNER").build());
         updatedGroupEntity.setSystemInvitation(false);
 
-        when(groupRepository.findById(GROUP_ID)).thenReturn(Optional.of(Mockito.mock(Group.class)));
+        final Group group = new Group();
+        group.setApiPrimaryOwner("api-primary-owner");
+
+        when(groupRepository.findById(GROUP_ID)).thenReturn(Optional.of(group));
         when(permissionService.hasPermission(RolePermission.ENVIRONMENT_GROUP, "DEFAULT", CREATE, UPDATE, DELETE)).thenReturn(true);
         when(membershipService.getRoles(any(), any(), any(), any())).thenReturn(Collections.emptySet());
 
@@ -85,15 +87,16 @@ public class GroupService_UpdateTest {
         verify(groupRepository)
             .update(
                 argThat(
-                    group ->
-                        group.isDisableMembershipNotifications() &&
-                        group.isEmailInvitation() &&
-                        group.getEventRules() == null &&
-                        group.isLockApiRole() &&
-                        group.isLockApplicationRole() &&
-                        group.getMaxInvitation() == 100 &&
-                        group.getName().equals("my-group-name") &&
-                        !group.isSystemInvitation()
+                    updatedGroup ->
+                        updatedGroup.isDisableMembershipNotifications() &&
+                        updatedGroup.isEmailInvitation() &&
+                        updatedGroup.getEventRules() == null &&
+                        updatedGroup.isLockApiRole() &&
+                        updatedGroup.isLockApplicationRole() &&
+                        updatedGroup.getMaxInvitation() == 100 &&
+                        updatedGroup.getName().equals("my-group-name") &&
+                        !updatedGroup.isSystemInvitation() &&
+                        updatedGroup.getApiPrimaryOwner().equals("api-primary-owner")
                 )
             );
 
@@ -122,7 +125,7 @@ public class GroupService_UpdateTest {
             Maps.<RoleScope, String>builder().put(RoleScope.API, "PRIMARY_OWNER").put(RoleScope.APPLICATION, "PRIMARY_OWNER").build()
         );
 
-        when(groupRepository.findById(GROUP_ID)).thenReturn(Optional.of(Mockito.mock(Group.class)));
+        when(groupRepository.findById(GROUP_ID)).thenReturn(Optional.of(new Group()));
         when(permissionService.hasPermission(RolePermission.ENVIRONMENT_GROUP, "DEFAULT", CREATE, UPDATE, DELETE)).thenReturn(true);
         when(membershipService.getRoles(any(), any(), any(), any())).thenReturn(Collections.emptySet());
 


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7448


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-7448-apipo-mapping/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
