### PR TITLE
feat(rest-api): allow gko to start & stop api without publish event

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -2927,10 +2927,6 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         if (optApi.isPresent()) {
             Api api = optApi.get();
 
-            if (DefinitionContext.isKubernetes(api.getOrigin())) {
-                throw new ApiNotManagedException("The api is managed externally (" + api.getOrigin() + "). Unable to start or stop it.");
-            }
-
             Api previousApi = new Api(api);
             api.setUpdatedAt(new Date());
             api.setLifecycleState(lifecycleState);
@@ -2957,9 +2953,12 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 default:
                     break;
             }
-            final ApiEntity deployedApi = deployLastPublishedAPI(executionContext, apiId, username, eventType);
-            if (deployedApi != null) {
-                return deployedApi;
+
+            if (!DefinitionContext.isKubernetes(api.getOrigin())) {
+                final ApiEntity deployedApi = deployLastPublishedAPI(executionContext, apiId, username, eventType);
+                if (deployedApi != null) {
+                    return deployedApi;
+                }
             }
             return apiEntity;
         } else {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl.java
@@ -195,10 +195,6 @@ public class ApiStateServiceImpl implements ApiStateService {
         if (optApi.isPresent()) {
             Api api = optApi.get();
 
-            if (DefinitionContext.isKubernetes(api.getOrigin())) {
-                throw new ApiNotManagedException("The api is managed externally (" + api.getOrigin() + "). Unable to start or stop it.");
-            }
-
             Api previousApi = new Api(api);
             api.setUpdatedAt(new Date());
             api.setLifecycleState(lifecycleState);
@@ -226,9 +222,12 @@ public class ApiStateServiceImpl implements ApiStateService {
                 default:
                     break;
             }
-            final ApiEntity deployedApi = deployLastPublishedAPI(executionContext, apiId, username, eventType);
-            if (deployedApi != null) {
-                return deployedApi;
+
+            if (!DefinitionContext.isKubernetes(updateApi.getOrigin())) {
+                final ApiEntity deployedApi = deployLastPublishedAPI(executionContext, apiId, username, eventType);
+                if (deployedApi != null) {
+                    return deployedApi;
+                }
             }
             return apiEntity;
         } else {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImplTest.java
@@ -1,0 +1,319 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.impl;
+
+import static io.gravitee.rest.api.model.EventType.PUBLISH_API;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.definition.jackson.datatype.GraviteeMapper;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.repository.management.model.ApiLifecycleState;
+import io.gravitee.repository.management.model.Event;
+import io.gravitee.repository.management.model.LifecycleState;
+import io.gravitee.rest.api.model.EventEntity;
+import io.gravitee.rest.api.model.EventQuery;
+import io.gravitee.rest.api.model.EventType;
+import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.service.*;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.search.SearchEngineService;
+import io.gravitee.rest.api.service.v4.*;
+import io.gravitee.rest.api.service.v4.ApiService;
+import io.gravitee.rest.api.service.v4.PlanService;
+import io.gravitee.rest.api.service.v4.mapper.ApiMapper;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ApiStateServiceImplTest {
+
+    private static final String API_ID = "id-api";
+    private static final String API_NAME = "myAPI";
+    private static final String USER_NAME = "myUser";
+    private final ObjectMapper objectMapper = new GraviteeMapper();
+
+    @Mock
+    private ApiRepository apiRepository;
+
+    @Mock
+    private AuditService auditService;
+
+    @Mock
+    private SearchEngineService searchEngineService;
+
+    @Mock
+    private ParameterService parameterService;
+
+    @Mock
+    private CategoryService categoryService;
+
+    @Mock
+    private PlanService planService;
+
+    @Mock
+    private EventService eventService;
+
+    @Mock
+    private FlowService flowService;
+
+    @Mock
+    private WorkflowService workflowService;
+
+    @Mock
+    private PrimaryOwnerService primaryOwnerService;
+
+    @Mock
+    private ApiNotificationService apiNotificationService;
+
+    @Mock
+    private ApiService apiService;
+
+    private Api api;
+    private Api updatedApi;
+    private ApiStateService apiStateService;
+
+    @AfterClass
+    public static void cleanSecurityContextHolder() {
+        // reset authentication to avoid side effect during test executions.
+        SecurityContextHolder.setContext(
+            new SecurityContext() {
+                @Override
+                public Authentication getAuthentication() {
+                    return null;
+                }
+
+                @Override
+                public void setAuthentication(Authentication authentication) {}
+            }
+        );
+    }
+
+    @Before
+    public void setUp() {
+        ApiMapper apiMapper = new ApiMapper(
+            new ObjectMapper(),
+            planService,
+            flowService,
+            categoryService,
+            parameterService,
+            workflowService
+        );
+        apiStateService =
+            new ApiStateServiceImpl(
+                apiService,
+                apiRepository,
+                apiMapper,
+                apiNotificationService,
+                primaryOwnerService,
+                auditService,
+                eventService,
+                objectMapper
+            );
+        reset(searchEngineService);
+        UserEntity admin = new UserEntity();
+        admin.setId(USER_NAME);
+
+        api = new Api();
+        api.setId(API_ID);
+        api.setName(API_NAME);
+        api.setEnvironmentId(GraviteeContext.getExecutionContext().getEnvironmentId());
+        api.setDefinitionVersion(DefinitionVersion.V4);
+
+        updatedApi = new Api(api);
+    }
+
+    @Test
+    public void shouldStartApiForTheFirstTime() throws TechnicalException {
+        api.setApiLifecycleState(ApiLifecycleState.CREATED);
+        when(apiRepository.findById(API_ID)).thenReturn(Optional.of(api));
+        when(apiService.findApiById(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(api);
+
+        final EventQuery query = new EventQuery();
+        query.setApi(API_ID);
+        query.setTypes(singleton(PUBLISH_API));
+        when(eventService.search(GraviteeContext.getExecutionContext(), query)).thenReturn(emptyList());
+
+        updatedApi.setLifecycleState(LifecycleState.STARTED);
+        when(apiRepository.update(any())).thenReturn(updatedApi);
+
+        apiStateService.start(GraviteeContext.getExecutionContext(), API_ID, USER_NAME);
+
+        verify(apiRepository, times(2)).update(argThat(api -> api.getLifecycleState().equals(LifecycleState.STARTED)));
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(Event.EventProperties.API_ID.getValue(), api.getId());
+        properties.put(Event.EventProperties.USER.getValue(), USER_NAME);
+        properties.put(Event.EventProperties.DEPLOYMENT_NUMBER.getValue(), "1");
+
+        verify(eventService)
+            .createApiEvent(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(singleton(GraviteeContext.getCurrentEnvironment())),
+                eq(EventType.PUBLISH_API),
+                argThat(argApi -> argApi.getId().equals(API_ID)),
+                eq(properties)
+            );
+
+        verify(apiNotificationService, times(1))
+            .triggerDeployNotification(eq(GraviteeContext.getExecutionContext()), argThat(argApi -> argApi.getId().equals(API_ID)));
+        verify(apiNotificationService, times(1))
+            .triggerStartNotification(eq(GraviteeContext.getExecutionContext()), argThat(argApi -> argApi.getId().equals(API_ID)));
+    }
+
+    @Test
+    public void shouldReStartApi() throws TechnicalException {
+        api.setApiLifecycleState(ApiLifecycleState.CREATED);
+        when(apiRepository.findById(API_ID)).thenReturn(Optional.of(api));
+
+        final EventEntity event = new EventEntity();
+        event.setType(PUBLISH_API);
+        event.setPayload("{ \"id\": \"" + API_ID + "\"}");
+        final EventQuery query = new EventQuery();
+        query.setApi(API_ID);
+        query.setTypes(singleton(PUBLISH_API));
+        when(eventService.search(GraviteeContext.getExecutionContext(), query)).thenReturn(singleton(event));
+
+        updatedApi.setLifecycleState(LifecycleState.STARTED);
+        when(apiRepository.update(any())).thenReturn(updatedApi);
+
+        apiStateService.start(GraviteeContext.getExecutionContext(), API_ID, USER_NAME);
+
+        verify(apiRepository, times(1)).update(argThat(api -> api.getLifecycleState().equals(LifecycleState.STARTED)));
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(Event.EventProperties.API_ID.getValue(), API_ID);
+        properties.put(Event.EventProperties.USER.getValue(), USER_NAME);
+
+        verify(eventService)
+            .createApiEvent(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(singleton(GraviteeContext.getCurrentEnvironment())),
+                eq(EventType.START_API),
+                argThat(argApi -> argApi.getId().equals(API_ID)),
+                eq(properties)
+            );
+
+        verify(apiNotificationService, times(1))
+            .triggerStartNotification(eq(GraviteeContext.getExecutionContext()), argThat(argApi -> argApi.getId().equals(API_ID)));
+    }
+
+    @Test
+    public void shouldStartApiWithKubernetesOrigin() throws TechnicalException {
+        api.setApiLifecycleState(ApiLifecycleState.CREATED);
+        api.setOrigin(Api.ORIGIN_KUBERNETES);
+        when(apiRepository.findById(API_ID)).thenReturn(Optional.of(api));
+        updatedApi.setOrigin(Api.ORIGIN_KUBERNETES);
+        when(apiRepository.update(any())).thenReturn(updatedApi);
+
+        apiStateService.start(GraviteeContext.getExecutionContext(), API_ID, USER_NAME);
+
+        verify(apiRepository, times(1)).update(argThat(api -> api.getLifecycleState().equals(LifecycleState.STARTED)));
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(Event.EventProperties.API_ID.getValue(), API_ID);
+        properties.put(Event.EventProperties.USER.getValue(), USER_NAME);
+
+        verifyNoInteractions(eventService);
+
+        verify(apiNotificationService, times(1))
+            .triggerStartNotification(eq(GraviteeContext.getExecutionContext()), argThat(argApi -> argApi.getId().equals(API_ID)));
+    }
+
+    @Test
+    public void shouldStopApi() throws TechnicalException {
+        api.setApiLifecycleState(ApiLifecycleState.CREATED);
+        api.setLifecycleState(LifecycleState.STARTED);
+        when(apiRepository.findById(API_ID)).thenReturn(Optional.of(api));
+
+        final EventEntity event = new EventEntity();
+        event.setType(PUBLISH_API);
+        event.setPayload("{ \"id\": \"" + API_ID + "\"}");
+        final EventQuery query = new EventQuery();
+        query.setApi(API_ID);
+        query.setTypes(singleton(PUBLISH_API));
+        when(eventService.search(GraviteeContext.getExecutionContext(), query)).thenReturn(singleton(event));
+
+        updatedApi.setLifecycleState(LifecycleState.STOPPED);
+        when(apiRepository.update(any())).thenReturn(updatedApi);
+
+        apiStateService.stop(GraviteeContext.getExecutionContext(), API_ID, USER_NAME);
+
+        verify(apiRepository, times(1)).update(argThat(api -> api.getLifecycleState().equals(LifecycleState.STOPPED)));
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(Event.EventProperties.API_ID.getValue(), API_ID);
+        properties.put(Event.EventProperties.USER.getValue(), USER_NAME);
+
+        verify(eventService)
+            .createApiEvent(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(singleton(GraviteeContext.getCurrentEnvironment())),
+                eq(EventType.STOP_API),
+                argThat(argApi -> argApi.getId().equals(API_ID)),
+                eq(properties)
+            );
+
+        verify(apiNotificationService, times(1))
+            .triggerStopNotification(eq(GraviteeContext.getExecutionContext()), argThat(argApi -> argApi.getId().equals(API_ID)));
+    }
+
+    @Test
+    public void shouldStopApiWithKubernetesOrigin() throws TechnicalException {
+        api.setApiLifecycleState(ApiLifecycleState.CREATED);
+        api.setLifecycleState(LifecycleState.STARTED);
+        api.setOrigin(Api.ORIGIN_KUBERNETES);
+        when(apiRepository.findById(API_ID)).thenReturn(Optional.of(api));
+
+        updatedApi.setLifecycleState(LifecycleState.STOPPED);
+        updatedApi.setOrigin(Api.ORIGIN_KUBERNETES);
+        when(apiRepository.update(any())).thenReturn(updatedApi);
+
+        apiStateService.stop(GraviteeContext.getExecutionContext(), API_ID, USER_NAME);
+
+        verify(apiRepository, times(1)).update(argThat(api -> api.getLifecycleState().equals(LifecycleState.STOPPED)));
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(Event.EventProperties.API_ID.getValue(), API_ID);
+        properties.put(Event.EventProperties.USER.getValue(), USER_NAME);
+
+        verifyNoInteractions(eventService);
+
+        verify(apiNotificationService, times(1))
+            .triggerStopNotification(eq(GraviteeContext.getExecutionContext()), argThat(argApi -> argApi.getId().equals(API_ID)));
+    }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8136

**Description**
- Allow gko to start & stop api without publish event
- Also Re add test for Start, ReStart & Stop api

Pr: https://github.com/gravitee-io/gravitee-kubernetes-operator/pull/40


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8136-start-stop-gko/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ljtbyljqwn.chromatic.com)
<!-- Storybook placeholder end -->
