### PR TITLE
fix: restore HTTP headers backward compatibility

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -46,7 +46,7 @@
     <properties>
         <!-- Versions of the plugins for the full distribution -->
         <!-- Management API & Gateway -->
-        <gravitee-connector-http.version>1.1.5</gravitee-connector-http.version>
+        <gravitee-connector-http.version>1.1.6</gravitee-connector-http.version>
         <gravitee-policy-apikey.version>2.4.0</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>1.5.0</gravitee-policy-assign-attributes.version>
         <gravitee-policy-assign-content.version>1.7.0</gravitee-policy-assign-content.version>
@@ -55,7 +55,7 @@
         <gravitee-policy-dynamic-routing.version>1.11.1</gravitee-policy-dynamic-routing.version>
         <gravitee-policy-generate-http-signature.version>1.1.0</gravitee-policy-generate-http-signature.version>
         <gravitee-policy-generate-jwt.version>1.5.0</gravitee-policy-generate-jwt.version>
-        <gravitee-policy-groovy.version>2.2.1</gravitee-policy-groovy.version>
+        <gravitee-policy-groovy.version>2.2.2</gravitee-policy-groovy.version>
         <gravitee-policy-html-json.version>1.6.0</gravitee-policy-html-json.version>
         <gravitee-policy-http-signature.version>1.5.0</gravitee-policy-http-signature.version>
         <gravitee-policy-ipfiltering.version>1.9.0</gravitee-policy-ipfiltering.version>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpHeaders.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpHeaders.java
@@ -15,18 +15,26 @@
  */
 package io.gravitee.gateway.http.vertx;
 
