### PR TITLE
Return null instead of empty list when getting an undefined header

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -46,7 +46,7 @@
     <properties>
         <!-- Versions of the plugins for the full distribution -->
         <!-- Management API & Gateway -->
-        <gravitee-connector-http.version>1.1.9</gravitee-connector-http.version>
+        <gravitee-connector-http.version>1.1.10</gravitee-connector-http.version>
         <gravitee-policy-apikey.version>2.4.0</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>1.5.0</gravitee-policy-assign-attributes.version>
         <gravitee-policy-assign-content.version>1.7.0</gravitee-policy-assign-content.version>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpHeaders.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpHeaders.java
@@ -138,7 +138,8 @@ public class VertxHttpHeaders implements HttpHeaders, MultiValueMap<String, Stri
      */
     @Override
     public List<String> get(Object key) {
-        return headers.getAll(String.valueOf(key));
+        String keyAsString = String.valueOf(key);
+        return contains(keyAsString) ? getAll(keyAsString) : null;
     }
 
     /**

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/http/vertx/VertxHttpHeadersTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/http/vertx/VertxHttpHeadersTest.java
@@ -119,8 +119,8 @@ public class VertxHttpHeadersTest {
     @Test
     public void shouldGet() {
         Object key = new Object();
-        assertThat(cut.get(key)).isEmpty();
-        assertThat(defaultHttpHeaders.get(key)).isEmpty();
+        assertThat(cut.get(key)).isNull();
+        assertThat(defaultHttpHeaders.get(key)).isNull();
 
         key = FIRST_HEADER;
         assertThat(cut.get(key)).hasSize(2);
@@ -131,8 +131,8 @@ public class VertxHttpHeadersTest {
         assertThat(defaultHttpHeaders.get(key)).hasSize(1);
 
         key = ACCEPT_LANGUAGE;
-        assertThat(cut.get(key)).isEmpty();
-        assertThat(defaultHttpHeaders.get(key)).isEmpty();
+        assertThat(cut.get(key)).isNull();
+        assertThat(defaultHttpHeaders.get(key)).isNull();
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <jetty94.wiremock.version>9.4.44.v20210927</jetty94.wiremock.version>
-        <gravitee-connector-http.version>1.1.9</gravitee-connector-http.version>
+        <gravitee-connector-http.version>1.1.10</gravitee-connector-http.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -67,10 +67,10 @@
         <gravitee-alert-api.version>1.9.0</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>1.10.0</gravitee-cockpit-api.version>
         <gravitee-common.version>1.25.0</gravitee-common.version>
-        <gravitee-connector-api.version>1.1.0</gravitee-connector-api.version>
+        <gravitee-connector-api.version>1.1.2</gravitee-connector-api.version>
         <gravitee-expression-language.version>1.9.3</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>1.32.3</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.32.4</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>1.20.4</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7812
https://github.com/gravitee-io/issues/issues/8153

Matching implementation done in https://github.com/gravitee-io/gravitee-gateway-api/pull/125

**Description**

Return null instead of an empty list when getting an undefined header.
Returning an empty list is causing the following EL to be evaluated to `true`:
`{#request.headers['X-Gravitee-No-Present'] != null}`
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7812-bump-gravitee-api/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qaflmbxjay.chromatic.com)
<!-- Storybook placeholder end -->
