### PR TITLE
fix(jupiter): set v3 execution mode by default

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -309,7 +309,9 @@ public enum Key {
     CONSOLE_ANALYTICS_PENDO_API_KEY("console.analytics.pendo.apikey", "", Set.of(SYSTEM)),
 
     JUPITER_MODE_ENABLED("api.jupiterMode.enabled", "false", Set.of(SYSTEM)),
-    JUPITER_MODE_DEFAULT("api.jupiterMode.default", "always", Set.of(SYSTEM));
+
+    // TODO: switch to 'always' to enabled Jupiter execution mode by default when jupiter will go GA.
+    JUPITER_MODE_DEFAULT("api.jupiterMode.default", "never", Set.of(SYSTEM));
 
     String key;
     String defaultValue;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/JupiterModeServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/JupiterModeServiceImpl.java
@@ -37,7 +37,8 @@ public class JupiterModeServiceImpl implements JupiterModeService {
     @Autowired
     public JupiterModeServiceImpl(
         @Value("${api.jupiterMode.enabled:false}") boolean enabled,
-        @Value("${api.jupiterMode.default:always}") String defaultMode
+        // TODO: switch to 'always' to enabled Jupiter execution mode by default when jupiter will go GA.
+        @Value("${api.jupiterMode.default:never}") String defaultMode
     ) {
         this.enabled = enabled;
         this.defaultMode = DefaultMode.fromLabel(defaultMode);


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7865

**Description**

Set v3 execution mode by default when Jupiter is enabled.
This default behavior will remain as long as Jupiter is not GA.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/jupiter-v3-default-mode/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cagugjfxkj.chromatic.com)
<!-- Storybook placeholder end -->
