### PR TITLE
feat: add messages count configuration in mock endpoint

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mock/src/main/java/io/gravitee/plugin/endpoint/mock/MockEndpointConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mock/src/main/java/io/gravitee/plugin/endpoint/mock/MockEndpointConnector.java
@@ -54,8 +54,12 @@ public class MockEndpointConnector implements EndpointAsyncConnector {
     }
 
     private Flowable<Message> generateMessageFlow() {
-        return Flowable
+        Flowable<Message> messageFlow = Flowable
             .interval(configuration.getMessageInterval(), TimeUnit.MILLISECONDS)
             .map(value -> new MockMessage(configuration.getMessageContent() + " " + value));
+        if (configuration.getMessageCount() != null) {
+            return messageFlow.limit(configuration.getMessageCount());
+        }
+        return messageFlow;
     }
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mock/src/main/java/io/gravitee/plugin/endpoint/mock/configuration/MockEndpointConnectorConfiguration.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mock/src/main/java/io/gravitee/plugin/endpoint/mock/configuration/MockEndpointConnectorConfiguration.java
@@ -35,4 +35,10 @@ public class MockEndpointConnectorConfiguration implements EndpointConnectorConf
      * Content of mocked messages.
      */
     private String messageContent;
+
+    /**
+     * Count of published messages.
+     * If null, there is no limit.
+     */
+    private Long messageCount;
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mock/src/main/resources/schemas/schema-form.json
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mock/src/main/resources/schemas/schema-form.json
@@ -14,6 +14,11 @@
       "title": "Content of published messages",
       "description": "Content of published messages. Will be suffixed with message index.",
       "default": "mock message"
+    },
+    "messageCount": {
+      "type": "integer",
+      "title": "Count of published messages",
+      "description": "Count of published messages. If not specified, there is no limit."
     }
   },
   "required": [


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8229
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/feat-mock-endpoint-messages-count/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zwppasfpbb.chromatic.com)
<!-- Storybook placeholder end -->
