### PR TITLE
fix(ci): update UI build version before packaging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -630,6 +630,10 @@ jobs:
             - artifactory-orb/install
             - artifactory-orb/configure
             - run:
+                name: Update Build version
+                command: |
+                  sed -i "s/-SNAPSHOT//" dist/build.json
+            - run:
                   name: Rename and zip dist folder
                   command: mv dist << parameters.apim-ui-project >>-${APIM_VERSION%-SNAPSHOT} && zip -r dist.zip << parameters.apim-ui-project >>-${APIM_VERSION%-SNAPSHOT}
                   working_directory: << parameters.apim-ui-project >>
@@ -669,6 +673,10 @@ jobs:
             - setup_remote_docker
             - webui-install:
                   apim-ui-project: << parameters.apim-ui-project >>
+            - run:
+                name: Update Build version
+                command: |
+                  sed -i -E "s/\"version\": \"(.*)\"/\"version\": \"${APIM_VERSION}\"/" << parameters.apim-ui-project >>/build.json
             - run:
                   name: Build
                   command: npm run build:prod
@@ -987,8 +995,13 @@ jobs:
                       export MVN_PRJ_VERSION_MINOR=$(echo $MVN_PRJ_VERSION | awk -F '.' '{print $2}')
                       export MVN_PRJ_VERSION_PATCH=$(echo $MVN_PRJ_VERSION | awk -F '.' '{print $3}')
 
-                      # Remove `-SNAPSHOT` from version                    
+                      # Remove `-SNAPSHOT` from source
+                      # Backend
                       sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" pom.xml
+                      
+                      # UI
+                      sed -i -E "s/\"version\": \"(.*)\"/\"version\": \"${APIM_VERSION%-SNAPSHOT}\"/" gravitee-apim-console-webui/build.json
+                      sed -i -E "s/\"version\": \"(.*)\"/\"version\": \"${APIM_VERSION%-SNAPSHOT}\"/" gravitee-apim-portal-webui/build.json
 
                       git add --update
                       git commit -m "${MVN_PRJ_VERSION}"


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8072

**Description**

Change the build version of UI before packaging
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-build-version-number-of-uis/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gktvenxqok.chromatic.com)
<!-- Storybook placeholder end -->
