### PR TITLE
fix: handle properly unset http.requestTimeout properly

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/TimeoutConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/TimeoutConfiguration.java
@@ -35,16 +35,21 @@ public class TimeoutConfiguration {
 
     @Bean
     public HttpRequestTimeoutConfiguration httpRequestTimeoutConfiguration(
-        @Value("${http.requestTimeout:30000}") long httpRequestTimeout,
+        @Value("${http.requestTimeout:#{null}}") Long httpRequestTimeout,
         @Value("${http.requestTimeoutGraceDelay:30}") long httpRequestTimeoutGraceDelay,
         @Value("${" + JUPITER_MODE_ENABLED_KEY + ":" + JUPITER_MODE_ENABLED_BY_DEFAULT + "}") boolean isJupiterEnabled
     ) {
-        if (httpRequestTimeout <= 0) {
+        if (httpRequestTimeout == null || httpRequestTimeout <= 0) {
             if (isJupiterEnabled) {
-                log.warn("Http request timeout cannot be set to 0. Setting it to default value: 30_000 ms");
+                log.warn("Http request timeout cannot be set to 0 or unset. Setting it to default value: 30_000 ms");
                 httpRequestTimeout = 30_000L;
             } else {
-                log.warn("A proper timeout should be set in order to avoid unclose connexion, suggested value is 30_000 ms");
+                if (httpRequestTimeout == null) {
+                    log.warn("Http request timeout is unset. Setting it to default value: 30_000 ms");
+                    httpRequestTimeout = 30_000L;
+                } else {
+                    log.warn("A proper timeout should be set in order to avoid unclose connexion, suggested value is 30_000 ms");
+                }
             }
         }
         return new HttpRequestTimeoutConfiguration(httpRequestTimeout, httpRequestTimeoutGraceDelay);


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7988

**Description**

Currently, warning messages and default setting of the property where done only if the property was set to 0 or less.
This commit implements the same behavior for unset property.

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/issues-7988-reactive-timeout-fix/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-srnddluidv.chromatic.com)
<!-- Storybook placeholder end -->
