### PR TITLE
feat: add origin in api list and search

### DIFF
--- a/gravitee-apim-console-webui/package-lock.json
+++ b/gravitee-apim-console-webui/package-lock.json
@@ -23,7 +23,7 @@
         "@fontsource/libre-franklin": "4.4.5",
         "@gravitee/ui-analytics": "3.6.0",
         "@gravitee/ui-components": "3.36.2",
-        "@gravitee/ui-particles-angular": "3.4.0",
+        "@gravitee/ui-particles-angular": "3.6.0",
         "@gravitee/ui-policy-studio-angular": "3.0.1",
         "@highcharts/map-collection": "1.1.4",
         "@toast-ui/editor": "2.5.2",
@@ -11263,9 +11263,9 @@
       }
     },
     "node_modules/@gravitee/ui-particles-angular": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@gravitee/ui-particles-angular/-/ui-particles-angular-3.4.0.tgz",
-      "integrity": "sha512-1CQi6nUKlA0UXwT2wETxe7LXJkKcziwzg0jem3Wxxi3/BlLDQtCyubxYtiikF0Bx9SRi9VJ7uVT0Plb3AaA3+w==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@gravitee/ui-particles-angular/-/ui-particles-angular-3.6.0.tgz",
+      "integrity": "sha512-BbyqEUDKKJEPJMDkujzUAjMNRLi00l5cBbafIVzfTrIwCVDe7gE64MwmY/Jx2lwbf/g2Ljlk7j7jJnLGR8SHng==",
       "dependencies": {
         "@fontsource/fira-mono": "4.5.0",
         "@fontsource/golos-ui": "^4.5.1",
@@ -56021,9 +56021,9 @@
       }
     },
     "@gravitee/ui-particles-angular": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@gravitee/ui-particles-angular/-/ui-particles-angular-3.4.0.tgz",
