### PR TITLE
build: don't use temporary versions in APIM dependencies so external …

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,10 +59,9 @@ commands:
         steps:
             - restore_cache:
                   keys:
-                      - gravitee-api-management-v6-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-                      - gravitee-api-management-v6-<< parameters.jobName >>-{{ .Branch }}-
-                      - gravitee-api-management-v6-<< parameters.jobName >>-
-                      - gravitee-api-management-v6-
+                      - gravitee-api-management-v7-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+                      - gravitee-api-management-v7-<< parameters.jobName >>-{{ .Branch }}-
+                      - gravitee-api-management-v7-<< parameters.jobName >>-
     save-maven-job-cache:
         description: Restore Maven cache for a dedicated job
         parameters:
@@ -74,7 +73,7 @@ commands:
             - save_cache:
                   paths:
                       - ~/.m2
-                  key: gravitee-api-management-v6-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+                  key: gravitee-api-management-v7-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
                   when: always
 
     notify-on-failure:
@@ -309,9 +308,9 @@ jobs:
                   at: .
             - restore_cache:
                   keys:
-                      - gravitee-api-management-v6-sonarcloud-analysis-{{ .Branch }}-{{ checksum "pom.xml" }}
-                      - gravitee-api-management-v6-sonarcloud-analysis-{{ .Branch }}-
-                      - gravitee-api-management-v6-sonarcloud-analysis-
+                      - gravitee-api-management-v7-sonarcloud-analysis-{{ .Branch }}-{{ checksum "pom.xml" }}
+                      - gravitee-api-management-v7-sonarcloud-analysis-{{ .Branch }}-
+                      - gravitee-api-management-v7-sonarcloud-analysis-
             - keeper/env-export:
                   secret-url: keeper://9x9YgyU6DWzux4DPoHAzDQ/field/password
                   var-name: SONAR_TOKEN
@@ -324,7 +323,7 @@ jobs:
             - save_cache:
                   paths:
                       - /opt/sonar-scanner/.sonar/cache
-                  key: gravitee-api-management-v6-sonarcloud-analysis-{{ .Branch }}-{{ checksum "pom.xml" }}
+                  key: gravitee-api-management-v7-sonarcloud-analysis-{{ .Branch }}-{{ checksum "pom.xml" }}
                   when: always
 
     validate:
@@ -367,7 +366,7 @@ jobs:
             - save_cache:
                   paths:
                       - ~/.m2/repository/io/gravitee/apim
-                  key: gravitee-api-management-v6-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+                  key: gravitee-api-management-v7-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
                   when: on_success
             - run:
                   name: "Exclude APIM artefacts from build cache"
@@ -412,7 +411,7 @@ jobs:
                   jobName: test
             - restore_cache:
                   keys:
-                      - gravitee-api-management-v6-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+                      - gravitee-api-management-v7-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
             - run:
                   name: Run tests
                   command: |
@@ -447,7 +446,7 @@ jobs:
                   jobName: test-repository
             - restore_cache:
                   keys:
-                      - gravitee-api-management-v6-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+                      - gravitee-api-management-v7-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
             - run:
                   name: Run tests
                   command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,6 +399,26 @@ jobs:
                   paths:
                       - ./docker-cache
 
+    community-build:
+        docker:
+            - image: cimg/openjdk:11.0
+        resource_class: medium
+        steps:
+            - checkout
+            - restore-maven-job-cache:
+                  jobName: community-build
+            - run:
+                  name: "Build project"
+                  command: |
+                      mvn clean install --no-transfer-progress --update-snapshots -DskipTests -Dskip.validation=true -T 2C
+            - notify-on-failure
+            - run:
+                  name: "Exclude APIM artefacts from build cache"
+                  command: |
+                      rm -rf ~/.m2/repository/io/gravitee/apim
+            - save-maven-job-cache:
+                  jobName: community-build
+
     test:
         docker:
             - image: cimg/openjdk:11.0
@@ -1440,6 +1460,13 @@ workflows:
             and:
                 - equal: [pull_requests, << pipeline.parameters.gio_action >>]
         jobs:
+            - community-build:
+                  filters:
+                      branches:
+                          only:
+                              - master
+                              - /^\d+\.\d+\.x$/
+                              - fix-community-buid
             - setup:
                   context: cicd-orchestrator
             - validate:

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -48,7 +48,7 @@
         <!-- Management API & Gateway -->
         <gravitee-alert-engine-connectors-ws.version>1.0.0</gravitee-alert-engine-connectors-ws.version>
         <gravitee-connector-http.version>2.0.1</gravitee-connector-http.version>
-        <gravitee-policy-apikey.version>2.5.0-prototype-reactive-SNAPSHOT</gravitee-policy-apikey.version>
+        <gravitee-policy-apikey.version>2.5.0</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>1.5.0</gravitee-policy-assign-attributes.version>
         <gravitee-policy-assign-content.version>1.7.0</gravitee-policy-assign-content.version>
         <gravitee-policy-cache.version>1.15.1</gravitee-policy-cache.version>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.2</version>
+        <version>20.3</version>
     </parent>
 
     <groupId>io.gravitee.apim</groupId>


### PR DESCRIPTION
**Issue**

N/A

**Description**

* don't use temporary versions in APIM dependencies so external contributor could checkout and build APIM without an access to artifactory.
* improve circleci cache key
* add a job in the PR workflow to check community build. Community build means that APIM can be built without any link to artifactory, as if an external contributor try to build APIM.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kbyjunaecz.chromatic.com)
<!-- Storybook placeholder end -->
