### PR TITLE
Gateway Testing SDK - Register Entrypoint plugins and deploy API V4

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/sme/SseEntrypointIntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/sme/SseEntrypointIntegrationTest.java
@@ -1,0 +1,114 @@
+package io.gravitee.gateway.tests.sme;/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.reactivex.observers.TestObserver;
+import io.reactivex.subscribers.TestSubscriber;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.reactivex.core.buffer.Buffer;
+import io.vertx.reactivex.core.http.HttpClient;
+import io.vertx.reactivex.core.http.HttpClientResponse;
+import io.vertx.reactivex.ext.web.client.HttpResponse;
+import io.vertx.reactivex.ext.web.client.WebClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@DeployApi({ "/apis/v4/sse-entrypoint.json" })
+class SseEntrypointIntegrationTest extends AbstractGatewayTest {
+
+    @Override
+    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
+        gatewayConfigurationBuilder.set("api.jupiterMode.enabled", "true");
+        gatewayConfigurationBuilder.set("api.jupiterMode.default", "always");
+    }
+
+    @Test
+    @DisplayName("Should deploy a V4 API with an SSE entrypoint")
+    void shouldDeployV4Api(HttpClient httpClient) {
+        final TestSubscriber<Buffer> obs = httpClient
+            .rxRequest(HttpMethod.GET, "/test")
+            .flatMap(
+                request -> {
+                    request.putHeader(HttpHeaderNames.ACCEPT.toString(), MediaType.TEXT_EVENT_STREAM);
+                    return request.rxSend();
+                }
+            )
+            .flatMapPublisher(HttpClientResponse::toFlowable)
+            .test();
+
+        obs
+            .awaitCount(3)
+            .assertValueAt(
+                0,
+                chunk -> {
+                    assertOnChunk(chunk, 0);
+                    return true;
+                }
+            )
+            .assertValueAt(
+                1,
+                chunk -> {
+                    // A message is followed by a double return as per developed in SseEntrypointConnector
+                    assertThat(chunk).isEqualTo(Buffer.buffer("\n\n"));
+                    return true;
+                }
+            )
+            .assertValueAt(
+                2,
+                chunk -> {
+                    assertOnChunk(chunk, 1);
+                    return true;
+                }
+            )
+            .assertNoErrors();
+    }
+
+    @Test
+    @DisplayName("Should not be able to call SSE Entrypoint if no ACCEPT header")
+    void shouldNotCallSseEntrypointWhenNoAcceptHeader(WebClient webClient) {
+        final TestObserver<HttpResponse<Buffer>> obs = webClient.get("/test").rxSend().test();
+
+        awaitTerminalEvent(obs)
+            .assertComplete()
+            .assertValue(
+                response -> {
+                    assertThat(response.statusCode()).isEqualTo(404);
+                    return true;
+                }
+            );
+        obs.assertNoErrors();
+    }
+
+    private void assertOnChunk(Buffer chunk, int messageNumber) {
+        final String[] splitMessage = chunk.toString().split("\n");
+        assertThat(splitMessage).hasSize(3);
+        assertThat(splitMessage[0]).startsWith("id: ");
+        assertThat(splitMessage[1]).isEqualTo("event: message");
+        assertThat(splitMessage[2]).isEqualTo("data: Mock data " + messageNumber);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/resources/apis/v4/sse-entrypoint.json
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/resources/apis/v4/sse-entrypoint.json
@@ -1,0 +1,39 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "apiVersion": "1.0",
+  "definitionVersion": "4.0.0",
+  "type": "async",
+  "description": "api v4 using SSE entrypoint",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "sse"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default",
+      "type": "mock",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "mock",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": "{\"messageInterval\":500, \"messageContent\":\"Mock data\", \"messageCount\":12}"
+        }
+      ]
+    }
+  ],
+  "flows": []
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/pom.xml
@@ -145,6 +145,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.gravitee.apim.plugin.endpoint</groupId>
+            <artifactId>gravitee-apim-plugin-endpoint-mock</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.gravitee.apim.definition</groupId>
             <artifactId>gravitee-apim-definition-jackson</artifactId>
             <version>${project.version}</version>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/pom.xml
@@ -139,6 +139,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.gravitee.apim.plugin.entrypoint</groupId>
+            <artifactId>gravitee-apim-plugin-entrypoint-sse</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.gravitee.apim.definition</groupId>
             <artifactId>gravitee-apim-definition-jackson</artifactId>
             <version>${project.version}</version>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/AbstractPolicyTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/AbstractPolicyTest.java
