### PR TITLE
feat: delete api with kubernetes origin

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
@@ -310,8 +310,8 @@ public class ApiResource extends AbstractResource {
     @ApiResponse(responseCode = "204", description = "API successfully deleted")
     @ApiResponse(responseCode = "500", description = "Internal server error")
     @Permissions({ @Permission(value = RolePermission.API_DEFINITION, acls = RolePermissionAction.DELETE) })
-    public Response deleteApi() {
-        apiService.delete(GraviteeContext.getExecutionContext(), api);
+    public Response deleteApi(@QueryParam("closePlans") boolean closePlans) {
+        apiService.delete(GraviteeContext.getExecutionContext(), api, closePlans);
 
         return Response.noContent().build();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
@@ -108,7 +108,7 @@ public interface ApiService {
         ImportSwaggerDescriptorEntity swaggerDescriptor
     );
 
-    void delete(ExecutionContext executionContext, String apiId);
+    void delete(ExecutionContext executionContext, String apiId, boolean closePlans);
 
     ApiEntity start(ExecutionContext executionContext, String apiId, String userId);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_DeleteTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_DeleteTest.java
@@ -15,8 +15,7 @@
  */
 package io.gravitee.rest.api.service.impl;
 
-import static io.gravitee.rest.api.model.EventType.PUBLISH_API;
-import static java.util.Collections.singleton;
+import static io.gravitee.definition.model.DefinitionContext.ORIGIN_MANAGEMENT;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -26,13 +25,12 @@ import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiQualityRuleRepository;
 import io.gravitee.repository.management.api.ApiRepository;
-import io.gravitee.repository.management.model.Api;
-import io.gravitee.repository.management.model.ApiLifecycleState;
-import io.gravitee.repository.management.model.LifecycleState;
-import io.gravitee.repository.management.model.Plan;
+import io.gravitee.repository.management.model.*;
 import io.gravitee.repository.management.model.flow.FlowReferenceType;
-import io.gravitee.rest.api.model.*;
-import io.gravitee.rest.api.model.mixin.ApiMixin;
+import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.PlanEntity;
+import io.gravitee.rest.api.model.PlanStatus;
+import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.configuration.flow.FlowService;
@@ -40,7 +38,6 @@ import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.exceptions.ApiNotDeletableException;
 import io.gravitee.rest.api.service.exceptions.ApiRunningStateException;
 import io.gravitee.rest.api.service.jackson.filter.ApiPermissionFilter;
-import io.gravitee.rest.api.service.notification.ApiHook;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import java.util.Collections;
 import java.util.Optional;
@@ -61,6 +58,7 @@ public class ApiService_DeleteTest {
 
     private static final String API_ID = "id-api";
     private static final String PLAN_ID = "my-plan";
+    private static final String SUBSCRIPTION_ID = "my-subscription";
 
     @InjectMocks
     private ApiServiceImpl apiService = new ApiServiceImpl();
@@ -142,9 +140,10 @@ public class ApiService_DeleteTest {
     @Test(expected = ApiRunningStateException.class)
     public void shouldNotDeleteBecauseRunningState() throws TechnicalException {
         when(api.getLifecycleState()).thenReturn(LifecycleState.STARTED);
+        when(api.getOrigin()).thenReturn(ORIGIN_MANAGEMENT);
         when(apiRepository.findById(API_ID)).thenReturn(Optional.of(api));
 
-        apiService.delete(GraviteeContext.getExecutionContext(), API_ID);
+        apiService.delete(GraviteeContext.getExecutionContext(), API_ID, false);
     }
 
     @Test
@@ -153,7 +152,7 @@ public class ApiService_DeleteTest {
         when(apiRepository.findById(API_ID)).thenReturn(Optional.of(api));
         when(planService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Collections.emptySet());
 
-        apiService.delete(GraviteeContext.getExecutionContext(), API_ID);
+        apiService.delete(GraviteeContext.getExecutionContext(), API_ID, false);
         verify(membershipService, times(1)).deleteReference(GraviteeContext.getExecutionContext(), MembershipReferenceType.API, API_ID);
         verify(mediaService, times(1)).deleteAllByApi(API_ID);
         verify(apiMetadataService, times(1)).deleteAllByApi(eq(GraviteeContext.getExecutionContext()), eq(API_ID));
@@ -162,12 +161,11 @@ public class ApiService_DeleteTest {
 
     @Test(expected = ApiNotDeletableException.class)
     public void shouldNotDeleteBecausePlanNotClosed() throws TechnicalException {
-        when(api.getLifecycleState()).thenReturn(LifecycleState.STOPPED);
         when(apiRepository.findById(API_ID)).thenReturn(Optional.of(api));
         when(planEntity.getStatus()).thenReturn(PlanStatus.PUBLISHED);
         when(planService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Collections.singleton(planEntity));
 
-        apiService.delete(GraviteeContext.getExecutionContext(), API_ID);
+        apiService.delete(GraviteeContext.getExecutionContext(), API_ID, false);
         verify(membershipService, times(1)).deleteReference(GraviteeContext.getExecutionContext(), MembershipReferenceType.API, API_ID);
     }
 
@@ -179,7 +177,7 @@ public class ApiService_DeleteTest {
         when(planEntity.getStatus()).thenReturn(PlanStatus.CLOSED);
         when(planService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Collections.singleton(planEntity));
 
-        apiService.delete(GraviteeContext.getExecutionContext(), API_ID);
+        apiService.delete(GraviteeContext.getExecutionContext(), API_ID, false);
 
         verify(planService, times(1)).delete(GraviteeContext.getExecutionContext(), PLAN_ID);
         verify(membershipService, times(1)).deleteReference(GraviteeContext.getExecutionContext(), MembershipReferenceType.API, API_ID);
@@ -194,7 +192,7 @@ public class ApiService_DeleteTest {
         when(planEntity.getStatus()).thenReturn(PlanStatus.STAGING);
         when(planService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Collections.singleton(planEntity));
 
-        apiService.delete(GraviteeContext.getExecutionContext(), API_ID);
+        apiService.delete(GraviteeContext.getExecutionContext(), API_ID, false);
 
         verify(planService, times(1)).delete(GraviteeContext.getExecutionContext(), PLAN_ID);
         verify(apiQualityRuleRepository, times(1)).deleteByApi(API_ID);
@@ -205,7 +203,29 @@ public class ApiService_DeleteTest {
     }
 
     @Test
-    public void shouldDeleteWithKubernetesOrigin() throws Exception {
+    public void shouldDeleteStoppedApiWithKubernetesOrigin() throws Exception {
+        final Api api = new Api();
+        api.setId(API_ID);
+        api.setOrigin(Api.ORIGIN_KUBERNETES);
+        when(apiRepository.findById(API_ID)).thenReturn(Optional.of(api));
+
+        apiService.delete(GraviteeContext.getExecutionContext(), API_ID, false);
+
+        verify(apiRepository).findById(eq(API_ID));
+        verify(apiRepository).delete(eq(API_ID));
+        verify(pageService).deleteAllByApi(eq(GraviteeContext.getExecutionContext()), eq(API_ID));
+        verify(topApiService).delete(eq(GraviteeContext.getExecutionContext()), eq(API_ID));
+        verify(searchEngineService).delete(eq(GraviteeContext.getExecutionContext()), argThat(_api -> _api.getId().equals(API_ID)));
+        verify(membershipService).deleteReference(eq(GraviteeContext.getExecutionContext()), eq(MembershipReferenceType.API), eq(API_ID));
+        verify(genericNotificationConfigService).deleteReference(eq(NotificationReferenceType.API), eq(API_ID));
+        verify(portalNotificationConfigService).deleteReference(eq(NotificationReferenceType.API), eq(API_ID));
+        verify(apiQualityRuleRepository).deleteByApi(eq(API_ID));
+        verify(mediaService).deleteAllByApi(eq(API_ID));
+        verify(apiMetadataService).deleteAllByApi(eq(GraviteeContext.getExecutionContext()), eq(API_ID));
+    }
+
+    @Test
+    public void shouldCloseAndDeletePlansForApiWithKubernetesOrigin() throws Exception {
         final Api api = new Api();
         api.setId(API_ID);
         api.setOrigin(Api.ORIGIN_KUBERNETES);
@@ -215,22 +235,34 @@ public class ApiService_DeleteTest {
         final PlanEntity planEntity = new PlanEntity();
         planEntity.setId(PLAN_ID);
         planEntity.setStatus(PlanStatus.PUBLISHED);
+        final PlanEntity closedPlan = new PlanEntity();
+        closedPlan.setId(PLAN_ID);
+        closedPlan.setStatus(PlanStatus.CLOSED);
         when(planService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Collections.singleton(planEntity));
+        when(planService.close(GraviteeContext.getExecutionContext(), PLAN_ID)).thenReturn(closedPlan);
 
-        apiService.delete(GraviteeContext.getExecutionContext(), API_ID);
+        apiService.delete(GraviteeContext.getExecutionContext(), API_ID, true);
 
-        verify(planService, times(1)).close(eq(GraviteeContext.getExecutionContext()), eq(PLAN_ID));
-        verify(apiRepository, times(1))
-            .update(
-                argThat(
-                    _api ->
-                        _api.getOrigin().equals(Api.ORIGIN_KUBERNETES) &&
-                        _api.getLifecycleState().equals(LifecycleState.STOPPED) &&
-                        _api.getApiLifecycleState().equals(ApiLifecycleState.UNPUBLISHED) &&
-                        _api.getVisibility().equals(io.gravitee.repository.management.model.Visibility.PRIVATE)
-                )
-            );
-        verify(searchEngineService, times(1))
-            .delete(eq(GraviteeContext.getExecutionContext()), argThat(_api -> _api.getId().equals(API_ID)));
+        verify(planService).close(eq(GraviteeContext.getExecutionContext()), eq(PLAN_ID));
+        verify(planService).delete(eq(GraviteeContext.getExecutionContext()), eq(PLAN_ID));
+        verify(apiRepository).delete(eq(API_ID));
+    }
+
+    @Test
+    public void shouldDeleteSubscriptionsAndApiWithKubernetesOrigin() throws Exception {
+        final Api api = new Api();
+        api.setId(API_ID);
+        api.setOrigin(Api.ORIGIN_KUBERNETES);
+        when(apiRepository.findById(API_ID)).thenReturn(Optional.of(api));
+
+        SubscriptionEntity subscription = new SubscriptionEntity();
+        subscription.setId(SUBSCRIPTION_ID);
+        when(subscriptionService.findByApi(GraviteeContext.getExecutionContext(), API_ID)).thenReturn(Collections.singleton(subscription));
+
+        apiService.delete(GraviteeContext.getExecutionContext(), API_ID, false);
+
+        verify(subscriptionService).findByApi(eq(GraviteeContext.getExecutionContext()), eq(API_ID));
+        verify(subscriptionService).delete(eq(GraviteeContext.getExecutionContext()), eq(SUBSCRIPTION_ID));
+        verify(apiRepository).delete(eq(API_ID));
     }
 }


### PR DESCRIPTION
**Issue**

gravitee-io/issues#8139

**Description**

Today instead of deleting the apis with a kubernetes origin we have a "partial archiving" system. Here is a pull request to remove everything related to an api even if the origin is kubernetes
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/issues-8139-delete-gko-api-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ghkoobucyq.chromatic.com)
<!-- Storybook placeholder end -->
<!-- E2E Coverage placeholder -->
---
### 🧪 End-to-End Coverage

| INSTRUCTIONS | BRANCHES |
| :----------: | :------: |
|   35% | 19%   |

A more detailed report has been uploaded to [circleci](https://output.circle-artifacts.com/output/job/a18dc943-6a5a-47d6-9153-50e27203d220/artifacts/0/gravitee-apim-e2e/jacoco/reports/index.html)
<!-- E2E Coverage placeholder end -->
