### PR TITLE
fix: check if api key exists before creating the subscription [ 3.10.x ]

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/apiKeyValidatedInput.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/apiKeyValidatedInput.component.ts
@@ -42,25 +42,27 @@ const ApiKeyValidatedInput: ng.IComponentOptions = {
 
     this.valueChange = function () {
       this.checkApiKeyUnicity(this.value);
-      this.onChange(this.value);
     };
 
     this.checkApiKeyUnicity = (apiKey: string) => {
       if (apiKey && apiKey.length > 0) {
-        ApiService.verifyApiKey(this.apiId, apiKey).then(
-          (response) => {
-            if (response && response.data) {
-              this.state = CustomApiKeyInputState.VALID;
-            } else {
+        ApiService.verifyApiKey(this.apiId, apiKey)
+          .then(
+            (response) => {
+              if (response && response.data) {
+                this.state = CustomApiKeyInputState.VALID;
+              } else {
+                this.state = CustomApiKeyInputState.INVALID;
+              }
+            },
+            () => {
               this.state = CustomApiKeyInputState.INVALID;
-            }
-          },
-          () => {
-            this.state = CustomApiKeyInputState.INVALID;
-          },
-        );
+            },
+          )
+          .then(() => this.emitChanges());
       } else {
         this.state = CustomApiKeyInputState.EMPTY;
+        this.emitChanges();
       }
     };
 
@@ -70,6 +72,13 @@ const ApiKeyValidatedInput: ng.IComponentOptions = {
 
     this.isApiKeyInvalid = () => {
       return this.state === CustomApiKeyInputState.INVALID;
+    };
+
+    this.emitChanges = () => {
+      this.onChange({
+        customApiKey: this.value,
+        customApiKeyInputState: this.state,
+      });
     };
   },
 };

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/dialog/subscription.accept.dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/dialog/subscription.accept.dialog.controller.ts
@@ -23,6 +23,7 @@ function DialogSubscriptionAcceptController($scope, $mdDialog, locals) {
   $scope.apiId = locals.apiId;
 
   this.customApiKey = null;
+  this.customApiKeyInputState = null;
 
   this.hide = function () {
     $mdDialog.cancel();
@@ -37,8 +38,9 @@ function DialogSubscriptionAcceptController($scope, $mdDialog, locals) {
     });
   };
 
-  this.onApiKeyValueChange = (customApiKey) => {
-    this.customApiKey = customApiKey;
+  this.onApiKeyValueChange = (apiKeyValidatedInput) => {
+    this.customApiKey = apiKeyValidatedInput.customApiKey;
+    this.customApiKeyInputState = apiKeyValidatedInput.customApiKeyInputState;
   };
 }
 

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/dialog/subscription.create.dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/dialog/subscription.create.dialog.controller.ts
@@ -32,6 +32,7 @@ function DialogSubscriptionCreateController(
   this.selectedPlan = null;
   this.selectedPlanCustomApiKey = null;
   this.plansWithSubscriptions = [];
+  this.customApiKeyInputState = null;
 
   this.$onInit = () => {
     this.canUseCustomApiKey = Constants.env.settings.plan.security.customApiKey.enabled;
@@ -88,8 +89,9 @@ function DialogSubscriptionCreateController(
     return this.plans.find((p) => p.general_conditions !== undefined && p.general_conditions !== '') != null;
   };
 
-  this.onApiKeyValueChange = (customApiKey) => {
-    this.selectedPlanCustomApiKey = customApiKey;
+  this.onApiKeyValueChange = (apiKeyValidatedInput) => {
+    this.selectedPlanCustomApiKey = apiKeyValidatedInput.customApiKey;
+    this.customApiKeyInputState = apiKeyValidatedInput.customApiKeyInputState;
   };
 }
 

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/dialog/subscription.renew.dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/dialog/subscription.renew.dialog.controller.ts
@@ -25,6 +25,7 @@ function DialogSubscriptionRenewController($scope, $mdDialog, locals) {
   $scope.apiId = locals.apiId;
   this.selectedPlanCustomApiKey = null;
   this.customValue = '';
+  this.customApiKeyInputState = null;
 
   this.cancel = function () {
     $mdDialog.hide({ confirmed: false });
@@ -34,8 +35,9 @@ function DialogSubscriptionRenewController($scope, $mdDialog, locals) {
     this.customValue ? $mdDialog.hide({ confirmed: true, customValue: this.customValue }) : $mdDialog.hide({ confirmed: true });
   };
 
-  this.onApiKeyValueChange = (customApiKey) => {
-    this.customValue = customApiKey;
+  this.onApiKeyValueChange = (apiKeyValidatedInput) => {
+    this.customValue = apiKeyValidatedInput.customApiKey;
+    this.customApiKeyInputState = apiKeyValidatedInput.customApiKeyInputState;
   };
 }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiKeyService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiKeyService.java
@@ -26,8 +26,6 @@ import java.util.List;
  * @author GraviteeSource Team
  */
 public interface ApiKeyService {
-    ApiKeyEntity generate(String subscription);
-
     ApiKeyEntity generate(String subscription, String customApiKey);
 
     ApiKeyEntity renew(String subscription);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/ApiKeyAlreadyExistingException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/ApiKeyAlreadyExistingException.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.exceptions;
+
+import io.gravitee.common.http.HttpStatusCode;
+import java.util.Map;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class ApiKeyAlreadyExistingException extends AbstractManagementException {
+
+    public ApiKeyAlreadyExistingException() {
+        super("API key already exists");
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "apiKey.existing";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return null;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
@@ -509,6 +509,10 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                 subscription.setClosedAt(new Date());
             }
 
+            if (planEntity.getSecurity() == PlanSecurityType.API_KEY && subscription.getStatus() == Subscription.Status.ACCEPTED) {
+                apiKeyService.generate(subscription.getId(), processSubscription.getCustomApiKey());
+            }
+
             subscription = subscriptionRepository.update(subscription);
 
             final ApplicationEntity application = applicationService.findById(
@@ -573,17 +577,6 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                             }
                         }
                     );
-            }
-
-            if (plan.getSecurity() == PlanSecurityType.API_KEY && subscription.getStatus() == Subscription.Status.ACCEPTED) {
-                if (StringUtils.isNotEmpty(processSubscription.getCustomApiKey())) {
-                    if (apiKeyService.exists(processSubscription.getCustomApiKey())) {
-                        throw new ApiKeyAlreadyActivatedException("The API key is already activated");
-                    }
-                    apiKeyService.generate(subscription.getId(), processSubscription.getCustomApiKey());
-                } else {
-                    apiKeyService.generate(subscription.getId());
-                }
             }
 
             return subscriptionEntity;


### PR DESCRIPTION
**Issue**

gravitee-io/issues#7332

**Description**

User should not be able to accepte a subscription with a custom api-key that already exists.

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-custom-api-key-3-10-x/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
