### PR TITLE
ci: improve cache using CIRCLE_WORKFLOW_WORKSPACE_ID as cache id

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,7 +268,7 @@ jobs:
             - save_cache:
                   paths:
                       - ~/.m2/repository/io/gravitee/apim
-                  key: gravitee-api-management-v6-build-apim-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+                  key: gravitee-api-management-v6-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
                   when: on_success
             - run:
                   name: "Exclude APIM artefacts from build cache"
@@ -294,7 +294,7 @@ jobs:
                   jobName: test
             - restore_cache:
                   keys:
-                      - gravitee-api-management-v6-build-apim-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+                      - gravitee-api-management-v6-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
             - run:
                   name: Run APIM definition tests
                   command: |
@@ -335,7 +335,7 @@ jobs:
                   jobName: test-repository
             - restore_cache:
                   keys:
-                      - gravitee-api-management-v6-build-apim-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+                      - gravitee-api-management-v6-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
             - run:
                   name: Run tests
                   command: |


### PR DESCRIPTION
ci: improve cache using CIRCLE_WORKFLOW_WORKSPACE_ID as cache id

As we keep the same cache ID when we use 'restart workflow from...' on the CircleCi workflow
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/ci-improvecache-3-10/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
