### PR TITLE
improve pages search

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_15_14/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_15_14/schema.yml
@@ -1,0 +1,58 @@
+databaseChangeLog:
+  - changeSet:
+      id: 3.15.14
+      author: GraviteeSource Team
+      changes:
+        - createIndex:
+            indexName: idx_${gravitee_prefix}pages_by_order
+            columns:
+              - column:
+                  name: order
+                  type: int
+            tableName: ${gravitee_prefix}pages
+        - createIndex:
+            indexName: idx_${gravitee_prefix}pages_by_type
+            columns:
+              - column:
+                  name: type
+                  type: nvarchar(64)
+            tableName: ${gravitee_prefix}pages
+        - createIndex:
+            indexName: idx_${gravitee_prefix}pages_refid_reftype
+            columns:
+              - column:
+                  name: reference_id
+                  type: nvarchar(64)
+              - column:
+                  name: reference_type
+                  type: nvarchar(64)
+            tableName: ${gravitee_prefix}pages
+        - createIndex:
+            indexName: idx_${gravitee_prefix}pages_parent_type
+            columns:
+              - column:
+                  name: parent_id
+                  type: nvarchar(64)
+              - column:
+                  name: type
+                  type: nvarchar(64)
+            tableName: ${gravitee_prefix}pages
+        - createIndex:
+            indexName: idx_${gravitee_prefix}pages_p_n_t_ri_rt
+            columns:
+              - column:
+                  name: parent_id
+                  type: nvarchar(64)
+              - column:
+                  name: name
+                  type: nvarchar(64)
+              - column:
+                  name: type
+                  type: nvarchar(64)
+              - column:
+                  name: reference_id
+                  type: nvarchar(64)
+              - column:
+                  name: reference_type
+                  type: nvarchar(64)
+            tableName: ${gravitee_prefix}pages

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -119,3 +119,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v3_15_0/schema.yml
   - include:
       - file: liquibase/changelogs/v3_15_3/schema.yml
+  - include:
+      - file: liquibase/changelogs/v3_15_14/schema.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/create-index.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/create-index.js
@@ -49,7 +49,11 @@ db.getCollection(`${prefix}keys`).reIndex();
 
 // "pages" collection
 db.getCollection(`${prefix}pages`).dropIndexes();
-db.getCollection(`${prefix}pages`).createIndex( { "api" : 1 }, { "name": "a1" } );
+db.getCollection(`${prefix}pages`).createIndex( { "order" : 1 }, { "name": "o1" } );
+db.getCollection(`${prefix}pages`).createIndex( { "parent" : 1, "name":1, "referenceId":1, "referenceType":1, "type":1 }, { "name": "p1n1ri1rt1t1" } );
+db.getCollection(`${prefix}pages`).createIndex( { "parent" : 1, "type":1 }, { "name": "p1t1" } );
+db.getCollection(`${prefix}pages`).createIndex( { "referenceId":1, "referenceType":1 }, { "name": "ri1rt1" } );
+db.getCollection(`${prefix}pages`).createIndex( { "type" : 1 }, { "name": "t1" } );
 db.getCollection(`${prefix}pages`).createIndex( { "useAutoFetch" : 1 }, { "name": "u1" } );
 db.getCollection(`${prefix}pages`).reIndex();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
@@ -545,7 +545,11 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
                         removeFromAPIPlans(groupId, updatedDate, api.getId());
 
                         //remove from API pages
-                        removeGroupFromPages(groupId, updatedDate, api.getId());
+                        PageCriteria apiPageCriteria = new PageCriteria.Builder()
+                            .referenceId(api.getId())
+                            .referenceType(PageReferenceType.API.name())
+                            .build();
+                        removeGroupFromPages(groupId, updatedDate, apiPageCriteria);
 
                         //remove idp group mapping using this group
                         removeIDPGroupMapping(groupId, updatedDate);
@@ -574,7 +578,11 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
             );
 
             //remove from portal pages
-            removeGroupFromPages(groupId, updatedDate, null);
+            PageCriteria environmentPageCriteria = new PageCriteria.Builder()
+                .referenceId(environmentId)
+                .referenceType(PageReferenceType.ENVIRONMENT.name())
+                .build();
+            removeGroupFromPages(groupId, updatedDate, environmentPageCriteria);
 
             //remove group
             groupRepository.delete(groupId);
@@ -646,14 +654,10 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         }
     }
 
-    private void removeGroupFromPages(String groupId, Date updatedDate, String apiId) {
+    private void removeGroupFromPages(String groupId, Date updatedDate, PageCriteria pageCriteria) {
         try {
-            PageCriteria.Builder criteriaBuilder = new PageCriteria.Builder();
-            if (apiId != null) {
-                criteriaBuilder.referenceId(apiId);
-            }
-            final List<Page> apiPages = this.pageRepository.search(criteriaBuilder.build());
-            for (Page page : apiPages) {
+            final List<Page> pages = this.pageRepository.search(pageCriteria);
+            for (Page page : pages) {
                 Set<AccessControl> accessControlsToRemove = page
                     .getAccessControls()
                     .stream()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/GroupService_DeleteTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/GroupService_DeleteTest.java
@@ -34,6 +34,7 @@ import io.gravitee.repository.management.model.AccessControl;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.Group;
 import io.gravitee.repository.management.model.Page;
+import io.gravitee.repository.management.model.PageReferenceType;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.alert.ApplicationAlertEventType;
 import io.gravitee.rest.api.model.alert.ApplicationAlertMembershipEvent;
@@ -142,7 +143,12 @@ public class GroupService_DeleteTest {
 
         when(applicationRepository.findByGroups(Collections.singletonList(GROUP_ID))).thenReturn(Collections.emptySet());
 
-        when(pageRepository.search(new PageCriteria.Builder().build())).thenReturn(Collections.emptyList());
+        when(
+            pageRepository.search(
+                new PageCriteria.Builder().referenceId(ENVIRONMENT_ID).referenceType(PageReferenceType.ENVIRONMENT.name()).build()
+            )
+        )
+            .thenReturn(Collections.emptyList());
 
         groupService.delete(ENVIRONMENT_ID, GROUP_ID);
 
@@ -211,7 +217,12 @@ public class GroupService_DeleteTest {
         accessControlToRemove.setReferenceId(GROUP_ID);
         AccessControl accessControlToKeep = new AccessControl();
         page.setAccessControls(new HashSet<>(Set.of(accessControlToRemove, accessControlToKeep)));
-        when(pageRepository.search(new PageCriteria.Builder().build())).thenReturn(List.of(page));
+        when(
+            pageRepository.search(
+                new PageCriteria.Builder().referenceId(ENVIRONMENT_ID).referenceType(PageReferenceType.ENVIRONMENT.name()).build()
+            )
+        )
+            .thenReturn(List.of(page));
 
         groupService.delete(ENVIRONMENT_ID, GROUP_ID);
 


### PR DESCRIPTION
**Issue**

N/A

**Description**

When a group is deleted, the Management API of APIM starts by removing all references of this group is different places.
This is particularly the case for documentation pages. Indeed, a group can be configured to handle access control on a page.

This PR improves the way pages are searched to be updated by specifying the right criteria.

This PR also provides some new indices for mongo.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kqtrnknnsl.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/pages-improvements/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
