### PR TITLE
fix: reword flow-mode into flow_mode [ 3.10.x ]

### DIFF
--- a/gravitee-apim-console-webui/package-lock.json
+++ b/gravitee-apim-console-webui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gravitee-apim-console-webui",
-  "version": "3.10.15",
+  "version": "3.10.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1875,9 +1875,9 @@
       }
     },
     "@gravitee/ui-components": {
-      "version": "3.35.3",
-      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.35.3.tgz",
-      "integrity": "sha512-6BNEQKzTBCM0zzae5SjlUjp15Eg6HGTycAwO9iTmxar/n9GnxSeqcs3wxfcEibRygGSD/QsNLeHtO8ISkomkbw==",
+      "version": "3.36.1",
+      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.36.1.tgz",
+      "integrity": "sha512-ALgPVdrTrYARHR57rjd3iIS/h89w/Bm/QfKrGk20fDf4ZZu28B1perQ+JuDKzIKxgIbUUzukGSI/WWt8SmZ51A==",
       "requires": {
         "@codemirror/basic-setup": "^0.19.1",
         "@codemirror/language-data": "^0.19.1",
@@ -11328,9 +11328,9 @@
       "dev": true
     },
     "lit": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.2.4.tgz",
-      "integrity": "sha512-O7t+uizo1/Br0y+5RaWRzPkd4MsoL4XY2eq7n2wrESyCCjeagq4ERZKsyKX40jbmsz4bAAs7/0qNRX11TuXzoA==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.2.6.tgz",
+      "integrity": "sha512-K2vkeGABfSJSfkhqHy86ujchJs3NR9nW1bEEiV+bXDkbiQ60Tv5GUausYN2mXigZn8lC1qXuc46ArQRKYmumZw==",
       "requires": {
         "@lit/reactive-element": "^1.3.0",
         "lit-element": "^3.2.0",
@@ -11347,9 +11347,9 @@
       }
     },
     "lit-html": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.4.tgz",
-      "integrity": "sha512-IPY0V0z/QWcTduxb6DlP46Un8n6tG+mHSAijGcPozfXTjVkvFLN4/irPzthtq/eC8RU+7CUqh6h4KB7tnRPJfg==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.6.tgz",
+      "integrity": "sha512-xOKsPmq/RAKJ6dUeOxhmOYFjcjf0Q7aSdfBJgdJkOfCUnkmmJPxNrlZpRBeVe1Gg50oYWMlgm6ccAE/SpJgSdw==",
       "requires": {
         "@types/trusted-types": "^2.0.2"
       }

--- a/gravitee-apim-console-webui/package.json
+++ b/gravitee-apim-console-webui/package.json
@@ -4,7 +4,7 @@
   "description": "Gravitee.io APIM - UI Console",
   "dependencies": {
     "@fontsource/libre-franklin": "^4.4.5",
-    "@gravitee/ui-components": "3.35.3",
+    "@gravitee/ui-components": "3.36.1",
     "@highcharts/map-collection": "^1.1.3",
     "@toast-ui/editor": "^2.5.2",
     "@toast-ui/editor-plugin-code-syntax-highlight": "^1.0.0",

--- a/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ts
@@ -126,7 +126,7 @@ class ApiHistoryController {
       resources: api.resources,
       plans: api.plans != null ? api.plans : [],
       properties: api.properties,
-      'flow-mode': api.flow_mode,
+      flow_mode: api.flow_mode,
     };
     this.studio.services = api.services || {};
   }

--- a/gravitee-apim-console-webui/src/management/api/design/design/design.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/design/design/design.controller.ts
@@ -179,7 +179,7 @@ class ApiDesignController {
         resources: this.api.resources,
         plans: this.UserService.isUserHasPermissions(['api-plan-r', 'api-plan-u']) && this.api.plans != null ? this.api.plans : [],
         properties: this.api.properties,
-        'flow-mode': this.api.flow_mode,
+        flow_mode: this.api.flow_mode,
       };
       this.services = this.api.services;
     }
@@ -192,7 +192,7 @@ class ApiDesignController {
     this.api.resources = definition.resources;
     this.api.properties = definition.properties;
     this.api.services = services;
-    this.api.flow_mode = definition['flow-mode'];
+    this.api.flow_mode = definition.flow_mode;
     this.ApiService.update(this.api).then(() => {
       this.NotificationService.show('Design of api has been updated');
       event.target.saved();

--- a/gravitee-apim-console-webui/src/organization/configuration/policies/policies.controller.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/policies.controller.ts
@@ -60,7 +60,7 @@ class PoliciesController {
                 return flow;
               })
             : [],
-        'flow-mode': this.organization.flowMode,
+        flow_mode: this.organization.flowMode,
       };
     }
   }
@@ -76,7 +76,7 @@ class PoliciesController {
       });
       return flow;
     });
-    this.organization.flowMode = definition['flow-mode'];
+    this.organization.flowMode = definition.flow_mode;
 
     this.showConfirmDialog().then((validation) => {
       if (validation) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/flow/configuration-schema-form.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/flow/configuration-schema-form.json
@@ -2,7 +2,7 @@
   "type": "object",
   "id": "apim",
   "properties": {
-    "flow-mode": {
+    "flow_mode": {
       "title": "Flow Mode",
       "description": "The flow mode",
       "type": "string",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/FlowServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/FlowServiceTest.java
@@ -110,7 +110,7 @@ public class FlowServiceTest {
             "  \"type\": \"object\",\n" +
             "  \"id\": \"apim\",\n" +
             "  \"properties\": {\n" +
-            "    \"flow-mode\": {\n" +
+            "    \"flow_mode\": {\n" +
             "      \"title\": \"Flow Mode\",\n" +
             "      \"description\": \"The flow mode\",\n" +
             "      \"type\": \"string\",\n" +


### PR DESCRIPTION
**Issue**

gravitee-io/issues#7625

**Description**

Currently on master we can not set the organization flow mode. It's due to a simple wording error on the ui-component. ( see https://github.com/gravitee-io/gravitee-ui-components/pull/598 ) To avoid to see this issue coming back we will reword all ``flow-mode`` to ``flow_mode`` on all supported versions.

The Json property has always been fixed to ``flow_mode``so this fix only concerns the frontend and the way we map the data. 

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-flow-mode/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
