### PR TITLE
feat: log PolicyException cause to help debugging policy problems

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/ExecutablePolicy.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/ExecutablePolicy.java
@@ -28,12 +28,16 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
 import jdk.dynalink.linker.support.Lookup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
 public class ExecutablePolicy implements Policy {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExecutablePolicy.class);
 
     private final String id;
     private final Object policy;
@@ -105,6 +109,7 @@ public class ExecutablePolicy implements Policy {
         try {
             headMethodHandle.invoke(policy, chain, context, context.request(), context.response());
         } catch (Throwable ex) {
+            LOGGER.error("Error during {} policy execution", id, ex);
             throw new PolicyException(ex);
         }
     }
@@ -115,6 +120,7 @@ public class ExecutablePolicy implements Policy {
             Object stream = streamMethodHandle.invoke(policy, chain, context, context.request(), context.response());
             return (stream != null) ? (ReadWriteStream<Buffer>) stream : null;
         } catch (Throwable ex) {
+            LOGGER.error("Error during {} policy execution", id, ex);
             throw new PolicyException(ex);
         }
     }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7257

**Description**

feat: log PolicyException cause to help debugging policy problems

I figured out that's the most relevant way to log those errors, cause logging them at a higher level (eg. in PolicyChain) would cause some exceptions to be logged twice.

To check the behavior, I manually thrown a runtime exception in the  `onRequest` method of a policy.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-etrqnzwsbs.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/chore-logpolicyexception/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
