### PR TITLE
refactor(e2e): use module imports instead relative path

### DIFF
--- a/gravitee-apim-e2e/api-test/src/gateway/plans-deployment.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/gateway/plans-deployment.spec.ts
@@ -28,7 +28,7 @@ import { APIPlansApi } from '@gravitee/management-webclient-sdk/src/lib/apis/API
 import { PlanStatus } from '@gravitee/management-webclient-sdk/src/lib/models/PlanStatus';
 import { PlanSecurityType } from '@gravitee/management-webclient-sdk/src/lib/models/PlanSecurityType';
 import { LifecycleAction } from '@gravitee/management-webclient-sdk/src/lib/models/LifecycleAction';
-import { fetchGatewaySuccess, fetchGatewayUnauthorized } from '../../../lib/utils/gateway';
+import { fetchGatewaySuccess, fetchGatewayUnauthorized } from '@gravitee/utils/gateway';
 import { ApplicationSubscriptionsApi } from '@gravitee/management-webclient-sdk/src/lib/apis/ApplicationSubscriptionsApi';
 import { Subscription } from '@gravitee/management-webclient-sdk/src/lib/models/Subscription';
 import { ApiKeyEntity } from '@gravitee/management-webclient-sdk/src/lib/models/ApiKeyEntity';

--- a/gravitee-apim-e2e/api-test/src/gateway/redeploy-api.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/gateway/redeploy-api.spec.ts
@@ -22,7 +22,7 @@ import { PlansFaker } from '@gravitee/fixtures/management/PlansFaker';
 import { PlanEntity } from '@gravitee/management-webclient-sdk/src/lib/models/PlanEntity';
 import { noContent, succeed } from '@lib/jest-utils';
 import { LifecycleAction } from '@gravitee/management-webclient-sdk/src/lib/models/LifecycleAction';
-import { fetchGatewaySuccess } from '../../../lib/utils/gateway';
+import { fetchGatewaySuccess } from '@gravitee/utils/gateway';
 import { PathOperatorOperatorEnum } from '@gravitee/management-webclient-sdk/src/lib/models/PathOperator';
 import { PlanStatus } from '@gravitee/management-webclient-sdk/src/lib/models/PlanStatus';
 import { UpdatePlanEntityFromJSON } from '@gravitee/management-webclient-sdk/src/lib/models/UpdatePlanEntity';

--- a/gravitee-apim-e2e/api-test/src/gateway/simple-proxy.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/gateway/simple-proxy.spec.ts
@@ -22,7 +22,7 @@ import { ApiEntity } from '@gravitee/management-webclient-sdk/src/lib/models/Api
 import { PlansFaker } from '@gravitee/fixtures/management/PlansFaker';
 import { LifecycleAction } from '@gravitee/management-webclient-sdk/src/lib/models/LifecycleAction';
 import { PlanStatus } from '@gravitee/management-webclient-sdk/src/lib/models/PlanStatus';
-import { fetchGatewaySuccess } from '../../../lib/utils/gateway';
+import { fetchGatewaySuccess } from '@gravitee/utils/gateway';
 import { APIPlansApi } from '@gravitee/management-webclient-sdk/src/lib/apis/APIPlansApi';
 import { LoadBalancerTypeEnum } from '@gravitee/management-webclient-sdk/src/lib/models/LoadBalancer';
 

--- a/gravitee-apim-e2e/api-test/src/policies/mock-policy.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/policies/mock-policy.spec.ts
@@ -24,7 +24,7 @@ import { PlanEntity } from '@gravitee/management-webclient-sdk/src/lib/models/Pl
 import { RuleMethodsEnum } from '@gravitee/management-webclient-sdk/src/lib/models/Rule';
 import { describeIfV3, noContent, succeed } from '@lib/jest-utils';
 import { LifecycleAction } from '@gravitee/management-webclient-sdk/src/lib/models/LifecycleAction';
-import { fetchGatewaySuccess } from '../../../lib/utils/gateway';
+import { fetchGatewaySuccess } from '@gravitee/utils/gateway';
 import { PathOperatorOperatorEnum } from '@gravitee/management-webclient-sdk/src/lib/models/PathOperator';
 import { PlanStatus } from '@gravitee/management-webclient-sdk/src/lib/models/PlanStatus';
 

