### PR TITLE
Test/fix flaxy websocket tests 

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/AbstractWebSocketGatewayTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/AbstractWebSocketGatewayTest.java
@@ -15,7 +15,11 @@
  */
 package io.gravitee.gateway.standalone.websocket;
 
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.Endpoint;
+import io.gravitee.definition.model.EndpointGroup;
 import io.gravitee.gateway.standalone.AbstractGatewayTest;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,5 +33,29 @@ public abstract class AbstractWebSocketGatewayTest extends AbstractGatewayTest {
 
     static {
         System.setProperty("vertx.disableWebsockets", Boolean.FALSE.toString());
+    }
+
+    /**
+     * Override this method to set dynamically the API endpoint target.
+     *
+     * @return Override API endpoint target
+     */
+    protected String getApiEndpointTarget() {
+        return null;
+    }
+
+    @Override
+    public void before(Api api) {
+        super.before(api);
+
+        if (getApiEndpointTarget() != null) {
+            Set<EndpointGroup> groups = api.getProxy().getGroups();
+            if (!groups.isEmpty()) {
+                Set<Endpoint> endpoints = groups.iterator().next().getEndpoints();
+                if (!endpoints.isEmpty()) {
+                    endpoints.iterator().next().setTarget(getApiEndpointTarget());
+                }
+            }
+        }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketAcceptTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketAcceptTest.java
@@ -35,10 +35,15 @@ import org.junit.rules.TestRule;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-// FIXME: These tests are flaky when run on CircleCI and need to be fixed
-@Ignore("These tests are flaky when run on CircleCI and need to be fixed")
 @ApiDescriptor("/io/gravitee/gateway/standalone/websocket/teams.json")
 public class WebsocketAcceptTest extends AbstractWebSocketGatewayTest {
+
+    private static final Integer WEBSOCKET_PORT = 16665;
+
+    @Override
+    protected String getApiEndpointTarget() {
+        return "http://localhost:" + WEBSOCKET_PORT;
+    }
 
     @Rule
     public final TestRule chain = RuleChain.outerRule(new ApiDeployer(this));
@@ -56,7 +61,7 @@ public class WebsocketAcceptTest extends AbstractWebSocketGatewayTest {
                     event.writeTextMessage("PING");
                 }
             )
-            .listen(16664);
+            .listen(WEBSOCKET_PORT);
 
         HttpClient httpClient = vertx.createHttpClient(new HttpClientOptions().setDefaultPort(8082).setDefaultHost("localhost"));
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketBidirectionalTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketBidirectionalTest.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.gateway.standalone.websocket;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+
 import io.gravitee.gateway.standalone.junit.annotation.ApiDescriptor;
 import io.gravitee.gateway.standalone.junit.rules.ApiDeployer;
 import io.vertx.core.Vertx;
@@ -22,13 +25,10 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.WebSocket;
-import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import java.util.concurrent.TimeUnit;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
@@ -62,7 +62,7 @@ public class WebsocketBidirectionalTest extends AbstractWebSocketGatewayTest {
                     event.frameHandler(
                         frame -> {
                             if (frame.isText()) {
-                                Assert.assertEquals("PONG", frame.textData());
+                                testContext.verify(() -> assertThat(frame.textData()).isEqualTo("PONG"));
                                 testContext.completeNow();
                             } else {
                                 testContext.failNow("The frame is not a text frame");
@@ -81,13 +81,13 @@ public class WebsocketBidirectionalTest extends AbstractWebSocketGatewayTest {
             event -> {
                 if (event.failed()) {
                     logger.error("An error occurred during websocket call", event.cause());
-                    Assert.fail();
+                    testContext.failNow("An error occurred during websocket call");
                 } else {
                     final WebSocket webSocket = event.result();
                     webSocket.frameHandler(
                         frame -> {
                             if (frame.isText()) {
-                                Assert.assertEquals("PING", frame.textData());
+                                testContext.verify(() -> assertThat(frame.textData()).isEqualTo("PING"));
                                 webSocket.writeTextMessage("PONG");
                             }
                         }
@@ -98,6 +98,8 @@ public class WebsocketBidirectionalTest extends AbstractWebSocketGatewayTest {
 
         testContext.awaitCompletion(10, TimeUnit.SECONDS);
         httpServer.close();
-        Assert.assertTrue(testContext.completed());
+
+        String failureMessage = testContext.causeOfFailure() != null ? testContext.causeOfFailure().getMessage() : null;
+        assertTrue(failureMessage, testContext.completed());
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketBidirectionalTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketBidirectionalTest.java
@@ -39,6 +39,13 @@ import org.junit.rules.TestRule;
 @ApiDescriptor("/io/gravitee/gateway/standalone/websocket/teams.json")
 public class WebsocketBidirectionalTest extends AbstractWebSocketGatewayTest {
 
+    private static final Integer WEBSOCKET_PORT = 16666;
+
+    @Override
+    protected String getApiEndpointTarget() {
+        return "http://localhost:" + WEBSOCKET_PORT;
+    }
+
     @Rule
     public final TestRule chain = RuleChain.outerRule(new ApiDeployer(this));
 
@@ -65,7 +72,7 @@ public class WebsocketBidirectionalTest extends AbstractWebSocketGatewayTest {
                     event.writeTextMessage("PING");
                 }
             )
-            .listen(16664);
+            .listen(WEBSOCKET_PORT);
 
         HttpClient httpClient = vertx.createHttpClient(new HttpClientOptions().setDefaultPort(8082).setDefaultHost("localhost"));
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketCloseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketCloseTest.java
@@ -40,6 +40,13 @@ import org.junit.rules.TestRule;
 @ApiDescriptor("/io/gravitee/gateway/standalone/websocket/teams.json")
 public class WebsocketCloseTest extends AbstractWebSocketGatewayTest {
 
+    private static final Integer WEBSOCKET_PORT = 16667;
+
+    @Override
+    protected String getApiEndpointTarget() {
+        return "http://localhost:" + WEBSOCKET_PORT;
+    }
+
     @Rule
     public final TestRule chain = RuleChain.outerRule(new ApiDeployer(this));
 
@@ -56,7 +63,7 @@ public class WebsocketCloseTest extends AbstractWebSocketGatewayTest {
                     event.close((short) HttpStatusCode.OK_200);
                 }
             )
-            .listen(16664);
+            .listen(WEBSOCKET_PORT);
 
         HttpClient httpClient = vertx.createHttpClient(new HttpClientOptions().setDefaultPort(8082).setDefaultHost("localhost"));
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketCloseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketCloseTest.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.gateway.standalone.websocket;
 
+import static org.junit.Assert.assertTrue;
+
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.gateway.standalone.junit.annotation.ApiDescriptor;
 import io.gravitee.gateway.standalone.junit.rules.ApiDeployer;
@@ -23,13 +25,10 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.WebSocket;
-import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import java.util.concurrent.TimeUnit;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
@@ -72,7 +71,7 @@ public class WebsocketCloseTest extends AbstractWebSocketGatewayTest {
             event -> {
                 if (event.failed()) {
                     logger.error("An error occurred during websocket call", event.cause());
-                    Assert.fail();
+                    testContext.failNow("An error occurred during websocket call");
                 } else {
                     final WebSocket webSocket = event.result();
                     webSocket.closeHandler(__ -> testContext.completeNow());
@@ -82,6 +81,8 @@ public class WebsocketCloseTest extends AbstractWebSocketGatewayTest {
 
         testContext.awaitCompletion(10, TimeUnit.SECONDS);
         httpServer.close();
-        Assert.assertTrue(testContext.completed());
+
+        String failureMessage = testContext.causeOfFailure() != null ? testContext.causeOfFailure().getMessage() : null;
+        assertTrue(failureMessage, testContext.completed());
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketHeadersTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketHeadersTest.java
@@ -35,6 +35,13 @@ import org.junit.rules.TestRule;
 @ApiDescriptor("/io/gravitee/gateway/standalone/websocket/teams.json")
 public class WebsocketHeadersTest extends AbstractWebSocketGatewayTest {
 
+    private static final Integer WEBSOCKET_PORT = 16668;
+
+    @Override
+    protected String getApiEndpointTarget() {
+        return "http://localhost:" + WEBSOCKET_PORT;
+    }
+
     @Rule
     public final TestRule chain = RuleChain.outerRule(new ApiDeployer(this));
 
@@ -57,7 +64,7 @@ public class WebsocketHeadersTest extends AbstractWebSocketGatewayTest {
                     event.writeTextMessage("PING");
                 }
             )
-            .listen(16664);
+            .listen(WEBSOCKET_PORT);
 
         // Wait for result
         final CountDownLatch latch = new CountDownLatch(1);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketPingFrameTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketPingFrameTest.java
@@ -40,6 +40,13 @@ import org.junit.rules.TestRule;
 @ApiDescriptor("/io/gravitee/gateway/standalone/websocket/teams.json")
 public class WebsocketPingFrameTest extends AbstractWebSocketGatewayTest {
 
+    private static final Integer WEBSOCKET_PORT = 16669;
+
+    @Override
+    protected String getApiEndpointTarget() {
+        return "http://localhost:" + WEBSOCKET_PORT;
+    }
+
     @Rule
     public final TestRule chain = RuleChain.outerRule(new ApiDeployer(this));
 
@@ -65,7 +72,7 @@ public class WebsocketPingFrameTest extends AbstractWebSocketGatewayTest {
                     );
                 }
             )
-            .listen(16664);
+            .listen(WEBSOCKET_PORT);
 
         HttpClient httpClient = vertx.createHttpClient(new HttpClientOptions().setDefaultPort(8082).setDefaultHost("localhost"));
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketRejectTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketRejectTest.java
@@ -15,7 +15,10 @@
  */
 package io.gravitee.gateway.standalone.websocket;
 
-import io.gravitee.common.http.HttpStatusCode;
+import static io.gravitee.common.http.HttpStatusCode.UNAUTHORIZED_401;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+
 import io.gravitee.gateway.standalone.junit.annotation.ApiDescriptor;
 import io.gravitee.gateway.standalone.junit.rules.ApiDeployer;
 import io.vertx.core.Vertx;
@@ -23,13 +26,10 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.UpgradeRejectedException;
-import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import java.util.concurrent.TimeUnit;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
@@ -52,23 +52,24 @@ public class WebsocketRejectTest extends AbstractWebSocketGatewayTest {
         VertxTestContext testContext = new VertxTestContext();
 
         HttpServer httpServer = vertx.createHttpServer();
-        httpServer.webSocketHandler(webSocket -> webSocket.reject(HttpStatusCode.UNAUTHORIZED_401)).listen(WEBSOCKET_PORT);
+        httpServer.webSocketHandler(webSocket -> webSocket.reject(UNAUTHORIZED_401)).listen(WEBSOCKET_PORT);
 
         HttpClient httpClient = vertx.createHttpClient(new HttpClientOptions().setDefaultPort(8082).setDefaultHost("localhost"));
 
         httpClient.webSocket(
             "/test",
             event -> {
-                Assert.assertTrue(event.failed());
-                Assert.assertEquals(UpgradeRejectedException.class, event.cause().getClass());
-                Assert.assertEquals(HttpStatusCode.UNAUTHORIZED_401, ((UpgradeRejectedException) event.cause()).getStatus());
-
+                testContext.verify(() -> assertThat(event.failed()).isTrue());
+                testContext.verify(() -> assertThat(event.cause().getClass()).isEqualTo(UpgradeRejectedException.class));
+                testContext.verify(() -> assertThat(((UpgradeRejectedException) event.cause()).getStatus()).isEqualTo(UNAUTHORIZED_401));
                 testContext.completeNow();
             }
         );
 
         testContext.awaitCompletion(10, TimeUnit.SECONDS);
         httpServer.close();
-        Assert.assertTrue(testContext.completed());
+
+        String failureMessage = testContext.causeOfFailure() != null ? testContext.causeOfFailure().getMessage() : null;
+        assertTrue(failureMessage, testContext.completed());
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketRejectTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketRejectTest.java
@@ -36,6 +36,13 @@ import org.junit.rules.TestRule;
 @ApiDescriptor("/io/gravitee/gateway/standalone/websocket/teams.json")
 public class WebsocketRejectTest extends AbstractWebSocketGatewayTest {
 
+    private static final Integer WEBSOCKET_PORT = 16661;
+
+    @Override
+    protected String getApiEndpointTarget() {
+        return "http://localhost:" + WEBSOCKET_PORT;
+    }
+
     @Rule
     public final TestRule chain = RuleChain.outerRule(new ApiDeployer(this));
 
@@ -45,7 +52,7 @@ public class WebsocketRejectTest extends AbstractWebSocketGatewayTest {
         VertxTestContext testContext = new VertxTestContext();
 
         HttpServer httpServer = vertx.createHttpServer();
-        httpServer.webSocketHandler(webSocket -> webSocket.reject(HttpStatusCode.UNAUTHORIZED_401)).listen(16664);
+        httpServer.webSocketHandler(webSocket -> webSocket.reject(HttpStatusCode.UNAUTHORIZED_401)).listen(WEBSOCKET_PORT);
 
         HttpClient httpClient = vertx.createHttpClient(new HttpClientOptions().setDefaultPort(8082).setDefaultHost("localhost"));
 


### PR DESCRIPTION
This tries to definitively fix websocket flaky tests with 2 commits :
- use a dedicated port for each tests
- use proper vertxTestContext assertions
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/test-fixflaxywebsockettests/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-sagueosbok.chromatic.com)
<!-- Storybook placeholder end -->
