### PR TITLE
fix(portal): don't apply filters on an empty APIs list

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/filtering/FilteringServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/filtering/FilteringServiceImpl.java
@@ -92,32 +92,37 @@ public class FilteringServiceImpl extends AbstractService implements FilteringSe
 
     @Override
     public Collection<String> filterApis(final Set<String> apis, final FilterType filterType, final FilterType excludedFilterType) {
-        final FilterType filter = excludedFilterType == null ? filterType : excludedFilterType;
-        final boolean excluded = excludedFilterType != null;
-        if (filter != null) {
-            switch (filter) {
-                case MINE:
-                    if (isAuthenticated()) {
-                        return getCurrentUserSubscribedApis(apis, excluded);
-                    } else {
-                        return Collections.emptyList();
-                    }
-                case STARRED:
-                    if (ratingService.isEnabled()) {
-                        return getRatedApis(apis, excluded);
-                    } else {
-                        return Collections.emptyList();
-                    }
-                case TRENDINGS:
-                    return getApisOrderByNumberOfSubscriptions(apis, excluded);
-                case FEATURED:
-                    return getTopApis(apis, excluded);
-                case ALL:
-                default:
-                    break;
-            }
+        if (apis == null || apis.isEmpty()) {
+            return apis;
         }
 
+        final FilterType filter = excludedFilterType == null ? filterType : excludedFilterType;
+        if (filter == null) {
+            return apis;
+        }
+
+        final boolean excluded = excludedFilterType != null;
+        switch (filter) {
+            case MINE:
+                if (isAuthenticated()) {
+                    return getCurrentUserSubscribedApis(apis, excluded);
+                } else {
+                    return Collections.emptyList();
+                }
+            case STARRED:
+                if (ratingService.isEnabled()) {
+                    return getRatedApis(apis, excluded);
+                } else {
+                    return Collections.emptyList();
+                }
+            case TRENDINGS:
+                return getApisOrderByNumberOfSubscriptions(apis, excluded);
+            case FEATURED:
+                return getTopApis(apis, excluded);
+            case ALL:
+            default:
+                break;
+        }
         // Apis is already ordered
         return apis;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/FilteringServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/FilteringServiceTest.java
@@ -16,8 +16,12 @@
 package io.gravitee.rest.api.service;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -131,6 +135,27 @@ public class FilteringServiceTest {
                     publishedApi4.getId()
                 )
             );
+    }
+
+    @Test
+    public void shouldNotApplyAnyFilterIfEmptyApiList() {
+        Set<String> apis = emptySet();
+        Collection<String> filteredList = filteringService.filterApis(apis, FilteringService.FilterType.TRENDINGS, null);
+        assertSame(apis, filteredList);
+
+        verifyNoInteractions(subscriptionService);
+    }
+
+    @Test
+    public void shouldNotApplyAnyFilterIfNoFilter() {
+        Collection<String> filteredList = filteringService.filterApis(mockApis, null, null);
+        assertSame(mockApis, filteredList);
+    }
+
+    @Test
+    public void shouldNotApplyAnyFilterIfAllFilter() {
+        Collection<String> filteredList = filteringService.filterApis(mockApis, FilteringService.FilterType.ALL, null);
+        assertSame(mockApis, filteredList);
     }
 
     @Test


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8341

**Description**

When using FilterService with an empty API list, database query ignore it and does not filter subscriptions on APIs. As a consequence it returns subscriptions for all APIs.
And the portal API returns API that the user is not allowed to access.

This PR prevents services to be executed if the current user can't access any API.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-upmgqwsgbb.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/8341-fix-portal-builtin-api-filter/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
