### PR TITLE
test: added test for weighted random lb

### DIFF
--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/endpoints/configure-lb-to-random-weighted-and-use-it.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/endpoints/configure-lb-to-random-weighted-and-use-it.spec.ts
@@ -13,8 +13,107 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { describe } from '@jest/globals';
 
-describe('Configure LB to random weighted and use it ', () => {
-  test.skip('To complete', async () => {});
+import { APIsApi } from '@management-apis/APIsApi';
+import { forManagementAsApiUser } from '@client-conf/*';
+import { afterAll, beforeAll, describe, expect } from '@jest/globals';
+import { succeed } from '@lib/jest-utils';
+import { ApisFaker } from '@management-fakers/ApisFaker';
+import { ApiEntity } from '@management-models/ApiEntity';
+import { PlansFaker } from '@management-fakers/PlansFaker';
+import { LifecycleAction } from '@management-models/LifecycleAction';
+import { PlanStatus } from '@management-models/PlanStatus';
+import { fetchGatewaySuccess } from '@lib/gateway';
+import { teardownApisAndApplications } from '@lib/management';
+import { LoadBalancerTypeEnum } from '@management-models/LoadBalancer';
+
+const orgId = 'DEFAULT';
+const envId = 'DEFAULT';
+const apisResourceAsPublisher = new APIsApi(forManagementAsApiUser());
+
+describe('Configure LB to round robin and use it', () => {
+  let createdApi: ApiEntity;
+
+  beforeAll(async () => {
+    // create an API with a published free plan and 2 endpoints in one endpoint group (lb: random)
+    createdApi = await succeed(
+      apisResourceAsPublisher.importApiDefinitionRaw({
+        envId,
+        orgId,
+        body: ApisFaker.apiImport({
+          plans: [PlansFaker.plan({ status: PlanStatus.PUBLISHED })],
+          proxy: ApisFaker.proxy({
+            groups: [
+              {
+                name: 'default-group',
+                endpoints: [
+                  {
+                    inherit: true,
+                    name: 'default',
+                    target: `${process.env.WIREMOCK_BASE_URL}/hello?name=endpoint0`,
+                    weight: 1,
+                    backup: false,
+                    type: 'http',
+                  },
+                  {
+                    inherit: true,
+                    name: 'endpoint2',
+                    target: `${process.env.WIREMOCK_BASE_URL}/hello?name=endpoint1`,
+                    weight: 2,
+                    backup: false,
+                    type: 'http',
+                  },
+                ],
+                load_balancing: {
+                  type: LoadBalancerTypeEnum.WEIGHTEDRANDOM,
+                },
+              },
+            ],
+          }),
+        }),
+      }),
+    );
+
+    // start it
+    await apisResourceAsPublisher.doApiLifecycleAction({
+      envId,
+      orgId,
+      api: createdApi.id,
+      action: LifecycleAction.START,
+    });
+  });
+
+  test('Should switch between two configured endpoints using a random loadbalancer', async () => {
+    expect(true).toBe(true);
+    const contextPath = createdApi.context_path;
+    const numberOfSendRequests = 30; // amount of request to be sent
+    let endpointHits: number[] = []; // array containing information about which endpoint was hit
+    let results: number[] = []; // array containing the sums of two consecutive numbers (target
+    let endpointCounter: number[] = [0, 0]; // array counting hits of each endpoint
+
+    for (let i = 0; i < numberOfSendRequests; i++) {
+      const response = await fetchGatewaySuccess({ contextPath }).then((res) => res.json());
+      let match = response.message.match(/Endpoint(\d)/);
+      endpointHits.push(match[1]);
+      endpointCounter[match[1]]++;
+    }
+
+    // sum up 2 consecutive numbers to check the distribution (verify randomness)
+    // 0: endpoint0 was reached twice in a row
+    // 1: endpoints alternated
+    // 2: endpoint1 was reached twice in a row
+    for (let i = 1; i < endpointHits.length; i++) {
+      results.push(+endpointHits[i - 1] + +endpointHits[i]);
+    }
+
+    expect(endpointCounter[0]).toBe(numberOfSendRequests / 3);
+    expect(endpointCounter[1]).toBe((numberOfSendRequests * 2) / 3);
+    expect(endpointHits.length).toBe(numberOfSendRequests);
+    expect(results.includes(0) || results.includes(2)).toBe(true);
+    expect(results).toContain(1);
+  });
+
+  afterAll(async () => {
+    await teardownApisAndApplications(orgId, envId, [createdApi.id]);
+  });
 });


### PR DESCRIPTION
**Description**
- added test for weighted random load balancer
- it checks, among others, that the target endpoints are reached in a ratio that corresponds to the configured weight


gravitee-io/issues#8077
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/test-8077-test-weighted-random-loadbalancer-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gnfewnfgmm.chromatic.com)
<!-- Storybook placeholder end -->
<!-- E2E Coverage placeholder -->
---
### 🧪 End-to-End Coverage

| INSTRUCTIONS | BRANCHES |
| :----------: | :------: |
|   36% | 21%   |

A more detailed report has been uploaded to [circleci](https://output.circle-artifacts.com/output/job/9b5d0a4a-7d08-4ab2-836a-483cf5abdf08/artifacts/0/gravitee-apim-e2e/jacoco/reports/index.html)
<!-- E2E Coverage placeholder end -->
