### PR TITLE
Use Maven CI friendly version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -751,8 +751,8 @@ jobs:
                       # Update maven dependencies versions from properties
                       mvn -Duser.home=${HOME} -s /tmp/.gravitee.settings.xml -B -U versions:update-properties -Dmaven.version.rules.serverId=artifactory-gravitee -Dincludes="io.gravitee.*:*" -Dexcludes="io.gravitee.policy:*,io.gravitee.connector:*,io.gravitee.resource:*,io.gravitee.service:*,io.gravitee.fetcher:*,io.gravitee.tracer:*,io.gravitee.repository:*,io.gravitee.reporter:*,io.gravitee.cockpit:*,io.gravitee.discovery:*,io.gravitee.notifier:*,com.graviteesource.notifier:*,com.graviteesource.policy:*" -DallowMajorUpdates=false -DallowMinorUpdates=false -DallowIncrementalUpdates=true -DgenerateBackupPoms=false -T 2C -no-transfer-progress
 
-                      # Remove `-SNAPSHOT` from versions
-                      mvn -Duser.home=${HOME} -s /tmp/.gravitee.settings.xml -B versions:set -DremoveSnapshot=true -DgenerateBackupPoms=false --no-transfer-progress
+                      # Remove `-SNAPSHOT` from version                    
+                      mvn versions:set-property -Dproperty=changelist -DnewVersion=
             - prepare-gpg
             - prepare-env-var
             - run:
@@ -790,8 +790,11 @@ jobs:
                       # If support branch for this version does not exist, create it, update versions, commit and push
                       if [ "x${GIT_BRANCH_FILTER}" == "x" ]; then
                         git checkout -b ${MAINTENANCE_GIT_BRANCH}
-                        # Set the version to the next support version (bump patch version + '-SNAPSHOT')                        
-                        mvn -Duser.home=${HOME} -s /tmp/.gravitee.settings.xml -B versions:set -DnextSnapshot=true -DgenerateBackupPoms=false
+                        # Set the version to the next support version (bump patch version + '-SNAPSHOT')        
+                        export NEXT_PATCH_VERSION=$((${MVN_PRJ_VERSION_PATCH}+1))
+                        export NEXT_SNAPSHOT_VERSION="${MVN_PRJ_VERSION_MAJOR}.${MVN_PRJ_VERSION_MINOR}.${NEXT_PATCH_VERSION}"     
+                        mvn versions:set-property -Dproperty=revision -DnewVersion=${NEXT_SNAPSHOT_VERSION}                    
+                        mvn versions:set-property -Dproperty=changelist -DnewVersion=-SNAPSHOT
                         git add --update
                         git commit -m 'chore: prepare next version [skip ci]'
                         if [ "${DRY_RUN}" == "false" ]; then
@@ -807,12 +810,17 @@ jobs:
                       # If releasing a feature version (i.e. patch number == 0) then bump the minor version for the next 
                       if [ "${MVN_PRJ_VERSION_PATCH}" == "0" ]; then
                         export NEXT_MINOR_VERSION=$((${MVN_PRJ_VERSION_MINOR}+1))
-                        export NEXT_SNAPSHOT_VERSION="${MVN_PRJ_VERSION_MAJOR}.${NEXT_MINOR_VERSION}.0-SNAPSHOT"
-                        mvn -Duser.home=${HOME} -s /tmp/.gravitee.settings.xml -B versions:set -DnewVersion=${NEXT_SNAPSHOT_VERSION} -DgenerateBackupPoms=false
+                        export NEXT_SNAPSHOT_VERSION="${MVN_PRJ_VERSION_MAJOR}.${NEXT_MINOR_VERSION}.0"
+                        mvn versions:set-property -Dproperty=revision -DnewVersion=${NEXT_SNAPSHOT_VERSION}                    
+                        mvn versions:set-property -Dproperty=changelist -DnewVersion=-SNAPSHOT                    
                       else
                         # Else just set the version to the next support version (bump patch version + '-SNAPSHOT')                        
