### PR TITLE
fix(gateway): fix flaky NullPointerException when k8s sync handleConf…

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/kubernetes/KubernetesSyncService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/kubernetes/KubernetesSyncService.java
@@ -112,11 +112,11 @@ public class KubernetesSyncService extends AbstractService<KubernetesSyncService
 
                 final io.gravitee.repository.management.model.Event event = new io.gravitee.repository.management.model.Event();
                 event.setProperties(Collections.singletonMap(API_ID.getValue(), apiDefinition.getId()));
+                event.setCreatedAt(new Date());
 
                 final io.gravitee.repository.management.model.Api api = new io.gravitee.repository.management.model.Api();
                 api.setEnvironmentId(configMap.getData().get(DATA_ENVIRONMENT_ID));
                 api.setDefinition(definition);
-                api.setDeployedAt(new Date());
                 api.setId(apiDefinition.getId());
 
                 switch (kubEvent.getType()) {


### PR DESCRIPTION
**Issue**

Part of https://github.com/gravitee-io/issues/issues/8136

**Description**

A random error appears on the gateway as if it could not deserialize the deployedAt (note sure). 

Fix this error on gw :
```
14:07:59.877 [vert.x-eventloop-thread-0] [] ERROR i.g.g.handlers.api.ApiReactorHandler - An unexpected error occurs while processing request
java.lang.NullPointerException: Cannot invoke "java.util.Date.getTime()" because the return value of "io.gravitee.gateway.handlers.api.definition.Api.getDeployedAt()" is null
	at io.gravitee.gateway.handlers.api.ApiReactorHandler.doHandle(ApiReactorHandler.java:91)
	at io.gravitee.gateway.reactor.handler.AbstractReactorHandler.handle(AbstractReactorHandler.java:74)
	at io.gravitee.gateway.reactor.impl.DefaultReactor.lambda$route$4(DefaultReactor.java:98)
	at io.gravitee.gateway.core.processor.chain.AbstractProcessorChain.handle(AbstractProcessorChain.java:43)
	at io.gravitee.gateway.core.processor.chain.AbstractProcessorChain.lambda$handle$0(AbstractProcessorChain.java:38)
	at io.gravitee.gateway.reactor.processor.transaction.TransactionProcessor.handle(TransactionProcessor.java:60)
	at io.gravitee.gateway.reactor.processor.transaction.TransactionProcessor.handle(TransactionProcessor.java:29)
	at io.gravitee.gateway.core.processor.chain.AbstractProcessorChain.handle(AbstractProcessorChain.java:41)
	at io.gravitee.gateway.core.processor.chain.AbstractProcessorChain.lambda$handle$0(AbstractProcessorChain.java:38)
	at io.gravitee.gateway.reactor.processor.forward.XForwardForProcessor.handle(XForwardForProcessor.java:62)
	at io.gravitee.gateway.reactor.processor.forward.XForwardForProcessor.handle(XForwardForProcessor.java:31)
	at io.gravitee.gateway.core.processor.chain.AbstractProcessorChain.handle(AbstractProcessorChain.java:41)
	at io.gravitee.gateway.reactor.impl.DefaultReactor.route(DefaultReactor.java:112)
	at io.gravitee.gateway.standalone.vertx.VertxReactorHandler.route(VertxReactorHandler.java:64)
	at
```

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-gko-updatedat-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lbrvluvjec.chromatic.com)
<!-- Storybook placeholder end -->
