### PR TITLE
test(e2e): reduce flakiness 

### DIFF
--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/properties/add-dynamic-properties-and-use-them.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/properties/add-dynamic-properties-and-use-them.spec.ts
@@ -122,7 +122,7 @@ describe('Add dynamic properties and use them', () => {
           return response.headers.get('x-version') === '1.0.0';
         },
         timeBetweenRetries: 1000,
-        failAfterMs: 5000,
+        failAfterMs: 10000,
       });
     });
   });
@@ -139,7 +139,7 @@ describe('Add dynamic properties and use them', () => {
           return response.headers.get('x-version') === '1.0.1';
         },
         timeBetweenRetries: 1000,
-        failAfterMs: 5000,
+        failAfterMs: 10000,
       });
     });
 

--- a/gravitee-apim-e2e/docker/common/docker-compose-apis.yml
+++ b/gravitee-apim-e2e/docker/common/docker-compose-apis.yml
@@ -68,6 +68,7 @@ services:
       - ./jacoco:/opt/jacoco
     environment:
       - gravitee_reporters_elasticsearch_endpoints_0=http://elasticsearch:9200
+      - gravitee_sync_delay=1000
       - "JAVA_OPTS=-javaagent:/opt/jacoco/lib/org.jacoco.agent-0.8.8-runtime.jar=destfile=/opt/jacoco/jacoco.exec"
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://admin:adminadmin@localhost:18082/_node" ]

--- a/gravitee-apim-e2e/lib/jest-retry.ts
+++ b/gravitee-apim-e2e/lib/jest-retry.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { test } from '@jest/globals';
+import { AsyncFn } from '@jest/types/build/Circus';
+
+function runTest(handler) {
+  return new Promise((resolve, reject) => {
+    const result = handler((err) => (err ? reject(err) : resolve({})));
+
+    if (result && result.then) {
+      result.catch(reject).then(resolve);
+    } else {
+      resolve({});
+    }
+  });
+}
+
+export function flakyRunner(retries = 3, delayMs = 1000) {
+  return {
+    async test(description: string, handler: AsyncFn) {
+      test(description, async () => {
+        let latestError;
+        for (let tries = 0; tries < retries; tries++) {
+          try {
+            await runTest(handler);
+            return;
+          } catch (error) {
+            latestError = error;
+            console.info('Test failed, available retries:', retries - tries);
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+          }
+        }
+
+        throw latestError;
+      });
+    },
+  };
+}

--- a/gravitee-apim-e2e/lib/jest-utils.ts
+++ b/gravitee-apim-e2e/lib/jest-utils.ts
@@ -99,3 +99,5 @@ export async function noContent<T>(promise: Promise<ApiResponse<T>>) {
 }
 
 export const testif = (condition) => (condition ? test : test.skip);
+
+export * from './jest-retry';


### PR DESCRIPTION

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/ci-smash-flaky-tests-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-iflcchystk.chromatic.com)
<!-- Storybook placeholder end -->
<!-- E2E Coverage placeholder -->
---
### 🧪 End-to-End Coverage

| INSTRUCTIONS | BRANCHES |
| :----------: | :------: |
|   38% | 22%   |

A more detailed report has been uploaded to [circleci](https://output.circle-artifacts.com/output/job/8bca5c77-bc8c-4897-bf01-6af25fa05b14/artifacts/0/gravitee-apim-e2e/jacoco/reports/index.html)
<!-- E2E Coverage placeholder end -->