--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/cors/enable-cors-and-use-it.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/cors/enable-cors-and-use-it.spec.ts
@@ -23,8 +23,8 @@ import { PlanSecurityType } from '@gravitee/management-webclient-sdk/src/lib/mod
 import { PlanStatus } from '@gravitee/management-webclient-sdk/src/lib/models/PlanStatus';
 import { LoadBalancerTypeEnum } from '@gravitee/management-webclient-sdk/src/lib/models/LoadBalancer';
 import { LifecycleAction } from '@gravitee/management-webclient-sdk/src/lib/models/LifecycleAction';
-import { teardownApisAndApplications } from '../../../../../../lib/utils/management';
-import { fetchGatewayBadRequest, fetchGatewaySuccess } from '../../../../../../lib/utils/gateway';
+import { teardownApisAndApplications } from '@gravitee/utils/management';
+import { fetchGatewayBadRequest, fetchGatewaySuccess } from '@gravitee/utils/gateway';
 import { PathOperatorOperatorEnum } from '@gravitee/management-webclient-sdk/src/lib/models/PathOperator';
 
 const orgId = 'DEFAULT';

--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/debug-mode/call-my-api-including-query-params-headers-body-and-view-debug-session-with-proper-info.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/debug-mode/call-my-api-including-query-params-headers-body-and-view-debug-session-with-proper-info.spec.ts
@@ -24,7 +24,7 @@ import { forManagementAsAdminUser, forManagementAsApiUser } from '@gravitee/util
 import { OrganizationApi } from '@gravitee/management-webclient-sdk/src/lib/apis/OrganizationApi';
 import { ApiEntity, ApiEntityToJSON } from '@gravitee/management-webclient-sdk/src/lib/models/ApiEntity';
 import { PathOperatorOperatorEnum } from '@gravitee/management-webclient-sdk/src/lib/models/PathOperator';
-import { teardownApisAndApplications } from '../../../../../../lib/utils/management';
+import { teardownApisAndApplications } from '@gravitee/utils/management';
 import { DebugApiEntity, DebugApiEntityFromJSON } from '@gravitee/management-webclient-sdk/src/lib/models/DebugApiEntity';
 import { describeIfV3, succeed } from '@lib/jest-utils';
 import { delayWhen, from, Observable, switchMap, tap, timer, map, retryWhen, Subscription } from 'rxjs';

--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/endpoints/configure-lb-to-random-and-use-it.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/endpoints/configure-lb-to-random-and-use-it.spec.ts
@@ -22,8 +22,8 @@ import { ApiEntity } from '@gravitee/management-webclient-sdk/src/lib/models/Api
 import { PlansFaker } from '@gravitee/fixtures/management/PlansFaker';
 import { LifecycleAction } from '@gravitee/management-webclient-sdk/src/lib/models/LifecycleAction';
 import { PlanStatus } from '@gravitee/management-webclient-sdk/src/lib/models/PlanStatus';
-import { fetchGatewaySuccess } from '../../../../../../lib/utils/gateway';
-import { teardownApisAndApplications } from '../../../../../../lib/utils/management';
+import { fetchGatewaySuccess } from '@gravitee/utils/gateway';
+import { teardownApisAndApplications } from '@gravitee/utils/management';
 import { LoadBalancerTypeEnum } from '@gravitee/management-webclient-sdk/src/lib/models/LoadBalancer';
 
 const orgId = 'DEFAULT';

--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/endpoints/configure-lb-to-round-robin-and-use-it.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/endpoints/configure-lb-to-round-robin-and-use-it.spec.ts
@@ -22,8 +22,8 @@ import { ApiEntity } from '@gravitee/management-webclient-sdk/src/lib/models/Api
 import { PlansFaker } from '@gravitee/fixtures/management/PlansFaker';
 import { LifecycleAction } from '@gravitee/management-webclient-sdk/src/lib/models/LifecycleAction';
 import { PlanStatus } from '@gravitee/management-webclient-sdk/src/lib/models/PlanStatus';
