### PR TITLE
fix: API rollback erases some plans data

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_CreateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_CreateWithDefinitionTest.java
@@ -427,7 +427,7 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
             );
 
         // check find plans by API has been called once to remove potential pre-existing plans on target API
-        verify(planService, times(1)).findByApi(GraviteeContext.getExecutionContext(), "id-api");
+        verify(planService, times(2)).findByApi(eq(GraviteeContext.getExecutionContext()), any());
         // check planService has been called twice to create 2 plans, with same IDs as API definition
         verify(planService, times(1))
             .createOrUpdatePlan(eq(GraviteeContext.getExecutionContext()), argThat(plan -> plan.getId().equals(plan1newId)));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_UpdateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_UpdateWithDefinitionTest.java
@@ -470,7 +470,7 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
 
         apiDuplicatorService.updateWithImportedDefinition(GraviteeContext.getExecutionContext(), apiEntity.getId(), toBeImport);
 
-        verify(planService, times(1)).findByApi(GraviteeContext.getExecutionContext(), apiEntity.getId());
+        verify(planService, times(2)).findByApi(GraviteeContext.getExecutionContext(), apiEntity.getId());
         // plan1, plan2 and plan4 has to be created or updated
         verify(planService, times(1))
             .createOrUpdatePlan(eq(GraviteeContext.getExecutionContext()), argThat(plan -> plan.getId().equals("plan-id1")));


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7863

**Description**

fix: API rollback erases some plans data

API rollback makes an import with plans data from gateway event API definition.
So, it misses some data comparing to plan entities we have in our database.

This is readPlansToImportFromDefinition point : merge definitions plans with existing database plans, to complete the data.

Since recent changes, ApiService.update updates plans in database,
So, we have to feed UpdateApiEntity plans before updating API, elsewhere we lost plans data during API rollback.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-apirollbackfix-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hjdoybuxuc.chromatic.com)
<!-- Storybook placeholder end -->
