### PR TITLE
Exclude all APIM artefacts from cache in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,9 +57,9 @@ commands:
         steps:
             - restore_cache:
                   keys:
-                      - gravitee-api-management-v7-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
-                      - gravitee-api-management-v7-<< parameters.jobName >>-{{ .Branch }}-
-                      - gravitee-api-management-v7-<< parameters.jobName >>-
+                      - gravitee-api-management-v8-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+                      - gravitee-api-management-v8-<< parameters.jobName >>-{{ .Branch }}-
+                      - gravitee-api-management-v8-<< parameters.jobName >>-
     save-maven-job-cache:
         description: Restore Maven cache for a dedicated job
         parameters:
@@ -68,10 +68,14 @@ commands:
                 type: string
                 default: ""
         steps:
+            - run:
+                  name: "Exclude all APIM artefacts from cache."
+                  command: |
+                      rm -rf ~/.m2/repository/io/gravitee/apim
             - save_cache:
                   paths:
                       - ~/.m2
-                  key: gravitee-api-management-v7-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
+                  key: gravitee-api-management-v8-<< parameters.jobName >>-{{ .Branch }}-{{ checksum "pom.xml" }}
                   when: always
 
     notify-on-failure:
@@ -220,9 +224,9 @@ jobs:
                   at: .
             - restore_cache:
                   keys:
-                      - gravitee-api-management-v7-sonarcloud-analysis-{{ .Branch }}-{{ checksum "pom.xml" }}
-                      - gravitee-api-management-v7-sonarcloud-analysis-{{ .Branch }}-
-                      - gravitee-api-management-v7-sonarcloud-analysis-
+                      - gravitee-api-management-v8-sonarcloud-analysis-{{ .Branch }}-{{ checksum "pom.xml" }}
+                      - gravitee-api-management-v8-sonarcloud-analysis-{{ .Branch }}-
+                      - gravitee-api-management-v8-sonarcloud-analysis-
             - keeper/env-export:
                   secret-url: keeper://9x9YgyU6DWzux4DPoHAzDQ/field/password
                   var-name: SONAR_TOKEN
@@ -235,7 +239,7 @@ jobs:
             - save_cache:
                   paths:
                       - /opt/sonar-scanner/.sonar/cache
-                  key: gravitee-api-management-v7-sonarcloud-analysis-{{ .Branch }}-{{ checksum "pom.xml" }}
+                  key: gravitee-api-management-v8-sonarcloud-analysis-{{ .Branch }}-{{ checksum "pom.xml" }}
                   when: always
 
     validate:
@@ -308,12 +312,8 @@ jobs:
             - save_cache:
                   paths:
                       - ~/.m2/repository/io/gravitee/apim
-                  key: gravitee-api-management-v7-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+                  key: gravitee-api-management-v8-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
                   when: on_success
-            - run:
-                  name: "Exclude APIM artefacts from build cache"
-                  command: |
-                      rm -rf ~/.m2/repository/io/gravitee/apim
             - save-maven-job-cache:
                   jobName: build
             - persist_to_workspace:
@@ -334,7 +334,7 @@ jobs:
                   jobName: test
             - restore_cache:
                   keys:
-                      - gravitee-api-management-v7-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+                      - gravitee-api-management-v8-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
             - run:
                   name: Run tests
                   command: |
@@ -369,7 +369,7 @@ jobs:
                   jobName: test-repository
             - restore_cache:
                   keys:
-                      - gravitee-api-management-v7-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
+                      - gravitee-api-management-v8-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
             - run:
                   name: Run tests
                   command: |


### PR DESCRIPTION
**Issue**

N/A

**Description**

Change made to avoid cache growing. Indeed, because of the restore cache job, for each new version, we will get the cache from an older version with older artefacts that are not needed.
The cache will continue growing but far slower.

Here's an example of what we can found in .m2:
![image](https://user-images.githubusercontent.com/13161768/183906961-9e70a12b-1583-4db0-933c-78cd17c43b63.png)
![image](https://user-images.githubusercontent.com/13161768/183907045-2e406dd1-cffc-4451-88b3-e539aff51bbb.png)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lzwjtsgbns.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/ci-improve-cache-management/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
