### PR TITLE
ci: rise test resource class to medium+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -422,7 +422,7 @@ jobs:
     test:
         docker:
             - image: cimg/openjdk:11.0
-        resource_class: medium
+        resource_class: medium+
         steps:
             - checkout
             - attach_workspace:


### PR DESCRIPTION
From time to time the test job is failing due to resource exhaustion

see e.g. https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/9548/workflows/c4c74295-341c-4551-ad37-dbbe5dbdc8f3/jobs/119881/resources
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/ci-rise-test-resources/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pdyhnsafkq.chromatic.com)
<!-- Storybook placeholder end -->
