### PR TITLE
fix: make API out of sync banner consistent with "</" data in policy …

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/flow/FlowStep.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/flow/FlowStep.java
@@ -33,10 +33,12 @@ public class FlowStep {
      * Step description
      */
     private String description;
+
     /**
      * Step policy configuration
      */
     private String configuration;
+
     /**
      * Step state
      */

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/FlowConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/FlowConverter.java
@@ -15,20 +15,39 @@
  */
 package io.gravitee.rest.api.service.converter;
 
-import io.gravitee.definition.model.flow.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.definition.model.flow.Consumer;
+import io.gravitee.definition.model.flow.ConsumerType;
 import io.gravitee.definition.model.flow.Flow;
-import io.gravitee.repository.management.model.flow.*;
+import io.gravitee.definition.model.flow.Operator;
+import io.gravitee.definition.model.flow.PathOperator;
+import io.gravitee.definition.model.flow.Step;
+import io.gravitee.repository.management.model.flow.FlowConsumer;
+import io.gravitee.repository.management.model.flow.FlowConsumerType;
+import io.gravitee.repository.management.model.flow.FlowOperator;
+import io.gravitee.repository.management.model.flow.FlowReferenceType;
+import io.gravitee.repository.management.model.flow.FlowStep;
 import io.gravitee.rest.api.service.common.UuidString;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Objects;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 /**
  * @author GraviteeSource Team
  */
 @Component
+@Slf4j
 public class FlowConverter {
+
+    private ObjectMapper objectMapper;
+
+    public FlowConverter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
 
     public Flow toDefinition(io.gravitee.repository.management.model.flow.Flow model) {
         Flow flow = new Flow();
@@ -40,13 +59,13 @@ public class FlowConverter {
         pathOperator.setPath(model.getPath());
         pathOperator.setOperator(Operator.valueOf(model.getOperator().name()));
         flow.setPathOperator(pathOperator);
-        flow.setPre(model.getPre().stream().map(this::toDefinitionFlow).collect(Collectors.toList()));
-        flow.setPost(model.getPost().stream().map(this::toDefinitionFlow).collect(Collectors.toList()));
-        flow.setConsumers(model.getConsumers().stream().map(this::toDefinitionFlow).collect(Collectors.toList()));
+        flow.setPre(model.getPre().stream().map(this::toDefinitionStep).filter(Objects::nonNull).collect(Collectors.toList()));
+        flow.setPost(model.getPost().stream().map(this::toDefinitionStep).filter(Objects::nonNull).collect(Collectors.toList()));
+        flow.setConsumers(model.getConsumers().stream().map(this::toDefinitionConsumer).collect(Collectors.toList()));
         return flow;
     }
 
-    public io.gravitee.repository.management.model.flow.Flow toModel(
+    public io.gravitee.repository.management.model.flow.Flow toRepository(
         Flow flowDefinition,
         FlowReferenceType referenceType,
         String referenceId,
@@ -59,8 +78,8 @@ public class FlowConverter {
         flow.setOrder(order);
         flow.setReferenceType(referenceType);
         flow.setReferenceId(referenceId);
-        flow.setPost(flowDefinition.getPost().stream().map(this::convertStep).collect(Collectors.toList()));
-        flow.setPre(flowDefinition.getPre().stream().map(this::convertStep).collect(Collectors.toList()));
+        flow.setPost(flowDefinition.getPost().stream().map(this::toRepositoryStep).collect(Collectors.toList()));
+        flow.setPre(flowDefinition.getPre().stream().map(this::toRepositoryStep).collect(Collectors.toList()));
         flow.setPath(flowDefinition.getPath());
         flow.setOperator(FlowOperator.valueOf(flowDefinition.getOperator().name()));
         flow.setName(flowDefinition.getName());
@@ -69,27 +88,27 @@ public class FlowConverter {
         flow.setCondition(flowDefinition.getCondition());
         flow.setConsumers(
             flowDefinition.getConsumers() != null
-                ? flowDefinition.getConsumers().stream().map(this::convertConsumer).collect(Collectors.toList())
+                ? flowDefinition.getConsumers().stream().map(this::toRepositoryConsumer).collect(Collectors.toList())
                 : Collections.emptyList()
         );
         return flow;
     }
 
-    private FlowConsumer convertConsumer(Consumer consumer) {
+    private FlowConsumer toRepositoryConsumer(Consumer consumer) {
         FlowConsumer flowConsumer = new FlowConsumer();
         flowConsumer.setConsumerId(consumer.getConsumerId());
         flowConsumer.setConsumerType(FlowConsumerType.valueOf(consumer.getConsumerType().name()));
         return flowConsumer;
     }
 
-    private Consumer toDefinitionFlow(FlowConsumer flowConsumer) {
+    private Consumer toDefinitionConsumer(FlowConsumer flowConsumer) {
         Consumer consumer = new Consumer();
         consumer.setConsumerId(flowConsumer.getConsumerId());
         consumer.setConsumerType(ConsumerType.valueOf(flowConsumer.getConsumerType().name()));
         return consumer;
     }
 
-    private FlowStep convertStep(Step step) {
+    private FlowStep toRepositoryStep(Step step) {
         FlowStep flowStep = new FlowStep();
         flowStep.setPolicy(step.getPolicy());
         flowStep.setName(step.getName());
@@ -100,14 +119,12 @@ public class FlowConverter {
         return flowStep;
     }
 
-    private Step toDefinitionFlow(FlowStep flowStep) {
-        Step step = new Step();
-        step.setPolicy(flowStep.getPolicy());
-        step.setName(flowStep.getName());
-        step.setEnabled(flowStep.isEnabled());
-        step.setConfiguration(flowStep.getConfiguration());
-        step.setDescription(flowStep.getDescription());
-        step.setCondition(flowStep.getCondition());
-        return step;
+    protected Step toDefinitionStep(FlowStep flowStep) {
+        try {
+            return objectMapper.readValue(objectMapper.writeValueAsString(flowStep), Step.class);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to convert repository flow step to model", e);
+            return null;
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/flow/FlowServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/flow/FlowServiceImpl.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.gravitee.definition.model.flow.*;
 import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.FlowRepository;
@@ -143,7 +142,7 @@ public class FlowServiceImpl extends AbstractService implements FlowService {
                 return List.of();
             } else {
                 for (int order = 0; order < flows.size(); ++order) {
-                    flowRepository.create(flowConverter.toModel(flows.get(order), flowReferenceType, referenceId, order));
+                    flowRepository.create(flowConverter.toRepository(flows.get(order), flowReferenceType, referenceId, order));
                 }
                 return flows;
             }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/FlowStepSerializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/FlowStepSerializer.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.jackson.ser;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
+import io.gravitee.repository.management.model.flow.FlowStep;
+import java.io.IOException;
+
+public class FlowStepSerializer extends StdScalarSerializer<FlowStep> {
+
+    public FlowStepSerializer(Class<FlowStep> vc) {
+        super(vc);
+    }
+
+    @Override
+    public void serialize(FlowStep step, JsonGenerator jsonGenerator, SerializerProvider provider) throws IOException {
+        jsonGenerator.writeStartObject();
+        jsonGenerator.writeStringField("name", step.getName());
+        jsonGenerator.writeStringField("description", step.getDescription());
+        jsonGenerator.writeBooleanField("enabled", step.isEnabled());
+        jsonGenerator.writeStringField("policy", step.getPolicy());
+        jsonGenerator.writeNumberField("order", step.getOrder());
+        if (step.getCondition() != null) {
+            jsonGenerator.writeStringField("condition", step.getCondition());
+        }
+        jsonGenerator.writeFieldName("configuration");
+        jsonGenerator.writeRawValue(step.getConfiguration());
+        jsonGenerator.writeEndObject();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/spring/ServiceConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/spring/ServiceConfiguration.java
@@ -31,6 +31,7 @@ import io.gravitee.plugin.fetcher.spring.FetcherPluginConfiguration;
 import io.gravitee.plugin.notifier.spring.NotifierPluginConfiguration;
 import io.gravitee.plugin.policy.spring.PolicyPluginConfiguration;
 import io.gravitee.plugin.resource.spring.ResourcePluginConfiguration;
+import io.gravitee.repository.management.model.flow.FlowStep;
 import io.gravitee.rest.api.fetcher.spring.FetcherConfigurationConfiguration;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.service.PasswordValidator;
@@ -38,6 +39,7 @@ import io.gravitee.rest.api.service.impl.search.configuration.SearchEngineConfig
 import io.gravitee.rest.api.service.impl.swagger.policy.PolicyOperationVisitorManager;
 import io.gravitee.rest.api.service.impl.swagger.policy.impl.PolicyOperationVisitorManagerImpl;
 import io.gravitee.rest.api.service.jackson.filter.ApiPermissionFilter;
+import io.gravitee.rest.api.service.jackson.ser.FlowStepSerializer;
 import io.gravitee.rest.api.service.jackson.ser.api.ApiCompositeSerializer;
 import io.gravitee.rest.api.service.jackson.ser.api.ApiSerializer;
 import io.gravitee.rest.api.service.quality.ApiQualityMetricLoader;
@@ -95,6 +97,7 @@ public class ServiceConfiguration {
         // register API serializer
         SimpleModule module = new SimpleModule();
         module.addSerializer(ApiEntity.class, apiSerializer());
+        module.addSerializer(FlowStep.class, new FlowStepSerializer(FlowStep.class));
 
         objectMapper.registerModule(module);
         return objectMapper;


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8343

**Description**

fix: make API out of sync banner consistent with "</" data in policy config

JsonSchemaService configuration validation escapes the slash in "</" string, leading to "<\/".

When deserializing a flow from API event, it's correctly interpreted as "</", thanks to jackson annotations on Step.configuration.
When reading a flow from database, it's not correctly interpreted, as the inline mapping in flowConverter doesn't benefit of jackson annotations tricks.

This fixes makes flowConverter use jackson for step conversion, in order to have the step.configuration correctly interpreted.

This way, the synchronizationService doesn't detect any irrelevant difference between deployed API, and API to deploy;
And the API out of sync banner doesn't appear when it's not relevant.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-apioutofsyncbaneer-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xeewndfcqq.chromatic.com)
<!-- Storybook placeholder end -->
