### PR TITLE
refactor(e2e): change fetch gateway retry mechanism

### DIFF
--- a/gravitee-apim-e2e/api-test/src/gateway/redeploy-api.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/gateway/redeploy-api.spec.ts
@@ -108,8 +108,7 @@ describe('Redeploy Api', () => {
       // Execute a request during which we will redeploy the api (only one try, no delay before call)
       const fetchUniqueGatewayCall = fetchGatewaySuccess({
         contextPath: createdApi.context_path + '?activeLatency=true',
-        failAfterMs: 0,
-        timeout: 0,
+        maxRetries: 1,
       });
 
       // Redeploy the api

--- a/gravitee-apim-e2e/api-test/src/gateway/redeploy-api.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/gateway/redeploy-api.spec.ts
@@ -91,7 +91,7 @@ describe('Redeploy Api', () => {
       // Fist fetch Gateway to be sure api is deployed
       await fetchGatewaySuccess({ contextPath: createdApi.context_path + '?activeLatency=false' });
 
-      // Update a Plan to desynchronize Api definition
+      // Update a Plan to de-synchronize Api definition
       await apiManagementApiAsApiUser.updateApiPlan({
         envId,
         orgId,
@@ -108,7 +108,7 @@ describe('Redeploy Api', () => {
       // Execute a request during which we will redeploy the api (only one try, no delay before call)
       const fetchUniqueGatewayCall = fetchGatewaySuccess({
         contextPath: createdApi.context_path + '?activeLatency=true',
-        maxRetries: 1,
+        maxRetries: 0,
       });
 
       // Redeploy the api

--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/flows/add-policies-to-flows-and-use-them.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/flows/add-policies-to-flows-and-use-them.spec.ts
@@ -198,8 +198,7 @@ describe('Add policies to flows and use them', () => {
         headers: {
           'x-cache-key': 'gravitee-test',
         },
-        timeout: 6000, // wait for cache eviction before calling the entrypoint
-      }).then((res) => res.json());
+      });
 
       expect(responseBody).not.toEqual(cachedResponseBody);
     });
@@ -216,15 +215,17 @@ describe('Add policies to flows and use them', () => {
     });
 
     test('Should respond with endpoint body with a new cache key', async () => {
-      const responseBody = await fetchGatewaySuccess({
+      await fetchGatewaySuccess({
         contextPath: `${createdApi.context_path}`,
-        failAfterMs: 5000,
         headers: {
           'x-cache-key': 'gravitee-dev',
         },
-      }).then((res) => res.json());
-
-      expect(responseBody).not.toEqual(cachedResponseBody);
+        async expectedResponseValidator(res) {
+          const responseBody = await res.json();
+          expect(responseBody).not.toEqual(cachedResponseBody);
+          return true;
+        },
+      });
     });
   });
 
@@ -239,16 +240,18 @@ describe('Add policies to flows and use them', () => {
     });
 
     test('Should respond with endpoint body with cache bypass header', async () => {
-      const responseBody = await fetchGatewaySuccess({
+      await fetchGatewaySuccess({
         contextPath: `${createdApi.context_path}`,
-        failAfterMs: 5000,
         headers: {
           'x-cache-key': 'gravitee-test',
           'x-gravitee-cache': 'BY_PASS',
         },
-      }).then((res) => res.json());
-
-      expect(responseBody).not.toEqual(cachedResponseBody);
+        async expectedResponseValidator(res) {
+          const responseBody = await res.json();
+          expect(responseBody).not.toEqual(cachedResponseBody);
+          return true;
+        },
+      });
     });
   });
 
@@ -263,15 +266,17 @@ describe('Add policies to flows and use them', () => {
     });
 
     test('Should respond with endpoint body with cache bypass query parameter', async () => {
-      const responseBody = await fetchGatewaySuccess({
+      await fetchGatewaySuccess({
         contextPath: `${createdApi.context_path}?cache=BY_PASS_`,
-        failAfterMs: 5000,
         headers: {
           'x-cache-key': 'gravitee-dev',
         },
-      }).then((res) => res.json());
-
-      expect(responseBody).not.toEqual(cachedResponseBody);
+        async expectedResponseValidator(res) {
+          const responseBody = await res.json();
+          expect(responseBody).not.toEqual(cachedResponseBody);
+          return true;
+        },
+      });
     });
   });
 
@@ -286,15 +291,18 @@ describe('Add policies to flows and use them', () => {
     });
 
     test('Should callout using request header and assign body content', async () => {
-      const responseBody = await fetchGatewaySuccess({
+      await fetchGatewaySuccess({
         contextPath: `${createdApi.context_path}`,
         headers: {
           'x-callout-name': 'gravitee',
         },
-      }).then((res) => res.json());
-
-      expect(responseBody.timestamp).toBeUndefined();
-      expect(responseBody.message).toBe('Hello, Gravitee!');
+        async expectedResponseValidator(res) {
+          const responseBody = await res.json();
+          expect(responseBody.timestamp).toBeUndefined();
+          expect(responseBody.message).toBe('Hello, Gravitee!');
+          return true;
+        },
+      });
     });
   });
 

--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/properties/add-dynamic-properties-and-use-them.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/properties/add-dynamic-properties-and-use-them.spec.ts
@@ -121,8 +121,7 @@ describe('Add dynamic properties and use them', () => {
         expectedResponseValidator: (response) => {
           return response.headers.get('x-version') === '1.0.0';
         },
-        timeBetweenRetries: 1000,
-        failAfterMs: 10000,
+        timeBetweenRetries: 2000,
       });
     });
   });
@@ -138,8 +137,7 @@ describe('Add dynamic properties and use them', () => {
         expectedResponseValidator: (response) => {
           return response.headers.get('x-version') === '1.0.1';
         },
-        timeBetweenRetries: 1000,
-        failAfterMs: 10000,
+        timeBetweenRetries: 2000,
       });
     });
 

--- a/gravitee-apim-e2e/docker/common/docker-compose-apis.yml
+++ b/gravitee-apim-e2e/docker/common/docker-compose-apis.yml
@@ -41,8 +41,8 @@ services:
       - gravitee_security_providers[0].users[1].email=admin@gravitee.io
       - "JAVA_OPTS=-javaagent:/opt/jacoco/lib/org.jacoco.agent-0.8.8-runtime.jar=destfile=/opt/jacoco/jacoco.exec"
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://admin:adminadmin@localhost:18083/_node" ]
-      interval: 2s
+      test: [ "CMD", "curl", "-f", "http://admin:admin@localhost:8083/management/organizations/DEFAULT/user" ]
+      interval: 3s
       timeout: 10s
       retries: 30
     networks:
@@ -57,9 +57,7 @@ services:
       - database
       - elasticsearch
     depends_on:
-      database:
-        condition: service_healthy
-      elasticsearch:
+      management_api:
         condition: service_healthy
     ports:
       - "8082:8082"


### PR DESCRIPTION

<!-- E2E Coverage placeholder -->
---
### 🧪 End-to-End Coverage

| INSTRUCTIONS | BRANCHES |
| :----------: | :------: |
|   39% | 22%   |

A more detailed report has been uploaded to [circleci](https://output.circle-artifacts.com/output/job/9a65f4f4-aedc-458f-940c-c3b31524d888/artifacts/0/gravitee-apim-e2e/jacoco/reports/index.html)
<!-- E2E Coverage placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/test-retry-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kedebzzieb.chromatic.com)
<!-- Storybook placeholder end -->
