### PR TITLE
ci: disable docker caching for e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1251,7 +1251,6 @@ jobs:
     e2e-test:
         machine:
             image: ubuntu-2004:202101-01
-            docker_layer_caching: true
         resource_class: large
         parameters:
             execution_mode:


### PR DESCRIPTION
Enabling docker caching in e2e test can lead to tests on one branch
being executed on a snapshot version of apim being  built by another
branch.

To re-enable the option, we need to compute the tag in a way that ensures
the image is related to the source code under test.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/ci-disable-e2e-docker-cache/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ujvgkvyefu.chromatic.com)
<!-- Storybook placeholder end -->
