### PR TITLE
Check uniqueness of clientId when restoring an application 

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Application.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Application.java
@@ -28,6 +28,10 @@ import java.util.Set;
  */
 public class Application {
 
+    public static final String METADATA_CLIENT_ID = "client_id";
+    public static final String METADATA_TYPE = "type";
+    public static final String METADATA_REGISTRATION_PAYLOAD = "registration_payload";
+
     public enum AuditEvent implements Audit.AuditEvent {
         APPLICATION_CREATED,
         APPLICATION_UPDATED,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/openapi.yaml
@@ -10,7 +10,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0
-  version: "3.10.17"
+  version: "3.10.18-SNAPSHOT"
 servers:
   - url: http://localhost:8083/portal/environments/{envId}
     description: The portal API for a given environment

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_RenewClientSecretTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_RenewClientSecretTest.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service;
+
+import static io.gravitee.repository.management.model.Application.METADATA_REGISTRATION_PAYLOAD;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApplicationRepository;
+import io.gravitee.repository.management.model.Application;
+import io.gravitee.repository.management.model.ApplicationStatus;
+import io.gravitee.repository.management.model.ApplicationType;
+import io.gravitee.rest.api.model.MembershipEntity;
+import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.RoleEntity;
+import io.gravitee.rest.api.model.configuration.application.registration.ClientRegistrationProviderEntity;
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
+import io.gravitee.rest.api.service.configuration.application.ClientRegistrationService;
+import io.gravitee.rest.api.service.exceptions.ApplicationArchivedException;
+import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
+import io.gravitee.rest.api.service.exceptions.ApplicationRenewClientSecretException;
+import io.gravitee.rest.api.service.impl.ApplicationServiceImpl;
+import io.gravitee.rest.api.service.impl.configuration.application.registration.client.register.ClientRegistrationResponse;
+import java.util.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ApplicationService_RenewClientSecretTest {
+
+    private static final String APP = "my-app";
+    private static final String ORGANIZATION_ID = "DEFAULT";
+    private static final String ENVIRONMENT_ID = "DEFAULT";
+
+    @InjectMocks
+    private ApplicationServiceImpl applicationService = new ApplicationServiceImpl();
+
+    @Mock
+    private ApplicationRepository applicationRepository;
+
+    @Mock
+    private MembershipService membershipService;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private AuditService auditService;
+
+    @Mock
+    private ParameterService parameterService;
+
+    @Mock
+    private ClientRegistrationService clientRegistrationService;
+
+    @Mock
+    private RoleService roleService;
+
+    @Test(expected = ApplicationNotFoundException.class)
+    public void should_throw_exception_cause_application_not_exists() throws TechnicalException {
+        when(applicationRepository.findById(APP)).thenReturn(Optional.empty());
+
+        applicationService.renewClientSecret(ORGANIZATION_ID, ENVIRONMENT_ID, APP);
+    }
+
+    @Test(expected = ApplicationArchivedException.class)
+    public void should_throw_exception_cause_application_archived() throws TechnicalException {
+        Application app = fakeApp();
+        app.setStatus(ApplicationStatus.ARCHIVED);
+
+        when(applicationRepository.findById(APP)).thenReturn(Optional.of(app));
+
+        applicationService.renewClientSecret(ORGANIZATION_ID, ENVIRONMENT_ID, APP);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void should_throw_exception_cause_client_registration_disabled() throws TechnicalException {
+        Application app = fakeApp();
+        app.setStatus(ApplicationStatus.ACTIVE);
+
+        when(applicationRepository.findById(APP)).thenReturn(Optional.of(app));
+
+        // client registration is disabled
+        when(parameterService.findAsBoolean(eq(Key.APPLICATION_REGISTRATION_ENABLED), any(), eq(ParameterReferenceType.ENVIRONMENT)))
+            .thenReturn(false);
+
+        applicationService.renewClientSecret(ORGANIZATION_ID, ENVIRONMENT_ID, APP);
+    }
+
+    @Test(expected = ApplicationRenewClientSecretException.class)
+    public void should_throw_exception_cause_no_auth_setting() throws TechnicalException {
+        Application app = fakeApp();
+        app.setStatus(ApplicationStatus.ACTIVE);
+        app.setMetadata(Map.of(METADATA_REGISTRATION_PAYLOAD, "{\"my\":\"payload\"}"));
+
+        when(applicationRepository.findById(APP)).thenReturn(Optional.of(app));
+
+        // client registration is enabled
+        when(parameterService.findAsBoolean(eq(Key.APPLICATION_REGISTRATION_ENABLED), any(), eq(ParameterReferenceType.ENVIRONMENT)))
+            .thenReturn(true);
+
+        applicationService.renewClientSecret(ORGANIZATION_ID, ENVIRONMENT_ID, APP);
+    }
+
+    @Test
+    public void should_update_application_with_clientId_renewed_from_clientRegistrationService() throws TechnicalException {
+        Application app = fakeApp();
+        app.setStatus(ApplicationStatus.ACTIVE);
+        app.setType(ApplicationType.BROWSER);
+        app.setMetadata(new HashMap<>(Map.of(METADATA_REGISTRATION_PAYLOAD, "{\"my\":\"payload\"}")));
+        when(applicationRepository.findById(APP)).thenReturn(Optional.of(app));
+        when(applicationRepository.update(any())).thenReturn(app);
+        when(roleService.findPrimaryOwnerRoleByOrganization(any(), any())).thenReturn(mock(RoleEntity.class));
+
+        MembershipEntity po = new MembershipEntity();
+        po.setReferenceType(MembershipReferenceType.APPLICATION);
+        po.setRoleId("APPLICATION_PRIMARY_OWNER");
+        when(membershipService.getMembershipsByReferencesAndRole(any(), any(), any())).thenReturn(Collections.singleton(po));
+
+        // client registration is enabled
+        when(parameterService.findAsBoolean(eq(Key.APPLICATION_REGISTRATION_ENABLED), any(), eq(ParameterReferenceType.ENVIRONMENT)))
+            .thenReturn(true);
+        ClientRegistrationProviderEntity clientRegistrationProvider = new ClientRegistrationProviderEntity();
+        clientRegistrationProvider.setRenewClientSecretSupport(true);
+        when(clientRegistrationService.findAll()).thenReturn(Set.of(clientRegistrationProvider));
+
+        // mock response from DCR with a new client ID
+        ClientRegistrationResponse clientRegistrationResponse = new ClientRegistrationResponse();
+        clientRegistrationResponse.setClientId("client-id-from-clientRegistration");
+        when(clientRegistrationService.renewClientSecret(any())).thenReturn(clientRegistrationResponse);
+
+        applicationService.renewClientSecret(ORGANIZATION_ID, ENVIRONMENT_ID, APP);
+
+        // check DCR service has been called
+        verify(clientRegistrationService).renewClientSecret("{\"my\":\"payload\"}");
+
+        // check application has been updated with new client ID
+        verify(applicationRepository)
+            .update(argThat(application -> application.getMetadata().get("client_id").equals("client-id-from-clientRegistration")));
+    }
+
+    private Application fakeApp() {
+        Application app = new Application();
+        app.setId(APP);
+        app.setEnvironmentId(ENVIRONMENT_ID);
+        return app;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_RestoreTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_RestoreTest.java
@@ -32,9 +32,12 @@ import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApplicationActiveException;
 import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
+import io.gravitee.rest.api.service.exceptions.ClientIdAlreadyExistsException;
 import io.gravitee.rest.api.service.impl.ApplicationServiceImpl;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,6 +53,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class ApplicationService_RestoreTest {
 
     private static final String APP = "my-app";
+
+    private static final String CLIENT_ID = "myClientId";
+    private static final String ENVIRONMENT_ID = "DEFAULT";
 
     @InjectMocks
     private ApplicationServiceImpl applicationService = new ApplicationServiceImpl();
@@ -88,6 +94,22 @@ public class ApplicationService_RestoreTest {
         app.setStatus(ApplicationStatus.ACTIVE);
 
         when(applicationRepository.findById(APP)).thenReturn(Optional.of(app));
+
+        applicationService.restore(APP);
+    }
+
+    @Test(expected = ClientIdAlreadyExistsException.class)
+    public void shouldNotRestoreApp_ClientIdAlreadyExists() throws TechnicalException {
+        Application appToRestore = fakeApp(false);
+        appToRestore.setStatus(ApplicationStatus.ARCHIVED);
+        appToRestore.setMetadata(Map.of(Application.METADATA_CLIENT_ID, CLIENT_ID));
+        appToRestore.setEnvironmentId(ENVIRONMENT_ID);
+
+        Application anotherApp = fakeApp(true);
+        anotherApp.setMetadata(Map.of(Application.METADATA_CLIENT_ID, CLIENT_ID));
+
+        when(applicationRepository.findById(APP)).thenReturn(Optional.of(appToRestore));
+        when(applicationRepository.findAllByEnvironment(ENVIRONMENT_ID, ApplicationStatus.ACTIVE)).thenReturn(Set.of(anotherApp));
 
         applicationService.restore(APP);
     }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6380

**Description**

 - Use constants instead of duplicating hardcoded strings
 - Check uniqueness of clientId when restoring an application 
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/6380-fix-app-restore/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
