### PR TITLE
use JDK 17 in every java jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,7 @@ parameters:
 jobs:
     setup:
         docker:
-            - image: cimg/openjdk:11.0
+            - image: cimg/openjdk:17.0
         resource_class: small
         steps:
             - checkout
@@ -339,7 +339,7 @@ jobs:
 
     validate:
         docker:
-            - image: cimg/openjdk:11.0
+            - image: cimg/openjdk:17.0
         resource_class: small
         steps:
             - checkout
@@ -395,7 +395,7 @@ jobs:
                   version: << pipeline.parameters.graviteeio_version >>-ee
     build:
         docker:
-            - image: cimg/openjdk:11.0
+            - image: cimg/openjdk:17.0
         resource_class: large
         steps:
             - checkout
@@ -432,7 +432,7 @@ jobs:
 
     build-images:
         docker:
-            - image: cimg/openjdk:11.0
+            - image: cimg/openjdk:17.0
         resource_class: medium
         steps:
             - checkout
@@ -450,7 +450,7 @@ jobs:
 
     community-build:
         docker:
-            - image: cimg/openjdk:11.0
+            - image: cimg/openjdk:17.0
         resource_class: medium
         steps:
             - checkout
@@ -470,7 +470,7 @@ jobs:
 
     test:
         docker:
-            - image: cimg/openjdk:11.0
+            - image: cimg/openjdk:17.0
         resource_class: medium+
         steps:
             - checkout
@@ -541,7 +541,7 @@ jobs:
 
     publish-on-artifactory:
         docker:
-            - image: cimg/openjdk:11.0
+            - image: cimg/openjdk:17.0
         resource_class: large
         environment:
             ALT_DEPLOYMENT_REPOSITORY: "artifactory-gravitee::default::https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots"
@@ -561,7 +561,7 @@ jobs:
 
     publish-on-nexus:
         docker:
-            - image: cimg/openjdk:11.0
+            - image: cimg/openjdk:17.0
         resource_class: large
         steps:
             - checkout
@@ -579,7 +579,7 @@ jobs:
 
     publish-images-azure-registry:
         docker:
-            - image: cimg/openjdk:11.0
+            - image: cimg/openjdk:17.0
         resource_class: small
         steps:
             - checkout
@@ -800,7 +800,7 @@ jobs:
                 default: ""
                 description: the name of the docker image to create
         docker:
-            - image: cimg/openjdk:11.0
+            - image: cimg/openjdk:17.0
         resource_class: small
         steps:
             - checkout
@@ -1071,7 +1071,7 @@ jobs:
 
     backend-build-and-publish-artifactory:
         docker:
-            - image: cimg/openjdk:11.0.13
+            - image: cimg/openjdk:17.0
         resource_class: large
         steps:
             - checkout
@@ -1254,7 +1254,7 @@ jobs:
 
     nexus-staging:
         docker:
-            - image: cimg/openjdk:11.0
+            - image: cimg/openjdk:17.0
         resource_class: xlarge
         steps:
             - checkout
@@ -1581,7 +1581,7 @@ jobs:
 
     package-bundle:
         docker:
-            - image: cimg/openjdk:11.0-node
+            - image: cimg/openjdk:17.0-node
         resource_class: medium
         environment:
             RELEASE_VERSION: << pipeline.parameters.graviteeio_version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -500,6 +500,7 @@ jobs:
     community-build:
         executor:
             name: openjdk
+            version: "11.0"
         steps:
             - checkout
             - restore-maven-job-cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,24 @@ orbs:
     aws-s3: circleci/aws-s3@3.0
 
 executors:
+    openjdk:
+        parameters:
+            class:
+                description: The resource class. Default is medium.
+                type: enum
+                enum: ["small", "medium", "medium+", "large", "xlarge"]
+                default: "medium"
+            version:
+                description: the version of the JDK. Default is 17.0
+                type: string
+                default: "17.0"
+            with_node:
+                description: should we use the "node" version of the image
+                type: boolean
+                default: false
+        docker:
+            - image: cimg/openjdk:<< parameters.version >><<# parameters.with_node >>-node<</ parameters.with_node >>
+        resource_class: << parameters.class >>
     node-lts:
         parameters:
             class:
@@ -265,9 +283,9 @@ parameters:
 
 jobs:
     setup:
-        docker:
-            - image: cimg/openjdk:17.0
-        resource_class: small
+        executor:
+            name: openjdk
+            class: small
         steps:
             - checkout
             - keeper/env-export:
@@ -346,9 +364,9 @@ jobs:
                   when: always
 
     validate:
-        docker:
-            - image: cimg/openjdk:17.0
-        resource_class: small
+        executor:
+            name: openjdk
+            class: small
         steps:
             - checkout
             - attach_workspace:
@@ -402,9 +420,9 @@ jobs:
                   docker-image-name: apim-portal-ui
                   version: << pipeline.parameters.graviteeio_version >>-ee
     build:
