### PR TITLE
fix: check if api key exists before creating the subscription [ 3.17.x ]

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/apiKeyValidatedInput.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/components/apiKeyValidatedInput.component.ts
@@ -43,25 +43,27 @@ const ApiKeyValidatedInput: ng.IComponentOptions = {
 
     this.valueChange = function () {
       this.checkApiKeyUnicity(this.value);
-      this.onChange(this.value);
     };
 
     this.checkApiKeyUnicity = (apiKey: string) => {
       if (apiKey?.length > 0 && this.apiId && this.applicationId) {
-        ApiService.verifyApiKey(this.apiId, this.applicationId, apiKey).then(
-          (response) => {
-            if (response && response.data) {
-              this.state = CustomApiKeyInputState.VALID;
-            } else {
+        ApiService.verifyApiKey(this.apiId, this.applicationId, apiKey)
+          .then(
+            (response) => {
+              if (response && response.data) {
+                this.state = CustomApiKeyInputState.VALID;
+              } else {
+                this.state = CustomApiKeyInputState.INVALID;
+              }
+            },
+            () => {
               this.state = CustomApiKeyInputState.INVALID;
-            }
-          },
-          () => {
-            this.state = CustomApiKeyInputState.INVALID;
-          },
-        );
+            },
+          )
+          .then(() => this.emitChanges());
       } else {
         this.state = CustomApiKeyInputState.EMPTY;
+        this.emitChanges();
       }
     };
 
@@ -71,6 +73,13 @@ const ApiKeyValidatedInput: ng.IComponentOptions = {
 
     this.isApiKeyInvalid = () => {
       return this.state === CustomApiKeyInputState.INVALID;
+    };
+
+    this.emitChanges = () => {
+      this.onChange({
+        customApiKey: this.value,
+        customApiKeyInputState: this.state,
+      });
     };
   },
 };

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/dialog/subscription.accept.dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/dialog/subscription.accept.dialog.controller.ts
@@ -21,6 +21,7 @@ class DialogSubscriptionAcceptController {
   private startingAt: Date;
   private endingAt: Date;
   private customApiKey: string;
+  private customApiKeyInputState: string;
   private reason: string;
 
   constructor(
@@ -48,9 +49,10 @@ class DialogSubscriptionAcceptController {
     });
   }
 
-  onApiKeyValueChange(apiKeyValue: string) {
-    this.customApiKey = apiKeyValue;
-  }
+  onApiKeyValueChange = (apiKeyValidatedInput) => {
+    this.customApiKey = apiKeyValidatedInput.customApiKey;
+    this.customApiKeyInputState = apiKeyValidatedInput.customApiKeyInputState;
+  };
 }
 
 export default DialogSubscriptionAcceptController;

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/dialog/subscription.accept.dialog.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/dialog/subscription.accept.dialog.html
@@ -53,6 +53,8 @@
 
   <md-dialog-actions layout="row">
     <md-button ng-click="$ctrl.hide()">Cancel</md-button>
-    <md-button class="md-raised md-primary" ng-click="$ctrl.save()" ng-disabled="SubscriptionForm.$invalid">Accept</md-button>
+    <md-button class="md-raised md-primary" ng-click="$ctrl.save()" ng-disabled="$ctrl.customApiKeyInputState === 'invalid'"
+      >Accept</md-button
+    >
   </md-dialog-actions>
 </md-dialog>

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/dialog/subscription.create.dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/dialog/subscription.create.dialog.controller.ts
@@ -90,8 +90,9 @@ function DialogSubscriptionCreateController(
     return this.plans.find((p) => p.general_conditions !== undefined && p.general_conditions !== '') != null;
   };
 
-  this.onApiKeyValueChange = (customApiKey) => {
-    this.selectedPlanCustomApiKey = customApiKey;
+  this.onApiKeyValueChange = (apiKeyValidatedInput) => {
+    this.selectedPlanCustomApiKey = apiKeyValidatedInput.customApiKey;
+    this.customApiKeyInputState = apiKeyValidatedInput.customApiKeyInputState;
   };
 }
 

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/dialog/subscription.create.dialog.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/dialog/subscription.create.dialog.html
@@ -64,7 +64,7 @@
             </md-radio-button>
 
             <div
-              ng-if="dialogSubscriptionCreateController.selectedPlan === plan.id && dialogSubscriptionCreateController.planIsApiKey(plan.id) && dialogSubscriptionCreateController.canUseCustomApiKey"
+              ng-if="dialogSubscriptionCreateController.selectedPlan.id === plan.id && dialogSubscriptionCreateController.planIsApiKey(plan.id) && dialogSubscriptionCreateController.canUseCustomApiKey"
               style="color: rgba(0, 0, 0, 0.54); font-size: smaller; margin: 0 0 0 30px"
             >
               <api-key-validated-input

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/dialog/subscription.renew.dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/dialog/subscription.renew.dialog.controller.ts
@@ -26,6 +26,7 @@ function DialogSubscriptionRenewController($scope, $mdDialog, locals) {
   $scope.applicationId = locals.applicationId;
   this.selectedPlanCustomApiKey = null;
   this.customValue = '';
+  this.customApiKeyInputState = null;
 
   this.cancel = function () {
     $mdDialog.hide({ confirmed: false });
@@ -35,8 +36,9 @@ function DialogSubscriptionRenewController($scope, $mdDialog, locals) {
     this.customValue ? $mdDialog.hide({ confirmed: true, customValue: this.customValue }) : $mdDialog.hide({ confirmed: true });
   };
 
-  this.onApiKeyValueChange = (customApiKey) => {
-    this.customValue = customApiKey;
+  this.onApiKeyValueChange = (apiKeyValidatedInput) => {
+    this.customValue = apiKeyValidatedInput.customApiKey;
+    this.customApiKeyInputState = apiKeyValidatedInput.customApiKeyInputState;
   };
 }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
@@ -100,6 +100,11 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
 
     @Override
     public ApiKeyEntity renew(SubscriptionEntity subscription, String customApiKey) {
+        final PlanEntity plan = planService.findById(subscription.getPlan());
+        if (!PlanSecurityType.API_KEY.equals(plan.getSecurity())) {
+            throw new TechnicalManagementException("Invalid plan security.");
+        }
+
         try {
             LOGGER.debug("Renew API Key for subscription {}", subscription.getId());
 


### PR DESCRIPTION
**Issue**

gravitee-io/issues#7332

**Description**

User should not be able to accepte a subscription with a custom api-key that already exists.
The difference with this [pr](https://github.com/gravitee-io/gravitee-api-management/pull/2122) is
 that in this version we introduce the shared api keys. That's why I did another dedicated pull request. I think this will facilitate the merges and the releases as the code as changed in the backend service.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-custom-api-key-3-17-x/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
