### PR TITLE
allow null host if no domain restriction

### DIFF
--- a/.run/Gateway - JDBC.run.xml
+++ b/.run/Gateway - JDBC.run.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Gateway - JDBC" type="Application" factoryName="Application" folderName="Gateway">
+    <envs>
+      <env name="GRAVITEE_MANAGEMENT_JDBC_DATABASE" value="gravitee" />
+      <env name="GRAVITEE_MANAGEMENT_JDBC_DRIVER" value="postgresql" />
+      <env name="GRAVITEE_MANAGEMENT_JDBC_HOST" value="localhost" />
+      <env name="GRAVITEE_MANAGEMENT_JDBC_PASSWORD" value="password" />
+      <env name="GRAVITEE_MANAGEMENT_JDBC_PORT" value="5432" />
+      <env name="GRAVITEE_MANAGEMENT_JDBC_URL" value="jdbc:postgresql://localhost:5432/gravitee" />
+      <env name="GRAVITEE_MANAGEMENT_JDBC_USERNAME" value="postgres" />
+      <env name="GRAVITEE_MANAGEMENT_TYPE" value="jdbc" />
+    </envs>
+    <option name="MAIN_CLASS_NAME" value="io.gravitee.gateway.standalone.GatewayContainer" />
+    <module name="gravitee-apim-gateway-standalone-container" />
+    <option name="VM_PARAMETERS" value="-Dgravitee.home=$ProjectFileDir$/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target/distribution" />
+    <option name="WORKING_DIRECTORY" value="$ProjectFileDir$" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/Gateway - MongoDB.run.xml
+++ b/.run/Gateway - MongoDB.run.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Gateway - MongoDB" type="Application" factoryName="Application" folderName="Gateway">
+    <option name="MAIN_CLASS_NAME" value="io.gravitee.gateway.standalone.GatewayContainer" />
+    <module name="gravitee-apim-gateway-standalone-container" />
+    <option name="VM_PARAMETERS" value="-Dgravitee.home=$ProjectFileDir$/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target/distribution" />
+    <option name="WORKING_DIRECTORY" value="$ProjectFileDir$" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/Rest API - JDBC.run.xml
+++ b/.run/Rest API - JDBC.run.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Rest API - JDBC" type="Application" factoryName="Application" folderName="Rest API">
+    <envs>
+      <env name="GRAVITEE_MANAGEMENT_JDBC_DATABASE" value="gravitee" />
+      <env name="GRAVITEE_MANAGEMENT_JDBC_DRIVER" value="postgresql" />
+      <env name="GRAVITEE_MANAGEMENT_JDBC_HOST" value="localhost" />
+      <env name="GRAVITEE_MANAGEMENT_JDBC_PASSWORD" value="password" />
+      <env name="GRAVITEE_MANAGEMENT_JDBC_PORT" value="5432" />
+      <env name="GRAVITEE_MANAGEMENT_JDBC_URL" value="jdbc:postgresql://localhost:5432/gravitee" />
+      <env name="GRAVITEE_MANAGEMENT_JDBC_USERNAME" value="postgres" />
+      <env name="GRAVITEE_MANAGEMENT_TYPE" value="jdbc" />
+    </envs>
+    <option name="MAIN_CLASS_NAME" value="io.gravitee.rest.api.standalone.GraviteeApisContainer" />
+    <module name="gravitee-apim-rest-api-standalone-container" />
+    <option name="VM_PARAMETERS" value="-Dgravitee.home=$ProjectFileDir$/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target/distribution" />
+    <option name="WORKING_DIRECTORY" value="$ProjectFileDir$" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/Rest API - MongoDB.run.xml
+++ b/.run/Rest API - MongoDB.run.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Rest API - MongoDB" type="Application" factoryName="Application" folderName="Rest API">
+    <option name="MAIN_CLASS_NAME" value="io.gravitee.rest.api.standalone.GraviteeApisContainer" />
+    <module name="gravitee-apim-rest-api-standalone-container" />
+    <option name="VM_PARAMETERS" value="-Dgravitee.home=$ProjectFileDir$/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target/distribution" />
+    <option name="WORKING_DIRECTORY" value="$ProjectFileDir$" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/gravitee-apim-console-webui/src/management/api/proxy/general/apiProxyEntrypoints.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/general/apiProxyEntrypoints.html
@@ -102,6 +102,7 @@
 
               <md-input-container class="md-block" flex-gt-sm>
                 <md-autocomplete
