### PR TITLE
fix: updating an application client_id updates it's subscriptions client_id

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -625,7 +625,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                         subscriptionService.update(
                             executionContext,
                             updateSubscriptionEntity,
-                            application.getMetadata().get("METADATA_CLIENT_ID")
+                            application.getMetadata().get(METADATA_CLIENT_ID)
                         );
                     }
                 );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_UpdateTest.java
@@ -476,4 +476,37 @@ public class ApplicationService_UpdateTest {
         verify(applicationRepository)
             .update(argThat(application -> application.getMetadata().get(METADATA_CLIENT_ID).equals("my-previous-client-id")));
     }
+
+    @Test
+    public void should_update_client_id_of_subscriptions() throws TechnicalException {
+        ApplicationSettings settings = new ApplicationSettings();
+        SimpleApplicationSettings clientSettings = new SimpleApplicationSettings();
+        clientSettings.setClientId(CLIENT_ID);
+        settings.setApp(clientSettings);
+
+        when(applicationRepository.findById(APPLICATION_ID)).thenReturn(Optional.of(existingApplication));
+        when(existingApplication.getStatus()).thenReturn(ApplicationStatus.ACTIVE);
+        when(existingApplication.getType()).thenReturn(ApplicationType.SIMPLE);
+        when(updateApplication.getSettings()).thenReturn(settings);
+        when(applicationRepository.update(any())).thenReturn(existingApplication);
+
+        when(roleService.findPrimaryOwnerRoleByOrganization(any(), any())).thenReturn(mock(RoleEntity.class));
+
+        MembershipEntity po = new MembershipEntity();
+        po.setMemberId(USER_NAME);
+        po.setMemberType(MembershipMemberType.USER);
+        po.setReferenceId(APPLICATION_ID);
+        po.setReferenceType(MembershipReferenceType.APPLICATION);
+        po.setRoleId("APPLICATION_PRIMARY_OWNER");
+        when(membershipService.getMembershipsByReferencesAndRole(any(), any(), any())).thenReturn(Collections.singleton(po));
+        when(applicationConverter.toApplication(any(UpdateApplicationEntity.class))).thenCallRealMethod();
+
+        List<SubscriptionEntity> subscriptions = List.of(mock(SubscriptionEntity.class), mock(SubscriptionEntity.class));
+        when(subscriptionService.search(any(), argThat(criteria -> criteria.getApplications().contains(APPLICATION_ID))))
+            .thenReturn(subscriptions);
+
+        applicationService.update(GraviteeContext.getExecutionContext(), APPLICATION_ID, updateApplication);
+
+        verify(subscriptionService, times(2)).update(any(), any(UpdateSubscriptionEntity.class), eq(CLIENT_ID));
+    }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8278

**Description**

fix: updating an application client_id updates it's subscriptions client_id

A bug as been introduced during a merge, using a literal instead of the enum.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-clientidupdate/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-amhmatweme.chromatic.com)
<!-- Storybook placeholder end -->
