### PR TITLE
chore: improve sdk testing developer experience

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/GatewayTestingExtensionTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/GatewayTestingExtensionTest.java
@@ -15,6 +15,8 @@
  */
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.testkit.engine.EngineTestKit;
@@ -33,6 +35,20 @@ import testcases.SuccessTestCase;
  * @author GraviteeSource Team
  */
 class GatewayTestingExtensionTest {
+
+    /**
+     * Setting this property allow to run test cases only in the context of the extension testing.
+     * *TestCase.java classes are not aimed to be run when running all tests in your IDE.
+     */
+    @BeforeEach
+    void setUp() {
+        System.setProperty("io.gravitee.sdk.testcase.enabled", "true");
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.clearProperty("io.gravitee.sdk.testcase.enabled");
+    }
 
     @Test
     @DisplayName("Should success tests")

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/ClientAuthenticationPEMInlineTestCase.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/ClientAuthenticationPEMInlineTestCase.java
@@ -34,6 +34,9 @@ import io.vertx.reactivex.ext.web.client.HttpResponse;
 import io.vertx.reactivex.ext.web.client.WebClient;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 /**
  *
@@ -52,6 +55,7 @@ import org.junit.jupiter.api.Test;
  */
 @GatewayTest
 @DeployApi("/apis/client-authentication-pem-inline-support.json")
+@EnableForGatewayTestingExtensionTesting
 public class ClientAuthenticationPEMInlineTestCase extends AbstractGatewayTest {
 
     public static final String ENDPOINT = "/team/my_team";

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/ConditionalPolicyTestCase.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/ConditionalPolicyTestCase.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.api.Test;
  */
 @GatewayTest
 @DeployApi({ "/apis/conditional-policy-flow.json" })
+@EnableForGatewayTestingExtensionTesting
 public class ConditionalPolicyTestCase extends AbstractGatewayTest {
 
     public static final String ENDPOINT = "/test/my_team";

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/EnableForGatewayTestingExtensionTesting.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/EnableForGatewayTestingExtensionTesting.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package testcases;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+/**
+ * This annotation allows to run *TestCase.java classes only if `io.gravitee.sdk.testcase.enabled` system property is set to true.
+ * It improves the developer experience avoiding failing tests when running all tests in the project.
+ *
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@EnabledIfSystemProperty(
+    named = "io.gravitee.sdk.testcase.enabled",
+    matches = "true",
+    disabledReason = "This test is disabled because it is only run in the context of GatewayTestingExtensionTest"
+)
+public @interface EnableForGatewayTestingExtensionTesting {
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/Http2HeadersTestCase.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/Http2HeadersTestCase.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.Test;
  */
 @GatewayTest
 @DeployApi("/apis/teams.json")
+@EnableForGatewayTestingExtensionTesting
 public class Http2HeadersTestCase extends AbstractHttp2GatewayTest {
 
     public static final String ENDPOINT = "/team/my_team";

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/InvalidApiClassLevelTestCase.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/InvalidApiClassLevelTestCase.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.Test;
  */
 @GatewayTest
 @DeployApi("/invalid.json")
+@EnableForGatewayTestingExtensionTesting
 public class InvalidApiClassLevelTestCase extends AbstractGatewayTest {
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/InvalidGatewayConfigFolderTestCase.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/InvalidGatewayConfigFolderTestCase.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.Test;
  */
 @GatewayTest(configFolder = "/non-existing")
 @DeployApi("fakeApi.json")
+@EnableForGatewayTestingExtensionTesting
 public class InvalidGatewayConfigFolderTestCase extends AbstractGatewayTest {
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/NotExtendingAbstractClassTestCase.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/NotExtendingAbstractClassTestCase.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.Test;
  */
 @GatewayTest
 @DeployApi("/apis/conditional-policy-flow.json")
+@EnableForGatewayTestingExtensionTesting
 public class NotExtendingAbstractClassTestCase {
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/RegisterTwiceSameApiClassLevelTestCase.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/RegisterTwiceSameApiClassLevelTestCase.java
@@ -50,6 +50,7 @@ import org.junit.jupiter.api.Test;
  */
 @GatewayTest
 @DeployApi({ "/apis/conditional-policy-flow.json", "/apis/conditional-policy-flow.json" })
+@EnableForGatewayTestingExtensionTesting
 public class RegisterTwiceSameApiClassLevelTestCase extends AbstractGatewayTest {
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/RegisterTwiceSameApiMethodLevelTestCase.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/RegisterTwiceSameApiMethodLevelTestCase.java
@@ -50,6 +50,7 @@ import org.junit.jupiter.api.Test;
  */
 @GatewayTest
 @DeployApi("/apis/conditional-policy-flow.json")
+@EnableForGatewayTestingExtensionTesting
 public class RegisterTwiceSameApiMethodLevelTestCase extends AbstractGatewayTest {
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/SuccessTestCase.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/SuccessTestCase.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.Test;
  */
 @GatewayTest
 @DeployApi({ "/apis/success-flow.json" })
+@EnableForGatewayTestingExtensionTesting
 public class SuccessTestCase extends AbstractGatewayTest {
 
     public static final String ON_REQUEST_POLICY = "on-request-policy";


### PR DESCRIPTION
**Description**

As a developper, you often use your IDE to `Run all` tests of a package.

Gateway Testing SDK is testing its `GatewayExtension` with classes that are themselves JUnit tests.
It allows to assert on the number of test succeeded or failed depending on what we expect as behavior from the `GatewayExtension`.

But when using `Run all`, the IDE also run the `*TestCase.java` classes.
It causes results like this, that can be really confusing:
<img width="1725" alt="image" src="https://user-images.githubusercontent.com/47851994/183072091-c8a8518d-63bd-445a-9496-a5d0310cd028.png">

This pull request fixes that by enabling those tests on condition a particular system property is present, and which is set by `GatewayTestingExtensionTest`. The result is that `TestCase` classes will be ignored, with a message explaining why.

<img width="1725" alt="image" src="https://user-images.githubusercontent.com/47851994/183071460-16f8b9a9-0a92-4e78-af53-118b0b7d5313.png">

Obviously, if you want to run a `TestCase` manually, you can still do that:
![image](https://user-images.githubusercontent.com/47851994/183072546-1eaa306e-b67c-4472-820a-162f6567321c.png)


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-prninsjgse.chromatic.com)
<!-- Storybook placeholder end -->
