### PR TITLE
Remove useless info icon in Dictionary screen

### DIFF
--- a/gravitee-apim-console-webui/src/management/configuration/dictionaries/dictionary.html
+++ b/gravitee-apim-console-webui/src/management/configuration/dictionaries/dictionary.html
@@ -136,18 +136,7 @@
         <br />
 
         <div ng-if="$ctrl.dictionary.provider">
-          <h6>
-            Configuration
-
-            <md-button
-              ng-if="$ctrl.dictionary.provider.type == 'HTTP'"
-              class="md-icon-button"
-              aria-label="Expected HTTP provider output"
-              ng-click="$ctrl.showExpectedProviderOutput()"
-            >
-              <ng-md-icon class="no-top" icon="info" style="fill: #b1bdc5"></ng-md-icon>
-            </md-button>
-          </h6>
+          <h6>Configuration</h6>
 
           <div ng-if="$ctrl.dictionary.provider.type == 'HTTP'" layout="column" layout-sm="column">
             <md-input-container class="md-block" flex-gt-sm>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5056

**Description**

Remove useless info icon in dictionary creation screen

This icon has never been linked to anything
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/5056-remove-useless-icon/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
