### PR TITLE
fix(build): allow to use SNAPSHOT version of parent-pom for the build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -920,4 +920,17 @@
             </plugin>
         </plugins>
     </build>
+
+    <repositories>
+        <repository>
+            <id>oss.sonatype.org-snapshot</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 </project>


### PR DESCRIPTION
**Issue**

N/A

**Description**

The community build is broken because it tries to use `gravitee-parent` 20.4-SNAPSHOT. But as the pom configuration to allow SNAPSHOT is in the parent, then APIM can't be built.

This PR adds the missing configuration.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-build-allow-to-fetch-snapshot-for-parent-pom/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pyubtveqhc.chromatic.com)
<!-- Storybook placeholder end -->
