### PR TITLE
fix: fix typo in response template config

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/proxy/general/response-templates/response-template-type.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/general/response-templates/response-template-type.html
@@ -50,7 +50,7 @@
           <span md-highlight-text="$ctrl.searchStatusCode" md-highlight-flags="^i">{{status.label}}</span>
         </md-item-template>
       </md-autocomplete>
-      <div class="hint">The status code send to the API consumer.</div>
+      <div class="hint">The status code sent to the API consumer.</div>
     </div>
 
     <!-- Headers -->


### PR DESCRIPTION
**Description**
This fixes a tiny little typo in the custom response template configuration. 

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-typo-on-response-template-page/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-byfpeswtlv.chromatic.com)
<!-- Storybook placeholder end -->
