### PR TITLE
Add some Slack notifications during the release process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -886,6 +886,26 @@ jobs:
                       else
                         echo "# --->>> THIS IS A DRY RUN"
                       fi;
+            - when:
+                  condition:
+                      not: << pipeline.parameters.dry_run>>
+                  steps:
+                      - slack/notify:
+                            channel: C02JENTV2AX
+                            event: pass
+                            custom: |
+                                {
+                                  "blocks": [
+                                    {
+                                      "type": "section",
+                                      "text": {
+                                        "type": "mrkdwn",
+                                        "text": "✅ APIM repository has been tagged.\nYou can continue the release by running: `npm run package_zip -- --version=<< pipeline.parameters.graviteeio_version >>`"
+                                      }
+                                    }
+                                  ]
+                                }
+            - notify-on-failure
 
     publish_prod_docker_images:
         parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -771,6 +771,28 @@ jobs:
             DRY_RUN: << pipeline.parameters.dry_run >>
         steps:
             - checkout
+            - keeper/env-export:
+                secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+                var-name: SLACK_ACCESS_TOKEN
+            - when:
+                  condition:
+                      not: << pipeline.parameters.dry_run>>
+                  steps:
+                      - slack/notify:
+                            channel: C02JENTV2AX
+                            event: always
+                            custom: |
+                                {
+                                  "blocks": [
+                                    {
+                                      "type": "section",
+                                      "text": {
+                                        "type": "mrkdwn",
+                                        "text": "🚀 Starting << pipeline.parameters.graviteeio_version >> release"
+                                      }
+                                    }
+                                  ]
+                                }
             - restore-maven-job-cache:
                   jobName: release
             - attach_workspace:
@@ -984,6 +1006,28 @@ jobs:
                       mvn clean deploy --activate-profiles gravitee-release --batch-mode -DskipTests -Dskip.validation=true --settings .gravitee.settings.xml --update-snapshots
             - save-maven-job-cache:
                   jobName: nexus-staging
+            - keeper/env-export:
+                secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+                var-name: SLACK_ACCESS_TOKEN
+            - when:
+                  condition:
+                      not: << pipeline.parameters.dry_run>>
+                  steps:
+                      - slack/notify:
+                            channel: C02JENTV2AX
+                            event: always
+                            custom: |
+                                {
+                                  "blocks": [
+                                    {
+                                      "type": "section",
+                                      "text": {
+                                        "type": "mrkdwn",
+                                        "text": "🎆 APIM - << pipeline.parameters.graviteeio_version >> released!"
+                                      }
+                                    }
+                                  ]
+                                }
 
     publish_rpm_packages:
         parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,11 @@ commands:
 
     notify-on-failure:
         steps:
+            - keeper/env-export:
+                  secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+                  var-name: SLACK_ACCESS_TOKEN
             - slack/notify:
+                  channel: C02JENTV2AX
                   branch_pattern: master,[0-9]+\.[0-9]+\.x
                   event: fail
                   template: basic_fail_1
@@ -1148,14 +1152,15 @@ workflows:
             - setup:
                   context: cicd-orchestrator
             - validate:
-                  context: gravitee-qa
+                  context: cicd-orchestrator
                   requires:
                       - setup
             - build:
-                  context: gravitee-qa
+                  context: cicd-orchestrator
                   requires:
                       - validate
             - test:
+                  context: cicd-orchestrator
                   requires:
                       - build
             - sonarcloud-analysis:
@@ -1170,6 +1175,7 @@ workflows:
                   requires:
                       - test
             - test-repository:
+                  context: cicd-orchestrator
                   requires:
                       - build
             - sonarcloud-analysis:
@@ -1179,6 +1185,7 @@ workflows:
                   requires:
                       - test-repository
             - publish-on-artifactory:
+                  context: cicd-orchestrator
                   filters:
                       branches:
                           only:
@@ -1188,6 +1195,7 @@ workflows:
                       - test
                       - test-repository
             - publish-on-nexus:
+                  context: cicd-orchestrator
                   filters:
                       branches:
                           only:
@@ -1223,10 +1231,12 @@ workflows:
             - webui-install:
                   name: Install APIM Console
                   apim-ui-project: gravitee-apim-console-webui
+                  context: cicd-orchestrator
                   requires:
                       - setup
             - webui-lint-test:
                   name: Lint & test APIM Console
+                  context: cicd-orchestrator
                   apim-ui-project: gravitee-apim-console-webui
                   requires:
                       - Install APIM Console
@@ -1241,6 +1251,7 @@ workflows:
                       - Lint & test APIM Console
             - webui-build:
                   name: Build APIM Console
+                  context: cicd-orchestrator
                   apim-ui-project: gravitee-apim-console-webui
                   requires:
                       - Install APIM Console
@@ -1267,11 +1278,13 @@ workflows:
                               - /^\d+\.\d+\.x$/
             - webui-install:
                   name: Install APIM Portal
+                  context: cicd-orchestrator
                   apim-ui-project: gravitee-apim-portal-webui
                   requires:
                       - setup
             - webui-lint-test:
                   name: Lint & test APIM Portal
+                  context: cicd-orchestrator
                   apim-ui-project: gravitee-apim-portal-webui
                   resource-class: large
                   requires:
@@ -1287,6 +1300,7 @@ workflows:
                       - Lint & test APIM Portal
             - webui-build:
                   name: Build APIM Portal
+                  context: cicd-orchestrator
                   apim-ui-project: gravitee-apim-portal-webui
                   requires:
                       - Install APIM Portal

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -772,8 +772,8 @@ jobs:
         steps:
             - checkout
             - keeper/env-export:
-                secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
-                var-name: SLACK_ACCESS_TOKEN
+                  secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+                  var-name: SLACK_ACCESS_TOKEN
             - when:
                   condition:
                       not: << pipeline.parameters.dry_run>>
@@ -1007,8 +1007,8 @@ jobs:
             - save-maven-job-cache:
                   jobName: nexus-staging
             - keeper/env-export:
-                secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
-                var-name: SLACK_ACCESS_TOKEN
+                  secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+                  var-name: SLACK_ACCESS_TOKEN
             - when:
                   condition:
                       not: << pipeline.parameters.dry_run>>

--- a/release/README.adoc
+++ b/release/README.adoc
@@ -47,8 +47,6 @@ Here are the steps to run to fully release APIM (Releasing 3.15.11, in the follo
 
 1. `npm run release -- --version=3.15.11`
 2. `npm run package_zip -- --version=3.15.11`:
- - ⚠️ ☣️  As the release process is under stabilization, it is needed to manually update the `gravitee-api-management` version, commit and create a tag on the `release` repo. Otherwise the package bundle step will fail. This will not be needed anymore as soon as the magic python script replaced by the use of the maven distribution pom.
- - The pipeline needs versions of EE packages as parameters. There are read from link:../gravitee-apim-distribution/pom.xml[gravitee-apim-distribution/pom.xml]
 3. `npm run docker_rpms -- --version=3.15.11`: You can also provide the `--latest` parameter to flag the image as `latest`.
 4. `npm run changelog -- --version=3.15.11`
 5. `npm run nexus_sync -- --version=3.15.11`


### PR DESCRIPTION
**Issue**

NA

**Description**

- announce the beginning and the end of a release on Slack automatically
- send Slack notification when the first release step is ok
- add missing slack configuration on notify-on-failure command

NB: All slack notifications are currently sent on `api-management_team_notifications` channel, we will move some of them to the public channel as soon as we will be confident enough ;)

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/add-release-announcement/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
