### PR TITLE
Updating an application client_id updates it's subscriptions client_id - 3.17.x

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -621,7 +621,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                         updateSubscriptionEntity.setStartingAt(subscriptionEntity.getStartingAt());
                         updateSubscriptionEntity.setEndingAt(subscriptionEntity.getEndingAt());
 
-                        subscriptionService.update(updateSubscriptionEntity, application.getMetadata().get("METADATA_CLIENT_ID"));
+                        subscriptionService.update(updateSubscriptionEntity, application.getMetadata().get(METADATA_CLIENT_ID));
                     }
                 );
             return convert(Collections.singleton(updatedApplication), organizationId).iterator().next();


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8281

**Description**

Updating an application client_id updates it's subscriptions client_id - 3.17.x

A bug has been introduced during a merge, using a literal instead of the enum.


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vyfqwoswoh.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/8281-fix-client-id/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
