### PR TITLE
test(e2e): fix api-import-by-url.spec.ts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1766,6 +1766,7 @@ workflows:
                           only:
                               - master
                               - /.*-run-e2e.*/
+                              - /.*merge.*/
                               - /^\d+\.\d+\.x$/
             - e2e-report:
                 context: cicd-orchestrator

--- a/gravitee-apim-e2e/api-test/src/imports/api-import-by-url.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/imports/api-import-by-url.spec.ts
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { afterAll, describe, expect, test } from '@jest/globals';
+import { describe, expect, test } from '@jest/globals';
 import { APIsApi } from '@management-apis/APIsApi';
 import { forManagementAsApiUser } from '@client-conf/*';
-import { fail, noContent, succeed } from '@lib/jest-utils';
+import { noContent, succeed } from '@lib/jest-utils';
 import { ApiEntity } from '@management-models/ApiEntity';
 
 const orgId = 'DEFAULT';
@@ -32,7 +32,7 @@ describe('API - Imports by url', () => {
       apisResourceAsPublisher.importApiDefinitionUrlRaw({
         envId,
         orgId,
-        body: `${process.env.WIREMOCK_BASE_PATH}/api-whattimeisit.json`,
+        body: `${process.env.WIREMOCK_BASE_URL}/api-whattimeisit.json`,
       }),
     );
     expect(createdApi).toBeTruthy();
@@ -45,7 +45,7 @@ describe('API - Imports by url', () => {
         envId,
         orgId,
         api: createdApi.id,
-        body: `${process.env.WIREMOCK_BASE_PATH}/api-whattimeisit.json`,
+        body: `${process.env.WIREMOCK_BASE_URL}/api-whattimeisit.json`,
       }),
     );
     expect(updatedApi).toBeTruthy();

--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/debug-mode/call-my-api-including-query-params-headers-body-and-view-debug-session-with-proper-info.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/debug-mode/call-my-api-including-query-params-headers-body-and-view-debug-session-with-proper-info.spec.ts
@@ -36,301 +36,303 @@ const envId = 'DEFAULT';
 const apisResource = new APIsApi(forManagementAsApiUser());
 const organizationApi = new OrganizationApi(forManagementAsAdminUser());
 
