### PR TITLE
fix: manage HTTP1/HTTP2 headers conversion

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/connector/AbstractConnector.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/connector/AbstractConnector.java
@@ -16,7 +16,6 @@
 package io.gravitee.gateway.http.connector;
 
 import io.gravitee.common.component.AbstractLifecycleComponent;
-import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.util.MultiValueMap;
 import io.gravitee.definition.model.HttpClientSslOptions;
 import io.gravitee.definition.model.HttpProxy;
@@ -121,7 +120,7 @@ public abstract class AbstractConnector<T extends HttpEndpoint> extends Abstract
 
             final String host = (port == UNSECURE_PORT || port == SECURE_PORT) ? url.getHost() : url.getHost() + ':' + port;
 
-            proxyRequest.headers().set(HttpHeaders.HOST, host);
+            convertHeadersForHttpVersion(url, proxyRequest, host);
 
             // Enhance proxy request with endpoint configuration
             if (endpoint.getHeaders() != null && !endpoint.getHeaders().isEmpty()) {
@@ -149,6 +148,8 @@ public abstract class AbstractConnector<T extends HttpEndpoint> extends Abstract
             throw new IllegalArgumentException();
         }
     }
+
+    protected abstract void convertHeadersForHttpVersion(URL url, ProxyRequest request, String host);
 
     protected abstract AbstractHttpProxyConnection create(ProxyRequest proxyRequest);
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/connector/http/Http2Connector.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/connector/http/Http2Connector.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.http.connector.http;
+
+import io.gravitee.definition.model.endpoint.HttpEndpoint;
+import io.gravitee.gateway.api.proxy.ProxyRequest;
+import io.gravitee.gateway.http.connector.AbstractConnector;
+import io.gravitee.gateway.http.connector.AbstractHttpProxyConnection;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import java.net.URL;
+import java.util.Set;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class Http2Connector<T extends HttpEndpoint> extends AbstractConnector<T> {
+
+    protected static final Set<CharSequence> HTTP2_ILLEGAL_HEADERS;
+
+    static {
+        HTTP2_ILLEGAL_HEADERS =
+            Set.of(
+                HttpHeaderNames.CONNECTION,
+                HttpHeaderNames.HOST,
+                HttpHeaderNames.PROXY_CONNECTION,
+                HttpHeaderNames.TRANSFER_ENCODING,
+                HttpHeaderNames.UPGRADE
+            );
+    }
+
+    @Autowired
+    public Http2Connector(T endpoint) {
+        super(endpoint);
+    }
+
+    @Override
+    protected void convertHeadersForHttpVersion(URL url, ProxyRequest request, String host) {
+        // TODO: support HTTP2 headers, something like:
+        //        request.headers().set(Http2PseudoHeaderNames.AUTHORITY, host);
+        //
+        //        if (!request.headers().contains(Http2PseudoHeaderNames.SCHEME)) {
+        //            String scheme = request.headers().contains(HttpHeaderNames.X_FORWARDED_PROTO)
+        //                ? request.headers().get(HttpHeaderNames.X_FORWARDED_PROTO)
+        //                : url.getProtocol();
+        //            request.headers().set(Http2PseudoHeaderNames.SCHEME, scheme);
+        //        }
+        //        if (!request.headers().contains(Http2PseudoHeaderNames.PATH)) {
+        //            request.headers().set(Http2PseudoHeaderNames.PATH, url.getFile());
+        //        }
+        // Strip all headers made illegal in HTTP/2 messages:
+        HTTP2_ILLEGAL_HEADERS.forEach(name -> request.headers().remove(name));
+    }
+
+    @Override
+    protected AbstractHttpProxyConnection create(ProxyRequest proxyRequest) {
+        return new HttpProxyConnection<>(endpoint, proxyRequest);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/connector/http/Http2PseudoHeaderNames.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/connector/http/Http2PseudoHeaderNames.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.http.connector.http;
+
+public final class Http2PseudoHeaderNames {
+
+    public static final String AUTHORITY = ":authority";
+    public static final String PATH = ":path";
+    public static final String SCHEME = ":scheme";
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/connector/http/HttpConnector.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/connector/http/HttpConnector.java
@@ -23,6 +23,8 @@ import io.gravitee.gateway.api.proxy.ProxyRequest;
 import io.gravitee.gateway.http.connector.AbstractConnector;
 import io.gravitee.gateway.http.connector.AbstractHttpProxyConnection;
 import io.gravitee.gateway.http.connector.http.ws.WebSocketProxyConnection;
+import java.net.URL;
+import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -31,9 +33,22 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 public class HttpConnector<T extends HttpEndpoint> extends AbstractConnector<T> {
 
+    protected static final Set<CharSequence> HTTP2_PSEUDO_HEADERS;
+
+    static {
+        HTTP2_PSEUDO_HEADERS = Set.of(Http2PseudoHeaderNames.AUTHORITY, Http2PseudoHeaderNames.PATH, Http2PseudoHeaderNames.SCHEME);
+    }
+
     @Autowired
     public HttpConnector(T endpoint) {
         super(endpoint);
+    }
+
+    @Override
+    protected void convertHeadersForHttpVersion(URL url, ProxyRequest request, String host) {
+        request.headers().set(HttpHeaders.HOST, host);
+        // Strip all HTTP/2 headers
+        HTTP2_PSEUDO_HEADERS.forEach(name -> request.headers().remove(name));
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/endpoint/HttpEndpointFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/endpoint/HttpEndpointFactory.java
@@ -17,8 +17,11 @@ package io.gravitee.gateway.http.endpoint;
 
 import io.gravitee.definition.model.Endpoint;
 import io.gravitee.definition.model.EndpointType;
+import io.gravitee.definition.model.HttpClientOptions;
+import io.gravitee.definition.model.ProtocolVersion;
 import io.gravitee.definition.model.endpoint.HttpEndpoint;
 import io.gravitee.gateway.api.Connector;
+import io.gravitee.gateway.http.connector.http.Http2Connector;
 import io.gravitee.gateway.http.connector.http.HttpConnector;
 
 /**
@@ -34,6 +37,11 @@ public class HttpEndpointFactory extends AbstractEndpointFactory {
 
     @Override
     protected Connector create(io.gravitee.definition.model.Endpoint endpoint) {
-        return new HttpConnector<>((HttpEndpoint) endpoint);
+        HttpEndpoint httpEndpoint = (HttpEndpoint) endpoint;
+        HttpClientOptions httpClientOptions = httpEndpoint.getHttpClientOptions();
+        if (httpClientOptions != null && ProtocolVersion.HTTP_2.equals(httpClientOptions.getVersion())) {
+            return new Http2Connector<>(httpEndpoint);
+        }
+        return new HttpConnector<>(httpEndpoint);
     }
 }


### PR DESCRIPTION
gravitee-io/issues#6719

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6719-fix-http2-3-10/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
