### PR TITLE
refactor: add log when kubernetes sync service is started

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/kubernetes/KubernetesSyncService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/kubernetes/KubernetesSyncService.java
@@ -33,6 +33,7 @@ import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.schedulers.Schedulers;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
@@ -70,6 +71,7 @@ public class KubernetesSyncService extends AbstractService<KubernetesSyncService
     }
 
     private void startWatch() {
+        logger.info("Kubernetes synchronization started at {}", Instant.now().toString());
         this.disposable =
             watch()
                 .flatMapCompletable(this::handleConfigMapEvent)


### PR DESCRIPTION
## Description

 add log when kubernetes sync service is started
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/refactor-kub-service-start-log/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pfwyomjhvi.chromatic.com)
<!-- Storybook placeholder end -->
