### PR TITLE
fix: load apis in portal using categories

### DIFF
--- a/gravitee-apim-portal-webui/src/app/pages/catalog/filtered-catalog/filtered-catalog.component.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/catalog/filtered-catalog/filtered-catalog.component.spec.ts
@@ -13,25 +13,40 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { createComponentFactory, Spectator } from '@ngneat/spectator/jest';
+import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { FilteredCatalogComponent } from './filtered-catalog.component';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ApiStatesPipe } from '../../../pipes/api-states.pipe';
 import { ApiLabelsPipe } from '../../../pipes/api-labels.pipe';
+import { Api, ApiService, ApisResponse, User } from '../../../../../projects/portal-webclient-sdk/src/lib';
+import { of } from 'rxjs';
+import { ConfigurationService } from '../../../services/configuration.service';
 
 describe('FilteredCatalogComponent', () => {
+  const category = 'cat';
+  const admin: User = { id: 'admin' };
+  const api1: Api = { id: 'api#1', name: 'api1', description: 'description', version: '1', owner: admin };
+  const api2: Api = { id: 'api#2', name: 'api2', description: 'description', version: '1', owner: admin };
+  const apisResponse: ApisResponse = { data: [api1, api2] };
+
   const createComponent = createComponentFactory({
     component: FilteredCatalogComponent,
     schemas: [CUSTOM_ELEMENTS_SCHEMA],
     imports: [HttpClientTestingModule, RouterTestingModule],
     declarations: [ApiStatesPipe, ApiLabelsPipe],
-    providers: [ApiStatesPipe, ApiLabelsPipe],
+    providers: [
+      ApiStatesPipe,
+      ApiLabelsPipe,
+      mockProvider(ConfigurationService, {
+        hasFeature: () => true,
+      }),
+    ],
   });
 
   let spectator: Spectator<FilteredCatalogComponent>;
-  let component;
+  let component: FilteredCatalogComponent;
 
   beforeEach(() => {
     spectator = createComponent();
@@ -40,5 +55,39 @@ describe('FilteredCatalogComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should load the apis and the promoted api', async () => {
+    expect.assertions(4);
+
+    spectator.component.currentCategory = category;
+    const apiServiceSpy = jest.spyOn(spectator.inject(ApiService), 'getApis').mockReturnValue(of(apisResponse) as any);
+
+    await spectator.component._load();
+
+    expect(apiServiceSpy).toHaveBeenCalledTimes(3);
+
+    // should load all others apis
+    expect(apiServiceSpy).toHaveBeenCalledWith({
+      category,
+      filter: null,
+      promoted: false,
+      page: 1,
+      size: 6,
+    });
+
+    // should load random list
+    expect(apiServiceSpy).toHaveBeenCalledWith({
+      filter2: undefined,
+      size: 4,
+    });
+
+    // should load promoted api of the category
+    expect(apiServiceSpy).toHaveBeenCalledWith({
+      category,
+      filter: null,
+      promoted: true,
+      size: 1,
+    });
   });
 });

--- a/gravitee-apim-portal-webui/src/app/pages/catalog/filtered-catalog/filtered-catalog.component.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/catalog/filtered-catalog/filtered-catalog.component.ts
@@ -156,7 +156,12 @@ export class FilteredCatalogComponent implements OnInit {
 
   _load() {
     if (this.page === 1 && this.hasPromotedApiMode()) {
-      this.promotedApi = this._loadPromotedApi({ size: 1, filter: this.filterApiQuery, promoted: true });
+      this.promotedApi = this._loadPromotedApi({
+        size: 1,
+        filter: this.computeFilterApiQuery(),
+        promoted: true,
+        category: this.currentCategory,
+      });
     }
     return Promise.all([this._loadRandomList(), this._loadCards()]);
   }
@@ -211,7 +216,7 @@ export class FilteredCatalogComponent implements OnInit {
       .getApis({
         page: this.page,
         size: this.size,
-        filter: this.filterApiQuery,
+        filter: this.computeFilterApiQuery(),
         category: this.currentCategory,
         promoted: fetchPromoted,
       })
@@ -372,5 +377,9 @@ export class FilteredCatalogComponent implements OnInit {
     } else {
       this.empty = false;
     }
+  }
+
+  private computeFilterApiQuery(): FilterApiQuery {
+    return !!this.currentCategory ? null : this.filterApiQuery;
   }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApisResource.java
@@ -200,10 +200,6 @@ public class ApisResource extends AbstractResource<Api, String> {
         return filter != null ? FilteringService.FilterType.valueOf(filter.name()) : null;
     }
 
-    private Collection<String> findApisForCurrentUser(ApisParam apisParam) {
-        return findApisForCurrentUser(apisParam, null);
-    }
-
     private Collection<String> findApisForCurrentUser(ApisParam apisParam, ApiQuery apiQuery) {
         return filteringService.filterApis(
             getAuthenticatedUserOrNull(),


### PR DESCRIPTION
**Issue**

gravitee-io/issues#7201

**Description**

Filter apis on Portal. Here I remove the router usage and reload directly the apis when the category is selected. See video below

https://user-images.githubusercontent.com/25704259/176173812-cbd735f6-17f8-4cb4-83f3-d46562e09fa4.mov
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dcjkmgmxzu.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-portal-categories/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
