### PR TITLE
fix(jdbc): drop commands.environment_id not null constraint during 3.18.2 upgrade

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_18_2/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_18_2/schema.yml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: 3.18.2
+      author: GraviteeSource Team
+      changes:
+        - dropNotNullConstraint:
+            columnDataType: nvarchar(64)
+            columnName: environment_id
+            tableName: ${gravitee_prefix}commands

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -127,3 +127,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v3_18_0/schema.yml
   - include:
       - file: liquibase/changelogs/v3_18_0/schema_flows.yml
+  - include:
+      - file: liquibase/changelogs/v3_18_2/schema.yml


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8110

**Description**

fix(jdbc): drop commands.environment_id not null constraint during 3.18.2 upgrade

This should have been done by 3.18.0 liquibase script. But failed due to an indentation problem.

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-jdbcdropconstraint/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wzekwcnrtn.chromatic.com)
<!-- Storybook placeholder end -->
