### PR TITLE
use wrapped handler instead of parent's one in VertxReactorTimeoutHandler

### DIFF
--- a/.run/Gateway - JDBC.run.xml
+++ b/.run/Gateway - JDBC.run.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Gateway - JDBC" type="Application" factoryName="Application" folderName="Gateway">
+    <envs>
+      <env name="GRAVITEE_MANAGEMENT_JDBC_DATABASE" value="gravitee" />
+      <env name="GRAVITEE_MANAGEMENT_JDBC_DRIVER" value="postgresql" />
+      <env name="GRAVITEE_MANAGEMENT_JDBC_HOST" value="localhost" />
+      <env name="GRAVITEE_MANAGEMENT_JDBC_PASSWORD" value="password" />
+      <env name="GRAVITEE_MANAGEMENT_JDBC_PORT" value="5432" />
+      <env name="GRAVITEE_MANAGEMENT_JDBC_URL" value="jdbc:postgresql://localhost:5432/gravitee" />
+      <env name="GRAVITEE_MANAGEMENT_JDBC_USERNAME" value="postgres" />
+      <env name="GRAVITEE_MANAGEMENT_TYPE" value="jdbc" />
+    </envs>
+    <option name="MAIN_CLASS_NAME" value="io.gravitee.gateway.standalone.GatewayContainer" />
+    <module name="gravitee-apim-gateway-standalone-container" />
+    <option name="VM_PARAMETERS" value="-Dgravitee.home=$ProjectFileDir$/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target/distribution" />
+    <option name="WORKING_DIRECTORY" value="$ProjectFileDir$" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/Gateway - MongoDB.run.xml
+++ b/.run/Gateway - MongoDB.run.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Gateway - MongoDB" type="Application" factoryName="Application" folderName="Gateway">
+    <option name="MAIN_CLASS_NAME" value="io.gravitee.gateway.standalone.GatewayContainer" />
+    <module name="gravitee-apim-gateway-standalone-container" />
+    <option name="VM_PARAMETERS" value="-Dgravitee.home=$ProjectFileDir$/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target/distribution" />
+    <option name="WORKING_DIRECTORY" value="$ProjectFileDir$" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/Rest API - JDBC.run.xml
+++ b/.run/Rest API - JDBC.run.xml
@@ -1,0 +1,21 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Rest API - JDBC" type="Application" factoryName="Application" folderName="Rest API">
+    <envs>
+      <env name="GRAVITEE_MANAGEMENT_JDBC_DATABASE" value="gravitee" />
+      <env name="GRAVITEE_MANAGEMENT_JDBC_DRIVER" value="postgresql" />
+      <env name="GRAVITEE_MANAGEMENT_JDBC_HOST" value="localhost" />
+      <env name="GRAVITEE_MANAGEMENT_JDBC_PASSWORD" value="password" />
+      <env name="GRAVITEE_MANAGEMENT_JDBC_PORT" value="5432" />
+      <env name="GRAVITEE_MANAGEMENT_JDBC_URL" value="jdbc:postgresql://localhost:5432/gravitee" />
+      <env name="GRAVITEE_MANAGEMENT_JDBC_USERNAME" value="postgres" />
+      <env name="GRAVITEE_MANAGEMENT_TYPE" value="jdbc" />
+    </envs>
+    <option name="MAIN_CLASS_NAME" value="io.gravitee.rest.api.standalone.GraviteeApisContainer" />
+    <module name="gravitee-apim-rest-api-standalone-container" />
+    <option name="VM_PARAMETERS" value="-Dgravitee.home=$ProjectFileDir$/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target/distribution" />
+    <option name="WORKING_DIRECTORY" value="$ProjectFileDir$" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/Rest API - MongoDB.run.xml
+++ b/.run/Rest API - MongoDB.run.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Rest API - MongoDB" type="Application" factoryName="Application" folderName="Rest API">
+    <option name="MAIN_CLASS_NAME" value="io.gravitee.rest.api.standalone.GraviteeApisContainer" />
+    <module name="gravitee-apim-rest-api-standalone-container" />
+    <option name="VM_PARAMETERS" value="-Dgravitee.home=$ProjectFileDir$/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target/distribution" />
+    <option name="WORKING_DIRECTORY" value="$ProjectFileDir$" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxReactorTimeoutHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxReactorTimeoutHandler.java
@@ -21,6 +21,7 @@ import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.api.handler.Handler;
 import io.gravitee.gateway.reactor.Reactor;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerRequest;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -45,6 +46,11 @@ public class VertxReactorTimeoutHandler extends VertxReactorHandler {
         this.handler = handler;
         this.vertx = vertx;
         this.timeout = timeout;
+    }
+
+    @Override
+    public void handle(HttpServerRequest httpServerRequest) {
+        handler.handle(httpServerRequest);
     }
 
     protected void route(final Request request, final Response response) {


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8228

**Description**

When `requestTimeout` is set, the `VertxWebSocketReactorHandler` class is wrapped into a `VertxReactorTimeoutHandler`. But this class does not use the handler of `VertxWebSocketReactorHandler`. That is why, at the end of the chain we have a `ClassCastException`

🙏🏻 thanks a lot to @gaetanmaisse & @jhaeyaert 
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/8228-fix-websocket-error/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
