### PR TITLE
chore: upgrade jwt policy to 2.1.1

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -65,7 +65,7 @@
         <gravitee-policy-json-validation.version>1.6.1</gravitee-policy-json-validation.version>
         <gravitee-policy-json-xml.version>1.1.1</gravitee-policy-json-xml.version>
         <gravitee-policy-jws.version>1.3.2</gravitee-policy-jws.version>
-        <gravitee-policy-jwt.version>2.1.0</gravitee-policy-jwt.version>
+        <gravitee-policy-jwt.version>2.1.1</gravitee-policy-jwt.version>
         <gravitee-policy-keyless.version>1.5.0</gravitee-policy-keyless.version>
         <gravitee-policy-latency.version>1.4.0</gravitee-policy-latency.version>
         <gravitee-policy-metrics-reporter.version>2.0.0</gravitee-policy-metrics-reporter.version>


### PR DESCRIPTION
Upgrade the jwt policy plugin to 2.1.1 since it has been released

Related to gravitee-io/issues#7930
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/jwt-policy-upgrade/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tsaxgylryz.chromatic.com)
<!-- Storybook placeholder end -->
