### PR TITLE
fix: fix mongo upgrade scripts calls to replaceOne

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.11.1/1-event-debug-migration.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.11.1/1-event-debug-migration.js
@@ -7,7 +7,7 @@ const events = db.getCollection(`${prefix}events`);
 events.find({type: "DEBUG_API"}).forEach((event) => {
   if(event.properties.api_id) {
     delete event.properties.api_id;
-    events.replaceOne({ _id: event.id }, event);
+    events.replaceOne({ _id: event._id }, event);
   }
 });
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.17.0/api-keys-cleanup.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.17.0/api-keys-cleanup.js
@@ -20,6 +20,6 @@ function unsetUndefined(doc) {
 db.getCollection(`${prefix}keys`).find({}).forEach(doc => {
     const changed = unsetUndefined(doc);
     if (changed) {
-        db.getCollection(`${prefix}keys`).replaceOne(doc);
+        db.getCollection(`${prefix}keys`).replaceOne({ _id: doc._id }, doc);
     }
 });

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.9.0/2-events-migration.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.9.0/2-events-migration.js
@@ -7,6 +7,6 @@ const events = db.getCollection(`${prefix}events`);
 events.find({environments: {$exists: false}}).forEach((event) => {
         event.environments = [event.environmentId];
         delete event.environmentId;
-        events.replaceOne({ _id: event.id }, event);
+        events.replaceOne({ _id: event._id }, event);
     }
 );


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8147
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-fixmongoupgrade/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-szxppbbqku.chromatic.com)
<!-- Storybook placeholder end -->
