### PR TITLE
E2E: Improve README and add script to simply run wiremock 

### DIFF
--- a/gravitee-apim-e2e/.env
+++ b/gravitee-apim-e2e/.env
@@ -2,7 +2,7 @@
 MANAGEMENT_BASE_URL=http://localhost:8083/management
 PORTAL_BASE_URL=http://localhost:8083/portal/environments
 GATEWAY_BASE_URL=http://localhost:8082
-WIREMOCK_BASE_URL=http://localhost:8080
+WIREMOCK_BASE_URL=http://localhost:8080 # If the gateway is run in docker change the variable to `WIREMOCK_BASE_URL=http://wiremock:8080`
 
 # usernames and passwords
 ADMIN_USERNAME=admin

--- a/gravitee-apim-e2e/README.md
+++ b/gravitee-apim-e2e/README.md
@@ -20,7 +20,9 @@ Then, the following NPM scripts are available:
  - `npm run test:api:mongo`: Run the APIM stack with mongo and the jest API tests in docker ([more details](./docker/api-tests/README.md))
  - `npm run test:api:jdbc`: Run the APIM stack with jdbc and the jest API tests in docker ([more details](./docker/api-tests/README.md))
  - `npm run test:api:dev`: Run the jest API tests against a locally running APIM
- - `npm run apim:serve`: Run the APIM stack in docker with last apim release by default in order to run tests locally from your IDE.  
+ - `npm run apim:serve`: Run the APIM stack in docker with last apim release by default in order to run tests locally from your IDE.
+    > We have to adapt wiremock according to the gateway location. With this command the gateway is executed in docker, so we have to change the variable to `WIREMOCK_BASE_URL=http://wiremock:8080` in .env
+ - `npm run apim:serve -- wiremock`: To run only wiremock on docker  
    To run with latest master use this env-var `APIM_REGISTRY=graviteeio.azurecr.io APIM_TAG=master-latest npm run apim:serve`
  - `npm run apim:clean`: Stop and remove the containers & volumes.
  - `npm run bulk`: Run jest bulk scripts to create data to local environment

--- a/gravitee-apim-e2e/scripts/run-docker-compose.sh
+++ b/gravitee-apim-e2e/scripts/run-docker-compose.sh
@@ -37,7 +37,7 @@ if [ -n "$1" ] && [ -n "$2" ]; then
   fi
 
   if [ "$mode" = "only-apim" ]; then
-    DB_PROVIDER=$databaseType docker-compose -f ./docker/common/docker-compose-base.yml -f ./docker/common/docker-compose-$databaseType.yml -f ./docker/common/docker-compose-apis.yml -f ./docker/common/docker-compose-wiremock.yml -f ./docker/common/docker-compose-uis.yml --project-directory $PWD up
+    DB_PROVIDER=$databaseType docker-compose -f ./docker/common/docker-compose-base.yml -f ./docker/common/docker-compose-$databaseType.yml -f ./docker/common/docker-compose-apis.yml -f ./docker/common/docker-compose-wiremock.yml -f ./docker/common/docker-compose-uis.yml --project-directory $PWD up $3
   elif [ "$mode" = "api-test" ]; then
     DB_PROVIDER=$databaseType docker-compose -f ./docker/common/docker-compose-base.yml -f ./docker/common/docker-compose-$databaseType.yml -f ./docker/common/docker-compose-apis.yml -f ./docker/common/docker-compose-wiremock.yml -f ./docker/api-tests/docker-compose-api-tests.yml --project-directory $PWD up --abort-on-container-exit --exit-code-from jest-e2e
   elif [ "$mode" = "ui-test" ]; then


### PR DESCRIPTION
**Issue**
na
**Description**
See code 

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- E2E Coverage placeholder -->
---
### 🧪 End-to-End Coverage

| INSTRUCTIONS | BRANCHES |
| :----------: | :------: |
|   36% | 21%   |

A more detailed report has been uploaded to [circleci](https://output.circle-artifacts.com/output/job/88cb16f2-314a-466f-bbcb-1c61d433fb05/artifacts/0/gravitee-apim-e2e/jacoco/reports/index.html)
<!-- E2E Coverage placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xblcrguoid.chromatic.com)
<!-- Storybook placeholder end -->
