### PR TITLE
fix(csrf): do not check for origin if no authentication cookie is passed

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/csrf/CsrfRequestMatcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/main/java/io/gravitee/rest/api/security/csrf/CsrfRequestMatcher.java
@@ -36,18 +36,17 @@ public class CsrfRequestMatcher implements RequestMatcher {
 
     @Override
     public boolean matches(HttpServletRequest request) {
+        return !allowedMethods.contains(request.getMethod()) && hasAuthenticationCookie(request) && hasRefererOrOrigin(request);
+    }
+
+    private boolean hasAuthenticationCookie(HttpServletRequest request) {
         return (
-            !allowedMethods.contains(request.getMethod()) &&
-            (
-                request.getHeader(HttpHeaders.REFERER) != null ||
-                request.getHeader(HttpHeaders.ORIGIN) != null ||
-                (
-                    request.getCookies() != null &&
-                    Arrays
-                        .stream(request.getCookies())
-                        .anyMatch(cookie -> TokenAuthenticationFilter.AUTH_COOKIE_NAME.equals(cookie.getName()))
-                )
-            )
+            request.getCookies() != null &&
+            Arrays.stream(request.getCookies()).anyMatch(cookie -> TokenAuthenticationFilter.AUTH_COOKIE_NAME.equals(cookie.getName()))
         );
+    }
+
+    private boolean hasRefererOrOrigin(HttpServletRequest request) {
+        return request.getHeader(HttpHeaders.REFERER) != null || request.getHeader(HttpHeaders.ORIGIN) != null;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/csrf/CsrfRequestMatcherTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/csrf/CsrfRequestMatcherTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.security.csrf;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.rest.api.security.filter.TokenAuthenticationFilter;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpHeaders;
+
+/**
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CsrfRequestMatcherTest {
+
+    private static final Cookie AUTH_COOKIE = mock(Cookie.class);
+    private static final String ORIGIN = "http://gravitee.io";
+
+    static {
+        when(AUTH_COOKIE.getName()).thenReturn(TokenAuthenticationFilter.AUTH_COOKIE_NAME);
+    }
+
+    private final CsrfRequestMatcher matcher = new CsrfRequestMatcher();
+
+    @Test
+    public void shouldMatchWithUnAllowedMethodAndAuthCookieAndReferer() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getMethod()).thenReturn("PUT");
+        when(request.getCookies()).thenReturn(new Cookie[] { AUTH_COOKIE });
+        when(request.getHeader(HttpHeaders.REFERER)).thenReturn(ORIGIN);
+        assertTrue(matcher.matches(request));
+    }
+
+    @Test
+    public void shouldMatchWithUnAllowedMethodAndAuthCookieAndOrigin() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getMethod()).thenReturn("PUT");
+        when(request.getCookies()).thenReturn(new Cookie[] { AUTH_COOKIE });
+        when(request.getHeader(HttpHeaders.ORIGIN)).thenReturn(ORIGIN);
+        assertTrue(matcher.matches(request));
+    }
+
+    @Test
+    public void shouldNotMatchWithAllowedMethod() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getMethod()).thenReturn("GET");
+        assertFalse(matcher.matches(request));
+    }
+
+    @Test
+    public void shouldNotMatchWithOutAuthenticationCookie() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getMethod()).thenReturn("PUT");
+        assertFalse(matcher.matches(request));
+    }
+
+    @Test
+    public void shouldNotMatchWithOutOriginOrReferer() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getMethod()).thenReturn("PUT");
+        when(request.getCookies()).thenReturn(new Cookie[] { AUTH_COOKIE });
+        assertFalse(matcher.matches(request));
+    }
+}


### PR DESCRIPTION
Some users are adding Origin and Referer headers to non browser calls to the API
(using e.g. basic or token auth).

As the csrf filter first checks for the origin header before checking if an authentication
cookie has been passed, those calls end up with an HTTP 403 response due to our CSRF filter.

As there is no need to enforce CSRF protection in that case, this revision changes the CSRF request
matcher to first check if there is an authentication cookie, then check if there is a Referer or a
Origin header.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-csrf-matcher/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
