### PR TITLE
Allow set "definition context" only at creation

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/UpdateApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/UpdateApiEntity.java
@@ -106,10 +106,6 @@ public class UpdateApiEntity {
     @Schema(description = "API's gravitee definition version")
     private String graviteeDefinitionVersion;
 
-    @JsonProperty(value = "definition_context")
-    @Schema(description = "the context where the api definition was created from")
-    private DefinitionContext definitionContext;
-
     @DeploymentRequired
     @JsonProperty(value = "flow_mode")
     @Schema(description = "API's flow mode.", example = "BEST_MATCH")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/ApiConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/ApiConverter.java
@@ -154,7 +154,6 @@ public class ApiConverter {
         updateApiEntity.setResponseTemplates(apiEntity.getResponseTemplates());
         updateApiEntity.setCategories(apiEntity.getCategories());
         updateApiEntity.setDisableMembershipNotifications(apiEntity.isDisableMembershipNotifications());
-        updateApiEntity.setDefinitionContext(apiEntity.getDefinitionContext());
         return updateApiEntity;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
@@ -73,8 +73,6 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
     public static final String API_DEFINITION_FIELD_PLANS = "plans";
     public static final String API_DEFINITION_FIELD_MEMBERS = "members";
     public static final String API_DEFINITION_FIELD_PAGES = "pages";
-    public static final String API_DEFINITION_CONTEXT_FIELD_ORIGIN = "origin";
-    public static final String API_DEFINITION_CONTEXT_FIELD_MODE = "mode";
 
     private final HttpClientService httpClientService;
     private final ImportConfiguration importConfiguration;
@@ -326,13 +324,6 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
         // cause plans definition may contain less data than plans entities (for example when rollback an API from gateway event)
         Map<String, PlanEntity> existingPlans = readApiPlansById(executionContext, apiJsonNode.getId());
         importedApi.setPlans(readPlansToImportFromDefinition(apiJsonNode, existingPlans));
-
-        if (apiJsonNode.hasDefinitionContext()) {
-            JsonNode definitionContextNode = apiJsonNode.getDefinitionContext();
-            String origin = definitionContextNode.get(API_DEFINITION_CONTEXT_FIELD_ORIGIN).asText();
-            String mode = definitionContextNode.get(API_DEFINITION_CONTEXT_FIELD_MODE).asText();
-            importedApi.setDefinitionContext(new DefinitionContext(origin, mode));
-        }
 
         return importedApi;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -1594,8 +1594,10 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             api.setEnvironmentId(apiToUpdate.getEnvironmentId());
             api.setDeployedAt(apiToUpdate.getDeployedAt());
             api.setCreatedAt(apiToUpdate.getCreatedAt());
+            api.setOrigin(apiToUpdate.getOrigin());
+            api.setMode(apiToUpdate.getMode());
 
-            if (DefinitionContext.isKubernetes(updateApiEntity.getDefinitionContext())) {
+            if (DefinitionContext.isKubernetes(api.getOrigin())) {
                 // Be sure that api is started when managed by k8s.
                 api.setLifecycleState(LifecycleState.STARTED);
                 if (updateApiEntity.getLifecycleState() != null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_CreateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_CreateWithDefinitionTest.java
@@ -580,9 +580,6 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
                 eq(GraviteeContext.getExecutionContext()),
                 argThat(
                     argument -> {
-                        assertEquals(Api.ORIGIN_KUBERNETES, argument.getDefinitionContext().getOrigin());
-                        assertEquals(Api.MODE_FULLY_MANAGED, argument.getDefinitionContext().getMode());
-
                         // Check ids and crossId has been preserved.
                         assertEquals(apiCrossId, argument.getCrossId());
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_CreateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_CreateWithDefinitionTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.definition.model.*;
 import io.gravitee.repository.management.api.ApiRepository;
@@ -131,7 +132,6 @@ public class ApiService_CreateWithDefinitionTest {
         api.setVersion("1.0");
         api.setName("k8s basic");
         api.setDescription("k8s basic example");
-        api.setDefinitionContext(new DefinitionContext(ORIGIN_KUBERNETES, MODE_FULLY_MANAGED));
 
         when(primaryOwnerService.getPrimaryOwner(any(), any(), any())).thenReturn(new PrimaryOwnerEntity(new UserEntity()));
 
@@ -151,7 +151,7 @@ public class ApiService_CreateWithDefinitionTest {
 
     @Test
     public void shouldNotStartApiIfNotManagedByKubernetes() throws Exception {
-        JsonNode definition = readDefinition("/io/gravitee/rest/api/management/service/import-new-kubernetes-api.definition.json");
+        JsonNode definition = readDefinition("/io/gravitee/rest/api/management/service/import-new-api.definition.json");
         UpdateApiEntity api = new UpdateApiEntity();
         Proxy proxy = new Proxy();
         EndpointGroup endpointGroup = new EndpointGroup();
@@ -164,7 +164,6 @@ public class ApiService_CreateWithDefinitionTest {
         api.setVersion("1.0");
         api.setName("k8s basic");
         api.setDescription("k8s basic example");
-        api.setDefinitionContext(new DefinitionContext(ORIGIN_MANAGEMENT, MODE_FULLY_MANAGED));
 
         when(primaryOwnerService.getPrimaryOwner(any(), any(), any())).thenReturn(new PrimaryOwnerEntity(new UserEntity()));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_UpdateTest.java
@@ -1172,6 +1172,27 @@ public class ApiService_UpdateTest {
         assertEquals(ExecutionMode.JUPITER, apiEntity.getExecutionMode());
     }
 
+    @Test
+    public void shouldKeepApiDefinitionContext() throws TechnicalException {
+        api.setOrigin(Api.ORIGIN_KUBERNETES);
+        api.setMode(Api.MODE_FULLY_MANAGED);
+        prepareUpdate();
+        updateApiEntity.setDefinitionContext(null);
+        when(apiRepository.update(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        apiService.update(GraviteeContext.getExecutionContext(), API_ID, updateApiEntity);
+
+        verify(apiRepository)
+            .update(
+                argThat(
+                    api ->
+                        api.getId().equals(API_ID) &&
+                        api.getOrigin().equals(Api.ORIGIN_KUBERNETES) &&
+                        api.getMode().equals(Api.MODE_FULLY_MANAGED)
+                )
+            );
+    }
+
     private void assertUpdate(
         final ApiLifecycleState fromLifecycleState,
         final io.gravitee.rest.api.model.api.ApiLifecycleState lifecycleState,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_UpdateTest.java
@@ -1177,7 +1177,6 @@ public class ApiService_UpdateTest {
         api.setOrigin(Api.ORIGIN_KUBERNETES);
         api.setMode(Api.MODE_FULLY_MANAGED);
         prepareUpdate();
-        updateApiEntity.setDefinitionContext(null);
         when(apiRepository.update(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
         apiService.update(GraviteeContext.getExecutionContext(), API_ID, updateApiEntity);


### PR DESCRIPTION
**Issue**
Child of : https://github.com/gravitee-io/issues/issues/8293
Part of : https://github.com/gravitee-io/issues/issues/8136

**Description**

allow set definition context only at creation. This cant be updatable (for the moment)

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/gko-fix-update-definition-context-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- E2E Coverage placeholder -->
---
### 🧪 End-to-End Coverage

| INSTRUCTIONS | BRANCHES |
| :----------: | :------: |
|   35% | 19%   |

A more detailed report has been uploaded to [circleci](https://output.circle-artifacts.com/output/job/4872a6ee-a792-40ec-b542-142e315afb39/artifacts/0/gravitee-apim-e2e/jacoco/reports/index.html)
<!-- E2E Coverage placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gymxsduisu.chromatic.com)
<!-- Storybook placeholder end -->
