### PR TITLE
[CI] Replace Python script by distribution to build bundle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,7 +346,7 @@ jobs:
 
     build:
         docker:
-            - image: cimg/openjdk:11.0
+            - image: cimg/openjdk:11.0-node
         resource_class: large
         steps:
             - checkout
@@ -1448,10 +1448,11 @@ jobs:
 
     package-bundle:
         docker:
-            - image: cimg/python:3.10
+            - image: cimg/openjdk:11.0-node
         resource_class: medium
         environment:
             RELEASE_VERSION: << pipeline.parameters.graviteeio_version >>
+            ARTIFACTORY_REPO_URL: "https://odbxikk7vo-artifactory.services.clever-cloud.com/external-dependencies-n-gravitee-all"
         steps:
             - keeper/env-export:
                   secret-url: keeper://R7NuqoW0KD-8l-kjx0-PgQ/field/login
@@ -1461,108 +1462,16 @@ jobs:
                   var-name: ARTIFACTORY_PASSWORD
             - checkout
             - run:
-                  name: "Install python libraries"
-                  command: |
-                      pip install requests
-
+                  name: Install dependencies
+                  command: printenv
+            - run:
+                  name: Install dependencies
+                  command: npm install
+                  working_directory: "./release"
             - run:
                   name: "Building package bundle"
-                  command: |
-                      python .circleci/package_bundles.py
-            - run:
-                  name: "Prepare bundles for uploading"
-                  command: |
-                      workingDir=$(pwd)
-
-                      ####################
-                      #Distribution - Full                                            
-                      ####################
-                      mkdir -p graviteeio-apim/distributions
-                      cp ./tmp/${RELEASE_VERSION}/dist/graviteeio-full-${RELEASE_VERSION}.zip graviteeio-apim/distributions/
-
-                      cd graviteeio-apim/distributions
-
-                      md5sum graviteeio-full-${RELEASE_VERSION}.zip > graviteeio-full-${RELEASE_VERSION}.zip.md5
-                      sha512sum graviteeio-full-${RELEASE_VERSION}.zip > graviteeio-full-${RELEASE_VERSION}.zip.sha512sum
-                      sha1sum graviteeio-full-${RELEASE_VERSION}.zip > graviteeio-full-${RELEASE_VERSION}.zip.sha1
-
-                      cd $workingDir
-
-                      #####################
-                      #Components - Gateway
-                      #####################
-                      mkdir -p graviteeio-apim/components/gravitee-gateway
-                      cp ./tmp/${RELEASE_VERSION}/gatewas/gravitee-apim-gateway-standalone-distribution-zip-${RELEASE_VERSION}.zip graviteeio-apim/components/gravitee-gateway/gravitee-apim-gateway-${RELEASE_VERSION}.zip
-
-                      cd graviteeio-apim/components/gravitee-gateway
-
-                      md5sum gravitee-apim-gateway-${RELEASE_VERSION}.zip > gravitee-apim-gateway-${RELEASE_VERSION}.zip.md5
-                      sha512sum gravitee-apim-gateway-${RELEASE_VERSION}.zip > gravitee-apim-gateway-${RELEASE_VERSION}.zip.sha512sum
-                      sha1sum gravitee-apim-gateway-${RELEASE_VERSION}.zip > gravitee-apim-gateway-${RELEASE_VERSION}.zip.sha1
-
-                      cd $workingDir
-
-                      ######################
-                      #Components - Rest API
-                      ######################
-                      mkdir -p graviteeio-apim/components/gravitee-management-rest-api
-                      cp ./tmp/${RELEASE_VERSION}/rests/gravitee-apim-rest-api-standalone-distribution-zip-${RELEASE_VERSION}.zip graviteeio-apim/components/gravitee-management-rest-api/gravitee-apim-rest-api-${RELEASE_VERSION}.zip
-
-                      cd graviteeio-apim/components/gravitee-management-rest-api
-
-                      md5sum gravitee-apim-rest-api-${RELEASE_VERSION}.zip > gravitee-apim-rest-api-${RELEASE_VERSION}.zip.md5
-                      sha512sum gravitee-apim-rest-api-${RELEASE_VERSION}.zip > gravitee-apim-rest-api-${RELEASE_VERSION}.zip.sha512sum
-                      sha1sum gravitee-apim-rest-api-${RELEASE_VERSION}.zip > gravitee-apim-rest-api-${RELEASE_VERSION}.zip.sha1
-
-                      cd $workingDir
-
-                      #####################
-                      #Components - Console
-                      #####################
-                      mkdir -p graviteeio-apim/components/gravitee-management-webui
-                      cp ./tmp/${RELEASE_VERSION}/consoles/gravitee-apim-console-webui-${RELEASE_VERSION}.zip graviteeio-apim/components/gravitee-management-webui/
-
-                      cd graviteeio-apim/components/gravitee-management-webui
-
-                      md5sum gravitee-apim-console-webui-${RELEASE_VERSION}.zip > gravitee-apim-console-webui-${RELEASE_VERSION}.zip.md5
-                      sha512sum gravitee-apim-console-webui-${RELEASE_VERSION}.zip > gravitee-apim-console-webui-${RELEASE_VERSION}.zip.sha512sum
-                      sha1sum gravitee-apim-console-webui-${RELEASE_VERSION}.zip > gravitee-apim-console-webui-${RELEASE_VERSION}.zip.sha1
-
-                      cd $workingDir
-
-                      ####################
-                      #Components - Portal
-                      ####################
-                      mkdir -p graviteeio-apim/components/gravitee-portal-webui
-                      cp ./tmp/${RELEASE_VERSION}/portals/gravitee-apim-portal-webui-${RELEASE_VERSION}.zip graviteeio-apim/components/gravitee-portal-webui/
-
-                      cd graviteeio-apim/components/gravitee-portal-webui
-
-                      md5sum gravitee-apim-portal-webui-${RELEASE_VERSION}.zip > gravitee-apim-portal-webui-${RELEASE_VERSION}.zip.md5
-                      sha512sum gravitee-apim-portal-webui-${RELEASE_VERSION}.zip > gravitee-apim-portal-webui-${RELEASE_VERSION}.zip.sha512sum
-                      sha1sum gravitee-apim-portal-webui-${RELEASE_VERSION}.zip > gravitee-apim-portal-webui-${RELEASE_VERSION}.zip.sha1
-
-                      cd $workingDir
-
-                      #############
-                      #Repositories 
-                      #############
-                      for repositoryZipFile in $(find ./tmp/${RELEASE_VERSION}/repositories/ -name '*.zip' | sed "s#./tmp/${RELEASE_VERSION}/repositories/##"); do
-                        # compute the destination folder on S3 to publish the artefact
-                        # e.g. gravitee-my-project-1.14.0.zip => graviteeio-apim/plugins/repositories/gravitee-my-project
-                        artefactFolderToSync=graviteeio-apim/plugins/repositories/${repositoryZipFile%-*p}                                               
-
-                        mkdir -p $artefactFolderToSync
-                        cp ./tmp/${RELEASE_VERSION}/repositories/$repositoryZipFile $artefactFolderToSync/
-
-                        cd $artefactFolderToSync
-
-                        md5sum $repositoryZipFile > $repositoryZipFile.md5
-                        sha512sum $repositoryZipFile > $repositoryZipFile.sha512sum
-                        sha1sum $repositoryZipFile > $repositoryZipFile.sha1
-
-                        cd $workingDir
-                      done
+                  working_directory: "./release"
+                  command: npm run zx -- --experimental ci-steps/package-bundles.mjs --version=<< pipeline.parameters.graviteeio_version >>
             - keeper/env-export:
                   secret-url: keeper://Mqmplmfu17bDR5XRLmO1mQ/field/password
                   var-name: AWS_ACCESS_KEY_ID