-import { fetchGatewaySuccess } from '../../../../../../lib/utils/gateway';
-import { teardownApisAndApplications } from '../../../../../../lib/utils/management';
+import { fetchGatewaySuccess } from '@gravitee/utils/gateway';
+import { teardownApisAndApplications } from '@gravitee/utils/management';
 
 const orgId = 'DEFAULT';
 const envId = 'DEFAULT';

--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/endpoints/configure-lb-to-round-robin-weighted-and-use-it.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/endpoints/configure-lb-to-round-robin-weighted-and-use-it.spec.ts
@@ -22,9 +22,9 @@ import { ApiEntity } from '@gravitee/management-webclient-sdk/src/lib/models/Api
 import { PlansFaker } from '@gravitee/fixtures/management/PlansFaker';
 import { LifecycleAction } from '@gravitee/management-webclient-sdk/src/lib/models/LifecycleAction';
 import { PlanStatus } from '@gravitee/management-webclient-sdk/src/lib/models/PlanStatus';
-import { fetchGatewaySuccess } from '../../../../../../lib/utils/gateway';
+import { fetchGatewaySuccess } from '@gravitee/utils/gateway';
 import { LoadBalancerTypeEnum } from '@gravitee/management-webclient-sdk/src/lib/models/LoadBalancer';
-import { teardownApisAndApplications } from '../../../../../../lib/utils/management';
+import { teardownApisAndApplications } from '@gravitee/utils/management';
 
 const orgId = 'DEFAULT';
 const envId = 'DEFAULT';

--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/endpoints/create-several-endpoint-groups-and-use-them.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/endpoints/create-several-endpoint-groups-and-use-them.spec.ts
@@ -25,8 +25,8 @@ import { PlanStatus } from '@gravitee/management-webclient-sdk/src/lib/models/Pl
 import { UpdateApiEntityFromJSON } from '@gravitee/management-webclient-sdk/src/lib/models/UpdateApiEntity';
 import { LoadBalancerTypeEnum } from '@gravitee/management-webclient-sdk/src/lib/models/LoadBalancer';
 import { LifecycleAction } from '@gravitee/management-webclient-sdk/src/lib/models/LifecycleAction';
-import { fetchGatewaySuccess } from '../../../../../../lib/utils/gateway';
-import { teardownApisAndApplications } from '../../../../../../lib/utils/management';
+import { fetchGatewaySuccess } from '@gravitee/utils/gateway';
+import { teardownApisAndApplications } from '@gravitee/utils/management';
 
 const orgId = 'DEFAULT';
 const envId = 'DEFAULT';

--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/flows/add-condition-on-flows-and-test-them.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/flows/add-condition-on-flows-and-test-them.spec.ts
@@ -22,12 +22,12 @@ import { PlansFaker } from '@gravitee/fixtures/management/PlansFaker';
 import { PlanStatus } from '@gravitee/management-webclient-sdk/src/lib/models/PlanStatus';
 import { PlanSecurityType } from '@gravitee/management-webclient-sdk/src/lib/models/PlanSecurityType';
 import { LifecycleAction } from '@gravitee/management-webclient-sdk/src/lib/models/LifecycleAction';
-import { fetchGatewaySuccess } from '../../../../../../lib/utils/gateway';
+import { fetchGatewaySuccess } from '@gravitee/utils/gateway';
 import { PathOperatorOperatorEnum } from '@gravitee/management-webclient-sdk/src/lib/models/PathOperator';
 import { PlanEntity } from '@gravitee/management-webclient-sdk/src/lib/models/PlanEntity';
 import { OrganizationEntityToJSON } from '@gravitee/management-webclient-sdk/src/lib/models/OrganizationEntity';
 import { OrganizationApi } from '@gravitee/management-webclient-sdk/src/lib/apis/OrganizationApi';
-import { teardownApisAndApplications } from '../../../../../../lib/utils/management';
+import { teardownApisAndApplications } from '@gravitee/utils/management';
 
 const orgId = 'DEFAULT';
 const envId = 'DEFAULT';

