### PR TITLE
Bump connector-http to 1.1.8

### DIFF
--- a/docker/quick-setup/https-gateway/docker-compose.yml
+++ b/docker/quick-setup/https-gateway/docker-compose.yml
@@ -29,7 +29,6 @@ volumes:
 services:
   mongodb:
     image: mongo:${MONGODB_VERSION:-4.0.28}
-    container_name: gio_apim_mongodb
     restart: always
     volumes:
       - data-mongo:/data/db
@@ -39,7 +38,6 @@ services:
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.7.0}
-    container_name: gio_apim_elasticsearch
     restart: always
     volumes:
       - data-elasticsearch:/usr/share/elasticsearch/data
@@ -61,8 +59,7 @@ services:
       - storage
 
   gateway:
-    image: graviteeio/apim-gateway:${APIM_VERSION:-nightly}
-    container_name: gio_apim_https_gateway
+    image: graviteeio/apim-gateway:${APIM_VERSION:-latest}
     restart: always
     ports:
       - "8082:8082"
@@ -72,10 +69,12 @@ services:
     volumes:
       - ./.logs/apim-gateway-internal:/opt/graviteeio-gateway/logs
       - ./.certificates:/opt/graviteeio-gateway/certificates
+      - ./.plugins:/opt/graviteeio-gateway/plugins-ext
     environment:
       - gravitee_management_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
       - gravitee_ratelimit_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
       - gravitee_reporters_elasticsearch_endpoints_0=http://elasticsearch:9200
+      - gravitee_http_alpn=true
       - gravitee_http_secured=true
       - gravitee_http_ssl_clientAuth=request
       - gravitee_http_ssl_keystore_type=pkcs12
@@ -84,13 +83,14 @@ services:
       - gravitee_http_ssl_truststore_type=pkcs12
       - gravitee_http_ssl_truststore_path=/opt/graviteeio-gateway/certificates/ca.p12
       - gravitee_http_ssl_truststore_password=ca-secret
+      - gravitee_plugins_path_0=$${gravitee.home}/plugins
+      - gravitee_plugins_path_1=$${gravitee.home}/plugins-ext
     networks:
       - storage
       - frontend
 
   management_api:
-    image: graviteeio/apim-management-api:${APIM_VERSION:-nightly}
-    container_name: gio_apim_management_api
+    image: graviteeio/apim-management-api:${APIM_VERSION:-latest}
     restart: always
     ports:
       - "8083:8083"
@@ -110,8 +110,7 @@ services:
       - frontend
 
   management_ui:
-    image: graviteeio/apim-management-ui:${APIM_VERSION:-nightly}
-    container_name: gio_apim_management_ui
+    image: graviteeio/apim-management-ui:${APIM_VERSION:-latest}
     restart: always
     ports:
       - "8084:8080"
@@ -125,8 +124,7 @@ services:
       - frontend
 
   portal_ui:
-    image: graviteeio/apim-portal-ui:${APIM_VERSION:-nightly}
-    container_name: gio_apim_portal_ui
+    image: graviteeio/apim-portal-ui:${APIM_VERSION:-latest}
     restart: always
     ports:
       - "8085:8080"

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -46,7 +46,7 @@
     <properties>
         <!-- Versions of the plugins for the full distribution -->
         <!-- Management API & Gateway -->
-        <gravitee-connector-http.version>1.1.6</gravitee-connector-http.version>
+        <gravitee-connector-http.version>1.1.8</gravitee-connector-http.version>
         <gravitee-policy-apikey.version>2.4.0</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>1.5.0</gravitee-policy-assign-attributes.version>
         <gravitee-policy-assign-content.version>1.7.0</gravitee-policy-assign-content.version>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <jetty94.wiremock.version>9.4.44.v20210927</jetty94.wiremock.version>
-        <gravitee-connector-http.version>1.1.6</gravitee-connector-http.version>
+        <gravitee-connector-http.version>1.1.8</gravitee-connector-http.version>
     </properties>
 
     <dependencyManagement>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/grpc/GrpcSecuredServerStreamingSSLTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/grpc/GrpcSecuredServerStreamingSSLTest.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.standalone.grpc;