@@ -1573,7 +1482,7 @@ jobs:
                   arguments: |
                       --endpoint-url https://cellar-c2.services.clever-cloud.com \
                       --acl public-read
-                  from: graviteeio-apim
+                  from: ./release/.tmp/<< pipeline.parameters.graviteeio_version >>/dist
                   to: "s3://gravitee-releases-downloads/graviteeio-apim"
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,7 +346,7 @@ jobs:
 
     build:
         docker:
-            - image: cimg/openjdk:11.0-node
+            - image: cimg/openjdk:11.0
         resource_class: large
         steps:
             - checkout
@@ -1481,7 +1481,7 @@ jobs:
             - aws-s3/sync:
                   arguments: |
                       --endpoint-url https://cellar-c2.services.clever-cloud.com \
-                      --acl public-read
+                      --acl public-read --dryrun
                   from: ./release/.tmp/<< pipeline.parameters.graviteeio_version >>/dist
                   to: "s3://gravitee-releases-downloads/graviteeio-apim"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -650,10 +650,10 @@ jobs:
             - artifactory-orb/install
             - artifactory-orb/configure
             - run:
-                name: Update Build version
-                command: |
-                  sed -i "s/-SNAPSHOT//" dist/build.json
-                working_directory: << parameters.apim-ui-project >>
+                  name: Update Build version
+                  command: |
+                      sed -i "s/-SNAPSHOT//" dist/build.json
+                  working_directory: << parameters.apim-ui-project >>
             - run:
                   name: Rename and zip dist folder
                   command: mv dist << parameters.apim-ui-project >>-${APIM_VERSION%-SNAPSHOT} && zip -r dist.zip << parameters.apim-ui-project >>-${APIM_VERSION%-SNAPSHOT}
@@ -695,9 +695,9 @@ jobs:
             - webui-install:
                   apim-ui-project: << parameters.apim-ui-project >>
             - run:
-                name: Update Build version
-                command: |
-                  sed -i -E "s/\"version\": \"(.*)\"/\"version\": \"${APIM_VERSION}\"/" << parameters.apim-ui-project >>/build.json
+                  name: Update Build version
+                  command: |
+                      sed -i -E "s/\"version\": \"(.*)\"/\"version\": \"${APIM_VERSION}\"/" << parameters.apim-ui-project >>/build.json
             - run:
                   name: Build
                   command: npm run build:prod
@@ -1024,7 +1024,7 @@ jobs:
                       # Remove `-SNAPSHOT` from source
                       # Backend
                       sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" pom.xml
-                      
+
                       # UI
                       sed -i -E "s/\"version\": \"(.*)\"/\"version\": \"${MVN_PRJ_VERSION}\"/" gravitee-apim-console-webui/build.json
                       sed -i -E "s/\"version\": \"(.*)\"/\"version\": \"${MVN_PRJ_VERSION}\"/" gravitee-apim-portal-webui/build.json
@@ -1289,107 +1289,107 @@ jobs:
                       cd gravitee-apim-e2e/jacoco
                       mv jacoco.exec jacoco-<< parameters.execution_mode >>-<< parameters.database >>.exec
             - persist_to_workspace:
-                root: .
-                paths:
-                  - gravitee-apim-e2e/jacoco/jacoco-*-*.exec
+                  root: .
+                  paths:
+                      - gravitee-apim-e2e/jacoco/jacoco-*-*.exec
             - when:
