### PR TITLE
escape a mysql/mariadb reserved word

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcFlowRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcFlowRepository.java
@@ -247,7 +247,11 @@ public class JdbcFlowRepository extends JdbcAbstractCrudRepository<Flow, String>
 
     private List<FlowSelector> getSelectors(final String flowId) {
         List<FlowSelector> flowSelectors = jdbcTemplate.query(
-            "select type, path, path_operator, condition, channel, channel_operator from " + FLOW_SELECTORS + " where flow_id = ?",
+            "select type, path, path_operator, " +
+            escapeReservedWord("condition") +
+            ", channel, channel_operator from " +
+            FLOW_SELECTORS +
+            " where flow_id = ?",
             (resultSet, i) -> {
                 String type = resultSet.getString(1);
                 FlowSelectorType flowSelectorType = FlowSelectorType.valueOf(type);


### PR DESCRIPTION
**Issue**

N/A

**Description**

DB tests failed for mysql and mariadb because of a reserved word: 'condition'
https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/10292/workflows/84fc1e78-8874-4096-9001-ad1b4fe2c83b
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-jdbc-tests-for-mysql-and-mariadb/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qqzvpegirg.chromatic.com)
<!-- Storybook placeholder end -->
