### PR TITLE
test: added tests for endpoint groups

### DIFF
--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/endpoints/create-several-endpoint-groups-and-use-them.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/endpoints/create-several-endpoint-groups-and-use-them.spec.ts
@@ -13,8 +13,166 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { describe } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect } from '@jest/globals';
+import { ApisFaker } from '@management-fakers/ApisFaker';
+import { PathOperatorOperatorEnum } from '@management-models/PathOperator';
+import { ApiEntity, ApiEntityToJSON } from '@management-models/ApiEntity';
+import { APIsApi } from '@management-apis/APIsApi';
+import { forManagementAsApiUser } from '@client-conf/*';
+import { PlansFaker } from '@management-fakers/PlansFaker';
+import { PlanSecurityType } from '@management-models/PlanSecurityType';
+import { PlanStatus } from '@management-models/PlanStatus';
+import { UpdateApiEntityFromJSON } from '@management-models/UpdateApiEntity';
+import { LoadBalancerTypeEnum } from '@management-models/LoadBalancer';
+import { LifecycleAction } from '@management-models/LifecycleAction';
+import { fetchGatewaySuccess } from '@lib/gateway';
+import { teardownApisAndApplications } from '@lib/management';
+
+const orgId = 'DEFAULT';
+const envId = 'DEFAULT';
+const apiManagementApiAsApiUser = new APIsApi(forManagementAsApiUser());
+let createdApi: ApiEntity;
 
 describe('Create several endpoint groups and use them', () => {
-  test.skip('To complete', async () => {});
+  beforeAll(async () => {
+    createdApi = await apiManagementApiAsApiUser.importApiDefinition({
+      envId,
+      orgId,
+      body: ApisFaker.apiImport({
+        plans: [PlansFaker.plan({ security: PlanSecurityType.KEYLESS, status: PlanStatus.PUBLISHED })],
+      }),
+    });
+
+    await apiManagementApiAsApiUser.updateApi({
+      orgId,
+      envId,
+      api: createdApi.id,
+      updateApiEntity: {
+        ...UpdateApiEntityFromJSON(ApiEntityToJSON(createdApi)),
+        proxy: {
+          virtual_hosts: [
+            {
+              path: createdApi.context_path,
+            },
+          ],
+          strip_context_path: false,
+          preserve_host: false,
+          groups: [
+            {
+              name: 'default-group',
+              endpoints: [
+                {
+                  backup: false,
+                  inherit: true,
+                  name: 'endpoint1',
+                  weight: 1,
+                  type: 'http',
+                  target: `${process.env.WIREMOCK_BASE_URL}/hello?name=endpoint1`,
+                },
+              ],
+              load_balancing: {
+                type: LoadBalancerTypeEnum.ROUNDROBIN,
+              },
+              http: {
+                connectTimeout: 5000,
+                idleTimeout: 60000,
+                keepAlive: true,
+                readTimeout: 10000,
+                pipelining: false,
+                maxConcurrentConnections: 100,
+                useCompression: true,
+                followRedirects: false,
+              },
+            },
+            {
+              name: 'endpoint_group_2',
+              endpoints: [
+                {
+                  backup: false,
+                  inherit: true,
+                  name: 'endpoint2',
+                  weight: 1,
+                  type: 'http',
+                  target: `${process.env.WIREMOCK_BASE_URL}/hello?name=endpoint2`,
+                },
+              ],
+              load_balancing: {
+                type: LoadBalancerTypeEnum.ROUNDROBIN,
+              },
+              services: {
+                discovery: {
+                  enabled: false,
+                },
+              },
+              http: {
+                connectTimeout: 5000,
+                idleTimeout: 60000,
+                keepAlive: true,
+                readTimeout: 10000,
+                pipelining: false,
+                maxConcurrentConnections: 100,
+                useCompression: true,
+                followRedirects: false,
+              },
+            },
+          ],
+        },
+        flows: [
+          {
+            name: '',
+            path_operator: {
+              path: '/',
+              operator: PathOperatorOperatorEnum.STARTSWITH,
+            },
+            condition: '',
+            consumers: [],
+            methods: [],
+            pre: [
+              {
+                name: 'Dynamic Routing',
+                description: '',
+                enabled: true,
+                policy: 'dynamic-routing',
+                configuration: {
+                  rules: [
+                    {
+                      pattern: '/route1',
+                      url: "{#endpoints['default-group']}",
+                    },
+                    {
+                      pattern: '/route2',
+                      url: "{#endpoints['endpoint_group_2']}",
+                    },
+                  ],
+                },
+              },
+            ],
+            post: [],
+            enabled: true,
+          },
+        ],
+      },
+    });
+
+    await apiManagementApiAsApiUser.doApiLifecycleAction({
+      envId,
+      orgId,
+      api: createdApi.id,
+      action: LifecycleAction.START,
+    });
+  });
+
+  test('should reach endpoint1 by calling default-group', async () => {
+    const response = await fetchGatewaySuccess({ contextPath: `${createdApi.context_path}/route1` }).then((res) => res.json());
+    expect(response.message).toEqual('Hello, Endpoint1!');
+  });
+
+  test('should reach endpoint2 by calling endpoint group 2', async () => {
+    const response = await fetchGatewaySuccess({ contextPath: `${createdApi.context_path}/route2` }).then((res) => res.json());
+    expect(response.message).toEqual('Hello, Endpoint2!');
+  });
+
+  afterAll(async () => {
+    await teardownApisAndApplications(orgId, envId, [createdApi.id]);
+  });
 });


### PR DESCRIPTION
**Description**
Added tests for endpoint groups that make sure that endpoints within different endpoint groups can be called and reached.

gravitee-io/issues#7698
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/test-7698-create-endpoint-groups-and-use-them-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-grbjzfinsb.chromatic.com)
<!-- Storybook placeholder end -->