-                condition:
-                  and:
-                    - equal: [ v3, << parameters.execution_mode >> ]
-                    - equal: [ mongo, << parameters.database >> ]
-                steps:
-                  - persist_to_workspace:
-                      root: .
-                      paths:
-                        - .git
-                        - gravitee-apim-gateway
-                        - gravitee-apim-rest-api
-                        - rest-api-docker-context
-                        - gateway-docker-context
-                        - gravitee-api-management
-                        - gravitee-apim-e2e/package.json
-                        - gravitee-apim-e2e/jacoco/lib
-                        - gravitee-apim-e2e/jacoco/*.xml
+                  condition:
+                      and:
+                          - equal: [v3, << parameters.execution_mode >>]
+                          - equal: [mongo, << parameters.database >>]
+                  steps:
+                      - persist_to_workspace:
+                            root: .
+                            paths:
+                                - .git
+                                - gravitee-apim-gateway
+                                - gravitee-apim-rest-api
+                                - rest-api-docker-context
+                                - gateway-docker-context
+                                - gravitee-api-management
+                                - gravitee-apim-e2e/package.json
+                                - gravitee-apim-e2e/jacoco/lib
+                                - gravitee-apim-e2e/jacoco/*.xml
             - notify-on-failure
             - store_test_results:
-                path: ~/test-results
+                  path: ~/test-results
     e2e-report:
-      machine:
-        image: ubuntu-2004:202101-01
-      resource_class: small
-      steps:
-        - attach_workspace:
-            at: .
-        - keeper/env-export:
-            secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
-            var-name: GITHUB_TOKEN
-        - run:
-            name: Merge E2E exec files
-            command: |
-              cd gravitee-apim-e2e
-              npm run test:report:merge
-        - run:
-            name: Generate e2e coverage report
-            command: |
-              cd gravitee-apim-e2e
-              npm run test:report
-        - run:
-            name: Remove Report Details (Only keep index files)
-            command: |
-              cd gravitee-apim-e2e/jacoco/reports
-              rm -f report.xml
-              find . -type f -not -name 'index.html' -name '*.html' -delete
-        - store_artifacts:
-            name: Upload jacoco report
-            path: gravitee-apim-e2e/jacoco/reports
-        - store_artifacts:
-            name: Upload jacoco exec file
-            path: gravitee-apim-e2e/jacoco/jacoco.exec
-        - gh/setup
-        - run:
-            name: Edit Pull Request Description
-            command: |
-              # First check there is an associated pull request, otherwise just stop the job here
-              if ! gh pr view --json title;
-              then
-                echo "No PR found for this branch, stopping the job here."
-                exit 0
-              fi
-              
-              # If PR state is different from OPEN
-              if [ "$(gh pr view --json state --jq .state)" != "OPEN" ];
-              then
-                echo "PR is not opened, stopping the job here."
-                exit 0
-              fi
-              
-              pushd gravitee-apim-e2e/jacoco/reports
-                export COVERAGE_SUMMARY=$(sed -nE 's/^.*<td>Total<([^>]+>){4}([^<]*)([^>]+>){4}([^<]*).*$/\2 | \4/p' index.html)
-              popd
-              
-              export COVERAGE_URL="https://output.circle-artifacts.com/output/job/${CIRCLE_WORKFLOW_JOB_ID}/artifacts/0/gravitee-apim-e2e/jacoco/reports/index.html"
-              
-              export PR_BODY_COVERAGE_SECTION="
-              <!-- E2E Coverage placeholder -->
-              ---
-              ### 🧪 End-to-End Coverage
-              
-              | INSTRUCTIONS | BRANCHES |
-              | :----------: | :------: |
-              |   ${COVERAGE_SUMMARY}   |
-              
-              A more detailed report has been uploaded to [circleci](${COVERAGE_URL})
-              <!-- E2E Coverage placeholder end -->
-              "
-              
-              export CLEAN_BODY=$(gh pr view --json body --jq .body | sed '/E2E Coverage placeholder -->/,/E2E Coverage placeholder end -->/d')
-              
-              echo "
-                Editing PR description with body:
-                  $CLEAN_BODY$PR_BODY_COVERAGE_SECTION
-              "
-              
-              gh pr edit --body "$CLEAN_BODY$PR_BODY_COVERAGE_SECTION"
+        machine:
+            image: ubuntu-2004:202101-01
+        resource_class: small
+        steps:
+            - attach_workspace:
+                  at: .
+            - keeper/env-export:
+                  secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+                  var-name: GITHUB_TOKEN
+            - run:
+                  name: Merge E2E exec files
+                  command: |
+                      cd gravitee-apim-e2e
+                      npm run test:report:merge
+            - run:
+                  name: Generate e2e coverage report
+                  command: |
+                      cd gravitee-apim-e2e
+                      npm run test:report
+            - run:
+                  name: Remove Report Details (Only keep index files)
+                  command: |
+                      cd gravitee-apim-e2e/jacoco/reports
+                      rm -f report.xml
+                      find . -type f -not -name 'index.html' -name '*.html' -delete
+            - store_artifacts:
+                  name: Upload jacoco report
+                  path: gravitee-apim-e2e/jacoco/reports
+            - store_artifacts:
+                  name: Upload jacoco exec file
+                  path: gravitee-apim-e2e/jacoco/jacoco.exec
+            - gh/setup
+            - run:
+                  name: Edit Pull Request Description
+                  command: |
+                      # First check there is an associated pull request, otherwise just stop the job here
+                      if ! gh pr view --json title;
+                      then
+                        echo "No PR found for this branch, stopping the job here."
+                        exit 0
+                      fi
+
+                      # If PR state is different from OPEN
+                      if [ "$(gh pr view --json state --jq .state)" != "OPEN" ];
+                      then
+                        echo "PR is not opened, stopping the job here."
+                        exit 0
+                      fi
+
+                      pushd gravitee-apim-e2e/jacoco/reports
+                        export COVERAGE_SUMMARY=$(sed -nE 's/^.*<td>Total<([^>]+>){4}([^<]*)([^>]+>){4}([^<]*).*$/\2 | \4/p' index.html)
+                      popd
+
+                      export COVERAGE_URL="https://output.circle-artifacts.com/output/job/${CIRCLE_WORKFLOW_JOB_ID}/artifacts/0/gravitee-apim-e2e/jacoco/reports/index.html"
+
+                      export PR_BODY_COVERAGE_SECTION="
+                      <!-- E2E Coverage placeholder -->
+                      ---
+                      ### 🧪 End-to-End Coverage
+
+                      | INSTRUCTIONS | BRANCHES |
+                      | :----------: | :------: |
+                      |   ${COVERAGE_SUMMARY}   |
+
+                      A more detailed report has been uploaded to [circleci](${COVERAGE_URL})
+                      <!-- E2E Coverage placeholder end -->
+                      "
+
+                      export CLEAN_BODY=$(gh pr view --json body --jq .body | sed '/E2E Coverage placeholder -->/,/E2E Coverage placeholder end -->/d')
+
+                      echo "
+                        Editing PR description with body:
+                          $CLEAN_BODY$PR_BODY_COVERAGE_SECTION
+                      "
+
+                      gh pr edit --body "$CLEAN_BODY$PR_BODY_COVERAGE_SECTION"
     e2e-cypress:
         machine:
             image: ubuntu-2004:202101-01
@@ -1463,9 +1463,6 @@ jobs:
             - checkout
             - run:
                   name: Install dependencies
-                  command: printenv
-            - run:
-                  name: Install dependencies
                   command: npm install
                   working_directory: "./release"
             - run:
@@ -1478,12 +1475,25 @@ jobs:
             - keeper/env-export:
                   secret-url: keeper://3-pU56sIqcyWWw7HxhxjaQ/field/password
                   var-name: AWS_SECRET_ACCESS_KEY
-            - aws-s3/sync:
-                  arguments: |
-                      --endpoint-url https://cellar-c2.services.clever-cloud.com \
-                      --acl public-read --dryrun
-                  from: ./release/.tmp/<< pipeline.parameters.graviteeio_version >>/dist
-                  to: "s3://gravitee-releases-downloads/graviteeio-apim"
+            - when:
+                  condition: << pipeline.parameters.dry_run>>
+                  steps:
+                      - aws-s3/sync:
+                            arguments: |
+                                --endpoint-url https://cellar-c2.services.clever-cloud.com \
+                                --acl public-read
+                            from: ./release/.tmp/<< pipeline.parameters.graviteeio_version >>/dist
+                            to: "s3://gravitee-dry-releases-downloads/graviteeio-apim"
+            - when:
+                  condition:
+                      not: << pipeline.parameters.dry_run>>
+                  steps:
+                      - aws-s3/sync:
+                            arguments: |
+                                --endpoint-url https://cellar-c2.services.clever-cloud.com \
+                                --acl public-read --dryrun
+                            from: ./release/.tmp/<< pipeline.parameters.graviteeio_version >>/dist
+                            to: "s3://gravitee-releases-downloads/graviteeio-apim"
 
 workflows:
     pull_requests:
@@ -1677,16 +1687,16 @@ workflows:
                               - /.*-run-e2e.*/
                               - /^\d+\.\d+\.x$/
             - e2e-report:
-                context: cicd-orchestrator
-                name: Generate E2E Test Reports
-                requires:
-                  - e2e-test
-                filters:
-                  branches:
-                    only:
-                      - master
-                      - /.*-run-e2e.*/
-                      - /^\d+\.\d+\.x$/
+                  context: cicd-orchestrator
+                  name: Generate E2E Test Reports
+                  requires:
+                      - e2e-test
+                  filters:
+                      branches:
+                          only:
+                              - master
+                              - /.*-run-e2e.*/
+                              - /^\d+\.\d+\.x$/
             - e2e-cypress:
                   name: Run Cypress UI tests
                   requires:

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -560,6 +560,13 @@
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-elasticsearch</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <scope>runtime</scope>
+        </dependency>
 
         <!-- Resources -->
         <dependency>