--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/flows/add-policies-to-flows-and-use-them.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/flows/add-policies-to-flows-and-use-them.spec.ts
@@ -22,9 +22,9 @@ import { PlansFaker } from '@gravitee/fixtures/management/PlansFaker';
 import { PlanSecurityType } from '@gravitee/management-webclient-sdk/src/lib/models/PlanSecurityType';
 import { PlanStatus } from '@gravitee/management-webclient-sdk/src/lib/models/PlanStatus';
 import { LifecycleAction } from '@gravitee/management-webclient-sdk/src/lib/models/LifecycleAction';
-import { teardownApisAndApplications } from '../../../../../../lib/utils/management';
+import { teardownApisAndApplications } from '@gravitee/utils/management';
 import { PathOperatorOperatorEnum } from '@gravitee/management-webclient-sdk/src/lib/models/PathOperator';
-import { fetchGatewaySuccess } from '../../../../../../lib/utils/gateway';
+import { fetchGatewaySuccess } from '@gravitee/utils/gateway';
 import { LoadBalancerTypeEnum } from '@gravitee/management-webclient-sdk/src/lib/models/LoadBalancer';
 import { flakyRunner, sleep } from '@lib/jest-utils';
 

--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/flows/create-global-flows-and-use-them.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/flows/create-global-flows-and-use-them.spec.ts
@@ -22,13 +22,13 @@ import { PlansFaker } from '@gravitee/fixtures/management/PlansFaker';
 import { PlanStatus } from '@gravitee/management-webclient-sdk/src/lib/models/PlanStatus';
 import { PlanSecurityType } from '@gravitee/management-webclient-sdk/src/lib/models/PlanSecurityType';
 import { LifecycleAction } from '@gravitee/management-webclient-sdk/src/lib/models/LifecycleAction';
-import { fetchGatewaySuccess } from '../../../../../../lib/utils/gateway';
+import { fetchGatewaySuccess } from '@gravitee/utils/gateway';
 import { PathOperatorOperatorEnum } from '@gravitee/management-webclient-sdk/src/lib/models/PathOperator';
 import { PlanEntity } from '@gravitee/management-webclient-sdk/src/lib/models/PlanEntity';
 import { OrganizationEntityToJSON } from '@gravitee/management-webclient-sdk/src/lib/models/OrganizationEntity';
 import { OrganizationApi } from '@gravitee/management-webclient-sdk/src/lib/apis/OrganizationApi';
 import { NewApiEntityFlowModeEnum } from '@gravitee/management-webclient-sdk/src/lib/models/NewApiEntity';
-import { teardownApisAndApplications } from '../../../../../../lib/utils/management';
+import { teardownApisAndApplications } from '@gravitee/utils/management';
 
 const orgId = 'DEFAULT';
 const envId = 'DEFAULT';

--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/flows/create-several-plan-flows-and-use-them.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/flows/create-several-plan-flows-and-use-them.spec.ts
@@ -29,14 +29,14 @@ import { ApplicationsFaker } from '@gravitee/fixtures/management/ApplicationsFak
 import { LifecycleAction } from '@gravitee/management-webclient-sdk/src/lib/models/LifecycleAction';
 import { ApplicationsApi } from '@gravitee/management-webclient-sdk/src/lib/apis/ApplicationsApi';
 import { ApplicationSubscriptionsApi } from '@gravitee/management-webclient-sdk/src/lib/apis/ApplicationSubscriptionsApi';
-import { fetchGatewaySuccess } from '../../../../../../lib/utils/gateway';
+import { fetchGatewaySuccess } from '@gravitee/utils/gateway';
 import { FlowMethodsEnum } from '@gravitee/management-webclient-sdk/src/lib/models/Flow';
 import { UpdatePlanEntityFromJSON } from '@gravitee/management-webclient-sdk/src/lib/models/UpdatePlanEntity';
 import { PathOperatorOperatorEnum } from '@gravitee/management-webclient-sdk/src/lib/models/PathOperator';
 import { PlanEntity, PlanEntityToJSON } from '@gravitee/management-webclient-sdk/src/lib/models/PlanEntity';
 import { UpdateApiEntityFromJSON } from '@gravitee/management-webclient-sdk/src/lib/models/UpdateApiEntity';
 import { succeed } from '@lib/jest-utils';
-import { teardownApisAndApplications } from '../../../../../../lib/utils/management';
+import { teardownApisAndApplications } from '@gravitee/utils/management';
 
 const orgId = 'DEFAULT';
 const envId = 'DEFAULT';

