### PR TITLE
fix: add support failover for jupiter

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/failover/FailoverRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/failover/FailoverRequest.java
@@ -49,7 +49,7 @@ class FailoverRequest extends RequestWrapper {
                     buffer = Buffer.buffer();
                 }
                 buffer.appendBuffer(result);
-                bodyHandler.handle(result);
+                handleBody(result);
             }
         );
 
@@ -76,11 +76,22 @@ class FailoverRequest extends RequestWrapper {
             resumed = true;
         } else {
             if (bodyHandler != null && buffer != null) {
-                bodyHandler.handle(buffer);
+                handleBody(buffer);
             }
-            endHandler.handle(null);
+            if (endHandler != null) {
+                endHandler.handle(null);
+            }
         }
 
         return this;
+    }
+
+    private void handleBody(Buffer result) {
+        try {
+            this.bodyHandler.handle(result);
+        } catch (Exception ignored) {
+            // Ignore eventual exception occurring when trying to handle body buffer.
+            // Some exception may occur when trying to write body to upstream while something goes wrong during connection.
+        }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/jupiter/policy/adapter/context/ExecutionContextAdapter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/jupiter/policy/adapter/context/ExecutionContextAdapter.java
@@ -19,6 +19,9 @@ import static io.gravitee.gateway.jupiter.api.context.ExecutionContext.ATTR_ADAP
 import static io.gravitee.gateway.jupiter.api.context.ExecutionContext.ATTR_INTERNAL_EXECUTION_FAILURE;
 
 import io.gravitee.el.TemplateEngine;
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.api.context.MutableExecutionContext;
 import io.gravitee.gateway.api.processor.ProcessorFailure;
 import io.gravitee.gateway.jupiter.api.ExecutionFailure;
 import io.gravitee.gateway.jupiter.api.context.ExecutionContext;
@@ -32,11 +35,11 @@ import java.util.Map;
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class ExecutionContextAdapter implements io.gravitee.gateway.api.ExecutionContext {
+public class ExecutionContextAdapter implements io.gravitee.gateway.api.ExecutionContext, MutableExecutionContext {
 
     private final RequestExecutionContext ctx;
-    private RequestAdapter adaptedRequest;
-    private ResponseAdapter adaptedResponse;
+    private Request adaptedRequest;
+    private Response adaptedResponse;
     private TemplateEngineAdapter adaptedTemplateEngine;
 
     private ExecutionContextAdapter(RequestExecutionContext ctx) {
@@ -66,7 +69,7 @@ public class ExecutionContextAdapter implements io.gravitee.gateway.api.Executio
     }
 
     @Override
-    public RequestAdapter request() {
+    public Request request() {
         if (adaptedRequest == null) {
             adaptedRequest = new RequestAdapter(ctx.request());
         }
@@ -74,7 +77,7 @@ public class ExecutionContextAdapter implements io.gravitee.gateway.api.Executio
     }
 
     @Override
-    public ResponseAdapter response() {
+    public Response response() {
         if (adaptedResponse == null) {
             adaptedResponse = new ResponseAdapter(ctx.response());
         }
@@ -145,5 +148,17 @@ public class ExecutionContextAdapter implements io.gravitee.gateway.api.Executio
         if (adaptedTemplateEngine != null) {
             adaptedTemplateEngine.restore();
         }
+    }
+
+    @Override
+    public MutableExecutionContext request(Request request) {
+        adaptedRequest = request;
+        return this;
+    }
+
+    @Override
+    public MutableExecutionContext response(Response response) {
+        adaptedResponse = response;
+        return this;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/jupiter/policy/adapter/context/RequestAdapter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/jupiter/policy/adapter/context/RequestAdapter.java
@@ -37,6 +37,8 @@ public class RequestAdapter implements io.gravitee.gateway.api.Request {
     private final Request request;
 
     private Runnable onResumeHandler;
+    private Handler<Buffer> bodyHandler;
+    private Handler<Void> endHandler;
 
     public RequestAdapter(Request request) {
         this.request = request;
@@ -179,11 +181,25 @@ public class RequestAdapter implements io.gravitee.gateway.api.Request {
 
     @Override
     public ReadStream<Buffer> bodyHandler(Handler<Buffer> bodyHandler) {
+        this.bodyHandler = bodyHandler;
         return this;
     }
 
     @Override
     public ReadStream<Buffer> endHandler(Handler<Void> endHandler) {
+        this.endHandler = endHandler;
         return this;
+    }
+
+    public Handler<Buffer> getBodyHandler() {
+        return bodyHandler;
+    }
+
+    public void setBodyHandler(Handler<Buffer> bodyHandler) {
+        this.bodyHandler = bodyHandler;
+    }
+
+    public Handler<Void> getEndHandler() {
+        return endHandler;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/jupiter/policy/adapter/context/ExecutionContextAdapterTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/jupiter/policy/adapter/context/ExecutionContextAdapterTest.java
@@ -16,15 +16,16 @@
 package io.gravitee.gateway.jupiter.policy.adapter.context;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import io.gravitee.el.TemplateEngine;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.processor.ProcessorFailure;
 import io.gravitee.gateway.core.processor.RuntimeProcessorFailure;
 import io.gravitee.gateway.jupiter.api.ExecutionFailure;
+import io.gravitee.gateway.jupiter.api.context.Request;
 import io.gravitee.gateway.jupiter.api.context.RequestExecutionContext;
+import io.gravitee.gateway.jupiter.api.context.Response;
 import io.gravitee.gateway.jupiter.reactor.handler.context.DefaultRequestExecutionContext;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -100,5 +101,47 @@ class ExecutionContextAdapterTest {
         contextAdapter.restore();
 
         verify(templateEngine).restore();
+    }
+
+    @Test
+    void shouldReplaceAdaptedRequest() {
+        final RequestExecutionContext ctx = mock(RequestExecutionContext.class);
+        final Request request = mock(Request.class);
+
+        when(ctx.request()).thenReturn(request);
+
+        final ExecutionContextAdapter contextAdapter = ExecutionContextAdapter.create(ctx);
+        final io.gravitee.gateway.api.Request adaptedRequest = contextAdapter.request();
+
+        assertNotNull(adaptedRequest);
+        assertTrue(adaptedRequest instanceof RequestAdapter);
+
+        // Try to override the current request with another one.
+        final io.gravitee.gateway.api.Request replaced = mock(io.gravitee.gateway.api.Request.class);
+        contextAdapter.request(replaced);
+
+        // The adapted request should have been replaced.
+        assertEquals(replaced, contextAdapter.request());
+    }
+
+    @Test
+    void shouldReplaceAdaptedResponse() {
+        final RequestExecutionContext ctx = mock(RequestExecutionContext.class);
+        final Response response = mock(Response.class);
+
+        when(ctx.response()).thenReturn(response);
+
+        final ExecutionContextAdapter contextAdapter = ExecutionContextAdapter.create(ctx);
+        final io.gravitee.gateway.api.Response adaptedResponse = contextAdapter.response();
+
+        assertNotNull(adaptedResponse);
+        assertTrue(adaptedResponse instanceof ResponseAdapter);
+
+        // Try to override the current response with another one.
+        final io.gravitee.gateway.api.Response replaced = mock(io.gravitee.gateway.api.Response.class);
+        contextAdapter.response(replaced);
+
+        // The adapted response should have been replaced.
+        assertEquals(replaced, contextAdapter.response());
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -466,8 +466,6 @@
                                 <exclude>**/Grpc*Test.java</exclude>
                                 <!-- TODO: https://github.com/gravitee-io/issues/issues/8075 -->
                                 <exclude>**/ClientConnectionResponseTemplateTest.java</exclude>
-                                <!-- TODO: https://github.com/gravitee-io/issues/issues/8086 -->
-                                <exclude>**/FailoverTest.java</exclude>
                             </excludes>
                         </configuration>
                     </execution>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8086

**Description**

Failover wasn't working for Jupiter due to a ClassCastException. As it relies on V3 code it should behave like in v3.

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8086-jupiter-failover/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-trmttvlyng.chromatic.com)
<!-- Storybook placeholder end -->
