### PR TITLE
Cockpit - Workaround for HelloCommand to always find default environment & organization 

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/EnvironmentService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/EnvironmentService.java
@@ -36,7 +36,9 @@ public interface EnvironmentService {
 
     void delete(String environmentId);
 
-    void initialize();
+    EnvironmentEntity initialize();
 
     EnvironmentEntity findByCockpitId(String cockpitId);
+
+    EnvironmentEntity getDefaultOrInitialize();
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/OrganizationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/OrganizationService.java
@@ -35,7 +35,7 @@ public interface OrganizationService {
 
     void delete(String organizationId);
 
-    void initialize();
+    OrganizationEntity initialize();
 
     /**
      * Find all existing organizations.
@@ -43,4 +43,6 @@ public interface OrganizationService {
      * @return the list of all organizations.
      */
     Collection<OrganizationEntity> findAll();
+
+    OrganizationEntity getDefaultOrInitialize();
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/producer/HelloCommandProducer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/producer/HelloCommandProducer.java
@@ -22,7 +22,11 @@ import io.gravitee.cockpit.api.command.hello.HelloCommand;
 import io.gravitee.cockpit.api.command.hello.HelloPayload;
 import io.gravitee.cockpit.api.command.hello.HelloReply;
 import io.gravitee.node.api.Node;
-import io.gravitee.rest.api.model.*;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.model.InstallationEntity;
+import io.gravitee.rest.api.model.OrganizationEntity;
+import io.gravitee.rest.api.model.UpdateEnvironmentEntity;
+import io.gravitee.rest.api.model.UpdateOrganizationEntity;
 import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.InstallationService;
 import io.gravitee.rest.api.service.OrganizationService;
@@ -110,7 +114,7 @@ public class HelloCommandProducer implements CommandProducer<HelloCommand, Hello
     }
 
     private void updateDefaultEnvironmentCockpitId(String defaultEnvironmentCockpitId) {
-        EnvironmentEntity defaultEnvironment = environmentService.findById(GraviteeContext.getDefaultEnvironment());
+        EnvironmentEntity defaultEnvironment = environmentService.getDefaultOrInitialize();
 
         UpdateEnvironmentEntity updateEnvironment = new UpdateEnvironmentEntity(defaultEnvironment);
         updateEnvironment.setCockpitId(defaultEnvironmentCockpitId);
@@ -119,7 +123,7 @@ public class HelloCommandProducer implements CommandProducer<HelloCommand, Hello
     }
 
     private void updateDefaultOrganizationCockpitId(String defaultOrganizationCockpitId) {
-        OrganizationEntity defaultOrganization = organizationService.findById(GraviteeContext.getDefaultOrganization());
+        OrganizationEntity defaultOrganization = organizationService.getDefaultOrInitialize();
 
         UpdateOrganizationEntity updateOrganization = new UpdateOrganizationEntity(defaultOrganization);
         updateOrganization.setCockpitId(defaultOrganizationCockpitId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EnvironmentServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EnvironmentServiceImpl.java
@@ -158,7 +158,7 @@ public class EnvironmentServiceImpl extends TransactionalService implements Envi
     }
 
     @Override
-    public void initialize() {
+    public EnvironmentEntity initialize() {
         Environment defaultEnvironment = new Environment();
         defaultEnvironment.setId(GraviteeContext.getDefaultEnvironment());
         defaultEnvironment.setName("Default environment");
@@ -167,6 +167,7 @@ public class EnvironmentServiceImpl extends TransactionalService implements Envi
         defaultEnvironment.setOrganizationId(GraviteeContext.getDefaultOrganization());
         try {
             environmentRepository.create(defaultEnvironment);
+            return convert(defaultEnvironment);
         } catch (TechnicalException ex) {
             LOGGER.error("An error occurs while trying to create default environment", ex);
             throw new TechnicalManagementException("An error occurs while trying to create default environment", ex);
@@ -198,6 +199,16 @@ public class EnvironmentServiceImpl extends TransactionalService implements Envi
                 "An error occurs while trying to find all environments by organization " + organizationId,
                 ex
             );
+        }
+    }
+
+    @Override
+    public EnvironmentEntity getDefaultOrInitialize() {
+        try {
+            return environmentRepository.findById(GraviteeContext.getDefaultEnvironment()).map(this::convert).orElseGet(this::initialize);
+        } catch (final Exception ex) {
+            LOGGER.error("Error while getting installation : {}", ex.getMessage());
+            throw new TechnicalManagementException("Error while getting installation", ex);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/OrganizationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/OrganizationServiceImpl.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.rest.api.service.impl;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.FlowMode;
 import io.gravitee.definition.model.flow.Flow;
@@ -213,7 +212,7 @@ public class OrganizationServiceImpl extends TransactionalService implements Org
     }
 
     @Override
-    public void initialize() {
+    public OrganizationEntity initialize() {
         Organization defaultOrganization = new Organization();
         defaultOrganization.setId(GraviteeContext.getDefaultOrganization());
         defaultOrganization.setName("Default organization");
@@ -221,6 +220,7 @@ public class OrganizationServiceImpl extends TransactionalService implements Org
         defaultOrganization.setDescription("Default organization");
         try {
             organizationRepository.create(defaultOrganization);
+            return convert(defaultOrganization);
         } catch (TechnicalException ex) {
             LOGGER.error("An error occurs while trying to create default organization", ex);
             throw new TechnicalManagementException("An error occurs while trying to create default organization", ex);
@@ -234,6 +234,16 @@ public class OrganizationServiceImpl extends TransactionalService implements Org
         } catch (TechnicalException ex) {
             LOGGER.error("An error occurs while trying to list all organizations", ex);
             throw new TechnicalManagementException("An error occurs while trying to list all organizations", ex);
+        }
+    }
+
+    @Override
+    public OrganizationEntity getDefaultOrInitialize() {
+        try {
+            return organizationRepository.findById(GraviteeContext.getDefaultOrganization()).map(this::convert).orElseGet(this::initialize);
+        } catch (final Exception ex) {
+            LOGGER.error("Error while getting installation : {}", ex.getMessage());
+            throw new TechnicalManagementException("Error while getting installation", ex);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/producer/HelloCommandProducerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/producer/HelloCommandProducerTest.java
@@ -19,7 +19,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.gravitee.cockpit.api.command.Command;
 import io.gravitee.cockpit.api.command.CommandStatus;
@@ -29,7 +31,6 @@ import io.gravitee.cockpit.api.command.hello.HelloReply;
 import io.gravitee.definition.model.FlowMode;
 import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.node.api.Node;
-import io.gravitee.repository.management.model.Installation;
 import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.InstallationEntity;
 import io.gravitee.rest.api.model.OrganizationEntity;
@@ -136,7 +137,7 @@ public class HelloCommandProducerTest {
         defaultEnvironment.setOrganizationId("org#1");
 
         when(installationService.getOrInitialize()).thenReturn(new InstallationEntity());
-        when(environmentService.findById(defaultEnvId)).thenReturn(defaultEnvironment);
+        when(environmentService.getDefaultOrInitialize()).thenReturn(defaultEnvironment);
 
         cut.handleReply(helloReply);
 
@@ -164,7 +165,7 @@ public class HelloCommandProducerTest {
         defaultOrganization.setFlowMode(FlowMode.DEFAULT);
 
         when(installationService.getOrInitialize()).thenReturn(new InstallationEntity());
-        when(organizationService.findById(defaultOrgId)).thenReturn(defaultOrganization);
+        when(organizationService.getDefaultOrInitialize()).thenReturn(defaultOrganization);
 
         cut.handleReply(helloReply);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/EnvironmentService_GetDefaultOrInitializeTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/EnvironmentService_GetDefaultOrInitializeTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.EnvironmentRepository;
+import io.gravitee.repository.management.model.Environment;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class EnvironmentService_GetDefaultOrInitializeTest {
+
+    @InjectMocks
+    private EnvironmentServiceImpl environmentService = new EnvironmentServiceImpl();
+
+    @Mock
+    private EnvironmentRepository mockEnvironmentRepository;
+
+    @After
+    public void tearDown() {
+        GraviteeContext.cleanContext();
+    }
+
+    @Test
+    public void shouldReturnDefaultEnvironment() throws TechnicalException {
+        Environment existingDefault = new Environment();
+        existingDefault.setId(GraviteeContext.getDefaultEnvironment());
+        when(mockEnvironmentRepository.findById(eq(GraviteeContext.getDefaultEnvironment()))).thenReturn(Optional.of(existingDefault));
+
+        EnvironmentEntity environment = environmentService.getDefaultOrInitialize();
+
+        assertThat(environment.getId()).isEqualTo(GraviteeContext.getDefaultEnvironment());
+    }
+
+    @Test
+    public void shouldCreateDefaultEnvironment() throws TechnicalException {
+        when(mockEnvironmentRepository.findById(eq(GraviteeContext.getDefaultEnvironment()))).thenReturn(Optional.empty());
+
+        EnvironmentEntity environment = environmentService.getDefaultOrInitialize();
+
+        assertThat(environment.getId()).isEqualTo(GraviteeContext.getDefaultEnvironment());
+        assertThat(environment.getName()).isEqualTo("Default environment");
+        assertThat(environment.getHrids()).isEqualTo(Collections.singletonList("default"));
+        assertThat(environment.getDescription()).isEqualTo("Default environment");
+        assertThat(environment.getOrganizationId()).isEqualTo(GraviteeContext.getDefaultOrganization());
+    }
+
+    @Test(expected = TechnicalManagementException.class)
+    public void shouldCatchExceptionIfThrow() throws TechnicalException {
+        when(mockEnvironmentRepository.findById(eq(GraviteeContext.getDefaultEnvironment()))).thenThrow(new TechnicalException(""));
+
+        environmentService.getDefaultOrInitialize();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/OrganizationService_GetDefaultOrInitializeTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/OrganizationService_GetDefaultOrInitializeTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.OrganizationRepository;
+import io.gravitee.repository.management.model.Organization;
+import io.gravitee.rest.api.model.OrganizationEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.configuration.flow.FlowService;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class OrganizationService_GetDefaultOrInitializeTest {
+
+    @InjectMocks
+    private OrganizationServiceImpl organizationService = new OrganizationServiceImpl();
+
+    @Mock
+    private OrganizationRepository mockOrganizationRepository;
+
+    @Mock
+    private FlowService mockFlowService;
+
+    @After
+    public void tearDown() {
+        GraviteeContext.cleanContext();
+    }
+
+    @Test
+    public void shouldReturnDefaultOrganization() throws TechnicalException {
+        Organization existingDefault = new Organization();
+        existingDefault.setId(GraviteeContext.getDefaultOrganization());
+        when(mockOrganizationRepository.findById(eq(GraviteeContext.getDefaultOrganization()))).thenReturn(Optional.of(existingDefault));
+
+        OrganizationEntity organization = organizationService.getDefaultOrInitialize();
+
+        assertThat(organization.getId()).isEqualTo(GraviteeContext.getDefaultEnvironment());
+    }
+
+    @Test
+    public void shouldCreateDefaultOrganization() throws TechnicalException {
+        when(mockOrganizationRepository.findById(eq(GraviteeContext.getDefaultOrganization()))).thenReturn(Optional.empty());
+
+        OrganizationEntity organization = organizationService.getDefaultOrInitialize();
+
+        assertThat(organization.getId()).isEqualTo(GraviteeContext.getDefaultEnvironment());
+        assertThat(organization.getName()).isEqualTo("Default organization");
+        assertThat(organization.getHrids()).isEqualTo(Collections.singletonList("default"));
+        assertThat(organization.getDescription()).isEqualTo("Default organization");
+    }
+
+    @Test(expected = TechnicalManagementException.class)
+    public void shouldCatchExceptionIfThrow() throws TechnicalException {
+        when(mockOrganizationRepository.findById(eq(GraviteeContext.getDefaultEnvironment()))).thenThrow(new TechnicalException(""));
+
+        organizationService.getDefaultOrInitialize();
+    }
+}


### PR DESCRIPTION
**Issue**
https://github.com/gravitee-io/issues/issues/7688

**Description**

As upgrades and plugin installation are executed in parallel. Until we find a better way. These changes allow the Hello command to create the environment and/or organization if it runs faster than the upgrader.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/7688-cockpit-hello/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-prdukjaomo.chromatic.com)
<!-- Storybook placeholder end -->