-        docker:
-            - image: cimg/openjdk:17.0
-        resource_class: large
+        executor:
+            name: openjdk
+            class: large
         steps:
             - checkout
             - attach_workspace:
@@ -439,9 +457,8 @@ jobs:
                       - ./gateway-docker-context
 
     build-images:
-        docker:
-            - image: cimg/openjdk:17.0
-        resource_class: medium
+        executor:
+            name: openjdk
         steps:
             - checkout
             - attach_workspace:
@@ -457,9 +474,8 @@ jobs:
                       - ./docker-cache
 
     community-build:
-        docker:
-            - image: cimg/openjdk:17.0
-        resource_class: medium
+        executor:
+            name: openjdk
         steps:
             - checkout
             - restore-maven-job-cache:
@@ -477,9 +493,9 @@ jobs:
                   jobName: community-build
 
     test:
-        docker:
-            - image: cimg/openjdk:17.0
-        resource_class: medium+
+        executor:
+            name: openjdk
+            class: medium+
         steps:
             - checkout
             - attach_workspace:
@@ -549,9 +565,9 @@ jobs:
                       - gravitee-apim-repository/gravitee-apim-repository-coverage/target/site/jacoco-aggregate/
 
     publish-on-artifactory:
-        docker:
-            - image: cimg/openjdk:17.0
-        resource_class: large
+        executor:
+            name: openjdk
+            class: large
         environment:
             ALT_DEPLOYMENT_REPOSITORY: "artifactory-gravitee::default::https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots"
         steps:
@@ -569,9 +585,9 @@ jobs:
                   jobName: publish-on-artifactory
 
     publish-on-nexus:
-        docker:
-            - image: cimg/openjdk:17.0
-        resource_class: large
+        executor:
+            name: openjdk
+            class: large
         steps:
             - checkout
             - attach_workspace:
@@ -587,9 +603,9 @@ jobs:
                   jobName: publish-on-nexus
 
     publish-images-azure-registry:
-        docker:
-            - image: cimg/openjdk:17.0
-        resource_class: small
+        executor:
+            name: openjdk
+            class: small
         steps:
             - checkout
             - attach_workspace:
@@ -808,9 +824,9 @@ jobs:
                 type: string
                 default: ""
                 description: the name of the docker image to create
-        docker:
-            - image: cimg/openjdk:17.0
-        resource_class: small
+        executor:
+            name: openjdk
+            class: small
         steps:
             - checkout
             - attach_workspace:
@@ -1079,9 +1095,9 @@ jobs:
                                 }
 
     backend-build-and-publish-artifactory:
-        docker:
-            - image: cimg/openjdk:17.0
-        resource_class: large
+        executor:
+            name: openjdk
+            class: large
         steps:
             - checkout
             - restore-maven-job-cache:
@@ -1262,9 +1278,9 @@ jobs:
                       docker logout
 
     nexus-staging:
-        docker:
-            - image: cimg/openjdk:17.0
-        resource_class: xlarge
+        executor:
+            name: openjdk
+            class: xlarge
         steps:
             - checkout
             - run:
@@ -1591,9 +1607,9 @@ jobs:
                       fi;
 
     package-bundle:
-        docker:
-            - image: cimg/openjdk:17.0-node
-        resource_class: medium
+        executor:
+            name: openjdk
+            with_node: true
         environment:
             RELEASE_VERSION: << pipeline.parameters.graviteeio_version >>
             ARTIFACTORY_REPO_URL: "https://odbxikk7vo-artifactory.services.clever-cloud.com/external-dependencies-n-gravitee-all"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,30 @@ orbs:
     aws-s3: circleci/aws-s3@3.0
 
 executors:
+    ubuntu:
+        parameters:
+            class:
+                description: The resource class. Default is medium.
+                type: enum
+                enum: ["medium", "large", "xlarge", "2xlarge"]
+                default: "medium"
+            version:
+                description: the version of the machine. Default is 2204
+                type: string
+                default: "2204"
+            tag:
+                description: the tag of the machine. Default is current
+                type: string
+                default: "current"
+            with_docker_layer_caching:
+                description: should we use Docker Layer Caching mechanism. Default is false
+                type: boolean
+                default: false
+        machine:
+            image: ubuntu-<< parameters.version >>:<< parameters.tag >>
+            docker_layer_caching: << parameters.with_docker_layer_caching >>
+        resource_class: << parameters.class >>
+
     openjdk:
         parameters:
             class:
@@ -529,9 +553,9 @@ jobs:
                       - gravitee-apim-plugin/gravitee-apim-plugin-coverage/target/site/jacoco-aggregate/
 
     test-repository:
-        machine:
-            image: ubuntu-2204:current
-        resource_class: large
+        executor:
+            name: ubuntu
+            class: large
         steps:
             - install-jdk-17-for-machine
             - checkout