--- a/release/ci-steps/package-bundles.mjs
+++ b/release/ci-steps/package-bundles.mjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env zx
+
+import xml2json from 'xml2json';
+
+console.log(chalk.magenta(`######################################`));
+console.log(chalk.magenta(`# 📦 Prepare APIM package bundles 📦 #`));
+console.log(chalk.magenta(`######################################`));
+
+console.log(chalk.blue(`Step 1: Prepare APIM distribution`));
+await within(async () => {
+  cd('../');
+  await $`mvn flatten:flatten`;
+});
+
+const pomXml = await fs.readFile(`../gravitee-apim-distribution/.flattened-pom.xml`, 'utf-8');
+const jsonPom = JSON.parse(await xml2json.toJson(pomXml, {}));
+
+const releasingVersion = argv.version; // jsonPom.project.parent.version;
+const tmpPath = `./.tmp/${releasingVersion}`;
+
+const resolveLinkedVersion = (allVersions, valueToResolve) => {
+  const versionLinkMatch = valueToResolve.match(/\${(.*?)}/);
+  return versionLinkMatch ? allVersions[versionLinkMatch[1]] : valueToResolve;
+};
+const distributionProperties = Object.fromEntries(
+  Object.entries(jsonPom.project.properties).map(([key, value]) => [key, resolveLinkedVersion(jsonPom.project.properties, value)]),
+);
+const distributionDependencies = jsonPom.project.dependencies.dependency.map((dependency) => ({
+  ...dependency,
+  version: resolveLinkedVersion(
+    {
+      ...distributionProperties,
+      'project.version': releasingVersion,
+    },
+    dependency.version,
+  ),
+}));
+
+console.log(chalk.blue(`Step 2: Download all dependencies from artifactory`));
+await $`mkdir -p ${tmpPath}`;
+cd(tmpPath);
+
+const allDependencies = [
+  ...distributionDependencies,
+  {
+    groupId: 'io.gravitee.apim.ui',
+    artifactId: 'gravitee-apim-console-webui',
+    version: releasingVersion,
+    type: 'zip',
+  },
+  {
+    groupId: 'io.gravitee.apim.ui',
+    artifactId: 'gravitee-apim-portal-webui',
+    version: releasingVersion,
+    type: 'zip',
+  },
+  {
+    groupId: 'io.gravitee.apim.rest.api.standalone.distribution',
+    artifactId: 'gravitee-apim-rest-api-standalone-distribution-zip',
+    version: releasingVersion,
+    type: 'zip',
+  },
+  {
+    groupId: 'io.gravitee.apim.gateway.standalone.distribution',
+    artifactId: 'gravitee-apim-gateway-standalone-distribution-zip',
+    version: releasingVersion,
+    type: 'zip',
+  },
+  {
+    groupId: 'io.gravitee.apim.repository',
+    artifactId: 'gravitee-apim-repository-hazelcast',
+    version: releasingVersion,
+    type: 'zip',
+  },
+  {
+    groupId: 'io.gravitee.apim.repository',
+    artifactId: 'gravitee-apim-repository-redis',
+    version: releasingVersion,
+    type: 'zip',
+  },
+].map((dependency) => {
+  const fileName = `${dependency.artifactId}-${dependency.version}.${dependency.type}`;
+  const path = `${dependency.groupId.replaceAll('.', '/')}/${dependency.artifactId}/${dependency.version}`;
+  return {
+    ...dependency,
+    fileName,
+    downloadUrl: `${process.env.ARTIFACTORY_REPO_URL}/${path}/${fileName}`,
+  };
+});
+const allDependenciesMap = new Map(
+  allDependencies.map((d) => {
+    return [d.artifactId, d];
+  }),
+);
+
+const createFileSum = async (file) => {
+  await $`md5sum ${file} > ${file}.md5`;
+  await $`sha512sum ${file} > ${file}.sha512sum`;
+  await $`sha1sum ${file} > ${file}.sha1`;
+};
+
+await spinner('Download all dependencies...', () =>
+  Promise.all(
+    allDependencies.map(async ({ downloadUrl }) => {
+      try {
+        await $`curl -u ${process.env.ARTIFACTORY_USERNAME}:${process.env.ARTIFACTORY_PASSWORD} -f -O ${downloadUrl}`;
+        return Promise.resolve(downloadUrl);
+      } catch (e) {
+        console.log(chalk.red(`Failed to download ${downloadUrl}`));
+        return Promise.reject();
+      }
+    }),
+  ),
+);
+
+console.log(chalk.green(`\n   ${allDependencies.length} dependencies downloaded`));
+
+console.log(chalk.blue(`Step 3; Packaging - Components / Rest API`));
+const restApiComponentDir = `./dist/components/gravitee-management-rest-api`;
+await $`rm -rf ${restApiComponentDir} && mkdir -p ${restApiComponentDir}`;
+
+await $`unzip -q -o ${allDependenciesMap.get('gravitee-apim-rest-api-standalone-distribution-zip').fileName} -d ${restApiComponentDir}`;
+await $`mv ${restApiComponentDir}/gravitee-apim-rest-api-standalone-${releasingVersion} ${restApiComponentDir}/gravitee-apim-rest-api-${releasingVersion}`;
+
+const restApiDependenciesExclusion = [
+  // GroupIds to exclude
+  'io.gravitee.apim.ui',
+  'io.gravitee.apim.gateway.standalone.distribution',
+  'io.gravitee.apim.rest.api.standalone.distribution',
+  'io.gravitee.apim.repository.gateway.bridge.http',
+  'io.gravitee.reporter',
+  'io.gravitee.tracer',
+  // ArtifactIds to exclude
+  'gravitee-gateway-services-ratelimit',
+  'gravitee-apim-repository-hazelcast',
+  'gravitee-apim-repository-redis',
+];
+await spinner('Add plugins to Rest API...', () =>
+  Promise.all(
+    allDependencies
+      .filter((d) => !restApiDependenciesExclusion.includes(d.artifactId) && !restApiDependenciesExclusion.includes(d.groupId))
+      .map(({ fileName }) => $`cp ${fileName} ${restApiComponentDir}/gravitee-apim-rest-api-${releasingVersion}/plugins`),
+  ),
+);
+await $`zip -q -r ${restApiComponentDir}/gravitee-apim-rest-api-${releasingVersion}.zip ${restApiComponentDir}/gravitee-apim-rest-api-${releasingVersion}/`;
+await createFileSum(`${restApiComponentDir}/gravitee-apim-rest-api-${releasingVersion}.zip`);
+
+console.log(chalk.blue(`Step 4: Packaging - Components / Gateway`));
+const gatewayComponentDir = `./dist/components/gravitee-gateway`;
+await $`rm -rf ${gatewayComponentDir} && mkdir -p ${gatewayComponentDir}`;
+
+await $`unzip -q -o ${allDependenciesMap.get('gravitee-apim-gateway-standalone-distribution-zip').fileName} -d ${gatewayComponentDir}`;
+await $`mv ${gatewayComponentDir}/gravitee-apim-gateway-standalone-${releasingVersion} ${gatewayComponentDir}/gravitee-apim-gateway-${releasingVersion}`;
+
+const gatewayDependenciesExclusion = [
+  // GroupIds to exclude
+  'io.gravitee.apim.ui',
+  'io.gravitee.apim.gateway.standalone.distribution',
+  'io.gravitee.apim.rest.api.standalone.distribution',
+  'io.gravitee.cockpit',
+  'io.gravitee.fetcher',
+  'io.gravitee.notifier',
+  'io.gravitee.tracer',
+  // ArtifactIds to exclude
+  'gravitee-apim-repository-elasticsearch',
+  'gravitee-apim-repository-hazelcast',
+  'gravitee-apim-repository-redis',
+];
+await spinner('Add plugins to Gateway...', () =>
+  Promise.all(
+    allDependencies
+      .filter((d) => !gatewayDependenciesExclusion.includes(d.artifactId) && !gatewayDependenciesExclusion.includes(d.groupId))
+      .map(async ({ fileName }) => $`cp ${fileName} ${gatewayComponentDir}/gravitee-apim-gateway-${releasingVersion}/plugins`),
+  ),
+);
+
+await $`zip -q -r ${gatewayComponentDir}/gravitee-apim-gateway-${releasingVersion}.zip ${gatewayComponentDir}/gravitee-apim-gateway-${releasingVersion}/`;
+await createFileSum(`${gatewayComponentDir}/gravitee-apim-gateway-${releasingVersion}.zip`);
+
+console.log(chalk.blue(`Step 5: Packaging - Components / Console`));
+const consoleComponentDir = `./dist/components/gravitee-management-webui`;
+await $`rm -rf ${consoleComponentDir} && mkdir -p ${consoleComponentDir}`;
+
+await $`cp ${allDependenciesMap.get('gravitee-apim-console-webui').fileName} ${consoleComponentDir}/`;
+await createFileSum(`${consoleComponentDir}/${allDependenciesMap.get('gravitee-apim-console-webui').fileName}`);
+
+console.log(chalk.blue(`Step 6: Packaging - Components / Portal`));
+const portalComponentDir = `./dist/components/gravitee-portal-webui`;
+await $`rm -rf ${portalComponentDir} && mkdir -p ${portalComponentDir}`;
+
+await $`cp ${allDependenciesMap.get('gravitee-apim-portal-webui').fileName} ${portalComponentDir}/`;
+await createFileSum(`${portalComponentDir}/${allDependenciesMap.get('gravitee-apim-portal-webui').fileName}`);
+
+console.log(chalk.blue(`Step 7: Packaging - Distribution / Full`));
+const fullDistributionDir = `./dist/distributions/graviteeio-full-${releasingVersion}`;
+await $`rm -rf ${fullDistributionDir} && mkdir -p ${fullDistributionDir}`;
+
+await $`unzip -q -o ${allDependenciesMap.get('gravitee-apim-console-webui').fileName} -d ${fullDistributionDir}`;
+await $`unzip -q -o ${allDependenciesMap.get('gravitee-apim-portal-webui').fileName} -d ${fullDistributionDir}`;
+
+await $`mv -f ${restApiComponentDir}/gravitee-apim-rest-api-${releasingVersion} ./${fullDistributionDir}/`;
+await $`mv -f ${gatewayComponentDir}/gravitee-apim-gateway-${releasingVersion} ./${fullDistributionDir}/`;
+
+await $`zip -q -r ${fullDistributionDir}.zip ${fullDistributionDir}/`;
+await createFileSum(`${fullDistributionDir}.zip`);
+await $`rm -rf ${fullDistributionDir}`;
+
+console.log(chalk.blue(`Step 8: Packaging - Plugins / All Repositories`));
+const repositoriesPluginDir = `./dist/plugins/repositories`;
+await $`rm -rf ${repositoriesPluginDir} && mkdir -p ${repositoriesPluginDir}`;
+
+await Promise.all(
+  allDependencies
+    .filter((d) => d.groupId.startsWith('io.gravitee.apim.repository'))
+    .map(async ({ fileName, artifactId }) => {
+      await $`mkdir -p  ${repositoriesPluginDir}/${artifactId} && cp ${fileName} ${repositoriesPluginDir}/${artifactId}/`;
+      await createFileSum(`${repositoriesPluginDir}/${artifactId}/${fileName}`);
+    }),
+);
+
+console.log(chalk.magenta(`📦 The package is ready!`));

