### PR TITLE
chore: bump security policies in distribution pom

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -48,7 +48,7 @@
         <!-- Management API & Gateway -->
         <gravitee-alert-engine-connectors-ws.version>1.0.0</gravitee-alert-engine-connectors-ws.version>
         <gravitee-connector-http.version>2.0.4</gravitee-connector-http.version>
-        <gravitee-policy-apikey.version>2.7.0-feat-jupiterPlans-SNAPSHOT</gravitee-policy-apikey.version>
+        <gravitee-policy-apikey.version>2.8.0</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>1.5.0</gravitee-policy-assign-attributes.version>
         <gravitee-policy-assign-content.version>1.7.0</gravitee-policy-assign-content.version>
         <gravitee-policy-cache.version>1.15.1</gravitee-policy-cache.version>
@@ -65,12 +65,12 @@
         <gravitee-policy-json-validation.version>1.6.1</gravitee-policy-json-validation.version>
         <gravitee-policy-json-xml.version>1.1.1</gravitee-policy-json-xml.version>
         <gravitee-policy-jws.version>1.3.2</gravitee-policy-jws.version>
-        <gravitee-policy-jwt.version>2.3.0-feat-jupiterPlans-SNAPSHOT</gravitee-policy-jwt.version>
-        <gravitee-policy-keyless.version>1.7.0-feat-jupiterPlans-SNAPSHOT</gravitee-policy-keyless.version>
+        <gravitee-policy-jwt.version>2.3.0</gravitee-policy-jwt.version>
+        <gravitee-policy-keyless.version>1.7.0</gravitee-policy-keyless.version>
         <gravitee-policy-latency.version>1.4.0</gravitee-policy-latency.version>
         <gravitee-policy-metrics-reporter.version>2.0.0</gravitee-policy-metrics-reporter.version>
         <gravitee-policy-mock.version>1.13.0</gravitee-policy-mock.version>
-        <gravitee-policy-oauth2.version>1.22.0-feat-jupiterPlans-SNAPSHOT</gravitee-policy-oauth2.version>
+        <gravitee-policy-oauth2.version>1.22.0</gravitee-policy-oauth2.version>
         <gravitee-policy-openid-connect-userinfo.version>1.5.2</gravitee-policy-openid-connect-userinfo.version>
         <gravitee-policy-override-http-method.version>1.3.0</gravitee-policy-override-http-method.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7991


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/chore-bumppolicies/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