@@ -16,29 +16,12 @@
 package io.gravitee.apim.gateway.tests.sdk;
 
 import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
-import io.gravitee.common.event.impl.SimpleEvent;
-import io.gravitee.gateway.policy.PolicyManifest;
-import io.gravitee.plugin.core.api.PluginEvent;
 import io.gravitee.plugin.core.api.PluginManifest;
-import io.gravitee.plugin.core.api.PluginManifestFactory;
-import io.gravitee.plugin.core.internal.PluginEventListener;
-import io.gravitee.plugin.core.internal.PluginImpl;
-import io.gravitee.plugin.core.internal.PluginRegistryImpl;
 import io.gravitee.plugin.policy.PolicyPlugin;
 import io.gravitee.policy.api.PolicyConfiguration;
-import java.io.IOException;
-import java.io.InputStream;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.net.URL;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Map;
-import java.util.Properties;
-import org.junit.platform.commons.PreconditionViolationException;
 
 /**
  * Inherit from this class to automatically register the policy you want to test.

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/GatewayTestingExtension.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/GatewayTestingExtension.java
@@ -19,12 +19,21 @@ import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployOrganization;
 import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
 import io.gravitee.apim.gateway.tests.sdk.runner.GatewayRunner;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.junit5.ScopedObject;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.reactivex.core.Vertx;
+import io.vertx.reactivex.core.http.HttpClient;
 import java.io.IOException;
+import java.util.Objects;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.platform.commons.PreconditionViolationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,7 +48,8 @@ import org.slf4j.LoggerFactory;
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class GatewayTestingExtension implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback, AfterAllCallback {
+public class GatewayTestingExtension
+    implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback, AfterAllCallback, ParameterResolver {
 
     public static final Logger LOGGER = LoggerFactory.getLogger(GatewayTestingExtension.class);
 
@@ -173,5 +183,41 @@ public class GatewayTestingExtension implements BeforeAllCallback, BeforeEachCal
         } else {
             throw new PreconditionViolationException("Test class must extend AbstractGatewayTest");
         }
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+        throws ParameterResolutionException {
+        return parameterContext.getParameter().getType() == HttpClient.class;
+    }
+
+    /**
+     * Vertx Webclient is not good when testing async APIs. So we inject the Vertx HttpClient which provides more freedom.
+     * @param parameterContext the context for the parameter for which an argument should
+     * be resolved; never {@code null}
+     * @param extensionContext the extension context for the {@code Executable}
+     * about to be invoked; never {@code null}
+     * @return the instance of HttpClient
+     * @throws ParameterResolutionException
+     */
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+        throws ParameterResolutionException {
+        final AbstractGatewayTest test = parameterContext
+            .getTarget()
+            .map(AbstractGatewayTest.class::cast)
+            .orElseThrow(() -> new PreconditionViolationException("You need to inject this in a child of AbstractGatewayTest"));
+        Vertx vertx = getStoredVertx(extensionContext);
+
+        final HttpClientOptions httpClientOptions = new HttpClientOptions().setDefaultPort(test.gatewayPort()).setDefaultHost("localhost");
+        test.configureHttpClient(httpClientOptions);
+        return vertx.createHttpClient(httpClientOptions);
+    }
+
+    private Vertx getStoredVertx(ExtensionContext extensionContext) {
+        ExtensionContext.Store store = extensionContext.getStore(ExtensionContext.Namespace.GLOBAL);
+        ScopedObject scopedObject = store.get(VertxExtension.VERTX_INSTANCE_KEY, ScopedObject.class);
+        Objects.requireNonNull(scopedObject, "A Vertx instance must exist, try adding the Vertx parameter as the first method argument");
+        return (Vertx) scopedObject.get();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/connector/EndpointBuilder.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/connector/EndpointBuilder.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.gateway.tests.sdk.connector;
+
+import io.gravitee.gateway.jupiter.api.connector.AbstractConnectorFactory;
+import io.gravitee.gateway.jupiter.api.connector.endpoint.EndpointConnectorConfiguration;
+import io.gravitee.gateway.jupiter.api.connector.endpoint.async.EndpointAsyncConnectorFactory;
+import io.gravitee.plugin.core.api.PluginManifest;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import java.net.URL;
+import java.nio.file.Path;
+
+public class EndpointBuilder {
+
+    private EndpointBuilder() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static EndpointConnectorPlugin<?> build(String id, Class<? extends EndpointAsyncConnectorFactory> entrypointConnectorFactory) {
+        return build(id, entrypointConnectorFactory, null);
+    }
+
+    public static EndpointConnectorPlugin<?> build(
+        String id,
+        Class<? extends EndpointAsyncConnectorFactory> entrypointConnectorFactory,
+        Class<? extends EndpointConnectorConfiguration> entrypointConfiguration
+    ) {
+        return new EndpointConnectorPlugin<>() {
+            @Override
+            public Class<? extends AbstractConnectorFactory<?>> endpointConnectorFactory() {
+                return entrypointConnectorFactory;
+            }
+
+            @Override
+            public String id() {
+                return id;
+            }
+
+            @Override
+            public String clazz() {
+                return entrypointConnectorFactory.getName();
+            }
+
+            @Override
+            public Path path() {
+                return null;
+            }
+
+            @Override
+            public PluginManifest manifest() {
+                return null;
+            }
+
+            @Override
+            public URL[] dependencies() {
+                return new URL[0];
+            }
+
+            @Override
+            public Class configuration() {
+                return entrypointConfiguration;
+            }
+        };
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/connector/EntrypointBuilder.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/connector/EntrypointBuilder.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.gateway.tests.sdk.connector;
+
+import io.gravitee.gateway.jupiter.api.connector.AbstractConnectorFactory;
+import io.gravitee.gateway.jupiter.api.connector.entrypoint.EntrypointConnectorConfiguration;
+import io.gravitee.gateway.jupiter.api.connector.entrypoint.async.EntrypointAsyncConnectorFactory;
+import io.gravitee.plugin.core.api.PluginManifest;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import java.net.URL;
+import java.nio.file.Path;
+
+public class EntrypointBuilder {
+
+    private EntrypointBuilder() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    public static EntrypointConnectorPlugin<?> build(
+        String id,
+        Class<? extends EntrypointAsyncConnectorFactory> entrypointConnectorFactory
+    ) {
+        return build(id, entrypointConnectorFactory, null);
+    }
+
+    public static EntrypointConnectorPlugin<?> build(
+        String id,
+        Class<? extends EntrypointAsyncConnectorFactory> entrypointConnectorFactory,
+        Class<? extends EntrypointConnectorConfiguration> entrypointConfiguration
+    ) {
+        return new EntrypointConnectorPlugin<>() {
+            @Override
+            public Class<? extends AbstractConnectorFactory<?>> entrypointConnectorFactory() {
+                return entrypointConnectorFactory;
+            }
+
+            @Override
+            public String id() {
+                return id;
+            }
+
+            @Override
+            public String clazz() {
+                return entrypointConnectorFactory.getName();
+            }
+
+            @Override
+            public Path path() {
+                return null;
+            }
+
+            @Override
+            public PluginManifest manifest() {
+                return null;
+            }
+
+            @Override
+            public URL[] dependencies() {
+                return new URL[0];
+            }
+
+            @Override
+            public Class configuration() {
+                return entrypointConfiguration;
+            }
+        };
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/converters/ApiDeploymentPreparer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/converters/ApiDeploymentPreparer.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.gateway.tests.sdk.converters;
+
+import io.gravitee.gateway.reactor.ReactableApi;
+
+/**
+ *
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface ApiDeploymentPreparer<D> {
+    /**
+     * Convert an API Definition to a {@link ReactableApi}
+     * @param definition the definition to transform
+     * @return the ReactableApi>
+     */
+    ReactableApi<D> toReactable(D definition);
+
+    /**
+     * Ensure minimal requirements for the API.
+     * @param definition the api definition to complete
+     */
+    void ensureMinimalRequirementForApi(D definition);
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/converters/LegacyApiDeploymentPreparer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/converters/LegacyApiDeploymentPreparer.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.gateway.tests.sdk.converters;
+
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.EndpointGroup;
+import io.gravitee.definition.model.Plan;
+import io.gravitee.gateway.reactor.ReactableApi;
+import java.util.Collections;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class LegacyApiDeploymentPreparer implements ApiDeploymentPreparer<Api> {
+
+    @Override
+    public ReactableApi<Api> toReactable(Api definition) {
+        return new io.gravitee.gateway.handlers.api.definition.Api(definition);
+    }
+
+    @Override
+    public void ensureMinimalRequirementForApi(Api definition) {
+        this.addDefaultKeylessPlanIfNeeded(definition);
+        this.addDefaultEndpointGroupIfNeeded(definition);
+    }
+
+    /**
+     * Override api plans to create a default Keyless plan and ensure their are published
+     * @param api is the api to override
+     */
+    protected void addDefaultKeylessPlanIfNeeded(Api api) {
+        if (api.getPlans() == null || api.getPlans().isEmpty()) {
+            // By default, add a keyless plan to the API
+            Plan plan = new Plan();
+            plan.setId("default_plan");
+            plan.setName("Default plan");
+            plan.setSecurity("key_less");
+            plan.setStatus("published");
+
+            api.setPlans(Collections.singletonList(plan));
+        } else {
+            api
+                .getPlans()
+                .stream()
+                .filter(plan -> plan.getStatus() == null || plan.getStatus().isEmpty())
+                .forEach(plan -> plan.setStatus("published"));
+        }
+    }
+
+    /**
+     * Add a default endpoint group to the api
+     */
+    private void addDefaultEndpointGroupIfNeeded(Api api) {
+        if (api.getProxy().getGroups() == null || api.getProxy().getGroups().isEmpty()) {
+            // Create a default endpoint group
+            EndpointGroup group = new EndpointGroup();
+            group.setName("default");
+            group.setEndpoints(Collections.emptySet());
+            api.getProxy().setGroups(Collections.singleton(group));
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/converters/V4ApiDeploymentPreparer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/converters/V4ApiDeploymentPreparer.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.gateway.tests.sdk.converters;
+
+import io.gravitee.definition.model.EndpointGroup;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.plan.Plan;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.gateway.reactor.ReactableApi;
+import java.util.Collections;
+import org.junit.platform.commons.PreconditionViolationException;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class V4ApiDeploymentPreparer implements ApiDeploymentPreparer<Api> {
+
+    @Override
+    public ReactableApi<Api> toReactable(Api definition) {
+        return new io.gravitee.gateway.jupiter.handlers.api.v4.Api(definition);
+    }
+
+    @Override
+    public void ensureMinimalRequirementForApi(Api definition) {
+        if (definition.getType() == null) {
+            throw new PreconditionViolationException("'type' field must be defined on a V4 API Definition");
+        }
+        this.addDefaultKeylessPlanIfNeeded(definition);
+        this.addDefaultEndpointGroupIfNeeded(definition);
+    }
+
+    /**
+     * Override api plans to create a default Keyless plan and ensure their are published
+     * @param api is the api to override
+     */
+    protected void addDefaultKeylessPlanIfNeeded(Api api) {
+        if (api.getPlans() == null || api.getPlans().isEmpty()) {
+            // By default, add a keyless plan to the API
+            Plan plan = new Plan();
+            plan.setId("default_plan");
+            plan.setName("Default plan");
+            final PlanSecurity planSecurity = new PlanSecurity();
+            planSecurity.setType("key-less");
+            plan.setSecurity(planSecurity);
+            plan.setStatus(PlanStatus.PUBLISHED);
+
+            api.setPlans(Collections.singletonList(plan));
+        } else {
+            api.getPlans().stream().filter(plan -> plan.getStatus() == null).forEach(plan -> plan.setStatus(PlanStatus.PUBLISHED));
+        }
+    }
+
+    /**
+     * Add a default endpoint group to the api
+     */
+    private void addDefaultEndpointGroupIfNeeded(Api api) {
+        if (ApiType.SYNC.equals(api.getType())) {
+            // TODO: implement this when sync api endpoints will be implemented
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/plugin/PluginRegister.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/plugin/PluginRegister.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.gateway.tests.sdk.plugin;
 import io.gravitee.gateway.policy.PolicyManifest;
 import io.gravitee.plugin.connector.ConnectorPlugin;
 import io.gravitee.plugin.core.api.PluginManifest;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
 import io.gravitee.plugin.policy.PolicyPlugin;
 import io.gravitee.plugin.resource.ResourcePlugin;
@@ -89,6 +90,23 @@ public interface PluginRegister {
      * @param entrypoints is the map containing entrypoints to deploy
      */
     default void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?>> entrypoints) {}
+
+    /**
+     * Override this method to register an endpoint to be used by the gateway.
+     * This method is useful if you want to register a dummy endpoint.
+     * For example:
+     * <pre>
+     *     {@code
+     *     @Override
+     *     public void configureEndpoints(Map<String, EndpointPlugin> endpoints) {
+     *         endpoints.put("mock", EndpointBuilder.build("endpoint-dummy", DummyEndpointConnectorFactory.class));
+     *     }
+     *     }
+     * </pre>
+     * You can check {@link io.gravitee.plugin.endpoint.mock.MockEndpointConnectorFactory} to know how to implement it.
+     * @param endpoints is the map containing endpoints to deploy
+     */
+    default void configureEndpoints(Map<String, EndpointConnectorPlugin<?>> endpoints) {}
 
     /**
      * Override this method to register a resource to be used by the gateway.

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/plugin/PluginRegister.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/plugin/PluginRegister.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.gateway.tests.sdk.plugin;
 import io.gravitee.gateway.policy.PolicyManifest;
 import io.gravitee.plugin.connector.ConnectorPlugin;
 import io.gravitee.plugin.core.api.PluginManifest;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
 import io.gravitee.plugin.policy.PolicyPlugin;
 import io.gravitee.plugin.resource.ResourcePlugin;
 import io.gravitee.reporter.api.Reporter;
@@ -63,7 +64,6 @@ public interface PluginRegister {
      *     {@code
      *     @Override
      *     public void configureConnectors(Map<String, ConnectorPlugin> connectors) {
-     *         super.configureConnectors(connectors);
      *         connectors.put("connector-http", ConnectorBuilder.build("connector-http", HttpConnectorFactory.class));
      *     }
      *     }
@@ -72,6 +72,23 @@ public interface PluginRegister {
      * @param connectors is the map containing connectors to deploy
      */
     default void configureConnectors(Map<String, ConnectorPlugin> connectors) {}
+
+    /**
+     * Override this method to register an entrypoint to be used by the gateway.
+     * This method is useful if you want to register a dummy entrypoint.
+     * For example:
+     * <pre>
+     *     {@code
+     *     @Override
+     *     public void configureEntrypoints(Map<String, EntrypointPlugin> entrypoints) {
+     *         entrypoints.put("entrypoint-dummy", EntrypointBuilder.build("entrypoint-dummy", DummyEntrypointConnectorFactory.class));
+     *     }
+     *     }
+     * </pre>
+     * You can check {@link io.gravitee.plugin.entrypoint.sse.SseEntrypointConnectorFactory} to know how to implement it.
+     * @param entrypoints is the map containing entrypoints to deploy
+     */
+    default void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?>> entrypoints) {}
 
     /**
      * Override this method to register a resource to be used by the gateway.

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/runner/ApiConfigurer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/runner/ApiConfigurer.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.gateway.tests.sdk.runner;
 
 import io.gravitee.definition.model.Api;
+import io.gravitee.gateway.reactor.ReactableApi;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -24,9 +25,20 @@ import io.gravitee.definition.model.Api;
 public interface ApiConfigurer {
     /**
      * Configure apis before their deployment.
+     * @deprecated see {@link #configureApi(ReactableApi, Class)}, this one is to use for version of the Gateway prior to 3.19.0.
      * Useful to modify programmatically each api that will be deployed during the tests.
      * For example, add a JWT plan, or set endpoint groups.
      * @param api is the api to apply this function code
      */
+    @Deprecated(since = "3.19.0")
     void configureApi(Api api);
+
+    /**
+     * Configure apis before their deployment.
+     * Useful to modify programmatically each api that will be deployed during the tests.
+     * For example, on api definition version under V4, add a JWT plan, or set endpoint groups.
+     * @param reactableApi is the api to apply this function code
+     * @param definitionClass is the class of the definition since V4 apis has a different model from previous versions.
+     */
+    void configureApi(ReactableApi<?> reactableApi, Class<?> definitionClass);
 }


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8249

https://github.com/gravitee-io/issues/issues/8286

## Description

### What's done

This PR aims to be able to register an `Entrypoint` plugin and to deploy a V4 API.
A test has also been done to test the `SseEntrypoint`.

### Important changes

A method has been introduce `configureApi(ReactableApi, Class)` to be able to manage all kind of APIs, since there are some important differences between V4 definition version and what's before.

We keep the original `configureApi(Api)` to not break compatibility. It's just flagged as `Deprecated`

### New things

When testing a V4 api with a Sse Entrypoint, we discovered some limits with the vertx `WebClient` injected by the Gateway Testing SDK.

Indeed, `WebClient` only deals with `Single<HttpResponse>`. In the case of a SSE call, request was never done, so we never received the response.

To compensate that, we now also injects an vertx `HttpClient` which is more permissive (see https://github.com/gravitee-io/gravitee-api-management/commit/158d18d14234b37f0d322c61d91c84e19ba84dd4).

The HttpClient allow to transform the `HttpResponse` in a Flowable<Buffer>. That means that we are now able to do assertions on different messages. (as you can see in https://github.com/gravitee-io/gravitee-api-management/commit/62a569ee84d95e11fc8873f3a53c2cb81ef9e03e)

To use the `HttpClient`, you can simply use it as a parameter of your test: `void shouldDeployV4Api(HttpClient httpClient)`

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/sme-sdk-3/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wlgdslpblc.chromatic.com)
<!-- Storybook placeholder end -->
