### PR TITLE
Set `engines` properties on Console and Portal `package.json`

### DIFF
--- a/gravitee-apim-console-webui/package-lock.json
+++ b/gravitee-apim-console-webui/package-lock.json
@@ -153,7 +153,8 @@
         "webpack-dev-server": "4.7.3"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": "^16.10",
+        "npm": "^7.24"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/gravitee-apim-console-webui/package.json
+++ b/gravitee-apim-console-webui/package.json
@@ -147,7 +147,8 @@
     "webpack-dev-server": "4.7.3"
   },
   "engines": {
-    "node": ">=14.17"
+    "node": "^16.10",
+    "npm": "^7.24"
   },
   "scripts": {
     "build:prod": "webpack -c ./conf/webpack-dist.conf.js",

--- a/gravitee-apim-portal-webui/package-lock.json
+++ b/gravitee-apim-portal-webui/package-lock.json
@@ -78,6 +78,10 @@
         "protractor": "~7.0.0",
         "ts-node": "8.10.2",
         "typescript": "4.6.4"
+      },
+      "engines": {
+        "node": "^16.10",
+        "npm": "^7.24"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/gravitee-apim-portal-webui/package.json
+++ b/gravitee-apim-portal-webui/package.json
@@ -59,6 +59,10 @@
     "tslib": "^2.0.0",
     "zone.js": "~0.11.4"
   },
+  "engines": {
+    "node": "^16.10",
+    "npm": "^7.24"
+  },
   "devDependencies": {
     "@angular-builders/jest": "13.0.3",
     "@angular-devkit/build-angular": "13.3.0",


### PR DESCRIPTION
**Issue**

NA

**Description**

For a couple of months Renovate isn't able to properly update the `package-lock.json` file, for instance:
 - https://github.com/gravitee-io/gravitee-api-management/pull/2221#issuecomment-1193448459
 - https://github.com/gravitee-io/gravitee-api-management/pull/2329
 - https://github.com/gravitee-io/gravitee-api-management/pull/2249

The goal of this PR is to help Renovate use the correct version of NPM when doing the update.
It looks like having `.nvmrc` in nested folders isn't working.

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/set-node-npm-engines/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ckwkpalusr.chromatic.com)
<!-- Storybook placeholder end -->