-      "integrity": "sha512-1CQi6nUKlA0UXwT2wETxe7LXJkKcziwzg0jem3Wxxi3/BlLDQtCyubxYtiikF0Bx9SRi9VJ7uVT0Plb3AaA3+w==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@gravitee/ui-particles-angular/-/ui-particles-angular-3.6.0.tgz",
+      "integrity": "sha512-BbyqEUDKKJEPJMDkujzUAjMNRLi00l5cBbafIVzfTrIwCVDe7gE64MwmY/Jx2lwbf/g2Ljlk7j7jJnLGR8SHng==",
       "requires": {
         "@fontsource/fira-mono": "4.5.0",
         "@fontsource/golos-ui": "^4.5.1",

--- a/gravitee-apim-console-webui/package.json
+++ b/gravitee-apim-console-webui/package.json
@@ -17,7 +17,7 @@
     "@fontsource/libre-franklin": "4.4.5",
     "@gravitee/ui-analytics": "3.6.0",
     "@gravitee/ui-components": "3.36.2",
-    "@gravitee/ui-particles-angular": "3.4.0",
+    "@gravitee/ui-particles-angular": "3.6.0",
     "@gravitee/ui-policy-studio-angular": "3.0.1",
     "@highcharts/map-collection": "1.1.4",
     "@toast-ui/editor": "2.5.2",

--- a/gravitee-apim-console-webui/src/entities/api/Api.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/api/Api.fixture.ts
@@ -193,6 +193,7 @@ export function fakeApi(modifier?: Partial<Api> | ((baseApi: Api) => Api)): Api 
     disable_membership_notifications: false,
     background_url:
       'https://master-apim-api.cloud.gravitee.io/management/organizations/DEFAULT/environments/DEFAULT/apis/aee23b1e-34b1-4551-a23b-1e34b165516a/background?hash=1642675655553',
+    origin: 'management',
   };
 
   if (isFunction(modifier)) {

--- a/gravitee-apim-console-webui/src/entities/api/Api.ts
+++ b/gravitee-apim-console-webui/src/entities/api/Api.ts
@@ -60,10 +60,12 @@ export interface Api {
   background_url?: string;
 
   etag?: string;
+  origin: ApiOrigin;
 }
 
 export type ApiVisibility = 'PUBLIC' | 'PRIVATE';
 export type ApiState = 'INITIALIZED' | 'STOPPED' | 'STARTED' | 'CLOSED';
+export type ApiOrigin = 'management' | 'kubernetes';
 
 export interface ApiEntrypoint {
   tags?: string[];

--- a/gravitee-apim-console-webui/src/entities/api/UpdateApi.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/api/UpdateApi.fixture.ts
@@ -136,6 +136,7 @@ export function fakeUpdateApi(modifier?: Partial<UpdateApi> | ((baseApi: UpdateA
     disable_membership_notifications: false,
     flow_mode: 'DEFAULT',
     gravitee: '2.0.0',
+    origin: 'management',
   };
 
   if (isFunction(modifier)) {

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
@@ -66,6 +66,13 @@
         <mat-icon *ngIf="element.lifecycleState !== 'PUBLISHED'" matTooltip="Unpublished" class="states__api-not-published" size="20"
           >cloud_off</mat-icon
         >
+        <mat-icon
+          *ngIf="element.origin === 'kubernetes'"
+          matTooltip="Kubernetes Origin"
+          class="states__api-origin"
+          size="20"
+          svgIcon="gio:kubernetes"
+        ></mat-icon>
         <span *ngIf="element.workflowBadge" [ngClass]="element.workflowBadge.class" class="states__api-workflow-badge">
           {{ element.workflowBadge.text }}
         </span>

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.scss
@@ -57,6 +57,10 @@
       vertical-align: top;
     }
 
+    &__api-origin {
+      color: #326de6;
+    }
+
     &__api-is-not-synced {
       color: mat.get-color-from-palette(gio.$mat-warning-palette, 'default');
     }

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
@@ -33,7 +33,7 @@ import { User as DeprecatedUser } from '../../../entities/user';
 import { fakeApi } from '../../../entities/api/Api.fixture';
 import { CONSTANTS_TESTING, GioHttpTestingModule } from '../../../shared/testing';
 import { fakePagedResult } from '../../../entities/pagedResult';
-import { Api, ApiLifecycleState, ApiState } from '../../../entities/api';
+import { Api, ApiLifecycleState, ApiOrigin, ApiState } from '../../../entities/api';
 
 describe('ApisListComponent', () => {
   const fakeUiRouter = { go: jest.fn() };
@@ -105,6 +105,16 @@ describe('ApisListComponent', () => {
       expect(rowCells).toEqual([['', '🪐 Planets', 'play_circlecloud_done', '/planets', '', 'admin', 'public', 'edit']]);
     }));
 
+    it('should display one row with kubernetes icon', fakeAsync(async () => {
+      await initComponent([fakeApi({ origin: 'kubernetes' })]);
+      expect(await loader.getHarness(MatIconHarness.with({ selector: '.states__api-origin' }))).toBeTruthy();
+    }));
+
+    it('should display one row without kubernetes icon', fakeAsync(async () => {
+      await initComponent([fakeApi({ origin: 'management' })]);
+      expect(await loader.getAllHarnesses(MatIconHarness.with({ selector: '.states__api-origin' }))).toHaveLength(0);
+    }));
+
     it('should order rows by name', fakeAsync(async () => {
       const planetsApi = fakeApi({ id: '1', name: 'Planets 🪐' });
       const unicornsApi = fakeApi({ id: '2', name: 'Unicorns 🦄' });
@@ -163,6 +173,7 @@ describe('ApisListComponent', () => {
           lifecycleState: 'PUBLISHED' as ApiLifecycleState,
           workflowState: 'REVIEW_OK',
           visibility: { label: 'PUBLIC', icon: 'public' },
+          origin: 'management' as ApiOrigin,
         };
 
         apiListComponent.onEditActionClicked(api);

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
@@ -20,7 +20,7 @@ import { BehaviorSubject, Observable, of, Subject } from 'rxjs';
 import { isEqual } from 'lodash';
 
 import { UIRouterState, UIRouterStateParams } from '../../../ajs-upgraded-providers';
-import { Api, ApiLifecycleState, ApiState } from '../../../entities/api';
+import { Api, ApiLifecycleState, ApiOrigin, ApiState } from '../../../entities/api';
 import { PagedResult } from '../../../entities/pagedResult';
 import { GioTableWrapperFilters } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
 import { ApiService } from '../../../services-ngx/api.service';
@@ -41,6 +41,7 @@ export type ApisTableDS = {
   isNotSynced$?: Observable<boolean>;
   qualityScore$?: Observable<{ score: number; class: string }>;
   visibility: { label: string; icon: string };
+  origin: ApiOrigin;
 }[];
 
 @Component({
@@ -157,6 +158,7 @@ export class ApiListComponent implements OnInit, OnDestroy {
             ? this.apiService.getQualityMetrics(api.id).pipe(map((a) => this.getQualityScore(Math.floor(a.score * 100))))
             : null,
           visibility: { label: api.visibility, icon: this.visibilitiesIcons[api.visibility] },
+          origin: api.origin,
         }))
       : [];
   }

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/gio-policy-studio-layout.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/gio-policy-studio-layout.component.spec.ts
@@ -20,6 +20,7 @@ import { InteractivityChecker } from '@angular/cdk/a11y';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { GioSaveBarModule } from '@gravitee/ui-particles-angular';
 import { MatTabsModule } from '@angular/material/tabs';
+import { omit } from 'lodash';
 
 import { GioPolicyStudioLayoutComponent } from './gio-policy-studio-layout.component';
 import { toApiDefinition } from './models/ApiDefinition';
@@ -87,15 +88,18 @@ describe('GioPolicyStudioLayoutComponent', () => {
       const req = httpTestingController.expectOne({ method: 'PUT', url: `${CONSTANTS_TESTING.env.baseURL}/apis/${api.id}` });
 
       expect(req.request.body).toStrictEqual(
-        fakeUpdateApi({
-          background: undefined,
-          categories: undefined,
-          paths: undefined,
-          picture: undefined,
-          plans: [],
-          flows: api.flows,
-          execution_mode: undefined,
-        }),
+        omit(
+          fakeUpdateApi({
+            background: undefined,
+            categories: undefined,
+            paths: undefined,
+            picture: undefined,
+            plans: [],
+            flows: api.flows,
+            execution_mode: undefined,
+          }),
+          'origin',
+        ),
       );
     });
 

--- a/gravitee-apim-console-webui/src/services-ngx/api.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api.service.spec.ts
@@ -15,6 +15,7 @@
  */
 import { HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+import { omit } from 'lodash';
 
 import { ApiService } from './api.service';
 
@@ -82,7 +83,7 @@ describe('ApiService', () => {
       });
 
       const req = httpTestingController.expectOne({ method: 'PUT', url: `${CONSTANTS_TESTING.env.baseURL}/apis/${apiId}` });
-      expect(req.request.body).toEqual(apiToUpdate);
+      expect(req.request.body).toEqual(omit(apiToUpdate, 'origin'));
       req.flush({});
     });
   });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
@@ -576,6 +576,10 @@ public class ApisResource extends AbstractResource {
             apiItem.setContextPath(api.getProxy().getVirtualHosts().get(0).getPath());
         }
 
+        if (api.getDefinitionContext() != null && !api.getDefinitionContext().getOrigin().isEmpty()) {
+            apiItem.setOrigin(api.getDefinitionContext().getOrigin());
+        }
+
         return apiItem;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiListItem.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiListItem.java
@@ -15,34 +15,43 @@
  */
 package io.gravitee.rest.api.model.api;
 
+import static io.gravitee.definition.model.DefinitionContext.ORIGIN_MANAGEMENT;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.common.component.Lifecycle;
-import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.definition.model.VirtualHost;
-import io.gravitee.rest.api.model.DeploymentRequired;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.Visibility;
 import io.gravitee.rest.api.model.WorkflowState;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Date;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class ApiListItem {
 
     @Schema(description = "Api's uuid.", example = "00f8c9e7-78fc-4907-b8c9-e778fc790750")
+    @EqualsAndHashCode.Include
     private String id;
 
     @Schema(description = "Api's name. Duplicate names can exists.", example = "My Api")
     private String name;
 
     @Schema(description = "Api's version. It's a simple string only used in the portal.", example = "v1.0")
+    @EqualsAndHashCode.Include
     private String version;
 
     @Schema(description = "Api's version. It's a simple string only used in the portal.", example = "v1.0")
@@ -107,242 +116,6 @@ public class ApiListItem {
     @Schema(description = "true if HealthCheck is enabled globally or on one endpoint")
     private boolean hasHealthCheckEnabled;
 
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
-
-    public Date getCreatedAt() {
-        return createdAt;
-    }
-
-    public void setCreatedAt(Date createdAt) {
-        this.createdAt = createdAt;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public Lifecycle.State getState() {
-        return state;
-    }
-
-    public void setState(Lifecycle.State state) {
-        this.state = state;
-    }
-
-    public Date getUpdatedAt() {
-        return updatedAt;
-    }
-
-    public void setUpdatedAt(Date updatedAt) {
-        this.updatedAt = updatedAt;
-    }
-
-    public String getVersion() {
-        return version;
-    }
-
-    public void setVersion(String version) {
-        this.version = version;
-    }
-
-    public Visibility getVisibility() {
-        return visibility;
-    }
-
-    public void setVisibility(Visibility visibility) {
-        this.visibility = visibility;
-    }
-
-    public PrimaryOwnerEntity getPrimaryOwner() {
-        return primaryOwner;
-    }
-
-    public void setPrimaryOwner(PrimaryOwnerEntity primaryOwner) {
-        this.primaryOwner = primaryOwner;
-    }
-
-    public String getRole() {
-        return role;
-    }
-
-    public void setRole(String role) {
-        this.role = role;
-    }
-
-    public String getPictureUrl() {
-        return pictureUrl;
-    }
-
-    public void setPictureUrl(String pictureUrl) {
-        this.pictureUrl = pictureUrl;
-    }
-
-    public List<VirtualHost> getVirtualHosts() {
-        return virtualHosts;
-    }
-
-    public void setVirtualHosts(List<VirtualHost> virtualHosts) {
-        this.virtualHosts = virtualHosts;
-    }
-
-    public Set<String> getCategories() {
-        return categories;
-    }
-
-    public void setCategories(Set<String> categories) {
-        this.categories = categories;
-    }
-
-    public List<String> getLabels() {
-        return labels;
-    }
-
-    public void setLabels(List<String> labels) {
-        this.labels = labels;
-    }
-
-    public Double getRate() {
-        return rate;
-    }
-
-    public void setRate(Double rate) {
-        this.rate = rate;
-    }
-
-    public int getNumberOfRatings() {
-        return numberOfRatings;
-    }
-
-    public void setNumberOfRatings(int numberOfRatings) {
-        this.numberOfRatings = numberOfRatings;
-    }
-
-    public Set<String> getTags() {
-        return tags;
-    }
-
-    public void setTags(Set<String> tags) {
-        this.tags = tags;
-    }
-
-    public ApiLifecycleState getLifecycleState() {
-        return lifecycleState;
-    }
-
-    public void setLifecycleState(ApiLifecycleState lifecycleState) {
-        this.lifecycleState = lifecycleState;
-    }
-
-    public WorkflowState getWorkflowState() {
-        return workflowState;
-    }
-
-    public void setWorkflowState(WorkflowState workflowState) {
-        this.workflowState = workflowState;
-    }
-
-    public String getContextPath() {
-        return contextPath;
-    }
-
-    public void setContextPath(String contextPath) {
-        this.contextPath = contextPath;
-    }
-
-    public boolean isHasHealthCheckEnabled() {
-        return hasHealthCheckEnabled;
-    }
-
-    public void setHasHealthCheckEnabled(boolean hasHealthCheckEnabled) {
-        this.hasHealthCheckEnabled = hasHealthCheckEnabled;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ApiListItem that = (ApiListItem) o;
-        return Objects.equals(id, that.id) && Objects.equals(version, that.version);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, version);
-    }
-
-    @Override
-    public String toString() {
-        return (
-            "ApiListItem{" +
-            "id='" +
-            id +
-            '\'' +
-            ", name='" +
-            name +
-            '\'' +
-            ", version='" +
-            version +
-            '\'' +
-            ", description='" +
-            description +
-            '\'' +
-            ", createdAt=" +
-            createdAt +
-            ", updatedAt=" +
-            updatedAt +
-            ", visibility=" +
-            visibility +
-            ", state=" +
-            state +
-            ", primaryOwner=" +
-            primaryOwner +
-            ", role='" +
-            role +
-            '\'' +
-            ", pictureUrl='" +
-            pictureUrl +
-            '\'' +
-            ", virtualHosts=" +
-            virtualHosts +
-            ", categories=" +
-            categories +
-            ", labels=" +
-            labels +
-            ", rate=" +
-            rate +
-            ", numberOfRatings=" +
-            numberOfRatings +
-            ", tags=" +
-            tags +
-            ", lifecycleState=" +
-            lifecycleState +
-            ", workflowState=" +
-            workflowState +
-            ", contextPath='" +
-            contextPath +
-            '\'' +
-            ", hasHealthCheckEnabled='" +
-            hasHealthCheckEnabled +
-            '\'' +
-            '}'
-        );
-    }
+    @Schema(description = "The origin of the api (management, kubernetes, ...).")
+    private String origin = ORIGIN_MANAGEMENT;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/ApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/ApiEntity.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.model.v4.api;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.gravitee.common.component.Lifecycle;
+import io.gravitee.definition.model.DefinitionContext;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
@@ -160,6 +161,9 @@ public class ApiEntity implements GenericApiEntity {
 
     @Schema(description = "the free list of labels associated with this API", example = "json, read_only, awesome")
     private List<String> labels;
+
+    @Schema(description = "the context where the api definition was created from")
+    private DefinitionContext definitionContext;
 
     @JsonIgnore
     private Map<String, Object> metadata = new HashMap<>();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/GenericApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/GenericApiEntity.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.model.v4.api;
 
 import io.gravitee.common.component.Lifecycle;
+import io.gravitee.definition.model.DefinitionContext;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.Visibility;
@@ -66,4 +67,6 @@ public interface GenericApiEntity extends Indexable {
     PrimaryOwnerEntity getPrimaryOwner();
 
     Set<String> getCategories();
+
+    DefinitionContext getDefinitionContext();
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcher.java
@@ -110,6 +110,7 @@ public class ApiDocumentSearcher extends AbstractDocumentSearcher {
         FIELD_DESCRIPTION,
         FIELD_PATHS,
         FIELD_TAGS,
+        FIELD_ORIGIN,
     };
 
     private BooleanQuery.Builder buildApiQuery(ExecutionContext executionContext, Optional<Query> filterQuery) {
@@ -292,7 +293,7 @@ public class ApiDocumentSearcher extends AbstractDocumentSearcher {
         String text = term.text();
         if (FIELD_CATEGORIES.equals(term.field())) {
             text = formatCategoryField(term.text());
-        } else if (!FIELD_PATHS.equals(term.field()) && !FIELD_TAGS.equals(term.field())) {
+        } else if (!FIELD_PATHS.equals(term.field()) && !FIELD_TAGS.equals(term.field()) && !FIELD_ORIGIN.equals(term.field())) {
             text = text.toLowerCase();
             field = field.concat("_lowercase");
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformer.java
@@ -70,6 +70,7 @@ public class ApiDocumentTransformer implements DocumentTransformer<GenericApiEnt
     public static final String FIELD_METADATA = "metadata";
     public static final String FIELD_METADATA_SPLIT = "metadata_split";
     private static final Pattern SPECIAL_CHARS = Pattern.compile("[|\\-+!(){}^\"~*?:&\\/]");
+    public static final String FIELD_ORIGIN = "origin";
 
     @Override
     public Document transform(GenericApiEntity api) {
@@ -176,6 +177,10 @@ public class ApiDocumentTransformer implements DocumentTransformer<GenericApiEnt
                         doc.add(new TextField(FIELD_METADATA_SPLIT, metadataValue.toString(), Field.Store.NO));
                     }
                 );
+        }
+
+        if (api.getDefinitionContext() != null && api.getDefinitionContext().getOrigin() != null) {
+            doc.add(new StringField(FIELD_ORIGIN, api.getDefinitionContext().getOrigin(), Field.Store.NO));
         }
 
         return doc;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcherTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcherTest.java
@@ -63,4 +63,12 @@ public class ApiDocumentSearcherTest {
             builder.build().toString()
         );
     }
+
+    @Test
+    public void shouldCompleteQueryWithOrigin() {
+        Query query = QueryBuilder.create(ApiEntity.class).setQuery("origin:kubernetes").build();
+        BooleanQuery.Builder builder = new BooleanQuery.Builder();
+        assertEquals("", searcher.completeQueryWithFilters(query, builder));
+        assertEquals("#(origin:\"kubernetes\" origin:kubernetes)", builder.build().toString());
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/ApiDocumentTransformerTest.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.service.impl.search.lucene.transformer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.gravitee.definition.model.DefinitionContext;
 import io.gravitee.definition.model.Proxy;
 import io.gravitee.definition.model.VirtualHost;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
@@ -86,6 +87,9 @@ public class ApiDocumentTransformerTest {
         metadatas.put("metadata2", "value2");
         metadatas.put("metadata3", "value3");
         toTransform.setMetadata(metadatas);
+        DefinitionContext context = new DefinitionContext();
+        context.setOrigin(DefinitionContext.ORIGIN_KUBERNETES);
+        toTransform.setDefinitionContext(context);
         return toTransform;
     }
 
@@ -105,5 +109,6 @@ public class ApiDocumentTransformerTest {
         assertThat(toTransform.getCreatedAt().getTime()).isEqualTo(((LongPoint) transformed.getField("createdAt")).numericValue());
         assertThat(toTransform.getUpdatedAt().getTime()).isEqualTo(((LongPoint) transformed.getField("updatedAt")).numericValue());
         assertThat(toTransform.getMetadata().values()).hasSameSizeAs(transformed.getFields("metadata"));
+        assertThat(toTransform.getDefinitionContext().getOrigin()).isEqualTo(transformed.get("origin"));
     }
 }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8142

**Description**

- [x] Add kubernetes icon for apis created with the gko
- [x] Enable origin search


https://user-images.githubusercontent.com/25704259/187707287-3c642077-390c-4a15-81f5-131d6a17bfea.mov
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/issues-8142-api-list-origin-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-afqyiptazr.chromatic.com)
<!-- Storybook placeholder end -->
<!-- E2E Coverage placeholder -->
---
### 🧪 End-to-End Coverage

| INSTRUCTIONS | BRANCHES |
| :----------: | :------: |
|   37% | 22%   |

A more detailed report has been uploaded to [circleci](https://output.circle-artifacts.com/output/job/22a1f55e-7311-491b-a1ce-4659ae578878/artifacts/0/gravitee-apim-e2e/jacoco/reports/index.html)
<!-- E2E Coverage placeholder end -->
