### PR TITLE
fix: handle membership null reference_id

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcMembershipRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcMembershipRepository.java
@@ -484,7 +484,14 @@ public class JdbcMembershipRepository extends JdbcAbstractCrudRepository<Members
                         referenceId
                     );
             } else {
-                memberships = jdbcTemplate.query(query, getOrm().getRowMapper(), memberId, memberType.name(), referenceType.name());
+                memberships =
+                    jdbcTemplate.query(
+                        query + " and reference_id is null",
+                        getOrm().getRowMapper(),
+                        memberId,
+                        memberType.name(),
+                        referenceType.name()
+                    );
             }
 
             return new HashSet<>(memberships);

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/MembershipRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/MembershipRepositoryTest.java
@@ -233,7 +233,6 @@ public class MembershipRepositoryTest extends AbstractRepositoryTest {
         assertEquals("API_OWNER", membership.getRoleId());
         assertEquals("api1", membership.getReferenceId());
         assertEquals("user1", membership.getMemberId());
-        assertEquals("API_OWNER", membership.getRoleId());
     }
 
     @Test
@@ -251,7 +250,22 @@ public class MembershipRepositoryTest extends AbstractRepositoryTest {
         assertEquals("API_OWNER", membership.getRoleId());
         assertEquals("api1", membership.getReferenceId());
         assertEquals("user1", membership.getMemberId());
-        assertEquals("API_OWNER", membership.getRoleId());
+    }
+
+    @Test
+    public void shouldFindMembershipWithNullReferenceId() throws TechnicalException {
+        Set<Membership> memberships = membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceId(
+            "group1",
+            MembershipMemberType.GROUP,
+            MembershipReferenceType.API,
+            null
+        );
+        assertNotNull("result must not be null", memberships);
+        assertFalse(memberships.isEmpty());
+        Membership membership = memberships.iterator().next();
+        assertEquals("11baec92-8823-4f8b-baec-9288238f8b5c", membership.getRoleId());
+        assertNull(membership.getReferenceId());
+        assertEquals("group1", membership.getMemberId());
     }
 
     @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/MembershipRepositoryMock.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/MembershipRepositoryMock.java
@@ -182,5 +182,28 @@ public class MembershipRepositoryMock extends AbstractRepositoryMock<MembershipR
             )
         )
             .thenReturn(singleton(mock(Membership.class)), emptySet());
+
+        when(
+            membershipRepository.findByMemberIdAndMemberTypeAndReferenceTypeAndReferenceId(
+                "group1",
+                MembershipMemberType.GROUP,
+                MembershipReferenceType.API,
+                null
+            )
+        )
+            .thenReturn(
+                new HashSet<>(
+                    singletonList(
+                        new Membership(
+                            "group_membership_default_api_role",
+                            "group1",
+                            MembershipMemberType.GROUP,
+                            null,
+                            MembershipReferenceType.API,
+                            "11baec92-8823-4f8b-baec-9288238f8b5c"
+                        )
+                    )
+                )
+            );
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/membership-tests/memberships.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/membership-tests/memberships.json
@@ -89,5 +89,16 @@
     "roleId": "OWNER",
     "createdAt" : "1439022010883",
     "updatedAt" : "1439022010883"
+  },
+  {
+    "id": "group_membership_default_api_role",
+    "memberId": "group1",
+    "memberType": "GROUP",
+    "referenceType": "API",
+    "referenceId" : null,
+    "roleId": "11baec92-8823-4f8b-baec-9288238f8b5c",
+    "source": "system",
+    "createdAt": "1439022010883",
+    "updatedAt": "1439022010883"
   }
 ]


### PR DESCRIPTION
**Issue**

gravitee-io/issues#7428

**Description**

⛈ Current behaviour

When we create an api and chose a group as primary owner the default api role for the group is set to primary owner. ( only for jdbc ) This issue is linked to the created memberships. Currently when we navigate to the group settings, we can get the api role for the group as we does not check that the reference id is null. For the default api role of a group the reference id is always null.

🌈 Expected behaviour

When we chose a group as primary owner of an API the group default api role should not change.

<img width="1788" alt="Screenshot 2022-06-13 at 09 52 45" src="https://user-images.githubusercontent.com/25704259/173535075-d9aa8744-d579-47b8-893d-0d612fcb19cd.png">

We can set/unset this value and it does not change anything about the created api. The api is still available in the apis list.

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-api-group-membership/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
