### PR TITLE
Test/e2e gateway tests improvments

### DIFF
--- a/gravitee-apim-e2e/lib/gateway.ts
+++ b/gravitee-apim-e2e/lib/gateway.ts
@@ -86,14 +86,14 @@ async function _fetchGateway(request: Partial<GatewayRequest>): Promise<Response
     headers: request.headers,
   });
 
+  if (response.status != request.expectedStatusCode) {
+    throw new Error(`[${request.method}] [${process.env.GATEWAY_BASE_URL}${request.contextPath}] returned HTTP ${response.status}`);
+  }
+
   const isValidResponse = await request.expectedResponseValidator(response);
 
   if (!isValidResponse) {
     throw new Error(`Unexpected response for [${request.method}] [${process.env.GATEWAY_BASE_URL}${request.contextPath}]`);
-  }
-
-  if (response.status != request.expectedStatusCode) {
-    throw new Error(`[${request.method}] [${process.env.GATEWAY_BASE_URL}${request.contextPath}] returned HTTP ${response.status}`);
   }
 
   return response;

--- a/gravitee-apim-e2e/lib/jest-utils.ts
+++ b/gravitee-apim-e2e/lib/jest-utils.ts
@@ -103,5 +103,6 @@ export const testif = (condition) => (condition ? test : test.skip);
 export const describeIf = (condition) => (condition ? describe : describe.skip);
 
 export const describeIfV3 = describeIf(process.env.JUPITER_MODE_ENABLED !== 'true');
+export const describeIfJupiter = describeIf(process.env.JUPITER_MODE_ENABLED == 'true');
 
 export * from './jest-retry';


### PR DESCRIPTION
**Description**

Checking gateway reponse status before validating response improves tests assertions.

Also introducing a new `describeIfJupiter`, to prepare incoming jupiter-specific tests.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/test-e2egatewayresponsecheck-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- E2E Coverage placeholder -->
---
### 🧪 End-to-End Coverage

| INSTRUCTIONS | BRANCHES |
| :----------: | :------: |
|   37% | 21%   |

A more detailed report has been uploaded to [circleci](https://output.circle-artifacts.com/output/job/c4f51f9c-3108-434e-b5be-699cc678bbba/artifacts/0/gravitee-apim-e2e/jacoco/reports/index.html)
<!-- E2E Coverage placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-czvwhkuqwp.chromatic.com)
<!-- Storybook placeholder end -->
