### PR TITLE
feat: delete api with kubernetes origin

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -1920,30 +1920,23 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             LOGGER.debug("Delete API {}", apiId);
 
             Api api = apiRepository.findById(apiId).orElseThrow(() -> new ApiNotFoundException(apiId));
-
+            Set<PlanEntity> plans = planService.findByApi(executionContext, apiId);
             if (DefinitionContext.isKubernetes(api.getOrigin())) {
-                // Quick win: when api is managed by Kubernetes, for now, just mark the api STOPPED, remove it from the search engine and mark it UNPUBLISHED from dev portal.
-                // This must be better handled with a higher concept such as 'archiving' or something close.
-
-                // Close all plans
-                // Quick win: Is intended to evolve with a flag in the query param depending on how the deletion will evolve
-                Set<PlanEntity> plans = planService.findByApi(executionContext, apiId);
                 plans
                     .stream()
                     .filter(plan -> plan.getStatus() != PlanStatus.CLOSED)
                     .forEach(plan -> planService.close(executionContext, plan.getId()));
 
-                api.setLifecycleState(LifecycleState.STOPPED);
-                api.setApiLifecycleState(ApiLifecycleState.UNPUBLISHED);
-                api.setVisibility(Visibility.PRIVATE);
-                apiRepository.update(api);
-                searchEngineService.delete(executionContext, convert(executionContext, api));
+                if (LifecycleState.STARTED == api.getLifecycleState() || ApiLifecycleState.PUBLISHED == api.getApiLifecycleState()) {
+                    api.setLifecycleState(LifecycleState.STOPPED);
+                    api.setApiLifecycleState(ApiLifecycleState.UNPUBLISHED);
+                    apiRepository.update(api);
+                }
             } else {
                 if (api.getLifecycleState() == LifecycleState.STARTED) {
                     throw new ApiRunningStateException(apiId);
                 } else {
                     // Delete plans
-                    Set<PlanEntity> plans = planService.findByApi(executionContext, apiId);
                     Set<String> plansNotClosed = plans
                         .stream()
                         .filter(plan -> plan.getStatus() == PlanStatus.PUBLISHED)
@@ -1953,63 +1946,63 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                     if (!plansNotClosed.isEmpty()) {
                         throw new ApiNotDeletableException(plansNotClosed);
                     }
-
-                    Collection<SubscriptionEntity> subscriptions = subscriptionService.findByApi(executionContext, apiId);
-                    subscriptions.forEach(sub -> subscriptionService.delete(executionContext, sub.getId()));
-
-                    plans.forEach(plan -> planService.delete(executionContext, plan.getId()));
-
-                    // Delete flows
-                    flowService.save(FlowReferenceType.API, apiId, null);
-
-                    // Delete events
-                    final EventQuery query = new EventQuery();
-                    query.setApi(apiId);
-                    eventService.search(executionContext, query).forEach(event -> eventService.delete(event.getId()));
-
-                    // https://github.com/gravitee-io/issues/issues/4130
-                    // Ensure we are sending a last UNPUBLISH_API event because the gateway couldn't be aware that the API (and
-                    // all its relative events) have been deleted.
-                    Map<String, String> properties = new HashMap<>(2);
-                    properties.put(Event.EventProperties.API_ID.getValue(), apiId);
-                    if (getAuthenticatedUser() != null) {
-                        properties.put(Event.EventProperties.USER.getValue(), getAuthenticatedUser().getUsername());
-                    }
-                    eventService.createApiEvent(
-                        executionContext,
-                        singleton(executionContext.getEnvironmentId()),
-                        EventType.UNPUBLISH_API,
-                        null,
-                        properties
-                    );
-
-                    // Delete pages
-                    pageService.deleteAllByApi(executionContext, apiId);
-
-                    // Delete top API
-                    topApiService.delete(executionContext, apiId);
-                    // Delete API
-                    apiRepository.delete(apiId);
-                    // Delete memberships
-                    membershipService.deleteReference(executionContext, MembershipReferenceType.API, apiId);
-                    // Delete notifications
-                    genericNotificationConfigService.deleteReference(NotificationReferenceType.API, apiId);
-                    portalNotificationConfigService.deleteReference(NotificationReferenceType.API, apiId);
-                    // Delete alerts
-                    final List<AlertTriggerEntity> alerts = alertService.findByReferenceWithEventCounts(AlertReferenceType.API, apiId);
-                    alerts.forEach(alert -> alertService.delete(alert.getId(), alert.getReferenceId()));
-                    // delete all reference on api quality rule
-                    apiQualityRuleRepository.deleteByApi(apiId);
-                    // Audit
-                    auditService.createApiAuditLog(executionContext, apiId, Collections.emptyMap(), API_DELETED, new Date(), api, null);
-                    // remove from search engine
-                    searchEngineService.delete(executionContext, convert(executionContext, api));
-
-                    mediaService.deleteAllByApi(apiId);
-
-                    apiMetadataService.deleteAllByApi(executionContext, apiId);
                 }
             }