--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/plans/create-an-api-with-api-key-plan-and-use-it.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/plans/create-an-api-with-api-key-plan-and-use-it.spec.ts
@@ -25,7 +25,7 @@ import { PlanStatus } from '@gravitee/management-webclient-sdk/src/lib/models/Pl
 import { ApiLifecycleState } from '@gravitee/management-webclient-sdk/src/lib/models/ApiLifecycleState';
 import { LifecycleAction } from '@gravitee/management-webclient-sdk/src/lib/models/LifecycleAction';
 import { ApplicationsFaker } from '@gravitee/fixtures/management/ApplicationsFaker';
-import { fetchGatewaySuccess, fetchGatewayUnauthorized } from '../../../../../../lib/utils/gateway';
+import { fetchGatewaySuccess, fetchGatewayUnauthorized } from '@gravitee/utils/gateway';
 import { APIsApi } from '@gravitee/management-webclient-sdk/src/lib/apis/APIsApi';
 import { forManagementAsApiUser } from '@gravitee/utils/configuration';
 import { ApplicationsApi } from '@gravitee/management-webclient-sdk/src/lib/apis/ApplicationsApi';

--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/plans/create-an-api-with-jwt-plan-and-use-it.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/plans/create-an-api-with-jwt-plan-and-use-it.spec.ts
@@ -30,9 +30,9 @@ import { PlanStatus } from '@gravitee/management-webclient-sdk/src/lib/models/Pl
 import { UpdatePlanEntityFromJSON } from '@gravitee/management-webclient-sdk/src/lib/models/UpdatePlanEntity';
 import { ApplicationsFaker } from '@gravitee/fixtures/management/ApplicationsFaker';
 import { LifecycleAction } from '@gravitee/management-webclient-sdk/src/lib/models/LifecycleAction';
-import { fetchGatewaySuccess, fetchGatewayUnauthorized } from '../../../../../../lib/utils/gateway';
+import { fetchGatewaySuccess, fetchGatewayUnauthorized } from '@gravitee/utils/gateway';
 import * as jwt from 'jsonwebtoken';
-import { teardownApisAndApplications } from '../../../../../../lib/utils/management';
+import { teardownApisAndApplications } from '@gravitee/utils/management';
 
 const orgId = 'DEFAULT';
 const envId = 'DEFAULT';

--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/plans/create-an-api-with-multiple-jwt-plan-and-use-them.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/plans/create-an-api-with-multiple-jwt-plan-and-use-them.spec.ts
@@ -29,9 +29,9 @@ import { PlanStatus } from '@gravitee/management-webclient-sdk/src/lib/models/Pl
 import { UpdatePlanEntityFromJSON } from '@gravitee/management-webclient-sdk/src/lib/models/UpdatePlanEntity';
 import { ApplicationsFaker } from '@gravitee/fixtures/management/ApplicationsFaker';
 import { LifecycleAction } from '@gravitee/management-webclient-sdk/src/lib/models/LifecycleAction';
-import { fetchGatewaySuccess, fetchGatewayUnauthorized } from '../../../../../../lib/utils/gateway';
+import { fetchGatewaySuccess, fetchGatewayUnauthorized } from '@gravitee/utils/gateway';
 import * as jwt from 'jsonwebtoken';
-import { teardownApisAndApplications } from '../../../../../../lib/utils/management';
+import { teardownApisAndApplications } from '@gravitee/utils/management';
 import { PathOperatorOperatorEnum } from '@gravitee/management-webclient-sdk/src/lib/models/PathOperator';
 import { describeIfJupiter } from '@lib/jest-utils';
 

--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/plans/create-an-api-with-multiple-oauth2-plan-and-use-them.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/plans/create-an-api-with-multiple-oauth2-plan-and-use-them.spec.ts
@@ -29,8 +29,8 @@ import { PlanStatus } from '@gravitee/management-webclient-sdk/src/lib/models/Pl
 import { UpdatePlanEntityFromJSON } from '@gravitee/management-webclient-sdk/src/lib/models/UpdatePlanEntity';
 import { ApplicationsFaker } from '@gravitee/fixtures/management/ApplicationsFaker';
 import { LifecycleAction } from '@gravitee/management-webclient-sdk/src/lib/models/LifecycleAction';
