### PR TITLE
test: fix flaky E2E tests

### DIFF
--- a/gravitee-apim-e2e/api-test/src/gateway/redeploy-api.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/gateway/redeploy-api.spec.ts
@@ -108,8 +108,7 @@ describe('Redeploy Api', () => {
       // Execute a request during which we will redeploy the api (only one try, no delay before call)
       const fetchUniqueGatewayCall = fetchGatewaySuccess({
         contextPath: createdApi.context_path + '?activeLatency=true',
-        failAfterMs: 0,
-        timeout: 0,
+        maxRetries: 0,
       });
 
       // Redeploy the api

--- a/gravitee-apim-e2e/api-test/src/policies/mock-policy.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/policies/mock-policy.spec.ts
@@ -92,11 +92,13 @@ describe('Mock policy', () => {
       );
       await succeed(apiManagementApiAsApiUser.deployApiRaw({ orgId, envId, api: createdApi.id }));
 
-      await fetchGatewaySuccess({ contextPath: createdApi.context_path })
-        .then((res) => res.json())
-        .then((body) => {
-          expect(body).toEqual(JSON.parse(mockContent));
-        });
+      await fetchGatewaySuccess({
+        contextPath: createdApi.context_path,
+        expectedResponseValidator: async (response) => {
+          const body = await response.json();
+          return body.message === JSON.parse(mockContent).message;
+        },
+      });
     });
   });
 

--- a/gravitee-apim-e2e/lib/gateway.ts
+++ b/gravitee-apim-e2e/lib/gateway.ts
@@ -16,62 +16,93 @@
 import 'dotenv/config';
 import fetchApi, { HeadersInit, Response } from 'node-fetch';
 
-export type HttpMethod = 'GET' | 'PUT' | 'POST' | 'DELETE';
+export type HttpMethod = 'GET' | 'PUT' | 'POST' | 'DELETE' | 'OPTIONS';
 
 interface GatewayRequest {
   contextPath: string;
   expectedStatusCode: number;
+  expectedResponseValidator: (response: Response) => boolean | Promise<boolean>; // Allows to validate if the expected request is the right one. Useful in case of api redeployment.
   method: HttpMethod;
   body?: string;
   headers?: HeadersInit;
   timeBetweenRetries: number;
-  failAfterMs: number;
-  timeout: number;
+  maxRetries: number;
 }
 
-export async function fetchGatewaySuccess(request?: Partial<GatewayRequest>) {
-  return _fetchGateway({ expectedStatusCode: 200, ...request });
+export interface Logger {
+  error(...data: any[]): void;
+  info(...data: any[]): void;
 }
 
-export async function fetchGatewayUnauthorized(request?: Partial<GatewayRequest>) {
-  return _fetchGateway({ expectedStatusCode: 401, ...request });
+export async function fetchGatewaySuccess(request?: Partial<GatewayRequest>, logger: Logger = console) {
+  return _fetchGatewayWithRetries({ expectedStatusCode: 200, ...request }, logger);
 }
 
-async function _fetchGateway(request?: Partial<GatewayRequest>): Promise<Response> {
-  request = <GatewayRequest>{
+export async function fetchGatewayUnauthorized(request?: Partial<GatewayRequest>, logger: Logger = console) {
+  return _fetchGatewayWithRetries({ expectedStatusCode: 401, ...request }, logger);
+}
+
+export async function fetchGatewayBadRequest(request?: Partial<GatewayRequest>, logger: Logger = console) {
+  return _fetchGatewayWithRetries({ expectedStatusCode: 400, ...request }, logger);
+}
+
+async function _fetchGatewayWithRetries(attributes: Partial<GatewayRequest>, logger: Logger): Promise<Response> {
+  const request = <GatewayRequest>{
     expectedStatusCode: 200,
     method: 'GET',
-    timeBetweenRetries: 500,
-    failAfterMs: 5000,
-    timeout: 1500,
-    ...request,
+    timeBetweenRetries: 1500,
+    maxRetries: 5,
+    expectedResponseValidator: () => true,
+    ...attributes,
   };
-  return new Promise((successCallback) => {
-    setTimeout(() => {
-      successCallback(_fetchGatewayWithRetries(request));
-    }, request.timeout);
-  });
+
+  if (request.maxRetries <= 0) {
+    return await _fetchGateway(request);
+  }
+
+  let lastError: Error;
+
+  for (let retries = request.maxRetries; retries > 0; --retries) {
+    try {
+      return await _fetchGateway(request);
+    } catch (error) {
+      // logger.info(error);
+      lastError = error;
+      if (retries > 0) {
+        logger.info(`Retrying in ${request.timeBetweenRetries} ms with ${retries} attempts`);
+        await sleep(request.timeBetweenRetries);
+      }
+    }
+  }
+
+  logger.info(
+    `[${request.method}] [${process.env.GATEWAY_BASE_URL}${request.contextPath}] failed after ${request.maxRetries} retries with error`,
+    lastError,
+  );
+
+  throw lastError;
 }
 
-async function _fetchGatewayWithRetries(request: Partial<GatewayRequest>): Promise<Response> {
-  console.log('Try to fetch gateway', request.contextPath, request.failAfterMs);
-  console.log('With headers', request.headers);
+async function _fetchGateway(request: Partial<GatewayRequest>): Promise<Response> {
   const response = await fetchApi(`${process.env.GATEWAY_BASE_PATH}${request.contextPath}`, {
     method: request.method,
     body: request.body,
     headers: request.headers,
   });
+
   if (response.status != request.expectedStatusCode) {
-    return new Promise((successCallback, failureCallback) => {
-      setTimeout(() => {
-        if (request.failAfterMs - request.timeBetweenRetries <= 0) {
-          failureCallback(new Error(`Gateway [${process.env.GATEWAY_BASE_PATH}${request.contextPath}] returned HTTP ${response.status}`));
-        } else {
-          request.failAfterMs -= request.timeBetweenRetries;
-          successCallback(_fetchGateway(request));
-        }
-      }, request.timeBetweenRetries);
-    });
+    throw new Error(`[${request.method}] [${process.env.GATEWAY_BASE_PATH}${request.contextPath}] returned HTTP ${response.status}`);
   }
+
+  const isValidResponse = await request.expectedResponseValidator(response);
+
+  if (!isValidResponse) {
+    throw new Error(`Unexpected response for [${request.method}] [${process.env.GATEWAY_BASE_URL}${request.contextPath}]`);
+  }
+
   return response;
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
test: fix flaky E2E tests

Mock policy test is flaky, cause sometimes it checks the gateway response before the API was properly redeployed.

That has already been fixed on master branch ;
So this commit reports improvements from the master branch to fix that in 3.18 :
- reported the whole gateway.ts, including the new expectedResponseValidator parameter
- reported mock-policy gateway assertions, using the expectedResponseValidator
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/test-fix-flaky-e2e-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-iypkjqtybh.chromatic.com)
<!-- Storybook placeholder end -->
