### PR TITLE
fix: run search index upgrader with admin role

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/SearchIndexUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/SearchIndexUpgrader.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.service.impl.upgrade;
 
+import static io.gravitee.rest.api.service.common.SecurityContextHelper.authenticateAsSystem;
 import static java.util.stream.Collectors.toList;
 
 import io.gravitee.repository.exceptions.TechnicalException;
@@ -29,19 +30,24 @@ import io.gravitee.repository.management.model.UserStatus;
 import io.gravitee.rest.api.model.PageEntity;
 import io.gravitee.rest.api.model.PageType;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
+import io.gravitee.rest.api.model.UserRoleEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.documentation.PageQuery;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.PageService;
 import io.gravitee.rest.api.service.Upgrader;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.common.SecurityContextHelper;
 import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.converter.UserConverter;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
 import org.jetbrains.annotations.NotNull;
@@ -148,6 +154,8 @@ public class SearchIndexUpgrader implements Upgrader, Ordered {
     }
 
     private CompletableFuture<?> runApiIndexationAsync(ExecutorService executorService, Api api) {
+        authenticateAsAdmin();
+
         String environmentId = api.getEnvironmentId();
         String organizationId = organizationIdByEnvironmentIdMap.computeIfAbsent(
             environmentId,
@@ -231,5 +239,12 @@ public class SearchIndexUpgrader implements Upgrader, Ordered {
     @Override
     public int getOrder() {
         return 250;
+    }
+
+    private void authenticateAsAdmin() {
+        UserRoleEntity adminRole = new UserRoleEntity();
+        adminRole.setScope(RoleScope.ORGANIZATION);
+        adminRole.setName(SystemRole.ADMIN.name());
+        authenticateAsSystem("SearchIndexUpgrader", Set.of(adminRole));
     }
 }


### PR DESCRIPTION
Indexing the API Primary Owner requires passing through the findById method
of GroupService, which performs permission checks and thus requires an
authenticated security context.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-search-index-upgrader/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-sdpdxsypzy.chromatic.com)
<!-- Storybook placeholder end -->
