### PR TITLE
[JEST test] create several plan flows and use them

### DIFF
--- a/gravitee-apim-e2e/.env
+++ b/gravitee-apim-e2e/.env
@@ -2,7 +2,7 @@
 MANAGEMENT_BASE_PATH=http://localhost:8083/management
 PORTAL_BASE_PATH=http://localhost:8083/portal/environments
 GATEWAY_BASE_PATH=http://localhost:8082
-WIREMOCK_BASE_PATH=http://wiremock:8080
+WIREMOCK_BASE_PATH=http://localhost:8080
 
 # usernames and passwords
 ADMIN_USERNAME=admin

--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/flows/create-several-plan-flows-and-use-them.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/flows/create-several-plan-flows-and-use-them.spec.ts
@@ -13,8 +13,357 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { describe } from '@jest/globals';
+import { APIsApi } from '@management-apis/APIsApi';
+import { forManagementAsApiUser } from '@client-conf/*';
+import { afterAll, beforeAll, describe, expect } from '@jest/globals';
+import { ApisFaker } from '@management-fakers/ApisFaker';
+import { ApiEntity, ApiEntityFlowModeEnum, ApiEntityToJSON } from '@management-models/ApiEntity';
+import { PlansFaker } from '@management-fakers/PlansFaker';
+import { PlanStatus } from '@management-models/PlanStatus';
+import { APIPlansApi } from '@management-apis/APIPlansApi';
+import { PlanSecurityType } from '@management-models/PlanSecurityType';
+import { ApplicationEntity } from '@management-models/ApplicationEntity';
+import { Subscription } from '@management-models/Subscription';
+import { ApiKeyEntity } from '@management-models/ApiKeyEntity';
+import { ApplicationsFaker } from '@management-fakers/ApplicationsFaker';
+import { LifecycleAction } from '@management-models/LifecycleAction';
+import { ApplicationsApi } from '@management-apis/ApplicationsApi';
+import { ApplicationSubscriptionsApi } from '@management-apis/ApplicationSubscriptionsApi';
+import { fetchGatewaySuccess } from '@lib/gateway';
+import { FlowMethodsEnum } from '@management-models/Flow';
+import { UpdatePlanEntityFromJSON } from '@management-models/UpdatePlanEntity';
+import { PathOperatorOperatorEnum } from '@management-models/PathOperator';
+import { PlanEntity, PlanEntityToJSON } from '@management-models/PlanEntity';
+import { UpdateApiEntityFromJSON } from '@management-models/UpdateApiEntity';
+import { succeed } from '@lib/jest-utils';
+
+const orgId = 'DEFAULT';
+const envId = 'DEFAULT';
+
+const apisResource = new APIsApi(forManagementAsApiUser());
+const applicationsResource = new ApplicationsApi(forManagementAsApiUser());
+const applicationSubscriptionsResource = new ApplicationSubscriptionsApi(forManagementAsApiUser());
+const apiPlansResource = new APIPlansApi(forManagementAsApiUser());
 
 describe('Create several plan flows and use them', () => {
-  test.skip('To complete', async () => {});
+  let createdApi: ApiEntity;
+  let createdApplication: ApplicationEntity;
+  let createdApiKey: ApiKeyEntity;
+  let createdKeylessPlan: PlanEntity;
+  let createdApiKeyPlan: PlanEntity;
+  let createdSubscription: Subscription;
+
+  beforeAll(async () => {
+    // Create new API
+    createdApi = await apisResource.createApi({
+      orgId,
+      envId,
+      newApiEntity: ApisFaker.newApi({
+        gravitee: '2.0.0',
+        // With flow on root path
+        flows: [
+          {
+            name: '',
+            path_operator: {
+              path: '/plan',
+              operator: PathOperatorOperatorEnum.STARTSWITH,
+            },
+            condition: '',
+            consumers: [],
+            methods: [],
+            pre: [],
+            post: [
+              // Add policy to test this flow and check flow mode
+              {
+                name: 'Transform Headers',
+                description: 'Add header to validate flow and flow mode',
+                enabled: true,
+                policy: 'transform-headers',
+                configuration: {
+                  addHeaders: [
+                    { name: 'X-Test', value: 'api-root-flow-ok' },
+                    { name: 'X-Flow-Mode', value: 'DEFAULT' },
+                  ],
+                  scope: 'RESPONSE',
+                },
+              },
+            ],
+            enabled: true,
+          },
+        ],
+      }),
+    });
+
+    // Create first KeylessPlan
+    createdKeylessPlan = await apisResource.createApiPlan({
+      orgId,
+      envId,
+      api: createdApi.id,
+      newPlanEntity: PlansFaker.newPlan({
+        security: PlanSecurityType.KEYLESS,
+        status: PlanStatus.PUBLISHED,
+        flows: [
+          // With static path flow and mock policy
+          {
+            name: '',
+            path_operator: {
+              path: '/plan/keyless/foo',
+              operator: PathOperatorOperatorEnum.STARTSWITH,
+            },
+            condition: '',
+            consumers: [],
+            methods: [FlowMethodsEnum.GET],
+            pre: [
+              {
+                name: 'Mock',
+                policy: 'mock',
+                description: 'This mock policy was created by a test',
+                enabled: true,
+                configuration: {
+                  status: '200',
+                  content: 'This is Keyless Foo plan',
+                },
+              },
+            ],
+            post: [],
+            enabled: true,
+          },
+          // With dynamic path flow and mock policy
+          {
+            name: '',
+            path_operator: {
+              path: '/plan/keyless/:planName',
+              operator: PathOperatorOperatorEnum.STARTSWITH,
+            },
+            condition: '',
+            consumers: [],
+            methods: [FlowMethodsEnum.GET],
+            pre: [
+              {
+                name: 'Mock',
+                policy: 'mock',
+                description: 'This mock policy was created by a test',
+                enabled: true,
+                configuration: {
+                  status: '200',
+                  content: 'This is Keyless :planName plan',
+                },
+              },
+            ],
+            post: [],
+            enabled: true,
+          },
+        ],
+      }),
+    });
+
+    // Create second plan with ApiKey
+    createdApiKeyPlan = await apisResource.createApiPlan({
+      orgId,
+      envId,
+      api: createdApi.id,
+      newPlanEntity: PlansFaker.newPlan({ security: PlanSecurityType.APIKEY, status: PlanStatus.PUBLISHED }),
+    });
+
+    // Update it to add flow and mock policy
+    const apiKeyPlan = await apiPlansResource.getApiPlan({ envId, orgId, plan: createdApiKeyPlan.id, api: createdApi.id });
+    apiKeyPlan.flows = [
+      {
+        name: '',
+        path_operator: {
+          path: '/plan/apikey/foo',
+          operator: PathOperatorOperatorEnum.STARTSWITH,
+        },
+        condition: '',
+        consumers: [],
+        methods: [],
+        pre: [
+          {
+            name: 'Mock',
+            policy: 'mock',
+            description: 'This mock policy was created by a test',
+            enabled: true,
+            configuration: {
+              status: '200',
+              content: 'This is ApiKey plan',
+            },
+          },
+        ],
+        post: [],
+        enabled: true,
+      },
+    ];
+    await apiPlansResource.updateApiPlan({
+      envId,
+      orgId,
+      plan: createdApiKeyPlan.id,
+      api: createdApi.id,
+      updatePlanEntity: UpdatePlanEntityFromJSON(PlanEntityToJSON(apiKeyPlan)),
+    });
+
+    // Create an application
+    createdApplication = await applicationsResource.createApplication({
+      envId,
+      orgId,
+      newApplicationEntity: ApplicationsFaker.newApplication(),
+    });
+
+    // Subscribe application to ApiKey plan
+    createdSubscription = await applicationSubscriptionsResource.createSubscriptionWithApplication({
+      envId,
+      orgId,
+      plan: createdApiKeyPlan.id,
+      application: createdApplication.id,
+    });
+
+    // Get the subscription api key
+    createdApiKey = (
+      await applicationSubscriptionsResource.getApiKeysForApplicationSubscription({
+        envId,
+        orgId,
+        application: createdApplication.id,
+        subscription: createdSubscription.id,
+      })
+    )[0];
+
+    // Start it
+    await apisResource.doApiLifecycleAction({
+      envId,
+      orgId,
+      api: createdApi.id,
+      action: LifecycleAction.START,
+    });
+
+    // Wait for the effective deployment
+    await fetchGatewaySuccess({ contextPath: createdApi.context_path });
+  });
+
+  describe('With `Default` Flow Mode', function () {
+    describe('Call on the Keyless plan', () => {
+      test('Should return 200 OK on `GET /plan/keyless/foo`', async () => {
+        const res = await fetchGatewaySuccess({
+          contextPath: `${createdApi.context_path}/plan/keyless/foo`,
+        });
+
+        expect(res.headers.get('X-Test')).toEqual('api-root-flow-ok');
+        expect(await res.text()).toEqual('This is Keyless :planName plan'); // 📝 Default mode effect.
+      });
+
+      test('Should return 200 OK on `GET /plan/keyless/dynamicPlanName`', async () => {
+        const res = await fetchGatewaySuccess({
+          contextPath: `${createdApi.context_path}/plan/keyless/dynamicPlanName`,
+        });
+
+        expect(await res.text()).toEqual('This is Keyless :planName plan');
+      });
+    });
+
+    describe('Call on the ApiKey plan', () => {
+      test('Should return 200 OK on `GET /plan/apikey/foo`', async () => {
+        const res = await fetchGatewaySuccess({
+          contextPath: `${createdApi.context_path}/plan/apikey/foo?${new URLSearchParams({ 'api-key': createdApiKey.key })}`,
+        });
+
+        expect(await res.text()).toEqual('This is ApiKey plan');
+      });
+    });
+  });
+
+  describe('With `Best Match` Flow Mode', function () {
+    beforeAll(async () => {
+      // Set flow mode to Best Match and update api
+      createdApi.flow_mode = ApiEntityFlowModeEnum.BESTMATCH;
+      createdApi.flows[0].post[0].configuration.addHeaders = [
+        { name: 'X-Test', value: 'api-root-flow-ok' },
+        { name: 'X-Flow-Mode', value: 'BEST_MATCH' },
+      ];
+      await apisResource.updateApi({
+        envId,
+        orgId,
+        api: createdApi.id,
+        updateApiEntity: UpdateApiEntityFromJSON(ApiEntityToJSON(createdApi)),
+      });
+
+      // Redeploy the api
+      await succeed(apisResource.deployApiRaw({ orgId, envId, api: createdApi.id }));
+
+      // Wait for the effective redeployment
+      await fetchGatewaySuccess({
+        contextPath: `${createdApi.context_path}/plan/keyless/foo`,
+        expectedResponseValidator: (response) => response.headers.get('X-Flow-Mode') === 'BEST_MATCH',
+      });
+    });
+
+    describe('Call on the Keyless plan', () => {
+      test('Should return 200 OK on `GET /plan/keyless/foo`', async () => {
+        const res = await fetchGatewaySuccess({
+          contextPath: `${createdApi.context_path}/plan/keyless/foo`,
+        });
+
+        expect(await res.text()).toEqual('This is Keyless Foo plan'); // 📝 Best match effect. Closer paths have priority
+      });
+
+      test('Should return 200 OK on `GET /plan/keyless/dynamicPlanName`', async () => {
+        const res = await fetchGatewaySuccess({
+          contextPath: `${createdApi.context_path}/plan/keyless/dynamicPlanName`,
+        });
+
+        expect(await res.text()).toEqual('This is Keyless :planName plan');
+      });
+    });
+
+    describe('Call on the ApiKey plan', () => {
+      test('Should return 200 OK on `GET /plan/apikey/foo`', async () => {
+        const res = await fetchGatewaySuccess({
+          contextPath: `${createdApi.context_path}/plan/apikey/foo?${new URLSearchParams({ 'api-key': createdApiKey.key })}`,
+        });
+        expect(res.headers.get('X-Test')).toEqual('api-root-flow-ok');
+        expect(await res.text()).toEqual('This is ApiKey plan');
+      });
+    });
+  });
+
+  afterAll(async () => {
+    if (createdApi) {
+      // stop API
+      await apisResource.doApiLifecycleAction({
+        envId,
+        orgId,
+        api: createdApi.id,
+        action: LifecycleAction.STOP,
+      });
+
+      // close Keyless plan
+      await apiPlansResource.closeApiPlan({
+        envId,
+        orgId,
+        plan: createdKeylessPlan.id,
+        api: createdApi.id,
+      });
+
+      // close ApiKey plan
+      await apiPlansResource.closeApiPlan({
+        envId,
+        orgId,
+        plan: createdApiKeyPlan.id,
+        api: createdApi.id,
+      });
+
+      // delete API
+      await apisResource.deleteApi({
+        envId,
+        orgId,
+        api: createdApi.id,
+      });
+    }
+
+    // delete application
+    if (createdApplication) {
+      await applicationsResource.deleteApplication({
+        envId,
+        orgId,
+        application: createdApplication.id,
+      });
+    }
+  });
 });


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7695

**Description**

Add new e2e test about plan and flow. See issue comment fore more details

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/7695-plan-flow-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nbzbncikvo.chromatic.com)
<!-- Storybook placeholder end -->
