### PR TITLE
fix: application update removes Oauth credential when DCR unreachable

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/ClientRegistrationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/ClientRegistrationServiceImpl.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.service.impl.configuration.application.registration
 import static io.gravitee.repository.management.model.Audit.AuditProperties.CLIENT_REGISTRATION_PROVIDER;
 import static java.util.Collections.singletonMap;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -403,9 +404,9 @@ public class ClientRegistrationServiceImpl extends AbstractService implements Cl
                 convert(registrationRequest, application),
                 application.getSettings().getoAuthClient().getClientId()
             );
-        } catch (Exception ex) {
+        } catch (JsonProcessingException ex) {
             LOGGER.error("Unexpected error while updating a client", ex);
-            return null;
+            throw new RegisteredClientNotUpdatableException();
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_UpdateTest.java
@@ -81,7 +81,7 @@ public class ApplicationService_UpdateTest {
     private UserService userService;
 
     @Mock
-    private UpdateApplicationEntity existingApplication;
+    private UpdateApplicationEntity applicationToUpdate;
 
     @Mock
     private Application application;
@@ -107,12 +107,12 @@ public class ApplicationService_UpdateTest {
         SimpleApplicationSettings clientSettings = new SimpleApplicationSettings();
         clientSettings.setClientId(CLIENT_ID);
         settings.setApp(clientSettings);
-        when(existingApplication.getSettings()).thenReturn(settings);
+        when(applicationToUpdate.getSettings()).thenReturn(settings);
         when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(application));
         when(application.getName()).thenReturn(APPLICATION_NAME);
         when(application.getStatus()).thenReturn(ApplicationStatus.ACTIVE);
-        when(existingApplication.getName()).thenReturn(APPLICATION_NAME);
-        when(existingApplication.getDescription()).thenReturn("My description");
+        when(applicationToUpdate.getName()).thenReturn(APPLICATION_NAME);
+        when(applicationToUpdate.getDescription()).thenReturn("My description");
         when(application.getType()).thenReturn(ApplicationType.SIMPLE);
         when(applicationRepository.update(any())).thenReturn(application);
 
@@ -130,7 +130,7 @@ public class ApplicationService_UpdateTest {
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment(),
             APPLICATION_ID,
-            existingApplication
+            applicationToUpdate
         );
 
         verify(applicationRepository)
@@ -148,7 +148,7 @@ public class ApplicationService_UpdateTest {
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment(),
             APPLICATION_ID,
-            existingApplication
+            applicationToUpdate
         );
     }
 
@@ -158,19 +158,19 @@ public class ApplicationService_UpdateTest {
         SimpleApplicationSettings clientSettings = new SimpleApplicationSettings();
         clientSettings.setClientId(CLIENT_ID);
         settings.setApp(clientSettings);
-        when(existingApplication.getSettings()).thenReturn(settings);
+        when(applicationToUpdate.getSettings()).thenReturn(settings);
         when(application.getType()).thenReturn(ApplicationType.SIMPLE);
         when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(application));
         when(applicationRepository.update(any())).thenThrow(TechnicalException.class);
 
-        when(existingApplication.getName()).thenReturn(APPLICATION_NAME);
-        when(existingApplication.getDescription()).thenReturn("My description");
+        when(applicationToUpdate.getName()).thenReturn(APPLICATION_NAME);
+        when(applicationToUpdate.getDescription()).thenReturn("My description");
 
         applicationService.update(
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment(),
             APPLICATION_ID,
-            existingApplication
+            applicationToUpdate
         );
     }
 
