### PR TITLE
fix: http request timeout refine default value assignation

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/TimeoutConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/TimeoutConfiguration.java
@@ -35,16 +35,25 @@ public class TimeoutConfiguration {
 
     @Bean
     public HttpRequestTimeoutConfiguration httpRequestTimeoutConfiguration(
-        @Value("${http.requestTimeout:30000}") long httpRequestTimeout,
+        @Value("${http.requestTimeout:#{null}}") Long httpRequestTimeout,
         @Value("${http.requestTimeoutGraceDelay:30}") long httpRequestTimeoutGraceDelay,
         @Value("${" + JUPITER_MODE_ENABLED_KEY + ":" + JUPITER_MODE_ENABLED_BY_DEFAULT + "}") boolean isJupiterEnabled
     ) {
-        if (httpRequestTimeout <= 0) {
-            if (isJupiterEnabled) {
-                log.warn("Http request timeout cannot be set to 0. Setting it to default value: 30_000 ms");
+        if (isJupiterEnabled) {
+            if (httpRequestTimeout == null) {
+                log.warn("Http request timeout cannot be unset. Setting it to default value: 30_000 ms");
                 httpRequestTimeout = 30_000L;
-            } else {
-                log.warn("A proper timeout should be set in order to avoid unclose connexion, suggested value is 30_000 ms");
+            } else if (httpRequestTimeout <= 0) {
+                log.warn(
+                    "A proper timeout (greater than 0) should be set in order to avoid unclose connection, suggested value is 30_000 ms"
+                );
+            }
+        } else {
+            if (httpRequestTimeout == null || httpRequestTimeout <= 0) {
+                log.warn(
+                    "A proper timeout (greater than 0) should be set in order to avoid unclose connection, suggested value is 30_000 ms"
+                );
+                httpRequestTimeout = 0L;
             }
         }
         return new HttpRequestTimeoutConfiguration(httpRequestTimeout, httpRequestTimeoutGraceDelay);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/SyncApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/SyncApiReactor.java
@@ -214,6 +214,10 @@ public class SyncApiReactor extends AbstractLifecycleComponent<ReactorHandler> i
     }
 
     private Completable timeoutAndError(Completable upstream, RequestExecutionContext ctx) {
+        // When timeout is configured with 0 or less, consider it as infinity: no timeout operator to use in the chain.
+        if (httpRequestTimeoutConfiguration.getHttpRequestTimeout() <= 0) {
+            return upstream.onErrorResumeNext(error -> processThrowable(ctx, error));
+        }
         return Completable.defer(
             () ->
                 upstream

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/DefaultHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/DefaultHttpRequestDispatcher.java
@@ -299,7 +299,7 @@ public class DefaultHttpRequestDispatcher
         io.gravitee.gateway.http.vertx.VertxHttpServerRequest request
     ) {
         SimpleExecutionContext simpleExecutionContext;
-        if (!isV3WebSocket(httpServerRequest)) {
+        if (httpRequestTimeoutConfiguration.getHttpRequestTimeout() > 0 && !isV3WebSocket(httpServerRequest)) {
             final long timeoutId = vertx.setTimer(
                 httpRequestTimeoutConfiguration.getHttpRequestTimeout(),
                 event -> {


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8273


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/issues-8273-timeout-adjustments/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-utttmdrkqf.chromatic.com)
<!-- Storybook placeholder end -->
