### PR TITLE
chore: bump connector-http to 1.1.7

### DIFF
--- a/docker/quick-setup/https-gateway/docker-compose.yml
+++ b/docker/quick-setup/https-gateway/docker-compose.yml
@@ -29,7 +29,6 @@ volumes:
 services:
   mongodb:
     image: mongo:${MONGODB_VERSION:-4.0.28}
-    container_name: gio_apim_mongodb
     restart: always
     volumes:
       - data-mongo:/data/db
@@ -39,7 +38,6 @@ services:
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.7.0}
-    container_name: gio_apim_elasticsearch
     restart: always
     volumes:
       - data-elasticsearch:/usr/share/elasticsearch/data
@@ -61,8 +59,7 @@ services:
       - storage
 
   gateway:
-    image: graviteeio/apim-gateway:${APIM_VERSION:-nightly}
-    container_name: gio_apim_https_gateway
+    image: graviteeio/apim-gateway:${APIM_VERSION:-latest}
     restart: always
     ports:
       - "8082:8082"
@@ -72,10 +69,12 @@ services:
     volumes:
       - ./.logs/apim-gateway-internal:/opt/graviteeio-gateway/logs
       - ./.certificates:/opt/graviteeio-gateway/certificates
+      - ./.plugins:/opt/graviteeio-gateway/plugins-ext
     environment:
       - gravitee_management_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
       - gravitee_ratelimit_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
       - gravitee_reporters_elasticsearch_endpoints_0=http://elasticsearch:9200
+      - gravitee_http_alpn=true
       - gravitee_http_secured=true
       - gravitee_http_ssl_clientAuth=request
       - gravitee_http_ssl_keystore_type=pkcs12
@@ -84,13 +83,14 @@ services:
       - gravitee_http_ssl_truststore_type=pkcs12
       - gravitee_http_ssl_truststore_path=/opt/graviteeio-gateway/certificates/ca.p12
       - gravitee_http_ssl_truststore_password=ca-secret
+      - gravitee_plugins_path_0=$${gravitee.home}/plugins
+      - gravitee_plugins_path_1=$${gravitee.home}/plugins-ext
     networks:
       - storage
       - frontend
 
   management_api:
-    image: graviteeio/apim-management-api:${APIM_VERSION:-nightly}
-    container_name: gio_apim_management_api
+    image: graviteeio/apim-management-api:${APIM_VERSION:-latest}
     restart: always
     ports:
       - "8083:8083"
@@ -110,8 +110,7 @@ services:
       - frontend
 
   management_ui:
-    image: graviteeio/apim-management-ui:${APIM_VERSION:-nightly}
-    container_name: gio_apim_management_ui
+    image: graviteeio/apim-management-ui:${APIM_VERSION:-latest}
     restart: always
     ports:
       - "8084:8080"
@@ -125,8 +124,7 @@ services:
       - frontend
 
   portal_ui:
-    image: graviteeio/apim-portal-ui:${APIM_VERSION:-nightly}
-    container_name: gio_apim_portal_ui
+    image: graviteeio/apim-portal-ui:${APIM_VERSION:-latest}
     restart: always
     ports:
       - "8085:8080"

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -46,7 +46,7 @@
     <properties>
         <!-- Versions of the plugins for the full distribution -->
         <!-- Management API & Gateway -->
-        <gravitee-connector-http.version>1.1.6</gravitee-connector-http.version>
+        <gravitee-connector-http.version>gravitee-connector-http-1.1.7-6719-fix-http2-SNAPSHOT</gravitee-connector-http.version>
         <gravitee-policy-apikey.version>2.4.0</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>1.5.0</gravitee-policy-assign-attributes.version>
         <gravitee-policy-assign-content.version>1.7.0</gravitee-policy-assign-content.version>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <jetty94.wiremock.version>9.4.44.v20210927</jetty94.wiremock.version>
-        <gravitee-connector-http.version>1.1.6</gravitee-connector-http.version>
+        <gravitee-connector-http.version>gravitee-connector-http-1.1.7-6719-fix-http2-SNAPSHOT</gravitee-connector-http.version>
     </properties>
 
     <dependencyManagement>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http2/Http2CustomHostTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http2/Http2CustomHostTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.standalone.http2;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.Assert.assertEquals;
+
+import io.gravitee.gateway.standalone.AbstractWiremockGatewayTest;
+import io.gravitee.gateway.standalone.junit.annotation.ApiDescriptor;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.fluent.Request;
+import org.junit.Test;
+
+/**
+ * @author Guillaume CUSNIEUX (guillaume.cusnieux at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ApiDescriptor("/io/gravitee/gateway/standalone/http2/custom-host.json")
+public class Http2CustomHostTest extends AbstractWiremockGatewayTest {
+
+    @Test
+    public void http2_custom_host() throws Exception {
+        wireMockRule.stubFor(get("/team/my_team").willReturn(ok()));
+
+        // First call is calling an endpoint where trustAll is defined to true, no need for truststore => 200
+        HttpResponse response = execute(Request.Get("http://localhost:8082/test/my_team")).returnResponse();
+        assertEquals("unknown host => 502", HttpStatus.SC_BAD_GATEWAY, response.getStatusLine().getStatusCode());
+
+        // Second call is calling an endpoint where trustAll is defined to false, without truststore => 502
+        response = execute(Request.Get("http://localhost:8082/test/my_team")).returnResponse();
+        assertEquals("custom host find the api => 200", HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
+
+        wireMockRule.verify(
+            getRequestedFor(urlPathEqualTo("/team/my_team")).withHeader(HttpHeaderNames.CACHE_CONTROL.toString(), equalTo("no-cache"))
+        );
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/resources/io/gravitee/gateway/standalone/http2/custom-host.json
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/resources/io/gravitee/gateway/standalone/http2/custom-host.json
@@ -1,0 +1,39 @@
+{
+  "id": "api-test",
+  "name": "api-test",
+
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "endpoint-1",
+        "type": "http",
+        "target": "http://localhost:8080/team",
+        "http": {
+          "version" : "HTTP_2"
+        },
+        "headers": {
+          "Host": "toto.com.org.io",
+          "Cache-Control": "no-cache"
+        }
+      }, {
+        "name": "endpoint-2",
+        "type": "http",
+        "target": "http://toto.com.org.io:8080/team",
+        "http": {
+          "version" : "HTTP_2"
+        },
+        "headers": {
+          "Host": "localhost",
+          "Cache-Control": "no-cache"
+        }
+      }
+    ],
+    "strip_context_path": false
+  },
+
+  "paths": {
+    "/*": [
+    ]
+  }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6719
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6719-fix-http2/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
