### PR TITLE
test: added tests for round-robin lb

### DIFF
--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/endpoints/configure-lb-to-round-robin-and-use-it.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/endpoints/configure-lb-to-round-robin-and-use-it.spec.ts
@@ -13,8 +13,90 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { describe } from '@jest/globals';
+import { APIsApi } from '@management-apis/APIsApi';
+import { forManagementAsApiUser } from '@client-conf/*';
+import { afterAll, beforeAll, describe, expect } from '@jest/globals';
+import { succeed } from '@lib/jest-utils';
+import { ApisFaker } from '@management-fakers/ApisFaker';
+import { ApiEntity } from '@management-models/ApiEntity';
+import { PlansFaker } from '@management-fakers/PlansFaker';
+import { LifecycleAction } from '@management-models/LifecycleAction';
+import { PlanStatus } from '@management-models/PlanStatus';
+import { fetchGatewaySuccess } from '@lib/gateway';
+import { teardownApisAndApplications } from '@lib/management';
+
+const orgId = 'DEFAULT';
+const envId = 'DEFAULT';
+const apisResourceAsPublisher = new APIsApi(forManagementAsApiUser());
 
 describe('Configure LB to round robin and use it', () => {
-  test.skip('To complete', async () => {});
+  let createdApi: ApiEntity;
+
+  beforeAll(async () => {
+    // create an API with a published free plan and 3 endpoints in one endpoint group (lb: round robin)
+    createdApi = await succeed(
+      apisResourceAsPublisher.importApiDefinitionRaw({
+        envId,
+        orgId,
+        body: ApisFaker.apiImport({
+          plans: [PlansFaker.plan({ status: PlanStatus.PUBLISHED })],
+          proxy: ApisFaker.proxy({
+            groups: [
+              {
+                name: 'default-group',
+                endpoints: [
+                  {
+                    inherit: true,
+                    name: 'default',
+                    target: `${process.env.WIREMOCK_BASE_URL}/hello?name=endpoint1`,
+                    weight: 1,
+                    backup: false,
+                    type: 'http',
+                  },
+                  {
+                    inherit: true,
+                    name: 'endpoint2',
+                    target: `${process.env.WIREMOCK_BASE_URL}/hello?name=endpoint2`,
+                    weight: 1,
+                    backup: false,
+                    type: 'http',
+                  },
+                  {
+                    inherit: true,
+                    name: 'endpoint3',
+                    target: `${process.env.WIREMOCK_BASE_URL}/hello?name=endpoint3`,
+                    weight: 1,
+                    backup: false,
+                    type: 'http',
+                  },
+                ],
+              },
+            ],
+          }),
+        }),
+      }),
+    );
+
+    // start it
+    await apisResourceAsPublisher.doApiLifecycleAction({
+      envId,
+      orgId,
+      api: createdApi.id,
+      action: LifecycleAction.START,
+    });
+  });
+
+  test('Should switch between three configured endpoints using round-robin', async () => {
+    const endpointArray = [1, 2, 3, 1];
+    const contextPath = createdApi.context_path;
+
+    for (let endpointNumber of endpointArray) {
+      const response = await fetchGatewaySuccess({ contextPath }).then((res) => res.json());
+      expect(response.message).toEqual(`Hello, Endpoint${endpointNumber}!`);
+    }
+  });
+
+  afterAll(async () => {
+    await teardownApisAndApplications(orgId, envId, [createdApi.id]);
+  });
 });


### PR DESCRIPTION
**Description**
Added tests for round-robin load balancer of endpoints in a single endpoint group

This test creates an API with 3 endpoints (all pointing to /hello endpoint in Wiremock) and then checks that a connection is made to all 3 endpoints in a round-robin manner.


gravitee-io/issues#8078
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8078-test-round-robin-lb-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pnxqraxbmz.chromatic.com)
<!-- Storybook placeholder end -->
<!-- E2E Coverage placeholder -->
---
### 🧪 End-to-End Coverage

| INSTRUCTIONS | BRANCHES |
| :----------: | :------: |
|   36% | 20%   |

A more detailed report has been uploaded to [circleci](https://output.circle-artifacts.com/output/job/32c5693a-809d-428e-8518-25761dc31edc/artifacts/0/gravitee-apim-e2e/jacoco/reports/index.html)
<!-- E2E Coverage placeholder end -->