@@ -1333,10 +1357,10 @@ jobs:
                 type: string
                 description: type and version of the database to test
                 default: ""
-        machine:
-            image: ubuntu-2204:current
-            docker_layer_caching: true
-        resource_class: large
+        executor:
+            name: ubuntu
+            class: large
+            with_docker_layer_caching: true
         steps:
             - when:
                   condition: << parameters.version >>
@@ -1377,9 +1401,8 @@ jobs:
                 type: string
                 description: version of the database to test
                 default: ""
-        machine:
-            image: ubuntu-2204:current
-        resource_class: medium
+        executor:
+            name: ubuntu
         steps:
             - when:
                   condition: << parameters.version >>
@@ -1415,9 +1438,9 @@ jobs:
                             command: exit 0
 
     e2e-test:
-        machine:
-            image: ubuntu-2204:current
-        resource_class: large
+        executor:
+            name: ubuntu
+            class: large
         parameters:
             execution_mode:
                 type: string
@@ -1474,9 +1497,8 @@ jobs:
             - store_test_results:
                   path: ~/test-results
     e2e-report:
-        machine:
-            image: ubuntu-2204:current
-        resource_class: small
+        executor:
+            name: ubuntu
         steps:
             - attach_workspace:
                   at: .
@@ -1551,9 +1573,8 @@ jobs:
 
                       gh pr edit --body "$CLEAN_BODY$PR_BODY_COVERAGE_SECTION"
     e2e-cypress:
-        machine:
-            image: ubuntu-2204:current
-        resource_class: medium
+        executor:
+            name: ubuntu
         steps:
             - checkout
             - attach_workspace:
@@ -1584,9 +1605,8 @@ jobs:
             graviteeio_version:
                 type: string
                 default: ""
-        machine:
-            image: ubuntu-2204:current
-        resource_class: medium
+        executor:
+            name: ubuntu
         steps:
             - keeper/env-export:
                   secret-url: keeper://8CG6HxY5gYsl-85eJKuIoA/field/password

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,14 @@ executors:
         resource_class: <<parameters.resource_class>>
 
 commands:
+    install-jdk-17-for-machine:
+        description: Install JDK 17 on machine executor
+        steps:
+            - run:
+                  command: |
+                      sudo apt update
+                      sudo apt install -y openjdk-17-jdk
+
     prepare-env-var:
         description: Prepare env variables used in [version.properties] files
         steps:
@@ -506,9 +514,10 @@ jobs:
 
     test-repository:
         machine:
-            image: ubuntu-2004:current
+            image: ubuntu-2204:current
         resource_class: large
         steps:
+            - install-jdk-17-for-machine
             - checkout
             - attach_workspace:
                   at: .
@@ -1309,13 +1318,14 @@ jobs:
                 description: type and version of the database to test
                 default: ""
         machine:
-            image: ubuntu-2004:current
+            image: ubuntu-2204:current
             docker_layer_caching: true
         resource_class: large
         steps:
             - when:
                   condition: << parameters.version >>
                   steps:
+                      - install-jdk-17-for-machine
                       - checkout
                       - attach_workspace:
                             at: .
@@ -1352,12 +1362,13 @@ jobs:
                 description: version of the database to test
                 default: ""
         machine:
-            image: ubuntu-2004:current
+            image: ubuntu-2204:current
         resource_class: medium
         steps:
             - when:
                   condition: << parameters.version >>
                   steps:
+                      - install-jdk-17-for-machine
                       - checkout
                       - attach_workspace:
                             at: .
@@ -1389,7 +1400,7 @@ jobs:
 
     e2e-test:
         machine:
-            image: ubuntu-2004:202101-01
+            image: ubuntu-2204:current
         resource_class: large
         parameters:
             execution_mode:
@@ -1448,7 +1459,7 @@ jobs:
                   path: ~/test-results
     e2e-report:
         machine:
-            image: ubuntu-2004:202101-01
+            image: ubuntu-2204:current
         resource_class: small
         steps:
             - attach_workspace:
@@ -1525,7 +1536,7 @@ jobs:
                       gh pr edit --body "$CLEAN_BODY$PR_BODY_COVERAGE_SECTION"
     e2e-cypress:
         machine:
-            image: ubuntu-2004:202101-01
+            image: ubuntu-2204:current
         resource_class: medium
         steps:
             - checkout
@@ -1558,7 +1569,7 @@ jobs:
                 type: string
                 default: ""
         machine:
-            image: ubuntu-2004:202201-01
+            image: ubuntu-2204:current
         resource_class: medium
         steps:
             - keeper/env-export:


### PR DESCRIPTION
**Issue**

N/A

**Description**

Use JDK 17 for all our jobs using a JDK
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/ci-use-jdk-17-in-jobs/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vwimedgrlo.chromatic.com)
<!-- Storybook placeholder end -->
