### PR TITLE
feat: allow to override the default background-image

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ThemeServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ThemeServiceImpl.java
@@ -254,6 +254,7 @@ public class ThemeServiceImpl extends AbstractService implements ThemeService {
             theme.setId(DEFAULT_THEME_ID);
             theme.setName("Default theme");
             theme.setDefinition(MAPPER.readDefinition(getDefaultDefinition()));
+            theme.setBackgroundImage(this.getDefaultBackgroundImage());
             theme.setLogo(this.getDefaultLogo());
             theme.setOptionalLogo(this.getDefaultOptionalLogo());
             theme.setFavicon(this.getDefaultFavicon());
@@ -348,6 +349,10 @@ public class ThemeServiceImpl extends AbstractService implements ThemeService {
         }
     }
 
+    public String getDefaultBackgroundImage() {
+        return getImage("background-image.png");
+    }
+
     public String getDefaultLogo() {
         return getImage("logo.png");
     }
@@ -362,8 +367,12 @@ public class ThemeServiceImpl extends AbstractService implements ThemeService {
 
     private String getImage(String filename) {
         String filepath = themesPath + "/" + filename;
+        File imageFile = new File(filepath);
+        if (!imageFile.exists()) {
+            return null;
+        }
         try {
-            byte[] image = Files.readAllBytes(new File(filepath).toPath());
+            byte[] image = Files.readAllBytes(imageFile.toPath());
             MimetypesFileTypeMap fileTypeMap = new MimetypesFileTypeMap();
             return "data:" + fileTypeMap.getContentType(filename) + ";base64," + Base64.getEncoder().encodeToString(image);
         } catch (IOException ex) {


### PR DESCRIPTION
**Issue**

NA

**Description**

In the portal, there is no default background image.
With this commit, we add the possibility to use a file in the `/themes` folder to add a background image: it needs to be `background-image.png`

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-digphjlhxz.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/override-default-portal-background-image/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
