### PR TITLE
build backend images only when required

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1603,6 +1603,13 @@ workflows:
             - build-images:
                   requires:
                       - build
+                  filters:
+                      branches:
+                          only:
+                              - master
+                              - /.*-run-e2e.*/
+                              - /.*merge.*/
+                              - /^\d+\.\d+\.x$/
             - test:
                   requires:
                       - build


### PR DESCRIPTION
**Issue**

N/A

**Description**

backend images are only needed by E2E jobs. So it is not necessary to build them on a standard PR.
