### PR TITLE
test(unit): add a retry rule for flaky tests

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -329,6 +329,13 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>io.gravitee.apim.test</groupId>
+            <artifactId>gravitee-apim-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Wiremock -->
         <dependency>
             <groupId>com.github.tomakehurst</groupId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketAcceptTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketAcceptTest.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.standalone.websocket;
 
 import io.gravitee.gateway.standalone.junit.annotation.ApiDescriptor;
 import io.gravitee.gateway.standalone.junit.rules.ApiDeployer;
+import io.gravitee.test.junit.rules.FlakyRunner;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
@@ -41,7 +42,7 @@ import org.junit.rules.TestRule;
 public class WebsocketAcceptTest extends AbstractWebSocketGatewayTest {
 
     @Rule
-    public final TestRule chain = RuleChain.outerRule(new ApiDeployer(this));
+    public final TestRule chain = RuleChain.outerRule(new FlakyRunner()).around(new ApiDeployer(this));
 
     @Test
     public void websocket_accepted_request() throws InterruptedException {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketBidirectionalTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketBidirectionalTest.java
@@ -17,18 +17,17 @@ package io.gravitee.gateway.standalone.websocket;
 
 import io.gravitee.gateway.standalone.junit.annotation.ApiDescriptor;
 import io.gravitee.gateway.standalone.junit.rules.ApiDeployer;
+import io.gravitee.test.junit.rules.FlakyRunner;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.WebSocket;
-import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
@@ -40,7 +39,7 @@ import org.junit.rules.TestRule;
 public class WebsocketBidirectionalTest extends AbstractWebSocketGatewayTest {
 
     @Rule
-    public final TestRule chain = RuleChain.outerRule(new ApiDeployer(this));
+    public final TestRule chain = RuleChain.outerRule(new FlakyRunner()).around(new ApiDeployer(this));
 
     @Test
     public void websocket_bidirectional_request() throws InterruptedException {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketCloseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketCloseTest.java
@@ -18,18 +18,17 @@ package io.gravitee.gateway.standalone.websocket;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.gateway.standalone.junit.annotation.ApiDescriptor;
 import io.gravitee.gateway.standalone.junit.rules.ApiDeployer;
+import io.gravitee.test.junit.rules.FlakyRunner;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.WebSocket;
-import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
@@ -41,7 +40,7 @@ import org.junit.rules.TestRule;
 public class WebsocketCloseTest extends AbstractWebSocketGatewayTest {
 
     @Rule
-    public final TestRule chain = RuleChain.outerRule(new ApiDeployer(this));
+    public final TestRule chain = RuleChain.outerRule(new FlakyRunner()).around(new ApiDeployer(this));
 
     @Test
     public void websocket_accepted_request() throws InterruptedException {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketHeadersTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketHeadersTest.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.standalone.websocket;
 
 import io.gravitee.gateway.standalone.junit.annotation.ApiDescriptor;
 import io.gravitee.gateway.standalone.junit.rules.ApiDeployer;
+import io.gravitee.test.junit.rules.FlakyRunner;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.*;
@@ -36,7 +37,7 @@ import org.junit.rules.TestRule;
 public class WebsocketHeadersTest extends AbstractWebSocketGatewayTest {
 
     @Rule
-    public final TestRule chain = RuleChain.outerRule(new ApiDeployer(this));
+    public final TestRule chain = RuleChain.outerRule(new FlakyRunner()).around(new ApiDeployer(this));
 
     @Test
     public void websocket_accepted_request() throws InterruptedException {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketPingFrameTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketPingFrameTest.java
@@ -17,19 +17,18 @@ package io.gravitee.gateway.standalone.websocket;
 
 import io.gravitee.gateway.standalone.junit.annotation.ApiDescriptor;
 import io.gravitee.gateway.standalone.junit.rules.ApiDeployer;
+import io.gravitee.test.junit.rules.FlakyRunner;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.WebSocket;
-import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
@@ -41,7 +40,7 @@ import org.junit.rules.TestRule;
 public class WebsocketPingFrameTest extends AbstractWebSocketGatewayTest {
 
     @Rule
-    public final TestRule chain = RuleChain.outerRule(new ApiDeployer(this));
+    public final TestRule chain = RuleChain.outerRule(new FlakyRunner()).around(new ApiDeployer(this));
 
     @Test
     public void websocket_bidirectional_request() throws InterruptedException {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketRejectTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketRejectTest.java
@@ -18,18 +18,17 @@ package io.gravitee.gateway.standalone.websocket;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.gateway.standalone.junit.annotation.ApiDescriptor;
 import io.gravitee.gateway.standalone.junit.rules.ApiDeployer;
+import io.gravitee.test.junit.rules.FlakyRunner;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.UpgradeRejectedException;
-import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
@@ -37,7 +36,7 @@ import org.junit.rules.TestRule;
 public class WebsocketRejectTest extends AbstractWebSocketGatewayTest {
 
     @Rule
-    public final TestRule chain = RuleChain.outerRule(new ApiDeployer(this));
+    public final TestRule chain = RuleChain.outerRule(new FlakyRunner()).around(new ApiDeployer(this));
 
     @Test
     public void websocket_rejected_request() throws InterruptedException {

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/pom.xml
@@ -87,6 +87,13 @@
             <artifactId>vertx-unit</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.apim.test</groupId>
+            <artifactId>gravitee-apim-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/test/java/io/gravitee/repository/bridge/server/handler/ApiKeysHandlerTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/test/java/io/gravitee/repository/bridge/server/handler/ApiKeysHandlerTest.java
@@ -22,6 +22,7 @@ import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.api.SubscriptionRepository;
 import io.gravitee.repository.management.model.ApiKey;
 import io.gravitee.repository.management.model.Subscription;
+import io.gravitee.test.junit.rules.FlakyRunner;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
@@ -40,7 +41,10 @@ import java.net.ServerSocket;
 import java.util.List;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -63,6 +67,9 @@ public class ApiKeysHandlerTest {
 
     private WebClient client;
     private Vertx vertx;
+
+    @Rule
+    public final TestRule chain = RuleChain.outerRule(new FlakyRunner());
 
     @Before
     public void setUp(TestContext context) throws Exception {

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/test/java/io/gravitee/repository/bridge/server/handler/SubscriptionsHandlerTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/test/java/io/gravitee/repository/bridge/server/handler/SubscriptionsHandlerTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.SubscriptionRepository;
 import io.gravitee.repository.management.model.Subscription;
+import io.gravitee.test.junit.rules.FlakyRunner;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
@@ -37,7 +38,10 @@ import java.net.ServerSocket;
 import java.util.List;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -48,6 +52,9 @@ import org.mockito.MockitoAnnotations;
  */
 @RunWith(VertxUnitRunner.class)
 public class SubscriptionsHandlerTest {
+
+    @Rule
+    public final TestRule chain = RuleChain.outerRule(new FlakyRunner());
 
     @Mock
     private SubscriptionRepository subscriptionRepository;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/pom.xml
@@ -71,6 +71,13 @@
         </dependency>
 
         <dependency>
+            <groupId>io.gravitee.apim.test</groupId>
+            <artifactId>gravitee-apim-test</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>provided</scope>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertyUpdaterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertyUpdaterTest.java
@@ -26,18 +26,18 @@ import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
-import io.gravitee.rest.api.services.dynamicproperties.DynamicPropertyUpdater;
 import io.gravitee.rest.api.services.dynamicproperties.model.DynamicProperty;
 import io.gravitee.rest.api.services.dynamicproperties.provider.Provider;
+import io.gravitee.test.junit.rules.FlakyRunner;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -46,6 +46,9 @@ import org.mockito.MockitoAnnotations;
  * @author GraviteeSource Team
  */
 public class DynamicPropertyUpdaterTest {
+
+    @Rule
+    public final TestRule chain = RuleChain.outerRule(new FlakyRunner());
 
     private static final long TIMEOUT_SECONDS = 5;
 

--- a/gravitee-apim-test/pom.xml
+++ b/gravitee-apim-test/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>gravitee-api-management</artifactId>
+        <groupId>io.gravitee.apim</groupId>
+        <version>3.19.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.gravitee.apim.test</groupId>
+    <artifactId>gravitee-apim-test</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/gravitee-apim-test/src/main/java/io/gravitee/test/junit/rules/FlakyRunner.java
+++ b/gravitee-apim-test/src/main/java/io/gravitee/test/junit/rules/FlakyRunner.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.test.junit.rules;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class FlakyRunner implements TestRule {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FlakyRunner.class);
+
+    private final int retryCount;
+    private final int secondsBetweenRetries;
+
+    private RetryableStatement statement;
+
+    public FlakyRunner(int retryCount, int secondsBetweenRetries) {
+        this.retryCount = retryCount;
+        this.secondsBetweenRetries = secondsBetweenRetries;
+    }
+
+    public FlakyRunner() {
+        this(2, 3);
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        statement = new RetryableStatement(base, retryCount);
+        return statement;
+    }
+
+    RetryableStatement statement() {
+        return statement;
+    }
+
+    class RetryableStatement extends Statement {
+
+        final Statement base;
+        final int maxRetries;
+
+        int retries;
+
+        RetryableStatement(Statement base, int maxRetries) {
+            this.base = base;
+            this.maxRetries = maxRetries;
+            this.retries = maxRetries;
+        }
+
+        @Override
+        public void evaluate() throws Throwable {
+            try {
+                base.evaluate();
+            } catch (Throwable t) {
+                if (--retries < 1) {
+                    throw new FlakyTestError("Test failed after " + maxRetries + "retries");
+                }
+                LOG.warn("Retrying failing test after {} seconds with {} attempts", secondsBetweenRetries, retries);
+                TimeUnit.SECONDS.sleep(secondsBetweenRetries);
+                evaluate();
+            }
+        }
+
+        public int retries() {
+            return retries;
+        }
+    }
+}

--- a/gravitee-apim-test/src/main/java/io/gravitee/test/junit/rules/FlakyTestError.java
+++ b/gravitee-apim-test/src/main/java/io/gravitee/test/junit/rules/FlakyTestError.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.test.junit.rules;
+
+import junit.framework.AssertionFailedError;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class FlakyTestError extends AssertionFailedError {
+
+    public FlakyTestError(String message) {
+        super(message);
+    }
+}

--- a/gravitee-apim-test/src/test/java/io/gravitee/test/junit/rules/FlakyRunnerTest.java
+++ b/gravitee-apim-test/src/test/java/io/gravitee/test/junit/rules/FlakyRunnerTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.test.junit.rules;
+
+import static org.junit.Assert.*;
+
+import junit.framework.AssertionFailedError;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class FlakyRunnerTest {
+
+    private static final FlakyRunner RUNNER = new FlakyRunner(2, 1);
+
+    @Rule
+    public final TestRule chain = RuleChain.outerRule(RUNNER);
+
+    @Test
+    public void shouldPassWithRetry() {
+        if (RUNNER.statement().retries() > 1) {
+            throw new AssertionFailedError();
+        }
+        assertEquals(1, RUNNER.statement().retries());
+    }
+}

--- a/gravitee-apim-test/src/test/resources/logback.xml
+++ b/gravitee-apim-test/src/test/resources/logback.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2015-2016, The Gravitee team (http://www.gravitee.io)
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+
+<configuration debug="true">
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.gravitee" level="INFO" />
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <module>gravitee-apim-repository</module>
         <module>gravitee-apim-rest-api</module>
         <module>gravitee-apim-gateway</module>
+        <module>gravitee-apim-test</module>
     </modules>
 
     <properties>


### PR DESCRIPTION

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/test-retry-flaky/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-sulaivxzic.chromatic.com)
<!-- Storybook placeholder end -->
