### PR TITLE
ci: remove parallelism for "Release on Nexus"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -944,7 +944,7 @@ jobs:
             - run:
                   name: Release on Nexus
                   command: |
-                      mvn clean deploy --activate-profiles gravitee-release --batch-mode -DskipTests -Dskip.validation=true --settings .gravitee.settings.xml -T 2C --update-snapshots
+                      mvn clean deploy --activate-profiles gravitee-release --batch-mode -DskipTests -Dskip.validation=true --settings .gravitee.settings.xml --update-snapshots
             - save-maven-job-cache:
                   jobName: nexus-staging
 


### PR DESCRIPTION
**Issue**

**Description**
Try to fix this erreur : https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/9815/workflows/d9124215-11b6-4345-ab66-55adc9d85e0a

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/3-10-x-ci-fix-nexus-release/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