+
+            Collection<SubscriptionEntity> subscriptions = subscriptionService.findByApi(executionContext, apiId);
+            subscriptions.forEach(sub -> subscriptionService.delete(executionContext, sub.getId()));
+
+            plans.forEach(plan -> planService.delete(executionContext, plan.getId()));
+
+            // Delete flows
+            flowService.save(FlowReferenceType.API, apiId, null);
+
+            // Delete events
+            final EventQuery query = new EventQuery();
+            query.setApi(apiId);
+            eventService.search(executionContext, query).forEach(event -> eventService.delete(event.getId()));
+
+            // https://github.com/gravitee-io/issues/issues/4130
+            // Ensure we are sending a last UNPUBLISH_API event because the gateway couldn't be aware that the API (and
+            // all its relative events) have been deleted.
+            Map<String, String> properties = new HashMap<>(2);
+            properties.put(Event.EventProperties.API_ID.getValue(), apiId);
+            if (getAuthenticatedUser() != null) {
+                properties.put(Event.EventProperties.USER.getValue(), getAuthenticatedUser().getUsername());
+            }
+            eventService.createApiEvent(
+                executionContext,
+                singleton(executionContext.getEnvironmentId()),
+                EventType.UNPUBLISH_API,
+                null,
+                properties
+            );
+
+            // Delete pages
+            pageService.deleteAllByApi(executionContext, apiId);
+
+            // Delete top API
+            topApiService.delete(executionContext, apiId);
+            // Delete API
+            apiRepository.delete(apiId);
+            // Delete memberships
+            membershipService.deleteReference(executionContext, MembershipReferenceType.API, apiId);
+            // Delete notifications
+            genericNotificationConfigService.deleteReference(NotificationReferenceType.API, apiId);
+            portalNotificationConfigService.deleteReference(NotificationReferenceType.API, apiId);
+            // Delete alerts
+            final List<AlertTriggerEntity> alerts = alertService.findByReferenceWithEventCounts(AlertReferenceType.API, apiId);
+            alerts.forEach(alert -> alertService.delete(alert.getId(), alert.getReferenceId()));
+            // delete all reference on api quality rule
+            apiQualityRuleRepository.deleteByApi(apiId);
+            // Audit
+            auditService.createApiAuditLog(executionContext, apiId, Collections.emptyMap(), API_DELETED, new Date(), api, null);
+            // remove from search engine
+            searchEngineService.delete(executionContext, convert(executionContext, api));
+
+            mediaService.deleteAllByApi(apiId);
+
+            apiMetadataService.deleteAllByApi(executionContext, apiId);
         } catch (TechnicalException ex) {
             LOGGER.error("An error occurs while trying to delete API {}", apiId, ex);
             throw new TechnicalManagementException("An error occurs while trying to delete API " + apiId, ex);


### PR DESCRIPTION
**Issue**

gravitee-io/issues#8139

**Description**

Today instead of deleting the apis with a kubernetes origin we have a "partial archiving" system. Here is a pull request to remove everything related to an api even if the origin is kubernetes
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/issues-8139-delete-gko-api/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pkxjoeyufv.chromatic.com)
<!-- Storybook placeholder end -->
