### PR TITLE
Do not escape inputs on frontend side

### DIFF
--- a/gravitee-apim-console-webui/src/user/registration/registration.controller.ts
+++ b/gravitee-apim-console-webui/src/user/registration/registration.controller.ts
@@ -45,14 +45,7 @@ class RegistrationController {
     const notificationService = this.NotificationService;
 
     this.ReCaptchaService.execute('register')
-      .then(() => {
-        const userToRegister = {
-          ...this.user,
-          firstname: escape(this.user.firstname),
-          lastname: escape(this.user.lastname),
-        };
-        return this.UserService.register(userToRegister);
-      })
+      .then(() => this.UserService.register(this.user))
       .then(
         () => {
           scope.formRegistration.$setPristine();


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8163

**Description**

The input values are already escaped on the backend side so escaping them twice is transforming them too much.
