### PR TITLE
docs: add details on perf readme

### DIFF
--- a/gravitee-apim-perf/README.md
+++ b/gravitee-apim-perf/README.md
@@ -52,6 +52,8 @@ To properly collect all the gateway's metrics, it is required to enable metrics 
 
 ```bash
 gravitee.services.metrics.enabled=true
+gravitee.services.metrics.include.http.client[0]=remote
+gravitee.services.metrics.exclude.http.client[0]=local
 ```
 
 Once the gateway has started, you can verify that metrics are properly enabled by typing the following:

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>1.37.3</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
-        <gravitee-node.version>1.24.2</gravitee-node.version>
+        <gravitee-node.version>1.25.0</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>
         <gravitee-plugin.version>1.24.1</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.2.0</gravitee-platform-repository-api.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8218

**Description**

Upgraded node to benefit from new metrics labels configuration and added some detail on the perf readme to enable / disable some metrics tags to properly collect the metrics during performance tests.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8218-prometheus-labels/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nohkunzhum.chromatic.com)
<!-- Storybook placeholder end -->