+
+import io.gravitee.gateway.grpc.manualflowcontrol.HelloReply;
+import io.gravitee.gateway.grpc.manualflowcontrol.HelloRequest;
+import io.gravitee.gateway.grpc.manualflowcontrol.StreamingGreeterGrpc;
+import io.gravitee.gateway.standalone.AbstractSecuredGatewayTest;
+import io.gravitee.gateway.standalone.junit.annotation.ApiDescriptor;
+import io.gravitee.gateway.standalone.junit.rules.ApiDeployer;
+import io.gravitee.gateway.standalone.wiremock.ResourceUtils;
+import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.net.PemKeyCertOptions;
+import io.vertx.grpc.VertxChannelBuilder;
+import io.vertx.grpc.VertxServer;
+import io.vertx.grpc.VertxServerBuilder;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+/**
+ *
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Ignore
+@ApiDescriptor("/io/gravitee/gateway/standalone/grpc/streaming-greeter-ssl.json")
+public class GrpcSecuredServerStreamingSSLTest extends AbstractSecuredGatewayTest {
+
+    @Rule
+    public final TestRule chain = RuleChain.outerRule(new ApiDeployer(this));
+
+    private static final int STREAM_MESSAGE_NUMBER = 3;
+    private static final long STREAM_SLEEP_MILLIS = 10;
+
+    @Test
+    public void simple_grpc_ssl_request() throws InterruptedException {
+        Vertx vertx = Vertx.vertx();
+
+        // Prepare gRPC Server
+        StreamingGreeterGrpc.StreamingGreeterImplBase service = new StreamingGreeterGrpc.StreamingGreeterImplBase() {
+            @Override
+            public StreamObserver<HelloRequest> sayHelloStreaming(StreamObserver<HelloReply> responseObserver) {
+                return new StreamObserver<>() {
+                    @Override
+                    public void onNext(HelloRequest helloRequest) {
+                        for (int i = 0; i < STREAM_MESSAGE_NUMBER; i++) {
+                            HelloReply helloReply = HelloReply
+                                .newBuilder()
+                                .setMessage("Hello " + helloRequest.getName() + " part " + i)
+                                .build();
+                            responseObserver.onNext(helloReply);
+
+                            try {
+                                Thread.sleep(STREAM_SLEEP_MILLIS);
+                            } catch (InterruptedException e) {
+                                responseObserver.onError(Status.ABORTED.asException());
+                            }
+                        }
+                        responseObserver.onCompleted();
+                    }
+
+                    @Override
+                    public void onError(Throwable throwable) {}
+
+                    @Override
+                    public void onCompleted() {}
+                };
+            }
+        };
+
+        PemKeyCertOptions pemKeyCertOptions = new PemKeyCertOptions();
+        pemKeyCertOptions.setCertPath(ResourceUtils.toPath("io/gravitee/gateway/standalone/server-cert.pem"));
+        pemKeyCertOptions.setKeyPath(ResourceUtils.toPath("io/gravitee/gateway/standalone/server-key.pem"));
+
+        VertxServer rpcServer = VertxServerBuilder
+            .forAddress(vertx, "localhost", 50051)
+            .useSsl(options -> options.setSsl(true).setUseAlpn(true).setPemKeyCertOptions(pemKeyCertOptions))
+            .addService(service)
+            .build();
+
+        // Wait for result
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // Prepare gRPC Client
+        ManagedChannel channel = VertxChannelBuilder
+            .forAddress(vertx, "localhost", 8082)
+            .useSsl(options -> options.setSsl(true).setUseAlpn(true).setTrustAll(true))
+            .build();
+
+        // Start is asynchronous
+        rpcServer.start(
+            new Handler<>() {
+                @Override
+                public void handle(AsyncResult<Void> event) {
+                    // Get a stub to use for interacting with the remote service
+                    StreamingGreeterGrpc.StreamingGreeterStub stub = StreamingGreeterGrpc.newStub(channel);
+
+                    // Call the remote service
+                    StreamObserver<HelloRequest> requestStreamObserver = stub.sayHelloStreaming(
+                        new StreamObserver<>() {
+                            @Override
+                            public void onNext(HelloReply helloReply) {}
+
+                            @Override
+                            public void onError(Throwable throwable) {
+                                throwable.printStackTrace();
+                                Assert.fail();
+                            }
+
+                            @Override
+                            public void onCompleted() {
+                                latch.countDown();
+                            }
+                        }
+                    );
+
+                    requestStreamObserver.onNext(HelloRequest.newBuilder().setName("David").build());
+                }
+            }
+        );
+
+        Assert.assertTrue(latch.await(10, TimeUnit.SECONDS));
+        rpcServer.shutdown(event -> channel.shutdownNow());
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/resources/io/gravitee/gateway/standalone/grpc/streaming-greeter-ssl.json
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/resources/io/gravitee/gateway/standalone/grpc/streaming-greeter-ssl.json
@@ -1,0 +1,24 @@
+{
+  "id": "api-streaming-greeter",
+  "name": "streaming-greeter",
+
+  "proxy": {
+    "context_path": "/manualflowcontrol.StreamingGreeter",
+    "endpoints": [
+      {
+        "name": "endpoint",
+        "type": "grpc",
+        "target": "https://localhost:50051/manualflowcontrol.StreamingGreeter",
+        "ssl": {
+          "trustAll": true
+        }
+      }
+    ],
+    "strip_context_path": false
+  },
+
+  "paths": {
+    "/*": [
+    ]
+  }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7760
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7760-fix-grpc-ssl/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
