### PR TITLE
chore: bump reporter-elasticsearch to 3.12.3

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -104,7 +104,7 @@
         <gravitee-fetcher-gitlab.version>1.11.0</gravitee-fetcher-gitlab.version>
         <gravitee-fetcher-http.version>1.12.0</gravitee-fetcher-http.version>
         <!-- Gateway Only -->
-        <gravitee-reporter-elasticsearch.version>3.12.2</gravitee-reporter-elasticsearch.version>
+        <gravitee-reporter-elasticsearch.version>3.12.3</gravitee-reporter-elasticsearch.version>
         <gravitee-reporter-file.version>2.5.2</gravitee-reporter-file.version>
         <gravitee-reporter-tcp.version>1.4.2</gravitee-reporter-tcp.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7930
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-7930-fix-es-headers-reporting/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
