### PR TITLE
GW fix flaky NullPointerException when k8s sync handleConfigMapEvent

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/ApiSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/ApiSynchronizer.java
@@ -219,7 +219,7 @@ public class ApiSynchronizer extends AbstractSynchronizer {
                 eventApiDefinition
             );
             apiDefinition.setEnabled(eventPayload.getLifecycleState() == LifecycleState.STARTED);
-            apiDefinition.setDeployedAt(apiEvent.getCreatedAt());
+            apiDefinition.setDeployedAt(eventPayload.getDeployedAt());
 
             enhanceWithOrgAndEnv(eventPayload.getEnvironmentId(), apiDefinition);
 


### PR DESCRIPTION

**Issue**

Part of https://github.com/gravitee-io/issues/issues/8136

**Description**

A random error appears on the gateway as if it could not deserialize the deployedAt (note sure). 

Quite strange to reproduce. If any of you want to look 👀  with me, let me know 🙏 . Otherwise, this change seems to be a way to get back to a normal situation (credit to @kamiiiel )

Fix this error on gw :
```
14:07:59.877 [vert.x-eventloop-thread-0] [] ERROR i.g.g.handlers.api.ApiReactorHandler - An unexpected error occurs while processing request
java.lang.NullPointerException: Cannot invoke "java.util.Date.getTime()" because the return value of "io.gravitee.gateway.handlers.api.definition.Api.getDeployedAt()" is null
	at io.gravitee.gateway.handlers.api.ApiReactorHandler.doHandle(ApiReactorHandler.java:91)
	at io.gravitee.gateway.reactor.handler.AbstractReactorHandler.handle(AbstractReactorHandler.java:74)
	at io.gravitee.gateway.reactor.impl.DefaultReactor.lambda$route$4(DefaultReactor.java:98)
	at io.gravitee.gateway.core.processor.chain.AbstractProcessorChain.handle(AbstractProcessorChain.java:43)
	at io.gravitee.gateway.core.processor.chain.AbstractProcessorChain.lambda$handle$0(AbstractProcessorChain.java:38)
	at io.gravitee.gateway.reactor.processor.transaction.TransactionProcessor.handle(TransactionProcessor.java:60)
	at io.gravitee.gateway.reactor.processor.transaction.TransactionProcessor.handle(TransactionProcessor.java:29)
	at io.gravitee.gateway.core.processor.chain.AbstractProcessorChain.handle(AbstractProcessorChain.java:41)
	at io.gravitee.gateway.core.processor.chain.AbstractProcessorChain.lambda$handle$0(AbstractProcessorChain.java:38)
	at io.gravitee.gateway.reactor.processor.forward.XForwardForProcessor.handle(XForwardForProcessor.java:62)
	at io.gravitee.gateway.reactor.processor.forward.XForwardForProcessor.handle(XForwardForProcessor.java:31)
	at io.gravitee.gateway.core.processor.chain.AbstractProcessorChain.handle(AbstractProcessorChain.java:41)
	at io.gravitee.gateway.reactor.impl.DefaultReactor.route(DefaultReactor.java:112)
	at io.gravitee.gateway.standalone.vertx.VertxReactorHandler.route(VertxReactorHandler.java:64)
	at
```

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-gko-updatedat/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-eugfcgwuih.chromatic.com)
<!-- Storybook placeholder end -->
