### PR TITLE
fix: use "state" property to enable/disable an API

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/ApiDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/ApiDeserializer.java
@@ -254,6 +254,12 @@ public class ApiDeserializer<T extends Api> extends StdScalarDeserializer<T> {
             api.setDefinitionContext(definitionContext);
         }
 
+        JsonNode stateNode = node.get("state");
+        if (stateNode != null) {
+            String state = stateNode.traverse(jp.getCodec()).readValueAs(String.class);
+            api.setState(state);
+        }
+
         return api;
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
@@ -664,4 +664,23 @@ public class ApiDeserializerTest extends AbstractTest {
         assertEquals(DefinitionContext.ORIGIN_KUBERNETES, definitionContext.getOrigin());
         assertEquals(DefinitionContext.MODE_FULLY_MANAGED, definitionContext.getMode());
     }
+
+    @Test
+    public void definition_withStartedState() throws Exception {
+        Api api = load("/io/gravitee/definition/jackson/api-state-started.json", Api.class);
+
+        String state = api.getState();
+        Assert.assertNotNull(state);
+        assertEquals("STARTED", state);
+    }
+
+    @Test
+    public void definition_withStoppedState() throws Exception {
+        Api api = load("/io/gravitee/definition/jackson/api-state-stoppd.json", Api.class);
+
+        String state = api.getState();
+        Assert.assertNotNull(state);
+        assertEquals("STOPPED", state);
+    }
+
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
@@ -682,5 +682,4 @@ public class ApiDeserializerTest extends AbstractTest {
         Assert.assertNotNull(state);
         assertEquals("STOPPED", state);
     }
-
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-state-started.json
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-state-started.json
@@ -1,0 +1,20 @@
+{
+  "id": "my-api",
+  "name": "my-team-api",
+  "state": "STARTED",
+  "proxy": {
+    "context_path": "/team",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://host1:8083/myapi"
+      }
+    ],
+    "strip_context_path": false
+  },
+
+  "paths": {
+    "/*": [
+    ]
+  }
+}

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-state-stoppd.json
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-state-stoppd.json
@@ -1,0 +1,20 @@
+{
+  "id": "my-api",
+  "name": "my-team-api",
+  "state": "STOPPED",
+  "proxy": {
+    "context_path": "/team",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://host1:8083/myapi"
+      }
+    ],
+    "strip_context_path": false
+  },
+
+  "paths": {
+    "/*": [
+    ]
+  }
+}

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Api.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Api.java
@@ -81,6 +81,9 @@ public class Api implements Serializable {
     @JsonProperty("execution_mode")
     private ExecutionMode executionMode;
 
+    @JsonProperty("state")
+    private String state;
+
     public Api() {}
 
     public String getId() {
@@ -228,6 +231,14 @@ public class Api implements Serializable {
 
     public void setDefinitionContext(DefinitionContext definitionContext) {
         this.definitionContext = definitionContext;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/kubernetes/KubernetesSyncService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/kubernetes/KubernetesSyncService.java
@@ -122,8 +122,12 @@ public class KubernetesSyncService extends AbstractService<KubernetesSyncService
                 switch (kubEvent.getType()) {
                     case "ADDED":
                     case "MODIFIED":
-                        event.setType(EventType.PUBLISH_API);
-                        api.setLifecycleState(LifecycleState.STARTED);
+                        api.setLifecycleState(LifecycleState.valueOf(apiDefinition.getState()));
+                        if (api.getLifecycleState() == LifecycleState.STARTED) {
+                            event.setType(EventType.PUBLISH_API);
+                        } else {
+                            event.setType(EventType.STOP_API);
+                        }
                         break;
                     case "DELETED":
                         event.setType(EventType.UNPUBLISH_API);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -692,6 +692,12 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         }
     }
 
+    private void checkApiDefinitionOrigin(Api api) {
+        if (DefinitionContext.isKubernetes(api.getOrigin())) {
+            throw new ApiNotManagedException("The api is managed externally (" + api.getOrigin() + "). Unable to deploy it.");
+        }
+    }
+
     private void checkEndpointsExists(UpdateApiEntity api) {
         if (api.getProxy().getGroups() == null || api.getProxy().getGroups().isEmpty()) {
             throw new EndpointMissingException();
@@ -1476,6 +1482,9 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 apiId
             );
             updateApiEntity.getProxy().setVirtualHosts(new ArrayList<>(sanitizedVirtualHosts));
+
+            // Make sure that the API is managed by the console
+            checkApiDefinitionOrigin(apiToUpdate);
 
             // check endpoints presence
             checkEndpointsExists(updateApiEntity);


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8136

**Description**

Using a "state" property the user must be able to start and stop and API
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-api-definition-state/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lsfcicitte.chromatic.com)
<!-- Storybook placeholder end -->
