### PR TITLE
fix: import api with pages [ 3.15.x ]

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_CreateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_CreateWithDefinitionTest.java
@@ -254,7 +254,6 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         );
 
         verify(apiService, times(1)).createWithApiDefinition(any(), eq("admin"), any());
-        verify(pageService, times(1)).createAsideFolder(eq(API_ID), eq(GraviteeContext.getCurrentEnvironment()));
         verify(membershipService, times(1))
             .addRoleToMemberOnReference(
                 GraviteeContext.getCurrentOrganization(),
@@ -333,7 +332,6 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         );
 
         verify(apiService, times(1)).createWithApiDefinition(any(), eq("admin"), any());
-        verify(pageService, times(1)).createAsideFolder(eq(API_ID), eq(GraviteeContext.getCurrentEnvironment()));
     }
 
     @Test
@@ -363,7 +361,6 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         );
 
         verify(apiService, times(1)).createWithApiDefinition(any(), eq("admin"), any());
-        verify(pageService, times(1)).createAsideFolder(eq(API_ID), eq(GraviteeContext.getCurrentEnvironment()));
     }
 
     @Test
@@ -393,7 +390,6 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         );
 
         verify(apiService, times(1)).createWithApiDefinition(any(), eq("admin"), any());
-        verify(pageService, times(1)).createAsideFolder(eq(API_ID), eq(GraviteeContext.getCurrentEnvironment()));
     }
 
     @Test
@@ -419,7 +415,6 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         );
 
         verify(apiService, times(1)).createWithApiDefinition(any(), eq("admin"), any());
-        verify(pageService, times(1)).createAsideFolder(eq(API_ID), eq(GraviteeContext.getCurrentEnvironment()));
     }
 
     @Test
@@ -555,7 +550,6 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         );
 
         verify(apiService, times(1)).createWithApiDefinition(any(), eq("admin"), any());
-        verify(pageService, times(1)).createAsideFolder(eq(API_ID), eq(GraviteeContext.getCurrentEnvironment()));
         verify(membershipService, times(1))
             .addRoleToMemberOnReference(
                 GraviteeContext.getCurrentOrganization(),


### PR DESCRIPTION
gravitee-io/issues#7876

**Issue**

Currently we check if the _aside system folder_ exist before creating the pages. If the floder does not exist we create it. 
On the other hand, when we call `updatePages ` we assert that the folder does not exist or we throw an exception. So here I removed the check in the method `createMediaAndSystemFolder` and directly call the `updatePages`.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-import-api-system-folder/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