--- a/release/ci-steps/package-bundles.mjs
+++ b/release/ci-steps/package-bundles.mjs
@@ -142,8 +142,12 @@ await spinner('Add plugins to Rest API...', () =>
       .map(({ fileName }) => $`cp ${fileName} ${restApiComponentDir}/gravitee-apim-rest-api-${releasingVersion}/plugins`),
   ),
 );
-await $`zip -q -r ${restApiComponentDir}/gravitee-apim-rest-api-${releasingVersion}.zip ${restApiComponentDir}/gravitee-apim-rest-api-${releasingVersion}/`;
-await createFileSum(`${restApiComponentDir}/gravitee-apim-rest-api-${releasingVersion}.zip`);
+
+await within(async () => {
+  cd(`${restApiComponentDir}`);
+  await $`zip -q -r gravitee-apim-rest-api-${releasingVersion}.zip gravitee-apim-rest-api-${releasingVersion}`;
+  await createFileSum(`gravitee-apim-rest-api-${releasingVersion}.zip`);
+});
 
 console.log(chalk.blue(`Step 4: Packaging - Components / Gateway`));
 const gatewayComponentDir = `./dist/components/gravitee-gateway`;
@@ -174,8 +178,11 @@ await spinner('Add plugins to Gateway...', () =>
   ),
 );
 
-await $`zip -q -r ${gatewayComponentDir}/gravitee-apim-gateway-${releasingVersion}.zip ${gatewayComponentDir}/gravitee-apim-gateway-${releasingVersion}/`;
-await createFileSum(`${gatewayComponentDir}/gravitee-apim-gateway-${releasingVersion}.zip`);
+await within(async () => {
+  cd(`${gatewayComponentDir}`);
+  await $`zip -q -r gravitee-apim-gateway-${releasingVersion}.zip gravitee-apim-gateway-${releasingVersion}`;
+  await createFileSum(`gravitee-apim-gateway-${releasingVersion}.zip`);
+});
 
 console.log(chalk.blue(`Step 5: Packaging - Components / Console`));
 const consoleComponentDir = `./dist/components/gravitee-management-webui`;
