### PR TITLE
test: added use-case test for add/edit/delete endpoint

### DIFF
--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/endpoints/add-edit-remove-several-endpoints-to-group-and-use-them.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/endpoints/add-edit-remove-several-endpoints-to-group-and-use-them.spec.ts
@@ -13,8 +13,127 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { describe } from '@jest/globals';
+import { APIsApi } from '@gravitee/management-webclient-sdk/src/lib/apis/APIsApi';
+import { forManagementAsApiUser } from '@gravitee/utils/configuration';
+import { afterAll, beforeAll, describe, expect } from '@jest/globals';
+import { succeed } from '@lib/jest-utils';
+import { ApisFaker } from '@gravitee/fixtures/management/ApisFaker';
+import { ApiEntity } from '@gravitee/management-webclient-sdk/src/lib/models/ApiEntity';
+import { PlansFaker } from '@gravitee/fixtures/management/PlansFaker';
+import { LifecycleAction } from '@gravitee/management-webclient-sdk/src/lib/models/LifecycleAction';
+import { PlanStatus } from '@gravitee/management-webclient-sdk/src/lib/models/PlanStatus';
+import { fetchGatewaySuccess } from '@gravitee/utils/gateway';
+import { teardownApisAndApplications } from '@gravitee/utils/management';
+
+const orgId = 'DEFAULT';
+const envId = 'DEFAULT';
+const apisResourceAsPublisher = new APIsApi(forManagementAsApiUser());
+
+const updateApi = async (api: ApiEntity) => {
+  const updateApiEntity = {
+    description: api.description,
+    version: api.version,
+    name: api.name,
+    proxy: api.proxy,
+    visibility: api.visibility,
+    plans: api.plans,
+  };
+
+  await succeed(
+    apisResourceAsPublisher.updateApiRaw({
+      envId,
+      orgId,
+      api: api.id,
+      updateApiEntity,
+    }),
+  );
+
+  return succeed(apisResourceAsPublisher.deployApiRaw({ orgId, envId, api: api.id }));
+};
 
 describe('Add/edit/remove several endpoints to group and use them', () => {
-  test.skip('To complete', async () => {});
+  let createdApi: ApiEntity;
+
+  beforeAll(async () => {
+    // create an API
+    createdApi = await succeed(
+      apisResourceAsPublisher.importApiDefinitionRaw({
+        envId,
+        orgId,
+        body: ApisFaker.apiImport({
+          plans: [PlansFaker.plan({ status: PlanStatus.PUBLISHED })],
+        }),
+      }),
+    );
+
+    // start it
+    await apisResourceAsPublisher.doApiLifecycleAction({
+      envId,
+      orgId,
+      api: createdApi.id,
+      action: LifecycleAction.START,
+    });
+  });
+
+  test('Should add another endpoint to the default-group', async () => {
+    // new endpoint
+    createdApi.proxy.groups[0].endpoints[1] = {
+      inherit: true,
+      name: 'endpoint2',
+      target: `${process.env.WIREMOCK_BASE_URL}/hello?name=endpoint2`,
+      type: 'http',
+      weight: 1,
+    };
+
+    const updatedApi = await updateApi(createdApi);
+    expect(updatedApi.proxy.groups[0].endpoints).toHaveLength(2);
+    const response1 = await fetchGatewaySuccess({ contextPath: createdApi.context_path }).then((res) => res.json());
+    expect(response1.message).toBe('Hello, World!');
+    const response2 = await fetchGatewaySuccess({ contextPath: createdApi.context_path }).then((res) => res.json());
+    await fetchGatewaySuccess({
+      contextPath: createdApi.context_path,
+      expectedResponseValidator: async (response) => {
+        const body = await response.json();
+        expect(body.message).toBe('Hello, Endpoint2!');
+        return true;
+      },
+    });
+  });
+
+  test('Should modify existing endpoint ', async () => {
+    // modify endpoint2
+    createdApi.proxy.groups[0].endpoints[1] = {
+      inherit: true,
+      name: 'updated endpoint2',
+      target: `${process.env.WIREMOCK_BASE_URL}/hello?name=endpoint2update`,
+      type: 'http',
+      weight: 1,
+    };
+
+    const updatedApi = await updateApi(createdApi);
+    expect(updatedApi.proxy.groups[0].endpoints).toHaveLength(2);
+    const response1 = await fetchGatewaySuccess({ contextPath: createdApi.context_path }).then((res) => res.json());
+    expect(response1.message).toBe('Hello, World!');
+
+    await fetchGatewaySuccess({
+      contextPath: createdApi.context_path,
+      expectedResponseValidator: async (response) => {
+        const body = await response.json();
+        expect(body.message).toBe('Hello, Endpoint2update!');
+        return true;
+      },
+    });
+  });
+
+  test('Should remove an endpoint', async () => {
+    createdApi.proxy.groups[0].endpoints.splice(-1); // delete endpoint2
+    const updatedApi = await updateApi(createdApi);
+    expect(updatedApi.proxy.groups[0].endpoints).toHaveLength(1);
+    const response = await fetchGatewaySuccess({ contextPath: createdApi.context_path }).then((res) => res.json());
+    expect(response.message).toBe('Hello, World!');
+  });
+
+  afterAll(async () => {
+    await teardownApisAndApplications(orgId, envId, [createdApi.id]);
+  });
 });


### PR DESCRIPTION
**Description**
- added use-case test UC-APIM13 for add/edit/delete an endpoint in a group


gravitee-io/issues#8098



<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/test-8098-add-edit-remove-several-endpoints-to-group-and-use/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ftwrkfsqdc.chromatic.com)
<!-- Storybook placeholder end -->
<!-- E2E Coverage placeholder -->
---
### 🧪 End-to-End Coverage

| INSTRUCTIONS | BRANCHES |
| :----------: | :------: |
|   35% | 19%   |

A more detailed report has been uploaded to [circleci](https://output.circle-artifacts.com/output/job/42398a67-f7e0-4007-ab00-c9733db2f9f5/artifacts/0/gravitee-apim-e2e/jacoco/reports/index.html)
<!-- E2E Coverage placeholder end -->
