### PR TITLE
fix: use correct path in constants.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -732,7 +732,6 @@ jobs:
                   command: npm run build:prod
                   environment:
                       NODE_OPTIONS: --max_old_space_size=4086
-                      BACKEND_ENV: apim-master
                   working_directory: << parameters.apim-ui-project >>
             - build-ui-image:
                   docker-image-name: << parameters.docker-image-name >>
@@ -884,6 +883,7 @@ jobs:
                       export BRANCH_ID=$(echo "$CIRCLE_BRANCH" | sed -E 's/[~^]+//g' | sed -E 's/[^a-zA-Z0-9]+/-/g' | sed -E 's/^-+|-+$//g' | tr "[:upper:]" "[:lower:]" | cut -c -60)
                       az login --service-principal -u $AZURE_APPLICATION_ID --tenant $AZURE_TENANT -p $AZURE_APPLICATION_SECRET
                       sed -i 's#<base href="/" />##' gravitee-apim-console-webui/dist/index.html
+                      sed -i 's#http://localhost:8083#https://apim-master-api.team-apim.gravitee.xyz#' gravitee-apim-console-webui/dist/constants.json
                       az storage blob upload-batch --overwrite true -s gravitee-apim-console-webui/dist -d "\$web/$BRANCH_ID"
             - notify-on-failure
 

--- a/gravitee-apim-console-webui/conf/webpack-dist.conf.js
+++ b/gravitee-apim-console-webui/conf/webpack-dist.conf.js
@@ -23,8 +23,6 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 
-const backendEnv = process.env.BACKEND_ENV || 'prod';
-
 module.exports = {
   mode: 'production',
   module: {
@@ -107,7 +105,7 @@ module.exports = {
     new CopyWebpackPlugin({
       patterns: [
         {
-          from: !!backendEnv ? `./constants.${backendEnv}.json` : `./constants.json`,
+          from: `./constants.prod.json`,
           to: 'constants.json',
         },
         {

--- a/gravitee-apim-console-webui/constants.apim-master.json
+++ b/gravitee-apim-console-webui/constants.apim-master.json
@@ -1,3 +1,0 @@
-{
-  "baseURL": "https://apim-master-api.team-apim.gravitee.xyz/management/organizations/DEFAULT/environments/DEFAULT"
-}


### PR DESCRIPTION
**Issue**

gravitee-io/issues#8283

**Description**

Use correct path in constants.json
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-constants-json/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-peckcidztk.chromatic.com)
<!-- Storybook placeholder end -->
