### PR TITLE
fix: do not use environment when deleting a sharding tag

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -2456,14 +2456,13 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
     @Override
     public void deleteTagFromAPIs(ExecutionContext executionContext, final String tagId) {
-        findAllByEnvironment(executionContext)
-            .forEach(
-                api -> {
-                    if (api.getTags() != null && api.getTags().contains(tagId)) {
-                        removeTag(executionContext, api.getId(), tagId);
-                    }
-                }
-            );
+        environmentService
+            .findByOrganization(executionContext.getOrganizationId())
+            .stream()
+            .map(ExecutionContext::new)
+            .flatMap(ctx -> findAllByEnvironment(ctx).stream())
+            .filter(api -> api.getTags() != null && api.getTags().contains(tagId))
+            .forEach(api -> removeTag(executionContext, api.getId(), tagId));
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_DeleteTagsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_DeleteTagsTest.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.model.MemberEntity;
+import io.gravitee.rest.api.model.RoleEntity;
+import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.service.*;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.configuration.flow.FlowService;
+import io.gravitee.rest.api.service.converter.ApiConverter;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ApiService_DeleteTagsTest {
+
+    @Mock
+    EnvironmentService environmentService;
+
+    @Mock
+    ApiRepository apiRepository;
+
+    @Mock
+    AuditService auditService;
+
+    @Mock
+    RoleService roleService;
+
+    @Mock
+    MembershipService membershipService;
+
+    @Mock
+    CategoryService categoryService;
+
+    @Mock
+    ApiConverter apiConverter;
+
+    @Mock
+    PlanService planService;
+
+    @Mock
+    FlowService flowService;
+
+    @Mock
+    ParameterService parameterService;
+
+    @Mock
+    ObjectMapper objectMapper;
+
+    @InjectMocks
+    private final ApiService apiService = new ApiServiceImpl();
+
+    @Test
+    public void shouldDeleteTags() throws TechnicalException, JsonProcessingException {
+        final ExecutionContext executionContext = new ExecutionContext("DEFAULT", null);
+
+        final EnvironmentEntity environment = new EnvironmentEntity();
+        environment.setId("DEFAULT");
+
+        final Api api = new Api();
+        api.setId("api-id");
+        api.setDefinition("{\"tags\": [\"intranet\"]}");
+
+        final ApiEntity apiEntity = new ApiEntity();
+        apiEntity.setId(api.getId());
+        apiEntity.setTags(Set.of("intranet"));
+
+        final io.gravitee.definition.model.Api apiDefinition = new io.gravitee.definition.model.Api();
+        apiDefinition.setTags(new HashSet<>(apiEntity.getTags()));
+
+        when(environmentService.findByOrganization("DEFAULT")).thenReturn(List.of(environment));
+        when(apiRepository.search(any())).thenReturn(List.of(api));
+        when(apiRepository.findById(any())).thenReturn(Optional.of(api));
+
+        when(roleService.findPrimaryOwnerRoleByOrganization(any(), any(RoleScope.class))).thenReturn(new RoleEntity());
+        when(membershipService.getMembersByReferencesAndRole(any(), any(), anyList(), any())).thenReturn(Set.of(new MemberEntity()));
+
+        when(apiConverter.toApiEntity(any(), any())).thenReturn(apiEntity);
+        when(apiConverter.toApiEntity(any())).thenReturn(apiEntity);
+
+        when(objectMapper.readValue(api.getDefinition(), io.gravitee.definition.model.Api.class)).thenReturn(apiDefinition);
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+
+        apiService.deleteTagFromAPIs(executionContext, "intranet");
+
+        verify(apiRepository, times(1)).update(argThat(apiUpdate -> !apiUpdate.getDefinition().contains("intranet")));
+    }
+}


### PR DESCRIPTION
see https://github.com/gravitee-io/issues/issues/7870
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/7870-fix-delete-sharding-tag/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fegjjrjctr.chromatic.com)
<!-- Storybook placeholder end -->
