### PR TITLE
[Debug mode] Hide policies with NO_TRANSFORMATION status

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/policy-studio/debug/models/DebugEvent.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/debug/models/DebugEvent.ts
@@ -52,7 +52,7 @@ interface DebugEventDebugStep {
   policyInstanceId: string;
   policyId: string;
   scope: 'ON_REQUEST' | 'ON_REQUEST_CONTENT' | 'ON_RESPONSE' | 'ON_RESPONSE_CONTENT';
-  status: 'COMPLETED' | 'ERROR' | 'SKIPPED';
+  status: 'COMPLETED' | 'ERROR' | 'SKIPPED' | 'NO_TRANSFORMATION';
   condition?: string;
   error?: {
     contentType?: string;

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/debug/models/DebugResponse.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/debug/models/DebugResponse.spec.ts
@@ -17,6 +17,7 @@
 import { RequestDebugStep, RequestPolicyDebugStep, ResponsePolicyDebugStep } from './DebugStep';
 import { fakeDebugEvent } from './DebugEvent.fixture';
 import { convertDebugEventToDebugResponse } from './DebugResponse';
+import { DebugEvent } from './DebugEvent';
 
 describe('convertDebugEventToDebugResponse', () => {
   const expectedRequestDebugSteps: RequestPolicyDebugStep[] = [
@@ -425,5 +426,25 @@ describe('convertDebugEventToDebugResponse', () => {
         },
       },
     ]);
+  });
+
+  it('should remove debug step with NO_TRANSFORMATION status', () => {
+    const mockDebugEvent = fakeDebugEvent();
+    const noTransformationDebugStep: DebugEvent['payload']['debugSteps'][number] = {
+      status: 'NO_TRANSFORMATION',
+      policyId: 'Noop',
+      policyInstanceId: 'Noop',
+      stage: 'API',
+      scope: 'ON_REQUEST_CONTENT',
+      result: {},
+      duration: 200,
+    };
+
+    mockDebugEvent.payload.debugSteps.unshift(noTransformationDebugStep);
+
+    const debugResponse = convertDebugEventToDebugResponse(mockDebugEvent);
+
+    expect(debugResponse.requestPolicyDebugSteps).toStrictEqual(expectedRequestDebugSteps);
+    expect(debugResponse.responsePolicyDebugSteps).toStrictEqual(expectedResponseDebugSteps);
   });
 });

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/debug/models/DebugResponse.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/debug/models/DebugResponse.ts
@@ -59,13 +59,16 @@ export type DebugResponse = {
 };
 
 export const convertDebugEventToDebugResponse = (event: DebugEvent): DebugResponse => {
+  // Filter out empty debug steps that are not relevant to display in the UI.
+  const filteredDebugSteps = event.payload.debugSteps.filter(filterEventDebugStep);
+
   // First, create the hydrated debug steps for the REQUEST with request initial data + attributes
   const requestPolicyDebugSteps =
-    event.payload.debugSteps && event.payload.debugSteps.length > 0
+    filteredDebugSteps && filteredDebugSteps.length > 0
       ? convertRequestDebugSteps(
           event.payload.request ?? {},
           event.payload.preprocessorStep ?? {},
-          event.payload.debugSteps.filter((event) => event.scope === 'ON_REQUEST' || event.scope === 'ON_REQUEST_CONTENT'),
+          filteredDebugSteps.filter((event) => event.scope === 'ON_REQUEST' || event.scope === 'ON_REQUEST_CONTENT'),
         )
       : [];
 
@@ -108,11 +111,11 @@ export const convertDebugEventToDebugResponse = (event: DebugEvent): DebugRespon
 
   // Finally, create the hydrated debug steps for the RESPONSE with initial request data + attributes
   const responsePolicyDebugSteps =
-    event.payload.debugSteps && event.payload.debugSteps.length > 0
+    filteredDebugSteps && filteredDebugSteps.length > 0
       ? convertResponseDebugSteps(
           event.payload.backendResponse ?? {},
           responsePreprocessorStep ?? {},
-          event.payload.debugSteps.filter((event) => event.scope === 'ON_RESPONSE' || event.scope === 'ON_RESPONSE_CONTENT'),
+          filteredDebugSteps.filter((event) => event.scope === 'ON_RESPONSE' || event.scope === 'ON_RESPONSE_CONTENT'),
         )
       : [];
 
@@ -167,7 +170,7 @@ export const convertDebugEventToDebugResponse = (event: DebugEvent): DebugRespon
 const convertRequestDebugSteps = (
   initialRequest: DebugEvent['payload']['request'],
   preprocessorStep: DebugEvent['payload']['preprocessorStep'],
-  debugSteps: DebugEvent['payload']['debugSteps'],
+  debugSteps: DebugEventDebugStepFiltered[],
 ): RequestPolicyDebugStep[] => {
   if (debugSteps.length === 0) {
     return [];
@@ -222,7 +225,7 @@ const convertRequestDebugSteps = (
 const convertResponseDebugSteps = (
   backendResponse: DebugEvent['payload']['backendResponse'],
   preprocessorStep: DebugEvent['payload']['preprocessorStep'],
-  debugSteps: DebugEvent['payload']['debugSteps'],
+  debugSteps: DebugEventDebugStepFiltered[],
 ): ResponsePolicyDebugStep[] => {
   if (debugSteps.length === 0) {
     return [];
@@ -273,3 +276,9 @@ const convertResponseDebugSteps = (
     [firstDebugStep],
   );
 };
+
+type DebugEventDebugStepFiltered = DebugEvent['payload']['debugSteps'][number] & {
+  status: 'COMPLETED' | 'ERROR' | 'SKIPPED';
+};
+const filterEventDebugStep = (step: DebugEvent['payload']['debugSteps'][number]): step is DebugEventDebugStepFiltered =>
+  step.status !== 'NO_TRANSFORMATION';


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7942

**Description**

ignore debug step with NO_TRANSFORMATION status

Now with simple assign :
<img width="1073" alt="image" src="https://user-images.githubusercontent.com/4974420/177186909-e0676a34-e5e7-49c1-a888-f1e41c22282c.png">
before : 

<img width="1184" alt="image" src="https://user-images.githubusercontent.com/4974420/177186953-3e75c6e6-9e19-43bd-91f9-ebb402375880.png">



**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/7942-debug-mode-no-transformation/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
