### PR TITLE
chore: bump gravitee-api-management to 3.19.0-SNAPSHOT

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-coverage/pom.xml
+++ b/gravitee-apim-definition/gravitee-apim-definition-coverage/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.gravitee.apim.definition</groupId>
         <artifactId>gravitee-apim-definition</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-definition-coverage</artifactId>

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/pom.xml
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.definition</groupId>
         <artifactId>gravitee-apim-definition</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-definition-jackson</artifactId>

--- a/gravitee-apim-definition/gravitee-apim-definition-model/pom.xml
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.definition</groupId>
         <artifactId>gravitee-apim-definition</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-definition-model</artifactId>

--- a/gravitee-apim-definition/pom.xml
+++ b/gravitee-apim-definition/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim</groupId>
         <artifactId>gravitee-api-management</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.apim.definition</groupId>

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee.apim</groupId>
         <artifactId>gravitee-api-management</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.apim.distribution</groupId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-buffer/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-buffer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-connector/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-connector/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-connector</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-core</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-coverage/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-coverage/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-coverage</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-dictionary/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-dictionary/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-dictionary</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-env/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-env/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-env</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-flow/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-flow/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-flow</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.handlers</groupId>
         <artifactId>gravitee-apim-gateway-handlers</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-handlers-api</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.apim.gateway.handlers</groupId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-http</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-platform/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-platform/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-platform</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-policy</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reporting/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reporting/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-reporting</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-repository/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-repository/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-repository</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-resource/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-resource/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-resource</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-apikey/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-apikey/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.security</groupId>
         <artifactId>gravitee-apim-gateway-security</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-security-apikey</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.security</groupId>
         <artifactId>gravitee-apim-gateway-security</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-security-core</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-jwt/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-jwt/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.security</groupId>
         <artifactId>gravitee-apim-gateway-security</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-security-jwt</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-keyless/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-keyless/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.security</groupId>
         <artifactId>gravitee-apim-gateway-security</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-security-keyless</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-oauth2/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-oauth2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.security</groupId>
         <artifactId>gravitee-apim-gateway-security</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-security-oauth2</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.apim.gateway.security</groupId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.services</groupId>
         <artifactId>gravitee-apim-gateway-services</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-endpoint-discovery/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-endpoint-discovery/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.services</groupId>
         <artifactId>gravitee-apim-gateway-services</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-services-endpoint-discovery</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.services</groupId>
         <artifactId>gravitee-apim-gateway-services</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-services-healthcheck</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-heartbeat/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-heartbeat/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.services</groupId>
         <artifactId>gravitee-apim-gateway-services</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-services-heartbeat</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-localregistry/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-localregistry/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.services</groupId>
         <artifactId>gravitee-apim-gateway-services</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-services-localregistry</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.services</groupId>
         <artifactId>gravitee-apim-gateway-services</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-services-sync</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.apim.gateway.services</groupId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-bootstrap/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-bootstrap/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.standalone</groupId>
         <artifactId>gravitee-apim-gateway-standalone</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-standalone-bootstrap</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.standalone</groupId>
         <artifactId>gravitee-apim-gateway-standalone</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-gateway-standalone-container</artifactId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/gravitee-apim-gateway-standalone-distribution-zip/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/gravitee-apim-gateway-standalone-distribution-zip/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway.standalone.distribution</groupId>
         <artifactId>gravitee-apim-gateway-standalone-distribution</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee.apim.distribution</groupId>
         <artifactId>gravitee-apim-distribution</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
         <relativePath>../../../gravitee-apim-distribution/pom.xml</relativePath>
     </parent>
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.gateway</groupId>
         <artifactId>gravitee-apim-gateway</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.apim.gateway.standalone</groupId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>gravitee-apim-gateway</artifactId>
         <groupId>io.gravitee.apim.gateway</groupId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-apim-gateway/pom.xml
+++ b/gravitee-apim-gateway/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim</groupId>
         <artifactId>gravitee-api-management</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.apim.gateway</groupId>

--- a/gravitee-apim-repository/gravitee-apim-repository-api/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.repository</groupId>
         <artifactId>gravitee-apim-repository</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-repository-api</artifactId>

