### PR TITLE
fix: resolve HTTP_2 endpoint behind nginx

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/connector/http/HttpProxyConnection.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/connector/http/HttpProxyConnection.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.http.connector.http;
 
 import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpHeadersValues;
+import io.gravitee.definition.model.ProtocolVersion;
 import io.gravitee.definition.model.endpoint.HttpEndpoint;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.handler.Handler;
@@ -332,7 +333,11 @@ public class HttpProxyConnection<T extends HttpProxyResponse> extends AbstractHt
         // with chunk value
         if (content) {
             String encoding = headers.getFirst(HttpHeaders.TRANSFER_ENCODING);
-            if (encoding != null && encoding.contains(HttpHeadersValues.TRANSFER_ENCODING_CHUNKED)) {
+            if (
+                encoding != null &&
+                encoding.contains(HttpHeadersValues.TRANSFER_ENCODING_CHUNKED) ||
+                ProtocolVersion.HTTP_2.equals(endpoint.getHttpClientOptions().getVersion())
+            ) {
                 httpClientRequest.setChunked(true);
             }
         } else {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http2/Http2CustomHostTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http2/Http2CustomHostTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.standalone.http2;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.Assert.assertEquals;
+
+import io.gravitee.gateway.standalone.AbstractWiremockGatewayTest;
+import io.gravitee.gateway.standalone.junit.annotation.ApiDescriptor;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.fluent.Request;
+import org.junit.Test;
+
+/**
+ * @author Guillaume CUSNIEUX (guillaume.cusnieux at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ApiDescriptor("/io/gravitee/gateway/standalone/http2/custom-host.json")
+public class Http2CustomHostTest extends AbstractWiremockGatewayTest {
+
+    @Test
+    public void http2_custom_host() throws Exception {
+        wireMockRule.stubFor(get("/team/my_team").willReturn(ok()));
+
+        // First call is calling an endpoint where trustAll is defined to true, no need for truststore => 200
+        HttpResponse response = execute(Request.Get("http://localhost:8082/test/my_team")).returnResponse();
+        assertEquals("unknown host => 502", HttpStatus.SC_BAD_GATEWAY, response.getStatusLine().getStatusCode());
+
+        // Second call is calling an endpoint where trustAll is defined to false, without truststore => 502
+        response = execute(Request.Get("http://localhost:8082/test/my_team")).returnResponse();
+        assertEquals("custom host find the api => 200", HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+
+        wireMockRule.verify(
+            getRequestedFor(urlPathEqualTo("/team/my_team")).withHeader(HttpHeaderNames.CACHE_CONTROL.toString(), equalTo("no-cache"))
+        );
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/resources/io/gravitee/gateway/standalone/http2/custom-host.json
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/resources/io/gravitee/gateway/standalone/http2/custom-host.json
@@ -1,0 +1,39 @@
+{
+  "id": "api-test",
+  "name": "api-test",
+
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "endpoint-1",
+        "type": "http",
+        "target": "http://localhost:8080/team",
+        "http": {
+          "version" : "HTTP_2"
+        },
+        "headers": {
+          "Host": "toto.com.org.io",
+          "Cache-Control": "no-cache"
+        }
+      }, {
+        "name": "endpoint-2",
+        "type": "http",
+        "target": "http://toto.com.org.io:8080/team",
+        "http": {
+          "version" : "HTTP_2"
+        },
+        "headers": {
+          "Host": "localhost",
+          "Cache-Control": "no-cache"
+        }
+      }
+    ],
+    "strip_context_path": false
+  },
+
+  "paths": {
+    "/*": [
+    ]
+  }
+}


### PR DESCRIPTION
From HTTP_2 RFC:

To ensure that the HTTP/1.1 request line can be reproduced
accurately, this pseudo-header field MUST be omitted when
translating from an HTTP/1.1 request that has a request target in
origin or asterisk form (see [RFC7230], Section 5.3). Clients
that generate HTTP/2 requests directly SHOULD use the :authority
pseudo-header field instead of the Host header field. An
intermediary that converts an HTTP/2 request to HTTP/1.1 MUST
create a Host header field if one is not present in a request by
copying the value of the :authority pseudo-header field.

We can trust Vertx to add the :authority pseudo-header instead of the Host header.

gravitee-io/issues#6719

**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6719-http2-headers-3-10/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
