### PR TITLE
chore: bump policy-openid-connect-userinfo to 1.5.1

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -70,7 +70,7 @@
         <gravitee-policy-metrics-reporter.version>1.2.2</gravitee-policy-metrics-reporter.version>
         <gravitee-policy-mock.version>1.13.0</gravitee-policy-mock.version>
         <gravitee-policy-oauth2.version>1.19.0</gravitee-policy-oauth2.version>
-        <gravitee-policy-openid-connect-userinfo.version>1.5.0</gravitee-policy-openid-connect-userinfo.version>
+        <gravitee-policy-openid-connect-userinfo.version>1.5.1</gravitee-policy-openid-connect-userinfo.version>
         <gravitee-policy-override-http-method.version>1.3.0</gravitee-policy-override-http-method.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->
         <!--    <gravitee-policy-quota.version>1.15.0</gravitee-policy-quota.version>    -->


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6883

**Description**

Need to be merged before https://github.com/gravitee-io/gravitee-policy-openid-connect-userinfo/pull/21


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-6883-openid-fail-header/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
