### PR TITLE
fix(rest-api): use snake_case everywhere for definition_context property

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/ApiDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/ApiDeserializer.java
@@ -248,7 +248,7 @@ public class ApiDeserializer<T extends Api> extends StdScalarDeserializer<T> {
             api.setResponseTemplates(responseTemplates);
         }
 
-        JsonNode definitionContextNode = node.get("definitionContext");
+        JsonNode definitionContextNode = node.get("definition_context");
         if (definitionContextNode != null) {
             DefinitionContext definitionContext = definitionContextNode.traverse(jp.getCodec()).readValueAs(DefinitionContext.class);
             api.setDefinitionContext(definitionContext);

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-with-definition-context.json
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-with-definition-context.json
@@ -12,7 +12,7 @@
     "strip_context_path": false,
     "preserve_host": true
   },
-  "definitionContext": {
+  "definition_context": {
     "origin": "kubernetes",
     "mode": "fully_managed"
   }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/jackson/ApiDefinitionDeserializer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/jackson/ApiDefinitionDeserializer.java
@@ -59,7 +59,7 @@ public class ApiDefinitionDeserializer extends ApiDeserializer<Api> {
             api.setEnabled(enabledNode.asBoolean());
         }
 
-        JsonNode definitionContextNode = node.get("definitionContext");
+        JsonNode definitionContextNode = node.get("definition_context");
         if (definitionContextNode != null) {
             api.setDefinitionContext(definitionContextNode.traverse(jp.getCodec()).readValueAs(DefinitionContext.class));
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
@@ -891,9 +891,7 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
 
     private boolean canRegenerateId(ImportApiJsonNode apiJsonNode) {
         // If the definition is managed by kubernetes, do not try to recalculate ids because k8s is the source of truth.
-        return !DefinitionContext.ORIGIN_KUBERNETES.equalsIgnoreCase(
-            apiJsonNode.getJsonNode().findPath("definition_context").findPath("origin").asText()
-        );
+        return !DefinitionContext.ORIGIN_KUBERNETES.equalsIgnoreCase(apiJsonNode.getDefinitionContextOrigin());
     }
 
     private void updatePagesHierarchy(List<ImportJsonNodeWithIds> pagesNodes, String parentId, String newParentId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/imports/ImportApiJsonNode.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/imports/ImportApiJsonNode.java
@@ -30,7 +30,9 @@ public class ImportApiJsonNode extends ImportJsonNodeWithIds {
     public static final String VIEWS = "views";
     public static final String API_MEDIA = "apiMedia";
     public static final String MEMBERS = "members";
-    public static final String DEFINITION_CONTEXT = "definitionContext";
+    public static final String DEFINITION_CONTEXT = "definition_context";
+
+    public static final String DEFINITION_CONTEXT_ORIGIN = "origin";
 
     public ImportApiJsonNode(JsonNode jsonNode) {
         super(jsonNode);
@@ -54,6 +56,10 @@ public class ImportApiJsonNode extends ImportJsonNodeWithIds {
 
     public JsonNode getDefinitionContext() {
         return getJsonNode().get(DEFINITION_CONTEXT);
+    }
+
+    public String getDefinitionContextOrigin() {
+        return getJsonNode().findPath(DEFINITION_CONTEXT).findPath(DEFINITION_CONTEXT_ORIGIN).asText();
     }
 
     public List<ImportJsonNodeWithIds> getPages() {


### PR DESCRIPTION
**Issue**
https://github.com/gravitee-io/issues/issues/7981

**Description**
use snake_case everywhere for definition_context property 

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-gko/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mcgvqnewfp.chromatic.com)
<!-- Storybook placeholder end -->
