### PR TITLE
Test/8063 test random loadbalancer run e2e

### DIFF
--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/endpoints/configure-lb-to-random-and-use-it.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/endpoints/configure-lb-to-random-and-use-it.spec.ts
@@ -30,7 +30,7 @@ const orgId = 'DEFAULT';
 const envId = 'DEFAULT';
 const apisResourceAsPublisher = new APIsApi(forManagementAsApiUser());
 
-describe('Configure LB to round robin and use it', () => {
+describe('Configure random LB and use it', () => {
   let createdApi: ApiEntity;
 
   beforeAll(async () => {

--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/endpoints/configure-lb-to-random-and-use-it.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/endpoints/configure-lb-to-random-and-use-it.spec.ts
@@ -13,8 +13,101 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { describe } from '@jest/globals';
+import { APIsApi } from '@management-apis/APIsApi';
+import { forManagementAsApiUser } from '@client-conf/*';
+import { afterAll, beforeAll, describe, expect } from '@jest/globals';
+import { succeed } from '@lib/jest-utils';
+import { ApisFaker } from '@management-fakers/ApisFaker';
+import { ApiEntity } from '@management-models/ApiEntity';
+import { PlansFaker } from '@management-fakers/PlansFaker';
+import { LifecycleAction } from '@management-models/LifecycleAction';
+import { PlanStatus } from '@management-models/PlanStatus';
+import { fetchGatewaySuccess } from '@lib/gateway';
+import { teardownApisAndApplications } from '@lib/management';
+import { LoadBalancerTypeEnum } from '@management-models/LoadBalancer';
 
-describe('Configure LB to random and use it', () => {
-  test.skip('To complete', async () => {});
+const orgId = 'DEFAULT';
+const envId = 'DEFAULT';
+const apisResourceAsPublisher = new APIsApi(forManagementAsApiUser());
+
+describe('Configure LB to round robin and use it', () => {
+  let createdApi: ApiEntity;
+
+  beforeAll(async () => {
+    // create an API with a published free plan and 2 endpoints in one endpoint group (lb: random)
+    createdApi = await succeed(
+      apisResourceAsPublisher.importApiDefinitionRaw({
+        envId,
+        orgId,
+        body: ApisFaker.apiImport({
+          plans: [PlansFaker.plan({ status: PlanStatus.PUBLISHED })],
+          proxy: ApisFaker.proxy({
+            groups: [
+              {
+                name: 'default-group',
+                endpoints: [
+                  {
+                    inherit: true,
+                    name: 'default',
+                    target: `${process.env.WIREMOCK_BASE_URL}/hello?name=endpoint0`,
+                    weight: 1,
+                    backup: false,
+                    type: 'http',
+                  },
+                  {
+                    inherit: true,
+                    name: 'endpoint2',
+                    target: `${process.env.WIREMOCK_BASE_URL}/hello?name=endpoint1`,
+                    weight: 1,
+                    backup: false,
+                    type: 'http',
+                  },
+                ],
+                load_balancing: {
+                  type: LoadBalancerTypeEnum.RANDOM,
+                },
+              },
+            ],
+          }),
+        }),
+      }),
+    );
+
+    // start it
+    await apisResourceAsPublisher.doApiLifecycleAction({
+      envId,
+      orgId,
+      api: createdApi.id,
+      action: LifecycleAction.START,
+    });
+  });
+
+  test('Should switch between two configured endpoints using a random loadbalancer', async () => {
+    expect(true).toBe(true);
+    const contextPath = createdApi.context_path;
+    let results = [];
+    let targets = [];
+
+    for (let i = 0; i < 20; i++) {
+      const response = await fetchGatewaySuccess({ contextPath }).then((res) => res.json());
+      if (response.message.match(/Endpoint0/)) targets.push(0);
+      if (response.message.match(/Endpoint1/)) targets.push(1);
+    }
+
+    // sum up 2 consecutive numbers to check the distribution (verify randomness)
+    // 0: endpoint0 was reached twice in a row
+    // 1: endpoints alternated
+    // 2: endpoint1 was reached twice in a row
+    for (let i = 1; i < targets.length; i++) {
+      results.push(targets[i - 1] + targets[i]);
+    }
+
+    expect(targets.length).toBe(20);
+    expect(results.includes(0) || results.includes(2)).toBe(true);
+    expect(results).toContain(1);
+  });
+
+  afterAll(async () => {
+    await teardownApisAndApplications(orgId, envId, [createdApi.id]);
+  });
 });

--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/endpoints/configure-lb-to-round-robin-weighted-and-use-it.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/endpoints/configure-lb-to-round-robin-weighted-and-use-it.spec.ts
@@ -82,7 +82,7 @@ describe('Configure LB to round robin weighted and use it', () => {
     });
   });
 
-  test('Should switch between three configured endpoints using round-robin', async () => {
+  test('Should switch between two configured endpoints using weighted round-robin', async () => {
     const contextPath = createdApi.context_path;
     let endpoint1 = 0;
     let endpoint2 = 0;


### PR DESCRIPTION
**Description**
- adds a test for random loadbalancer for API endpoints in a endpoint group
- fixes a small typo in a weighted round-robin test
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/test-8063-test-random-loadbalancer-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-yshkpimobe.chromatic.com)
<!-- Storybook placeholder end -->
<!-- E2E Coverage placeholder -->
---
### 🧪 End-to-End Coverage

| INSTRUCTIONS | BRANCHES |
| :----------: | :------: |
|   36% | 21%   |

A more detailed report has been uploaded to [circleci](https://output.circle-artifacts.com/output/job/e1055f20-37aa-41e3-a254-89af2cee102b/artifacts/0/gravitee-apim-e2e/jacoco/reports/index.html)
<!-- E2E Coverage placeholder end -->
