### PR TITLE
fix: API history shows inconsistent differences with 'to deploy' API

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ts
@@ -410,13 +410,6 @@ class ApiHistoryController {
 
   stringifyCurrentApi() {
     const payload = _.cloneDeep(this.api);
-    // Because server add "/" to virtual_hosts at deploy
-    payload.proxy.virtual_hosts = payload.proxy.virtual_hosts.map((host) => {
-      if (!host.path.endsWith('/')) {
-        host.path = `${host.path}/`;
-      }
-      return host;
-    });
 
     delete payload.deployed_at;
     delete payload.created_at;
@@ -439,6 +432,39 @@ class ApiHistoryController {
     delete payload.tags;
     delete payload.workflow_state;
     delete payload.response_templates;
+
+    if (payload.flows && _.isEmpty(payload.flows)) {
+      delete payload.flows;
+    }
+    if (payload.plans && _.isEmpty(payload.plans)) {
+      delete payload.plans;
+    }
+    if (payload.resources && _.isEmpty(payload.resources)) {
+      delete payload.resources;
+    }
+    if (payload.services && _.isEmpty(payload.services)) {
+      delete payload.services;
+    }
+
+    if (payload.plans) {
+      _.forEach(payload.plans, (plan) => {
+        delete plan.characteristics;
+        delete plan.comment_message;
+        delete plan.comment_required;
+        delete plan.created_at;
+        delete plan.cross_id;
+        delete plan.description;
+        delete plan.excluded_groups;
+        delete plan.need_redeploy_at;
+        delete plan.general_conditions;
+        delete plan.order;
+        delete plan.published_at;
+        delete plan.type;
+        delete plan.updated_at;
+        delete plan.closed_at;
+        delete plan.validation;
+      });
+    }
 
     return JSON.stringify({ definition: JSON.stringify(payload) });
   }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7864

**Description**

fix: API history shows inconsistent differences with 'to deploy' API

The API 'to deploy' (ApiEntity) is stringified to be compared with the deployed API from gateway event.

Before being stringified, some transformations are done to match the gateway event API format.

Some modifications were missing :
- On gateway event creation, ApiSerializer removes some empty data : flows, plans, resources, and services. So we have to remove them before comparison.
- Gateway Plan definition contains less data than PlanEntity in api to deploy (ApiEntity). So, we have to remove those data before comparison.

Also, there was a rule to add a "/" add the end of the virtual host, which was deleted cause seems no more relevant.

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-apihistoryinconsistentdifferences/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-njmihyrdqv.chromatic.com)
<!-- Storybook placeholder end -->
