### PR TITLE
test(e2e): enabled CORS on an API and use it

### DIFF
--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/cors/enable-cors-and-use-it.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/cors/enable-cors-and-use-it.spec.ts
@@ -1,0 +1,317 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { afterAll, beforeAll, describe, expect } from '@jest/globals';
+import { APIsApi } from '@management-apis/APIsApi';
+import { forManagementAsApiUser } from '@client-conf/*';
+import { ApiEntity } from '@management-models/ApiEntity';
+import { ApisFaker } from '@management-fakers/ApisFaker';
+import { PlansFaker } from '@management-fakers/PlansFaker';
+import { PlanSecurityType } from '@management-models/PlanSecurityType';
+import { PlanStatus } from '@management-models/PlanStatus';
+import { LoadBalancerTypeEnum } from '@management-models/LoadBalancer';
+import { LifecycleAction } from '@management-models/LifecycleAction';
+import { teardownApisAndApplications } from '@lib/management';
+import { fetchGatewayBadRequest, fetchGatewaySuccess } from '@lib/gateway';
+import { PathOperatorOperatorEnum } from '@management-models/PathOperator';
+
+const orgId = 'DEFAULT';
+const envId = 'DEFAULT';
+
+const apisResource = new APIsApi(forManagementAsApiUser());
+
+describe('Enable CORS on an API and use it', () => {
+  let createdApi: ApiEntity;
+
+  const expectNoAccessControlHeaders = (preflightResponse) => {
+    expect(preflightResponse.headers.has('Access-Control-Allow-Headers')).toBe(false);
+    expect(preflightResponse.headers.has('Access-Control-Allow-Methods')).toBe(false);
+  };
+
+  describe('Running policies on preflight requests', () => {
+    beforeAll(async () => {
+      createdApi = await apisResource.importApiDefinition({
+        envId,
+        orgId,
+        body: ApisFaker.apiImport({
+          plans: [PlansFaker.plan({ security: PlanSecurityType.KEYLESS, status: PlanStatus.PUBLISHED })],
+          flows: [
+            {
+              name: '',
+              path_operator: {
+                path: '/',
+                operator: PathOperatorOperatorEnum.STARTSWITH,
+              },
+              condition: '',
+              consumers: [],
+              methods: [],
+              pre: [],
+              post: [
+                {
+                  name: 'Transform Headers',
+                  description: '',
+                  enabled: true,
+                  policy: 'transform-headers',
+                  configuration: {
+                    addHeaders: [
+                      {
+                        name: 'x-cors-enabled',
+                        value: 'true',
+                      },
+                    ],
+                    scope: 'RESPONSE',
+                  },
+                },
+              ],
+              enabled: true,
+            },
+          ],
+          proxy: ApisFaker.proxy({
+            groups: [
+              {
+                name: 'default-group',
+                endpoints: [
+                  {
+                    backup: false,
+                    inherit: true,
+                    name: 'default',
+                    weight: 1,
+                    type: 'http',
+                    target: `${process.env.WIREMOCK_BASE_URL}/hello`,
+                  },
+                ],
+                load_balancing: {
+                  type: LoadBalancerTypeEnum.ROUNDROBIN,
+                },
+                http: {
+                  connectTimeout: 5000,
+                  idleTimeout: 60000,
+                  keepAlive: true,
+                  readTimeout: 10000,
+                  pipelining: false,
+                  maxConcurrentConnections: 100,
+                  useCompression: true,
+                  followRedirects: false,
+                },
+              },
+            ],
+            cors: {
+              enabled: true,
+              allowCredentials: true,
+              allowOrigin: ['https://gravitee.io'],
+              allowHeaders: ['x-gravitee-test'],
+              allowMethods: ['GET'],
+              runPolicies: true,
+              maxAge: -1,
+            },
+          }),
+        }),
+      });
+
+      await apisResource.doApiLifecycleAction({
+        envId,
+        orgId,
+        api: createdApi.id,
+        action: LifecycleAction.START,
+      });
+    });
+
+    test('should accept preflight request, and return cross origin headers in response', async () => {
+      const preflightResponse = await fetchGatewaySuccess({
+        contextPath: createdApi.context_path,
+        method: 'OPTIONS',
+        headers: {
+          Origin: 'https://gravitee.io',
+          'Access-Control-Request-Method': 'GET',
+          'Access-Control-Request-Headers': 'x-gravitee-test',
+        },
+      });
+      expect(preflightResponse.headers.get('Access-Control-Allow-Origin')).toBe('https://gravitee.io');
+      expect(preflightResponse.headers.get('Access-Control-Allow-Headers')).toBe('x-gravitee-test');
+      expect(preflightResponse.headers.get('Access-Control-Allow-Methods')).toBe('GET');
+      expect(preflightResponse.headers.get('Access-Control-Allow-Credentials')).toBe('true');
+      expect(preflightResponse.headers.get('x-cors-enabled')).toBe('true');
+    });
+
+    test('should reject preflight request with 200 with forbidden origin', async () => {
+      const preflightResponse = await fetchGatewaySuccess({
+        contextPath: createdApi.context_path,
+        method: 'OPTIONS',
+        headers: {
+          Origin: 'https://gravitee.dev',
+          'Access-Control-Request-Method': 'GET',
+          'Access-Control-Request-Headers': 'x-gravitee-test',
+        },
+      });
+      expectNoAccessControlHeaders(preflightResponse);
+      expect(preflightResponse.headers.get('x-cors-enabled')).toBe('true');
+    });
+
+    test('should reject preflight request with 200 with forbidden header', async () => {
+      const preflightResponse = await fetchGatewaySuccess({
+        contextPath: createdApi.context_path,
+        method: 'OPTIONS',
+        headers: {
+          origin: 'https://gravitee.io',
+          'Access-Control-Request-Method': 'GET',
+          'Access-Control-Request-Headers': 'x-gravitee-test, x-gravitee-dev',
+        },
+      });
+      expect(preflightResponse.headers.get('Access-Control-Allow-Origin')).toBe('https://gravitee.io');
+      expect(preflightResponse.headers.get('Access-Control-Allow-Credentials')).toBe('true');
+      expect(preflightResponse.headers.has('Access-Control-Allow-Headers')).toBe(false);
+      expect(preflightResponse.headers.has('Access-Control-Allow-Methods')).toBe(false);
+      expect(preflightResponse.headers.get('x-cors-enabled')).toBe('true');
+    });
+
+    test('should reject preflight request with 200 with forbidden method', async () => {
+      const preflightResponse = await fetchGatewaySuccess({
+        contextPath: createdApi.context_path,
+        method: 'OPTIONS',
+        headers: {
+          Origin: 'https://gravitee.io',
+          'Access-Control-Request-Method': 'PUT',
+          'Access-Control-Request-Headers': 'x-gravitee-test',
+        },
+      });
+      expect(preflightResponse.headers.get('Access-Control-Allow-Origin')).toBe('https://gravitee.io');
+      expect(preflightResponse.headers.get('Access-Control-Allow-Credentials')).toBe('true');
+      expect(preflightResponse.headers.has('Access-Control-Allow-Headers')).toBe(false);
+      expect(preflightResponse.headers.has('Access-Control-Allow-Methods')).toBe(false);
+      expect(preflightResponse.headers.get('x-cors-enabled')).toBe('true');
+    });
+
+    afterAll(async () => {
+      await teardownApisAndApplications(orgId, envId, [createdApi.id]);
+    });
+  });
+
+  describe('Without running policies on preflight requests', () => {
+    beforeAll(async () => {
+      createdApi = await apisResource.importApiDefinition({
+        envId,
+        orgId,
+        body: ApisFaker.apiImport({
+          plans: [PlansFaker.plan({ security: PlanSecurityType.KEYLESS, status: PlanStatus.PUBLISHED })],
+          proxy: ApisFaker.proxy({
+            groups: [
+              {
+                name: 'default-group',
+                endpoints: [
+                  {
+                    backup: false,
+                    inherit: true,
+                    name: 'default',
+                    weight: 1,
+                    type: 'http',
+                    target: `${process.env.WIREMOCK_BASE_URL}/hello`,
+                  },
+                ],
+                load_balancing: {
+                  type: LoadBalancerTypeEnum.ROUNDROBIN,
+                },
+                http: {
+                  connectTimeout: 5000,
+                  idleTimeout: 60000,
+                  keepAlive: true,
+                  readTimeout: 10000,
+                  pipelining: false,
+                  maxConcurrentConnections: 100,
+                  useCompression: true,
+                  followRedirects: false,
+                },
+              },
+            ],
+            cors: {
+              enabled: true,
+              allowCredentials: true,
+              allowOrigin: ['https://gravitee.io'],
+              allowHeaders: ['x-gravitee-test'],
+              allowMethods: ['GET', 'PUT'],
+              runPolicies: false,
+              maxAge: -1,
+            },
+          }),
+        }),
+      });
+
+      await apisResource.doApiLifecycleAction({
+        envId,
+        orgId,
+        api: createdApi.id,
+        action: LifecycleAction.START,
+      });
+    });
+
+    test('should accept preflight request, and return cross origin headers in response', async () => {
+      const preflightResponse = await fetchGatewaySuccess({
+        contextPath: createdApi.context_path,
+        method: 'OPTIONS',
+        headers: {
+          Origin: 'https://gravitee.io',
+          'Access-Control-Request-Method': 'PUT',
+          'Access-Control-Request-Headers': 'x-gravitee-test',
+        },
+      });
+      expect(preflightResponse.headers.get('Access-Control-Allow-Origin')).toBe('https://gravitee.io');
+      expect(preflightResponse.headers.get('Access-Control-Allow-Headers')).toBe('x-gravitee-test');
+      expect(preflightResponse.headers.get('Access-Control-Allow-Methods')).toBe('GET, PUT');
+      expect(preflightResponse.headers.get('Access-Control-Allow-Credentials')).toBe('true');
+    });
+
+    test('should reject preflight request with 400 with forbidden origin', async () => {
+      const preflightResponse = await fetchGatewayBadRequest({
+        contextPath: createdApi.context_path,
+        method: 'OPTIONS',
+        headers: {
+          Origin: 'https://gravitee.dev',
+          'Access-Control-Request-Method': 'GET',
+          'Access-Control-Request-Headers': 'x-gravitee-test',
+        },
+      });
+      expectNoAccessControlHeaders(preflightResponse);
+    });
+
+    test('should reject preflight request with 400 with forbidden header', async () => {
+      const preflightResponse = await fetchGatewayBadRequest({
+        contextPath: createdApi.context_path,
+        method: 'OPTIONS',
+        headers: {
+          origin: 'https://gravitee.io',
+          'Access-Control-Request-Method': 'GET',
+          'Access-Control-Request-Headers': 'x-gravitee-test, x-gravitee-dev',
+        },
+      });
+      expectNoAccessControlHeaders(preflightResponse);
+    });
+
+    test('should reject preflight request with 400 with forbidden method', async () => {
+      const preflightResponse = await fetchGatewayBadRequest({
+        contextPath: createdApi.context_path,
+        method: 'OPTIONS',
+        headers: {
+          Origin: 'https://gravitee.io',
+          'Access-Control-Request-Method': 'HEAD',
+          'Access-Control-Request-Headers': 'x-gravitee-test',
+        },
+      });
+      expectNoAccessControlHeaders(preflightResponse);
+    });
+
+    afterAll(async () => {
+      await teardownApisAndApplications(orgId, envId, [createdApi.id]);
+    });
+  });
+});

