### PR TITLE
3.15.x new env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -825,10 +825,10 @@ jobs:
                   name: Restart APIM cluster pods
                   command: |
                       export K8S_NAME=apim-${CIRCLE_BRANCH//\./-}
-                      export K8S_NAMESPACE=apim-${CIRCLE_BRANCH//\./-}
+                      export K8S_NAMESPACE=apim-apim-${CIRCLE_BRANCH//\./-}
 
                       az login --service-principal -u $AZURE_APPLICATION_ID --tenant $AZURE_TENANT -p $AZURE_APPLICATION_SECRET
-                      az aks get-credentials --resource-group apim-hprod --name apim-hprod
+                      az aks get-credentials --admin --resource-group Devs-Preprod-Hosted --name gravitee-devs-preprod-aks-cluster
 
                       kubectl rollout restart deployment/${K8S_NAME}-apim3-api -n ${K8S_NAMESPACE}
                       kubectl rollout restart deployment/${K8S_NAME}-apim3-portal -n ${K8S_NAMESPACE}


### PR DESCRIPTION
Issue
https://github.com/gravitee-io/issues/issues/8029

Description
change cluster to Devs-Preprod-Hosted

Additional context
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/3-15-x-new-env/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
