### PR TITLE
Align all `nginx` docker images to `nginx:1.23-alpine`

### DIFF
--- a/gravitee-apim-console-webui/docker/Dockerfile
+++ b/gravitee-apim-console-webui/docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM nginx:1.22-alpine as base
+FROM nginx:1.23-alpine as base
 ENV CONFD_VERSION="0.16.0"
 ENV CONFD_URL="https://github.com/kelseyhightower/confd/releases/download"
 

--- a/gravitee-apim-console-webui/docker/Dockerfile-from-download
+++ b/gravitee-apim-console-webui/docker/Dockerfile-from-download
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM nginx:1.21-alpine
+FROM nginx:1.23-alpine
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEIO_VERSION=0

--- a/gravitee-apim-portal-webui/docker/Dockerfile
+++ b/gravitee-apim-portal-webui/docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM nginx:1.22-alpine as base
+FROM nginx:1.23-alpine as base
 ENV CONFD_VERSION="0.16.0"
 ENV CONFD_URL="https://github.com/kelseyhightower/confd/releases/download"
 

--- a/gravitee-apim-portal-webui/docker/Dockerfile-from-download
+++ b/gravitee-apim-portal-webui/docker/Dockerfile-from-download
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM nginx:1.21-alpine
+FROM nginx:1.23-alpine
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEIO_VERSION=0


### PR DESCRIPTION
**Issue**

NA

**Description**

Previously dev images were based on `1.22` and prod images on `1.21`, so PR aligns all `nginx` docker images to `nginx:1.23-alpine`. I picked the most recent one to include as less security vulns as possible ;)


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/align-docker-images/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bjhhedriks.chromatic.com)
<!-- Storybook placeholder end -->
