### PR TITLE
Update dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,10 +57,9 @@ commands:
         steps:
             - restore_cache:
                   keys:
-                      - gravitee-api-management-v6-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-                      - gravitee-api-management-v6-<< parameters.jobName >>-{{ .Branch }}-
-                      - gravitee-api-management-v6-<< parameters.jobName >>-
-                      - gravitee-api-management-v6-
+                      - gravitee-api-management-v7-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+                      - gravitee-api-management-v7-<< parameters.jobName >>-{{ .Branch }}-
+                      - gravitee-api-management-v7-<< parameters.jobName >>-
     save-maven-job-cache:
         description: Restore Maven cache for a dedicated job
         parameters:
@@ -72,7 +71,7 @@ commands:
             - save_cache:
                   paths:
                       - ~/.m2
-                  key: gravitee-api-management-v6-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+                  key: gravitee-api-management-v7-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
                   when: always
 
     notify-on-failure:
@@ -210,9 +209,9 @@ jobs:
                   at: .
             - restore_cache:
                   keys:
-                      - gravitee-api-management-v6-sonarcloud-analysis-{{ .Branch }}-{{ checksum "pom.xml" }}
-                      - gravitee-api-management-v6-sonarcloud-analysis-{{ .Branch }}-
-                      - gravitee-api-management-v6-sonarcloud-analysis-
+                      - gravitee-api-management-v7-sonarcloud-analysis-{{ .Branch }}-{{ checksum "pom.xml" }}
+                      - gravitee-api-management-v7-sonarcloud-analysis-{{ .Branch }}-
+                      - gravitee-api-management-v7-sonarcloud-analysis-
             - keeper/env-export:
                   secret-url: keeper://9x9YgyU6DWzux4DPoHAzDQ/field/password
                   var-name: SONAR_TOKEN
@@ -225,7 +224,7 @@ jobs:
             - save_cache:
                   paths:
                       - /opt/sonar-scanner/.sonar/cache
-                  key: gravitee-api-management-v6-sonarcloud-analysis-{{ .Branch }}-{{ checksum "pom.xml" }}
+                  key: gravitee-api-management-v7-sonarcloud-analysis-{{ .Branch }}-{{ checksum "pom.xml" }}
                   when: always
 
     validate:
@@ -268,7 +267,7 @@ jobs:
             - save_cache:
                   paths:
                       - ~/.m2/repository/io/gravitee/apim
-                  key: gravitee-api-management-v6-build-apim-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+                  key: gravitee-api-management-v7-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
                   when: on_success
             - run:
                   name: "Exclude APIM artefacts from build cache"
@@ -294,7 +293,7 @@ jobs:
                   jobName: test
             - restore_cache:
                   keys:
-                      - gravitee-api-management-v6-build-apim-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+                      - gravitee-api-management-v7-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
             - run:
                   name: Run APIM definition tests
                   command: |
@@ -335,7 +334,7 @@ jobs:
                   jobName: test-repository
             - restore_cache:
                   keys:
-                      - gravitee-api-management-v6-build-apim-{{ .Environment.CIRCLE_WORKFLOW_ID }}
+                      - gravitee-api-management-v7-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
             - run:
                   name: Run tests
                   command: |

--- a/pom.xml
+++ b/pom.xml
@@ -61,9 +61,9 @@
         <changelist>-SNAPSHOT</changelist>
 
         <!-- Vert.X version is mandatory for vertx-grpc-protoc-plugin in gravitee-apim-gateway-standalone-container -->
-        <vertx.version>4.1.3</vertx.version>
+        <vertx.version>4.1.8</vertx.version>
         <!-- Gravitee dependencies version -->
-        <gravitee-bom.version>1.4</gravitee-bom.version>
+        <gravitee-bom.version>1.5</gravitee-bom.version>
         <gravitee-alert-api.version>1.9.0</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>1.7.0</gravitee-cockpit-api.version>
         <gravitee-common.version>1.20.5</gravitee-common.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7837

**Description**

* bump gravitee-bom version (to get updated dependencies)
* using CIRCLE_WORKFLOW_WORKSPACE_ID as cache id for "local" cache
* changing cache key (v6 -> v7)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/bump-bom/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