-describeIfV3('Call my API (incl. query params, Headers and body) and view debug session with proper info', () => {
-  let apiEntity: ApiEntity;
+describe('Call my API (incl. query params, Headers and body) and view debug session with proper info', () => {
+  describeIfV3('-- only if v3 --', () => {
+    let apiEntity: ApiEntity;
 
-  beforeAll(async () => {
-    // Create Global Flow
-    const organization = await organizationApi.get({ orgId });
-    await organizationApi.update({
-      orgId,
-      updateOrganizationEntity: {
-        ...OrganizationEntityToJSON(organization),
-        flows: [
-          {
-            name: `[Testing flow] Platform`,
-            path_operator: {
-              path: '/',
-              operator: PathOperatorOperatorEnum.STARTSWITH,
+    beforeAll(async () => {
+      // Create Global Flow
+      const organization = await organizationApi.get({ orgId });
+      await organizationApi.update({
+        orgId,
+        updateOrganizationEntity: {
+          ...OrganizationEntityToJSON(organization),
+          flows: [
+            {
+              name: `[Testing flow] Platform`,
+              path_operator: {
+                path: '/',
+                operator: PathOperatorOperatorEnum.STARTSWITH,
+              },
+              consumers: [],
+              methods: [],
+              pre: [],
+              post: [fakePolicyToAddHeader({ name: 'X-Test-Platform-Policy', scope: 'RESPONSE' })],
+              enabled: true,
             },
-            consumers: [],
-            methods: [],
-            pre: [],
-            post: [fakePolicyToAddHeader({ name: 'X-Test-Platform-Policy', scope: 'RESPONSE' })],
-            enabled: true,
-          },
-        ],
-      },
-    });
+          ],
+        },
+      });
 
-    // Create new API
-    apiEntity = await apisResource.createApi({
-      orgId,
-      envId,
-      newApiEntity: ApisFaker.newApi({
-        gravitee: '2.0.0',
-        // With flow on root path
-        flows: [
-          {
-            name: `[Testing flow] API`,
-            path_operator: {
-              path: '/',
-              operator: PathOperatorOperatorEnum.STARTSWITH,
-            },
-            consumers: [],
-            methods: [],
-            pre: [
-              fakePolicyToAddHeader({ name: 'X-Test-Api-Request-Policy', scope: 'REQUEST' }),
-              fakePolicyToAddHeader({
-                name: 'X-Test-Api-Request-Conditioned-Policy',
-                scope: 'REQUEST',
-                condition: '{#request.headers["Use-Conditioned-Flow"] != null && #request.headers["Use-Conditioned-Flow"][0] == "true"}',
-              }),
-              fakePolicyToAddHeader({ name: 'X-Test-Api-Request-Disabled-Policy', scope: 'REQUEST', enabled: false }),
-              {
-                name: 'Assign content',
-                description: 'Validate request content change',
-                enabled: true,
-                policy: 'policy-assign-content',
-                configuration: {
+      // Create new API
+      apiEntity = await apisResource.createApi({
+        orgId,
+        envId,
+        newApiEntity: ApisFaker.newApi({
+          gravitee: '2.0.0',
+          // With flow on root path
+          flows: [
+            {
+              name: `[Testing flow] API`,
+              path_operator: {
+                path: '/',
+                operator: PathOperatorOperatorEnum.STARTSWITH,
+              },
+              consumers: [],
+              methods: [],
+              pre: [
+                fakePolicyToAddHeader({ name: 'X-Test-Api-Request-Policy', scope: 'REQUEST' }),
+                fakePolicyToAddHeader({
+                  name: 'X-Test-Api-Request-Conditioned-Policy',
                   scope: 'REQUEST',
-                  body: 'Validate content change\n${request.getContent()}',
+                  condition: '{#request.headers["Use-Conditioned-Flow"] != null && #request.headers["Use-Conditioned-Flow"][0] == "true"}',
+                }),
+                fakePolicyToAddHeader({ name: 'X-Test-Api-Request-Disabled-Policy', scope: 'REQUEST', enabled: false }),
+                {
+                  name: 'Assign content',
+                  description: 'Validate request content change',
+                  enabled: true,
+                  policy: 'policy-assign-content',
+                  configuration: {
+                    scope: 'REQUEST',
+                    body: 'Validate content change\n${request.getContent()}',
+                  },
                 },
-              },
-            ],
-            post: [
-              fakePolicyToAddHeader({ name: 'X-Test-Api-Response-Policy', scope: 'RESPONSE' }),
-              fakePolicyToAddHeader({
-                name: 'X-Test-Api-Response-Conditioned-Policy',
-                scope: 'RESPONSE',
-                condition: '{#request.headers["Use-Conditioned-Flow"] != null && #request.headers["Use-Conditioned-Flow"][0] == "true"}',
-              }),
-              fakePolicyToAddHeader({ name: 'X-Test-Api-Response-Disabled-Policy', scope: 'RESPONSE', enabled: false }),
-              {
-                name: 'JSON to XML',
-                description: 'Validate response content change',
-                enabled: true,
-                policy: 'json-xml',
-                configuration: {
-                  rootElement: 'root',
+              ],
+              post: [
+                fakePolicyToAddHeader({ name: 'X-Test-Api-Response-Policy', scope: 'RESPONSE' }),
+                fakePolicyToAddHeader({
+                  name: 'X-Test-Api-Response-Conditioned-Policy',
                   scope: 'RESPONSE',
+                  condition: '{#request.headers["Use-Conditioned-Flow"] != null && #request.headers["Use-Conditioned-Flow"][0] == "true"}',
+                }),
+                fakePolicyToAddHeader({ name: 'X-Test-Api-Response-Disabled-Policy', scope: 'RESPONSE', enabled: false }),
+                {
+                  name: 'JSON to XML',
+                  description: 'Validate response content change',
+                  enabled: true,
+                  policy: 'json-xml',
+                  configuration: {
+                    rootElement: 'root',
+                    scope: 'RESPONSE',
+                  },
                 },
-              },
-            ],
-            enabled: true,
-          },
-        ],
-      }),
-    });
-
-    // Create first KeylessPlan
-    await apisResource.createApiPlan({
-      orgId,
-      envId,
-      api: apiEntity.id,
-      newPlanEntity: PlansFaker.newPlan({
-        security: PlanSecurityType.KEYLESS,
-        status: PlanStatus.PUBLISHED,
-      }),
-    });
-
-    // Fetch api description (with keyless plan)
-    apiEntity = await apisResource.getApi({ orgId, envId, api: apiEntity.id });
-  });
-
-  describe('Get debug event on `GET /`', () => {
-    let debugResult;
-
-    beforeEach((done) => {
-      createAndWaitForDebugResult$({
-        ...DebugApiEntityFromJSON(ApiEntityToJSON(apiEntity)),
-        entrypoints: undefined,
-        request: {
-          body: '',
-          headers: {},
-          method: 'GET',
-          path: '/',
-        },
-      }).subscribe((value) => {
-        debugResult = JSON.parse(value.payload);
-        done();
-      });
-    });
-
-    test('Should contain response', () => {
-      // Expect final Response
-      expect(debugResult.response.statusCode).toEqual(200);
-      expect(debugResult.response.body).toContain('Hello');
-      expect(Object.keys(debugResult.response.headers)).toContain('X-Test-Platform-Policy');
-      expect(Object.keys(debugResult.response.headers)).toContain('X-Test-Api-Response-Policy');
-      expect(Object.keys(debugResult.response.headers)).not.toContain('X-Test-Api-Response-Conditioned-Policy');
-    });
-
-    test('Should contain debug steps', () => {
-      expect(debugResult.debugSteps.length).toEqual(13);
-
-      // Step 1 key-less
-      expect(debugResult.debugSteps[0].policyId).toEqual('key-less');
-
-      // Step 4 Request transform-headers
-      expect(debugResult.debugSteps[3].policyId).toEqual('transform-headers');
-      expect(debugResult.debugSteps[3].status).toEqual('COMPLETED');
-      expect(Object.keys(debugResult.debugSteps[3].result.headers)).toContain('X-Test-Api-Request-Policy');
-
-      // Step 5 Request Conditioned transform-headers
-      expect(debugResult.debugSteps[4].policyId).toEqual('transform-headers');
-      expect(debugResult.debugSteps[4].status).toEqual('SKIPPED');
-
-      // Step 6 Request assign-content
-      expect(debugResult.debugSteps[5].policyId).toEqual('policy-assign-content');
-      expect(debugResult.debugSteps[5].status).toEqual('COMPLETED');
-      expect(debugResult.debugSteps[5].scope).toEqual('ON_REQUEST_CONTENT');
-      expect(debugResult.debugSteps[5].result.body).toContain('Validate content change');
-
-      // Step 9 Response Conditioned transform-headers
-      expect(debugResult.debugSteps[8].policyId).toEqual('transform-headers');
-      expect(debugResult.debugSteps[8].status).toEqual('COMPLETED');
-      expect(Object.keys(debugResult.debugSteps[8].result.headers)).toContain('X-Test-Api-Response-Policy');
-
-      // Step 10 Response Conditioned transform-headers
-      expect(debugResult.debugSteps[9].policyId).toEqual('transform-headers');
-      expect(debugResult.debugSteps[9].status).toEqual('SKIPPED');
-
-      // Step 12 Platform Response transform-headers
-      expect(debugResult.debugSteps[11].policyId).toEqual('transform-headers');
-      expect(debugResult.debugSteps[11].status).toEqual('COMPLETED');
-      expect(debugResult.debugSteps[11].stage).toEqual('PLATFORM');
-      expect(Object.keys(debugResult.debugSteps[11].result.headers)).toContain('X-Test-Api-Response-Policy');
-      expect(Object.keys(debugResult.debugSteps[11].result.headers)).toContain('X-Test-Platform-Policy');
-
-      // Step 13 Response json-xml
-      expect(debugResult.debugSteps[12].policyId).toEqual('json-xml');
-      expect(debugResult.debugSteps[12].status).toEqual('COMPLETED');
-      expect(debugResult.debugSteps[12].scope).toEqual('ON_RESPONSE_CONTENT');
-      expect(debugResult.debugSteps[12].result.body).toContain('<root><message>Hello, World!</message></root>');
-    });
-  });
-
-  describe('Get debug event on `GET /?name=TheFox`', () => {
-    let debugResult;
-    let debugEventSubscription: Subscription;
-
-    beforeEach((done) => {
-      debugEventSubscription = createAndWaitForDebugResult$({
-        ...DebugApiEntityFromJSON(ApiEntityToJSON(apiEntity)),
-        entrypoints: undefined,
-        request: {
-          body: '',
-          headers: {},
-          method: 'GET',
-          path: '/?name=TheFox',
-        },
-      }).subscribe((value) => {
-        debugResult = JSON.parse(value.payload);
-        done();
-      });
-    });
-
-    afterEach(() => {
-      debugEventSubscription.unsubscribe();
-    });
-
-    test('Should send query params to backend', () => {
-      expect(debugResult.response.body).toEqual('<root><message>Hello, TheFox!</message></root>');
-    });
-  });
-
-  describe('Get debug event on `GET /` with headers', () => {
-    let debugResult;
-
-    beforeEach((done) => {
-      createAndWaitForDebugResult$({
-        ...DebugApiEntityFromJSON(ApiEntityToJSON(apiEntity)),
-        entrypoints: undefined,
-        request: {
-          body: '',
-          headers: {
-            'string-header': ['string-value'],
-            'array-header': ['1', '2', '3'],
-          },
-          method: 'GET',
-          path: '/',
-        },
-      }).subscribe((value) => {
-        debugResult = JSON.parse(value.payload);
-        done();
-      });
-    });
-
-    test('Should contain preprocessorStep', () => {
-      expect(debugResult.preprocessorStep.headers['array-header']).toEqual(['1', '2', '3']);
-      expect(debugResult.preprocessorStep.headers['string-header']).toEqual(['string-value']);
-    });
-  });
-
-  describe('Get debug event on `GET /` with body', () => {
-    let debugResult;
-
-    beforeEach((done) => {
-      createAndWaitForDebugResult$({
-        ...DebugApiEntityFromJSON(ApiEntityToJSON(apiEntity)),
-        entrypoints: undefined,
-        request: {
-          body: 'The body',
-          headers: {},
-          method: 'GET',
-          path: '/',
-        },
-      }).subscribe((value) => {
-        debugResult = JSON.parse(value.payload);
-        done();
-      });
-    });
-
-    test('Should contain body in the policy-assign-content', () => {
-      // Expect final Response
-      expect(debugResult.debugSteps[5].policyId).toEqual('policy-assign-content');
-      expect(debugResult.debugSteps[5].status).toEqual('COMPLETED');
-      expect(debugResult.debugSteps[5].result.body).toContain('The body');
-    });
-  });
-
-  afterAll(async () => {
-    await teardownApisAndApplications(orgId, envId, [apiEntity.id]);
-  });
-
-  const createAndWaitForDebugResult$ = (debugApiEntity: DebugApiEntity): Observable<EventEntity> => {
-    return from(
-      succeed(
-        apisResource.debugAPIRaw({
-          orgId,
-          envId,
-          api: apiEntity.id,
-          debugApiEntity,
+              ],
+              enabled: true,
+            },
+          ],
         }),
-      ),
-    ).pipe(
-      // Create debug request event
-      switchMap((debugApiResponse) => from(apisResource.getEvent({ orgId, envId, api: apiEntity.id, eventId: debugApiResponse.id }))),
-      // Throw error if debug request is not successful
-      map((value) => {
-        if (value.properties['api_debug_status'] !== 'SUCCESS') {
-          // error will be picked up by retryWhen
-          throw value;
-        }
-        return value;
-      }),
-      // Retry pipe operators if error is thrown
-      retryWhen((errors) =>
-        errors.pipe(
-          // log error message
-          tap((value) => console.info(`Fail to get SUCCESS event`, value)),
-          // restart in 1 seconds
-          delayWhen((value) => timer(1000)),
+      });
+
+      // Create first KeylessPlan
+      await apisResource.createApiPlan({
+        orgId,
+        envId,
+        api: apiEntity.id,
+        newPlanEntity: PlansFaker.newPlan({
+          security: PlanSecurityType.KEYLESS,
+          status: PlanStatus.PUBLISHED,
+        }),
+      });
+
+      // Fetch api description (with keyless plan)
+      apiEntity = await apisResource.getApi({ orgId, envId, api: apiEntity.id });
+    });
+
+    describe('Get debug event on `GET /`', () => {
+      let debugResult;
+
+      beforeEach((done) => {
+        createAndWaitForDebugResult$({
+          ...DebugApiEntityFromJSON(ApiEntityToJSON(apiEntity)),
+          entrypoints: undefined,
+          request: {
+            body: '',
+            headers: {},
+            method: 'GET',
+            path: '/',
+          },
+        }).subscribe((value) => {
+          debugResult = JSON.parse(value.payload);
+          done();
+        });
+      });
+
+      test('Should contain response', () => {
+        // Expect final Response
+        expect(debugResult.response.statusCode).toEqual(200);
+        expect(debugResult.response.body).toContain('Hello');
+        expect(Object.keys(debugResult.response.headers)).toContain('X-Test-Platform-Policy');
+        expect(Object.keys(debugResult.response.headers)).toContain('X-Test-Api-Response-Policy');
+        expect(Object.keys(debugResult.response.headers)).not.toContain('X-Test-Api-Response-Conditioned-Policy');
+      });
+
+      test('Should contain debug steps', () => {
+        expect(debugResult.debugSteps.length).toEqual(13);
+
+        // Step 1 key-less
+        expect(debugResult.debugSteps[0].policyId).toEqual('key-less');
+
+        // Step 4 Request transform-headers
+        expect(debugResult.debugSteps[3].policyId).toEqual('transform-headers');
+        expect(debugResult.debugSteps[3].status).toEqual('COMPLETED');
+        expect(Object.keys(debugResult.debugSteps[3].result.headers)).toContain('X-Test-Api-Request-Policy');
+
+        // Step 5 Request Conditioned transform-headers
+        expect(debugResult.debugSteps[4].policyId).toEqual('transform-headers');
+        expect(debugResult.debugSteps[4].status).toEqual('SKIPPED');
+
+        // Step 6 Request assign-content
+        expect(debugResult.debugSteps[5].policyId).toEqual('policy-assign-content');
+        expect(debugResult.debugSteps[5].status).toEqual('COMPLETED');
+        expect(debugResult.debugSteps[5].scope).toEqual('ON_REQUEST_CONTENT');
+        expect(debugResult.debugSteps[5].result.body).toContain('Validate content change');
+
+        // Step 9 Response Conditioned transform-headers
+        expect(debugResult.debugSteps[8].policyId).toEqual('transform-headers');
+        expect(debugResult.debugSteps[8].status).toEqual('COMPLETED');
+        expect(Object.keys(debugResult.debugSteps[8].result.headers)).toContain('X-Test-Api-Response-Policy');
+
+        // Step 10 Response Conditioned transform-headers
+        expect(debugResult.debugSteps[9].policyId).toEqual('transform-headers');
+        expect(debugResult.debugSteps[9].status).toEqual('SKIPPED');
+
+        // Step 12 Platform Response transform-headers
+        expect(debugResult.debugSteps[11].policyId).toEqual('transform-headers');
+        expect(debugResult.debugSteps[11].status).toEqual('COMPLETED');
+        expect(debugResult.debugSteps[11].stage).toEqual('PLATFORM');
+        expect(Object.keys(debugResult.debugSteps[11].result.headers)).toContain('X-Test-Api-Response-Policy');
+        expect(Object.keys(debugResult.debugSteps[11].result.headers)).toContain('X-Test-Platform-Policy');
+
+        // Step 13 Response json-xml
+        expect(debugResult.debugSteps[12].policyId).toEqual('json-xml');
+        expect(debugResult.debugSteps[12].status).toEqual('COMPLETED');
+        expect(debugResult.debugSteps[12].scope).toEqual('ON_RESPONSE_CONTENT');
+        expect(debugResult.debugSteps[12].result.body).toContain('<root><message>Hello, World!</message></root>');
+      });
+    });
+
+    describe('Get debug event on `GET /?name=TheFox`', () => {
+      let debugResult;
+      let debugEventSubscription: Subscription;
+
+      beforeEach((done) => {
+        debugEventSubscription = createAndWaitForDebugResult$({
+          ...DebugApiEntityFromJSON(ApiEntityToJSON(apiEntity)),
+          entrypoints: undefined,
+          request: {
+            body: '',
+            headers: {},
+            method: 'GET',
+            path: '/?name=TheFox',
+          },
+        }).subscribe((value) => {
+          debugResult = JSON.parse(value.payload);
+          done();
+        });
+      });
+
+      afterEach(() => {
+        debugEventSubscription.unsubscribe();
+      });
+
+      test('Should send query params to backend', () => {
+        expect(debugResult.response.body).toEqual('<root><message>Hello, TheFox!</message></root>');
+      });
+    });
+
+    describe('Get debug event on `GET /` with headers', () => {
+      let debugResult;
+
+      beforeEach((done) => {
+        createAndWaitForDebugResult$({
+          ...DebugApiEntityFromJSON(ApiEntityToJSON(apiEntity)),
+          entrypoints: undefined,
+          request: {
+            body: '',
+            headers: {
+              'string-header': ['string-value'],
+              'array-header': ['1', '2', '3'],
+            },
+            method: 'GET',
+            path: '/',
+          },
+        }).subscribe((value) => {
+          debugResult = JSON.parse(value.payload);
+          done();
+        });
+      });
+
+      test('Should contain preprocessorStep', () => {
+        expect(debugResult.preprocessorStep.headers['array-header']).toEqual(['1', '2', '3']);
+        expect(debugResult.preprocessorStep.headers['string-header']).toEqual(['string-value']);
+      });
+    });
+
+    describe('Get debug event on `GET /` with body', () => {
+      let debugResult;
+
+      beforeEach((done) => {
+        createAndWaitForDebugResult$({
+          ...DebugApiEntityFromJSON(ApiEntityToJSON(apiEntity)),
+          entrypoints: undefined,
+          request: {
+            body: 'The body',
+            headers: {},
+            method: 'GET',
+            path: '/',
+          },
+        }).subscribe((value) => {
+          debugResult = JSON.parse(value.payload);
+          done();
+        });
+      });
+
+      test('Should contain body in the policy-assign-content', () => {
+        // Expect final Response
+        expect(debugResult.debugSteps[5].policyId).toEqual('policy-assign-content');
+        expect(debugResult.debugSteps[5].status).toEqual('COMPLETED');
+        expect(debugResult.debugSteps[5].result.body).toContain('The body');
+      });
+    });
+
+    afterAll(async () => {
+      await teardownApisAndApplications(orgId, envId, [apiEntity.id]);
+    });
+
+    const createAndWaitForDebugResult$ = (debugApiEntity: DebugApiEntity): Observable<EventEntity> => {
+      return from(
+        succeed(
+          apisResource.debugAPIRaw({
+            orgId,
+            envId,
+            api: apiEntity.id,
+            debugApiEntity,
+          }),
         ),
-      ),
-    );
-  };
+      ).pipe(
+        // Create debug request event
+        switchMap((debugApiResponse) => from(apisResource.getEvent({ orgId, envId, api: apiEntity.id, eventId: debugApiResponse.id }))),
+        // Throw error if debug request is not successful
+        map((value) => {
+          if (value.properties['api_debug_status'] !== 'SUCCESS') {
+            // error will be picked up by retryWhen
+            throw value;
+          }
+          return value;
+        }),
+        // Retry pipe operators if error is thrown
+        retryWhen((errors) =>
+          errors.pipe(
+            // log error message
+            tap((value) => console.info(`Fail to get SUCCESS event`, value)),
+            // restart in 1 seconds
+            delayWhen((value) => timer(1000)),
+          ),
+        ),
+      );
+    };
+  });
 });
 
 // Create Transform Headers policy to add header

--- a/gravitee-apim-e2e/docker/common/docker-compose-apis.yml
+++ b/gravitee-apim-e2e/docker/common/docker-compose-apis.yml
@@ -19,7 +19,7 @@ version: '3.8'
 services:
   management_api:
     image: ${APIM_REGISTRY:-graviteeio}/apim-management-api:${APIM_TAG:-3}
-    container_name: gio_apim_management_api
+    container_name: gio_e2_apim_management_api_e2e
     restart: always
     links:
       - database
@@ -54,7 +54,7 @@ services:
 
   gateway:
     image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_TAG:-3}
-    container_name: gio_apim_gateway
+    container_name: gio_apim_gateway_e2e
     restart: always
     links:
       - database

--- a/gravitee-apim-e2e/docker/common/docker-compose-base.yml
+++ b/gravitee-apim-e2e/docker/common/docker-compose-base.yml
@@ -28,7 +28,7 @@ volumes:
 services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.7.0}
-    container_name: gio_apim_elasticsearch
+    container_name: gio_apim_elasticsearch_e2e
     restart: always
     volumes:
       - data-elasticsearch:/usr/share/elasticsearch/data

--- a/gravitee-apim-e2e/docker/common/docker-compose-jdbc.yml
+++ b/gravitee-apim-e2e/docker/common/docker-compose-jdbc.yml
@@ -23,7 +23,7 @@ volumes:
 
 services:
   database:
-    container_name: gio_apim_postgresql
+    container_name: gio_apim_postgresql_e2e
     image: postgres:13
     restart: always
     environment:

--- a/gravitee-apim-e2e/docker/common/docker-compose-mongo.yml
+++ b/gravitee-apim-e2e/docker/common/docker-compose-mongo.yml
@@ -22,7 +22,7 @@ volumes:
 services:
   database:
     image: circleci/mongo:${MONGODB_VERSION:-5}
-    container_name: gio_apim_mongodb
+    container_name: gio_apim_mongodb_e2e
     restart: always
     ports:
       - "30017:27017"

--- a/gravitee-apim-e2e/docker/common/docker-compose-uis.yml
+++ b/gravitee-apim-e2e/docker/common/docker-compose-uis.yml
@@ -20,7 +20,7 @@ services:
 
   nginx:
     image: nginx:latest
-    container_name: nginx
+    container_name: nginx_e2e
     restart: unless-stopped
     depends_on:
       management_ui:
@@ -41,7 +41,7 @@ services:
 
   management_ui:
     image: ${APIM_REGISTRY:-graviteeio}/apim-management-ui:${APIM_TAG:-3}
-    container_name: gio_apim_management_ui
+    container_name: gio_apim_management_ui_e2e
     restart: always
     ports:
       - "8084:8080"
@@ -60,7 +60,7 @@ services:
 
   portal_ui:
     image: ${APIM_REGISTRY:-graviteeio}/apim-portal-ui:${APIM_TAG:-3}
-    container_name: gio_apim_portal_ui
+    container_name: gio_apim_portal_ui_e2e
     restart: always
     ports:
       - "8085:8080"

--- a/gravitee-apim-e2e/docker/common/docker-compose-wiremock.yml
+++ b/gravitee-apim-e2e/docker/common/docker-compose-wiremock.yml
@@ -24,5 +24,3 @@ services:
       - ./api-test/resources/wiremock:/home/wiremock
     ports:
       - "8080:8080"
-    networks:
-      - apim

--- a/gravitee-apim-e2e/lib/gateway.ts
+++ b/gravitee-apim-e2e/lib/gateway.ts
@@ -58,7 +58,7 @@ async function _fetchGatewayWithRetries(attributes: Partial<GatewayRequest>): Pr
     try {
       return await _fetchGateway(request);
     } catch (error) {
-      console.info(error);
+      // console.info(error);
       lastError = error;
       if (retries > 0) {
         console.info(`Retrying in ${request.timeBetweenRetries} ms with ${retries} attempts`);


### PR DESCRIPTION
**Issue**

This test is broken due to a merge. 
Others tests failed due to https://github.com/gravitee-io/issues/issues/8153

**Description**

I removed the apim network from the wiremock container to use it locally. 

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/test-ci-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lvstmthwda.chromatic.com)
<!-- Storybook placeholder end -->
