### PR TITLE
test: added test for weighted round-robin lb

### DIFF
--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/endpoints/configure-lb-to-round-robin-weighted-and-use-it.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/endpoints/configure-lb-to-round-robin-weighted-and-use-it.spec.ts
@@ -13,8 +13,91 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { describe } from '@jest/globals';
+import { APIsApi } from '@management-apis/APIsApi';
+import { forManagementAsApiUser } from '@client-conf/*';
+import { afterAll, beforeAll, describe, expect } from '@jest/globals';
+import { succeed } from '@lib/jest-utils';
+import { ApisFaker } from '@management-fakers/ApisFaker';
+import { ApiEntity } from '@management-models/ApiEntity';
+import { PlansFaker } from '@management-fakers/PlansFaker';
+import { LifecycleAction } from '@management-models/LifecycleAction';
+import { PlanStatus } from '@management-models/PlanStatus';
+import { fetchGatewaySuccess } from '@lib/gateway';
+import { LoadBalancerTypeEnum } from '@management-models/LoadBalancer';
+import { teardownApisAndApplications } from '@lib/management';
 
-describe('Configure LB to round robin weighted and use it ', () => {
-  test.skip('To complete', async () => {});
+const orgId = 'DEFAULT';
+const envId = 'DEFAULT';
+const apisResourceAsPublisher = new APIsApi(forManagementAsApiUser());
+
+describe('Configure LB to round robin weighted and use it', () => {
+  let createdApi: ApiEntity;
+
+  beforeAll(async () => {
+    // create an API with a published free plan and 2 endpoints in one endpoint group (lb: weighted round robin)
+    createdApi = await succeed(
+      apisResourceAsPublisher.importApiDefinitionRaw({
+        envId,
+        orgId,
+        body: ApisFaker.apiImport({
+          plans: [PlansFaker.plan({ status: PlanStatus.PUBLISHED })],
+          proxy: ApisFaker.proxy({
+            groups: [
+              {
+                name: 'default-group',
+                endpoints: [
+                  {
+                    inherit: true,
+                    name: 'default',
+                    target: `${process.env.WIREMOCK_BASE_URL}/hello?name=endpoint1`,
+                    weight: 1,
+                    backup: false,
+                    type: 'http',
+                  },
+                  {
+                    inherit: true,
+                    name: 'endpoint2',
+                    target: `${process.env.WIREMOCK_BASE_URL}/hello?name=endpoint2`,
+                    weight: 2,
+                    backup: false,
+                    type: 'http',
+                  },
+                ],
+                load_balancing: {
+                  type: LoadBalancerTypeEnum.WEIGHTEDROUNDROBIN,
+                },
+              },
+            ],
+          }),
+        }),
+      }),
+    );
+
+    // start it
+    await apisResourceAsPublisher.doApiLifecycleAction({
+      envId,
+      orgId,
+      api: createdApi.id,
+      action: LifecycleAction.START,
+    });
+  });
+
+  test('Should switch between three configured endpoints using round-robin', async () => {
+    const contextPath = createdApi.context_path;
+    let endpoint1 = 0;
+    let endpoint2 = 0;
+
+    for (let i = 0; i < 6; i++) {
+      const response = await fetchGatewaySuccess({ contextPath }).then((res) => res.json());
+      if (response.message.match(/Endpoint1/)) endpoint1++;
+      if (response.message.match(/Endpoint2/)) endpoint2++;
+    }
+
+    expect(endpoint1).toBe(2);
+    expect(endpoint2).toBe(4);
+  });
+
+  afterAll(async () => {
+    await teardownApisAndApplications(orgId, envId, [createdApi.id]);
+  });
 });


### PR DESCRIPTION
**Description**
This test creates an API two endpoints in one endpoint group with different weights. It then sends several requests, counts which target it reached and checks that this number matches with the ratio that was defined by the weights.

gravitee-io/issues#8079
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/test-8079-test-weighted-round-robin-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ljpzlurhmc.chromatic.com)
<!-- Storybook placeholder end -->
<!-- E2E Coverage placeholder -->
---
### 🧪 End-to-End Coverage

| INSTRUCTIONS | BRANCHES |
| :----------: | :------: |
|   36% | 20%   |

A more detailed report has been uploaded to [circleci](https://output.circle-artifacts.com/output/job/446ba2e4-f725-4b7f-ad9f-e6280e3870ae/artifacts/0/gravitee-apim-e2e/jacoco/reports/index.html)
<!-- E2E Coverage placeholder end -->
