### PR TITLE
Add missing fields in v1 to v2 plan migration

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/migration/APIV1toAPIV2Converter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/migration/APIV1toAPIV2Converter.java
@@ -15,15 +15,7 @@
  */
 package io.gravitee.rest.api.service.migration;
 
-import static io.gravitee.common.http.HttpMethod.CONNECT;
-import static io.gravitee.common.http.HttpMethod.DELETE;
-import static io.gravitee.common.http.HttpMethod.GET;
-import static io.gravitee.common.http.HttpMethod.HEAD;
-import static io.gravitee.common.http.HttpMethod.OPTIONS;
-import static io.gravitee.common.http.HttpMethod.PATCH;
-import static io.gravitee.common.http.HttpMethod.POST;
-import static io.gravitee.common.http.HttpMethod.PUT;
-import static io.gravitee.common.http.HttpMethod.TRACE;
+import static io.gravitee.common.http.HttpMethod.*;
 import static io.gravitee.rest.api.service.validator.JsonHelper.clearNullValues;
 import static java.util.Collections.reverseOrder;
 
@@ -32,7 +24,6 @@ import com.github.fge.jackson.JsonLoader;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.FlowMode;
-import io.gravitee.definition.model.Plan;
 import io.gravitee.definition.model.Rule;
 import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.definition.model.flow.Operator;
@@ -44,16 +35,7 @@ import io.gravitee.rest.api.model.PolicyEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.NavigableMap;
-import java.util.Set;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
@@ -159,6 +141,9 @@ public class APIV1toAPIV2Converter {
                     plan.setName(planEntity.getName());
                     plan.setSecurity(planEntity.getSecurity());
                     plan.setSecurityDefinition(planEntity.getSecurityDefinition());
+                    plan.setValidation(planEntity.getValidation());
+                    plan.setDescription(planEntity.getDescription());
+                    plan.setType(planEntity.getType());
                     plan.setStatus(planEntity.getStatus());
                     plan.setFlows(migratePathsToFlows(planEntity.getPaths(), policies));
                     if (planEntity.getTags() != null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/migration/APIV1toAPIV2ConverterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/migration/APIV1toAPIV2ConverterTest.java
@@ -27,7 +27,10 @@ import io.gravitee.rest.api.service.jackson.ser.api.ApiCompositeSerializer;
 import io.gravitee.rest.api.service.spring.ServiceConfiguration;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.*;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
@@ -133,7 +136,10 @@ public class APIV1toAPIV2ConverterTest {
                     "api",
                     "selectionRule",
                     "status",
-                    "tags"
+                    "tags",
+                    "validation",
+                    "description",
+                    "type"
                 );
 
             assertThat(actualPlans.get(i).getPaths()).isEmpty();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/service/migration/api-withOnlyPlans-migrated.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/service/migration/api-withOnlyPlans-migrated.json
@@ -14,6 +14,9 @@
     "security" : "API_KEY",
     "securityDefinition" : "{\"propagateApiKey\":false}",
     "paths" : {},
+    "validation": "MANUAL",
+    "description": "Plan description",
+    "type": "API",
     "flows" : [ {
       "name" : "",
       "path-operator" : {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/service/migration/api-withPathsAndPlans-migrated.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/service/migration/api-withPathsAndPlans-migrated.json
@@ -146,6 +146,9 @@
     "name" : "plan-name",
     "security" : "API_KEY",
     "securityDefinition" : "{\"propagateApiKey\":false}",
+    "validation": "MANUAL",
+    "description": "Plan description",
+    "type": "API",
     "paths" : {},
     "flows" : [ {
       "name" : "",


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7940

**Description**

Add missing fields in v1 to v2 plan migration.

When importing an API with a v1 definition containing a plan without `validation` attribute, APIM will:
  1. Create all API nested entities first, it will so validate, convert (and add a default value to `validation` attribute) and store the plan in the DB
  2. Create the API in DB (without the plans as they are stored in their own collection)
  3. Get the resulting `ApiEntity`, which contains a `plan` from the original definition i.e. without `validation` attribute
  4. Migrate the v1 definition into v2, by doing a query in DB to get all the plans related to the API (the one created during step 1. so they contain a `validation` attribute). During this v1 -> v2 conversion the plans are converted too BUT some properties were missing
  5. Update the API created during 2. BUT with some plans data that are completed  



<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/7940-fix-plan-migration/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kzjrgyimpd.chromatic.com)
<!-- Storybook placeholder end -->
