### PR TITLE
docs: add description on TransferOwnership [ 3.10.x ]

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/TransferOwnership.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/TransferOwnership.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.management.rest.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.rest.api.model.MembershipMemberType;
+import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.NotNull;
 
 /**
@@ -28,18 +29,22 @@ public class TransferOwnership {
     /**
      * Member identifier
      */
+    @ApiModelProperty(name = "id", value = "User's technical identifier.")
     private String id;
 
     /**
      * Member reference
      */
+    @ApiModelProperty(name = "reference", value = "User's reference for user providing from an identity provider.")
     private String reference;
 
     /**
      * Member type
      */
+    @ApiModelProperty(name = "type", value = "Type's name", required = true, example = "USER")
     private MembershipMemberType type;
 
+    @ApiModelProperty(name = "role", value = "Role's name", required = true)
     @JsonProperty("role")
     private String poRole;
 


### PR DESCRIPTION
**Description**

Add annotations to have a description on the transfert ownership attributes

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/docs-transfer-ownership-description/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
