### PR TITLE
enhance cockpitURL with analytics params

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/portal/general/dialog/promote-api/promoteApiDialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/general/dialog/promote-api/promoteApiDialog.controller.ts
@@ -18,6 +18,7 @@ import { IOnInit } from 'angular';
 import '@gravitee/ui-components/wc/gv-select';
 import * as angular from 'angular';
 
+import { CockpitService, UtmCampaign } from '../../../../../../services-ngx/cockpit.service';
 import { PromotionService } from '../../../../../../services/promotion.service';
 import NotificationService from '../../../../../../services/notification.service';
 
@@ -36,6 +37,7 @@ export class PromoteApiDialogController implements IOnInit {
   private hasCockpit: boolean;
 
   constructor(
+    private readonly cockpitService: CockpitService,
     private readonly promotionService: PromotionService,
     private readonly NotificationService: NotificationService,
     private readonly $mdDialog: angular.material.IDialogService,
@@ -78,7 +80,7 @@ export class PromoteApiDialogController implements IOnInit {
           err.interceptorFuture.cancel();
           this.hasCockpit = false;
           const { cockpitURL } = err.data.parameters;
-          this.cockpitURL = cockpitURL;
+          this.cockpitURL = this.cockpitService.addQueryParamsForAnalytics(cockpitURL, UtmCampaign.API_PROMOTION);
         }
       })
       .finally(() => {

--- a/gravitee-apim-console-webui/src/organization/configuration/cockpit/org-settings-cockpit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/cockpit/org-settings-cockpit.component.spec.ts
@@ -54,7 +54,7 @@ describe('OrgSettingsCockpitComponent', () => {
       expect(component.icon).toEqual('explore');
       expect(component.title).toEqual('Meet Cockpit...');
       expect(component.message).toEqual(
-        'Create an account on <a href="https://cockpit.gravitee.io" target="_blank">Cockpit</a>, register your current installation and start creating new organizations and environments!',
+        'Create an account on <a href="https://cockpit.gravitee.io?utm_source=apim&utm_medium=InApp&utm_campaign=discover_cockpit&utm_term=not_registered" target="_blank">Cockpit</a>, register your current installation and start creating new organizations and environments!',
       );
     });
 
@@ -71,7 +71,7 @@ describe('OrgSettingsCockpitComponent', () => {
       expect(component.icon).toEqual('schedule');
       expect(component.title).toEqual('Almost there!');
       expect(component.message).toEqual(
-        'Your installation is connected but it still has to be accepted on <a href="https://cockpit.gravitee.io" target="_blank">Cockpit</a>!',
+        'Your installation is connected but it still has to be accepted on <a href="https://cockpit.gravitee.io?utm_source=apim&utm_medium=InApp&utm_campaign=discover_cockpit&utm_term=pending" target="_blank">Cockpit</a>!',
       );
     });
 
@@ -88,7 +88,7 @@ describe('OrgSettingsCockpitComponent', () => {
       expect(component.icon).toEqual('check_circle');
       expect(component.title).toEqual('Congratulation!');
       expect(component.message).toEqual(
-        'Your installation is now connected to <a href="https://cockpit.gravitee.io" target="_blank">Cockpit</a>, you can now explore all the possibilities offered by Cockpit!',
+        'Your installation is now connected to <a href="https://cockpit.gravitee.io?utm_source=apim&utm_medium=InApp&utm_campaign=discover_cockpit&utm_term=registered" target="_blank">Cockpit</a>, you can now explore all the possibilities offered by Cockpit!',
       );
     });
 
@@ -105,7 +105,7 @@ describe('OrgSettingsCockpitComponent', () => {
       expect(component.icon).toEqual('warning');
       expect(component.title).toEqual('No luck!');
       expect(component.message).toEqual(
-        'Seems that your installation is connected to <a href="https://cockpit.gravitee.io" target="_blank">Cockpit</a>, but has been rejected...',
+        'Seems that your installation is connected to <a href="https://cockpit.gravitee.io?utm_source=apim&utm_medium=InApp&utm_campaign=discover_cockpit&utm_term=rejected" target="_blank">Cockpit</a>, but has been rejected...',
       );
     });
 
@@ -122,7 +122,7 @@ describe('OrgSettingsCockpitComponent', () => {
       expect(component.icon).toEqual('gps_off');
       expect(component.title).toEqual('Installation unlinked!');
       expect(component.message).toEqual(
-        'Seems that your installation is connected to <a href="https://cockpit.gravitee.io" target="_blank">Cockpit</a>, but is not linked anymore...',
+        'Seems that your installation is connected to <a href="https://cockpit.gravitee.io?utm_source=apim&utm_medium=InApp&utm_campaign=discover_cockpit&utm_term=removed" target="_blank">Cockpit</a>, but is not linked anymore...',
       );
     });
   });

