### PR TITLE
ci: add master gateway full v3 (jupiter disabled)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -948,6 +948,7 @@ jobs:
                       kubectl rollout restart deployment/${K8S_NAME}-apim3-portal -n ${K8S_NAMESPACE}
                       kubectl rollout restart deployment/${K8S_NAME}-apim3-ui -n ${K8S_NAMESPACE}
                       kubectl rollout restart deployment/${K8S_NAME}-apim3-gateway -n ${K8S_NAMESPACE}
+                      kubectl rollout restart deployment/${K8S_NAME}-v3-apim3-gateway -n ${K8S_NAMESPACE}
 
                       kubectl rollout restart deployment/${K8S_NAME}-jdbc-apim3-api -n ${K8S_NAMESPACE}-jdbc
                       kubectl rollout restart deployment/${K8S_NAME}-jdbc-apim3-portal -n ${K8S_NAMESPACE}-jdbc


### PR DESCRIPTION
Add a configuration to deploy a second gateway with jupiter disabled so execution of apis will be fully in v3 whatever the configured execution mode at api level.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/add-master-full-v3-gateway/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-eqrfsahsdb.chromatic.com)
<!-- Storybook placeholder end -->
