### PR TITLE
chore: bump reporter-file to 2.5.3 and reporter-tcp to 1.4.3

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -105,8 +105,8 @@
         <gravitee-fetcher-http.version>1.12.0</gravitee-fetcher-http.version>
         <!-- Gateway Only -->
         <gravitee-reporter-elasticsearch.version>3.12.4</gravitee-reporter-elasticsearch.version>
-        <gravitee-reporter-file.version>2.5.2</gravitee-reporter-file.version>
-        <gravitee-reporter-tcp.version>1.4.2</gravitee-reporter-tcp.version>
+        <gravitee-reporter-file.version>2.5.3</gravitee-reporter-file.version>
+        <gravitee-reporter-tcp.version>1.4.3</gravitee-reporter-tcp.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->
         <!--    <gravitee-gateway-services-ratelimit.version>1.15.0</gravitee-gateway-services-ratelimit.version>    -->
         <gravitee-tracer-jaeger.version>1.1.0</gravitee-tracer-jaeger.version>


### PR DESCRIPTION
gravitee-io/issues#7930


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-7930-fix-es-headers-reporting-4/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
