### PR TITLE
Bump some gravitee dependencies lost during 3.15.x merge

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -47,7 +47,7 @@
         <!-- Versions of the plugins for the full distribution -->
         <!-- Management API & Gateway -->
         <gravitee-alert-engine-connectors-ws.version>1.0.0</gravitee-alert-engine-connectors-ws.version>
-        <gravitee-connector-http.version>2.0.4</gravitee-connector-http.version>
+        <gravitee-connector-http.version>2.0.5</gravitee-connector-http.version>
         <gravitee-policy-apikey.version>2.5.0</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>1.5.0</gravitee-policy-assign-attributes.version>
         <gravitee-policy-assign-content.version>1.7.0</gravitee-policy-assign-content.version>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <jetty94.wiremock.version>9.4.44.v20210927</jetty94.wiremock.version>
-        <gravitee-connector-http.version>1.1.11</gravitee-connector-http.version>
+        <gravitee-connector-http.version>2.0.5</gravitee-connector-http.version>
     </properties>
 
     <dependencyManagement>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <gravitee-connector-http.version>1.1.2</gravitee-connector-http.version>
+        <gravitee-connector-http.version>2.0.5</gravitee-connector-http.version>
         <junit-jupiter.version>5.8.2</junit-jupiter.version>
         <reactiverse-junit5-rx-java2-web-client.version>0.3.0</reactiverse-junit5-rx-java2-web-client.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <gravitee-alert-api.version>1.9.1</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>1.12.0</gravitee-cockpit-api.version>
         <gravitee-common.version>1.27.0</gravitee-common.version>
-        <gravitee-connector-api.version>1.1.2</gravitee-connector-api.version>
+        <gravitee-connector-api.version>1.1.4</gravitee-connector-api.version>
         <gravitee-expression-language.version>1.9.5</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>1.34.2</gravitee-gateway-api.version>


### PR DESCRIPTION
**Issue**

NA

**Description**

`gravitee-connector-http` and `gravitee-connector-api` should have been bumped during the 3.15 merge, but it looks it has been forgotten so this PR just update them to the latest version on `3.18.x`

Also, I realigned all the `gravitee-connector-http` versions

Related to:
gravitee-io/issues#8228
gravitee-io/issues#8324
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/bump-deps/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
