### PR TITLE
fix: remove platform filter to be able to trigger platform alerts

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AlertServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AlertServiceImpl.java
@@ -15,8 +15,8 @@
  */
 package io.gravitee.rest.api.service.impl;
 
-import static io.gravitee.rest.api.service.common.GraviteeContext.ReferenceContextType.ENVIRONMENT;
-import static io.gravitee.rest.api.service.common.GraviteeContext.ReferenceContextType.ORGANIZATION;
+import static io.gravitee.rest.api.model.alert.AlertReferenceType.API;
+import static io.gravitee.rest.api.model.alert.AlertReferenceType.APPLICATION;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
 
@@ -542,34 +542,8 @@ public class AlertServiceImpl extends TransactionalService implements AlertServi
             trigger.setFilters(filters);
         }
 
-        switch (referenceType) {
-            case API:
-            case APPLICATION:
-                filters.add(StringCondition.equals(referenceType.name().toLowerCase(), referenceId).build());
-                break;
-            case PLATFORM:
-                // Add filters to make sure we will receive alert notifications only for events on the same organization / environment.
-                // For now, it seems that alerts are managed at organization level only. The behavior will change with https://github.com/gravitee-io/issues/issues/6079).
-                // It would be preferable to use a 'in' filter but this kind of filter does not exist yet. To keep backward compatibility we will rely on pattern matching.
-                filters.add(
-                    StringCondition
-                        .matches(
-                            ORGANIZATION.name().toLowerCase(),
-                            "(?:.*,|^)" + GraviteeContext.getCurrentOrganization() + "(?:,.*|$)|\\*",
-                            true
-                        )
-                        .build()
-                );
-                filters.add(
-                    StringCondition
-                        .matches(
-                            ENVIRONMENT.name().toLowerCase(),
-                            "(?:.*|^)" + GraviteeContext.getCurrentEnvironment() + "(?:,.*|$)|\\*",
-                            true
-                        )
-                        .build()
-                );
-                break;
+        if (referenceType == APPLICATION || referenceType == API) {
+            filters.add(StringCondition.equals(referenceType.name().toLowerCase(), referenceId).build());
         }
     }
 


### PR DESCRIPTION
gravitee-io/issues#8269

**Issue**

gravitee-io/issues#8269


**Description**

With the filters the platform alerts can not be triggered as this is not something we send to alert engine. We need to remove it to be able to trigger the platform alerts
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gmawjkwgdh.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-8269-platform-alerts/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