-import { fetchGatewaySuccess, fetchGatewayUnauthorized } from '../../../../../../lib/utils/gateway';
-import { teardownApisAndApplications } from '../../../../../../lib/utils/management';
+import { fetchGatewaySuccess, fetchGatewayUnauthorized } from '@gravitee/utils/gateway';
+import { teardownApisAndApplications } from '@gravitee/utils/management';
 import { PathOperatorOperatorEnum } from '@gravitee/management-webclient-sdk/src/lib/models/PathOperator';
 import { UpdateApiEntityFromJSON } from '@gravitee/management-webclient-sdk/src/lib/models/UpdateApiEntity';
 import { Resource } from '@gravitee/management-webclient-sdk/src/lib/models/Resource';

--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/plans/create-an-api-with-oauth2-plan-and-use-it.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/plans/create-an-api-with-oauth2-plan-and-use-it.spec.ts
@@ -29,10 +29,10 @@ import { PlanStatus } from '@gravitee/management-webclient-sdk/src/lib/models/Pl
 import { UpdatePlanEntityFromJSON } from '@gravitee/management-webclient-sdk/src/lib/models/UpdatePlanEntity';
 import { ApplicationsFaker } from '@gravitee/fixtures/management/ApplicationsFaker';
 import { LifecycleAction } from '@gravitee/management-webclient-sdk/src/lib/models/LifecycleAction';
-import { fetchGatewaySuccess, fetchGatewayUnauthorized } from '../../../../../../lib/utils/gateway';
+import { fetchGatewaySuccess, fetchGatewayUnauthorized } from '@gravitee/utils/gateway';
 import { UpdateApiEntityFromJSON } from '@gravitee/management-webclient-sdk/src/lib/models/UpdateApiEntity';
 import { PathOperatorOperatorEnum } from '@gravitee/management-webclient-sdk/src/lib/models';
-import { teardownApisAndApplications } from '../../../../../../lib/utils/management';
+import { teardownApisAndApplications } from '@gravitee/utils/management';
 
 const orgId = 'DEFAULT';
 const envId = 'DEFAULT';

--- a/gravitee-apim-e2e/api-test/use-case-test/src/portal/consumer/subscribe-to-APIs/subscribe-to-plan-keyless-apikey-jwt-oauth-and-used-it.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/portal/consumer/subscribe-to-APIs/subscribe-to-plan-keyless-apikey-jwt-oauth-and-used-it.spec.ts
@@ -25,15 +25,13 @@ import { ApiLifecycleState } from '@gravitee/management-webclient-sdk/src/lib/mo
 import { LifecycleAction } from '@gravitee/management-webclient-sdk/src/lib/models/LifecycleAction';
 import { PortalApplicationFaker } from '@gravitee/fixtures/portal/PortalApplicationFaker';
 import { GetSubscriptionByIdIncludeEnum, SubscriptionApi } from '@gravitee/portal-webclient-sdk/src/lib/apis/SubscriptionApi';
-import { fetchGatewaySuccess } from '../../../../../../lib/utils/gateway';
+import { fetchGatewaySuccess } from '@gravitee/utils/gateway';
 import { APIsApi } from '@gravitee/management-webclient-sdk/src/lib/apis/APIsApi';
 import { forManagementAsApiUser, forPortalAsAppUser } from '@gravitee/utils/configuration';
 import { ApplicationApi } from '@gravitee/portal-webclient-sdk/src/lib/apis/ApplicationApi';
 import * as jwt from 'jsonwebtoken';
 import { UpdateApiEntityFromJSON } from '@gravitee/management-webclient-sdk/src/lib/models/UpdateApiEntity';
-import { teardownApisAndApplications } from '../../../../../../lib/utils/management';
-import { describeIfV3 } from '@lib/jest-utils';
-import faker from '@faker-js/faker';
+import { teardownApisAndApplications } from '@gravitee/utils/management';
 
 const orgId = 'DEFAULT';
 const envId = 'DEFAULT';


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/XXXXX

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/refactor-e2e-imports/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kaqrwqpxgo.chromatic.com)
<!-- Storybook placeholder end -->
