### PR TITLE
Use correct permission to access transfer ownership screen

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/portal/userGroupAccess/transferOwnership/transferOwnership.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/userGroupAccess/transferOwnership/transferOwnership.controller.ts
@@ -122,7 +122,7 @@ class ApiTransferOwnershipController {
   }
 
   isAllowedToTransferOwnership(): boolean {
-    return this.UserService.currentUser.isOrganizationAdmin() || this.UserService.currentUser.allowedTo(['api-members-u']);
+    return this.UserService.currentUser.isOrganizationAdmin() || this.UserService.currentUser.allowedTo(['api-member-u']);
   }
 
   canUseGroupAsPrimaryOwner(): boolean {

--- a/gravitee-apim-console-webui/src/management/application/details/members/application-members.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/members/application-members.controller.ts
@@ -196,7 +196,7 @@ class ApplicationMembersController {
   }
 
   isAllowedToTransferOwnership() {
-    return this.UserService.currentUser.isOrganizationAdmin() || this.UserService.currentUser.allowedTo(['api-members-u']);
+    return this.UserService.currentUser.isOrganizationAdmin() || this.UserService.currentUser.allowedTo(['api-member-u']);
   }
 
   toggleDisableMembershipNotifications() {


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7859

**Description**

Use correct permission to access the transfer ownership screen

Wrong permission was introduced with 7a45634b
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/7859-fix-api-transfert/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jgcuhoshxs.chromatic.com)
<!-- Storybook placeholder end -->
