### PR TITLE
feat(entrypoint): add a new http-get entrypoint

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ConnectorFeature.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ConnectorFeature.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.model.v4;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Map;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RequiredArgsConstructor
+@Getter
+@Schema(name = "ConnectorFeatureV4")
+public enum ConnectorFeature {
+    LIMIT("limit"),
+    RESUME("resume");
+
+    private static final Map<String, ConnectorFeature> LABELS_MAP = Map.of(LIMIT.label, LIMIT, RESUME.label, RESUME);
+
+    @JsonValue
+    private final String label;
+
+    public static ConnectorFeature fromLabel(final String label) {
+        if (label != null) {
+            return LABELS_MAP.get(label);
+        }
+        return null;
+    }
+}

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -143,6 +143,13 @@
         <!-- Entrypoints -->
         <dependency>
             <groupId>io.gravitee.apim.plugin.entrypoint</groupId>
+            <artifactId>gravitee-apim-plugin-entrypoint-http-get</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.apim.plugin.entrypoint</groupId>
             <artifactId>gravitee-apim-plugin-entrypoint-http-post</artifactId>
             <version>${project.version}</version>
             <scope>runtime</scope>

--- a/gravitee-apim-e2e/lib/management-webclient-sdk/src/lib/models/ConnectorPluginEntityV4.ts
+++ b/gravitee-apim-e2e/lib/management-webclient-sdk/src/lib/models/ConnectorPluginEntityV4.ts
@@ -20,6 +20,12 @@ import { exists, mapValues } from '../runtime';
 export interface ConnectorPluginEntityV4 {
     /**
      * 
+     * @type {Array<string>}
+     * @memberof ConnectorPluginEntityV4
+     */
+    availableFeatures?: Array<ConnectorPluginEntityV4AvailableFeaturesEnum>;
+    /**
+     * 
      * @type {string}
      * @memberof ConnectorPluginEntityV4
      */
@@ -66,6 +72,15 @@ export interface ConnectorPluginEntityV4 {
 /**
  * @export
  */
+export const ConnectorPluginEntityV4AvailableFeaturesEnum = {
+    LIMIT: 'LIMIT',
+    RESUME: 'RESUME'
+} as const;
+export type ConnectorPluginEntityV4AvailableFeaturesEnum = typeof ConnectorPluginEntityV4AvailableFeaturesEnum[keyof typeof ConnectorPluginEntityV4AvailableFeaturesEnum];
+
+/**
+ * @export
+ */
 export const ConnectorPluginEntityV4SupportedApiTypeEnum = {
     SYNC: 'SYNC',
     ASYNC: 'ASYNC'
@@ -102,6 +117,7 @@ export function ConnectorPluginEntityV4FromJSONTyped(json: any, ignoreDiscrimina
     }
     return {
         
+        'availableFeatures': !exists(json, 'availableFeatures') ? undefined : json['availableFeatures'],
         'category': !exists(json, 'category') ? undefined : json['category'],
         'description': !exists(json, 'description') ? undefined : json['description'],
         'id': !exists(json, 'id') ? undefined : json['id'],
@@ -121,6 +137,7 @@ export function ConnectorPluginEntityV4ToJSON(value?: ConnectorPluginEntityV4 | 
     }
     return {
         
+        'availableFeatures': value.availableFeatures,
         'category': value.category,
         'description': value.description,
         'id': value.id,

--- a/gravitee-apim-e2e/lib/management-webclient-sdk/src/lib/models/EntrypointExpandEntityV4.ts
+++ b/gravitee-apim-e2e/lib/management-webclient-sdk/src/lib/models/EntrypointExpandEntityV4.ts
@@ -20,6 +20,12 @@ import { exists, mapValues } from '../runtime';
 export interface EntrypointExpandEntityV4 {
     /**
      * 
+     * @type {Array<string>}
+     * @memberof EntrypointExpandEntityV4
+     */
+    availableFeatures?: Array<EntrypointExpandEntityV4AvailableFeaturesEnum>;
+    /**
+     * 
      * @type {string}
      * @memberof EntrypointExpandEntityV4
      */
@@ -78,6 +84,15 @@ export interface EntrypointExpandEntityV4 {
 /**
  * @export
  */
+export const EntrypointExpandEntityV4AvailableFeaturesEnum = {
+    LIMIT: 'LIMIT',
+    RESUME: 'RESUME'
+} as const;
+export type EntrypointExpandEntityV4AvailableFeaturesEnum = typeof EntrypointExpandEntityV4AvailableFeaturesEnum[keyof typeof EntrypointExpandEntityV4AvailableFeaturesEnum];
+
+/**
+ * @export
+ */
 export const EntrypointExpandEntityV4SupportedApiTypeEnum = {
     SYNC: 'SYNC',
     ASYNC: 'ASYNC'
@@ -114,6 +129,7 @@ export function EntrypointExpandEntityV4FromJSONTyped(json: any, ignoreDiscrimin
     }
     return {
         
+        'availableFeatures': !exists(json, 'availableFeatures') ? undefined : json['availableFeatures'],
         'category': !exists(json, 'category') ? undefined : json['category'],
         'description': !exists(json, 'description') ? undefined : json['description'],
         'icon': !exists(json, 'icon') ? undefined : json['icon'],
@@ -135,6 +151,7 @@ export function EntrypointExpandEntityV4ToJSON(value?: EntrypointExpandEntityV4 
     }
     return {
         
+        'availableFeatures': value.availableFeatures,
         'category': value.category,
         'description': value.description,
         'icon': value.icon,

--- a/gravitee-apim-plugin/gravitee-apim-plugin-coverage/pom.xml
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-coverage/pom.xml
@@ -45,6 +45,11 @@
         </dependency>
         <dependency>
             <groupId>io.gravitee.apim.plugin.entrypoint</groupId>
+            <artifactId>gravitee-apim-plugin-entrypoint-http-get</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.apim.plugin.entrypoint</groupId>
             <artifactId>gravitee-apim-plugin-entrypoint-http-post</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/resources/plugin.properties
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/resources/plugin.properties
@@ -4,3 +4,4 @@ version=${project.version}
 description=${project.description}
 class=io.gravitee.plugin.endpoint.kafka.KafkaEndpointConnectorFactory
 type=endpoint-connector
+features=limit,resume

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/resources/schemas/schema-form.json
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/resources/schemas/schema-form.json
@@ -22,7 +22,7 @@
           "title": "enabled",
           "description": "Allow to enable or disable the consumer capability.",
           "type": "boolean",
-          "default": "true"
+          "default": true
         },
         "autoOffsetReset": {
           "title": "auto.offset.reset",

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mock/src/main/java/io/gravitee/plugin/endpoint/mock/configuration/MockEndpointConnectorConfiguration.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mock/src/main/java/io/gravitee/plugin/endpoint/mock/configuration/MockEndpointConnectorConfiguration.java
@@ -29,7 +29,7 @@ public class MockEndpointConnectorConfiguration implements EndpointConnectorConf
     /**
      * Interval between mock messages publication, in milliseconds.
      */
-    private Long messageInterval = 1000L;
+    private Long messageInterval = 1_000L;
 
     /**
      * Content of mocked messages.
@@ -40,5 +40,5 @@ public class MockEndpointConnectorConfiguration implements EndpointConnectorConf
      * Count of published messages.
      * If null, there is no limit.
      */
-    private Long messageCount;
+    private Integer messageCount;
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mock/src/main/resources/plugin.properties
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mock/src/main/resources/plugin.properties
@@ -4,3 +4,4 @@ version=${project.version}
 description=${project.description}
 class=io.gravitee.plugin.endpoint.mock.MockEndpointConnectorFactory
 type=endpoint-connector
+features=limit,resume

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-get/pom.xml
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-get/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.gravitee.apim.plugin.entrypoint</groupId>
+        <artifactId>gravitee-apim-plugin-entrypoint</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+    </parent>
+
+    <artifactId>gravitee-apim-plugin-entrypoint-http-get</artifactId>
+    <name>Gravitee.io APIM - Plugin - Entrypoint HTTP Get</name>
+    <description>Entrypoint that allows exposing AsyncAPI using HTTP Get</description>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Import bom to properly inherit all dependencies -->
+            <dependency>
+                <groupId>io.gravitee</groupId>
+                <artifactId>gravitee-bom</artifactId>
+                <version>${gravitee-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- Gravitee dependencies -->
+        <dependency>
+            <groupId>io.gravitee.gateway</groupId>
+            <artifactId>gravitee-gateway-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.common</groupId>
+            <artifactId>gravitee-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <!-- Tests -->
+        <dependency>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-buffer</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-core</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-get/src/main/assembly/plugin-assembly.xml
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-get/src/main/assembly/plugin-assembly.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" ?>
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly>
+	<id>plugin</id>
+	<formats>
+		<format>zip</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+
+	<!-- Include the main plugin Jar file -->
+	<files>
+		<file>
+			<source>${project.build.directory}/${project.build.finalName}.jar</source>
+		</file>
+	</files>
+
+	<!-- Include plugin schema configuration -->
+	<fileSets>
+		<fileSet>
+			<directory>src/main/resources/schemas</directory>
+			<outputDirectory>schemas</outputDirectory>
+		</fileSet>
+	</fileSets>
+
+	<!-- Finally include plugin dependencies -->
+	<dependencySets>
+		<dependencySet>
+			<outputDirectory>lib</outputDirectory>
+			<useProjectArtifact>false</useProjectArtifact>
+		</dependencySet>
+	</dependencySets>
+</assembly>

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-get/src/main/java/io/gravitee/plugin/entrypoint/http/get/HttpGetEntrypointConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-get/src/main/java/io/gravitee/plugin/entrypoint/http/get/HttpGetEntrypointConnector.java
@@ -1,0 +1,330 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.entrypoint.http.get;
+
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.jupiter.api.ConnectorMode;
+import io.gravitee.gateway.jupiter.api.ExecutionFailure;
+import io.gravitee.gateway.jupiter.api.ListenerType;
+import io.gravitee.gateway.jupiter.api.connector.entrypoint.async.EntrypointAsyncConnector;
+import io.gravitee.gateway.jupiter.api.context.ExecutionContext;
+import io.gravitee.gateway.jupiter.api.context.InternalContextAttributes;
+import io.gravitee.gateway.jupiter.api.message.Message;
+import io.gravitee.plugin.entrypoint.http.get.configuration.HttpGetEntrypointConnectorConfiguration;
+import io.reactivex.Completable;
+import io.reactivex.Flowable;
+import io.vertx.core.json.JsonObject;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@AllArgsConstructor
+@Slf4j
+public class HttpGetEntrypointConnector implements EntrypointAsyncConnector {
+
+    /**
+     * Internal attribute used to store the id of the last message sent to a client. Restricted for this entrypoint.
+     */
+    static final String ATTR_INTERNAL_LAST_MESSAGE_ID = "last.message.id";
+    /**
+     * Internal attribute used to store the content type of the response.
+     */
+    static final String ATTR_INTERNAL_RESPONSE_CONTENT_TYPE = "response.content-type";
+    static final String CURSOR_QUERY_PARAM = "cursor";
+    static final String LIMIT_QUERY_PARAM = "limit";
+
+    static final Set<ConnectorMode> SUPPORTED_MODES = Set.of(ConnectorMode.SUBSCRIBE);
+
+    protected final HttpGetEntrypointConnectorConfiguration configuration;
+
+    @Override
+    public ListenerType supportedListenerType() {
+        return ListenerType.HTTP;
+    }
+
+    @Override
+    public Set<ConnectorMode> supportedModes() {
+        return SUPPORTED_MODES;
+    }
+
+    @Override
+    public int matchCriteriaCount() {
+        return 1;
+    }
+
+    @Override
+    public boolean matches(final ExecutionContext ctx) {
+        return (HttpMethod.GET == ctx.request().method());
+    }
+
+    @Override
+    public Completable handleRequest(final ExecutionContext ctx) {
+        return Completable.defer(
+            () -> {
+                String acceptHeader = ctx.request().headers().get(HttpHeaderNames.ACCEPT);
+                final String contentType = (acceptHeader == null || acceptHeader.isEmpty() || acceptHeader.equals(MediaType.WILDCARD))
+                    ? MediaType.TEXT_PLAIN
+                    : acceptHeader;
+                if (
+                    !contentType.equals(MediaType.APPLICATION_JSON) &&
+                    !contentType.equals(MediaType.APPLICATION_XML) &&
+                    !contentType.equals(MediaType.TEXT_PLAIN)
+                ) {
+                    return ctx.interruptWith(
+                        new ExecutionFailure(HttpStatusCode.BAD_REQUEST_400).message("Unsupported accept header: " + acceptHeader)
+                    );
+                }
+                ctx.putInternalAttribute(ATTR_INTERNAL_RESPONSE_CONTENT_TYPE, contentType);
+
+                ctx.putInternalAttribute(
+                    InternalContextAttributes.ATTR_INTERNAL_MESSAGES_LIMIT_DURATION_MS,
+                    configuration.getMessagesLimitDurationMs()
+                );
+
+                int messagesLimitCount = configuration.getMessagesLimitCount();
+                if (ctx.request().parameters().containsKey(LIMIT_QUERY_PARAM)) {
+                    String limit = ctx.request().parameters().getFirst(LIMIT_QUERY_PARAM);
+                    if (limit != null && !limit.isEmpty()) {
+                        messagesLimitCount = Math.min(messagesLimitCount, Integer.parseInt(limit));
+                    }
+                }
+                ctx.putInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_MESSAGES_LIMIT_COUNT, messagesLimitCount);
+
+                if (ctx.request().parameters().containsKey(CURSOR_QUERY_PARAM)) {
+                    String cursor = ctx.request().parameters().getFirst(CURSOR_QUERY_PARAM);
+                    if (cursor != null && !cursor.isEmpty()) {
+                        ctx.putInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_MESSAGES_RESUME_LASTID, cursor);
+                    }
+                }
+
+                return Completable.complete();
+            }
+        );
+    }
+
+    @Override
+    public Completable handleResponse(final ExecutionContext ctx) {
+        return Completable.fromRunnable(
+            () -> {
+                String contentType = ctx.getInternalAttribute(ATTR_INTERNAL_RESPONSE_CONTENT_TYPE);
+                ctx.response().headers().add(HttpHeaderNames.CONTENT_TYPE, contentType);
+                ctx.response().chunks(messagesToBuffer(ctx, contentType));
+            }
+        );
+    }
+
+    private Flowable<Buffer> messagesToBuffer(ExecutionContext ctx, final String contentType) {
+        final AtomicBoolean first = new AtomicBoolean(true);
+        Long messagesLimitDurationMs = ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_MESSAGES_LIMIT_DURATION_MS);
+        Integer messagesLimitCount = ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_MESSAGES_LIMIT_COUNT);
+
+        Flowable<Message> limitedMessageFlowable = ctx.response().messages();
+
+        if (messagesLimitCount != null) {
+            limitedMessageFlowable = limitedMessageFlowable.take(messagesLimitCount);
+        }
+
+        if (messagesLimitDurationMs != null && messagesLimitDurationMs > 0) {
+            long start = ctx.request().timestamp();
+            limitedMessageFlowable =
+                limitedMessageFlowable.takeUntil(message -> (System.currentTimeMillis()) > start + messagesLimitDurationMs);
+        }
+
+        if (contentType.equals(MediaType.APPLICATION_JSON)) {
+            return Flowable
+                .just(Buffer.buffer("{\"items\":["))
+                .concatWith(
+                    limitedMessageFlowable.map(
+                        message -> {
+                            ctx.putInternalAttribute(ATTR_INTERNAL_LAST_MESSAGE_ID, message.id());
+                            return toJsonBuffer(message, first.getAndSet(false));
+                        }
+                    )
+                )
+                .concatWith(Flowable.just(Buffer.buffer("]")))
+                .concatWith(computePagination(ctx, contentType))
+                .concatWith(Flowable.just(Buffer.buffer("}")));
+        } else if (contentType.equals(MediaType.APPLICATION_XML)) {
+            return Flowable
+                .just(Buffer.buffer("<response><items>"))
+                .concatWith(
+                    limitedMessageFlowable.map(
+                        message -> {
+                            ctx.putInternalAttribute(ATTR_INTERNAL_LAST_MESSAGE_ID, message.id());
+                            return this.toXmlBuffer(message);
+                        }
+                    )
+                )
+                .concatWith(Flowable.just(Buffer.buffer("</items>")))
+                .concatWith(computePagination(ctx, contentType))
+                .concatWith(Flowable.just(Buffer.buffer("</response>")));
+        } else {
+            return Flowable
+                .just(Buffer.buffer("items="))
+                .concatWith(
+                    limitedMessageFlowable.map(
+                        message -> {
+                            ctx.putInternalAttribute(ATTR_INTERNAL_LAST_MESSAGE_ID, message.id());
+                            return toPlainTextBuffer(message, first.getAndSet(false));
+                        }
+                    )
+                )
+                .concatWith(computePagination(ctx, contentType));
+        }
+    }
+
+    private Buffer toJsonBuffer(Message message, boolean isFirstElement) {
+        JsonObject jsonMessage = new JsonObject();
+
+        if (configuration.isHeadersInPayload()) {
+            JsonObject headers = JsonObject.mapFrom(message.headers());
+            jsonMessage.put("headers", headers);
+        }
+        jsonMessage.put("id", message.id());
+        jsonMessage.put("content", message.content().toString());
+
+        if (configuration.isMetadataInPayload()) {
+            JsonObject metadata = JsonObject.mapFrom(message.metadata());
+            jsonMessage.put("metadata", metadata);
+        }
+
+        String messageString = (!isFirstElement ? "," : "") + jsonMessage.encode();
+        return Buffer.buffer(messageString);
+    }
+
+    private Buffer toXmlBuffer(Message message) {
+        StringBuilder messageBuilder = new StringBuilder();
+        messageBuilder.append("<item>");
+
+        if (configuration.isHeadersInPayload()) {
+            messageBuilder.append("<headers>");
+            message
+                .headers()
+                .toListValuesMap()
+                .forEach(
+                    (header, values) ->
+                        messageBuilder
+                            .append("<")
+                            .append(header)
+                            .append(">")
+                            .append(String.join(",", values))
+                            .append("</")
+                            .append(header)
+                            .append(">")
+                );
+            messageBuilder.append("</headers>");
+        }
+
+        messageBuilder.append("<id>").append(message.id()).append("</id>");
+        messageBuilder.append("<content><![CDATA[").append(message.content().toString()).append("]]></content>");
+
+        if (configuration.isMetadataInPayload()) {
+            messageBuilder.append("<metadata>");
+            message
+                .metadata()
+                .forEach(
+                    (key, value) -> messageBuilder.append("<").append(key).append(">").append(value).append("</").append(key).append(">")
+                );
+            messageBuilder.append("</metadata>");
+        }
+
+        messageBuilder.append("</item>");
+        return Buffer.buffer(messageBuilder.toString());
+    }
+
+    private Buffer toPlainTextBuffer(Message message, boolean isFirstElement) {
+        StringBuilder messageBuilder = new StringBuilder();
+        if (!isFirstElement) {
+            messageBuilder.append(", ");
+        }
+        messageBuilder.append("(");
+        if (configuration.isHeadersInPayload()) {
+            messageBuilder.append(message.headers().toListValuesMap());
+            messageBuilder.append(", ");
+        }
+        messageBuilder.append("id=");
+        messageBuilder.append(message.id());
+        messageBuilder.append(", content=");
+        messageBuilder.append(message.content());
+
+        if (configuration.isMetadataInPayload()) {
+            messageBuilder.append(", ");
+            messageBuilder.append(message.metadata());
+        }
+
+        messageBuilder.append(")");
+        return Buffer.buffer(messageBuilder.toString());
+    }
+
+    private Flowable<Buffer> computePagination(ExecutionContext ctx, String contentType) {
+        return Flowable.defer(
+            () -> {
+                String limit = ctx.request().parameters().getFirst(LIMIT_QUERY_PARAM);
+                String currentCursor = ctx.request().parameters().getFirst(CURSOR_QUERY_PARAM);
+                String nextCursor = ctx.getInternalAttribute(ATTR_INTERNAL_LAST_MESSAGE_ID);
+
+                if (contentType.equals(MediaType.APPLICATION_JSON)) {
+                    List<String> paginationString = new ArrayList<>();
+                    if (currentCursor != null && !currentCursor.isEmpty()) {
+                        paginationString.add("\"cursor\":\"" + currentCursor + "\"");
+                    }
+                    if (nextCursor != null && !nextCursor.isEmpty()) {
+                        paginationString.add("\"nextCursor\":\"" + nextCursor + "\"");
+                    }
+                    if (limit != null && !limit.isEmpty()) {
+                        paginationString.add("\"limit\":\"" + limit + "\"");
+                    }
+                    return Flowable.just(Buffer.buffer(",\"pagination\":{" + String.join(",", paginationString) + "}"));
+                } else if (contentType.equals(MediaType.APPLICATION_XML)) {
+                    StringBuilder paginationString = new StringBuilder();
+                    if (currentCursor != null && !currentCursor.isEmpty()) {
+                        paginationString.append("<cursor>" + currentCursor + "</cursor>");
+                    }
+                    if (nextCursor != null && !nextCursor.isEmpty()) {
+                        paginationString.append("<nextCursor>" + nextCursor + "</nextCursor>");
+                    }
+                    if (limit != null && !limit.isEmpty()) {
+                        paginationString.append("<limit>" + limit + "</limit>");
+                    }
+                    return Flowable.just(Buffer.buffer("<pagination>" + String.join("", paginationString) + "</pagination>"));
+                } else {
+                    List<String> paginationString = new ArrayList<>();
+                    if (currentCursor != null && !currentCursor.isEmpty()) {
+                        paginationString.add("cursor=" + currentCursor);
+                    }
+                    if (nextCursor != null && !nextCursor.isEmpty()) {
+                        paginationString.add("nextCursor=" + nextCursor);
+                    }
+                    if (limit != null && !limit.isEmpty()) {
+                        paginationString.add("limit=" + limit);
+                    }
+                    return Flowable.just(Buffer.buffer("\npagination=(" + String.join(", ", paginationString) + ")"));
+                }
+            }
+        );
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-get/src/main/java/io/gravitee/plugin/entrypoint/http/get/HttpGetEntrypointConnectorFactory.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-get/src/main/java/io/gravitee/plugin/entrypoint/http/get/HttpGetEntrypointConnectorFactory.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.entrypoint.http.get;
+
+import io.gravitee.gateway.jupiter.api.ConnectorMode;
+import io.gravitee.gateway.jupiter.api.connector.ConnectorFactoryHelper;
+import io.gravitee.gateway.jupiter.api.connector.entrypoint.async.EntrypointAsyncConnectorFactory;
+import io.gravitee.gateway.jupiter.api.exception.PluginConfigurationException;
+import io.gravitee.plugin.entrypoint.http.get.configuration.HttpGetEntrypointConnectorConfiguration;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Slf4j
+@AllArgsConstructor
+public class HttpGetEntrypointConnectorFactory implements EntrypointAsyncConnectorFactory {
+
+    private ConnectorFactoryHelper connectorFactoryHelper;
+
+    @Override
+    public Set<ConnectorMode> supportedModes() {
+        return HttpGetEntrypointConnector.SUPPORTED_MODES;
+    }
+
+    @Override
+    public HttpGetEntrypointConnector createConnector(final String configuration) {
+        try {
+            return new HttpGetEntrypointConnector(
+                connectorFactoryHelper.getConnectorConfiguration(HttpGetEntrypointConnectorConfiguration.class, configuration)
+            );
+        } catch (PluginConfigurationException e) {
+            log.error("Can't create connector cause no valid configuration", e);
+            return null;
+        }
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-get/src/main/java/io/gravitee/plugin/entrypoint/http/get/configuration/HttpGetEntrypointConnectorConfiguration.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-get/src/main/java/io/gravitee/plugin/entrypoint/http/get/configuration/HttpGetEntrypointConnectorConfiguration.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.entrypoint.http.get.configuration;
+
+import io.gravitee.gateway.jupiter.api.connector.entrypoint.EntrypointConnectorConfiguration;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@NoArgsConstructor
+@Getter
+public class HttpGetEntrypointConnectorConfiguration implements EntrypointConnectorConfiguration {
+
+    /**
+     * Maximum number of messages to retrieve. <br/>
+     * Default is 500.
+     */
+    private int messagesLimitCount = 500;
+
+    /**
+     * Maximum duration in milliseconds to wait to retrieve messages. <br/>
+     * Default is 30_000.
+     */
+    private long messagesLimitDurationMs = 30_000;
+
+    /**
+     * Allow sending messages headers to client in payload. Each header will be sent as extra field in payload. <br/>
+     * For JSON and XML, in a dedicated headers object. For plain text, following 'key=value' format. <br/>
+     * Default is false.
+     */
+    private boolean headersInPayload = false;
+
+    /**
+     * Allow sending messages metadata to client in payload. Each metadata will be sent as extra field in payload. <br/>
+     * For JSON and XML, in a dedicated metadata object. For plain text, following 'key=value' format. <br/>
+     * Default is false.
+     */
+    private boolean metadataInPayload = false;
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-get/src/main/resources/plugin.properties
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-get/src/main/resources/plugin.properties
@@ -1,0 +1,7 @@
+id=http-get
+name=Entrypoint HTTP Get
+version=${project.version}
+description=${project.description}
+class=io.gravitee.plugin.entrypoint.http.get.HttpGetEntrypointConnectorFactory
+type=entrypoint-connector
+features=limit,resume

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-get/src/main/resources/schemas/schema-form.json
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-get/src/main/resources/schemas/schema-form.json
@@ -1,0 +1,31 @@
+{
+  "type": "object",
+  "id": "urn:jsonschema:io:gravitee:plugin:entrypoint:http:get:configuration:HttpGetEntrypointConnectorConfiguration",
+  "properties": {
+    "messagesLimitCount": {
+      "type": "integer",
+      "title": "Limit messages count",
+      "description": "Maximum number of messages to retrieve. Default is 500.",
+      "default": 500
+    },
+    "messagesLimitDurationMs": {
+      "type": "number",
+      "title": "Limit messages duration (in ms)",
+      "description": "Maximum duration in milliseconds to wait to retrieve messages. Default is 30000.",
+      "default": 30000
+    },
+    "headersInPayload": {
+      "type": "boolean",
+      "default": "false",
+      "title": "Allow sending messages headers to client in payload.",
+      "description": "Allow sending messages headers to client in payload. Each header will be sent as extra field in payload. For JSON and XML, in a dedicated headers object. For plain text, following 'key=value' format. Default is false."
+    },
+    "metadataInPayload": {
+      "type": "boolean",
+      "default": "false",
+      "title": "Allow sending messages metadata to client in payload.",
+      "description": "Allow sending messages metadata to client in payload. Each metadata will be sent as extra field in the payload. For JSON and XML, in a dedicated metadata object. For plain text, following 'key=value' format. Default is false."
+    }
+  },
+  "additionalProperties": false
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-get/src/test/java/io/gravitee/plugin/entrypoint/http/get/HttpGetEntrypointConnectorFactoryTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-get/src/test/java/io/gravitee/plugin/entrypoint/http/get/HttpGetEntrypointConnectorFactoryTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.entrypoint.http.get;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.gateway.jupiter.api.ConnectorMode;
+import io.gravitee.gateway.jupiter.api.connector.ConnectorFactoryHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class HttpGetEntrypointConnectorFactoryTest {
+
+    private HttpGetEntrypointConnectorFactory httpGetEntrypointConnectorFactory;
+
+    @BeforeEach
+    void beforeEach() {
+        httpGetEntrypointConnectorFactory = new HttpGetEntrypointConnectorFactory(new ConnectorFactoryHelper(null, new ObjectMapper()));
+    }
+
+    @Test
+    void shouldSupportSubscribeMode() {
+        assertThat(httpGetEntrypointConnectorFactory.supportedModes()).contains(ConnectorMode.SUBSCRIBE);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "wrong", "", "  " })
+    void shouldCreateConnectorWithWrongConfiguration(String configuration) {
+        HttpGetEntrypointConnector connector = httpGetEntrypointConnectorFactory.createConnector(configuration);
+        assertThat(connector).isNull();
+    }
+
+    @Test
+    void shouldCreateConnectorWithNullConfiguration() {
+        HttpGetEntrypointConnector connector = httpGetEntrypointConnectorFactory.createConnector(null);
+        assertThat(connector).isNotNull();
+        assertThat(connector.configuration).isNotNull();
+        assertThat(connector.configuration.getMessagesLimitCount()).isEqualTo(500);
+        assertThat(connector.configuration.getMessagesLimitDurationMs()).isEqualTo(30_000);
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-get/src/test/java/io/gravitee/plugin/entrypoint/http/get/HttpGetEntrypointConnectorTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-get/src/test/java/io/gravitee/plugin/entrypoint/http/get/HttpGetEntrypointConnectorTest.java
@@ -1,0 +1,439 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.entrypoint.http.get;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.common.util.LinkedMultiValueMap;
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.jupiter.api.ExecutionFailure;
+import io.gravitee.gateway.jupiter.api.ListenerType;
+import io.gravitee.gateway.jupiter.api.context.ExecutionContext;
+import io.gravitee.gateway.jupiter.api.context.InternalContextAttributes;
+import io.gravitee.gateway.jupiter.api.context.Request;
+import io.gravitee.gateway.jupiter.api.context.Response;
+import io.gravitee.gateway.jupiter.api.message.DefaultMessage;
+import io.gravitee.gateway.jupiter.api.message.Message;
+import io.gravitee.gateway.jupiter.core.context.interruption.InterruptionFailureException;
+import io.gravitee.plugin.entrypoint.http.get.configuration.HttpGetEntrypointConnectorConfiguration;
+import io.reactivex.Completable;
+import io.reactivex.Flowable;
+import io.reactivex.subscribers.TestSubscriber;
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class HttpGetEntrypointConnectorTest {
+
+    @Mock
+    private ExecutionContext mockExecutionContext;
+
+    @Mock
+    private Request mockRequest;
+
+    @Mock
+    private Response mockResponse;
+
+    @Mock
+    private HttpGetEntrypointConnectorConfiguration configuration = new HttpGetEntrypointConnectorConfiguration();
+
+    @Captor
+    private ArgumentCaptor<Flowable<Buffer>> chunksCaptor;
+
+    private HttpGetEntrypointConnector httpGetEntrypointConnector;
+
+    @BeforeEach
+    void beforeEach() {
+        httpGetEntrypointConnector = new HttpGetEntrypointConnector(configuration);
+        lenient().when(configuration.isHeadersInPayload()).thenReturn(true);
+        lenient().when(configuration.isMetadataInPayload()).thenReturn(true);
+    }
+
+    @Test
+    void shouldSupportHttpListener() {
+        assertThat(httpGetEntrypointConnector.supportedListenerType()).isEqualTo(ListenerType.HTTP);
+    }
+
+    @Test
+    void shouldMatchesCriteriaReturnValidCount() {
+        assertThat(httpGetEntrypointConnector.matchCriteriaCount()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldMatchesWithValidContext() {
+        when(mockRequest.method()).thenReturn(HttpMethod.GET);
+        when(mockExecutionContext.request()).thenReturn(mockRequest);
+
+        boolean matches = httpGetEntrypointConnector.matches(mockExecutionContext);
+
+        assertThat(matches).isTrue();
+    }
+
+    @Test
+    void shouldNotMatchesWithBadMethod() {
+        when(mockRequest.method()).thenReturn(HttpMethod.POST);
+        when(mockExecutionContext.request()).thenReturn(mockRequest);
+
+        boolean matches = httpGetEntrypointConnector.matches(mockExecutionContext);
+
+        assertThat(matches).isFalse();
+    }
+
+    @Test
+    void shouldInterruptWithFailureBadAcceptHeader() {
+        final HttpHeaders requestHttpHeaders = HttpHeaders.create();
+        requestHttpHeaders.add(HttpHeaderNames.ACCEPT, MediaType.APPLICATION_GRPC);
+        when(mockRequest.headers()).thenReturn(requestHttpHeaders);
+
+        when(mockExecutionContext.request()).thenReturn(mockRequest);
+
+        when(mockExecutionContext.interruptWith(any(ExecutionFailure.class)))
+            .thenAnswer(i -> Completable.error(new InterruptionFailureException(i.getArgument(0))));
+
+        httpGetEntrypointConnector
+            .handleRequest(mockExecutionContext)
+            .test()
+            .assertError(
+                e -> {
+                    assertTrue(e instanceof InterruptionFailureException);
+                    assertEquals(HttpStatusCode.BAD_REQUEST_400, ((InterruptionFailureException) e).getExecutionFailure().statusCode());
+                    assertEquals(
+                        "Unsupported accept header: " + MediaType.APPLICATION_GRPC,
+                        ((InterruptionFailureException) e).getExecutionFailure().message()
+                    );
+                    return true;
+                }
+            );
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "0,2", "1,2", "6,2" })
+    void shouldSetupInternalAttributeWithConfigurationValuesOnRequest(String limitQueryParam, int messagesLimitCount) {
+        final HttpHeaders requestHttpHeaders = HttpHeaders.create();
+        requestHttpHeaders.add(HttpHeaderNames.ACCEPT, MediaType.WILDCARD);
+        when(mockRequest.headers()).thenReturn(requestHttpHeaders);
+
+        LinkedMultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        queryParams.add(HttpGetEntrypointConnector.CURSOR_QUERY_PARAM, "1234");
+        queryParams.add(HttpGetEntrypointConnector.LIMIT_QUERY_PARAM, limitQueryParam);
+        when(mockRequest.parameters()).thenReturn(queryParams);
+        when(mockExecutionContext.request()).thenReturn(mockRequest);
+        when(configuration.getMessagesLimitCount()).thenReturn(messagesLimitCount);
+        when(configuration.getMessagesLimitDurationMs()).thenReturn(1_000L);
+        httpGetEntrypointConnector.handleRequest(mockExecutionContext).test().assertComplete();
+
+        verify(mockExecutionContext)
+            .putInternalAttribute(
+                InternalContextAttributes.ATTR_INTERNAL_MESSAGES_LIMIT_COUNT,
+                Math.min(messagesLimitCount, Integer.parseInt(limitQueryParam))
+            );
+        verify(mockExecutionContext).putInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_MESSAGES_LIMIT_DURATION_MS, 1_000L);
+        verify(mockExecutionContext).putInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_MESSAGES_RESUME_LASTID, "1234");
+        verify(mockExecutionContext)
+            .putInternalAttribute(HttpGetEntrypointConnector.ATTR_INTERNAL_RESPONSE_CONTENT_TYPE, MediaType.TEXT_PLAIN);
+    }
+
+    @Test
+    void shouldCompleteAndEndWhenResponseMessagesComplete() {
+        when(mockExecutionContext.getInternalAttribute(HttpGetEntrypointConnector.ATTR_INTERNAL_RESPONSE_CONTENT_TYPE))
+            .thenReturn(MediaType.APPLICATION_JSON);
+
+        LinkedMultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        when(mockRequest.parameters()).thenReturn(queryParams);
+        when(mockExecutionContext.request()).thenReturn(mockRequest);
+
+        final HttpHeaders httpHeaders = HttpHeaders.create();
+        when(mockResponse.headers()).thenReturn(httpHeaders);
+        Flowable<Message> empty = Flowable.empty();
+        when(mockResponse.messages()).thenReturn(empty);
+        when(mockExecutionContext.response()).thenReturn(mockResponse);
+
+        httpGetEntrypointConnector.handleResponse(mockExecutionContext).test().assertComplete();
+
+        assertThat(httpHeaders).isNotNull();
+        assertThat(httpHeaders.get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo(MediaType.APPLICATION_JSON);
+        verify(mockResponse).chunks(chunksCaptor.capture());
+
+        final TestSubscriber<Buffer> chunkObs = chunksCaptor.getValue().test();
+
+        chunkObs
+            .assertComplete()
+            .assertValueCount(4)
+            .assertValueAt(0, message -> message.toString().equals("{\"items\":["))
+            .assertValueAt(1, message -> message.toString().equals("]"))
+            .assertValueAt(2, message -> message.toString().equals(",\"pagination\":{}"))
+            .assertValueAt(3, message -> message.toString().equals("}"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void shouldJsonArrayOfMessageAndCompleteAndEndWhenResponseMessagesComplete(boolean withHeadersAndMetadata) throws InterruptedException {
+        when(mockExecutionContext.getInternalAttribute(HttpGetEntrypointConnector.ATTR_INTERNAL_RESPONSE_CONTENT_TYPE))
+            .thenReturn(MediaType.APPLICATION_JSON);
+        when(mockExecutionContext.getInternalAttribute(HttpGetEntrypointConnector.ATTR_INTERNAL_LAST_MESSAGE_ID)).thenReturn("2");
+        when(mockExecutionContext.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_MESSAGES_LIMIT_DURATION_MS))
+            .thenReturn(30_000L);
+        when(mockExecutionContext.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_MESSAGES_LIMIT_COUNT)).thenReturn(2);
+
+        LinkedMultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        queryParams.add(HttpGetEntrypointConnector.CURSOR_QUERY_PARAM, "0");
+        queryParams.add(HttpGetEntrypointConnector.LIMIT_QUERY_PARAM, "2");
+        when(mockRequest.parameters()).thenReturn(queryParams);
+        when(mockRequest.timestamp()).thenReturn(Instant.now().toEpochMilli());
+        when(mockExecutionContext.request()).thenReturn(mockRequest);
+
+        final HttpHeaders httpHeaders = HttpHeaders.create();
+        when(mockResponse.headers()).thenReturn(httpHeaders);
+        Flowable<Message> messages = Flowable.just(
+            createMessage("1", MediaType.APPLICATION_JSON),
+            createMessage("2", null),
+            createMessage("Non returned messaged due to count limit", null)
+        );
+        when(mockResponse.messages()).thenReturn(messages);
+        when(mockExecutionContext.response()).thenReturn(mockResponse);
+
+        when(configuration.isHeadersInPayload()).thenReturn(withHeadersAndMetadata);
+        when(configuration.isMetadataInPayload()).thenReturn(withHeadersAndMetadata);
+
+        httpGetEntrypointConnector.handleResponse(mockExecutionContext).test().assertComplete();
+
+        assertThat(httpHeaders).isNotNull();
+        assertThat(httpHeaders.get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo(MediaType.APPLICATION_JSON);
+        verify(mockResponse).chunks(chunksCaptor.capture());
+
+        final TestSubscriber<Buffer> chunkObs = chunksCaptor.getValue().test();
+
+        chunkObs
+            .await()
+            .assertComplete()
+            .assertValueCount(6)
+            .assertValueAt(0, message -> message.toString().equals("{\"items\":["))
+            .assertValueAt(
+                1,
+                message ->
+                    withHeadersAndMetadata
+                        ? message
+                            .toString()
+                            .equals(
+                                "{\"headers\":{\"X-My-Header-1\":[\"headerValue1\"]},\"id\":\"1\",\"content\":\"{\\\"foo\\\": \\\"1\\\"}\",\"metadata\":{\"myKey\":\"myValue1\"}}"
+                            )
+                        : message.toString().equals("{\"id\":\"1\",\"content\":\"{\\\"foo\\\": \\\"1\\\"}\"}")
+            )
+            .assertValueAt(
+                2,
+                message ->
+                    withHeadersAndMetadata
+                        ? message
+                            .toString()
+                            .equals(
+                                ",{\"headers\":{\"X-My-Header-2\":[\"headerValue2\"]},\"id\":\"2\",\"content\":\"2\",\"metadata\":{\"myKey\":\"myValue2\"}}"
+                            )
+                        : message.toString().equals(",{\"id\":\"2\",\"content\":\"2\"}")
+            )
+            .assertValueAt(3, message -> message.toString().equals("]"))
+            .assertValueAt(
+                4,
+                message -> message.toString().equals(",\"pagination\":{\"cursor\":\"0\",\"nextCursor\":\"2\",\"limit\":\"2\"}")
+            )
+            .assertValueAt(5, message -> message.toString().equals("}"));
+
+        verify(mockExecutionContext).putInternalAttribute(HttpGetEntrypointConnector.ATTR_INTERNAL_LAST_MESSAGE_ID, "2");
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void shouldXmlArrayOfMessageAndCompleteAndEndWhenResponseMessagesComplete(boolean withHeadersAndMetadata) throws InterruptedException {
+        when(mockExecutionContext.getInternalAttribute(HttpGetEntrypointConnector.ATTR_INTERNAL_RESPONSE_CONTENT_TYPE))
+            .thenReturn(MediaType.APPLICATION_XML);
+        when(mockExecutionContext.getInternalAttribute(HttpGetEntrypointConnector.ATTR_INTERNAL_LAST_MESSAGE_ID)).thenReturn("2");
+        when(mockExecutionContext.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_MESSAGES_LIMIT_DURATION_MS))
+            .thenReturn(30_000L);
+        when(mockExecutionContext.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_MESSAGES_LIMIT_COUNT)).thenReturn(2);
+
+        LinkedMultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        queryParams.add(HttpGetEntrypointConnector.CURSOR_QUERY_PARAM, "0");
+        queryParams.add(HttpGetEntrypointConnector.LIMIT_QUERY_PARAM, "2");
+        when(mockRequest.parameters()).thenReturn(queryParams);
+        when(mockRequest.timestamp()).thenReturn(Instant.now().toEpochMilli());
+        when(mockExecutionContext.request()).thenReturn(mockRequest);
+
+        final HttpHeaders responseHttpHeaders = HttpHeaders.create();
+        when(mockResponse.headers()).thenReturn(responseHttpHeaders);
+        Flowable<Message> messages = Flowable.just(
+            createMessage("1", MediaType.APPLICATION_XML),
+            createMessage("2", null),
+            createMessage("Non returned messaged due to count limit", null)
+        );
+        when(mockResponse.messages()).thenReturn(messages);
+        when(mockExecutionContext.response()).thenReturn(mockResponse);
+
+        when(configuration.isHeadersInPayload()).thenReturn(withHeadersAndMetadata);
+        when(configuration.isMetadataInPayload()).thenReturn(withHeadersAndMetadata);
+
+        httpGetEntrypointConnector.handleResponse(mockExecutionContext).test().assertComplete();
+
+        assertThat(responseHttpHeaders).isNotNull();
+        assertThat(responseHttpHeaders.get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo(MediaType.APPLICATION_XML);
+        verify(mockResponse).chunks(chunksCaptor.capture());
+
+        final TestSubscriber<Buffer> chunkObs = chunksCaptor.getValue().test();
+
+        chunkObs
+            .await()
+            .assertComplete()
+            .assertValueCount(6)
+            .assertValueAt(0, message -> message.toString().equals("<response><items>"))
+            .assertValueAt(
+                1,
+                message ->
+                    withHeadersAndMetadata
+                        ? message
+                            .toString()
+                            .equals(
+                                "<item><headers><X-My-Header-1>headerValue1</X-My-Header-1></headers><id>1</id><content><![CDATA[<foo>1</foo>]]></content><metadata><myKey>myValue1</myKey></metadata></item>"
+                            )
+                        : message.toString().equals("<item><id>1</id><content><![CDATA[<foo>1</foo>]]></content></item>")
+            )
+            .assertValueAt(
+                2,
+                message ->
+                    withHeadersAndMetadata
+                        ? message
+                            .toString()
+                            .equals(
+                                "<item><headers><X-My-Header-2>headerValue2</X-My-Header-2></headers><id>2</id><content><![CDATA[2]]></content><metadata><myKey>myValue2</myKey></metadata></item>"
+                            )
+                        : message.toString().equals("<item><id>2</id><content><![CDATA[2]]></content></item>")
+            )
+            .assertValueAt(3, message -> message.toString().equals("</items>"))
+            .assertValueAt(
+                4,
+                message ->
+                    message.toString().equals("<pagination><cursor>0</cursor><nextCursor>2</nextCursor><limit>2</limit></pagination>")
+            )
+            .assertValueAt(5, message -> message.toString().equals("</response>"));
+
+        verify(mockExecutionContext).putInternalAttribute(HttpGetEntrypointConnector.ATTR_INTERNAL_LAST_MESSAGE_ID, "2");
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void shouldTextPlainArrayOfMessageAndCompleteAndEndWhenResponseMessagesComplete(boolean withHeadersAndMetadata)
+        throws InterruptedException {
+        when(mockExecutionContext.getInternalAttribute(HttpGetEntrypointConnector.ATTR_INTERNAL_RESPONSE_CONTENT_TYPE))
+            .thenReturn(MediaType.TEXT_PLAIN);
+        when(mockExecutionContext.getInternalAttribute(HttpGetEntrypointConnector.ATTR_INTERNAL_LAST_MESSAGE_ID)).thenReturn("2");
+        when(mockExecutionContext.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_MESSAGES_LIMIT_DURATION_MS))
+            .thenReturn(30_000L);
+        when(mockExecutionContext.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_MESSAGES_LIMIT_COUNT)).thenReturn(2);
+
+        LinkedMultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        queryParams.add(HttpGetEntrypointConnector.CURSOR_QUERY_PARAM, "0");
+        queryParams.add(HttpGetEntrypointConnector.LIMIT_QUERY_PARAM, "2");
+        when(mockRequest.parameters()).thenReturn(queryParams);
+        when(mockRequest.timestamp()).thenReturn(Instant.now().toEpochMilli());
+        when(mockExecutionContext.request()).thenReturn(mockRequest);
+
+        final HttpHeaders responseHttpHeaders = HttpHeaders.create();
+        when(mockResponse.headers()).thenReturn(responseHttpHeaders);
+        Flowable<Message> messages = Flowable.just(
+            createMessage("1", null),
+            createMessage("2", null),
+            createMessage("Non returned messaged due to count limit", null)
+        );
+        when(mockResponse.messages()).thenReturn(messages);
+        when(mockExecutionContext.response()).thenReturn(mockResponse);
+
+        when(configuration.isHeadersInPayload()).thenReturn(withHeadersAndMetadata);
+        when(configuration.isMetadataInPayload()).thenReturn(withHeadersAndMetadata);
+
+        when(configuration.isHeadersInPayload()).thenReturn(withHeadersAndMetadata);
+        when(configuration.isMetadataInPayload()).thenReturn(withHeadersAndMetadata);
+
+        httpGetEntrypointConnector.handleResponse(mockExecutionContext).test().assertComplete();
+
+        assertThat(responseHttpHeaders).isNotNull();
+        assertThat(responseHttpHeaders.get(HttpHeaderNames.CONTENT_TYPE)).isEqualTo(MediaType.TEXT_PLAIN);
+        verify(mockResponse).chunks(chunksCaptor.capture());
+
+        final TestSubscriber<Buffer> chunkObs = chunksCaptor.getValue().test();
+
+        chunkObs
+            .await()
+            .assertComplete()
+            .assertValueCount(4)
+            .assertValueAt(0, message -> message.toString().equals("items="))
+            .assertValueAt(
+                1,
+                message ->
+                    withHeadersAndMetadata
+                        ? message.toString().equals("({X-My-Header-1=[headerValue1]}, id=1, content=1, {myKey=myValue1})")
+                        : message.toString().equals("(id=1, content=1)")
+            )
+            .assertValueAt(
+                2,
+                message ->
+                    withHeadersAndMetadata
+                        ? message.toString().equals(", ({X-My-Header-2=[headerValue2]}, id=2, content=2, {myKey=myValue2})")
+                        : message.toString().equals(", (id=2, content=2)")
+            )
+            .assertValueAt(3, message -> message.toString().equals("\npagination=(cursor=0, nextCursor=2, limit=2)"));
+
+        verify(mockExecutionContext).putInternalAttribute(HttpGetEntrypointConnector.ATTR_INTERNAL_LAST_MESSAGE_ID, "2");
+    }
+
+    private Message createMessage(String messageContent, String contentType) {
+        String content = messageContent;
+        if (MediaType.APPLICATION_JSON.equals(contentType)) {
+            content = "{\"foo\": \"" + messageContent + "\"}";
+        } else if (MediaType.APPLICATION_XML.equals(contentType)) {
+            content = "<foo>" + messageContent + "</foo>";
+        }
+
+        return DefaultMessage
+            .builder()
+            .id(messageContent)
+            .headers(HttpHeaders.create().set("X-My-Header-" + messageContent, "headerValue" + messageContent))
+            .content(Buffer.buffer(content))
+            .metadata(Map.of("myKey", "myValue" + messageContent))
+            .build();
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/main/resources/plugin.properties
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/main/resources/plugin.properties
@@ -4,3 +4,4 @@ version=${project.version}
 description=${project.description}
 class=io.gravitee.plugin.entrypoint.http.post.HttpPostEntrypointConnectorFactory
 type=entrypoint-connector
+features=

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-sse/src/main/resources/plugin.properties
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-sse/src/main/resources/plugin.properties
@@ -4,3 +4,4 @@ version=${project.version}
 description=${project.description}
 class=io.gravitee.plugin.entrypoint.sse.SseEntrypointConnectorFactory
 type=entrypoint-connector
+features=resume

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/main/resources/plugin.properties
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/main/resources/plugin.properties
@@ -4,3 +4,4 @@ version=${project.version}
 description=${project.description}
 class=io.gravitee.plugin.entrypoint.webhook.WebhookEntrypointConnectorFactory
 type=entrypoint-connector
+features=

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/pom.xml
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/pom.xml
@@ -35,6 +35,7 @@
     <modules>
         <module>gravitee-apim-plugin-entrypoint-handler</module>
         <module>gravitee-apim-plugin-entrypoint-sse</module>
+        <module>gravitee-apim-plugin-entrypoint-http-get</module>
         <module>gravitee-apim-plugin-entrypoint-http-post</module>
         <module>gravitee-apim-plugin-entrypoint-webhook</module>
         <module>gravitee-apim-plugin-entrypoint-websocket</module>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/v4/connector/AbstractConnectorsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/v4/connector/AbstractConnectorsResource.java
@@ -57,6 +57,7 @@ public abstract class AbstractConnectorsResource {
         connectorExpandPluginEntity.setVersion(endpointPluginEntity.getVersion());
         connectorExpandPluginEntity.setSupportedApiType(endpointPluginEntity.getSupportedApiType());
         connectorExpandPluginEntity.setSupportedModes(endpointPluginEntity.getSupportedModes());
+        connectorExpandPluginEntity.setAvailableFeatures(endpointPluginEntity.getAvailableFeatures());
 
         return connectorExpandPluginEntity;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/connector/ConnectorPluginEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/connector/ConnectorPluginEntity.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.model.v4.connector;
 
 import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.ConnectorFeature;
 import io.gravitee.definition.model.v4.ConnectorMode;
 import io.gravitee.rest.api.model.platform.plugin.PlatformPluginEntity;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -41,4 +42,6 @@ public class ConnectorPluginEntity extends PlatformPluginEntity {
     private ApiType supportedApiType;
 
     private Set<ConnectorMode> supportedModes;
+
+    private Set<ConnectorFeature> availableFeatures;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
@@ -296,11 +296,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.assertj</groupId>
-			<artifactId>assertj-core</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-email</artifactId>
 			<scope>test</scope>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/AbstractConnectorPluginService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/AbstractConnectorPluginService.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.service.v4.impl;
 
 import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.ConnectorFeature;
 import io.gravitee.definition.model.v4.ConnectorMode;
 import io.gravitee.gateway.jupiter.api.connector.ConnectorFactory;
 import io.gravitee.plugin.core.api.ConfigurablePlugin;
@@ -26,6 +27,7 @@ import io.gravitee.rest.api.model.v4.connector.ConnectorPluginEntity;
 import io.gravitee.rest.api.service.JsonSchemaService;
 import io.gravitee.rest.api.service.impl.AbstractPluginService;
 import io.gravitee.rest.api.service.v4.ConnectorPluginService;
+import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -73,6 +75,18 @@ public abstract class AbstractConnectorPluginService<T extends ConfigurablePlugi
                     .supportedModes()
                     .stream()
                     .map(connectorMode -> ConnectorMode.fromLabel(connectorMode.getLabel()))
+                    .collect(Collectors.toSet())
+            );
+        }
+        if (
+            plugin.manifest().properties() != null &&
+            plugin.manifest().properties().get("features") != null &&
+            !plugin.manifest().properties().get("features").isEmpty()
+        ) {
+            entity.setAvailableFeatures(
+                Arrays
+                    .stream(plugin.manifest().properties().get("features").split(","))
+                    .map(ConnectorFeature::fromLabel)
                     .collect(Collectors.toSet())
             );
         }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8037

**Description**

 - Add a Http Get entrypoint.
 - Number of message to retrieve can be configured in API definition or directly in the request
 - Output format depends on Accept header in the request.

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8037-http-get-entrypoint/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mbytedksgc.chromatic.com)
<!-- Storybook placeholder end -->
