### PR TITLE
fix: add organization and environment in alert events

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/EndpointHealthcheckResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/EndpointHealthcheckResolver.java
@@ -20,12 +20,12 @@ import static io.gravitee.common.util.VertxProxyOptionsUtils.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
-import io.gravitee.definition.model.Api;
 import io.gravitee.definition.model.Endpoint;
 import io.gravitee.definition.model.EndpointGroup;
 import io.gravitee.definition.model.endpoint.HttpEndpoint;
 import io.gravitee.definition.model.services.healthcheck.HealthCheckService;
 import io.gravitee.gateway.env.GatewayConfiguration;
+import io.gravitee.gateway.handlers.api.definition.Api;
 import io.gravitee.gateway.services.healthcheck.grpc.GrpcEndpointRule;
 import io.gravitee.gateway.services.healthcheck.http.HttpEndpointRule;
 import io.gravitee.node.api.configuration.Configuration;
@@ -141,9 +141,9 @@ public class EndpointHealthcheckResolver implements InitializingBean {
                         : endpoint.getHealthCheck();
                     // The following has to be managed by the connector-api
                     if (endpoint.getType().equalsIgnoreCase("grpc")) {
-                        return new GrpcEndpointRule(api.getId(), endpoint, healthcheck, systemProxyOptions);
+                        return new GrpcEndpointRule(api, endpoint, healthcheck, systemProxyOptions);
                     } else {
-                        return new HttpEndpointRule(api.getId(), endpoint, healthcheck, systemProxyOptions);
+                        return new HttpEndpointRule(api, endpoint, healthcheck, systemProxyOptions);
                     }
                 }
             )
@@ -200,9 +200,9 @@ public class EndpointHealthcheckResolver implements InitializingBean {
                     ? rootHealthCheck
                     : httpEndpoint.getHealthCheck();
                 if (endpoint.getType().equalsIgnoreCase("http")) {
-                    return new HttpEndpointRule(api.getId(), httpEndpoint, healthcheck, systemProxyOptions);
+                    return new HttpEndpointRule(api, httpEndpoint, healthcheck, systemProxyOptions);
                 } else if (endpoint.getType().equalsIgnoreCase("grpc")) {
-                    return new GrpcEndpointRule(api.getId(), httpEndpoint, healthcheck, systemProxyOptions);
+                    return new GrpcEndpointRule(api, httpEndpoint, healthcheck, systemProxyOptions);
                 }
             }
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/EndpointRule.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/EndpointRule.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.services.healthcheck;
 import io.gravitee.definition.model.Endpoint;
 import io.gravitee.definition.model.services.healthcheck.Step;
 import io.gravitee.el.TemplateEngine;
+import io.gravitee.gateway.handlers.api.definition.Api;
 import io.gravitee.gateway.services.healthcheck.rule.EndpointRuleHandler;
 import io.vertx.core.Vertx;
 import io.vertx.core.net.ProxyOptions;
