### PR TITLE
fix: bean configuration for debug mode

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/impl/DefaultReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/impl/DefaultReactor.java
@@ -47,6 +47,8 @@ public class DefaultReactor extends AbstractService<Reactor> implements Reactor,
 
     private final Logger LOGGER = LoggerFactory.getLogger(DefaultReactor.class);
 
+    protected EntrypointResolver entrypointResolver;
+
     @Autowired
     protected EventManager eventManager;
 
@@ -54,22 +56,24 @@ public class DefaultReactor extends AbstractService<Reactor> implements Reactor,
     private ReactorHandlerRegistry reactorHandlerRegistry;
 
     @Autowired
-    private EntrypointResolver entrypointResolver;
-
-    @Autowired
     private GatewayConfiguration gatewayConfiguration;
-
-    @Autowired
-    @Qualifier("v3RequestProcessorChainFactory")
-    private RequestProcessorChainFactory requestProcessorChainFactory;
-
-    @Autowired
-    @Qualifier("v3ResponseProcessorChainFactory")
-    private ResponseProcessorChainFactory responseProcessorChainFactory;
 
     @Autowired
     @Qualifier("v3NotFoundProcessorChainFactory")
     private NotFoundProcessorChainFactory notFoundProcessorChainFactory;
+
+    private final RequestProcessorChainFactory requestProcessorChainFactory;
+    private final ResponseProcessorChainFactory responseProcessorChainFactory;
+
+    public DefaultReactor(
+        EntrypointResolver entrypointResolver,
+        RequestProcessorChainFactory requestProcessorChainFactory,
+        ResponseProcessorChainFactory responseProcessorChainFactory
+    ) {
+        this.entrypointResolver = entrypointResolver;
+        this.requestProcessorChainFactory = requestProcessorChainFactory;
+        this.responseProcessorChainFactory = responseProcessorChainFactory;
+    }
 
     @Override
     public void route(Request serverRequest, Response serverResponse, Handler<ExecutionContext> handler) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/spring/ReactorConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/spring/ReactorConfiguration.java
