### PR TITLE
fix: search api [ 3.15.x ]

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
@@ -239,12 +239,6 @@ public class JdbcApiRepository extends JdbcAbstractPageableRepository<Api> imple
 
     @Override
     public Set<Api> search(ApiCriteria apiCriteria, ApiFieldInclusionFilter apiFieldInclusionFilter) {
-        final JdbcHelper.CollatingRowMapper<Api> rowMapper = new JdbcHelper.CollatingRowMapper<>(
-            getOrm().getRowMapper(),
-            CHILD_ADDER,
-            "id"
-        );
-
         final StringBuilder sbQuery = new StringBuilder("select a.id");
 
         if (apiFieldInclusionFilter.hasCategories()) {
@@ -258,6 +252,12 @@ public class JdbcApiRepository extends JdbcAbstractPageableRepository<Api> imple
         }
 
         addCriteriaClauses(sbQuery, apiCriteria);
+
+        final JdbcHelper.CollatingRowMapper<Api> rowMapper = new JdbcHelper.CollatingRowMapper<>(
+            getOrm().getRowMapper(),
+            apiFieldInclusionFilter.hasCategories() ? CHILD_ADDER : (Api parent, ResultSet rs) -> {},
+            "id"
+        );
 
         List<Api> apis = executeQuery(sbQuery, apiCriteria, rowMapper);
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
@@ -191,14 +191,9 @@ public class JdbcTestRepositoryInitializer implements TestRepositoryInitializer 
         System.clearProperty("liquibase.databaseChangeLogTableName");
         System.clearProperty("liquibase.databaseChangeLogLockTableName");
         System.clearProperty("gravitee_prefix");
-        jt.execute(
-            (Connection con) -> {
-                for (final String table : tablesToTruncate) {
-                    jt.execute("truncate table " + escapeReservedWord(prefix + table));
-                }
-                jt.execute("truncate table " + escapeReservedWord(rateLimitPrefix + "ratelimit"));
-                return null;
-            }
-        );
+        for (final String table : tablesToTruncate) {
+            jt.update("delete from " + escapeReservedWord(prefix + table));
+        }
+        jt.update("delete from " + escapeReservedWord(rateLimitPrefix + "ratelimit"));
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryImpl.java
@@ -127,7 +127,14 @@ public class ApiMongoRepositoryImpl implements ApiMongoRepositoryCustom {
     private Query buildQuery(ApiFieldInclusionFilter apiFieldInclusionFilter, ApiCriteria... orApiCriteria) {
         final Query query = new Query();
         if (apiFieldInclusionFilter != null) {
-            query.fields().include(apiFieldInclusionFilter.includedFields());
+            String[] fields = apiFieldInclusionFilter.includedFields();
+            // If there is no field to include, then the Mongo query will behave like there is no filter, and so will include all available fields.
+            // In that case we need to explicitly add the "_id" column.
+            if (fields.length > 0) {
+                query.fields().include(fields);
+            } else {
+                query.fields().include("_id");
+            }
         }
         fillQuery(query, orApiCriteria);
         query.with(Sort.by(ASC, "name"));

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/ApiRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/ApiRepositoryTest.java
@@ -407,6 +407,26 @@ public class ApiRepositoryTest extends AbstractRepositoryTest {
     }
 
     @Test
+    public void shouldNotIncludeCategories() {
+        ApiCriteria criteria = new ApiCriteria.Builder().lifecycleStates(singletonList(PUBLISHED)).build();
+        ApiFieldInclusionFilter filter = ApiFieldInclusionFilter.builder().build();
+
+        Set<Api> apis = apiRepository.search(criteria, filter);
+        assertNotNull(apis);
+        assertFalse(apis.isEmpty());
+        assertEquals(3, apis.size());
+
+        assertTrue(apis.stream().map(Api::getId).collect(toList()).containsAll(asList("api-to-update", "grouped-api", "big-name")));
+        assertTrue(apis.stream().map(Api::getName).anyMatch(Objects::isNull));
+        assertTrue(apis.stream().map(Api::getDefinition).anyMatch(Objects::isNull));
+        assertTrue(apis.stream().map(Api::getPicture).anyMatch(Objects::isNull));
+        assertTrue(apis.stream().map(Api::getBackground).anyMatch(Objects::isNull));
+
+        List<String> categories = apis.stream().map(Api::getCategories).filter(Objects::nonNull).flatMap(Set::stream).collect(toList());
+        assertEquals(0, categories.size());
+    }
+
+    @Test
     public void shouldListCategories() throws TechnicalException {
         final Set<String> categories = apiRepository.listCategories(new ApiCriteria.Builder().build());
         assertNotNull(categories);

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/ApiRepositoryMock.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/ApiRepositoryMock.java
@@ -192,11 +192,22 @@ public class ApiRepositoryMock extends AbstractRepositoryMock<ApiRepository> {
         when(groupedApiProjection.getId()).thenReturn("grouped-api");
         when(groupedApiProjection.getCategories()).thenReturn(Set.of("category-1"));
 
+        Api groupedApiProjectionWithoutCategory = Mockito.mock(Api.class);
+        when(groupedApiProjectionWithoutCategory.getId()).thenReturn("grouped-api");
+
         Api bigNameApiProjection = Mockito.mock(Api.class);
         when(bigNameApiProjection.getId()).thenReturn("big-name");
 
-        when(apiRepository.search(any(), any(ApiFieldInclusionFilter.class)))
+        when(apiRepository.search(any(), argThat((ApiFieldInclusionFilter filter) -> null != filter && filter.hasCategories())))
             .thenReturn(Set.of(apiToUpdateProjection, groupedApiProjection, bigNameApiProjection));
+
+        when(
+            apiRepository.search(
+                any(),
+                argThat((ApiFieldInclusionFilter filter) -> null != filter && Boolean.FALSE.equals(filter.hasCategories()))
+            )
+        )
+            .thenReturn(Set.of(apiToUpdateProjection, groupedApiProjectionWithoutCategory, bigNameApiProjection));
 
         Set<String> categories = new LinkedHashSet<>();
         categories.add("category-1");


### PR DESCRIPTION
**Issue**

gravitee-io/issues#7882

**Description**

Here is a fix on the api search mehod. This issue happens when you tries to the user details in the organization settings for example. The query is conditioned by the inclusion or exclusion of the categories for a performance purpose. However the row mapper always tries to access to the column **_category_**. Doing `rs.getString("category")` will always throw an exception on all relational databases. To avoid it we check the inclusion of the categories and adapt the child adder lambda.

Here we add a missing unit tests too that reveal that with mongo we return all fields we we don't include the categories.

The commit 6c3d791 is a "partial cherry pick" from master to improve repository test time.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-search-api/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-txzbdpasim.chromatic.com)
<!-- Storybook placeholder end -->
