### PR TITLE
feat(apim): Add support for using APIM Management API as a bridge

### DIFF
--- a/.circleci/package_bundles.py
+++ b/.circleci/package_bundles.py
@@ -458,8 +458,7 @@ def prepare_mgmt_bundle(mgmt):
     copy_files_into(fetchers_path, bundle_path + "plugins")
     copy_files_into(repositories_path, bundle_path + "plugins",
                     [".*gravitee-repository-ehcache.*", ".*gravitee-apim-repository-gateway-bridge-http-client.*",
-                     ".*gravitee-apim-repository-gateway-bridge-http-server.*", ".*gravitee-apim-repository-hazelcast.*",
-                     ".*gravitee-apim-repository-redis.*"])
+                     ".*gravitee-apim-repository-hazelcast.*", ".*gravitee-apim-repository-redis.*"])
     copy_files_into(services_path, bundle_path + "plugins", [".*gravitee-gateway-services-ratelimit.*"])
     copy_files_into(connectors_path, bundle_path + "plugins", [".*gravitee-connector-kafka.*"])
     copy_files_into(notifiers_path, bundle_path + "plugins")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -10,7 +10,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0
-  version: "3.18.1-SNAPSHOT"
+  version: "3.18.4-SNAPSHOT"
 servers:
   - url: http://localhost:8083/portal/environments/{envId}
     description: The portal API for a given environment

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
@@ -161,7 +161,7 @@
             <unpack>false</unpack>
             <excludes>
                 <exclude>*:*:jar</exclude>
-                <exclude>io.gravitee.apim.repository.gateway.bridge.http:*:zip</exclude>
+                <exclude>io.gravitee.apim.repository.gateway.bridge.http:gravitee-apim-repository-gateway-bridge-http-client:zip</exclude>
                 <exclude>io.gravitee.policy:gravitee-gateway-services-ratelimit:zip</exclude>
                 <exclude>io.gravitee.reporter:*:zip</exclude>
                 <exclude>io.gravitee.tracer:*:zip</exclude>

--- a/release/ci-steps/package-bundles.mjs
+++ b/release/ci-steps/package-bundles.mjs
@@ -179,13 +179,13 @@ const restApiDependenciesExclusion = [
   'io.gravitee.apim.ui',
   'io.gravitee.apim.gateway.standalone.distribution',
   'io.gravitee.apim.rest.api.standalone.distribution',
-  'io.gravitee.apim.repository.gateway.bridge.http',
   'io.gravitee.reporter',
   'io.gravitee.tracer',
   // ArtifactIds to exclude
   'gravitee-gateway-services-ratelimit',
   'gravitee-apim-repository-hazelcast',
   'gravitee-apim-repository-redis',
+  'gravitee-apim-repository-gateway-bridge-http-client'
 ];
 await spinner('Add plugins to Rest API...', () =>
   Promise.all(


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8133

**Description**

Currently  we only use APIM gateway as a bridge server but it is also possible to just use and configure APIM REST API to act as a bridge server.
This PR is trying to add the "gravitee-apim-repository-gateway-bridge-http-server" to the APIM REST API bundle by default so the end users will be able to configure server bridge plugin if they want, according to their needs.


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/arch-159-management-api-as-a-bridge/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bmwyheuyfy.chromatic.com)
<!-- Storybook placeholder end -->
