### PR TITLE
fix: use latest release version of gateway api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <gravitee-connector-api.version>1.1.0</gravitee-connector-api.version>
         <gravitee-expression-language.version>1.10.1</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>1.35.0-jupiter-debug-SNAPSHOT</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.35.0</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>1.24.2</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>


### PR DESCRIPTION
**Description**

Use latest release of gateway api instead of snapshot




<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-gateway-api-version/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hwqtoivixc.chromatic.com)
<!-- Storybook placeholder end -->