+                  ng-if="apiProxyCtrl.domainRestrictions.length > 0"
                   aria-label="Listening host"
                   class="gravitee-listening-host"
                   md-autoselect="true"
@@ -122,6 +123,14 @@
                 >
                   <span>{{computedHost}}</span>
                 </md-autocomplete>
+                <input
+                  ng-if="apiProxyCtrl.domainRestrictions.length === 0"
+                  aria-label="Listening host"
+                  class="gravitee-listening-host"
+                  ng-pattern="apiProxyCtrl.hostPattern"
+                  ng-model="vHost.host"
+                  placeholder="Listening host"
+                />
                 <div
                   class="hint"
                   ng-if="vHost.host === undefined || vHost.host === '' || apiProxyCtrl.formApi['vhost'+$index+'-host'].$dirty"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/VirtualHostServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/VirtualHostServiceImpl.java
@@ -82,25 +82,6 @@ public class VirtualHostServiceImpl extends TransactionalService implements Virt
         // validate domain restrictions
         validateDomainRestrictions(sanitizedVirtualHosts, currentEnv.getDomainRestrictions());
 
-        // In virtual host mode, every vhost should have a host set
-        final boolean virtualHostModeEnabled =
-            sanitizedVirtualHosts.size() > 1 ||
-            sanitizedVirtualHosts.iterator().next().getHost() != null ||
-            currentEnv.getDomainRestrictions() != null &&
-            !currentEnv.getDomainRestrictions().isEmpty();
-        if (virtualHostModeEnabled) {
-            final List<VirtualHost> nullHostVirtualHosts = sanitizedVirtualHosts
-                .stream()
-                .filter(virtualHost -> virtualHost.getHost() == null)
-                .collect(Collectors.toList());
-            if (!nullHostVirtualHosts.isEmpty()) {
-                throw new InvalidVirtualHostNullHostException(
-                    "In Virtual Host mode, all listening host have to be configured",
-                    nullHostVirtualHosts
-                );
-            }
-        }
-
         // Get all the API of the currentEnvironment, except the one to update
         Set<ApiEntity> apis = apiRepository
             .search(null)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/VirtualHostServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/VirtualHostServiceTest.java
@@ -244,8 +244,8 @@ public class VirtualHostServiceTest {
         virtualHostService.sanitizeAndValidate(GraviteeContext.getExecutionContext(), Collections.singletonList(vhost));
     }
 
-    @Test(expected = InvalidVirtualHostNullHostException.class)
-    public void validate_notMultipleVirtualHostWithMissingHost() {
+    @Test
+    public void validate_allowNullHostInVirtualHost() {
         final VirtualHost vhost1 = new VirtualHost("host1", "/path_1");
         final VirtualHost vhost2 = new VirtualHost(null, "/path_2");
         final VirtualHost vhost3 = new VirtualHost("host3", "/path_3");


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8300

**Description**

- remove the check on the null host in VirtualHostService
- when no domainRestriction exists, display a classical input in the UI form instead of an autocomplete input. It prevents a null host to be sent.
```json
{
  "vhost": {
    "path": "/foo"
  }
}
```
instead of
```json
{
  "vhost": {
    "host": null,
    "path": "/foo"
  }
}
```

Indeed, if `"host": null` is sent, it will be interpreted as "null" by the VirtualHost service in charge of sanitization. It's easier and with less impact to fix like this in the UI instead that playing with the deserialization.

**Additional context**

As mention in the linked issue, this rollback is temporary.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kyhxbyykzj.chromatic.com)
<!-- Storybook placeholder end -->
