### PR TITLE
Bump `gravitee-policy-callout-http` to 1.15.1

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -51,7 +51,7 @@
         <gravitee-policy-assign-attributes.version>1.5.0</gravitee-policy-assign-attributes.version>
         <gravitee-policy-assign-content.version>1.7.0</gravitee-policy-assign-content.version>
         <gravitee-policy-cache.version>1.15.1</gravitee-policy-cache.version>
-        <gravitee-policy-callout-http.version>1.15.0</gravitee-policy-callout-http.version>
+        <gravitee-policy-callout-http.version>1.15.1</gravitee-policy-callout-http.version>
         <gravitee-policy-dynamic-routing.version>1.11.1</gravitee-policy-dynamic-routing.version>
         <gravitee-policy-generate-http-signature.version>1.1.0</gravitee-policy-generate-http-signature.version>
         <gravitee-policy-generate-jwt.version>1.5.0</gravitee-policy-generate-jwt.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8109

**Description**

Bump `gravitee-policy-callout-http` to 1.15.1
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-owfymtmgxx.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/8109-bump-gravitee-policy-callout-http/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