+import io.gravitee.common.util.LinkedCaseInsensitiveMap;
+import io.gravitee.common.util.MultiValueMap;
+import io.gravitee.gateway.api.http.DefaultHttpHeaders;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.vertx.core.MultiMap;
+import io.vertx.core.http.impl.headers.HeadersMultiMap;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
+ * Implements {@link MultiValueMap<String,String>} for backward compatibility due to the changes to Headers in 3.15.
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class VertxHttpHeaders implements HttpHeaders {
+public class VertxHttpHeaders implements HttpHeaders, MultiValueMap<String, String> {
 
     private final MultiMap headers;
 
@@ -102,5 +110,126 @@ public class VertxHttpHeaders implements HttpHeaders {
     @Override
     public Iterator<Map.Entry<String, String>> iterator() {
         return headers.iterator();
+    }
+
+    @Override
+    public Map<String, String> toSingleValueMap() {
+        return HttpHeaders.super.toSingleValueMap();
+    }
+
+    @Override
+    public boolean containsAllKeys(Collection<String> names) {
+        return HttpHeaders.super.containsAllKeys(names);
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return contains(String.valueOf(key));
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return entrySet().stream().anyMatch(entry -> value.equals(entry.getValue()));
+    }
+
+    /**
+     * @see LinkedCaseInsensitiveMap#get(Object)
+     * Contrary to {@link DefaultHttpHeaders#get(CharSequence)}, the list of values is returned, not only the first element
+     */
+    @Override
+    public List<String> get(Object key) {
+        return headers.getAll(String.valueOf(key));
+    }
+
+    /**
+     * @see HashMap#putVal(int, Object, Object, boolean, boolean), returns the previous value if present, else null.
+     */
+    @Override
+    public List<String> put(String key, List<String> value) {
+        final List<String> previousValues = headers.getAll(key);
+        for (int i = 0; i < value.size(); i++) {
+            // For the first element, we need to use set to override previous value, then we use add to add new ones.
+            if (i == 0) {
+                headers.set(key, value.get(i));
+            } else {
+                headers.add(key, value.get(i));
+            }
+        }
+        return previousValues.isEmpty() ? null : previousValues;
+    }
+
+    /**
+     * @see HashMap#remove(Object), returns the previous value (can bee {@code null}) associated with {@code key} or null if none.
+     */
+    @Override
+    public List<String> remove(Object key) {
+        final List<String> previousValues = headers.getAll(String.valueOf(key));
+        headers.remove(String.valueOf(key));
+        return previousValues;
+    }
+
+    @Override
+    public void putAll(Map<? extends String, ? extends List<String>> map) {
+        final MultiMap multimap = HeadersMultiMap.headers();
+
+        // Flatten the Map<String, List<String>> to be able to add each entry one by one to a new Multimap object
+        map
+            .entrySet()
+            .stream()
+            .flatMap(entry -> entry.getValue().stream().map(v -> Map.entry(entry.getKey(), v)))
+            .forEach(entry -> multimap.add(entry.getKey(), entry.getValue()));
+
+        headers.setAll(multimap);
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return headers.entries().stream().map(Entry::getKey).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Collection<List<String>> values() {
+        return headers
+            .entries()
+            .stream()
+            .collect(Collectors.groupingBy(Entry::getKey))
+            .values()
+            .stream()
+            .map(entries -> entries.stream().map(Entry::getValue).collect(Collectors.toList()))
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public Set<Entry<String, List<String>>> entrySet() {
+        return headers
+            .entries()
+            .stream()
+            .collect(Collectors.groupingBy(Entry::getKey))
+            .entrySet()
+            .stream()
+            .map(entry -> Map.entry(entry.getKey(), entry.getValue().stream().map(Entry::getValue).collect(Collectors.toList())))
+            .collect(Collectors.toSet());
+    }
+
+    @Override
+    public String getFirst(String header) {
+        return this.headers.get(header);
+    }
+
+    @Override
+    public void add(String name, String value) {
+        headers.add(name, value);
+    }
+
+    @Override
+    public void set(String name, String value) {
+        this.headers.set(name, value);
+    }
+
+    @Override
+    public void setAll(Map<String, String> values) {
+        for (Entry<String, String> entry : values.entrySet()) {
+            set(entry.getKey(), entry.getValue());
+        }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/http/vertx/VertxHttpHeadersTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/http/vertx/VertxHttpHeadersTest.java
@@ -1,0 +1,284 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.http.vertx;
+
+import static io.gravitee.gateway.api.http.HttpHeaderNames.ACCEPT_LANGUAGE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.gateway.api.http.DefaultHttpHeaders;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.vertx.core.http.impl.headers.HeadersMultiMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class VertxHttpHeadersTest {
+
+    public static final String FIRST_HEADER = "First-Header";
+    public static final String SECOND_HEADER = "Second-Header";
+    public static final String FIRST_HEADER_VALUE_1 = "first-header-value-1";
+    public static final String FIRST_HEADER_VALUE_2 = "first-header-value-2";
+    public static final String SECOND_HEADER_VALUE = "second-header-value";
+    private VertxHttpHeaders cut;
+
+    private DefaultHttpHeaders defaultHttpHeaders;
+
+    @Before
+    public void setUp() {
+        cut = new VertxHttpHeaders(HeadersMultiMap.headers());
+        cut.add(FIRST_HEADER, FIRST_HEADER_VALUE_1);
+        cut.add(FIRST_HEADER, FIRST_HEADER_VALUE_2);
+        cut.add(SECOND_HEADER, SECOND_HEADER_VALUE);
+
+        // Tests will be also done on DefaultHttpHeaders to verify there is no divergence between both implementations.
+        defaultHttpHeaders = (DefaultHttpHeaders) HttpHeaders.create(cut);
+    }
+
+    @Test
+    public void shouldConvertToSingleValueMap() {
+        final Map<String, String> result = cut.toSingleValueMap();
+        assertThat(result).containsEntry(FIRST_HEADER, FIRST_HEADER_VALUE_1).containsEntry(SECOND_HEADER, SECOND_HEADER_VALUE);
+
+        // In case of multiple values for one header name, this conversion is only taking the first value
+        assertThat(result.values()).doesNotContain(FIRST_HEADER_VALUE_2);
+
+        final Map<String, String> defaultHttpHeadersResult = defaultHttpHeaders.toSingleValueMap();
+        assertThat(result).isEqualTo(defaultHttpHeadersResult);
+    }
+
+    @Test
+    public void shouldContainAllKeys() {
+        assertThat(cut.containsAllKeys(List.of())).isTrue();
+        assertThat(defaultHttpHeaders.containsAllKeys(List.of())).isTrue();
+
+        assertThat(cut.containsAllKeys(List.of(FIRST_HEADER))).isTrue();
+        assertThat(defaultHttpHeaders.containsAllKeys(List.of(FIRST_HEADER))).isTrue();
+
+        assertThat(cut.containsAllKeys(List.of(FIRST_HEADER, SECOND_HEADER))).isTrue();
+        assertThat(defaultHttpHeaders.containsAllKeys(List.of(FIRST_HEADER, SECOND_HEADER))).isTrue();
+
+        assertThat(cut.containsAllKeys(List.of(FIRST_HEADER, SECOND_HEADER, ACCEPT_LANGUAGE))).isFalse();
+        assertThat(defaultHttpHeaders.containsAllKeys(List.of(FIRST_HEADER, SECOND_HEADER, ACCEPT_LANGUAGE))).isFalse();
+
+        assertThat(cut.containsAllKeys(List.of(ACCEPT_LANGUAGE))).isFalse();
+        assertThat(defaultHttpHeaders.containsAllKeys(List.of(ACCEPT_LANGUAGE))).isFalse();
+    }
+
+    @Test
+    public void shouldContainKey() {
+        Object key = new Object();
+        assertThat(cut.containsKey(key)).isFalse();
+        assertThat(defaultHttpHeaders.containsKey(key)).isFalse();
+
+        key = FIRST_HEADER;
+        assertThat(cut.containsKey(key)).isTrue();
+        assertThat(defaultHttpHeaders.containsKey(key)).isTrue();
+
+        key = ACCEPT_LANGUAGE;
+        assertThat(cut.containsKey(key)).isFalse();
+        assertThat(defaultHttpHeaders.containsKey(key)).isFalse();
+    }
+
+    @Test
+    public void shouldContainValue() {
+        Object value = new Object();
+        assertThat(cut.containsValue(value)).isFalse();
+        assertThat(defaultHttpHeaders.containsValue(value)).isFalse();
+
+        value = List.of(FIRST_HEADER_VALUE_1, FIRST_HEADER_VALUE_2);
+        assertThat(cut.containsValue(value)).isTrue();
+        assertThat(defaultHttpHeaders.containsValue(value)).isTrue();
+
+        value = List.of(SECOND_HEADER_VALUE);
+        assertThat(cut.containsValue(value)).isTrue();
+        assertThat(defaultHttpHeaders.containsValue(value)).isTrue();
+
+        value = List.of(ACCEPT_LANGUAGE);
+        assertThat(cut.containsValue(value)).isFalse();
+        assertThat(defaultHttpHeaders.containsValue(value)).isFalse();
+    }
+
+    @Test
+    public void shouldGet() {
+        Object key = new Object();
+        assertThat(cut.get(key)).isEmpty();
+        assertThat(defaultHttpHeaders.get(key)).isEmpty();
+
+        key = FIRST_HEADER;
+        assertThat(cut.get(key)).hasSize(2);
+        assertThat(defaultHttpHeaders.get(key)).hasSize(2);
+
+        key = SECOND_HEADER;
+        assertThat(cut.get(key)).hasSize(1);
+        assertThat(defaultHttpHeaders.get(key)).hasSize(1);
+
+        key = ACCEPT_LANGUAGE;
+        assertThat(cut.get(key)).isEmpty();
+        assertThat(defaultHttpHeaders.get(key)).isEmpty();
+    }
+
+    @Test
+    public void shouldPut() {
+        // Putting a new header
+        final List<String> headerTestValues = List.of("test-value1", "test-value2");
+        final List<String> testHeader = cut.put("test", headerTestValues);
+        final List<String> testHeaderFromDefaultHttpHeaders = defaultHttpHeaders.put("test", headerTestValues);
+
+        assertThat(testHeader).isNull();
+        assertThat(testHeaderFromDefaultHttpHeaders).isNull();
+        assertThat(cut.getAll("test")).isEqualTo(headerTestValues);
+        assertThat(defaultHttpHeaders.getAll("test")).isEqualTo(headerTestValues);
+        assertThat(cut.size()).isEqualTo(3);
+        assertThat(defaultHttpHeaders.size()).isEqualTo(3);
+
+        // Putting a header already present in the map
+        final List<String> firstHeaderNewValues = List.of("first-overridden-1", "first-overridden-2", "first-overridden-3");
+        final List<String> firstHeaderOverridden = cut.put(FIRST_HEADER, firstHeaderNewValues);
+        final List<String> firstHeaderOverriddenDefaultHttpHeaders = defaultHttpHeaders.put(FIRST_HEADER, firstHeaderNewValues);
+
+        assertThat(firstHeaderOverridden).hasSize(2).containsExactlyElementsOf(List.of(FIRST_HEADER_VALUE_1, FIRST_HEADER_VALUE_2));
+        assertThat(firstHeaderOverriddenDefaultHttpHeaders)
+            .hasSize(2)
+            .containsExactlyElementsOf(List.of(FIRST_HEADER_VALUE_1, FIRST_HEADER_VALUE_2));
+        assertThat(cut.getAll(FIRST_HEADER)).containsExactlyElementsOf(firstHeaderNewValues);
+        assertThat(defaultHttpHeaders.getAll(FIRST_HEADER)).containsExactlyElementsOf(firstHeaderNewValues);
+    }
+
+    @Test
+    public void shouldRemove() {
+        final HttpHeaders headers = cut.remove(FIRST_HEADER);
+        final HttpHeaders defaultHttpHeadersResult = defaultHttpHeaders.remove(FIRST_HEADER);
+
+        assertThat(headers.contains(FIRST_HEADER)).isFalse();
+        assertThat(defaultHttpHeadersResult.contains(FIRST_HEADER)).isFalse();
+    }
+
+    @Test
+    public void shouldPutAll() {
+        final List<String> putAllHeaders = List.of("test-value1", "test-value2");
+        final Map<String, List<String>> mapToAdd = Map.of("Put-All-Header", putAllHeaders, FIRST_HEADER, List.of("new-value"));
+
+        cut.putAll(mapToAdd);
+        defaultHttpHeaders.putAll(mapToAdd);
+
+        assertThat(cut.getAll("Put-All-Header")).hasSize(2).containsExactlyElementsOf(putAllHeaders);
+        assertThat(defaultHttpHeaders.getAll("Put-All-Header")).hasSize(2).containsExactlyElementsOf(putAllHeaders);
+
+        // Existing headers in the map should be overridden by this operation
+        assertThat(cut.getAll(FIRST_HEADER)).hasSize(1).containsExactly("new-value");
+        assertThat(defaultHttpHeaders.getAll(FIRST_HEADER)).hasSize(1).containsExactly("new-value");
+    }
+
+    @Test
+    public void shouldGetKeySet() {
+        assertThat(cut.keySet()).hasSize(2).containsExactly(FIRST_HEADER, SECOND_HEADER);
+        assertThat(defaultHttpHeaders.keySet()).hasSize(2).containsExactly(FIRST_HEADER, SECOND_HEADER);
+    }
+
+    @Test
+    public void shouldGetValues() {
+        assertThat(cut.values())
+            .hasSize(2)
+            .containsExactly(List.of(FIRST_HEADER_VALUE_1, FIRST_HEADER_VALUE_2), List.of(SECOND_HEADER_VALUE));
+
+        assertThat(defaultHttpHeaders.values())
+            .hasSize(2)
+            .containsExactly(List.of(FIRST_HEADER_VALUE_1, FIRST_HEADER_VALUE_2), List.of(SECOND_HEADER_VALUE));
+    }
+
+    @Test
+    public void shouldGetEntrySet() {
+        assertThat(cut.entrySet())
+            .hasSize(2)
+            .containsExactly(
+                Map.entry(FIRST_HEADER, List.of(FIRST_HEADER_VALUE_1, FIRST_HEADER_VALUE_2)),
+                Map.entry(SECOND_HEADER, List.of(SECOND_HEADER_VALUE))
+            );
+
+        assertThat(defaultHttpHeaders.entrySet())
+            .hasSize(2)
+            .containsExactly(
+                Map.entry(FIRST_HEADER, List.of(FIRST_HEADER_VALUE_1, FIRST_HEADER_VALUE_2)),
+                Map.entry(SECOND_HEADER, List.of(SECOND_HEADER_VALUE))
+            );
+    }
+
+    @Test
+    public void shouldGetFirst() {
+        assertThat(cut.getFirst(FIRST_HEADER)).isEqualTo(FIRST_HEADER_VALUE_1);
+        assertThat(defaultHttpHeaders.getFirst(FIRST_HEADER)).isEqualTo(FIRST_HEADER_VALUE_1);
+    }
+
+    @Test
+    public void shouldNotGetFirst() {
+        assertThat(cut.getFirst("Content-Type")).isNull();
+        assertThat(defaultHttpHeaders.getFirst("Content-Type")).isNull();
+    }
+
+    @Test
+    public void shouldAddValue() {
+        cut.add(FIRST_HEADER, "new-value");
+        defaultHttpHeaders.add(FIRST_HEADER, "new-value");
+
+        assertThat(cut.getAll(FIRST_HEADER)).hasSize(3).containsExactly(FIRST_HEADER_VALUE_1, FIRST_HEADER_VALUE_2, "new-value");
+        assertThat(defaultHttpHeaders.getAll(FIRST_HEADER))
+            .hasSize(3)
+            .containsExactly(FIRST_HEADER_VALUE_1, FIRST_HEADER_VALUE_2, "new-value");
+    }
+
+    @Test
+    public void shouldAddValueNonExistingKey() {
+        cut.add("New-Header", "new-value");
+        defaultHttpHeaders.add("New-Header", "new-value");
+
+        assertThat(cut.getAll("New-Header")).hasSize(1).containsExactly("new-value");
+        assertThat(defaultHttpHeaders.getAll("New-Header")).hasSize(1).containsExactly("new-value");
+    }
+
+    @Test
+    public void shouldSetValue() {
+        cut.set(FIRST_HEADER, "new-value");
+        cut.set("New-Header", "new-value");
+        defaultHttpHeaders.set(FIRST_HEADER, "new-value");
+        defaultHttpHeaders.set("New-Header", "new-value");
+
+        assertThat(cut.getAll(FIRST_HEADER)).hasSize(1).containsExactly("new-value");
+        assertThat(defaultHttpHeaders.getAll(FIRST_HEADER)).hasSize(1).containsExactly("new-value");
+
+        assertThat(cut.getAll("New-Header")).hasSize(1).containsExactly("new-value");
+        assertThat(defaultHttpHeaders.getAll("New-Header")).hasSize(1).containsExactly("new-value");
+    }
+
+    @Test
+    public void shouldSetAll() {
+        final Map<String, String> mapToAdd = Map.of("Put-All-Header", "test-value1", FIRST_HEADER, "new-value");
+
+        cut.setAll(mapToAdd);
+        defaultHttpHeaders.setAll(mapToAdd);
+
+        assertThat(cut.getAll("Put-All-Header")).hasSize(1).containsExactly("test-value1");
+        assertThat(defaultHttpHeaders.getAll("Put-All-Header")).hasSize(1).containsExactly("test-value1");
+
+        // Existing headers in the map should be overridden by this operation
+        assertThat(cut.getAll(FIRST_HEADER)).hasSize(1).containsExactly("new-value");
+        assertThat(defaultHttpHeaders.getAll(FIRST_HEADER)).hasSize(1).containsExactly("new-value");
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <jetty94.wiremock.version>9.4.44.v20210927</jetty94.wiremock.version>
-        <gravitee-connector-http.version>1.1.5</gravitee-connector-http.version>
+        <gravitee-connector-http.version>1.1.6</gravitee-connector-http.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -63,9 +63,9 @@
         <gravitee-cockpit-api.version>1.10.0</gravitee-cockpit-api.version>
         <gravitee-common.version>1.25.0</gravitee-common.version>
         <gravitee-connector-api.version>1.1.0</gravitee-connector-api.version>
-        <gravitee-expression-language.version>1.9.2</gravitee-expression-language.version>
+        <gravitee-expression-language.version>1.9.3</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>1.31.2</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.32.3</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>1.20.4</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7812

**Description**

3.15 introduced a refactoring of the HTTP Headers used in the Gateway. It does not rely on gravitee-common HTTPHeaders anymore but on gateway-api HTTPHeaders.

This new version is used as an Iterable<Map.Entry<String, String>>, breaking the contract for users using MultiValueMap<String, String> methods, or multi value capabilities.

To not break this new contract and open the possibilities too wildly to the policies relying on it, MultiValueMap is implemented at implementation level, to keep the "old behavior" only internally

**Blocked by**

https://github.com/gravitee-io/gravitee-gateway-api/pull/118
https://github.com/gravitee-io/gravitee-expression-language/pull/48
https://github.com/gravitee-io/gravitee-policy-groovy
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-7812-retro-headers/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xtjtbjxpba.chromatic.com)
<!-- Storybook placeholder end -->
