### PR TITLE
fix: use a correct api definition and fix the test accordingly

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_UpdateTest.java
@@ -87,6 +87,8 @@ public class ApiService_UpdateTest {
     private static final String USER_NAME = "myUser";
     public static final String API_DEFINITION =
         "{\n" +
+        "  \"id\" : \"id-api\",\n" +
+        "  \"name\" : \"myAPI\",\n" +
         "  \"description\" : \"Gravitee.io\",\n" +
         "  \"paths\" : { },\n" +
         "  \"path_mappings\":[],\n" +
@@ -904,6 +906,16 @@ public class ApiService_UpdateTest {
         final Workflow workflow = new Workflow();
         workflow.setState(WorkflowState.REQUEST_FOR_CHANGES.name());
         when(workflowService.create(any(), any(), any(), any(), any(), any())).thenReturn(workflow);
+
+        when(
+            parameterService.find(
+                GraviteeContext.getExecutionContext(),
+                Key.PORTAL_ENTRYPOINT,
+                GraviteeContext.getExecutionContext().getEnvironmentId(),
+                ParameterReferenceType.ENVIRONMENT
+            )
+        )
+            .thenReturn(Key.PORTAL_ENTRYPOINT.defaultValue());
     }
 
     @Test


### PR DESCRIPTION
**Issue**

N/A

**Description**

A unit test was wrongly "green". An error in the code lead the test to be good.
Example of stacktrace:
```
12:01:33.415 [main] ERROR i.g.r.a.s.converter.ApiConverter - Unexpected error while generating API definition
com.fasterxml.jackson.databind.JsonMappingException: ID property is required
 at [Source: (String)"{
  "description" : "Gravitee.io",
  "paths" : { },
  ...
```

After adding ID and Name in the API definition, the test was failing due to a missing mock for the parameter service.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-shouldtracereviewasked-unit-test/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pvsgbnwhmt.chromatic.com)
<!-- Storybook placeholder end -->
