### PR TITLE
fix: inaccessible API properties from EL in debug mode

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/context/ExecutionContextFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/context/ExecutionContextFactory.java
@@ -31,12 +31,18 @@ import java.util.List;
  */
 public class ExecutionContextFactory {
 
-    private final List<TemplateVariableProvider> providers = new ArrayList<>();
+    private final List<TemplateVariableProvider> providers;
 
     private final ComponentProvider componentProvider;
 
     public ExecutionContextFactory(ComponentProvider componentProvider) {
         this.componentProvider = componentProvider;
+        this.providers = new ArrayList<>();
+    }
+
+    public ExecutionContextFactory(ExecutionContextFactory executionContextFactory) {
+        this.providers = executionContextFactory.providers;
+        this.componentProvider = executionContextFactory.componentProvider;
     }
 
     /**
@@ -53,5 +59,9 @@ public class ExecutionContextFactory {
 
     public void addTemplateVariableProvider(TemplateVariableProvider templateVariableProvider) {
         this.providers.add(templateVariableProvider);
+    }
+
+    public List<TemplateVariableProvider> getProviders() {
+        return providers;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/handlers/api/DebugApiContextHandlerFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/handlers/api/DebugApiContextHandlerFactory.java
@@ -96,6 +96,6 @@ public class DebugApiContextHandlerFactory extends ApiReactorHandlerFactory {
         ComponentProvider componentProvider,
         DefaultReferenceRegister referenceRegister
     ) {
-        return new DebugExecutionContextFactory(componentProvider);
+        return new DebugExecutionContextFactory(super.v3ExecutionContextFactory(api, componentProvider, referenceRegister));
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/handler/context/DebugExecutionContextFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/reactor/handler/context/DebugExecutionContextFactory.java
@@ -25,8 +25,8 @@ import io.gravitee.gateway.reactor.handler.context.ExecutionContextFactory;
  */
 public class DebugExecutionContextFactory extends ExecutionContextFactory {
 
-    public DebugExecutionContextFactory(ComponentProvider componentProvider) {
-        super(componentProvider);
+    public DebugExecutionContextFactory(ExecutionContextFactory executionContextFactory) {
+        super(executionContextFactory);
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/handlers/api/DebugApiContextHandlerFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/handlers/api/DebugApiContextHandlerFactoryTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.debug.handlers.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.gateway.core.component.ComponentProvider;
+import io.gravitee.gateway.core.endpoint.ref.impl.DefaultReferenceRegister;
+import io.gravitee.gateway.debug.reactor.handler.context.DebugExecutionContextFactory;
+import io.gravitee.gateway.handlers.api.context.ApiTemplateVariableProvider;
+import io.gravitee.gateway.handlers.api.definition.Api;
+import io.gravitee.gateway.reactor.handler.context.ApiTemplateVariableProviderFactory;
+import io.gravitee.gateway.reactor.handler.context.ExecutionContextFactory;
+import java.util.ArrayList;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.context.ApplicationContext;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DebugApiContextHandlerFactoryTest {
+
+    @InjectMocks
+    private DebugApiContextHandlerFactory debugApiContextHandlerFactory;
+
+    @Mock
+    private ApplicationContext applicationContext;
+
+    @Mock
+    private Api api;
+
+    @Mock
+    private ComponentProvider componentProvider;
+
+    @Mock
+    private DefaultReferenceRegister referenceRegister;
+
+    @Test
+    public void building_v3ExecutionContextFactory_should_put_ApiTemplateVariableProvider_in_context() {
+        when(applicationContext.getBean(ApiTemplateVariableProviderFactory.class))
+            .thenReturn(mock(ApiTemplateVariableProviderFactory.class));
+        when(applicationContext.getBean(ApiTemplateVariableProviderFactory.class).getTemplateVariableProviders())
+            .thenReturn(new ArrayList<>());
+
+        ExecutionContextFactory executionContextFactory = debugApiContextHandlerFactory.v3ExecutionContextFactory(
+            api,
+            componentProvider,
+            referenceRegister
+        );
+
+        assertTrue(executionContextFactory instanceof DebugExecutionContextFactory);
+        assertEquals(2, executionContextFactory.getProviders().size());
+        assertTrue(executionContextFactory.getProviders().contains(referenceRegister));
+        assertTrue(
+            executionContextFactory.getProviders().stream().filter(ApiTemplateVariableProvider.class::isInstance).findAny().isPresent()
+        );
+    }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7917

**Description**

Fill Debug Api execution context with relevant variables providers,
In order to make API properties available in SPEL template.

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-debugmodevariableproviders/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vyzdgqsqlr.chromatic.com)
<!-- Storybook placeholder end -->
