### PR TITLE
Bump `gravitee-connector-http` to 1.1.11 

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -46,7 +46,7 @@
     <properties>
         <!-- Versions of the plugins for the full distribution -->
         <!-- Management API & Gateway -->
-        <gravitee-connector-http.version>1.1.10</gravitee-connector-http.version>
+        <gravitee-connector-http.version>1.1.11</gravitee-connector-http.version>
         <gravitee-policy-apikey.version>2.4.0</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>1.5.0</gravitee-policy-assign-attributes.version>
         <gravitee-policy-assign-content.version>1.7.0</gravitee-policy-assign-content.version>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <jetty94.wiremock.version>9.4.44.v20210927</jetty94.wiremock.version>
-        <gravitee-connector-http.version>1.1.10</gravitee-connector-http.version>
+        <gravitee-connector-http.version>1.1.11</gravitee-connector-http.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8228
https://github.com/gravitee-io/issues/issues/8324

**Description**

Bump `gravitee-connector-http` to 1.1.11 to fix two issues with websocket:
- Do not consider `ws` as a secure protocol
- Set WS subprotocols based on the `sec-websocket-protocol` header
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vqquhipqty.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-websocket/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
