### PR TITLE
fix: API out of sync banner is displayed even after deployment

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/ApiConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/ApiConverter.java
@@ -83,11 +83,8 @@ public class ApiConverter {
                 if (apiDefinition.getFlowMode() != null) {
                     apiEntity.setFlowMode(apiDefinition.getFlowMode());
                 }
-                if (DefinitionVersion.V2.equals(apiDefinition.getDefinitionVersion())) {
+                if (apiDefinition.getFlows() != null) {
                     apiEntity.setFlows(apiDefinition.getFlows());
-                } else {
-                    apiEntity.setFlows(null);
-                    apiEntity.setPlans(null);
                 }
 
                 // Issue https://github.com/gravitee-io/issues/issues/3356

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/converter/ApiConverterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/converter/ApiConverterTest.java
@@ -15,14 +15,21 @@
  */
 package io.gravitee.rest.api.service.converter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.definition.model.Proxy;
+import io.gravitee.definition.model.flow.Flow;
+import io.gravitee.repository.management.model.Api;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.api.UpdateApiEntity;
+import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -30,6 +37,9 @@ public class ApiConverterTest {
 
     @InjectMocks
     private ApiConverter apiConverter;
+
+    @Mock
+    ObjectMapper objectMapper;
 
     @Test
     public void toUpdateApiEntity_should_keep_crossId() {
@@ -49,6 +59,38 @@ public class ApiConverterTest {
         UpdateApiEntity updateApiEntity = apiConverter.toUpdateApiEntity(apiEntity, true);
 
         assertNull("test-cross-id", updateApiEntity.getCrossId());
+    }
+
+    @Test
+    public void toApiEntity_should_get_flows_from_api_definition() throws JsonProcessingException {
+        Api api = new Api();
+        api.setDefinition("my-api-definition");
+
+        io.gravitee.definition.model.Api apiDefinition = new io.gravitee.definition.model.Api();
+        apiDefinition.setProxy(new Proxy());
+        apiDefinition.setFlows(List.of(new Flow(), new Flow()));
+        when(objectMapper.readValue("my-api-definition", io.gravitee.definition.model.Api.class)).thenReturn(apiDefinition);
+
+        ApiEntity apiEntity = apiConverter.toApiEntity(api);
+
+        assertNotNull(apiEntity.getFlows());
+        assertEquals(2, apiEntity.getFlows().size());
+    }
+
+    @Test
+    public void toApiEntity_should_set_empty_flows_list_if_no_flows_in_definition() throws JsonProcessingException {
+        Api api = new Api();
+        api.setDefinition("my-api-definition");
+
+        io.gravitee.definition.model.Api apiDefinition = new io.gravitee.definition.model.Api();
+        apiDefinition.setProxy(new Proxy());
+        apiDefinition.setFlows(null);
+        when(objectMapper.readValue("my-api-definition", io.gravitee.definition.model.Api.class)).thenReturn(apiDefinition);
+
+        ApiEntity apiEntity = apiConverter.toApiEntity(api);
+
+        assertNotNull(apiEntity.getFlows());
+        assertEquals(0, apiEntity.getFlows().size());
     }
 
     private ApiEntity buildTestApiEntity() {


### PR DESCRIPTION
**Description**

fix: API out of sync banner is displayed even after deployment

To display this banner, ApiSynchronizationProcessor compares the api from gateway event to the one read in database.

When an API doesn't have any API flow :
- ApiService reads flows in database, resulting with an empty ApiEntity.flows list
- ApiConverter reads flows in gateway event's definition, resulting with a null ApiEntity.flows list

That's why ApiSynchronizationProcessor detects a difference.

This fix makes ApiConverter keep the empty -not null- list in ApiEntity if flows are not set in gateway event.
At all, there is no need to force plans or flows to null for a V1 API.

**Issue**

https://github.com/gravitee-io/issues/issues/7830
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-apisyncforflows/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rmqyemiqla.chromatic.com)
<!-- Storybook placeholder end -->