@@ -187,13 +187,13 @@ public class ApplicationService_UpdateTest {
         SimpleApplicationSettings clientSettings = new SimpleApplicationSettings();
         clientSettings.setClientId(CLIENT_ID);
         settings.setApp(clientSettings);
-        when(existingApplication.getSettings()).thenReturn(settings);
+        when(applicationToUpdate.getSettings()).thenReturn(settings);
 
         when(application.getName()).thenReturn(APPLICATION_NAME);
         when(application.getStatus()).thenReturn(ApplicationStatus.ACTIVE);
         when(application.getType()).thenReturn(ApplicationType.SIMPLE);
-        when(existingApplication.getName()).thenReturn(APPLICATION_NAME);
-        when(existingApplication.getDescription()).thenReturn("My description");
+        when(applicationToUpdate.getName()).thenReturn(APPLICATION_NAME);
+        when(applicationToUpdate.getDescription()).thenReturn("My description");
         when(applicationRepository.update(any())).thenReturn(application);
 
         when(roleService.findPrimaryOwnerRoleByOrganization(any(), any())).thenReturn(mock(RoleEntity.class));
@@ -210,7 +210,7 @@ public class ApplicationService_UpdateTest {
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment(),
             APPLICATION_ID,
-            existingApplication
+            applicationToUpdate
         );
 
         verify(applicationRepository)
@@ -240,13 +240,13 @@ public class ApplicationService_UpdateTest {
         clientSettings.setClientId(CLIENT_ID);
         settings.setApp(clientSettings);
 
-        when(existingApplication.getSettings()).thenReturn(settings);
+        when(applicationToUpdate.getSettings()).thenReturn(settings);
 
         applicationService.update(
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment(),
             APPLICATION_ID,
-            existingApplication
+            applicationToUpdate
         );
     }
 
@@ -259,7 +259,7 @@ public class ApplicationService_UpdateTest {
         // oauth app settings
         ApplicationSettings settings = new ApplicationSettings();
         settings.setoAuthClient(new OAuthClientSettings());
-        when(existingApplication.getSettings()).thenReturn(settings);
+        when(applicationToUpdate.getSettings()).thenReturn(settings);
 
         // client registration is disabled
         when(parameterService.findAsBoolean(eq(Key.APPLICATION_REGISTRATION_ENABLED), any(), eq(ParameterReferenceType.ENVIRONMENT)))
@@ -269,7 +269,7 @@ public class ApplicationService_UpdateTest {
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment(),
             APPLICATION_ID,
-            existingApplication
+            applicationToUpdate
         );
     }
 
@@ -282,8 +282,8 @@ public class ApplicationService_UpdateTest {
         // oauth app settings doesn't contain grant types
         ApplicationSettings settings = new ApplicationSettings();
         settings.setoAuthClient(new OAuthClientSettings());
-        when(existingApplication.getSettings()).thenReturn(settings);
-        when(existingApplication.getSettings()).thenReturn(settings);
+        when(applicationToUpdate.getSettings()).thenReturn(settings);
+        when(applicationToUpdate.getSettings()).thenReturn(settings);
 
         // client registration is enabled
         when(parameterService.findAsBoolean(eq(Key.APPLICATION_REGISTRATION_ENABLED), any(), eq(ParameterReferenceType.ENVIRONMENT)))
@@ -293,7 +293,7 @@ public class ApplicationService_UpdateTest {
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment(),
             APPLICATION_ID,
-            existingApplication
+            applicationToUpdate
         );
     }
 
@@ -302,8 +302,8 @@ public class ApplicationService_UpdateTest {
         when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(application));
         when(application.getName()).thenReturn(APPLICATION_NAME);
         when(application.getStatus()).thenReturn(ApplicationStatus.ACTIVE);
-        when(existingApplication.getName()).thenReturn(APPLICATION_NAME);
-        when(existingApplication.getDescription()).thenReturn("My description");
+        when(applicationToUpdate.getName()).thenReturn(APPLICATION_NAME);
+        when(applicationToUpdate.getDescription()).thenReturn("My description");
         when(application.getType()).thenReturn(ApplicationType.BROWSER);
         when(application.getMetadata()).thenReturn(Map.of(METADATA_CLIENT_ID, "my-previous-client-id"));
         when(application.getMetadata()).thenReturn(Map.of(METADATA_REGISTRATION_PAYLOAD, "{}"));
@@ -328,7 +328,7 @@ public class ApplicationService_UpdateTest {
         oAuthClientSettings.setGrantTypes(List.of("application-grant-type"));
         oAuthClientSettings.setApplicationType("application-type");
         settings.setoAuthClient(oAuthClientSettings);
-        when(existingApplication.getSettings()).thenReturn(settings);
+        when(applicationToUpdate.getSettings()).thenReturn(settings);
 
         ApplicationTypeEntity applicationTypeEntity = new ApplicationTypeEntity();
         ApplicationGrantTypeEntity applicationGrantTypeEntity = new ApplicationGrantTypeEntity();
@@ -341,13 +341,13 @@ public class ApplicationService_UpdateTest {
         // mock response from DCR with a new client ID
         ClientRegistrationResponse clientRegistrationResponse = new ClientRegistrationResponse();
         clientRegistrationResponse.setClientId("client-id-from-clientRegistration");
-        when(clientRegistrationService.update(any(), same(existingApplication))).thenReturn(clientRegistrationResponse);
+        when(clientRegistrationService.update(any(), same(applicationToUpdate))).thenReturn(clientRegistrationResponse);
 
         applicationService.update(
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment(),
             APPLICATION_ID,
-            existingApplication
+            applicationToUpdate
         );
 
         // ensure application has been updated with the new client_id from DCR
@@ -360,8 +360,8 @@ public class ApplicationService_UpdateTest {
         when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(application));
         when(application.getName()).thenReturn(APPLICATION_NAME);
         when(application.getStatus()).thenReturn(ApplicationStatus.ACTIVE);
-        when(existingApplication.getName()).thenReturn(APPLICATION_NAME);
-        when(existingApplication.getDescription()).thenReturn("My description");
+        when(applicationToUpdate.getName()).thenReturn(APPLICATION_NAME);
+        when(applicationToUpdate.getDescription()).thenReturn("My description");
         when(application.getType()).thenReturn(ApplicationType.BROWSER);
         when(application.getMetadata())
             .thenReturn(Map.of(METADATA_REGISTRATION_PAYLOAD, "{}", METADATA_CLIENT_ID, "my-previous-client-id"));
@@ -386,7 +386,7 @@ public class ApplicationService_UpdateTest {
         oAuthClientSettings.setGrantTypes(List.of("application-grant-type"));
         oAuthClientSettings.setApplicationType("application-type");
         settings.setoAuthClient(oAuthClientSettings);
-        when(existingApplication.getSettings()).thenReturn(settings);
+        when(applicationToUpdate.getSettings()).thenReturn(settings);
 
         ApplicationTypeEntity applicationTypeEntity = new ApplicationTypeEntity();
         ApplicationGrantTypeEntity applicationGrantTypeEntity = new ApplicationGrantTypeEntity();
@@ -397,13 +397,13 @@ public class ApplicationService_UpdateTest {
         when(applicationTypeService.getApplicationType("application-type")).thenReturn(applicationTypeEntity);
 
         // DCR throws exception
-        when(clientRegistrationService.update(any(), same(existingApplication))).thenThrow(RuntimeException.class);
+        when(clientRegistrationService.update(any(), same(applicationToUpdate))).thenThrow(RuntimeException.class);
 
         applicationService.update(
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment(),
             APPLICATION_ID,
-            existingApplication
+            applicationToUpdate
         );
 
         // ensure application has been updated, but kept the previous client_id

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApplicationService_UpdateTest.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.rest.api.service;
 
+import static io.gravitee.repository.management.model.Application.METADATA_CLIENT_ID;
+import static io.gravitee.repository.management.model.Application.METADATA_REGISTRATION_PAYLOAD;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.*;
@@ -30,17 +32,19 @@ import io.gravitee.rest.api.model.MembershipReferenceType;
 import io.gravitee.rest.api.model.RoleEntity;
 import io.gravitee.rest.api.model.UpdateApplicationEntity;
 import io.gravitee.rest.api.model.application.ApplicationSettings;
+import io.gravitee.rest.api.model.application.OAuthClientSettings;
 import io.gravitee.rest.api.model.application.SimpleApplicationSettings;
+import io.gravitee.rest.api.model.configuration.application.ApplicationGrantTypeEntity;
+import io.gravitee.rest.api.model.configuration.application.ApplicationTypeEntity;
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.configuration.application.ApplicationTypeService;
 import io.gravitee.rest.api.service.configuration.application.ClientRegistrationService;
-import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
-import io.gravitee.rest.api.service.exceptions.ClientIdAlreadyExistsException;
-import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import io.gravitee.rest.api.service.exceptions.*;
 import io.gravitee.rest.api.service.impl.ApplicationServiceImpl;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import io.gravitee.rest.api.service.impl.configuration.application.registration.client.register.ClientRegistrationResponse;
+import java.util.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -93,6 +97,9 @@ public class ApplicationService_UpdateTest {
 
     @Mock
     private ClientRegistrationService clientRegistrationService;
+
+    @Mock
+    private ApplicationTypeService applicationTypeService;
 
     @Test
     public void shouldUpdate() throws TechnicalException {
@@ -173,7 +180,7 @@ public class ApplicationService_UpdateTest {
         when(application.getId()).thenReturn(APPLICATION_ID);
 
         Map<String, String> metadata = new HashMap<>();
-        metadata.put("client_id", CLIENT_ID);
+        metadata.put(METADATA_CLIENT_ID, CLIENT_ID);
         when(application.getMetadata()).thenReturn(metadata);
 
         ApplicationSettings settings = new ApplicationSettings();
@@ -219,7 +226,7 @@ public class ApplicationService_UpdateTest {
         when(other.getId()).thenReturn("other-app");
 
         Map<String, String> metadata = new HashMap<>();
-        metadata.put("client_id", CLIENT_ID);
+        metadata.put(METADATA_CLIENT_ID, CLIENT_ID);
         when(other.getMetadata()).thenReturn(metadata);
 
         when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(application));
@@ -241,5 +248,166 @@ public class ApplicationService_UpdateTest {
             APPLICATION_ID,
             existingApplication
         );
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void should_throw_exception_cause_client_registration_is_disabled() throws TechnicalException {
+        when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(application));
+        when(application.getStatus()).thenReturn(ApplicationStatus.ACTIVE);
+        when(application.getType()).thenReturn(ApplicationType.BROWSER);
+
+        // oauth app settings
+        ApplicationSettings settings = new ApplicationSettings();
+        settings.setoAuthClient(new OAuthClientSettings());
+        when(existingApplication.getSettings()).thenReturn(settings);
+
+        // client registration is disabled
+        when(parameterService.findAsBoolean(eq(Key.APPLICATION_REGISTRATION_ENABLED), any(), eq(ParameterReferenceType.ENVIRONMENT)))
+            .thenReturn(false);
+
+        applicationService.update(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
+            APPLICATION_ID,
+            existingApplication
+        );
+    }
+
+    @Test(expected = ApplicationGrantTypesNotFoundException.class)
+    public void should_throw_exception_cause_oAuth_client_settings_has_no_grant_types() throws TechnicalException {
+        when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(application));
+        when(application.getStatus()).thenReturn(ApplicationStatus.ACTIVE);
+        when(application.getType()).thenReturn(ApplicationType.BROWSER);
+
+        // oauth app settings doesn't contain grant types
+        ApplicationSettings settings = new ApplicationSettings();
+        settings.setoAuthClient(new OAuthClientSettings());
+        when(existingApplication.getSettings()).thenReturn(settings);
+        when(existingApplication.getSettings()).thenReturn(settings);
+
+        // client registration is enabled
+        when(parameterService.findAsBoolean(eq(Key.APPLICATION_REGISTRATION_ENABLED), any(), eq(ParameterReferenceType.ENVIRONMENT)))
+            .thenReturn(true);
+
+        applicationService.update(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
+            APPLICATION_ID,
+            existingApplication
+        );
+    }
+
+    @Test
+    public void should_update_with_oauth2_clientId_from_client_registration_service() throws TechnicalException {
+        when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(application));
+        when(application.getName()).thenReturn(APPLICATION_NAME);
+        when(application.getStatus()).thenReturn(ApplicationStatus.ACTIVE);
+        when(existingApplication.getName()).thenReturn(APPLICATION_NAME);
+        when(existingApplication.getDescription()).thenReturn("My description");
+        when(application.getType()).thenReturn(ApplicationType.BROWSER);
+        when(application.getMetadata()).thenReturn(Map.of(METADATA_CLIENT_ID, "my-previous-client-id"));
+        when(application.getMetadata()).thenReturn(Map.of(METADATA_REGISTRATION_PAYLOAD, "{}"));
+        when(applicationRepository.update(any())).thenReturn(application);
+        when(roleService.findPrimaryOwnerRoleByOrganization(any(), any())).thenReturn(mock(RoleEntity.class));
+
+        MembershipEntity po = new MembershipEntity();
+        po.setMemberId(USER_NAME);
+        po.setMemberType(MembershipMemberType.USER);
+        po.setReferenceId(APPLICATION_ID);
+        po.setReferenceType(MembershipReferenceType.APPLICATION);
+        po.setRoleId("APPLICATION_PRIMARY_OWNER");
+        when(membershipService.getMembershipsByReferencesAndRole(any(), any(), any())).thenReturn(Collections.singleton(po));
+
+        // client registration is enabled
+        when(parameterService.findAsBoolean(eq(Key.APPLICATION_REGISTRATION_ENABLED), any(), eq(ParameterReferenceType.ENVIRONMENT)))
+            .thenReturn(true);
+
+        // oauth app settings contains everything required
+        ApplicationSettings settings = new ApplicationSettings();
+        OAuthClientSettings oAuthClientSettings = new OAuthClientSettings();
+        oAuthClientSettings.setGrantTypes(List.of("application-grant-type"));
+        oAuthClientSettings.setApplicationType("application-type");
+        settings.setoAuthClient(oAuthClientSettings);
+        when(existingApplication.getSettings()).thenReturn(settings);
+
+        ApplicationTypeEntity applicationTypeEntity = new ApplicationTypeEntity();
+        ApplicationGrantTypeEntity applicationGrantTypeEntity = new ApplicationGrantTypeEntity();
+        applicationGrantTypeEntity.setType("application-grant-type");
+        applicationGrantTypeEntity.setResponse_types(List.of("response-type"));
+        applicationTypeEntity.setAllowed_grant_types(List.of(applicationGrantTypeEntity));
+        applicationTypeEntity.setRequires_redirect_uris(false);
+        when(applicationTypeService.getApplicationType("application-type")).thenReturn(applicationTypeEntity);
+
+        // mock response from DCR with a new client ID
+        ClientRegistrationResponse clientRegistrationResponse = new ClientRegistrationResponse();
+        clientRegistrationResponse.setClientId("client-id-from-clientRegistration");
+        when(clientRegistrationService.update(any(), same(existingApplication))).thenReturn(clientRegistrationResponse);
+
+        applicationService.update(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
+            APPLICATION_ID,
+            existingApplication
+        );
+
+        // ensure application has been updated with the new client_id from DCR
+        verify(applicationRepository)
+            .update(argThat(application -> application.getMetadata().get(METADATA_CLIENT_ID).equals("client-id-from-clientRegistration")));
+    }
+
+    @Test
+    public void should_update_with_previous_oAuth2_clientId_when_registration_service_fails() throws TechnicalException {
+        when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(application));
+        when(application.getName()).thenReturn(APPLICATION_NAME);
+        when(application.getStatus()).thenReturn(ApplicationStatus.ACTIVE);
+        when(existingApplication.getName()).thenReturn(APPLICATION_NAME);
+        when(existingApplication.getDescription()).thenReturn("My description");
+        when(application.getType()).thenReturn(ApplicationType.BROWSER);
+        when(application.getMetadata())
+            .thenReturn(Map.of(METADATA_REGISTRATION_PAYLOAD, "{}", METADATA_CLIENT_ID, "my-previous-client-id"));
+        when(applicationRepository.update(any())).thenReturn(application);
+        when(roleService.findPrimaryOwnerRoleByOrganization(any(), any())).thenReturn(mock(RoleEntity.class));
+
+        MembershipEntity po = new MembershipEntity();
+        po.setMemberId(USER_NAME);
+        po.setMemberType(MembershipMemberType.USER);
+        po.setReferenceId(APPLICATION_ID);
+        po.setReferenceType(MembershipReferenceType.APPLICATION);
+        po.setRoleId("APPLICATION_PRIMARY_OWNER");
+        when(membershipService.getMembershipsByReferencesAndRole(any(), any(), any())).thenReturn(Collections.singleton(po));
+
+        // client registration is enabled
+        when(parameterService.findAsBoolean(eq(Key.APPLICATION_REGISTRATION_ENABLED), any(), eq(ParameterReferenceType.ENVIRONMENT)))
+            .thenReturn(true);
+
+        // oauth app settings contains everything required
+        ApplicationSettings settings = new ApplicationSettings();
+        OAuthClientSettings oAuthClientSettings = new OAuthClientSettings();
+        oAuthClientSettings.setGrantTypes(List.of("application-grant-type"));
+        oAuthClientSettings.setApplicationType("application-type");
+        settings.setoAuthClient(oAuthClientSettings);
+        when(existingApplication.getSettings()).thenReturn(settings);
+
+        ApplicationTypeEntity applicationTypeEntity = new ApplicationTypeEntity();
+        ApplicationGrantTypeEntity applicationGrantTypeEntity = new ApplicationGrantTypeEntity();
+        applicationGrantTypeEntity.setType("application-grant-type");
+        applicationGrantTypeEntity.setResponse_types(List.of("response-type"));
+        applicationTypeEntity.setAllowed_grant_types(List.of(applicationGrantTypeEntity));
+        applicationTypeEntity.setRequires_redirect_uris(false);
+        when(applicationTypeService.getApplicationType("application-type")).thenReturn(applicationTypeEntity);
+
+        // DCR throws exception
+        when(clientRegistrationService.update(any(), same(existingApplication))).thenThrow(RuntimeException.class);
+
+        applicationService.update(
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment(),
+            APPLICATION_ID,
+            existingApplication
+        );
+
+        // ensure application has been updated, but kept the previous client_id
+        verify(applicationRepository)
+            .update(argThat(application -> application.getMetadata().get(METADATA_CLIENT_ID).equals("my-previous-client-id")));
     }
 }


### PR DESCRIPTION
**Description**

Application update removes Oauth credentials from metadata when DCR unreachable.
This fix preserves previous Oauth credentials if DRC update fails.

**Issue**

gravitee-io/issues#7953
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-appupdatewithunreachabledcr/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