@@ -29,7 +30,7 @@ import org.springframework.core.env.Environment;
  * @author GraviteeSource Team
  */
 public interface EndpointRule<T extends Endpoint> {
-    String api();
+    Api api();
 
     T endpoint();
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/grpc/GrpcEndpointRule.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/grpc/GrpcEndpointRule.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.services.healthcheck.grpc;
 import io.gravitee.definition.model.endpoint.HttpEndpoint;
 import io.gravitee.definition.model.services.healthcheck.HealthCheckService;
 import io.gravitee.el.TemplateEngine;
+import io.gravitee.gateway.handlers.api.definition.Api;
 import io.gravitee.gateway.services.healthcheck.EndpointRule;
 import io.gravitee.gateway.services.healthcheck.rule.AbstractEndpointRule;
 import io.gravitee.gateway.services.healthcheck.rule.EndpointRuleHandler;
@@ -31,7 +32,7 @@ import org.springframework.core.env.Environment;
  */
 public class GrpcEndpointRule extends AbstractEndpointRule<HttpEndpoint> {
 
-    public GrpcEndpointRule(String api, HttpEndpoint endpoint, HealthCheckService service, ProxyOptions systemProxyOptions) {
+    public GrpcEndpointRule(Api api, HttpEndpoint endpoint, HealthCheckService service, ProxyOptions systemProxyOptions) {
         super(api, endpoint, service, systemProxyOptions);
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/http/HttpEndpointRule.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/http/HttpEndpointRule.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.services.healthcheck.http;
 import io.gravitee.definition.model.endpoint.HttpEndpoint;
 import io.gravitee.definition.model.services.healthcheck.HealthCheckService;
 import io.gravitee.el.TemplateEngine;
+import io.gravitee.gateway.handlers.api.definition.Api;
 import io.gravitee.gateway.services.healthcheck.EndpointRule;
 import io.gravitee.gateway.services.healthcheck.rule.AbstractEndpointRule;
 import io.gravitee.gateway.services.healthcheck.rule.EndpointRuleHandler;
@@ -31,7 +32,7 @@ import org.springframework.core.env.Environment;
  */
 public class HttpEndpointRule extends AbstractEndpointRule<HttpEndpoint> {
 
-    public HttpEndpointRule(String api, HttpEndpoint endpoint, HealthCheckService service, ProxyOptions systemProxyOptions) {
+    public HttpEndpointRule(Api api, HttpEndpoint endpoint, HealthCheckService service, ProxyOptions systemProxyOptions) {
         super(api, endpoint, service, systemProxyOptions);
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/AbstractEndpointRule.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/AbstractEndpointRule.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.services.healthcheck.rule;
 import io.gravitee.definition.model.Endpoint;
 import io.gravitee.definition.model.services.healthcheck.HealthCheckService;
 import io.gravitee.definition.model.services.healthcheck.Step;
+import io.gravitee.gateway.handlers.api.definition.Api;
 import io.gravitee.gateway.services.healthcheck.EndpointRule;
 import io.vertx.core.net.ProxyOptions;
 import java.util.List;
@@ -28,13 +29,13 @@ import java.util.List;
  */
 public abstract class AbstractEndpointRule<T extends Endpoint> implements EndpointRule<T> {
 
-    private final String api;
+    private final Api api;
     private final T endpoint;
     private final HealthCheckService service;
     private ProxyOptions systemProxyOptions;
 
-    public AbstractEndpointRule(
-        final String api,
+    protected AbstractEndpointRule(
+        final Api api,
         final T endpoint,
         final HealthCheckService service,
         final ProxyOptions systemProxyOptions
@@ -46,7 +47,7 @@ public abstract class AbstractEndpointRule<T extends Endpoint> implements Endpoi
     }
 
     @Override
-    public String api() {
+    public Api api() {
         return api;
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleHandler.java
@@ -208,7 +208,7 @@ public abstract class EndpointRuleHandler<T extends Endpoint> implements Handler
                 requestPreparationEvent -> {
                     HttpClientRequest healthRequest = requestPreparationEvent.result();
                     final EndpointStatus.Builder healthBuilder = EndpointStatus
-                        .forEndpoint(rule.api(), endpoint.getName())
+                        .forEndpoint(rule.api().getId(), endpoint.getName())
                         .on(currentTimeMillis());
 
                     long startTime = currentTimeMillis();
@@ -268,7 +268,7 @@ public abstract class EndpointRuleHandler<T extends Endpoint> implements Handler
                 }
             );
         } catch (Exception ex) {
-            logger.error("An unexpected error has occurred while configuring Healthcheck for API : {}", rule.api(), ex);
+            logger.error("An unexpected error has occurred while configuring Healthcheck for API : {}", rule.api().getId(), ex);
         }
     }
 
@@ -415,7 +415,7 @@ public abstract class EndpointRuleHandler<T extends Endpoint> implements Handler
                 .context(CONTEXT_NODE_HOSTNAME, node.hostname())
                 .context(CONTEXT_NODE_APPLICATION, node.application())
                 .type(EVENT_TYPE)
-                .property(PROP_API, rule.api())
+                .property(PROP_API, rule.api().getId())
                 .property(PROP_ENDPOINT_NAME, rule.endpoint().getName())
                 .property(PROP_STATUS_OLD, previousStatusName)
                 .property(PROP_STATUS_NEW, rule.endpoint().getStatus().name())
@@ -423,6 +423,8 @@ public abstract class EndpointRuleHandler<T extends Endpoint> implements Handler
                 .property(PROP_TENANT, () -> node.metadata().get("tenant"))
                 .property(PROP_RESPONSE_TIME, responseTime)
                 .property(PROP_MESSAGE, endpointStatus.getSteps().get(0).getMessage())
+                .organization(rule.api().getOrganizationId())
+                .environment(rule.api().getEnvironmentId())
                 .build();
             alertEventProducer.send(event);
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/test/java/io/gravitee/gateway/services/healthcheck/EndpointHealthcheckResolverTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/test/java/io/gravitee/gateway/services/healthcheck/EndpointHealthcheckResolverTest.java
@@ -24,7 +24,7 @@ import io.gravitee.definition.model.endpoint.HttpEndpoint;
 import io.gravitee.definition.model.services.Services;
 import io.gravitee.definition.model.services.healthcheck.HealthCheckService;
 import io.gravitee.gateway.env.GatewayConfiguration;
-import io.gravitee.gateway.services.healthcheck.http.HttpEndpointRule;
+import io.gravitee.gateway.handlers.api.definition.Api;
 import io.vertx.core.json.JsonObject;
 import java.util.*;
 import org.junit.Before;
@@ -249,7 +249,8 @@ public class EndpointHealthcheckResolverTest {
 
         assertNotNull(resolve);
         assertEquals(1, resolve.size());
-        assertEquals("api-id", resolve.get(0).api());
+        assertNotNull(resolve.get(0).api());
+        assertEquals("api-id", resolve.get(0).api().getId());
     }
 
     @Test
@@ -290,7 +291,8 @@ public class EndpointHealthcheckResolverTest {
 
         assertNotNull(resolve);
         assertEquals(1, resolve.size());
-        assertEquals("api-id", resolve.get(0).api());
+        assertNotNull(resolve.get(0).api());
+        assertEquals("api-id", resolve.get(0).api().getId());
     }
 
     @Test
@@ -332,7 +334,8 @@ public class EndpointHealthcheckResolverTest {
 
         assertNotNull(resolve);
         assertEquals(1, resolve.size());
-        assertEquals("api-id", resolve.get(0).api());
+        assertNotNull(resolve.get(0).api());
+        assertEquals("api-id", resolve.get(0).api().getId());
     }
 
     @Test
@@ -378,7 +381,8 @@ public class EndpointHealthcheckResolverTest {
 
         assertNotNull(resolve);
         assertEquals(1, resolve.size());
-        assertEquals("api-id", resolve.get(0).api());
+        assertNotNull(resolve.get(0).api());
+        assertEquals("api-id", resolve.get(0).api().getId());
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/test/java/io/gravitee/gateway/services/healthcheck/http/AbstractManagedEndpointRuleHandlerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/test/java/io/gravitee/gateway/services/healthcheck/http/AbstractManagedEndpointRuleHandlerTest.java
@@ -28,6 +28,7 @@ import io.gravitee.definition.model.endpoint.HttpEndpoint;
 import io.gravitee.definition.model.services.healthcheck.Request;
 import io.gravitee.definition.model.services.healthcheck.Response;
 import io.gravitee.el.TemplateEngine;
+import io.gravitee.gateway.handlers.api.definition.Api;
 import io.gravitee.gateway.services.healthcheck.EndpointRule;
 import io.gravitee.reporter.api.health.EndpointStatus;
 import io.gravitee.reporter.api.health.Step;
@@ -249,7 +250,10 @@ public abstract class AbstractManagedEndpointRuleHandlerTest {
 
     private EndpointRule createEndpointRule(String targetPath) {
         EndpointRule rule = mock(EndpointRule.class);
+        Api api = new Api();
+        api.setId("an-api");
         when(rule.endpoint()).thenReturn(createEndpoint(targetPath));
+        when(rule.api()).thenReturn(api);
         when(rule.schedule()).thenReturn("*/5 * * * * *");
         return rule;
     }


### PR DESCRIPTION
**Issue**

gravitee-io/issues#8269


**Description**

With the filters the platform alerts can not be triggered as this is not something we send to alert engine. We need to remove it to be able to trigger the platform alerts

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/issues-8269-platform-alerts-trigger/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-oymczptqhv.chromatic.com)
<!-- Storybook placeholder end -->