-                        mvn -Duser.home=${HOME} -s /tmp/.gravitee.settings.xml -B versions:set -DnextSnapshot=true -DgenerateBackupPoms=false
+                        export NEXT_PATCH_VERSION=$((${MVN_PRJ_VERSION_PATCH}+1))
+                        export NEXT_SNAPSHOT_VERSION="${MVN_PRJ_VERSION_MAJOR}.${MVN_PRJ_VERSION_MINOR}.${NEXT_PATCH_VERSION}"     
+                        mvn versions:set-property -Dproperty=revision -DnewVersion=${NEXT_SNAPSHOT_VERSION}                    
+                        mvn versions:set-property -Dproperty=changelist -DnewVersion=-SNAPSHOT
                       fi;
+                    
                       git add --update
                       git commit -m 'chore: prepare next version [skip ci]'
                       if [ "${DRY_RUN}" == "false" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ graviteebot.gpg.pub.key
 
 # Deepcode (Snyk Code) cache
 **/.dccache
+
+# Exclude flattened version of the pom, for details see https://maven.apache.org/maven-ci-friendly.html#install-deploy
+.flattened-pom.xml

--- a/gravitee-apim-console-webui/pom.xml
+++ b/gravitee-apim-console-webui/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>io.gravitee.apim</groupId>
     <artifactId>gravitee-api-management</artifactId>
-    <version>3.10.17-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
   </parent>
 
   <groupId>io.gravitee.apim.ui</groupId>

--- a/gravitee-apim-definition/gravitee-apim-definition-coverage/pom.xml
+++ b/gravitee-apim-definition/gravitee-apim-definition-coverage/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.gravitee.apim.definition</groupId>
         <artifactId>gravitee-apim-definition</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-definition-coverage</artifactId>

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/pom.xml
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.definition</groupId>
         <artifactId>gravitee-apim-definition</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-definition-jackson</artifactId>

--- a/gravitee-apim-definition/gravitee-apim-definition-model/pom.xml
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.definition</groupId>
         <artifactId>gravitee-apim-definition</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-definition-model</artifactId>

--- a/gravitee-apim-definition/pom.xml
+++ b/gravitee-apim-definition/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim</groupId>
         <artifactId>gravitee-api-management</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <groupId>io.gravitee.apim.definition</groupId>

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee.apim</groupId>
         <artifactId>gravitee-api-management</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <groupId>io.gravitee.apim.distribution</groupId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-buffer/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-buffer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-core</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-coverage/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-coverage/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-coverage</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-dictionary/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-dictionary/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-dictionary</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-env/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-env/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-env</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-flow/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-flow/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-flow</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.handlers</groupId>
         <artifactId>gravitee-apim-gateway-handlers</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-handlers-api</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <groupId>io.gravitee.apim.gateway.handlers</groupId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-http</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-platform/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-platform/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-platform</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-policy</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reporting/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reporting/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-reporting</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-repository/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-repository/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-repository</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-resource/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-resource/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-resource</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-apikey/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-apikey/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.security</groupId>
         <artifactId>gravitee-apim-gateway-security</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-security-apikey</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.security</groupId>
         <artifactId>gravitee-apim-gateway-security</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-security-core</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-jwt/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-jwt/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.security</groupId>
         <artifactId>gravitee-apim-gateway-security</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-security-jwt</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-keyless/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-keyless/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.security</groupId>
         <artifactId>gravitee-apim-gateway-security</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-security-keyless</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-oauth2/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-oauth2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.security</groupId>
         <artifactId>gravitee-apim-gateway-security</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-security-oauth2</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <groupId>io.gravitee.apim.gateway.security</groupId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-endpoint-discovery/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-endpoint-discovery/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.services</groupId>
         <artifactId>gravitee-apim-gateway-services</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-services-endpoint-discovery</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.services</groupId>
         <artifactId>gravitee-apim-gateway-services</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-services-healthcheck</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-heartbeat/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-heartbeat/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.services</groupId>
         <artifactId>gravitee-apim-gateway-services</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-services-heartbeat</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-localregistry/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-localregistry/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.services</groupId>
         <artifactId>gravitee-apim-gateway-services</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-services-localregistry</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.services</groupId>
         <artifactId>gravitee-apim-gateway-services</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-services-sync</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <groupId>io.gravitee.apim.gateway.services</groupId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-bootstrap/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-bootstrap/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.standalone</groupId>
         <artifactId>gravitee-apim-gateway-standalone</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-standalone-bootstrap</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.standalone</groupId>
         <artifactId>gravitee-apim-gateway-standalone</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-standalone-container</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/gravitee-apim-gateway-standalone-distribution-zip/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/gravitee-apim-gateway-standalone-distribution-zip/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.standalone.distribution</groupId>
         <artifactId>gravitee-apim-gateway-standalone-distribution</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee.apim.distribution</groupId>
         <artifactId>gravitee-apim-distribution</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../../gravitee-apim-distribution/pom.xml</relativePath>
     </parent>
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <groupId>io.gravitee.apim.gateway.standalone</groupId>

--- a/gravitee-apim-gateway/pom.xml
+++ b/gravitee-apim-gateway/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim</groupId>
         <artifactId>gravitee-api-management</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <groupId>io.gravitee.apim.gateway</groupId>

--- a/gravitee-apim-portal-webui/pom.xml
+++ b/gravitee-apim-portal-webui/pom.xml
@@ -31,7 +31,7 @@
   <parent>
     <groupId>io.gravitee.apim</groupId>
     <artifactId>gravitee-api-management</artifactId>
-    <version>3.10.17-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
   </parent>
 
   <groupId>io.gravitee.apim.ui</groupId>

--- a/gravitee-apim-repository/gravitee-apim-repository-api/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.repository</groupId>
         <artifactId>gravitee-apim-repository</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-repository-api</artifactId>

--- a/gravitee-apim-repository/gravitee-apim-repository-coverage/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-coverage/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.gravitee.apim.repository</groupId>
         <artifactId>gravitee-apim-repository</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-repository-coverage</artifactId>

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee.apim.repository</groupId>
         <artifactId>gravitee-apim-repository</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-repository-elasticsearch</artifactId>

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.repository.gateway.bridge.http</groupId>
         <artifactId>gravitee-apim-repository-gateway-bridge-http</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-repository-gateway-bridge-http-client</artifactId>

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.repository.gateway.bridge.http</groupId>
         <artifactId>gravitee-apim-repository-gateway-bridge-http</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-repository-gateway-bridge-http-server</artifactId>

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.repository</groupId>
         <artifactId>gravitee-apim-repository</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <groupId>io.gravitee.apim.repository.gateway.bridge.http</groupId>

--- a/gravitee-apim-repository/gravitee-apim-repository-hazelcast/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-hazelcast/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>io.gravitee.apim.repository</groupId>
 		<artifactId>gravitee-apim-repository</artifactId>
-		<version>3.10.17-SNAPSHOT</version>
+		<version>${revision}${sha1}${changelist}</version>
 	</parent>
 
 	<artifactId>gravitee-apim-repository-hazelcast</artifactId>

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee.apim.repository</groupId>
         <artifactId>gravitee-apim-repository</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-repository-jdbc</artifactId>

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee.apim.repository</groupId>
         <artifactId>gravitee-apim-repository</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
 	<artifactId>gravitee-apim-repository-mongodb</artifactId>

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>io.gravitee.apim.repository</groupId>
 		<artifactId>gravitee-apim-repository</artifactId>
-		<version>3.10.17-SNAPSHOT</version>
+		<version>${revision}${sha1}${changelist}</version>
 	</parent>
 
 	<artifactId>gravitee-apim-repository-redis</artifactId>

--- a/gravitee-apim-repository/gravitee-apim-repository-test/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee.apim.repository</groupId>
         <artifactId>gravitee-apim-repository</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-repository-test</artifactId>

--- a/gravitee-apim-repository/pom.xml
+++ b/gravitee-apim-repository/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee.apim</groupId>
         <artifactId>gravitee-api-management</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <groupId>io.gravitee.apim.repository</groupId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-coverage/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-coverage/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api</groupId>
         <artifactId>gravitee-apim-rest-api</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-coverage</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-fetcher/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-fetcher/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api</groupId>
         <artifactId>gravitee-apim-rest-api</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-fetcher</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-api/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-api/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.idp</groupId>
         <artifactId>gravitee-apim-rest-api-idp</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-idp-api</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-core/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-core/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.idp</groupId>
         <artifactId>gravitee-apim-rest-api-idp</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-idp-core</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-ldap/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-ldap/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.idp</groupId>
         <artifactId>gravitee-apim-rest-api-idp</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-idp-ldap</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-memory/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-memory/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.idp</groupId>
         <artifactId>gravitee-apim-rest-api-idp</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-idp-memory</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-repository/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-repository/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.idp</groupId>
         <artifactId>gravitee-apim-rest-api-idp</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-idp-repository</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api</groupId>
         <artifactId>gravitee-apim-rest-api</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <groupId>io.gravitee.apim.rest.api.idp</groupId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
         <groupId>io.gravitee.apim.rest.api.management</groupId>
         <artifactId>gravitee-apim-rest-api-management</artifactId>
-		<version>3.10.17-SNAPSHOT</version>
+		<version>${revision}${sha1}${changelist}</version>
     </parent>
 
 	<artifactId>gravitee-apim-rest-api-management-rest</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-security/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-security/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
         <groupId>io.gravitee.apim.rest.api.management</groupId>
         <artifactId>gravitee-apim-rest-api-management</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
 	<artifactId>gravitee-apim-rest-api-management-security</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api</groupId>
         <artifactId>gravitee-apim-rest-api</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <groupId>io.gravitee.apim.rest.api.management</groupId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
         <groupId>io.gravitee.apim.rest.api</groupId>
         <artifactId>gravitee-apim-rest-api</artifactId>
-		<version>3.10.17-SNAPSHOT</version>
+		<version>${revision}${sha1}${changelist}</version>
     </parent>
 
 	<artifactId>gravitee-apim-rest-api-model</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
         <groupId>io.gravitee.apim.rest.api.portal</groupId>
         <artifactId>gravitee-apim-rest-api-portal</artifactId>
-		<version>3.10.17-SNAPSHOT</version>
+		<version>${revision}${sha1}${changelist}</version>
     </parent>
 
 	<artifactId>gravitee-apim-rest-api-portal-rest</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/openapi.yaml
@@ -10,7 +10,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0
-  version: "3.10.16"
+  version: "3.10.17-SNAPSHOT"
 servers:
   - url: http://localhost:8083/portal/environments/{envId}
     description: The portal API for a given environment

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-security/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-security/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
         <groupId>io.gravitee.apim.rest.api.portal</groupId>
         <artifactId>gravitee-apim-rest-api-portal</artifactId>
-		<version>3.10.17-SNAPSHOT</version>
+		<version>${revision}${sha1}${changelist}</version>
     </parent>
 
 	<artifactId>gravitee-apim-rest-api-portal-security</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api</groupId>
         <artifactId>gravitee-apim-rest-api</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <groupId>io.gravitee.apim.rest.api.portal</groupId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
         <groupId>io.gravitee.apim.rest.api</groupId>
         <artifactId>gravitee-apim-rest-api</artifactId>
-		<version>3.10.17-SNAPSHOT</version>
+		<version>${revision}${sha1}${changelist}</version>
     </parent>
 
 	<artifactId>gravitee-apim-rest-api-repository</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
         <groupId>io.gravitee.apim.rest.api</groupId>
         <artifactId>gravitee-apim-rest-api</artifactId>
-		<version>3.10.17-SNAPSHOT</version>
+		<version>${revision}${sha1}${changelist}</version>
     </parent>
 
 	<artifactId>gravitee-apim-rest-api-security</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
         <groupId>io.gravitee.apim.rest.api</groupId>
         <artifactId>gravitee-apim-rest-api</artifactId>
-		<version>3.10.17-SNAPSHOT</version>
+		<version>${revision}${sha1}${changelist}</version>
     </parent>
 
 	<artifactId>gravitee-apim-rest-api-service</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-auto-fetch/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-auto-fetch/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.services</groupId>
         <artifactId>gravitee-apim-rest-api-services</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.services</groupId>
         <artifactId>gravitee-apim-rest-api-services</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-services-dictionary</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.services</groupId>
         <artifactId>gravitee-apim-rest-api-services</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-services-dynamic-properties</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-search-indexer/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-search-indexer/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.services</groupId>
         <artifactId>gravitee-apim-rest-api-services</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-subscription-pre-expiration-notif/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-subscription-pre-expiration-notif/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.services</groupId>
         <artifactId>gravitee-apim-rest-api-services</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-services-subscription-pre-expiration-notif</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-subscriptions/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-subscriptions/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.services</groupId>
         <artifactId>gravitee-apim-rest-api-services</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-services-subscriptions</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-sync/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-sync/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.services</groupId>
         <artifactId>gravitee-apim-rest-api-services</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-services-sync</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-v3-upgrader/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-v3-upgrader/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.services</groupId>
         <artifactId>gravitee-apim-rest-api-services</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-services-v3-upgrader</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api</groupId>
         <artifactId>gravitee-apim-rest-api</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <groupId>io.gravitee.apim.rest.api.services</groupId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>gravitee-apim-rest-api</artifactId>
         <groupId>io.gravitee.apim.rest.api</groupId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-bootstrap/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-bootstrap/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.standalone</groupId>
         <artifactId>gravitee-apim-rest-api-standalone</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-standalone-bootstrap</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.standalone</groupId>
         <artifactId>gravitee-apim-rest-api-standalone</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-standalone-container</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/gravitee-apim-rest-api-standalone-distribution-zip/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/gravitee-apim-rest-api-standalone-distribution-zip/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.standalone.distribution</groupId>
         <artifactId>gravitee-apim-rest-api-standalone-distribution</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.distribution</groupId>
         <artifactId>gravitee-apim-distribution</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
         <relativePath>../../../gravitee-apim-distribution/pom.xml</relativePath>
     </parent>
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api</groupId>
         <artifactId>gravitee-apim-rest-api</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <groupId>io.gravitee.apim.rest.api.standalone</groupId>

--- a/gravitee-apim-rest-api/pom.xml
+++ b/gravitee-apim-rest-api/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim</groupId>
         <artifactId>gravitee-api-management</artifactId>
-        <version>3.10.17-SNAPSHOT</version>
+        <version>${revision}${sha1}${changelist}</version>
     </parent>
 
     <groupId>io.gravitee.apim.rest.api</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>io.gravitee.apim</groupId>
     <artifactId>gravitee-api-management</artifactId>
-    <version>3.10.17-SNAPSHOT</version>
+    <version>${revision}${sha1}${changelist}</version>
     <packaging>pom</packaging>
 
     <name>Gravitee.io APIM</name>
@@ -55,6 +55,11 @@
     </modules>
 
     <properties>
+        <!-- Version properties -->
+        <revision>3.10.17</revision>
+        <sha1/>
+        <changelist>-SNAPSHOT</changelist>
+
         <!-- Vert.X version is mandatory for vertx-grpc-protoc-plugin in gravitee-apim-gateway-standalone-container -->
         <vertx.version>4.1.3</vertx.version>
         <!-- Gravitee dependencies version -->
@@ -829,6 +834,31 @@
                         <phase>verify</phase>
                         <goals>
                             <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.2.7</version>
+                <configuration>
+                    <updatePomFile>true</updatePomFile>
+                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
**Issue**

NA

**Description**

Use `revision` and `changelist` properties to avoid 80+ conflicts when merging a support branch in an upper one.
With this, we ensure the version is only set once and so there will be only 1 conflict related to it and to one for each pom.xml file.

For details see https://maven.apache.org/maven-ci-friendly.html
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/improve-maven-integration-and-ci/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