--- a/gravitee-apim-repository/gravitee-apim-repository-coverage/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-coverage/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.gravitee.apim.repository</groupId>
         <artifactId>gravitee-apim-repository</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-repository-coverage</artifactId>

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee.apim.repository</groupId>
         <artifactId>gravitee-apim-repository</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-repository-elasticsearch</artifactId>

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.repository.gateway.bridge.http</groupId>
         <artifactId>gravitee-apim-repository-gateway-bridge-http</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-repository-gateway-bridge-http-client</artifactId>

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.repository.gateway.bridge.http</groupId>
         <artifactId>gravitee-apim-repository-gateway-bridge-http</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-repository-gateway-bridge-http-server</artifactId>

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.repository</groupId>
         <artifactId>gravitee-apim-repository</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.apim.repository.gateway.bridge.http</groupId>

--- a/gravitee-apim-repository/gravitee-apim-repository-hazelcast/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-hazelcast/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>io.gravitee.apim.repository</groupId>
 		<artifactId>gravitee-apim-repository</artifactId>
-		<version>3.18.0-SNAPSHOT</version>
+		<version>3.19.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>gravitee-apim-repository-hazelcast</artifactId>

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee.apim.repository</groupId>
         <artifactId>gravitee-apim-repository</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-repository-jdbc</artifactId>

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee.apim.repository</groupId>
         <artifactId>gravitee-apim-repository</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
 	<artifactId>gravitee-apim-repository-mongodb</artifactId>

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>io.gravitee.apim.repository</groupId>
 		<artifactId>gravitee-apim-repository</artifactId>
-		<version>3.18.0-SNAPSHOT</version>
+		<version>3.19.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>gravitee-apim-repository-redis</artifactId>

--- a/gravitee-apim-repository/gravitee-apim-repository-test/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee.apim.repository</groupId>
         <artifactId>gravitee-apim-repository</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-repository-test</artifactId>

--- a/gravitee-apim-repository/pom.xml
+++ b/gravitee-apim-repository/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee.apim</groupId>
         <artifactId>gravitee-api-management</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.apim.repository</groupId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-coverage/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-coverage/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api</groupId>
         <artifactId>gravitee-apim-rest-api</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-coverage</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-fetcher/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-fetcher/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api</groupId>
         <artifactId>gravitee-apim-rest-api</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-fetcher</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-api/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-api/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.idp</groupId>
         <artifactId>gravitee-apim-rest-api-idp</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-idp-api</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-core/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-core/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.idp</groupId>
         <artifactId>gravitee-apim-rest-api-idp</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-idp-core</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-ldap/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-ldap/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.idp</groupId>
         <artifactId>gravitee-apim-rest-api-idp</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-idp-ldap</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-memory/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-memory/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.idp</groupId>
         <artifactId>gravitee-apim-rest-api-idp</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-idp-memory</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-repository/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/gravitee-apim-rest-api-idp-repository/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.idp</groupId>
         <artifactId>gravitee-apim-rest-api-idp</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-idp-repository</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-idp/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api</groupId>
         <artifactId>gravitee-apim-rest-api</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.apim.rest.api.idp</groupId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
         <groupId>io.gravitee.apim.rest.api.management</groupId>
         <artifactId>gravitee-apim-rest-api-management</artifactId>
-		<version>3.18.0-SNAPSHOT</version>
+		<version>3.19.0-SNAPSHOT</version>
     </parent>
 
 	<artifactId>gravitee-apim-rest-api-management-rest</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-security/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-security/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
         <groupId>io.gravitee.apim.rest.api.management</groupId>
         <artifactId>gravitee-apim-rest-api-management</artifactId>
-		<version>3.18.0-SNAPSHOT</version>
+		<version>3.19.0-SNAPSHOT</version>
     </parent>
 
 	<artifactId>gravitee-apim-rest-api-management-security</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api</groupId>
         <artifactId>gravitee-apim-rest-api</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.apim.rest.api.management</groupId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
         <groupId>io.gravitee.apim.rest.api</groupId>
         <artifactId>gravitee-apim-rest-api</artifactId>
-		<version>3.18.0-SNAPSHOT</version>
+		<version>3.19.0-SNAPSHOT</version>
     </parent>
 
 	<artifactId>gravitee-apim-rest-api-model</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
         <groupId>io.gravitee.apim.rest.api.portal</groupId>
         <artifactId>gravitee-apim-rest-api-portal</artifactId>
-		<version>3.18.0-SNAPSHOT</version>
+		<version>3.19.0-SNAPSHOT</version>
     </parent>
 
 	<artifactId>gravitee-apim-rest-api-portal-rest</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-security/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-security/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
         <groupId>io.gravitee.apim.rest.api.portal</groupId>
         <artifactId>gravitee-apim-rest-api-portal</artifactId>
