### PR TITLE
refactor(jupiter): improve request/response body cache

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/adapter/invoker/InvokerAdapter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/adapter/invoker/InvokerAdapter.java
@@ -88,6 +88,7 @@ public class InvokerAdapter implements Invoker, io.gravitee.gateway.api.Invoker 
             .doFinally(adaptedCtx::restore)
             .onErrorResumeNext(
                 throwable -> {
+                    log.error("An error occurred when invoking the backend.", throwable);
                     // In case of any error, make sure to reset the response content.
                     ctx.response().chunks(Flowable.empty());
                     return ctx.interruptWith(new ExecutionFailure(HttpStatusCode.BAD_GATEWAY_502));

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpHeaders.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpHeaders.java
@@ -138,7 +138,8 @@ public class VertxHttpHeaders implements HttpHeaders, MultiValueMap<String, Stri
      */
     @Override
     public List<String> get(Object key) {
-        return headers.getAll(String.valueOf(key));
+        String keyAsString = String.valueOf(key);
+        return contains(keyAsString) ? getAll(keyAsString) : null;
     }
 
     /**

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/jupiter/http/vertx/VertxHttpServerResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/jupiter/http/vertx/VertxHttpServerResponse.java
@@ -120,7 +120,7 @@ public class VertxHttpServerResponse extends AbstractHttpChunks implements Mutab
 
                 if (chunks != null) {
                     return nativeResponse.rxSend(
-                        chunks
+                        chunks()
                             .map(buffer -> io.vertx.reactivex.core.buffer.Buffer.buffer(buffer.getNativeBuffer()))
                             .doOnNext(
                                 buffer ->

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/http/vertx/VertxHttpHeadersTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/http/vertx/VertxHttpHeadersTest.java
@@ -119,8 +119,8 @@ public class VertxHttpHeadersTest {
     @Test
     public void shouldGet() {
         Object key = new Object();
-        assertThat(cut.get(key)).isEmpty();
-        assertThat(defaultHttpHeaders.get(key)).isEmpty();
+        assertThat(cut.get(key)).isNull();
+        assertThat(defaultHttpHeaders.get(key)).isNull();
 
         key = FIRST_HEADER;
         assertThat(cut.get(key)).hasSize(2);
@@ -131,8 +131,8 @@ public class VertxHttpHeadersTest {
         assertThat(defaultHttpHeaders.get(key)).hasSize(1);
 
         key = ACCEPT_LANGUAGE;
-        assertThat(cut.get(key)).isEmpty();
-        assertThat(defaultHttpHeaders.get(key)).isEmpty();
+        assertThat(cut.get(key)).isNull();
+        assertThat(defaultHttpHeaders.get(key)).isNull();
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -10,7 +10,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0
-  version: "3.18.2-SNAPSHOT"
+  version: "3.19.0-SNAPSHOT"
 servers:
   - url: http://localhost:8083/portal/environments/{envId}
     description: The portal API for a given environment

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <gravitee-connector-api.version>1.1.0</gravitee-connector-api.version>
         <gravitee-expression-language.version>1.10.1</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>1.37.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.37.2</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>1.24.2</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>


### PR DESCRIPTION
**Issue**

gravitee-io/issues#8030

**Description**

Optimizations have been made to avoid use of rx `.cache()` operator and manage caching by ourselves.
Use of .cache() operator was necessary to avoid consuming request or response body multiple time or applying body transformation several times and cause unexpected behavior.

Multiple unit tests have been added to test the different scenario where the body need to be manipulated several time during the request processing. 

Body can be consumed multiple times when:

- using an EL expression base on body request/response on a flow or policy condition
- using the debug mode
- using the logging feature and enable body logging for request and response


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8030-optimize-body-cache/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dnqczdkltg.chromatic.com)
<!-- Storybook placeholder end -->