--- a/gravitee-apim-console-webui/src/organization/configuration/cockpit/org-settings-cockpit.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/cockpit/org-settings-cockpit.component.ts
@@ -17,6 +17,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { takeUntil, tap } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 
+import { CockpitService, UtmCampaign } from '../../../services-ngx/cockpit.service';
 import { InstallationService } from '../../../services-ngx/installation.service';
 import { Installation } from '../../../entities/installation/installation';
 
@@ -34,7 +35,7 @@ export class OrgSettingsCockpitComponent implements OnInit, OnDestroy {
 
   private unsubscribe$: Subject<boolean> = new Subject<boolean>();
 
-  constructor(private readonly installationService: InstallationService) {}
+  constructor(private readonly installationService: InstallationService, private readonly cockpitService: CockpitService) {}
 
   ngOnInit(): void {
     this.installationService
@@ -55,9 +56,15 @@ export class OrgSettingsCockpitComponent implements OnInit, OnDestroy {
   }
 
   private setupVM(installation: Installation): void {
-    const cockpitLink = `<a href="${installation.cockpitURL}" target="_blank">Cockpit</a>`;
+    const cockpitInstallationStatus = installation.additionalInformation.COCKPIT_INSTALLATION_STATUS;
+    const enhancedCockpitURL = this.cockpitService.addQueryParamsForAnalytics(
+      installation.cockpitURL,
+      UtmCampaign.DISCOVER_COCKPIT,
+      cockpitInstallationStatus,
+    );
+    const cockpitLink = `<a href="${enhancedCockpitURL}" target="_blank">Cockpit</a>`;
 
-    switch (installation.additionalInformation.COCKPIT_INSTALLATION_STATUS) {
+    switch (cockpitInstallationStatus) {
       case 'PENDING':
         this.icon = 'schedule';
         this.title = 'Almost there!';

--- a/gravitee-apim-console-webui/src/services-ngx/cockpit.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/cockpit.service.spec.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestBed } from '@angular/core/testing';
+
+import { CockpitService, UtmCampaign } from './cockpit.service';
+
+describe('CockpitService', () => {
+  let cockpitService: CockpitService;
+  const COCKPIT_URL = 'https://fake.cockpit.url';
+
+  beforeEach(() => {
+    cockpitService = TestBed.inject<CockpitService>(CockpitService);
+  });
+
+  it('should configure URL with API_PROMOTION campaign with exsiting query params', (done) => {
+    const enhancedURL = cockpitService.addQueryParamsForAnalytics(`${COCKPIT_URL}?foo=bar`, UtmCampaign.API_PROMOTION);
+    expect(enhancedURL).toEqual(`${COCKPIT_URL}?foo=bar&utm_source=apim&utm_medium=InApp&utm_campaign=api_promotion`);
+    done();
+  });
+
+  it('should configure URL with API_PROMOTION campaign', (done) => {
+    const enhancedURL = cockpitService.addQueryParamsForAnalytics(COCKPIT_URL, UtmCampaign.API_PROMOTION);
+    expect(enhancedURL).toEqual(`${COCKPIT_URL}?utm_source=apim&utm_medium=InApp&utm_campaign=api_promotion`);
+    done();
+  });
+
+  it('should configure URL with DiscoverCockpit campaign and PENDING installation status', (done) => {
+    const enhancedURL = cockpitService.addQueryParamsForAnalytics(COCKPIT_URL, UtmCampaign.DISCOVER_COCKPIT, 'PENDING');
+    expect(enhancedURL).toEqual(`${COCKPIT_URL}?utm_source=apim&utm_medium=InApp&utm_campaign=discover_cockpit&utm_term=pending`);
+    done();
+  });
+
+  it('should configure URL with DiscoverCockpit campaign and ACCEPTED installation status', (done) => {
+    const enhancedURL = cockpitService.addQueryParamsForAnalytics(COCKPIT_URL, UtmCampaign.DISCOVER_COCKPIT, 'ACCEPTED');
+    expect(enhancedURL).toEqual(`${COCKPIT_URL}?utm_source=apim&utm_medium=InApp&utm_campaign=discover_cockpit&utm_term=registered`);
+    done();
+  });
+
+  it('should configure URL with DiscoverCockpit campaign and REJECTED installation status', (done) => {
+    const enhancedURL = cockpitService.addQueryParamsForAnalytics(COCKPIT_URL, UtmCampaign.DISCOVER_COCKPIT, 'REJECTED');
+    expect(enhancedURL).toEqual(`${COCKPIT_URL}?utm_source=apim&utm_medium=InApp&utm_campaign=discover_cockpit&utm_term=rejected`);
+    done();
+  });
+
+  it('should configure URL with DiscoverCockpit campaign and DELETED installation status', (done) => {
+    const enhancedURL = cockpitService.addQueryParamsForAnalytics(COCKPIT_URL, UtmCampaign.DISCOVER_COCKPIT, 'DELETED');
+    expect(enhancedURL).toEqual(`${COCKPIT_URL}?utm_source=apim&utm_medium=InApp&utm_campaign=discover_cockpit&utm_term=removed`);
+    done();
+  });
+
+  it('should configure URL with DiscoverCockpit campaign and no installation status', (done) => {
+    const enhancedURL = cockpitService.addQueryParamsForAnalytics(COCKPIT_URL, UtmCampaign.DISCOVER_COCKPIT);
+    expect(enhancedURL).toEqual(`${COCKPIT_URL}?utm_source=apim&utm_medium=InApp&utm_campaign=discover_cockpit&utm_term=not_registered`);
+    done();
+  });
+
+  it('should configure URL with DiscoverCockpit campaign and unknown installation status', (done) => {
+    const enhancedURL = cockpitService.addQueryParamsForAnalytics(COCKPIT_URL, UtmCampaign.DISCOVER_COCKPIT, 'UNKNOWN');
+    expect(enhancedURL).toEqual(`${COCKPIT_URL}?utm_source=apim&utm_medium=InApp&utm_campaign=discover_cockpit&utm_term=not_registered`);
+    done();
+  });
+});

--- a/gravitee-apim-console-webui/src/services-ngx/cockpit.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/cockpit.service.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Injectable } from '@angular/core';
+
+export enum UtmCampaign {
+  API_PROMOTION = 'api_promotion',
+  DISCOVER_COCKPIT = 'discover_cockpit',
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class CockpitService {
+  addQueryParamsForAnalytics(cockpitUrl: string, utmCampaign: UtmCampaign, cockpitInstallationStatus?: string): string {
+    let enhancedCockpitUrl = cockpitUrl;
+    if (enhancedCockpitUrl.indexOf('?') > 0) {
+      enhancedCockpitUrl += '&';
+    } else {
+      enhancedCockpitUrl += '?';
+    }
+
+    // common query parameters
+    enhancedCockpitUrl += 'utm_source=apim&utm_medium=InApp';
+
+    // add campaign param
+    enhancedCockpitUrl += `&utm_campaign=${utmCampaign}`;
+
+    // if DISCOVER_COCKPIT, add cockpit installation status
+    if (utmCampaign === UtmCampaign.DISCOVER_COCKPIT) {
+      const utmTerm = this.computeCockpitStatusForQueryParam(cockpitInstallationStatus);
+      enhancedCockpitUrl += `&utm_term=${utmTerm}`;
+    }
+
+    return enhancedCockpitUrl;
+  }
+
+  private computeCockpitStatusForQueryParam(cockpitInstallationStatus: string): string {
+    switch (cockpitInstallationStatus) {
+      case 'PENDING':
+        return 'pending';
+
+      case 'ACCEPTED':
+        return 'registered';
+
+      case 'REJECTED':
+        return 'rejected';
+
+      case 'DELETED':
+        return 'removed';
+
+      default:
+        return 'not_registered';
+    }
+  }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8170

**Description**

This PR creates a new ngx service to be able to enhance cockpit URL by adding query parameters useful for analytics.
The cockpit URL is modified during API Promotion, in case the installation is not yet registered and in the cockpit discovery screen (in Organization settings)

**Additional information**

Questions remain unanswered in the issue regarding the wording. So this PR may have to be adapted.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qeryvtirwc.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/8170-query-parameter-in-links-for-analytics/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
