### PR TITLE
fix: create api with system folder

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
@@ -335,6 +335,19 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
         }
 
         updatePages(createdApiEntity.getId(), jsonNode, environmentId);
+
+        List<PageEntity> search = pageService.search(
+            new PageQuery.Builder()
+                .api(createdApiEntity.getId())
+                .name(SystemFolderType.ASIDE.folderName())
+                .type(PageType.SYSTEM_FOLDER)
+                .build(),
+            environmentId
+        );
+
+        if (search.isEmpty()) {
+            pageService.createAsideFolder(createdApiEntity.getId(), environmentId);
+        }
     }
 
     private String fetchApiDefinitionContentFromURL(String apiDefinitionOrURL) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_CreateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_CreateWithDefinitionTest.java
@@ -254,6 +254,7 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         );
 
         verify(apiService, times(1)).createWithApiDefinition(any(), eq("admin"), any());
+        verify(pageService, times(1)).createAsideFolder(eq(API_ID), eq(GraviteeContext.getCurrentEnvironment()));
         verify(membershipService, times(1))
             .addRoleToMemberOnReference(
                 GraviteeContext.getCurrentOrganization(),
@@ -332,6 +333,7 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         );
 
         verify(apiService, times(1)).createWithApiDefinition(any(), eq("admin"), any());
+        verify(pageService, times(1)).createAsideFolder(eq(API_ID), eq(GraviteeContext.getCurrentEnvironment()));
     }
 
     @Test
@@ -361,6 +363,7 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         );
 
         verify(apiService, times(1)).createWithApiDefinition(any(), eq("admin"), any());
+        verify(pageService, times(1)).createAsideFolder(eq(API_ID), eq(GraviteeContext.getCurrentEnvironment()));
     }
 
     @Test
@@ -390,6 +393,7 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         );
 
         verify(apiService, times(1)).createWithApiDefinition(any(), eq("admin"), any());
+        verify(pageService, times(1)).createAsideFolder(eq(API_ID), eq(GraviteeContext.getCurrentEnvironment()));
     }
 
     @Test
@@ -415,6 +419,7 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         );
 
         verify(apiService, times(1)).createWithApiDefinition(any(), eq("admin"), any());
+        verify(pageService, times(1)).createAsideFolder(eq(API_ID), eq(GraviteeContext.getCurrentEnvironment()));
     }
 
     @Test
@@ -550,6 +555,7 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         );
 
         verify(apiService, times(1)).createWithApiDefinition(any(), eq("admin"), any());
+        verify(pageService, times(1)).createAsideFolder(eq(API_ID), eq(GraviteeContext.getCurrentEnvironment()));
         verify(membershipService, times(1))
             .addRoleToMemberOnReference(
                 GraviteeContext.getCurrentOrganization(),


### PR DESCRIPTION
**Issue**

gravitee-io/issues#7876

**Description**

This commit fix a regression on the api creation introduced in the commit 49a3f44. In the previous commit I fixed the api import with the system folder aside. However I removed a piece of code that allow the creation of this folder in the normal flow using api create option.

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-import-create-api-system-folder/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
