### PR TITLE
test(e2e): limit random group.name to 64 characters due to JDBC field limitation

### DIFF
--- a/gravitee-apim-e2e/api-test/src/documentation/documentation.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/documentation/documentation.spec.ts
@@ -30,6 +30,7 @@ import { ApiApi, GetPageByApiIdAndPageIdIncludeEnum } from '@portal-apis/ApiApi'
 import { MetadataFormat } from '@management-models/MetadataFormat';
 import { APIMetadataApi } from '@management-apis/APIMetadataApi';
 import { UpdateApiEntityFromJSON } from '@management-models/UpdateApiEntity';
+import { GroupsFaker } from '@management-fakers/GroupsFaker';
 
 const orgId = 'DEFAULT';
 const envId = 'DEFAULT';
@@ -59,8 +60,7 @@ describe('Documentation', () => {
     createdReaderGroup = await configurationManagementApiAsAdminUser.createGroup({
       orgId,
       envId,
-      newGroupEntity: {
-        name: `E2e Doc Reader -${faker.random.word()}-${faker.datatype.uuid()}`,
+      newGroupEntity: GroupsFaker.newGroup({
         event_rules: [
           {
             event: 'API_CREATE',
@@ -69,7 +69,7 @@ describe('Documentation', () => {
         lock_api_role: false,
         lock_application_role: false,
         disable_membership_notifications: false,
-      },
+      }),
     });
 
     // Get user member

--- a/gravitee-apim-e2e/lib/fixtures/management/GroupsFaker.ts
+++ b/gravitee-apim-e2e/lib/fixtures/management/GroupsFaker.ts
@@ -18,7 +18,7 @@ import { NewGroupEntity } from '@management-models/NewGroupEntity';
 
 export class GroupsFaker {
   static newGroup(attributes?: Partial<NewGroupEntity>): NewGroupEntity {
-    const name = faker.commerce.productName();
+    const name = faker.commerce.productName().substring(0, 64);
 
     return {
       name,


### PR DESCRIPTION
This fixes flaky e2e test for JDBC
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/test-fixflakyjdbc-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-acfkfljbxh.chromatic.com)
<!-- Storybook placeholder end -->
<!-- E2E Coverage placeholder -->
---
### 🧪 End-to-End Coverage

| INSTRUCTIONS | BRANCHES |
| :----------: | :------: |
|   35% | 19%   |

A more detailed report has been uploaded to [circleci](https://output.circle-artifacts.com/output/job/f984dc3c-a4dd-4e1c-a1b3-3dd876e43d2b/artifacts/0/gravitee-apim-e2e/jacoco/reports/index.html)
<!-- E2E Coverage placeholder end -->