-		<version>3.18.0-SNAPSHOT</version>
+		<version>3.19.0-SNAPSHOT</version>
     </parent>
 
 	<artifactId>gravitee-apim-rest-api-portal-security</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api</groupId>
         <artifactId>gravitee-apim-rest-api</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.apim.rest.api.portal</groupId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
         <groupId>io.gravitee.apim.rest.api</groupId>
         <artifactId>gravitee-apim-rest-api</artifactId>
-		<version>3.18.0-SNAPSHOT</version>
+		<version>3.19.0-SNAPSHOT</version>
     </parent>
 
 	<artifactId>gravitee-apim-rest-api-repository</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
         <groupId>io.gravitee.apim.rest.api</groupId>
         <artifactId>gravitee-apim-rest-api</artifactId>
-		<version>3.18.0-SNAPSHOT</version>
+		<version>3.19.0-SNAPSHOT</version>
     </parent>
 
 	<artifactId>gravitee-apim-rest-api-security</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
         <groupId>io.gravitee.apim.rest.api</groupId>
         <artifactId>gravitee-apim-rest-api</artifactId>
-		<version>3.18.0-SNAPSHOT</version>
+		<version>3.19.0-SNAPSHOT</version>
     </parent>
 
 	<artifactId>gravitee-apim-rest-api-service</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-auto-fetch/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-auto-fetch/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.services</groupId>
         <artifactId>gravitee-apim-rest-api-services</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.services</groupId>
         <artifactId>gravitee-apim-rest-api-services</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-services-dictionary</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.services</groupId>
         <artifactId>gravitee-apim-rest-api-services</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-services-dynamic-properties</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-search-indexer/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-search-indexer/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.services</groupId>
         <artifactId>gravitee-apim-rest-api-services</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-subscription-pre-expiration-notif/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-subscription-pre-expiration-notif/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.services</groupId>
         <artifactId>gravitee-apim-rest-api-services</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-services-subscription-pre-expiration-notif</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-subscriptions/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-subscriptions/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.services</groupId>
         <artifactId>gravitee-apim-rest-api-services</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-services-subscriptions</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-sync/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-sync/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.services</groupId>
         <artifactId>gravitee-apim-rest-api-services</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-services-sync</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-v3-upgrader/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-v3-upgrader/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.services</groupId>
         <artifactId>gravitee-apim-rest-api-services</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-services-v3-upgrader</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api</groupId>
         <artifactId>gravitee-apim-rest-api</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.apim.rest.api.services</groupId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>gravitee-apim-rest-api</artifactId>
         <groupId>io.gravitee.apim.rest.api</groupId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-bootstrap/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-bootstrap/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.standalone</groupId>
         <artifactId>gravitee-apim-rest-api-standalone</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-standalone-bootstrap</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.standalone</groupId>
         <artifactId>gravitee-apim-rest-api-standalone</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>gravitee-apim-rest-api-standalone-container</artifactId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/gravitee-apim-rest-api-standalone-distribution-zip/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/gravitee-apim-rest-api-standalone-distribution-zip/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api.standalone.distribution</groupId>
         <artifactId>gravitee-apim-rest-api-standalone-distribution</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.distribution</groupId>
         <artifactId>gravitee-apim-distribution</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
         <relativePath>../../../gravitee-apim-distribution/pom.xml</relativePath>
     </parent>
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim.rest.api</groupId>
         <artifactId>gravitee-apim-rest-api</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.apim.rest.api.standalone</groupId>

--- a/gravitee-apim-rest-api/pom.xml
+++ b/gravitee-apim-rest-api/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee.apim</groupId>
         <artifactId>gravitee-api-management</artifactId>
-        <version>3.18.0-SNAPSHOT</version>
+        <version>3.19.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.apim.rest.api</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
     <groupId>io.gravitee.apim</groupId>
     <artifactId>gravitee-api-management</artifactId>
-    <version>3.18.0-SNAPSHOT</version>
+    <version>3.19.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Gravitee.io APIM</name>


### PR DESCRIPTION
chore: bump gravitee-api-management to 3.19.0-SNAPSHOT
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/chore-bumpapim/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-thdngkurbx.chromatic.com)
<!-- Storybook placeholder end -->
