### PR TITLE
HTTP-Post entrypoint

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -143,6 +143,13 @@
         <!-- Entrypoints -->
         <dependency>
             <groupId>io.gravitee.apim.plugin.entrypoint</groupId>
+            <artifactId>gravitee-apim-plugin-entrypoint-http-post</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.apim.plugin.entrypoint</groupId>
             <artifactId>gravitee-apim-plugin-entrypoint-sse</artifactId>
             <version>${project.version}</version>
             <scope>runtime</scope>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/jupiter/http/vertx/VertxMessageServerRequestTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/jupiter/http/vertx/VertxMessageServerRequestTest.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.http.vertx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.http.IdGenerator;
+import io.reactivex.Flowable;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.reactivex.core.http.HttpHeaders;
+import io.vertx.reactivex.core.http.HttpServerRequest;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class VertxMessageServerRequestTest {
+
+    @Mock
+    private HttpServerRequest httpServerRequest;
+
+    @Mock
+    private IdGenerator idGenerator;
+
+    private AtomicInteger subscriptionCount;
+    private VertxMessageServerRequest cut;
+
+    @BeforeEach
+    void init() {
+        subscriptionCount = new AtomicInteger(0);
+        Flowable<io.vertx.reactivex.core.buffer.Buffer> chunks = Flowable
+            .just(
+                io.vertx.reactivex.core.buffer.Buffer.buffer("chunk1"),
+                io.vertx.reactivex.core.buffer.Buffer.buffer("chunk2"),
+                io.vertx.reactivex.core.buffer.Buffer.buffer("chunk3")
+            )
+            .doOnSubscribe(subscription -> subscriptionCount.incrementAndGet());
+
+        when(httpServerRequest.method()).thenReturn(HttpMethod.POST);
+        when(httpServerRequest.headers()).thenReturn(HttpHeaders.headers());
+        when(httpServerRequest.toFlowable()).thenReturn(chunks);
+        cut = new VertxMessageServerRequest(httpServerRequest, idGenerator);
+    }
+
+    @Test
+    void shouldSubscribeOnceWhenIgnoringAndReplacingExistingChunks() {
+        long initRequestLength = cut.metrics().getRequestContentLength();
+        cut.body().test().assertValue(buffer -> buffer.toString().equals("chunk1chunk2chunk3"));
+
+        assertEquals(initRequestLength + 18, cut.metrics.getRequestContentLength());
+        assertEquals(1, subscriptionCount.get());
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-coverage/pom.xml
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-coverage/pom.xml
@@ -45,6 +45,11 @@
         </dependency>
         <dependency>
             <groupId>io.gravitee.apim.plugin.entrypoint</groupId>
+            <artifactId>gravitee-apim-plugin-entrypoint-http-post</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.apim.plugin.entrypoint</groupId>
             <artifactId>gravitee-apim-plugin-entrypoint-sse</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mock/pom.xml
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mock/pom.xml
@@ -74,6 +74,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.simplify4u</groupId>
+            <artifactId>slf4j-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mock/src/main/java/io/gravitee/plugin/endpoint/mock/MockEndpointConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mock/src/main/java/io/gravitee/plugin/endpoint/mock/MockEndpointConnector.java
@@ -27,11 +27,13 @@ import java.nio.charset.StandardCharsets;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author GraviteeSource Team
  */
 @AllArgsConstructor
+@Slf4j
 public class MockEndpointConnector implements EndpointAsyncConnector {
 
     static final Set<ConnectorMode> SUPPORTED_MODES = Set.of(ConnectorMode.PUBLISH, ConnectorMode.SUBSCRIBE);
@@ -45,7 +47,12 @@ public class MockEndpointConnector implements EndpointAsyncConnector {
 
     @Override
     public Completable connect(MessageExecutionContext ctx) {
-        return Completable.fromRunnable(() -> ctx.response().messages(generateMessageFlow()));
+        return ctx
+            .request()
+            .messages()
+            .doOnNext(message -> log.info("Received message:\n" + message.content().toString()))
+            .ignoreElements()
+            .andThen(Completable.fromRunnable(() -> ctx.response().messages(generateMessageFlow())));
     }
 
     private Flowable<Message> generateMessageFlow() {

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/pom.xml
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.gravitee.apim.plugin.entrypoint</groupId>
+        <artifactId>gravitee-apim-plugin-entrypoint</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+    </parent>
+
+    <artifactId>gravitee-apim-plugin-entrypoint-http-post</artifactId>
+    <name>Gravitee.io APIM - Plugin - Entrypoint HTTP Post</name>
+    <description>Entrypoint that allows exposing AsyncAPI using HTTP Post</description>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Import bom to properly inherit all dependencies -->
+            <dependency>
+                <groupId>io.gravitee</groupId>
+                <artifactId>gravitee-bom</artifactId>
+                <version>${gravitee-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- Gravitee dependencies -->
+        <dependency>
+            <groupId>io.gravitee.gateway</groupId>
+            <artifactId>gravitee-gateway-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.common</groupId>
+            <artifactId>gravitee-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <!-- Tests -->
+        <dependency>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-buffer</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/main/assembly/plugin-assembly.xml
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/main/assembly/plugin-assembly.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" ?>
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly>
+	<id>plugin</id>
+	<formats>
+		<format>zip</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+
+	<!-- Include the main plugin Jar file -->
+	<files>
+		<file>
+			<source>${project.build.directory}/${project.build.finalName}.jar</source>
+		</file>
+	</files>
+
+	<!-- Include plugin schema configuration -->
+	<fileSets>
+		<fileSet>
+			<directory>src/main/resources/schemas</directory>
+			<outputDirectory>schemas</outputDirectory>
+		</fileSet>
+	</fileSets>
+
+	<!-- Finally include plugin dependencies -->
+	<dependencySets>
+		<dependencySet>
+			<outputDirectory>lib</outputDirectory>
+			<useProjectArtifact>false</useProjectArtifact>
+		</dependencySet>
+	</dependencySets>
+</assembly>

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/main/java/io/gravitee/plugin/entrypoint/http/post/HttpPostEntrypointConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/main/java/io/gravitee/plugin/entrypoint/http/post/HttpPostEntrypointConnector.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.entrypoint.http.post;
+
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.jupiter.api.ApiType;
+import io.gravitee.gateway.jupiter.api.ConnectorMode;
+import io.gravitee.gateway.jupiter.api.connector.entrypoint.async.EntrypointAsyncConnector;
+import io.gravitee.gateway.jupiter.api.context.MessageExecutionContext;
+import io.gravitee.gateway.jupiter.api.message.DefaultMessage;
+import io.gravitee.gateway.jupiter.api.message.Message;
+import io.reactivex.Completable;
+import io.reactivex.Maybe;
+import java.util.Map;
+import java.util.Set;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@NoArgsConstructor
+@Slf4j
+public class HttpPostEntrypointConnector implements EntrypointAsyncConnector {
+
+    static final Set<ConnectorMode> SUPPORTED_MODES = Set.of(ConnectorMode.PUBLISH);
+
+    @Override
+    public Set<ConnectorMode> supportedModes() {
+        return SUPPORTED_MODES;
+    }
+
+    @Override
+    public int matchCriteriaCount() {
+        return 1;
+    }
+
+    @Override
+    public boolean matches(final MessageExecutionContext ctx) {
+        return (HttpMethod.POST == ctx.request().method());
+    }
+
+    @Override
+    public Completable handleRequest(final MessageExecutionContext ctx) {
+        return Completable.fromRunnable(
+            () -> {
+                Maybe<Message> messageFlowable = ctx
+                    .request()
+                    .body()
+                    .map(
+                        buffer ->
+                            DefaultMessage.builder().headers(HttpHeaders.create(ctx.request().headers())).content(buffer.getBytes()).build()
+                    );
+                ctx.request().messages(messageFlowable.toFlowable());
+            }
+        );
+    }
+
+    @Override
+    public Completable handleResponse(final MessageExecutionContext ctx) {
+        return Completable.defer(() -> ctx.response().end());
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/main/java/io/gravitee/plugin/entrypoint/http/post/HttpPostEntrypointConnectorFactory.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/main/java/io/gravitee/plugin/entrypoint/http/post/HttpPostEntrypointConnectorFactory.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.entrypoint.http.post;
+
+import io.gravitee.gateway.jupiter.api.ApiType;
+import io.gravitee.gateway.jupiter.api.ConnectorMode;
+import io.gravitee.gateway.jupiter.api.connector.entrypoint.async.EntrypointAsyncConnectorFactory;
+import io.gravitee.plugin.entrypoint.http.post.configuration.HttpPostEntrypointConnectorConfiguration;
+import java.util.Set;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class HttpPostEntrypointConnectorFactory extends EntrypointAsyncConnectorFactory {
+
+    public HttpPostEntrypointConnectorFactory() {
+        super(HttpPostEntrypointConnectorConfiguration.class);
+    }
+
+    @Override
+    public Set<ConnectorMode> supportedModes() {
+        return HttpPostEntrypointConnector.SUPPORTED_MODES;
+    }
+
+    @Override
+    public HttpPostEntrypointConnector createConnector(final String configuration) {
+        return new HttpPostEntrypointConnector();
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/main/java/io/gravitee/plugin/entrypoint/http/post/configuration/HttpPostEntrypointConnectorConfiguration.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/main/java/io/gravitee/plugin/entrypoint/http/post/configuration/HttpPostEntrypointConnectorConfiguration.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.entrypoint.http.post.configuration;
+
+import io.gravitee.gateway.jupiter.api.connector.entrypoint.EntrypointConnectorConfiguration;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class HttpPostEntrypointConnectorConfiguration implements EntrypointConnectorConfiguration {}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/main/resources/plugin.properties
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/main/resources/plugin.properties
@@ -1,0 +1,6 @@
+id=http-post
+name=Entrypoint HTTP Post
+version=${project.version}
+description=${project.description}
+class=io.gravitee.plugin.entrypoint.http.post.HttpPostEntrypointConnectorFactory
+type=entrypoint-connector

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/main/resources/schemas/schema-form.json
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/main/resources/schemas/schema-form.json
@@ -1,0 +1,6 @@
+{
+  "type": "object",
+  "id": "urn:jsonschema:io:gravitee:plugin:entrypoint:http:post:configuration:HttpPostEntrypointConnectorConfiguration",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/test/java/io/gravitee/plugin/entrypoint/http/post/DummyMessageRequest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/test/java/io/gravitee/plugin/entrypoint/http/post/DummyMessageRequest.java
@@ -1,0 +1,166 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.entrypoint.http.post;
+
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.common.http.HttpVersion;
+import io.gravitee.common.util.MultiValueMap;
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.jupiter.api.context.MessageRequest;
+import io.gravitee.gateway.jupiter.api.message.Message;
+import io.gravitee.reporter.api.http.Metrics;
+import io.reactivex.Completable;
+import io.reactivex.Flowable;
+import io.reactivex.FlowableTransformer;
+import io.reactivex.Maybe;
+import javax.net.ssl.SSLSession;
+
+public class DummyMessageRequest implements MessageRequest {
+
+    Flowable<Message> flowableMessages;
+    HttpMethod method;
+    Maybe<Buffer> body;
+
+    HttpHeaders headers;
+
+    @Override
+    public Flowable<Message> messages() {
+        return flowableMessages;
+    }
+
+    @Override
+    public void messages(Flowable<Message> messages) {
+        flowableMessages = messages;
+    }
+
+    @Override
+    public HttpMethod method() {
+        return method;
+    }
+
+    public void method(HttpMethod method) {
+        this.method = method;
+    }
+
+    @Override
+    public Maybe<Buffer> body() {
+        return body;
+    }
+
+    public void body(Maybe<Buffer> body) {
+        this.body = body;
+    }
+
+    @Override
+    public HttpHeaders headers() {
+        return headers;
+    }
+
+    public void headers(HttpHeaders headers) {
+        this.headers = headers;
+    }
+
+    @Override
+    public String id() {
+        return null;
+    }
+
+    @Override
+    public String transactionId() {
+        return null;
+    }
+
+    @Override
+    public String uri() {
+        return null;
+    }
+
+    @Override
+    public String host() {
+        return null;
+    }
+
+    @Override
+    public String path() {
+        return null;
+    }
+
+    @Override
+    public String pathInfo() {
+        return null;
+    }
+
+    @Override
+    public String contextPath() {
+        return null;
+    }
+
+    @Override
+    public MultiValueMap<String, String> parameters() {
+        return null;
+    }
+
+    @Override
+    public MultiValueMap<String, String> pathParameters() {
+        return null;
+    }
+
+    @Override
+    public String scheme() {
+        return null;
+    }
+
+    @Override
+    public HttpVersion version() {
+        return null;
+    }
+
+    @Override
+    public long timestamp() {
+        return 0;
+    }
+
+    @Override
+    public String remoteAddress() {
+        return null;
+    }
+
+    @Override
+    public String localAddress() {
+        return null;
+    }
+
+    @Override
+    public SSLSession sslSession() {
+        return null;
+    }
+
+    @Override
+    public Metrics metrics() {
+        return null;
+    }
+
+    @Override
+    public boolean ended() {
+        return false;
+    }
+
+    @Override
+    public Completable onMessages(FlowableTransformer<Message, Message> onMessages) {
+        return null;
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/test/java/io/gravitee/plugin/entrypoint/http/post/HttpPostEntrypointConnectorFactoryTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/test/java/io/gravitee/plugin/entrypoint/http/post/HttpPostEntrypointConnectorFactoryTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.entrypoint.http.post;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.gateway.jupiter.api.ApiType;
+import io.gravitee.gateway.jupiter.api.ConnectorMode;
+import io.gravitee.plugin.entrypoint.http.post.HttpPostEntrypointConnector;
+import io.gravitee.plugin.entrypoint.http.post.HttpPostEntrypointConnectorFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class HttpPostEntrypointConnectorFactoryTest {
+
+    private HttpPostEntrypointConnectorFactory httpPostEntrypointConnectorFactory;
+
+    @BeforeEach
+    void beforeEach() {
+        httpPostEntrypointConnectorFactory = new HttpPostEntrypointConnectorFactory();
+    }
+
+    @Test
+    void shouldSupportSubscribeMode() {
+        assertThat(httpPostEntrypointConnectorFactory.supportedModes()).contains(ConnectorMode.PUBLISH);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "wrong", "", "  " })
+    void shouldCreateConnectorWithWrongConfiguration(String configuration) {
+        HttpPostEntrypointConnector connector = httpPostEntrypointConnectorFactory.createConnector(configuration);
+        assertThat(connector).isNotNull();
+    }
+
+    @Test
+    void shouldCreateConnectorWithNullConfiguration() {
+        HttpPostEntrypointConnector connector = httpPostEntrypointConnectorFactory.createConnector(null);
+        assertThat(connector).isNotNull();
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/test/java/io/gravitee/plugin/entrypoint/http/post/HttpPostEntrypointConnectorTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/test/java/io/gravitee/plugin/entrypoint/http/post/HttpPostEntrypointConnectorTest.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.entrypoint.http.post;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.jupiter.api.context.MessageExecutionContext;
+import io.gravitee.gateway.jupiter.api.context.MessageResponse;
+import io.reactivex.Completable;
+import io.reactivex.Maybe;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class HttpPostEntrypointConnectorTest {
+
+    @Mock
+    private MessageExecutionContext mockMessageExecutionContext;
+
+    @Mock
+    private MessageResponse mockMessageResponse;
+
+    private HttpPostEntrypointConnector httpPostEntrypointConnector;
+
+    @BeforeEach
+    void beforeEach() {
+        httpPostEntrypointConnector = new HttpPostEntrypointConnector();
+    }
+
+    @Test
+    void shouldMatchesCriteriaReturnValidCount() {
+        assertThat(httpPostEntrypointConnector.matchCriteriaCount()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldMatchesWithValidContext() {
+        DummyMessageRequest dummyMessageRequest = new DummyMessageRequest();
+        dummyMessageRequest.method(HttpMethod.POST);
+        when(mockMessageExecutionContext.request()).thenReturn(dummyMessageRequest);
+
+        boolean matches = httpPostEntrypointConnector.matches(mockMessageExecutionContext);
+
+        assertThat(matches).isTrue();
+    }
+
+    @Test
+    void shouldNotMatchesWithBadMethod() {
+        DummyMessageRequest dummyMessageRequest = new DummyMessageRequest();
+        dummyMessageRequest.method(HttpMethod.GET);
+        when(mockMessageExecutionContext.request()).thenReturn(dummyMessageRequest);
+
+        boolean matches = httpPostEntrypointConnector.matches(mockMessageExecutionContext);
+
+        assertThat(matches).isFalse();
+    }
+
+    @Test
+    void shouldCompleteAndSetRequestBufferInRequestMessage() {
+        DummyMessageRequest dummyMessageRequest = new DummyMessageRequest();
+        dummyMessageRequest.headers(HttpHeaders.create());
+        dummyMessageRequest.body(Maybe.just(Buffer.buffer("bodyContent")));
+        when(mockMessageExecutionContext.request()).thenReturn(dummyMessageRequest);
+        httpPostEntrypointConnector.handleRequest(mockMessageExecutionContext).test().assertComplete();
+
+        dummyMessageRequest.messages().test().assertValue(message -> "bodyContent".equals(message.content().toString()));
+    }
+
+    @Test
+    void shouldCompleteAndEndWhenResponseMessagesComplete() {
+        when(mockMessageResponse.end()).thenReturn(Completable.complete());
+        when(mockMessageExecutionContext.response()).thenReturn(mockMessageResponse);
+        httpPostEntrypointConnector.handleResponse(mockMessageExecutionContext).test().assertComplete();
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/pom.xml
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/pom.xml
@@ -35,5 +35,6 @@
     <modules>
         <module>gravitee-apim-plugin-entrypoint-handler</module>
         <module>gravitee-apim-plugin-entrypoint-sse</module>
+        <module>gravitee-apim-plugin-entrypoint-http-post</module>
     </modules>
 </project>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/pom.xml
@@ -147,23 +147,6 @@
             <scope>runtime</scope>
             <type>zip</type>
         </dependency>
-
-        <dependency>
-            <groupId>io.gravitee.apim.plugin.entrypoint</groupId>
-            <artifactId>gravitee-apim-plugin-entrypoint-sse</artifactId>
-            <version>${project.version}</version>
-            <scope>runtime</scope>
-            <type>zip</type>
-        </dependency>
-
-        <dependency>
-            <groupId>io.gravitee.apim.plugin.endpoint</groupId>
-            <artifactId>gravitee-apim-plugin-endpoint-mock</artifactId>
-            <version>${project.version}</version>
-            <scope>runtime</scope>
-            <type>zip</type>
-        </dependency>
-
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,7 @@
         <owasp-java-html-sanitizer.version>20211018.2</owasp-java-html-sanitizer.version>
         <protobuf-java.version>3.19.3</protobuf-java.version>
         <reactor-adapter.version>3.4.6</reactor-adapter.version>
+        <slf4j-mock.version>2.2.0</slf4j-mock.version>
         <snakeyaml.version>1.31</snakeyaml.version>
         <swagger-jaxrs2.version>2.1.13</swagger-jaxrs2.version>
         <swagger-core.version>2.1.13</swagger-core.version>
@@ -755,6 +756,12 @@
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>
                 <version>${asm.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.simplify4u</groupId>
+                <artifactId>slf4j-mock</artifactId>
+                <version>${slf4j-mock.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8036

**Description**

Add a new entrypoint: HTTP-Post. This entrypoint creates a async message based on the body of an HTTP request.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8036-http-post-entrypoint/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gerllfefxb.chromatic.com)
<!-- Storybook placeholder end -->
