### PR TITLE
fix(e2e): set wiremock `global-response-templating` option

### DIFF
--- a/gravitee-apim-e2e/docker/common/docker-compose-wiremock.yml
+++ b/gravitee-apim-e2e/docker/common/docker-compose-wiremock.yml
@@ -19,6 +19,7 @@ version: '3.8'
 services:
   wiremock:
     image: wiremock/wiremock:2.33.2
+    command: "--global-response-templating"
     volumes:
       - ./api-test/resources/wiremock:/home/wiremock
     ports:


### PR DESCRIPTION
**Issue**
😿 

**Description**

 set wiremock `global-response-templating` option

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-wiremock-config-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dyaeppaymz.chromatic.com)
<!-- Storybook placeholder end -->
<!-- E2E Coverage placeholder -->
---
### 🧪 End-to-End Coverage

| INSTRUCTIONS | BRANCHES |
| :----------: | :------: |
|   37% | 21%   |

A more detailed report has been uploaded to [circleci](https://output.circle-artifacts.com/output/job/4548b01f-d60d-4203-8e4a-2f9d1d784734/artifacts/0/gravitee-apim-e2e/jacoco/reports/index.html)
<!-- E2E Coverage placeholder end -->
