### PR TITLE
fix: bump gravitee-reporter-file fixes retainDays configuration inaccuracies

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -105,7 +105,7 @@
         <gravitee-fetcher-http.version>1.12.0</gravitee-fetcher-http.version>
         <!-- Gateway Only -->
         <gravitee-reporter-elasticsearch.version>3.12.4</gravitee-reporter-elasticsearch.version>
-        <gravitee-reporter-file.version>2.5.3</gravitee-reporter-file.version>
+        <gravitee-reporter-file.version>2.5.4</gravitee-reporter-file.version>
         <gravitee-reporter-tcp.version>1.4.3</gravitee-reporter-tcp.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->
         <!--    <gravitee-gateway-services-ratelimit.version>1.15.0</gravitee-gateway-services-ratelimit.version>    -->


### PR DESCRIPTION
fix: bump gravitee-reporter-file fixes retainDays configuration inaccuracies

**Issue**

https://github.com/gravitee-io/issues/issues/8090
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-bumpfilereporter/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
