### PR TITLE
fix(jdbc): rate limit at platform level can use null subscription

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_15_14/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_15_14/schema.yml
@@ -56,3 +56,7 @@ databaseChangeLog:
                   name: reference_type
                   type: nvarchar(64)
             tableName: ${gravitee_prefix}pages
+        - dropNotNullConstraint:
+            tableName: ${gravitee_rate_limit_prefix}ratelimit
+            columnName: subscription
+            columnDataType: nvarchar(64)


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7975

**Description**

fix(jdbc): rate limit at platform level can use null subscription

It makes JDBC rate limit behave like mongo.
When using rate limit at platform policy level ; rate limit is not related to a subscription, so subscription in database has to be nullable.

Rate limit works nice even with a null subscription,
Key is composed by API / rateType / resolvedPath and makes it relevant.

