### PR TITLE
feat(jupiter): websocket support

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -648,7 +648,7 @@
                 <!-- Versions of the plugins for the full distribution on dev environment-->
                 <!-- Management API & Gateway -->
                 <!-- Community plugins -->
-                <gravitee-connector-kafka.version>1.1.0</gravitee-connector-kafka.version>
+                <gravitee-connector-kafka.version>1.1.1</gravitee-connector-kafka.version>
                 <gravitee-policy-aws-lambda.version>1.1.0</gravitee-policy-aws-lambda.version>
                 <gravitee-policy-basic-authentication.version>1.2.0</gravitee-policy-basic-authentication.version>
                 <gravitee-policy-circuit-breaker.version>1.0.1</gravitee-policy-circuit-breaker.version>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/adapter/invoker/ConnectionHandlerAdapter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/adapter/invoker/ConnectionHandlerAdapter.java
@@ -70,15 +70,17 @@ public class ConnectionHandlerAdapter implements Handler<ProxyConnection> {
     private void handleProxyResponse(ProxyConnection connection, ProxyResponse proxyResponse) {
         try {
             // In case of connectivity error, a 502 error may already have been returned to the client and the response is complete.
-            if (proxyResponse.connected() && !ctx.response().ended()) {
+            if (!ctx.response().ended()) {
                 // Set the response status with the status coming from the invoker.
                 ctx.response().status(proxyResponse.status());
 
                 // Capture invoker headers and copy them to the response.
                 proxyResponse.headers().forEach(entry -> ctx.response().headers().add(entry.getKey(), entry.getValue()));
 
-                // Keep a reference on the proxy response to be able to resume it when a subscription will occur on the Flowable<Buffer> chunks.
-                chunks.initialize(ctx, connection, proxyResponse);
+                if (proxyResponse.connected()) {
+                    // Keep a reference on the proxy response to be able to resume it when a subscription will occur on the Flowable<Buffer> chunks.
+                    chunks.initialize(ctx, connection, proxyResponse);
+                }
             } else {
                 tryCancel(proxyResponse);
             }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/adapter/invoker/FlowableProxyResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/adapter/invoker/FlowableProxyResponse.java
@@ -78,7 +78,8 @@ public class FlowableProxyResponse extends Flowable<Buffer> {
             // Finally, pass the subscription to the subscriber, so it can invoke onNext on it.
             subscriber.onSubscribe(subscription);
         } else {
-            subscriber.onComplete();
+            log.debug("Proxy response not defined, completing without any value.");
+            EmptySubscription.complete(subscriber);
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/jupiter/http/vertx/VertxHttpServerResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/jupiter/http/vertx/VertxHttpServerResponse.java
@@ -17,7 +17,6 @@ package io.gravitee.gateway.jupiter.http.vertx;
 
 import io.gravitee.common.http.HttpHeadersValues;
 import io.gravitee.common.http.HttpVersion;
-import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.http.vertx.VertxHttpHeaders;
 import io.gravitee.gateway.jupiter.core.context.MutableResponse;
@@ -108,6 +107,10 @@ public class VertxHttpServerResponse extends AbstractHttpChunks implements Mutab
     public Completable end() {
         return Completable.defer(
             () -> {
+                if (serverRequest.isWebSocketUpgraded()) {
+                    return Completable.complete();
+                }
+
                 if (!valid()) {
                     return Completable.error(new IllegalStateException("The response is already ended"));
                 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/jupiter/http/vertx/ws/VertxWebSocket.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/jupiter/http/vertx/ws/VertxWebSocket.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.http.vertx.ws;
+
+import static io.vertx.reactivex.core.http.WebSocketFrame.*;
+
+import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.gateway.api.ws.WebSocket;
+import io.gravitee.gateway.api.ws.WebSocketFrame;
+import io.vertx.reactivex.core.buffer.Buffer;
+import io.vertx.reactivex.core.http.HttpServerRequest;
+import io.vertx.reactivex.core.http.ServerWebSocket;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class VertxWebSocket implements WebSocket {
+
+    private final HttpServerRequest httpServerRequest;
+
+    private boolean closed;
+    private boolean upgraded;
+    private ServerWebSocket webSocket;
+
+    public VertxWebSocket(final HttpServerRequest httpServerRequest) {
+        this.httpServerRequest = httpServerRequest;
+    }
+
+    @Override
+    public CompletableFuture<WebSocket> upgrade() {
+        if (upgraded) {
+            return CompletableFuture.completedFuture(this);
+        }
+
+        final CompletableFuture<WebSocket> future = new CompletableFuture<>();
+
+        httpServerRequest.toWebSocket(
+            result -> {
+                if (result.failed()) {
+                    future.completeExceptionally(result.cause());
+                } else {
+                    webSocket = result.result();
+                    upgraded = true;
+                    future.complete(this);
+                }
+            }
+        );
+
+        return future;
+    }
+
+    @Override
+    public WebSocket reject(int statusCode) {
+        if (upgraded) {
+            webSocket.close((short) statusCode);
+        }
+        return this;
+    }
+
+    @Override
+    public WebSocket write(WebSocketFrame frame) {
+        if (upgraded) {
+            final io.vertx.reactivex.core.http.WebSocketFrame webSocketFrame = convert(frame);
+
+            if (webSocketFrame == null) {
+                this.close();
+            } else {
+                webSocket.writeFrame(webSocketFrame);
+            }
+        }
+        return this;
+    }
+
+    @Override
+    public WebSocket close() {
+        if (upgraded && !closed) {
+            webSocket.close();
+        }
+        return this;
+    }
+
+    @Override
+    public WebSocket frameHandler(Handler<WebSocketFrame> frameHandler) {
+        if (upgraded) {
+            webSocket.frameHandler(frame -> frameHandler.handle(new VertxWebSocketFrame(frame)));
+        }
+        return this;
+    }
+
+    @Override
+    public WebSocket closeHandler(Handler<Void> closeHandler) {
+        if (upgraded) {
+            webSocket.closeHandler(
+                event -> {
+                    closed = true;
+                    closeHandler.handle(event);
+                }
+            );
+        }
+        return this;
+    }
+
+    @Override
+    public boolean upgraded() {
+        return upgraded;
+    }
+
+    private io.vertx.reactivex.core.http.WebSocketFrame convert(io.gravitee.gateway.api.ws.WebSocketFrame frame) {
+        switch (frame.type()) {
+            case BINARY:
+                return binaryFrame(Buffer.buffer(frame.data().getNativeBuffer()), frame.isFinal());
+            case TEXT:
+                return textFrame(frame.data().toString(), frame.isFinal());
+            case CONTINUATION:
+                return continuationFrame(Buffer.buffer(frame.data().toString()), frame.isFinal());
+            case PING:
+                return pingFrame(Buffer.buffer(frame.data().toString()));
+            case PONG:
+                return pongFrame(Buffer.buffer(frame.data().toString()));
+            default:
+                return null;
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/jupiter/http/vertx/ws/VertxWebSocketFrame.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/jupiter/http/vertx/ws/VertxWebSocketFrame.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.http.vertx.ws;
+
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.ws.WebSocketFrame;
+
+/**
+ *  @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class VertxWebSocketFrame implements WebSocketFrame {
+
+    private final io.vertx.reactivex.core.http.WebSocketFrame frame;
+
+    VertxWebSocketFrame(io.vertx.reactivex.core.http.WebSocketFrame frame) {
+        this.frame = frame;
+    }
+
+    @Override
+    public Type type() {
+        switch (frame.type()) {
+            case TEXT:
+                return Type.TEXT;
+            case BINARY:
+                return Type.BINARY;
+            case PING:
+                return Type.PING;
+            case PONG:
+                return Type.PONG;
+            case CONTINUATION:
+                return Type.CONTINUATION;
+            default:
+                return Type.CLOSE;
+        }
+    }
+
+    @Override
+    public Buffer data() {
+        return Buffer.buffer(frame.binaryData().getByteBuf());
+    }
+
+    @Override
+    public boolean isFinal() {
+        return frame.isFinal();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/jupiter/http/vertx/VertxHttpServerRequestTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/jupiter/http/vertx/VertxHttpServerRequestTest.java
@@ -16,15 +16,17 @@
 package io.gravitee.gateway.jupiter.http.vertx;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import io.gravitee.common.http.IdGenerator;
 import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.ws.WebSocket;
 import io.reactivex.Flowable;
 import io.reactivex.Maybe;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.subscribers.TestSubscriber;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpVersion;
 import io.vertx.reactivex.core.http.HttpHeaders;
 import io.vertx.reactivex.core.http.HttpServerRequest;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -33,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
@@ -49,22 +52,19 @@ class VertxHttpServerRequestTest {
     @Mock
     private IdGenerator idGenerator;
 
-    private Flowable<io.vertx.reactivex.core.buffer.Buffer> chunks;
-
     private AtomicInteger subscriptionCount;
     private VertxHttpServerRequest cut;
 
     @BeforeEach
     void init() {
         subscriptionCount = new AtomicInteger(0);
-        chunks =
-            Flowable
-                .just(
-                    io.vertx.reactivex.core.buffer.Buffer.buffer("chunk1"),
-                    io.vertx.reactivex.core.buffer.Buffer.buffer("chunk2"),
-                    io.vertx.reactivex.core.buffer.Buffer.buffer("chunk3")
-                )
-                .doOnSubscribe(subscription -> subscriptionCount.incrementAndGet());
+        Flowable<io.vertx.reactivex.core.buffer.Buffer> chunks = Flowable
+            .just(
+                io.vertx.reactivex.core.buffer.Buffer.buffer("chunk1"),
+                io.vertx.reactivex.core.buffer.Buffer.buffer("chunk2"),
+                io.vertx.reactivex.core.buffer.Buffer.buffer("chunk3")
+            )
+            .doOnSubscribe(subscription -> subscriptionCount.incrementAndGet());
 
         when(httpServerRequest.method()).thenReturn(HttpMethod.POST);
         when(httpServerRequest.headers()).thenReturn(HttpHeaders.headers());
@@ -163,5 +163,157 @@ class VertxHttpServerRequestTest {
 
         obs.assertValue(buffer -> NEW_CHUNK.equals(buffer.toString()));
         assertEquals(1, subscriptionCount.get());
+    }
+
+    @Test
+    void shouldNotBeWebSocketWhenHttp2() {
+        when(httpServerRequest.getHeader(HttpHeaders.CONNECTION)).thenReturn("Upgrade");
+        when(httpServerRequest.getHeader(HttpHeaders.UPGRADE)).thenReturn("websocket");
+        when(httpServerRequest.version()).thenReturn(HttpVersion.HTTP_2);
+        assertFalse(cut.isWebSocket());
+    }
+
+    @Test
+    void shouldNotBeWebSocketWhenNoConnectionHeader() {
+        when(httpServerRequest.getHeader(HttpHeaders.CONNECTION)).thenReturn(null);
+        when(httpServerRequest.getHeader(HttpHeaders.UPGRADE)).thenReturn("websocket");
+        when(httpServerRequest.method()).thenReturn(HttpMethod.GET);
+        when(httpServerRequest.version()).thenReturn(HttpVersion.HTTP_1_1);
+        assertFalse(cut.isWebSocket());
+    }
+
+    @Test
+    void shouldNotBeWebSocketWhenNoUpgradeHeader() {
+        when(httpServerRequest.getHeader(HttpHeaders.CONNECTION)).thenReturn("Upgrade");
+        when(httpServerRequest.getHeader(HttpHeaders.UPGRADE)).thenReturn(null);
+        when(httpServerRequest.method()).thenReturn(HttpMethod.GET);
+        when(httpServerRequest.version()).thenReturn(HttpVersion.HTTP_1_1);
+        assertFalse(cut.isWebSocket());
+    }
+
+    @Test
+    void shouldNotBeWebSocketWhenNotGetMethod() {
+        when(httpServerRequest.getHeader(HttpHeaders.CONNECTION)).thenReturn("Upgrade");
+        when(httpServerRequest.getHeader(HttpHeaders.UPGRADE)).thenReturn("websocket");
+        when(httpServerRequest.method()).thenReturn(HttpMethod.POST);
+        when(httpServerRequest.version()).thenReturn(HttpVersion.HTTP_1_1);
+        assertFalse(cut.isWebSocket());
+    }
+
+    @Test
+    void shouldNotBeWebSocketWhenNotUpgradeWebSocket() {
+        when(httpServerRequest.getHeader(HttpHeaders.CONNECTION)).thenReturn("Upgrade");
+        when(httpServerRequest.getHeader(HttpHeaders.UPGRADE)).thenReturn("something else");
+        when(httpServerRequest.method()).thenReturn(HttpMethod.GET);
+        when(httpServerRequest.version()).thenReturn(HttpVersion.HTTP_1_1);
+        assertFalse(cut.isWebSocket());
+    }
+
+    @Test
+    void shouldBeWebSocket() {
+        when(httpServerRequest.getHeader(HttpHeaders.CONNECTION)).thenReturn("Upgrade");
+        when(httpServerRequest.getHeader(HttpHeaders.UPGRADE)).thenReturn("websocket");
+        when(httpServerRequest.method()).thenReturn(HttpMethod.GET);
+        when(httpServerRequest.version()).thenReturn(HttpVersion.HTTP_1_1);
+        assertTrue(cut.isWebSocket());
+    }
+
+    @Test
+    void shouldBeWebSocketConnectionHeaderMultiValues() {
+        when(httpServerRequest.getHeader(HttpHeaders.CONNECTION)).thenReturn("keep-alive, Upgrade");
+        when(httpServerRequest.getHeader(HttpHeaders.UPGRADE)).thenReturn("websocket");
+        when(httpServerRequest.method()).thenReturn(HttpMethod.GET);
+        when(httpServerRequest.version()).thenReturn(HttpVersion.HTTP_1_1);
+        assertTrue(cut.isWebSocket());
+    }
+
+    @Test
+    void shouldCheckWebSocketOnlyOnce() {
+        when(httpServerRequest.getHeader(HttpHeaders.CONNECTION)).thenReturn("Upgrade");
+        when(httpServerRequest.getHeader(HttpHeaders.UPGRADE)).thenReturn("websocket");
+        when(httpServerRequest.method()).thenReturn(HttpMethod.GET);
+        when(httpServerRequest.version()).thenReturn(HttpVersion.HTTP_1_1);
+
+        for (int i = 0; i < 10; i++) {
+            assertTrue(cut.isWebSocket());
+        }
+
+        verify(httpServerRequest).getHeader(HttpHeaders.CONNECTION);
+        verify(httpServerRequest).getHeader(HttpHeaders.UPGRADE);
+        verify(httpServerRequest, times(2)).method(); // Also called in the constructor.
+        verify(httpServerRequest).version();
+    }
+
+    @Test
+    void shouldCreateWebSocket() {
+        when(httpServerRequest.getHeader(HttpHeaders.CONNECTION)).thenReturn("Upgrade");
+        when(httpServerRequest.getHeader(HttpHeaders.UPGRADE)).thenReturn("websocket");
+        when(httpServerRequest.method()).thenReturn(HttpMethod.GET);
+        when(httpServerRequest.version()).thenReturn(HttpVersion.HTTP_1_1);
+
+        assertNotNull(cut.webSocket());
+    }
+
+    @Test
+    void shouldCreateWebSocketOnlyOnce() {
+        when(httpServerRequest.getHeader(HttpHeaders.CONNECTION)).thenReturn("Upgrade");
+        when(httpServerRequest.getHeader(HttpHeaders.UPGRADE)).thenReturn("websocket");
+        when(httpServerRequest.method()).thenReturn(HttpMethod.GET);
+        when(httpServerRequest.version()).thenReturn(HttpVersion.HTTP_1_1);
+
+        final WebSocket webSocket = cut.webSocket();
+
+        for (int i = 0; i < 10; i++) {
+            assertSame(webSocket, cut.webSocket());
+        }
+    }
+
+    @Test
+    void shouldNoCreateWebSocketWhenRequestIsNotWebSocket() {
+        assertNull(cut.webSocket());
+    }
+
+    @Test
+    void shouldNotBeWebSocketUpgradedWhenRequestIsNotWebSocket() {
+        assertFalse(cut.isWebSocketUpgraded());
+    }
+
+    @Test
+    void shouldNotBeWebSocketUpgradedWhenWebSocketNotCreated() {
+        when(httpServerRequest.getHeader(HttpHeaders.CONNECTION)).thenReturn("Upgrade");
+        when(httpServerRequest.getHeader(HttpHeaders.UPGRADE)).thenReturn("websocket");
+        when(httpServerRequest.method()).thenReturn(HttpMethod.GET);
+        when(httpServerRequest.version()).thenReturn(HttpVersion.HTTP_1_1);
+
+        assertTrue(cut.isWebSocket());
+        assertFalse(cut.isWebSocketUpgraded());
+    }
+
+    @Test
+    void shouldNotBeWebSocketUpgradedWhenWebSocketHasBeenCreatedButNotUpgraded() {
+        when(httpServerRequest.getHeader(HttpHeaders.CONNECTION)).thenReturn("Upgrade");
+        when(httpServerRequest.getHeader(HttpHeaders.UPGRADE)).thenReturn("websocket");
+        when(httpServerRequest.method()).thenReturn(HttpMethod.GET);
+        when(httpServerRequest.version()).thenReturn(HttpVersion.HTTP_1_1);
+
+        final WebSocket webSocket = cut.webSocket();
+        ReflectionTestUtils.setField(webSocket, "upgraded", false);
+
+        assertNotNull(webSocket);
+        assertFalse(cut.isWebSocketUpgraded());
+    }
+
+    @Test
+    void shouldBeWebSocketUpgradedWhenWebSocketHasBeenCreatedAndUpgraded() {
+        when(httpServerRequest.getHeader(HttpHeaders.CONNECTION)).thenReturn("Upgrade");
+        when(httpServerRequest.getHeader(HttpHeaders.UPGRADE)).thenReturn("websocket");
+        when(httpServerRequest.method()).thenReturn(HttpMethod.GET);
+        when(httpServerRequest.version()).thenReturn(HttpVersion.HTTP_1_1);
+
+        final WebSocket webSocket = cut.webSocket();
+        ReflectionTestUtils.setField(webSocket, "upgraded", true);
+
+        assertNotNull(webSocket);
+        assertTrue(cut.isWebSocketUpgraded());
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/jupiter/http/vertx/ws/VertxWebSocketTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/jupiter/http/vertx/ws/VertxWebSocketTest.java
@@ -1,0 +1,245 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.http.vertx.ws;
+
+import static io.vertx.core.http.WebSocketFrameType.CLOSE;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.gateway.api.ws.WebSocket;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.http.WebSocketFrameType;
+import io.vertx.reactivex.core.buffer.Buffer;
+import io.vertx.reactivex.core.http.HttpServerRequest;
+import io.vertx.reactivex.core.http.ServerWebSocket;
+import io.vertx.reactivex.core.http.WebSocketFrame;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class VertxWebSocketTest {
+
+    protected static final String FRAME_DATA = "Test";
+
+    @Mock
+    private HttpServerRequest httpServerRequest;
+
+    @Mock
+    private ServerWebSocket webSocket;
+
+    @Mock
+    private WebSocketFrame webSocketFrame;
+
+    @Captor
+    private ArgumentCaptor<Handler<AsyncResult<ServerWebSocket>>> handlerCaptor;
+
+    private VertxWebSocket cut;
+
+    @BeforeEach
+    void init() throws Exception {
+        lenient().doNothing().when(httpServerRequest).toWebSocket(handlerCaptor.capture());
+        cut = new VertxWebSocket(httpServerRequest);
+    }
+
+    @Test
+    void shouldUpgradeToWebSocket() throws ExecutionException, InterruptedException {
+        final CompletableFuture<WebSocket> upgradeFuture = cut.upgrade();
+        final AsyncResult<ServerWebSocket> asyncResult = mock(AsyncResult.class);
+        when(asyncResult.failed()).thenReturn(false);
+        when(asyncResult.result()).thenReturn(webSocket);
+
+        handlerCaptor.getValue().handle(asyncResult);
+
+        assertEquals(cut, upgradeFuture.get());
+        assertTrue(cut.upgraded());
+    }
+
+    @Test
+    void shouldFailWhenUpgradeToWebSocketFails() {
+        final CompletableFuture<WebSocket> upgradeFuture = cut.upgrade();
+        final AsyncResult<ServerWebSocket> asyncResult = mock(AsyncResult.class);
+        when(asyncResult.failed()).thenReturn(true);
+        when(asyncResult.cause()).thenReturn(new RuntimeException("Mock exception"));
+
+        handlerCaptor.getValue().handle(asyncResult);
+
+        assertThrows(Exception.class, upgradeFuture::get, "Mock exception");
+        assertFalse(cut.upgraded());
+    }
+
+    @Test
+    void shouldUpgradeToWebSocketOnce() throws ExecutionException, InterruptedException {
+        final CompletableFuture<WebSocket> upgradeFuture = cut.upgrade();
+        final AsyncResult<ServerWebSocket> asyncResult = mock(AsyncResult.class);
+        when(asyncResult.failed()).thenReturn(false);
+        when(asyncResult.result()).thenReturn(webSocket);
+
+        handlerCaptor.getValue().handle(asyncResult);
+
+        assertEquals(cut, upgradeFuture.get());
+        assertTrue(cut.upgraded());
+
+        for (int i = 0; i < 10; i++) {
+            cut.upgrade().get();
+        }
+
+        verify(httpServerRequest).toWebSocket(any(Handler.class));
+    }
+
+    @Test
+    void shouldReject() {
+        ReflectionTestUtils.setField(cut, "upgraded", true);
+        ReflectionTestUtils.setField(cut, "webSocket", webSocket);
+
+        cut.reject(400);
+        verify(webSocket).close(eq((short) 400));
+    }
+
+    @Test
+    void shouldNotRejectIfNotUpgraded() {
+        ReflectionTestUtils.setField(cut, "upgraded", false);
+
+        cut.reject(400);
+        verifyNoInteractions(webSocket);
+    }
+
+    @Test
+    void shouldClose() {
+        ReflectionTestUtils.setField(cut, "upgraded", true);
+        ReflectionTestUtils.setField(cut, "webSocket", webSocket);
+
+        cut.close();
+        verify(webSocket).close();
+    }
+
+    @Test
+    void shouldNotCloseIfNotUpgraded() {
+        ReflectionTestUtils.setField(cut, "upgraded", false);
+
+        cut.close();
+        verifyNoInteractions(webSocket);
+    }
+
+    @Test
+    void shouldNotCloseIfAlreadyClosed() {
+        ReflectionTestUtils.setField(cut, "upgraded", true);
+        ReflectionTestUtils.setField(cut, "closed", true);
+
+        cut.close();
+        verifyNoInteractions(webSocket);
+    }
+
+    @Test
+    void shouldSetCloseHandlerOnWebSocket() {
+        ReflectionTestUtils.setField(cut, "upgraded", true);
+        ReflectionTestUtils.setField(cut, "webSocket", webSocket);
+
+        cut.closeHandler(result -> {});
+
+        verify(webSocket).closeHandler(any(Handler.class));
+    }
+
+    @Test
+    void shouldInvokeCloseHandler() {
+        ReflectionTestUtils.setField(cut, "upgraded", true);
+        ReflectionTestUtils.setField(cut, "webSocket", webSocket);
+
+        final io.gravitee.gateway.api.handler.Handler<Void> closeHandler = mock(io.gravitee.gateway.api.handler.Handler.class);
+        cut.closeHandler(closeHandler);
+
+        final ArgumentCaptor<Handler> closeHandlerCaptor = ArgumentCaptor.forClass(Handler.class);
+        verify(webSocket).closeHandler(closeHandlerCaptor.capture());
+
+        closeHandlerCaptor.getValue().handle(null);
+        verify(closeHandler).handle(null);
+        assertTrue((Boolean) ReflectionTestUtils.getField(cut, "closed"));
+    }
+
+    @Test
+    void shouldNotSetCloseHandlerOnWebSocketIfNotUpgraded() {
+        ReflectionTestUtils.setField(cut, "upgraded", false);
+
+        cut.closeHandler(result -> {});
+
+        verifyNoInteractions(webSocket);
+    }
+
+    @Test
+    void shouldSetFrameHandlerOnWebSocket() {
+        ReflectionTestUtils.setField(cut, "upgraded", true);
+        ReflectionTestUtils.setField(cut, "webSocket", webSocket);
+
+        cut.frameHandler(result -> {});
+
+        verify(webSocket).frameHandler(any(Handler.class));
+    }
+
+    @Test
+    void shouldNotSetFrameHandlerOnWebSocketIfNotUpgraded() {
+        ReflectionTestUtils.setField(cut, "upgraded", false);
+
+        cut.frameHandler(result -> {});
+
+        verifyNoInteractions(webSocket);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = WebSocketFrameType.class, names = { "CLOSE" }, mode = EnumSource.Mode.EXCLUDE)
+    void shouldWriteFrame(WebSocketFrameType frameType) {
+        ReflectionTestUtils.setField(cut, "upgraded", true);
+        ReflectionTestUtils.setField(cut, "webSocket", webSocket);
+
+        when(webSocketFrame.type()).thenReturn(frameType);
+        when(webSocketFrame.binaryData()).thenReturn(Buffer.buffer(FRAME_DATA));
+
+        cut.write(new VertxWebSocketFrame(webSocketFrame));
+        verify(webSocket).writeFrame(argThat(frame -> frame.type() == frameType && FRAME_DATA.equals(frame.textData())));
+    }
+
+    @Test
+    void shouldWriteCloseFrame() {
+        ReflectionTestUtils.setField(cut, "upgraded", true);
+        ReflectionTestUtils.setField(cut, "webSocket", webSocket);
+
+        when(webSocketFrame.type()).thenReturn(CLOSE);
+
+        cut.write(new VertxWebSocketFrame(webSocketFrame));
+        verify(webSocket).close();
+    }
+
+    @Test
+    void shouldNotWriteFrameIfNotUpgraded() {
+        ReflectionTestUtils.setField(cut, "upgraded", false);
+
+        cut.write(new VertxWebSocketFrame(webSocketFrame));
+        verifyNoInteractions(webSocket);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/jupiter/policy/adapter/context/RequestAdapter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/jupiter/policy/adapter/context/RequestAdapter.java
@@ -159,12 +159,12 @@ public class RequestAdapter implements io.gravitee.gateway.api.Request {
 
     @Override
     public boolean isWebSocket() {
-        return false;
+        return request.isWebSocket();
     }
 
     @Override
     public WebSocket websocket() {
-        return null;
+        return request.webSocket();
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketRejectTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketRejectTest.java
@@ -41,13 +41,9 @@ public class WebsocketRejectTest extends AbstractWebSocketGatewayTest {
 
     @Test
     public void websocket_rejected_request() throws InterruptedException {
-        Vertx vertx = Vertx.vertx();
         VertxTestContext testContext = new VertxTestContext();
 
-        HttpServer httpServer = vertx.createHttpServer();
         httpServer.webSocketHandler(webSocket -> webSocket.reject(HttpStatusCode.UNAUTHORIZED_401)).listen(16664);
-
-        HttpClient httpClient = vertx.createHttpClient(new HttpClientOptions().setDefaultPort(8082).setDefaultHost("localhost"));
 
         httpClient.webSocket(
             "/test",
@@ -61,7 +57,6 @@ public class WebsocketRejectTest extends AbstractWebSocketGatewayTest {
         );
 
         testContext.awaitCompletion(10, TimeUnit.SECONDS);
-        httpServer.close();
         Assert.assertTrue(testContext.completed());
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/resources/io/gravitee/gateway/standalone/websocket/teams.json
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/resources/io/gravitee/gateway/standalone/websocket/teams.json
@@ -1,6 +1,7 @@
 {
   "id": "api-test",
   "name": "api-test",
+  "gravitee": "2.0.0",
   "proxy": {
     "context_path": "/test",
     "endpoints": [
@@ -15,10 +16,5 @@
     ],
     "strip_context_path": false,
     "dumpRequest": true
-  },
-
-  "paths": {
-    "/*": [
-    ]
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.3</version>
+        <version>20.4-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.apim</groupId>
@@ -64,7 +64,7 @@
         <gravitee-connector-api.version>1.1.0</gravitee-connector-api.version>
         <gravitee-expression-language.version>1.10.1</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>1.36.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.37.0-jupiter-websocket-support-SNAPSHOT</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>1.24.2</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>


### PR DESCRIPTION
This adds the support of websocket as we know it in the current v3:
2 known use cases:

- Websocket to websocket endpoint (you can use https://www.piesocket.com/websocket-tester for testing)
- Websocket to kafka (you can follow instructions from the docs for testing and use the following docker composer to start a kafka instance locally https://github.com/tchiotludo/akhq/blob/dev/docker-compose.yml).

Don't forget to enable the websocket support on the gateway configuration (eg: `gravitee.http.websocket.enabled=true`).

Requires to review https://github.com/gravitee-io/gravitee-gateway-api/pull/123

Tips: you can use websocat as a websocket client.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/jupiter-websocket-support/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-klduizkvkm.chromatic.com)
<!-- Storybook placeholder end -->
