### PR TITLE
fix(console): do not open the documentation when pendo is enable

### DIFF
--- a/gravitee-apim-console-webui/src/components/contextual/contextual-doc.controller.ts
+++ b/gravitee-apim-console-webui/src/components/contextual/contextual-doc.controller.ts
@@ -25,6 +25,11 @@ class ContextualDocController implements IOnInit, IOnDestroy {
 
   constructor(private $transitions, private $http, public $state, private $window, private $rootScope) {
     'ngInject';
+    if (window.pendo && window.pendo.isReady()) {
+      // Do nothing, Pendo provide documentation
+      this.isOpen = false;
+      return;
+    }
 
     // init contextual page visibility
     if ($window.localStorage.getItem(this.contextualDocVisibilityKey) !== null) {
@@ -44,6 +49,12 @@ class ContextualDocController implements IOnInit, IOnDestroy {
   }
 
   $onInit(): void {
+    if (window.pendo && window.pendo.isReady()) {
+      // Do nothing, Pendo provide documentation
+      this.isOpen = false;
+      return;
+    }
+
     // watch for open documentation events
     this.openContextualDocumentationListener = this.$rootScope.$on('openContextualDocumentation', () => {
       this.openDocumentation();


### PR DESCRIPTION
**Issue**
n/a

**Description**

sad we got screwed with the local storage as we all had the inactive doc. but if not we need to ignore it too when pendo is enabled

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/3-18-x-fix-pendo/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-eewijedkwm.chromatic.com)
<!-- Storybook placeholder end -->
