### PR TITLE
fix: add planId in subscription cache key

### DIFF
--- a/gravitee-apim-e2e/api-test/use-case-test/src/portal/consumer/subscribe-to-APIs/subscribe-to-plan-keyless-apikey-jwt-oauth-and-used-it.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/portal/consumer/subscribe-to-APIs/subscribe-to-plan-keyless-apikey-jwt-oauth-and-used-it.spec.ts
@@ -153,7 +153,7 @@ describe('Subscribe to API Key & JWT plans and use them', () => {
     });
   });
 
-  describeIfV3('Gateway call with JWT token in HTTP header', () => {
+  describe('Gateway call with JWT token in HTTP header', () => {
     describe('Gateway call with correct `Authorization` header using portal subscription', () => {
       test('Should return 200 OK', async () => {
         const token = jwt.sign({ foo: 'bar', client_id: createdPortalApplication.settings.app.client_id }, JWT_SECURE_GIVEN_KEY, {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionService.java
@@ -38,8 +38,8 @@ public class SubscriptionService implements io.gravitee.gateway.api.service.Subs
     }
 
     @Override
-    public Optional<Subscription> getByApiAndClientId(String api, String clientId) {
-        return Optional.ofNullable(cacheByApiClientId.get(buildClientIdCacheKey(api, clientId)));
+    public Optional<Subscription> getByApiAndClientIdAndPlan(String api, String clientId, String plan) {
+        return Optional.ofNullable(cacheByApiClientId.get(buildClientIdCacheKey(api, clientId, plan)));
     }
 
     @Override
@@ -68,7 +68,11 @@ public class SubscriptionService implements io.gravitee.gateway.api.service.Subs
         String key = buildClientIdCacheKey(subscription);
 
         // remove subscription from cache if its client_id changed
-        if (cachedSubscription != null && !cachedSubscription.getClientId().equals(subscription.getClientId())) {
+        if (
+            cachedSubscription != null &&
+            cachedSubscription.getClientId() != null &&
+            !cachedSubscription.getClientId().equals(subscription.getClientId())
+        ) {
             cacheByApiClientId.evict(buildClientIdCacheKey(cachedSubscription));
         }
 
@@ -81,10 +85,10 @@ public class SubscriptionService implements io.gravitee.gateway.api.service.Subs
     }
 
     private String buildClientIdCacheKey(Subscription subscription) {
-        return buildClientIdCacheKey(subscription.getApi(), subscription.getClientId());
+        return buildClientIdCacheKey(subscription.getApi(), subscription.getClientId(), subscription.getPlan());
     }
 
-    private String buildClientIdCacheKey(String api, String clientId) {
-        return String.format("%s.%s", api, clientId);
+    private String buildClientIdCacheKey(String api, String clientId, String plan) {
+        return String.format("%s.%s.%s", api, clientId, plan);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/security/plan/SecurityPlan.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/security/plan/SecurityPlan.java
@@ -141,7 +141,7 @@ public class SecurityPlan {
                     if (subscriptionId != null) {
                         subscriptionOpt = subscriptionService.getById(subscriptionId);
                     } else if (api != null && clientId != null) {
-                        subscriptionOpt = subscriptionService.getByApiAndClientId(api, clientId);
+                        subscriptionOpt = subscriptionService.getByApiAndClientIdAndPlan(api, clientId, plan.getId());
                     }
 
                     if (subscriptionOpt.isPresent()) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/service/SubscriptionServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/service/SubscriptionServiceTest.java
@@ -28,7 +28,7 @@ public class SubscriptionServiceTest {
 
     @Test
     public void should_add_and_getById_accepted_subscription_in_cache() {
-        Subscription subscription = buildAcceptedSubscription("sub1", "my-api", "my-client-id");
+        Subscription subscription = buildAcceptedSubscription("sub1", "my-api", "my-client-id", "plan-id");
 
         subscriptionService.save(subscription);
 
@@ -43,22 +43,22 @@ public class SubscriptionServiceTest {
 
     @Test
     public void should_add_and_getByApiAndClientId_accepted_subscription_in_cache() {
-        Subscription subscription = buildAcceptedSubscription("sub1", "my-api", "my-client-id");
+        Subscription subscription = buildAcceptedSubscription("sub1", "my-api", "my-client-id", "plan-id");
 
         subscriptionService.save(subscription);
 
         // should find subscription in cache with relevant id
-        assertTrue(subscriptionService.getByApiAndClientId("my-api", "my-client-id").isPresent());
-        assertSame(subscription, subscriptionService.getByApiAndClientId("my-api", "my-client-id").get());
+        assertTrue(subscriptionService.getByApiAndClientIdAndPlan("my-api", "my-client-id", "plan-id").isPresent());
+        assertSame(subscription, subscriptionService.getByApiAndClientIdAndPlan("my-api", "my-client-id", "plan-id").get());
 
         // should not find with other keys
-        assertFalse(subscriptionService.getByApiAndClientId("another-api", "my-client-id").isPresent());
-        assertFalse(subscriptionService.getByApiAndClientId("my-api", "another-client-id").isPresent());
+        assertFalse(subscriptionService.getByApiAndClientIdAndPlan("another-api", "my-client-id", "plan-id").isPresent());
+        assertFalse(subscriptionService.getByApiAndClientIdAndPlan("my-api", "another-client-id", "plan-id").isPresent());
     }
 
     @Test
     public void should_remove_rejected_subscription_from_cache() {
-        Subscription subscription = buildAcceptedSubscription("sub1", "my-api", "my-client-id");
+        Subscription subscription = buildAcceptedSubscription("sub1", "my-api", "my-client-id", "plan-id");
 
         subscriptionService.save(subscription);
 
@@ -72,26 +72,27 @@ public class SubscriptionServiceTest {
 
     @Test
     public void should_update_subscription_clientId_in_cache() {
-        Subscription oldSubscription = buildAcceptedSubscription("sub1", "my-api", "old-client-id");
+        Subscription oldSubscription = buildAcceptedSubscription("sub1", "my-api", "old-client-id", "plan-id");
 
         subscriptionService.save(oldSubscription);
 
-        Subscription newSubscription = buildAcceptedSubscription("sub1", "my-api", "new-client-id");
+        Subscription newSubscription = buildAcceptedSubscription("sub1", "my-api", "new-client-id", "plan-id");
 
         subscriptionService.save(newSubscription);
 
         // should find subscription in cache with its new client id
-        assertTrue(subscriptionService.getByApiAndClientId("my-api", "new-client-id").isPresent());
-        assertSame(newSubscription, subscriptionService.getByApiAndClientId("my-api", "new-client-id").get());
+        assertTrue(subscriptionService.getByApiAndClientIdAndPlan("my-api", "new-client-id", "plan-id").isPresent());
+        assertSame(newSubscription, subscriptionService.getByApiAndClientIdAndPlan("my-api", "new-client-id", "plan-id").get());
 
         // should not find it with its old client id
-        assertFalse(subscriptionService.getByApiAndClientId("my-api", "old-client-id").isPresent());
+        assertFalse(subscriptionService.getByApiAndClientIdAndPlan("my-api", "old-client-id", "plan-id").isPresent());
     }
 
-    private Subscription buildAcceptedSubscription(String id, String api, String clientId) {
+    private Subscription buildAcceptedSubscription(String id, String api, String clientId, String plan) {
         Subscription subscription = new Subscription();
         subscription.setId(id);
         subscription.setApi(api);
+        subscription.setPlan(plan);
         subscription.setClientId(clientId);
         subscription.setStatus("ACCEPTED");
         return subscription;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/security/plan/SecurityPlanTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/security/plan/SecurityPlanTest.java
@@ -167,7 +167,7 @@ class SecurityPlanTest {
         when(ctx.getAttribute(ExecutionContext.ATTR_API)).thenReturn(API_ID);
         when(ctx.getAttribute(SecurityPlan.CONTEXT_ATTRIBUTE_CLIENT_ID)).thenReturn(CLIENT_ID);
         when(ctx.getComponent(SubscriptionService.class)).thenReturn(subscriptionService);
-        when(subscriptionService.getByApiAndClientId(API_ID, CLIENT_ID)).thenReturn(Optional.of(subscription));
+        when(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).thenReturn(Optional.of(subscription));
 
         final SecurityPlan cut = new SecurityPlan(plan, policy);
         final TestObserver<Void> obs = cut.execute(ctx).test();
@@ -213,7 +213,7 @@ class SecurityPlanTest {
         when(ctx.getAttribute(ExecutionContext.ATTR_API)).thenReturn(API_ID);
         when(ctx.getAttribute(SecurityPlan.CONTEXT_ATTRIBUTE_CLIENT_ID)).thenReturn(CLIENT_ID);
         when(ctx.getComponent(SubscriptionService.class)).thenReturn(subscriptionService);
-        when(subscriptionService.getByApiAndClientId(API_ID, CLIENT_ID)).thenReturn(Optional.of(subscription));
+        when(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).thenReturn(Optional.of(subscription));
         when(policy.onInvalidSubscription(ctx)).thenReturn(Completable.error(new RuntimeException(MOCK_EXCEPTION)));
 
         final SecurityPlan cut = new SecurityPlan(plan, policy);
@@ -238,7 +238,7 @@ class SecurityPlanTest {
         when(ctx.getAttribute(ExecutionContext.ATTR_API)).thenReturn(API_ID);
         when(ctx.getAttribute(SecurityPlan.CONTEXT_ATTRIBUTE_CLIENT_ID)).thenReturn(CLIENT_ID);
         when(ctx.getComponent(SubscriptionService.class)).thenReturn(subscriptionService);
-        when(subscriptionService.getByApiAndClientId(API_ID, CLIENT_ID)).thenReturn(Optional.of(subscription));
+        when(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).thenReturn(Optional.of(subscription));
         when(policy.onInvalidSubscription(ctx)).thenReturn(Completable.error(new RuntimeException(MOCK_EXCEPTION)));
 
         final SecurityPlan cut = new SecurityPlan(plan, policy);
@@ -255,7 +255,7 @@ class SecurityPlanTest {
         when(ctx.getAttribute(ExecutionContext.ATTR_API)).thenReturn(API_ID);
         when(ctx.getAttribute(SecurityPlan.CONTEXT_ATTRIBUTE_CLIENT_ID)).thenReturn(CLIENT_ID);
         when(ctx.getComponent(SubscriptionService.class)).thenReturn(subscriptionService);
-        when(subscriptionService.getByApiAndClientId(API_ID, CLIENT_ID)).thenReturn(Optional.empty());
+        when(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID)).thenReturn(Optional.empty());
         when(policy.onInvalidSubscription(ctx)).thenReturn(Completable.error(new RuntimeException(MOCK_EXCEPTION)));
 
         final SecurityPlan cut = new SecurityPlan(plan, policy);
@@ -272,7 +272,8 @@ class SecurityPlanTest {
         when(ctx.getAttribute(ExecutionContext.ATTR_API)).thenReturn(API_ID);
         when(ctx.getAttribute(SecurityPlan.CONTEXT_ATTRIBUTE_CLIENT_ID)).thenReturn(CLIENT_ID);
         when(ctx.getComponent(SubscriptionService.class)).thenReturn(subscriptionService);
-        when(subscriptionService.getByApiAndClientId(API_ID, CLIENT_ID)).thenThrow(new RuntimeException("Mock TechnicalException"));
+        when(subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID))
+            .thenThrow(new RuntimeException("Mock TechnicalException"));
         when(policy.onInvalidSubscription(ctx)).thenReturn(Completable.error(new RuntimeException(MOCK_EXCEPTION)));
 
         final SecurityPlan cut = new SecurityPlan(plan, policy);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-jwt/src/main/java/io/gravitee/gateway/security/jwt/policy/CheckSubscriptionPolicy.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-jwt/src/main/java/io/gravitee/gateway/security/jwt/policy/CheckSubscriptionPolicy.java
@@ -53,7 +53,7 @@ public class CheckSubscriptionPolicy implements Policy {
         executionContext.request().metrics().setSecurityType(JWT);
         executionContext.request().metrics().setSecurityToken(clientId);
 
-        Optional<Subscription> subscriptionOpt = subscriptionService.getByApiAndClientId(api, clientId);
+        Optional<Subscription> subscriptionOpt = subscriptionService.getByApiAndClientIdAndPlan(api, clientId, plan);
         if (subscriptionOpt.isPresent()) {
             Subscription subscription = subscriptionOpt.get();
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-jwt/src/test/java/io/gravitee/gateway/security/jwt/policy/CheckSubscriptionPolicyTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-jwt/src/test/java/io/gravitee/gateway/security/jwt/policy/CheckSubscriptionPolicyTest.java
@@ -65,7 +65,7 @@ public class CheckSubscriptionPolicyTest {
         when(executionContext.getComponent(SubscriptionService.class)).thenReturn(subscriptionService);
 
         // no subscription found in cache for this API / clientID
-        when(subscriptionService.getByApiAndClientId("api-id", "my-client-id")).thenReturn(Optional.empty());
+        when(subscriptionService.getByApiAndClientIdAndPlan("api-id", "my-client-id", "plan-id")).thenReturn(Optional.empty());
 
         policy.execute(policyChain, executionContext);
 
@@ -97,7 +97,7 @@ public class CheckSubscriptionPolicyTest {
         // subscription found in cache, with invalid time
         Subscription subscription = mock(Subscription.class);
         when(subscription.isTimeValid(anyLong())).thenReturn(false);
-        when(subscriptionService.getByApiAndClientId("api-id", "my-client-id")).thenReturn(Optional.of(subscription));
+        when(subscriptionService.getByApiAndClientIdAndPlan("api-id", "my-client-id", "plan-id")).thenReturn(Optional.of(subscription));
 
         policy.execute(policyChain, executionContext);
 
@@ -132,7 +132,7 @@ public class CheckSubscriptionPolicyTest {
         Subscription subscription = mock(Subscription.class);
         when(subscription.isTimeValid(anyLong())).thenReturn(true);
         when(subscription.getPlan()).thenReturn("plan-id");
-        when(subscriptionService.getByApiAndClientId("api-id", "my-client-id")).thenReturn(Optional.of(subscription));
+        when(subscriptionService.getByApiAndClientIdAndPlan("api-id", "my-client-id", "plan-id")).thenReturn(Optional.of(subscription));
 
         policy.execute(policyChain, executionContext);
 
@@ -158,7 +158,7 @@ public class CheckSubscriptionPolicyTest {
         // subscription found in cache, with an invalid plan
         Subscription subscription = mock(Subscription.class);
         when(subscription.getPlan()).thenReturn("plan2-id");
-        when(subscriptionService.getByApiAndClientId("api-id", "my-client-id")).thenReturn(Optional.of(subscription));
+        when(subscriptionService.getByApiAndClientIdAndPlan("api-id", "my-client-id", "plan-id")).thenReturn(Optional.of(subscription));
 
         policy.execute(policyChain, executionContext);
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-oauth2/src/main/java/io/gravitee/gateway/security/oauth2/policy/CheckSubscriptionPolicy.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-oauth2/src/main/java/io/gravitee/gateway/security/oauth2/policy/CheckSubscriptionPolicy.java
@@ -69,7 +69,7 @@ public class CheckSubscriptionPolicy implements Policy {
         executionContext.request().metrics().setSecurityType(OAUTH2);
         executionContext.request().metrics().setSecurityToken(clientId);
 
-        Optional<Subscription> subscriptionOpt = subscriptionService.getByApiAndClientId(api, clientId);
+        Optional<Subscription> subscriptionOpt = subscriptionService.getByApiAndClientIdAndPlan(api, clientId, plan);
 
         if (subscriptionOpt.isPresent()) {
             Subscription subscription = subscriptionOpt.get();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-oauth2/src/test/java/io/gravitee/gateway/security/oauth2/policy/CheckSubscriptionPolicyTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-oauth2/src/test/java/io/gravitee/gateway/security/oauth2/policy/CheckSubscriptionPolicyTest.java
@@ -92,7 +92,7 @@ public class CheckSubscriptionPolicyTest {
         when(executionContext.getComponent(SubscriptionService.class)).thenReturn(subscriptionService);
 
         // no subscription found in cache for this API / clientID
-        when(subscriptionService.getByApiAndClientId("api-id", "my-client-id")).thenReturn(Optional.empty());
+        when(subscriptionService.getByApiAndClientIdAndPlan("api-id", "my-client-id", "plan-id")).thenReturn(Optional.empty());
 
         policy.execute(policyChain, executionContext);
 
@@ -124,7 +124,7 @@ public class CheckSubscriptionPolicyTest {
         // subscription found in cache, with invalid time
         Subscription subscription = mock(Subscription.class);
         when(subscription.isTimeValid(anyLong())).thenReturn(false);
-        when(subscriptionService.getByApiAndClientId("api-id", "my-client-id")).thenReturn(Optional.of(subscription));
+        when(subscriptionService.getByApiAndClientIdAndPlan("api-id", "my-client-id", "plan-id")).thenReturn(Optional.of(subscription));
 
         policy.execute(policyChain, executionContext);
 
@@ -159,7 +159,7 @@ public class CheckSubscriptionPolicyTest {
         Subscription subscription = mock(Subscription.class);
         when(subscription.isTimeValid(anyLong())).thenReturn(true);
         when(subscription.getPlan()).thenReturn("plan-id");
-        when(subscriptionService.getByApiAndClientId("api-id", "my-client-id")).thenReturn(Optional.of(subscription));
+        when(subscriptionService.getByApiAndClientIdAndPlan("api-id", "my-client-id", "plan-id")).thenReturn(Optional.of(subscription));
 
         policy.execute(policyChain, executionContext);
 
@@ -185,7 +185,7 @@ public class CheckSubscriptionPolicyTest {
         // subscription found in cache, with an invalid plan
         Subscription subscription = mock(Subscription.class);
         when(subscription.getPlan()).thenReturn("plan2-id");
-        when(subscriptionService.getByApiAndClientId("api-id", "my-client-id")).thenReturn(Optional.of(subscription));
+        when(subscriptionService.getByApiAndClientIdAndPlan("api-id", "my-client-id", "plan-id")).thenReturn(Optional.of(subscription));
 
         policy.execute(policyChain, executionContext);
 

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <gravitee-connector-api.version>1.1.0</gravitee-connector-api.version>
         <gravitee-expression-language.version>1.10.1</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>1.37.2</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.37.3</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>1.24.2</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8232

**Description**

fix: add planId in subscription cache key

In 3.19, we replaced the SubscriptionRepositoryWrapper by a SubscriptionService, handling subscriptions.

This introduced a regression :
The cache key composed by API + clientId is not enough, and leads to subscriptions overwriting others.
Adding the planId make it more relevant.

This reactivates the e2e test that was excluded from Jupiter

Note that the subscription.client_id is set with the application client_id ; so it can be set even for an API key plan subscription.

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-fixsubscriptioncache-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- E2E Coverage placeholder -->
---
### 🧪 End-to-End Coverage

| INSTRUCTIONS | BRANCHES |
| :----------: | :------: |
|   36% | 21%   |

A more detailed report has been uploaded to [circleci](https://output.circle-artifacts.com/output/job/d1179c50-0ee5-4db4-8988-3ad8d6b9c8f6/artifacts/0/gravitee-apim-e2e/jacoco/reports/index.html)
<!-- E2E Coverage placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pijlclhymh.chromatic.com)
<!-- Storybook placeholder end -->
