### PR TITLE
3.18.x pendo

### DIFF
--- a/gravitee-apim-console-webui/conf/webpack.conf.js
+++ b/gravitee-apim-console-webui/conf/webpack.conf.js
@@ -166,7 +166,7 @@ module.exports = {
         secure: false,
         changeOrigin: true,
         onProxyReq: function (proxyReq, req, res) {
-          proxyReq.setHeader('origin', 'https://apim-master-console.team-apim.gravitee.xyz');
+          proxyReq.setHeader('origin', `https://${env}`);
         },
       },
     },

--- a/gravitee-apim-console-webui/src/components/navbar/_navbar.scss
+++ b/gravitee-apim-console-webui/src/components/navbar/_navbar.scss
@@ -16,6 +16,11 @@ md-toolbar.topnavbar {
   }
 }
 
+.topnavbar-contextual-doc {
+  // Allow Pendo to add a badge
+  overflow: initial;
+}
+
 .gv-navbar-link:hover,
 .gv-navbar-link:focus {
   color: inherit;

--- a/gravitee-apim-console-webui/src/components/navbar/navbar.component.ts
+++ b/gravitee-apim-console-webui/src/components/navbar/navbar.component.ts
@@ -132,6 +132,11 @@ export const NavbarComponent: ng.IComponentOptions = {
     this.getUserPicture = () => UserService.currentUserPicture();
 
     this.openContextualDocumentation = () => {
+      if (window.pendo && window.pendo.isReady()) {
+        // Do nothing Pendo use this button to trigger the "Resource Center"
+        return;
+      }
+
       this.$rootScope.$broadcast('openContextualDocumentation');
     };
 

--- a/gravitee-apim-console-webui/src/components/navbar/navbar.html
+++ b/gravitee-apim-console-webui/src/components/navbar/navbar.html
@@ -24,10 +24,11 @@
   </div>
   <span flex></span>
   <md-button
-    class="gv-navbar-button"
+    class="gv-navbar-button topnavbar-contextual-doc"
     ng-click="$ctrl.openContextualDocumentation();"
     aria-label="Display contextual documentation"
     ng-if="$ctrl.displayContextualDocumentationButton"
+    data-pendoId="sidenav-resource-center"
   >
     <ng-md-icon icon="live_help" gv-theme-element="portal.navbar.help"></ng-md-icon>
   </md-button>


### PR DESCRIPTION
**Issue**
https://github.com/gravitee-io/issues/issues/8292

**Description**

When pendo is enable and ready do no open contextual doc. The button is kept so that it can be used by Pendo  with `data-pendoId="sidenav-resource-center"` ( like cockpit )


To test 
Locally : `BACKEND_ENV=apim-3-18-x-api.team-apim.gravitee.xyz npm run serve`
or wait master release into 3.18x env




**Additional context**
<img width="1249" alt="image" src="https://user-images.githubusercontent.com/4974420/184850485-e4aacea8-8d23-4a15-b804-b0508dfc9adc.png">

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/3-18-x-pendo/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-reznrrineu.chromatic.com)
<!-- Storybook placeholder end -->
