### PR TITLE
chore: bump policy xslt version to 1.6.2

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -91,7 +91,7 @@
         <gravitee-policy-xml-json.version>1.8.1</gravitee-policy-xml-json.version>
         <gravitee-policy-xml-threat-protection.version>1.3.2</gravitee-policy-xml-threat-protection.version>
         <gravitee-policy-xml-validation.version>1.1.0</gravitee-policy-xml-validation.version>
-        <gravitee-policy-xslt.version>1.6.1</gravitee-policy-xslt.version>
+        <gravitee-policy-xslt.version>1.6.2</gravitee-policy-xslt.version>
         <gravitee-resource-cache.version>1.8.1</gravitee-resource-cache.version>
         <gravitee-resource-oauth2-provider-am.version>1.14.2</gravitee-resource-oauth2-provider-am.version>
         <gravitee-resource-oauth2-provider-generic.version>1.16.2</gravitee-resource-oauth2-provider-generic.version>


### PR DESCRIPTION
see https://github.com/gravitee-io/issues/issues/8382

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tjjqqmiobj.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/chore-bump-policy-xslt-version/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
