### PR TITLE
chore: bump gravitee-policy-regex-threat-protection to 1.2.2

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -75,7 +75,7 @@
         <!--	<gravitee-policy-quota.version>1.13.0</gravitee-policy-quota.version>	-->
         <!--	<gravitee-policy-spikearrest.version>1.13.0</gravitee-policy-spikearrest.version>	-->
         <gravitee-policy-ratelimit.version>1.13.2</gravitee-policy-ratelimit.version>
-        <gravitee-policy-regex-threat-protection.version>1.2.1</gravitee-policy-regex-threat-protection.version>
+        <gravitee-policy-regex-threat-protection.version>1.2.2</gravitee-policy-regex-threat-protection.version>
         <gravitee-policy-request-content-limit.version>1.7.0</gravitee-policy-request-content-limit.version>
         <gravitee-policy-request-validation.version>1.12.0</gravitee-policy-request-validation.version>
         <gravitee-policy-resource-filtering.version>1.8.0</gravitee-policy-resource-filtering.version>


### PR DESCRIPTION
gravitee-io/issues#8272
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/8272-threat-policy/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
