### PR TITLE
replace powermock by mockito to increase code coverage

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-apikey/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-apikey/pom.xml
@@ -41,5 +41,10 @@
             <groupId>io.gravitee.apim.repository</groupId>
             <artifactId>gravitee-apim-repository-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-apikey/src/test/java/io/gravitee/gateway/security/apikey/ApiKeyAuthenticationHandlerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-apikey/src/test/java/io/gravitee/gateway/security/apikey/ApiKeyAuthenticationHandlerTest.java
@@ -46,16 +46,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.env.Environment;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(Metrics.class)
+@RunWith(MockitoJUnitRunner.class)
 public class ApiKeyAuthenticationHandlerTest {
 
     @InjectMocks
@@ -98,7 +96,6 @@ public class ApiKeyAuthenticationHandlerTest {
     public void shouldNotHandleRequest() {
         when(authenticationContext.request()).thenReturn(request);
         when(request.headers()).thenReturn(HttpHeaders.create());
-        when(api.getId()).thenReturn("api-id");
 
         MultiValueMap<String, String> parameters = mock(MultiValueMap.class);
         when(request.parameters()).thenReturn(parameters);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-apikey/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-apikey/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-security/gravitee-apim-gateway-security-core/pom.xml
@@ -42,5 +42,11 @@
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/reactor/processor/DebugEventCompletionProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/debug/reactor/processor/DebugEventCompletionProcessorTest.java
@@ -18,7 +18,6 @@ package io.gravitee.gateway.debug.reactor.processor;
 import static io.gravitee.repository.management.model.Event.EventProperties.API_DEBUG_STATUS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
-import static org.powermock.api.mockito.PowerMockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -51,11 +50,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 /**

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/jupiter/debug/reactor/processor/DebugCompletionProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/jupiter/debug/reactor/processor/DebugCompletionProcessorTest.java
@@ -19,18 +19,13 @@ import static io.gravitee.repository.management.model.Event.EventProperties.API_
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
-import static org.powermock.api.mockito.PowerMockito.when;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.gravitee.definition.model.Api;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.core.component.CustomComponentProvider;
 import io.gravitee.gateway.debug.core.invoker.InvokerResponse;
 import io.gravitee.gateway.debug.definition.DebugApi;
-import io.gravitee.gateway.http.vertx.VertxHttpServerResponse;
 import io.gravitee.gateway.jupiter.api.ExecutionPhase;
 import io.gravitee.gateway.jupiter.core.context.MutableRequest;
 import io.gravitee.gateway.jupiter.core.context.MutableResponse;

--- a/gravitee-apim-gateway/pom.xml
+++ b/gravitee-apim-gateway/pom.xml
@@ -92,16 +92,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
@@ -256,13 +256,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.powermock</groupId>
-			<artifactId>powermock-module-junit4</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.powermock</groupId>
-			<artifactId>powermock-api-mockito2</artifactId>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-inline</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -125,6 +125,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.GeneralSecurityException;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -778,7 +779,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 .stream()
                 .findFirst();
             if (optionalMaxDuration.isPresent() && optionalMaxDuration.get() > 0) {
-                long maxEndDate = System.currentTimeMillis() + optionalMaxDuration.get();
+                long maxEndDate = Instant.now().toEpochMilli() + optionalMaxDuration.get();
 
                 // if no condition set, add one
                 if (logging.getCondition() == null || logging.getCondition().isEmpty()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeployModelCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeployModelCommandHandlerTest.java
@@ -18,6 +18,9 @@ package io.gravitee.rest.api.service.cockpit.command.handler;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.cockpit.api.command.Command;
@@ -37,25 +40,23 @@ import io.gravitee.rest.api.service.cockpit.services.ApiServiceCockpit;
 import io.gravitee.rest.api.service.cockpit.services.CockpitApiPermissionChecker;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.reactivex.observers.TestObserver;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import org.assertj.core.api.Assertions;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * @author Julien GIOVARESCO (julien.giovaresco at graviteesource.com)
  * @author GraviteeSource Team
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(GraviteeContext.class)
-@PowerMockIgnore({ "javax.security.*", "com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "javax.management.*" })
+@RunWith(MockitoJUnitRunner.class)
 public class DeployModelCommandHandlerTest {
 
     public static final String ENVIRONMENT_ID = "environment#id";
@@ -78,10 +79,17 @@ public class DeployModelCommandHandlerTest {
 
     private DeployModelCommandHandler cut;
 
+    MockedStatic<GraviteeContext> mockedStaticGraviteeContext;
+
     @Before
     public void setUp() throws Exception {
         cut = new DeployModelCommandHandler(apiService, cockpitApiService, permissionChecker, userService, environmentService);
-        PowerMockito.spy(GraviteeContext.class);
+        mockedStaticGraviteeContext = mockStatic(GraviteeContext.class);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        mockedStaticGraviteeContext.close();
     }
 
     @Test
@@ -99,8 +107,6 @@ public class DeployModelCommandHandlerTest {
         payload.setLabels(List.of("label1", "label2"));
 
         DeployModelCommand command = new DeployModelCommand(payload);
-
-        when(apiService.exists(payload.getModelId())).thenReturn(false);
 
         UserEntity user = new UserEntity();
         user.setId("user#id");
@@ -146,8 +152,7 @@ public class DeployModelCommandHandlerTest {
         obs.awaitTerminalEvent();
         obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
 
-        PowerMockito.verifyStatic(GraviteeContext.class);
-        GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
+        mockedStaticGraviteeContext.verify(() -> GraviteeContext.getExecutionContext(), times(4));
         GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
     }
 
@@ -161,8 +166,6 @@ public class DeployModelCommandHandlerTest {
         payload.setLabels(List.of("label1", "label2"));
 
         DeployModelCommand command = new DeployModelCommand(payload);
-
-        when(apiService.exists(payload.getModelId())).thenReturn(false);
 
         UserEntity user = new UserEntity();
         user.setId("user#id");
@@ -218,8 +221,6 @@ public class DeployModelCommandHandlerTest {
         payload.setLabels(List.of("label1", "label2"));
 
         DeployModelCommand command = new DeployModelCommand(payload);
-
-        when(apiService.exists(payload.getModelId())).thenReturn(false);
 
         UserEntity user = new UserEntity();
         user.setId("user#id");
@@ -459,8 +460,6 @@ public class DeployModelCommandHandlerTest {
 
         DeployModelCommand command = new DeployModelCommand(payload);
 
-        when(apiService.exists(payload.getModelId())).thenReturn(false);
-
         UserEntity user = new UserEntity();
         user.setId("user#id");
         user.setSourceId(payload.getUserId());
@@ -516,8 +515,6 @@ public class DeployModelCommandHandlerTest {
 
         DeployModelCommand command = new DeployModelCommand(payload);
 
-        when(apiService.exists(payload.getModelId())).thenReturn(false);
-
         UserEntity user = new UserEntity();
         user.setId("user#id");
         user.setSourceId(payload.getUserId());
@@ -567,8 +564,6 @@ public class DeployModelCommandHandlerTest {
         payload.setLabels(List.of("label1", "label2"));
 
         DeployModelCommand command = new DeployModelCommand(payload);
-
-        when(apiService.exists(payload.getModelId())).thenReturn(false);
 
         UserEntity user = new UserEntity();
         user.setId("user#id");
@@ -659,8 +654,6 @@ public class DeployModelCommandHandlerTest {
 
         DeployModelCommand command = new DeployModelCommand(payload);
 
-        when(apiService.exists(payload.getModelId())).thenReturn(false);
-
         UserEntity user = new UserEntity();
         user.setId("user#id");
         user.setSourceId(payload.getUserId());
@@ -703,7 +696,7 @@ public class DeployModelCommandHandlerTest {
         obs.awaitTerminalEvent();
         obs.assertNoErrors();
 
-        PowerMockito.verifyStatic(GraviteeContext.class);
+        mockedStaticGraviteeContext.verify(() -> GraviteeContext.getExecutionContext(), times(5));
         GraviteeContext.cleanContext();
     }
 
@@ -717,8 +710,6 @@ public class DeployModelCommandHandlerTest {
         payload.setLabels(List.of("label1", "label2"));
 
         DeployModelCommand command = new DeployModelCommand(payload);
-
-        when(apiService.exists(payload.getModelId())).thenReturn(false);
 
         UserEntity user = new UserEntity();
         user.setId("user#id");
@@ -744,7 +735,7 @@ public class DeployModelCommandHandlerTest {
         obs.awaitTerminalEvent();
         obs.assertNoErrors();
 
-        PowerMockito.verifyStatic(GraviteeContext.class);
+        mockedStaticGraviteeContext.verify(() -> GraviteeContext.getExecutionContext(), times(3));
         GraviteeContext.cleanContext();
     }
 
@@ -758,8 +749,6 @@ public class DeployModelCommandHandlerTest {
         payload.setLabels(List.of("label1", "label2"));
 
         DeployModelCommand command = new DeployModelCommand(payload);
-
-        when(apiService.exists(payload.getModelId())).thenReturn(false);
 
         UserEntity user = new UserEntity();
         user.setId("user#id");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImplTest.java
@@ -47,13 +47,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 
 /**
  * @author GraviteeSource Team
  */
 @RunWith(MockitoJUnitRunner.class)
-@PrepareForTest(GraviteeContext.class)
 public class ApiServiceCockpitImplTest {
 
     private static final String API_ID = "api#id";

--- a/pom.xml
+++ b/pom.xml
@@ -120,11 +120,13 @@
         <json-smart.version>2.4.7</json-smart.version>
         <jsoup.version>1.14.3</jsoup.version>
         <lucene.version>7.7.3</lucene.version>
+        <!-- mockito version to remove when https://github.com/gravitee-io/issues/issues/8257 will be completed -->
+        <mockito-inline.version>3.11.2</mockito-inline.version>
+        <!-- -->
         <netty-tcnative-boringssl-static.version>2.0.48.Final</netty-tcnative-boringssl-static.version>
         <nimbus-jose-jwt.version>9.15.2</nimbus-jose-jwt.version>
         <owasp-java-html-sanitizer.version>20211018.2</owasp-java-html-sanitizer.version>
         <protobuf-java.version>3.19.3</protobuf-java.version>
-        <powermock.version>2.0.9</powermock.version>
         <reactor-adapter.version>3.4.6</reactor-adapter.version>
         <snakeyaml.version>1.30</snakeyaml.version>
         <swagger-jaxrs2.version>2.1.13</swagger-jaxrs2.version>
@@ -734,6 +736,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-inline</artifactId>
+                <version>${mockito-inline.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.openjdk.jmh</groupId>
                 <artifactId>jmh-core</artifactId>
                 <version>${jmh.version}</version>
@@ -749,18 +757,6 @@
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>
                 <version>${asm.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-module-junit4</artifactId>
-                <version>${powermock.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-api-mockito2</artifactId>
-                <version>${powermock.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
**Issue**

N/A

**Description**

In some test classes, we have to mock static classes (like System or Instant). Sometimes, to do that, we use Powermock.
Unfortunately, Powermock is not compatible with Jacoco, and all reports from classes running powermock are just empty.

So I made this PR to remove powermock.
- https://www.baeldung.com/java-override-system-time#2-using-mockito
- https://stackoverflow.com/questions/65965396/mockito-3-6-using-mockstatic-in-before-or-beforeclass-with-junit4

**Additional context**

Some changes in this PR should be improved during a technical sprint: https://github.com/gravitee-io/issues/issues/8257
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-powermock-jacoco-issue/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xpwedztykd.chromatic.com)
<!-- Storybook placeholder end -->
