### PR TITLE
fix: API import process fails during members roles creation

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
@@ -486,7 +486,7 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
         return roleIdsToImport;
     }
 
-    private void addOrUpdateMembers(
+    protected void addOrUpdateMembers(
         String apiId,
         String organizationId,
         String environmentId,
@@ -509,16 +509,27 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
                 UserEntity userEntity = userService.findBySource(memberToImport.getSource(), memberToImport.getSourceId(), false);
 
                 rolesToImport.forEach(
-                    role ->
-                        membershipService.addRoleToMemberOnReference(
-                            organizationId,
-                            environmentId,
-                            MembershipReferenceType.API,
-                            apiId,
-                            MembershipMemberType.USER,
-                            userEntity.getId(),
-                            role
-                        )
+                    role -> {
+                        try {
+                            membershipService.addRoleToMemberOnReference(
+                                organizationId,
+                                environmentId,
+                                MembershipReferenceType.API,
+                                apiId,
+                                MembershipMemberType.USER,
+                                userEntity.getId(),
+                                role
+                            );
+                        } catch (Exception e) {
+                            LOGGER.warn(
+                                "Unable to add role '{}' to member '{}' on API '{}' due to : {}",
+                                role,
+                                userEntity.getId(),
+                                apiId,
+                                e.getMessage()
+                            );
+                        }
+                    }
                 );
             } catch (UserNotFoundException unfe) {}
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImplTest.java
@@ -50,6 +50,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class ApiDuplicatorServiceImplTest {
 
     private static final String API_ID = "id-api";
+    public static final String ORGANIZATION_ID = "DEFAULT";
     public static final String ENVIRONMENT_ID = "DEFAULT";
 
     @InjectMocks
@@ -378,6 +379,35 @@ public class ApiDuplicatorServiceImplTest {
         when(apiMetadataService.update(any())).thenThrow(new RuntimeException("fake exception"));
 
         apiDuplicatorService.updateMetadata(API_ID, metadataNode);
+    }
+
+    @Test
+    public void addOrUpdateMembers_shouldAddRolesUsingMembershipService_butNotFailIfItThrowsException() {
+        var currentPo = new ApiDuplicatorServiceImpl.MemberToImport();
+        currentPo.setSource("source");
+        currentPo.setSourceId("currentPo-sourceId");
+
+        var memberToImport = new ApiDuplicatorServiceImpl.MemberToImport();
+        memberToImport.setRoles(List.of("member-role"));
+        memberToImport.setSource("source");
+        memberToImport.setSourceId("memberToImport-sourceId");
+
+        when(userService.findBySource(any(), any(), eq(false))).thenReturn(new UserEntity());
+        when(membershipService.addRoleToMemberOnReference(any(), any(), any(), any(), any(), any(), any()))
+            .thenThrow(RuntimeException.class);
+
+        apiDuplicatorService.addOrUpdateMembers(
+            API_ID,
+            ORGANIZATION_ID,
+            ENVIRONMENT_ID,
+            "po-role-id",
+            currentPo,
+            memberToImport,
+            List.of("new-role"),
+            false
+        );
+
+        verify(membershipService).addRoleToMemberOnReference(eq(ORGANIZATION_ID), eq(ENVIRONMENT_ID), any(), any(), any(), any(), any());
     }
 
     /*


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7822

**Description**

**Just duplicate the try/catch block that is already present in 3.15**

fix: API import process fails during members roles creation

API imports process associates roles in 'members.roles' array to the member.
But some roles in this array may not exists on the target environment (for example, if API was exported with members and roles from another environment).

This fix ignores errors that can happen during roles to member associations,
Logging them at WARN level.

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-importwithunknownroleexception/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
