### PR TITLE
fix: resolve HTTP_2 endpoint behind nginx

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/connector/http/HttpProxyConnection.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/connector/http/HttpProxyConnection.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.http.connector.http;
 import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpHeadersValues;
 import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.definition.model.ProtocolVersion;
 import io.gravitee.definition.model.endpoint.HttpEndpoint;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.handler.Handler;
@@ -277,7 +278,8 @@ public class HttpProxyConnection<T extends HttpProxyResponse> extends AbstractHt
         // with chunk value
         if (content) {
             String encoding = headers.getFirst(HttpHeaders.TRANSFER_ENCODING);
-            if (encoding != null && encoding.contains(HttpHeadersValues.TRANSFER_ENCODING_CHUNKED)) {
+            if (encoding != null && encoding.contains(HttpHeadersValues.TRANSFER_ENCODING_CHUNKED) ||
+                ProtocolVersion.HTTP_2.equals(endpoint.getHttpClientOptions().getVersion())) {
                 httpClientRequest.setChunked(true);
             }
         } else {


### PR DESCRIPTION
From [HTTP_2 RFC](https://datatracker.ietf.org/doc/html/rfc7540):

  To ensure that the HTTP/1.1 request line can be reproduced
  accurately, this pseudo-header field MUST be omitted when
  translating from an HTTP/1.1 request that has a request target in
  origin or asterisk form (see [RFC7230], Section 5.3).  Clients
  that generate HTTP/2 requests directly SHOULD use the :authority
  pseudo-header field instead of the Host header field.  An
  intermediary that converts an HTTP/2 request to HTTP/1.1 MUST
  create a Host header field if one is not present in a request by
  copying the value of the :authority pseudo-header field.

We can trust Vertx to add the `:authority` pseudo-header instead of the `Host` header.

gravitee-io/issues#6719
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6719-http2-headers-3-5/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
