### PR TITLE
fix: discard empty groups when getting user membership

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
@@ -772,16 +772,16 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 );
             Set<UserMembership> userMemberships = new HashSet<>(userMembershipMap.values());
 
-            // Find all application Ids and api Ids liked to all user groups
+            // Find all application Ids and api Ids linked to all user groups
             if (type.equals(MembershipReferenceType.APPLICATION) || type.equals(MembershipReferenceType.API)) {
                 String[] groupIds = groupService.findByUser(userId).stream().map(GroupEntity::getId).toArray(String[]::new);
 
                 List<String> resourceIds = new ArrayList<>();
 
-                if (type.equals(MembershipReferenceType.APPLICATION)) {
+                if (type.equals(MembershipReferenceType.APPLICATION) && groupIds.length > 0) {
                     Set<Application> groupApplications = applicationRepository.findByGroups(List.of(groupIds));
                     groupApplications.forEach(application -> resourceIds.add(application.getId()));
-                } else if (type.equals(MembershipReferenceType.API)) {
+                } else if (type.equals(MembershipReferenceType.API) && groupIds.length > 0) {
                     ApiCriteria criteria = new ApiCriteria.Builder().groups(groupIds).build();
                     Set<Api> groupApis = apiRepository.search(criteria, ApiFieldInclusionFilter.builder().build());
                     groupApis.forEach(api -> resourceIds.add(api.getId()));


### PR DESCRIPTION
see https://github.com/gravitee-io/issues/issues/8344


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8344-fix-api-memberships/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dccdxfrgec.chromatic.com)
<!-- Storybook placeholder end -->
