### PR TITLE
Use `ACCEPTED` as default status when getting subscriptions

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionsResource.java
@@ -288,8 +288,9 @@ public class ApiSubscriptionsResource extends AbstractResource {
         private ListStringParam applications;
 
         @QueryParam("status")
+        @DefaultValue("ACCEPTED")
         @Parameter(
-            description = "Subscription status",
+            description = "Comma separated list of Subscription status, default is ACCEPTED",
             explode = Explode.FALSE,
             schema = @Schema(type = "array", defaultValue = "[\"ACCEPTED\"]")
         )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionsResource.java
@@ -221,8 +221,9 @@ public class ApplicationSubscriptionsResource extends AbstractResource {
         private ListStringParam apis;
 
         @QueryParam("status")
+        @DefaultValue("ACCEPTED")
         @Parameter(
-            description = "Subscription status",
+            description = "Comma separated list of Subscription status, default is ACCEPTED",
             explode = Explode.FALSE,
             schema = @Schema(type = "array", defaultValue = "[\"ACCEPTED\"]")
         )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionsResourceTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.management.rest.resource;
 
 import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -27,6 +28,7 @@ import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.pagedresult.Metadata;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
+import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.List;
@@ -250,5 +252,43 @@ public class ApiSubscriptionsResourceTest extends AbstractResourceTest {
 
         assertEquals(OK_200, response.getStatus());
         verify(subscriptionService, times(1)).search(any(), any(), eq(true), eq(false));
+    }
+
+    @Test
+    public void get_subscriptions_with_default_status() {
+        when(subscriptionService.search(any(), any(), anyBoolean(), anyBoolean()))
+            .thenReturn(new Page<>(List.of(new SubscriptionEntity()), 1, 1, 1));
+        when(subscriptionService.getMetadata(any())).thenReturn(mock(Metadata.class));
+
+        final Response response = envTarget().request().get();
+
+        assertEquals(OK_200, response.getStatus());
+
+        ArgumentCaptor<SubscriptionQuery> subscriptionQueryCaptor = ArgumentCaptor.forClass(SubscriptionQuery.class);
+
+        verify(subscriptionService, times(1)).search(subscriptionQueryCaptor.capture(), any(), anyBoolean(), anyBoolean());
+
+        SubscriptionQuery subscriptionQuery = subscriptionQueryCaptor.getValue();
+        assertThat(subscriptionQuery).extracting(SubscriptionQuery::getStatuses).isEqualTo(List.of(SubscriptionStatus.ACCEPTED));
+    }
+
+    @Test
+    public void get_subscriptions_with_status_from_query_params() {
+        when(subscriptionService.search(any(), any(), anyBoolean(), anyBoolean()))
+            .thenReturn(new Page<>(List.of(new SubscriptionEntity()), 1, 1, 1));
+        when(subscriptionService.getMetadata(any())).thenReturn(mock(Metadata.class));
+
+        final Response response = envTarget().queryParam("status", "PENDING, REJECTED, ACCEPTED").request().get();
+
+        assertEquals(OK_200, response.getStatus());
+
+        ArgumentCaptor<SubscriptionQuery> subscriptionQueryCaptor = ArgumentCaptor.forClass(SubscriptionQuery.class);
+
+        verify(subscriptionService, times(1)).search(subscriptionQueryCaptor.capture(), any(), anyBoolean(), anyBoolean());
+
+        SubscriptionQuery subscriptionQuery = subscriptionQueryCaptor.getValue();
+        assertThat(subscriptionQuery)
+            .extracting(SubscriptionQuery::getStatuses)
+            .isEqualTo(List.of(SubscriptionStatus.PENDING, SubscriptionStatus.REJECTED, SubscriptionStatus.ACCEPTED));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionsResourceTest.java
@@ -17,9 +17,11 @@ package io.gravitee.rest.api.management.rest.resource;
 
 import static io.gravitee.common.http.HttpStatusCode.CREATED_201;
 import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -28,11 +30,13 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.pagedresult.Metadata;
+import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import java.util.List;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
@@ -101,5 +105,52 @@ public class ApplicationSubscriptionsResourceTest extends AbstractResourceTest {
         assertEquals(1, data.size());
 
         verify(subscriptionService, times(1)).search(any(), any(), eq(false), eq(true));
+    }
+
+    @Test
+    public void shouldGetSubscriptions_WithDefaultStatus() {
+        reset(apiService, planService, subscriptionService, userService);
+
+        when(subscriptionService.search(any(), any(), anyBoolean(), anyBoolean()))
+            .thenReturn(new Page<>(List.of(new SubscriptionEntity()), 1, 1, 1));
+        when(subscriptionService.getMetadata(any())).thenReturn(mock(Metadata.class));
+
+        final Response response = envTarget().path(APPLICATION).path("subscriptions").request().get();
+
+        assertEquals(OK_200, response.getStatus());
+
+        ArgumentCaptor<SubscriptionQuery> subscriptionQueryCaptor = ArgumentCaptor.forClass(SubscriptionQuery.class);
+
+        verify(subscriptionService, times(1)).search(subscriptionQueryCaptor.capture(), any(), anyBoolean(), anyBoolean());
+
+        SubscriptionQuery subscriptionQuery = subscriptionQueryCaptor.getValue();
+        assertThat(subscriptionQuery).extracting(SubscriptionQuery::getStatuses).isEqualTo(List.of(SubscriptionStatus.ACCEPTED));
+    }
+
+    @Test
+    public void shouldGetSubscriptions_WithStatusFromQueryParams() {
+        reset(apiService, planService, subscriptionService, userService);
+
+        when(subscriptionService.search(any(), any(), anyBoolean(), anyBoolean()))
+            .thenReturn(new Page<>(List.of(new SubscriptionEntity()), 1, 1, 1));
+        when(subscriptionService.getMetadata(any())).thenReturn(mock(Metadata.class));
+
+        final Response response = envTarget()
+            .path(APPLICATION)
+            .path("subscriptions")
+            .queryParam("status", "PENDING, REJECTED, ACCEPTED")
+            .request()
+            .get();
+
+        assertEquals(OK_200, response.getStatus());
+
+        ArgumentCaptor<SubscriptionQuery> subscriptionQueryCaptor = ArgumentCaptor.forClass(SubscriptionQuery.class);
+
+        verify(subscriptionService, times(1)).search(subscriptionQueryCaptor.capture(), any(), anyBoolean(), anyBoolean());
+
+        SubscriptionQuery subscriptionQuery = subscriptionQueryCaptor.getValue();
+        assertThat(subscriptionQuery)
+            .extracting(SubscriptionQuery::getStatuses)
+            .isEqualTo(List.of(SubscriptionStatus.PENDING, SubscriptionStatus.REJECTED, SubscriptionStatus.ACCEPTED));
     }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7879

**Description**

Use `ACCEPTED` as default status when getting subscriptions
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wqezxvwswk.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7879-fix-default-filter-on-subscription-status/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
