### PR TITLE
fix: fix Api out of sync baneer with flows having multiple methods

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/ser/FlowSerializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/ser/FlowSerializer.java
@@ -15,16 +15,18 @@
  */
 package io.gravitee.definition.jackson.datatype.api.ser;
 
+import static java.util.Comparator.comparing;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
 import io.gravitee.common.http.HttpMethod;
-import io.gravitee.definition.model.Rule;
 import io.gravitee.definition.model.flow.Consumer;
 import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.definition.model.flow.PathOperator;
 import io.gravitee.definition.model.flow.Step;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -60,7 +62,9 @@ public class FlowSerializer extends StdScalarSerializer<Flow> {
 
         jgen.writeArrayFieldStart("methods");
         if (flow.getMethods() != null) {
-            for (HttpMethod method : flow.getMethods()) {
+            List<HttpMethod> sortedMethods = new ArrayList<>(flow.getMethods());
+            sortedMethods.sort(comparing(HttpMethod::name));
+            for (HttpMethod method : sortedMethods) {
                 jgen.writeString(method.toString().toUpperCase());
             }
         }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/FlowSerializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/FlowSerializerTest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.jackson.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.definition.jackson.AbstractTest;
+import io.gravitee.definition.model.flow.Flow;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class FlowSerializerTest extends AbstractTest {
+
+    @Test
+    public void should_serialize_methods_in_the_same_order() throws JsonProcessingException {
+        Flow flow1 = new Flow();
+        flow1.setMethods(Set.of(HttpMethod.POST, HttpMethod.PUT));
+
+        Flow flow2 = new Flow();
+        flow2.setMethods(Set.of(HttpMethod.PUT, HttpMethod.POST));
+
+        String flow1json = objectMapper().writeValueAsString(flow1);
+        String flow2json = objectMapper().writeValueAsString(flow2);
+
+        assertEquals(flow1json, flow2json);
+    }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7830

**Description**

This makes flows methods serialization order predictable.

Flows methods is a Set, so we can't guarantee its order when it's serialized.

That causes problems in ApiSynchronizationProcessor, which compares serialized flows :
It can produces 2 different strings with methods in different order, even is there is no change.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-flowsmethodsserialization/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rwbmgmpcdp.chromatic.com)
<!-- Storybook placeholder end -->