@@ -201,8 +208,18 @@ await $`unzip -q -o ${allDependenciesMap.get('gravitee-apim-portal-webui').fileN
 await $`mv -f ${restApiComponentDir}/gravitee-apim-rest-api-${releasingVersion} ./${fullDistributionDir}/`;
 await $`mv -f ${gatewayComponentDir}/gravitee-apim-gateway-${releasingVersion} ./${fullDistributionDir}/`;
 
-await $`zip -q -r ${fullDistributionDir}.zip ${fullDistributionDir}/`;
-await createFileSum(`${fullDistributionDir}.zip`);
+// TODO: Remove the following lines to align names of these components to match the naming convention `gravitee-*` and not `graviteeio-*`
+await $`mv ${fullDistributionDir}/gravitee-apim-console-webui-${releasingVersion} ${fullDistributionDir}/graviteeio-apim-console-webui-${releasingVersion}`;
+await $`mv ${fullDistributionDir}/gravitee-apim-portal-webui-${releasingVersion} ${fullDistributionDir}/graviteeio-apim-portal-webui-${releasingVersion}`;
+await $`mv ${fullDistributionDir}/gravitee-apim-gateway-${releasingVersion} ${fullDistributionDir}/graviteeio-apim-gateway-${releasingVersion}`;
+await $`mv ${fullDistributionDir}/gravitee-apim-rest-api-${releasingVersion} ${fullDistributionDir}/graviteeio-apim-rest-api-${releasingVersion}`;
+
+await within(async () => {
+  cd(`./dist/distributions`);
+  await $`zip -q -r graviteeio-full-${releasingVersion}.zip graviteeio-full-${releasingVersion}`;
+  await createFileSum(`graviteeio-full-${releasingVersion}.zip`);
+});
+
 await $`rm -rf ${fullDistributionDir}`;
 
 console.log(chalk.blue(`Step 8: Packaging - Plugins / All Repositories`));

--- a/release/ci-steps/package-bundles.mjs
+++ b/release/ci-steps/package-bundles.mjs
@@ -119,33 +119,11 @@ console.log(chalk.blue(`Step 3; Packaging - Components / Rest API`));
 const restApiComponentDir = `./dist/components/gravitee-management-rest-api`;
 await $`rm -rf ${restApiComponentDir} && mkdir -p ${restApiComponentDir}`;
 
-await $`unzip -q -o ${allDependenciesMap.get('gravitee-apim-rest-api-standalone-distribution-zip').fileName} -d ${restApiComponentDir}`;
-await $`mv ${restApiComponentDir}/gravitee-apim-rest-api-standalone-${releasingVersion} ${restApiComponentDir}/gravitee-apim-rest-api-${releasingVersion}`;
-
-const restApiDependenciesExclusion = [
-  // GroupIds to exclude
-  'io.gravitee.apim.ui',
-  'io.gravitee.apim.gateway.standalone.distribution',
-  'io.gravitee.apim.rest.api.standalone.distribution',
-  'io.gravitee.apim.repository.gateway.bridge.http',
-  'io.gravitee.reporter',
-  'io.gravitee.tracer',
-  // ArtifactIds to exclude
-  'gravitee-gateway-services-ratelimit',
-  'gravitee-apim-repository-hazelcast',
-  'gravitee-apim-repository-redis',
-];
-await spinner('Add plugins to Rest API...', () =>
-  Promise.all(
-    allDependencies
-      .filter((d) => !restApiDependenciesExclusion.includes(d.artifactId) && !restApiDependenciesExclusion.includes(d.groupId))
-      .map(({ fileName }) => $`cp ${fileName} ${restApiComponentDir}/gravitee-apim-rest-api-${releasingVersion}/plugins`),
-  ),
-);
+await $`cp ${allDependenciesMap.get('gravitee-apim-rest-api-standalone-distribution-zip').fileName} ${restApiComponentDir}`;
 
 await within(async () => {
   cd(`${restApiComponentDir}`);
-  await $`zip -q -r gravitee-apim-rest-api-${releasingVersion}.zip gravitee-apim-rest-api-${releasingVersion}`;
+  await $`mv ${allDependenciesMap.get('gravitee-apim-rest-api-standalone-distribution-zip').fileName} gravitee-apim-rest-api-${releasingVersion}.zip`;
   await createFileSum(`gravitee-apim-rest-api-${releasingVersion}.zip`);
 });
 
@@ -153,34 +131,11 @@ console.log(chalk.blue(`Step 4: Packaging - Components / Gateway`));
 const gatewayComponentDir = `./dist/components/gravitee-gateway`;
 await $`rm -rf ${gatewayComponentDir} && mkdir -p ${gatewayComponentDir}`;
 
-await $`unzip -q -o ${allDependenciesMap.get('gravitee-apim-gateway-standalone-distribution-zip').fileName} -d ${gatewayComponentDir}`;
-await $`mv ${gatewayComponentDir}/gravitee-apim-gateway-standalone-${releasingVersion} ${gatewayComponentDir}/gravitee-apim-gateway-${releasingVersion}`;
-
-const gatewayDependenciesExclusion = [
-  // GroupIds to exclude
-  'io.gravitee.apim.ui',
-  'io.gravitee.apim.gateway.standalone.distribution',
-  'io.gravitee.apim.rest.api.standalone.distribution',
-  'io.gravitee.cockpit',
-  'io.gravitee.fetcher',
-  'io.gravitee.notifier',
-  'io.gravitee.tracer',
-  // ArtifactIds to exclude
-  'gravitee-apim-repository-elasticsearch',
-  'gravitee-apim-repository-hazelcast',
-  'gravitee-apim-repository-redis',
-];
-await spinner('Add plugins to Gateway...', () =>
-  Promise.all(
-    allDependencies
-      .filter((d) => !gatewayDependenciesExclusion.includes(d.artifactId) && !gatewayDependenciesExclusion.includes(d.groupId))
-      .map(async ({ fileName }) => $`cp ${fileName} ${gatewayComponentDir}/gravitee-apim-gateway-${releasingVersion}/plugins`),
-  ),
-);
+await $`cp ${allDependenciesMap.get('gravitee-apim-gateway-standalone-distribution-zip').fileName} ${gatewayComponentDir}`;
 
 await within(async () => {
   cd(`${gatewayComponentDir}`);
-  await $`zip -q -r gravitee-apim-gateway-${releasingVersion}.zip gravitee-apim-gateway-${releasingVersion}`;
+  await $`mv ${allDependenciesMap.get('gravitee-apim-gateway-standalone-distribution-zip').fileName} gravitee-apim-gateway-${releasingVersion}.zip`;
   await createFileSum(`gravitee-apim-gateway-${releasingVersion}.zip`);
 });
 
@@ -202,11 +157,60 @@ console.log(chalk.blue(`Step 7: Packaging - Distribution / Full`));
 const fullDistributionDir = `./dist/distributions/graviteeio-full-${releasingVersion}`;
 await $`rm -rf ${fullDistributionDir} && mkdir -p ${fullDistributionDir}`;
 
+// Console
 await $`unzip -q -o ${allDependenciesMap.get('gravitee-apim-console-webui').fileName} -d ${fullDistributionDir}`;
+
+// Portal
 await $`unzip -q -o ${allDependenciesMap.get('gravitee-apim-portal-webui').fileName} -d ${fullDistributionDir}`;
 
-await $`mv -f ${restApiComponentDir}/gravitee-apim-rest-api-${releasingVersion} ./${fullDistributionDir}/`;
-await $`mv -f ${gatewayComponentDir}/gravitee-apim-gateway-${releasingVersion} ./${fullDistributionDir}/`;
+// Rest API
+await $`unzip -q -o ${restApiComponentDir}/gravitee-apim-rest-api-${releasingVersion}.zip -d ${fullDistributionDir}`;
+await $`mv ${fullDistributionDir}/gravitee-apim-rest-api-standalone-${releasingVersion} ${fullDistributionDir}/gravitee-apim-rest-api-${releasingVersion}`;
+const restApiDependenciesExclusion = [
+  // GroupIds to exclude
+  'io.gravitee.apim.ui',
+  'io.gravitee.apim.gateway.standalone.distribution',
+  'io.gravitee.apim.rest.api.standalone.distribution',
+  'io.gravitee.apim.repository.gateway.bridge.http',
+  'io.gravitee.reporter',
+  'io.gravitee.tracer',
+  // ArtifactIds to exclude
+  'gravitee-gateway-services-ratelimit',
+  'gravitee-apim-repository-hazelcast',
+  'gravitee-apim-repository-redis',
+];
+await spinner('Add plugins to Rest API...', () =>
+    Promise.all(
+        allDependencies
+            .filter((d) => !restApiDependenciesExclusion.includes(d.artifactId) && !restApiDependenciesExclusion.includes(d.groupId))
+            .map(({ fileName }) => $`cp ${fileName} ${fullDistributionDir}/gravitee-apim-rest-api-${releasingVersion}/plugins`),
+    ),
+);
+
+// Gateway
+await $`unzip -q -o ${gatewayComponentDir}/gravitee-apim-gateway-${releasingVersion}.zip -d ${fullDistributionDir}`;
+await $`mv ${fullDistributionDir}/gravitee-apim-gateway-standalone-${releasingVersion} ${fullDistributionDir}/gravitee-apim-gateway-${releasingVersion}`;
+const gatewayDependenciesExclusion = [
+  // GroupIds to exclude
+  'io.gravitee.apim.ui',
+  'io.gravitee.apim.gateway.standalone.distribution',
+  'io.gravitee.apim.rest.api.standalone.distribution',
+  'io.gravitee.cockpit',
+  'io.gravitee.fetcher',
+  'io.gravitee.notifier',
+  'io.gravitee.tracer',
+  // ArtifactIds to exclude
+  'gravitee-apim-repository-elasticsearch',
+  'gravitee-apim-repository-hazelcast',
+  'gravitee-apim-repository-redis',
+];
+await spinner('Add plugins to Gateway...', () =>
+    Promise.all(
+        allDependencies
+            .filter((d) => !gatewayDependenciesExclusion.includes(d.artifactId) && !gatewayDependenciesExclusion.includes(d.groupId))
+            .map(async ({ fileName }) => $`cp ${fileName} ${fullDistributionDir}/gravitee-apim-gateway-${releasingVersion}/plugins`),
+    ),
+);
 
 // TODO: Remove the following lines to align names of these components to match the naming convention `gravitee-*` and not `graviteeio-*`
 await $`mv ${fullDistributionDir}/gravitee-apim-console-webui-${releasingVersion} ${fullDistributionDir}/graviteeio-apim-console-webui-${releasingVersion}`;

--- a/release/package-lock.json
+++ b/release/package-lock.json
@@ -9,10 +9,121 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "dotenv": "^16.0.1"
+        "dotenv": "^16.0.1",
+        "xml2json": "^0.12.0",
+        "zx": "^7.0.7"
       },
       "devDependencies": {
         "prettier": "2.5.1"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/minimist": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
+    },
+    "node_modules/@types/node": {
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
+    },
+    "node_modules/@types/ps-tree": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/ps-tree/-/ps-tree-1.1.2.tgz",
+      "integrity": "sha512-ZREFYlpUmPQJ0esjxoG1fMvB2HNaD3z+mjqdSosZvd3RalncI9NEur73P8ZJz4YQdL64CmV1w0RuqoRUlhQRBw=="
+    },
+    "node_modules/@types/which": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.1.tgz",
+      "integrity": "sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ=="
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+      "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dotenv": {
@@ -21,6 +132,350 @@
       "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
+    },
+    "node_modules/event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==",
+      "dependencies": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g=="
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globby": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.2.tgz",
+      "integrity": "sha512-LKSDZXToac40u8Q1PQtZihbNdTYSNMuWe+K5l+oa6KgDzSvVrHXlJy40hUP522RjAIoNLJYBJi7ow+rbFpIhHQ==",
+      "dependencies": {
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.11",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+    },
+    "node_modules/hoek": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/isemail": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+      "dependencies": {
+        "punycode": "2.x.x"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/joi": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
+      "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
+      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
+      "dependencies": {
+        "hoek": "5.x.x",
+        "isemail": "3.x.x",
+        "topo": "3.x.x"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
+    "node_modules/joi/node_modules/hoek": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
+      "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w==",
+      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g=="
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+    },
+    "node_modules/nan": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
+      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA=="
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-expat": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/node-expat/-/node-expat-2.4.0.tgz",
+      "integrity": "sha512-X8Y/Zk/izfNgfayeOeUGqze7KlaOwVJ9SDTjHUMKd0hu0aFTRpLlLCBwmx79cTPiQWD24I1YOafF+U+rTvEMfQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "nan": "^2.13.2"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.8.tgz",
+      "integrity": "sha512-KtpD1YhGszhntMpBDyp5lyagk8KIMopC1LEb7cQUAh7zcosaX5uK8HnbNb2i3NTQK3sIawCItS0uFC3QzcLHdg==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "dependencies": {
+        "through": "~2.3"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/prettier": {
@@ -34,19 +489,694 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/ps-tree": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
+      "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
+      "dependencies": {
+        "event-stream": "=3.3.4"
+      },
+      "bin": {
+        "ps-tree": "bin/ps-tree.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==",
+      "dependencies": {
+        "duplexer": "~0.1.1"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/topo": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
+      "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
+      "deprecated": "This module has moved and is now available at @hapi/topo. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
+      "dependencies": {
+        "hoek": "6.x.x"
+      }
+    },
+    "node_modules/topo/node_modules/hoek": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+      "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==",
+      "deprecated": "This module has moved and is now available at @hapi/hoek. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues."
+    },
+    "node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/xml2json": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/xml2json/-/xml2json-0.12.0.tgz",
+      "integrity": "sha512-EPJHRWJnJUYbJlzR4pBhZODwWdi2IaYGtDdteJi0JpZ4OD31IplWALuit8r73dJuM4iHZdDVKY1tLqY2UICejg==",
+      "dependencies": {
+        "hoek": "^4.2.1",
+        "joi": "^13.1.2",
+        "node-expat": "^2.3.18"
+      },
+      "bin": {
+        "xml2json": "bin/xml2json"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
+      "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/zx": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/zx/-/zx-7.0.7.tgz",
+      "integrity": "sha512-cWF5cWqqrTVxgEPmQ8w/LvUXOK3rJTdgC+Tt1nz113+YncNIO0X6UXgCY72UfE8Az/lwOubbEJARXpQ+7RiM9g==",
+      "dependencies": {
+        "@types/fs-extra": "^9.0.13",
+        "@types/minimist": "^1.2.2",
+        "@types/node": "^17.0",
+        "@types/ps-tree": "^1.1.2",
+        "@types/which": "^2.0.1",
+        "chalk": "^5.0.1",
+        "fs-extra": "^10.1.0",
+        "globby": "^13.1.2",
+        "minimist": "^1.2.6",
+        "node-fetch": "^3.2.6",
+        "ps-tree": "^1.2.0",
+        "which": "^2.0.2",
+        "yaml": "^2.1.1"
+      },
+      "bin": {
+        "zx": "build/cli.js"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      }
     }
   },
   "dependencies": {
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "requires": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
+    },
+    "@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/minimist": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ=="
+    },
+    "@types/node": {
+      "version": "17.0.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
+    },
+    "@types/ps-tree": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/ps-tree/-/ps-tree-1.1.2.tgz",
+      "integrity": "sha512-ZREFYlpUmPQJ0esjxoG1fMvB2HNaD3z+mjqdSosZvd3RalncI9NEur73P8ZJz4YQdL64CmV1w0RuqoRUlhQRBw=="
+    },
+    "@types/which": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.1.tgz",
+      "integrity": "sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ=="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "chalk": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+      "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w=="
+    },
+    "data-uri-to-buffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "requires": {
+        "path-type": "^4.0.0"
+      }
+    },
     "dotenv": {
       "version": "16.0.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
       "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
+    },
+    "duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
+    },
+    "event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==",
+      "requires": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
+      }
+    },
+    "fast-glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      }
+    },
+    "fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "requires": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "requires": {
+        "fetch-blob": "^3.1.2"
+      }
+    },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g=="
+    },
+    "fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "globby": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.2.tgz",
+      "integrity": "sha512-LKSDZXToac40u8Q1PQtZihbNdTYSNMuWe+K5l+oa6KgDzSvVrHXlJy40hUP522RjAIoNLJYBJi7ow+rbFpIhHQ==",
+      "requires": {
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.11",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+    },
+    "hoek": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+    },
+    "ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+    },
+    "isemail": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.2.0.tgz",
+      "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
+      "requires": {
+        "punycode": "2.x.x"
+      }
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "joi": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
+      "integrity": "sha512-xuY5VkHfeOYK3Hdi91ulocfuFopwgbSORmIwzcwHKESQhC7w1kD5jaVSPnqDxS2I8t3RZ9omCKAxNwXN5zG1/Q==",
+      "requires": {
+        "hoek": "5.x.x",
+        "isemail": "3.x.x",
+        "topo": "3.x.x"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
+          "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w=="
+        }
+      }
+    },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
+    },
+    "map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g=="
+    },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+    },
+    "micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "requires": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      }
+    },
+    "minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+    },
+    "nan": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
+      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA=="
+    },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+    },
+    "node-expat": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/node-expat/-/node-expat-2.4.0.tgz",
+      "integrity": "sha512-X8Y/Zk/izfNgfayeOeUGqze7KlaOwVJ9SDTjHUMKd0hu0aFTRpLlLCBwmx79cTPiQWD24I1YOafF+U+rTvEMfQ==",
+      "requires": {
+        "bindings": "^1.5.0",
+        "nan": "^2.13.2"
+      }
+    },
+    "node-fetch": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.8.tgz",
+      "integrity": "sha512-KtpD1YhGszhntMpBDyp5lyagk8KIMopC1LEb7cQUAh7zcosaX5uK8HnbNb2i3NTQK3sIawCItS0uFC3QzcLHdg==",
+      "requires": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      }
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+    },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "requires": {
+        "through": "~2.3"
+      }
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "prettier": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
       "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
       "dev": true
+    },
+    "ps-tree": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
+      "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
+      "requires": {
+        "event-stream": "=3.3.4"
+      }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+    },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew=="
+    },
+    "split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==",
+      "requires": {
+        "through": "2"
+      }
+    },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==",
+      "requires": {
+        "duplexer": "~0.1.1"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "topo": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
+      "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
+      "requires": {
+        "hoek": "6.x.x"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+          "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
+        }
+      }
+    },
+    "universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+    },
+    "web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
+    },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "xml2json": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/xml2json/-/xml2json-0.12.0.tgz",
+      "integrity": "sha512-EPJHRWJnJUYbJlzR4pBhZODwWdi2IaYGtDdteJi0JpZ4OD31IplWALuit8r73dJuM4iHZdDVKY1tLqY2UICejg==",
+      "requires": {
+        "hoek": "^4.2.1",
+        "joi": "^13.1.2",
+        "node-expat": "^2.3.18"
+      }
+    },
+    "yaml": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
+      "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw=="
+    },
+    "zx": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/zx/-/zx-7.0.7.tgz",
+      "integrity": "sha512-cWF5cWqqrTVxgEPmQ8w/LvUXOK3rJTdgC+Tt1nz113+YncNIO0X6UXgCY72UfE8Az/lwOubbEJARXpQ+7RiM9g==",
+      "requires": {
+        "@types/fs-extra": "^9.0.13",
+        "@types/minimist": "^1.2.2",
+        "@types/node": "^17.0",
+        "@types/ps-tree": "^1.1.2",
+        "@types/which": "^2.0.1",
+        "chalk": "^5.0.1",
+        "fs-extra": "^10.1.0",
+        "globby": "^13.1.2",
+        "minimist": "^1.2.6",
+        "node-fetch": "^3.2.6",
+        "ps-tree": "^1.2.0",
+        "which": "^2.0.2",
+        "yaml": "^2.1.1"
+      }
     }
   }
 }

--- a/release/package.json
+++ b/release/package.json
@@ -5,7 +5,9 @@
   "author": "Gravitee Team",
   "license": "MIT",
   "dependencies": {
-    "dotenv": "^16.0.1"
+    "dotenv": "^16.0.1",
+    "xml2json": "^0.12.0",
+    "zx": "^7.0.7"
   },
   "scripts": {
     "prettier": "prettier --check \"**/*.{js,mjs,json}\"",
@@ -14,7 +16,8 @@
     "package_zip": "zx steps/2-package_zip.mjs",
     "docker_rpms": "zx steps/3-docker_and_rpms.mjs",
     "changelog": "zx steps/4-generate_changelog.mjs",
-    "nexus_sync": "zx steps/5-nexus_sync.mjs"
+    "nexus_sync": "zx steps/5-nexus_sync.mjs",
+    "zx": "zx"
   },
   "devDependencies": {
     "prettier": "2.5.1"

--- a/release/steps/2-package_zip.mjs
+++ b/release/steps/2-package_zip.mjs
@@ -14,8 +14,6 @@ console.log(chalk.blue(`Triggering Package Zip Pipeline`));
 const tagSteps = await question(
   chalk.blue(
     '⚠️ Before packaging, you have to:\n' +
-      " - Update gravitee-io/release's release.json to update 'gravitee-api-management' version\n" +
-      ' - Commit\n' +
       " - Create a tag for the new version (To create a tag, use 'git tag -a {version}' then 'git push origin {version}')\n" +
       '\n' +
       'Is it ok ? (y/n)\n',
@@ -28,7 +26,7 @@ if (tagSteps !== 'y') {
 
 // Use the preconfigured payload from config folder with the good parameters
 const body = {
-  branch: versions.branch,
+  branch: '7813-remove-python',//versions.branch,
   parameters: {
     gio_action: 'package_bundle',
     dry_run: isDryRun(),


### PR DESCRIPTION
**Issue**
https://github.com/gravitee-io/issues/issues/7813

**Description**

ci: refactor prepare APIM package bundles

To test run `npm run package_zip -- --version=3.18.0 --dry-run`
Result : https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/9754/workflows/484f24b1-4f5a-496c-805d-9640f2770598/jobs/123233

⚠️ :
The only change I noticed was on the prefix `graviteeio` inside `graviteeio-full-3.18.0.zip` has not been retained. 
but if needed I can add the code that renames these parts when composing the `graviteeio-full`. 

IMHO: I would be up for only and always having `gravitee` prefix and remove all `graviteeio` only used for the full zip ... 🤷‍♂️ 



**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ccvqwgavej.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/7813-remove-python/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
