### PR TITLE
Properly load assets when refreshing a portal page in Docker env

### DIFF
--- a/gravitee-apim-portal-webui/docker/config/templates/default.conf.tmpl
+++ b/gravitee-apim-portal-webui/docker/config/templates/default.conf.tmpl
@@ -23,7 +23,7 @@ server {
     location / {
         try_files $uri$args $uri$args/ $uri $uri/ /index.html =404;
         root /usr/share/nginx/html;
-        sub_filter '<base href="/"' '<base href="{{ getenv "PORTAL_BASE_HREF" "/" }}"';
+        sub_filter '<base href="./"' '<base href="{{ getenv "PORTAL_BASE_HREF" "/" }}"';
         sub_filter_once on;
     }
 


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8317

**Description**

The base href was changed in 99392eaa8f843735116232564231cb582c6642be but the update wasn't applied to the Nginx config used in the Docker image.
Causing the app to try to load assets using the wrong URL.

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8317-fix-portal-base-href/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-izlwqqbinc.chromatic.com)
<!-- Storybook placeholder end -->