--- a/gravitee-apim-e2e/lib/gateway.ts
+++ b/gravitee-apim-e2e/lib/gateway.ts
@@ -17,7 +17,7 @@ import 'dotenv/config';
 import fetchApi, { HeadersInit, Response } from 'node-fetch';
 import { sleep } from '@lib/jest-utils';
 
-export type HttpMethod = 'GET' | 'PUT' | 'POST' | 'DELETE';
+export type HttpMethod = 'GET' | 'PUT' | 'POST' | 'DELETE' | 'OPTIONS';
 
 interface GatewayRequest {
   contextPath: string;
@@ -36,6 +36,10 @@ export async function fetchGatewaySuccess(request?: Partial<GatewayRequest>) {
 
 export async function fetchGatewayUnauthorized(request?: Partial<GatewayRequest>) {
   return _fetchGatewayWithRetries({ expectedStatusCode: 401, ...request });
+}
+
+export async function fetchGatewayBadRequest(request?: Partial<GatewayRequest>) {
+  return _fetchGatewayWithRetries({ expectedStatusCode: 400, ...request });
 }
 
 async function _fetchGatewayWithRetries(attributes: Partial<GatewayRequest>): Promise<Response> {


### PR DESCRIPTION
see: https://github.com/gravitee-io/issues/issues/7902


<!-- E2E Coverage placeholder -->
---
### 🧪 End-to-End Coverage

| INSTRUCTIONS | BRANCHES |
| :----------: | :------: |
|   39% | 23%   |

A more detailed report has been uploaded to [circleci](https://output.circle-artifacts.com/output/job/2c013440-673c-4ecb-8038-938bf1548b2d/artifacts/0/gravitee-apim-e2e/jacoco/reports/index.html)
<!-- E2E Coverage placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/7902-test-cors-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ktsakprjsy.chromatic.com)
<!-- Storybook placeholder end -->
