### PR TITLE
fix: missing application in refreshed subscription

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/task/SubscriptionRefresher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/task/SubscriptionRefresher.java
@@ -57,6 +57,7 @@ public abstract class SubscriptionRefresher implements Callable<Result<Boolean>>
     private Subscription convertModelSubscriptionToCache(io.gravitee.repository.management.model.Subscription subscriptionModel) {
         Subscription subscription = new Subscription();
         subscription.setApi(subscriptionModel.getApi());
+        subscription.setApplication(subscriptionModel.getApplication());
         subscription.setClientId(subscriptionModel.getClientId());
         subscription.setStartingAt(subscriptionModel.getStartingAt());
         subscription.setEndingAt(subscriptionModel.getEndingAt());


### PR DESCRIPTION
The application was not properly set in the subscription object when refreshed on the gateway side.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-missing-app-in-subscription/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-deavjtsahq.chromatic.com)
<!-- Storybook placeholder end -->
