### PR TITLE
accessControl fields should never be null

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PageMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PageMongo.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.repository.mongodb.management.internal.model;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -46,7 +47,7 @@ public class PageMongo extends Auditable {
     private Map<String, String> configuration;
     private boolean homepage;
     private boolean excludedAccessControls;
-    private Set<AccessControlMongo> accessControls;
+    private Set<AccessControlMongo> accessControls = new HashSet<>();
     private List<PageMediaMongo> attachedMedia;
     private String parentId;
     private Map<String, String> metadata;

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/PageRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/PageRepositoryTest.java
@@ -460,4 +460,12 @@ public class PageRepositoryTest extends AbstractRepositoryTest {
         Integer maxPortalPageOrder = pageRepository.findMaxPageReferenceIdAndReferenceTypeOrder("DEFAULT", PageReferenceType.ENVIRONMENT);
         assertEquals(Integer.valueOf(20), maxPortalPageOrder);
     }
+
+    @Test
+    public void shouldHaveEmptyAccessControls() throws TechnicalException {
+        Optional<Page> homePage = pageRepository.findById("home");
+        assertTrue(homePage.isPresent());
+        assertNotNull(homePage.get().getAccessControls());
+        assertEquals(0, homePage.get().getAccessControls().size());
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/PageRepositoryMock.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/PageRepositoryMock.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.config.mock;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
@@ -385,5 +386,11 @@ public class PageRepositoryMock extends AbstractRepositoryMock<PageRepository> {
         // search autoFetch
         when(pageRepository.search(argThat(criteria -> criteria != null && Boolean.TRUE.equals(criteria.getUseAutoFetch()))))
             .thenReturn(Arrays.asList(findApiPage));
+
+        // find homepage to check accessControl list
+        Page homePage = new Page();
+        homePage.setId("home");
+        homePage.setAccessControls(emptySet());
+        when(pageRepository.findById("home")).thenReturn(of(homePage));
     }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8323

**Description**

- initialize accessControl list in mongo.
- JDBC was already ok


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gtrvmcfpyx.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/8323-fix-group-deletion-after-3-8-migration/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