@@ -43,6 +43,8 @@ import io.gravitee.gateway.reactor.processor.transaction.TransactionProcessorFac
 import io.gravitee.gateway.report.ReporterService;
 import io.gravitee.node.api.Node;
 import io.gravitee.plugin.alert.AlertEventProducer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -57,10 +59,25 @@ public class ReactorConfiguration {
 
     private static final String HEX_FORMAT = "hex";
 
+    //    @Autowired
+    //    protected io.gravitee.gateway.reactor.handler.EntrypointResolver entrypointResolver;
+    //
+    //    @Autowired
+    //    @Qualifier("v3RequestProcessorChainFactory")
+    //    private RequestProcessorChainFactory requestProcessorChainFactory;
+    //
+    //    @Autowired
+    //    @Qualifier("v3ResponseProcessorChainFactory")
+    //    private ResponseProcessorChainFactory responseProcessorChainFactory;
+
     @Bean
-    public Reactor v3Reactor() {
+    public Reactor v3Reactor(
+        io.gravitee.gateway.reactor.handler.EntrypointResolver entrypointResolver,
+        @Qualifier("v3RequestProcessorChainFactory") RequestProcessorChainFactory requestProcessorChainFactory,
+        @Qualifier("v3ResponseProcessorChainFactory") ResponseProcessorChainFactory responseProcessorChainFactory
+    ) {
         // DefaultReactor bean must be kept while we are still supporting v3 execution mode.
-        return new DefaultReactor();
+        return new DefaultReactor(entrypointResolver, requestProcessorChainFactory, responseProcessorChainFactory);
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/ReactorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/ReactorTest.java
@@ -25,6 +25,8 @@ import io.gravitee.gateway.reactor.handler.EntrypointResolver;
 import io.gravitee.gateway.reactor.handler.ReactorHandlerRegistry;
 import io.gravitee.gateway.reactor.handler.context.ExecutionContextFactory;
 import io.gravitee.gateway.reactor.impl.DefaultReactor;
+import io.gravitee.gateway.reactor.processor.RequestProcessorChainFactory;
+import io.gravitee.gateway.reactor.processor.ResponseProcessorChainFactory;
 import io.gravitee.gateway.reactor.processor.transaction.TransactionProcessorFactory;
 import java.util.Optional;
 import org.junit.Before;
@@ -40,9 +42,6 @@ import org.mockito.Spy;
  */
 public class ReactorTest {
 
-    @InjectMocks
-    private DefaultReactor reactor;
-
     @Mock
     private EntrypointResolver handlerResolver;
 
@@ -54,6 +53,18 @@ public class ReactorTest {
 
     @Mock
     private ExecutionContextFactory executionContextFactory;
+
+    @Mock
+    private EntrypointResolver entrypointResolver;
+
+    @Mock
+    private RequestProcessorChainFactory requestProcessorChainFactory;
+
+    @Mock
+    private ResponseProcessorChainFactory responseProcessorChainFactory;
+
+    @InjectMocks
+    private DefaultReactor reactor = new DefaultReactor(entrypointResolver, requestProcessorChainFactory, responseProcessorChainFactory);
 
     private DummyReactorHandler dummyReactorHandler = new DummyReactorHandler();
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/DebugConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/DebugConfiguration.java
@@ -124,7 +124,7 @@ public class DebugConfiguration {
 
     @Bean
     @Qualifier("debugEntryPointResolver")
-    public EntrypointResolver reactorHandlerResolver(
+    public EntrypointResolver debugEntryPointResolver(
         @Qualifier("debugReactorHandlerRegistry") ReactorHandlerRegistry reactorHandlerRegistry
     ) {
         return new DefaultEntrypointResolver(reactorHandlerRegistry);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/DebugReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/DebugReactor.java
@@ -23,19 +23,28 @@ import io.gravitee.gateway.debug.definition.DebugApi;
 import io.gravitee.gateway.debug.vertx.VertxDebugHttpClientConfiguration;
 import io.gravitee.gateway.reactor.Reactable;
 import io.gravitee.gateway.reactor.ReactorEvent;
+import io.gravitee.gateway.reactor.handler.EntrypointResolver;
 import io.gravitee.gateway.reactor.handler.ReactorHandlerRegistry;
 import io.gravitee.gateway.reactor.impl.DefaultReactor;
 import io.gravitee.gateway.reactor.impl.ReactableWrapper;
+import io.gravitee.gateway.reactor.processor.RequestProcessorChainFactory;
+import io.gravitee.gateway.reactor.processor.ResponseProcessorChainFactory;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.EventRepository;
 import io.gravitee.repository.management.model.ApiDebugStatus;
 import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
-import io.vertx.core.http.*;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.RequestOptions;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
-import io.vertx.core.net.*;
-import java.util.*;
+import io.vertx.core.net.OpenSSLEngineOptions;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -60,6 +69,14 @@ public class DebugReactor extends DefaultReactor {
     @Autowired
     @Qualifier("debugReactorHandlerRegistry")
     private ReactorHandlerRegistry reactorHandlerRegistry;
+
+    public DebugReactor(
+        EntrypointResolver entrypointResolver,
+        RequestProcessorChainFactory requestProcessorChainFactory,
+        ResponseProcessorChainFactory responseProcessorChainFactory
+    ) {
+        super(entrypointResolver, requestProcessorChainFactory, responseProcessorChainFactory);
+    }
 
     @Override
     public void onEvent(Event<ReactorEvent, Reactable> reactorEvent) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/vertx/VertxDebugConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/vertx/VertxDebugConfiguration.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.gateway.debug.reactor.DebugReactor;
 import io.gravitee.gateway.debug.reactor.processor.DebugResponseProcessorChainFactory;
 import io.gravitee.gateway.reactor.Reactor;
+import io.gravitee.gateway.reactor.handler.EntrypointResolver;
 import io.gravitee.gateway.reactor.processor.NotFoundProcessorChainFactory;
 import io.gravitee.gateway.reactor.processor.RequestProcessorChainFactory;
 import io.gravitee.gateway.reactor.processor.ResponseProcessorChainFactory;
@@ -46,8 +47,12 @@ public class VertxDebugConfiguration {
     }
 
     @Bean
-    public Reactor reactor() {
-        return new DebugReactor();
+    public Reactor reactor(
+        @Qualifier("debugEntryPointResolver") EntrypointResolver entrypointResolver,
+        @Qualifier("debugRequestProcessorChainFactory") RequestProcessorChainFactory requestProcessorChainFactory,
+        @Qualifier("debugResponseProcessorChainFactory") ResponseProcessorChainFactory responseProcessorChainFactory
+    ) {
+        return new DebugReactor(entrypointResolver, requestProcessorChainFactory, responseProcessorChainFactory);
     }
 
     @Bean
@@ -61,11 +66,13 @@ public class VertxDebugConfiguration {
     }
 
     @Bean
+    @Qualifier("debugRequestProcessorChainFactory")
     public RequestProcessorChainFactory requestProcessorChainFactory() {
         return new RequestProcessorChainFactory();
     }
 
     @Bean
+    @Qualifier("debugResponseProcessorChainFactory")
     public ResponseProcessorChainFactory responseProcessorChainFactory(EventRepository eventRepository, ObjectMapper objectMapper) {
         return new DebugResponseProcessorChainFactory(eventRepository, objectMapper);
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/reactor/DebugReactorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/reactor/DebugReactorTest.java
@@ -34,8 +34,11 @@ import io.gravitee.definition.model.HttpRequest;
 import io.gravitee.gateway.debug.definition.DebugApi;
 import io.gravitee.gateway.debug.vertx.VertxDebugHttpClientConfiguration;
 import io.gravitee.gateway.reactor.ReactorEvent;
+import io.gravitee.gateway.reactor.handler.EntrypointResolver;
 import io.gravitee.gateway.reactor.handler.ReactorHandlerRegistry;
 import io.gravitee.gateway.reactor.impl.ReactableWrapper;
+import io.gravitee.gateway.reactor.processor.RequestProcessorChainFactory;
+import io.gravitee.gateway.reactor.processor.ResponseProcessorChainFactory;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.EventRepository;
 import io.gravitee.repository.management.model.ApiDebugStatus;
@@ -47,7 +50,6 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClientResponse;
-import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -70,8 +72,14 @@ public class DebugReactorTest {
 
     private static final String PAYLOAD = "Debugged Api payload";
 
-    @InjectMocks
-    private final DebugReactor debugReactor = new DebugReactor();
+    @Mock
+    private EntrypointResolver entrypointResolver;
+
+    @Mock
+    private RequestProcessorChainFactory requestProcessorChainFactory;
+
+    @Mock
+    private ResponseProcessorChainFactory responseProcessorChainFactory;
 
     @Mock
     private ReactorHandlerRegistry reactorHandlerRegistry;
@@ -87,6 +95,13 @@ public class DebugReactorTest {
 
     @Mock
     private VertxDebugHttpClientConfiguration debugHttpClientConfiguration;
+
+    @InjectMocks
+    private final DebugReactor debugReactor = new DebugReactor(
+        entrypointResolver,
+        requestProcessorChainFactory,
+        responseProcessorChainFactory
+    );
 
     @Captor
     ArgumentCaptor<io.gravitee.repository.management.model.Event> eventCaptor;


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7828

**Description**

Jupiter implementations comes with some changes regarding spring beans qualifications: some beans are now injected with a new bean name.

That causes two problems for the debug mode:
- We had two `EntrypointResolver` bean to inject, causing an error
- Injected `Request|ResponseProcessorChainFactory`  where the one from production code, not from debug service.

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/issues-7828-debug-mode-bean/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vcuylcrdsr.chromatic.com)
<!-- Storybook placeholder end -->
