### PR TITLE
refactor(e2e): rename URL environment variables

### DIFF
--- a/gravitee-apim-e2e/.env
+++ b/gravitee-apim-e2e/.env
@@ -1,8 +1,8 @@
 # services base paths
-MANAGEMENT_BASE_PATH=http://localhost:8083/management
-PORTAL_BASE_PATH=http://localhost:8083/portal/environments
-GATEWAY_BASE_PATH=http://localhost:8082
-WIREMOCK_BASE_PATH=http://localhost:8080
+MANAGEMENT_BASE_URL=http://localhost:8083/management
+PORTAL_BASE_URL=http://localhost:8083/portal/environments
+GATEWAY_BASE_URL=http://localhost:8082
+WIREMOCK_BASE_URL=http://localhost:8080
 
 # usernames and passwords
 ADMIN_USERNAME=admin

--- a/gravitee-apim-e2e/api-test/src/gateway/simple-proxy.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/gateway/simple-proxy.spec.ts
@@ -51,7 +51,7 @@ describe('Gateway - Simple proxy', () => {
                   {
                     inherit: true,
                     name: 'default',
-                    target: `${process.env.WIREMOCK_BASE_PATH}/hello`,
+                    target: `${process.env.WIREMOCK_BASE_URL}/hello`,
                     weight: 1,
                     backup: false,
                     type: 'http',

--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/flows/add-policies-to-flows-and-use-them.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/flows/add-policies-to-flows-and-use-them.spec.ts
@@ -55,7 +55,7 @@ describe('Add policies to flows and use them', () => {
                 {
                   inherit: true,
                   name: 'default',
-                  target: `${process.env.WIREMOCK_BASE_PATH}/whattimeisit`,
+                  target: `${process.env.WIREMOCK_BASE_URL}/whattimeisit`,
                   weight: 1,
                   backup: false,
                   type: 'http',
@@ -118,7 +118,7 @@ describe('Add policies to flows and use them', () => {
                   scope: 'REQUEST',
                   errorStatusCode: '500',
                   errorCondition: '{#calloutResponse.status >= 400 and #calloutResponse.status <= 599}',
-                  url: `${process.env.WIREMOCK_BASE_PATH}/hello?name={#request.headers['x-callout-name']}`,
+                  url: `${process.env.WIREMOCK_BASE_URL}/hello?name={#request.headers['x-callout-name']}`,
                   exitOnError: false,
                 },
               },

--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/plans/create-an-api-with-oauth2-plan-and-use-it.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/plans/create-an-api-with-oauth2-plan-and-use-it.spec.ts
@@ -150,7 +150,7 @@ describe('Create an API with OAuth2 plan and use it', () => {
             type: 'oauth2',
             configuration: {
               // 📝 We pass the client_id in url to allow wiremock to add it introspectionEndpoint response. Next this allows the gateway to find the right application.
-              authorizationServerUrl: `${process.env.WIREMOCK_BASE_PATH}/${createdApplication.settings.app.client_id}`,
+              authorizationServerUrl: `${process.env.WIREMOCK_BASE_URL}/${createdApplication.settings.app.client_id}`,
               introspectionEndpoint: '/oauth/check_token',
               useSystemProxy: false,
               introspectionEndpointMethod: 'GET',

--- a/gravitee-apim-e2e/api-test/use-case-test/src/portal/consumer/subscribe-to-APIs/subscribe-to-plan-keyless-apikey-jwt-oauth-and-used-it.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/portal/consumer/subscribe-to-APIs/subscribe-to-plan-keyless-apikey-jwt-oauth-and-used-it.spec.ts
@@ -243,7 +243,7 @@ describe('Subscribe to OAuth plan and use it', () => {
             type: 'oauth2',
             configuration: {
               // 📝 We pass the client_id in url to allow wiremock to add it introspectionEndpoint response. Next this allows the gateway to find the right application.
-              authorizationServerUrl: `${process.env.WIREMOCK_BASE_PATH}/${createdPortalApplication.settings.app.client_id}`,
+              authorizationServerUrl: `${process.env.WIREMOCK_BASE_URL}/${createdPortalApplication.settings.app.client_id}`,
               introspectionEndpoint: '/oauth/check_token',
               useSystemProxy: false,
               introspectionEndpointMethod: 'GET',

--- a/gravitee-apim-e2e/docker/api-tests/docker-compose-api-tests.yml
+++ b/gravitee-apim-e2e/docker/api-tests/docker-compose-api-tests.yml
@@ -24,10 +24,10 @@ services:
       - ./:/test
     command: npm run test:api:ci
     environment:
-      - MANAGEMENT_BASE_PATH=http://management_api:8083/management
-      - PORTAL_BASE_PATH=http://management_api:8083/portal/environments
-      - GATEWAY_BASE_PATH=http://gateway:8082
-      - WIREMOCK_BASE_PATH=http://wiremock:8080
+      - MANAGEMENT_BASE_URL=http://management_api:8083/management
+      - PORTAL_BASE_URL=http://management_api:8083/portal/environments
+      - GATEWAY_BASE_URL=http://gateway:8082
+      - WIREMOCK_BASE_URL=http://wiremock:8080
     depends_on:
       management_api:
         condition: service_healthy

--- a/gravitee-apim-e2e/lib/configuration.ts
+++ b/gravitee-apim-e2e/lib/configuration.ts
@@ -59,7 +59,7 @@ export const forManagementAsSimpleUser = () => {
 
 export const forManagement = (auth: BasicAuthentication = ADMIN_USER, headers = {}) => {
   return new ManagementConfiguration({
-    basePath: process.env.MANAGEMENT_BASE_PATH,
+    basePath: process.env.MANAGEMENT_BASE_URL,
     fetchApi,
     ...auth,
     headers: { ...defaultHeaders, ...headers },
@@ -76,7 +76,7 @@ const defaultHeaders = {
 
 export const forPortal = ({ auth = ANONYMOUS, envId = 'DEFAULT', headers = {} }) => {
   return new PortalConfiguration({
-    basePath: `${process.env.PORTAL_BASE_PATH}/${envId}`,
+    basePath: `${process.env.PORTAL_BASE_URL}/${envId}`,
     fetchApi,
     ...auth,
     headers: { ...defaultHeaders, ...headers },

--- a/gravitee-apim-e2e/lib/fixtures/management/ApisFaker.ts
+++ b/gravitee-apim-e2e/lib/fixtures/management/ApisFaker.ts
@@ -127,7 +127,7 @@ export class ApisFaker {
       name,
       description,
       version,
-      endpoint: `${process.env.WIREMOCK_BASE_PATH}/hello`,
+      endpoint: `${process.env.WIREMOCK_BASE_URL}/hello`,
       ...attributes,
     };
   }
@@ -148,7 +148,7 @@ export class ApisFaker {
             {
               inherit: true,
               name: 'default',
-              target: `${process.env.WIREMOCK_BASE_PATH}/hello`,
+              target: `${process.env.WIREMOCK_BASE_URL}/hello`,
               weight: 1,
               backup: false,
               type: 'http',

--- a/gravitee-apim-e2e/lib/gateway.ts
+++ b/gravitee-apim-e2e/lib/gateway.ts
@@ -57,7 +57,7 @@ async function _fetchGateway(request?: Partial<GatewayRequest>): Promise<Respons
 async function _fetchGatewayWithRetries(request: Partial<GatewayRequest>): Promise<Response> {
   console.log('Try to fetch gateway', request.contextPath, request.failAfterMs);
   console.log('With headers', request.headers);
-  const response = await fetchApi(`${process.env.GATEWAY_BASE_PATH}${request.contextPath}`, {
+  const response = await fetchApi(`${process.env.GATEWAY_BASE_URL}${request.contextPath}`, {
     method: request.method,
     body: request.body,
     headers: request.headers,
@@ -69,7 +69,7 @@ async function _fetchGatewayWithRetries(request: Partial<GatewayRequest>): Promi
     return new Promise((successCallback, failureCallback) => {
       setTimeout(() => {
         if (request.failAfterMs - request.timeBetweenRetries <= 0) {
-          failureCallback(new Error(`Gateway [${process.env.GATEWAY_BASE_PATH}${request.contextPath}] returned HTTP ${response.status}`));
+          failureCallback(new Error(`Gateway [${process.env.GATEWAY_BASE_URL}${request.contextPath}] returned HTTP ${response.status}`));
         } else {
           request.failAfterMs -= request.timeBetweenRetries;
           successCallback(_fetchGateway(request));


### PR DESCRIPTION
Using e.g. `MANAGEMENT_BASE_PATH` for the management API base URL is kind of misleading.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/refactor-rename-e2e-url-env-var/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-owdhzvyenk.chromatic.com)
<!-- Storybook placeholder end -->
