### PR TITLE
feat: improve authentication workflow of subscription based plans

### DIFF
--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/plans/create-an-api-with-multiple-jwt-plan-and-use-them.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/plans/create-an-api-with-multiple-jwt-plan-and-use-them.spec.ts
@@ -42,8 +42,7 @@ const apisResource = new APIsApi(forManagementAsApiUser());
 const applicationsResource = new ApplicationsApi(forManagementAsApiUser());
 const applicationSubscriptionsResource = new ApplicationSubscriptionsApi(forManagementAsApiUser());
 
-// FIXME : restore this test for gateway V3 when V3 behavior is fixed
-describeIfJupiter('Create an API with multiple JWT plans and use then', () => {
+describe('Create an API with multiple JWT plans and use then', () => {
   const MY_SECURE_GIVEN_KEY = 'MY_SECURE_GIVEN_KEY_eyJpc3MiOiJncmF2aXRl';
 
   let createdApi: ApiEntity;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandlerFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandlerFactory.java
@@ -21,6 +21,7 @@ import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.el.TemplateVariableProvider;
 import io.gravitee.gateway.api.Invoker;
 import io.gravitee.gateway.api.endpoint.resolver.EndpointResolver;
+import io.gravitee.gateway.api.service.SubscriptionService;
 import io.gravitee.gateway.connector.ConnectorRegistry;
 import io.gravitee.gateway.core.classloader.DefaultClassLoader;
 import io.gravitee.gateway.core.component.ComponentProvider;
@@ -496,7 +497,7 @@ public class ApiReactorHandlerFactory implements ReactorFactory<Api> {
     }
 
     public AuthenticationHandlerEnhancer authenticationHandlerEnhancer(Api api) {
-        return new PlanBasedAuthenticationHandlerEnhancer(api.getDefinition(), applicationContext.getBean(SubscriptionRepository.class));
+        return new PlanBasedAuthenticationHandlerEnhancer(api.getDefinition(), applicationContext.getBean(SubscriptionService.class));
     }
 
     public AuthenticationHandlerSelector authenticationHandlerSelector(AuthenticationHandlerManager authenticationHandlerManager) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/security/PlanBasedAuthenticationHandlerEnhancer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/security/PlanBasedAuthenticationHandlerEnhancer.java
@@ -16,9 +16,9 @@
 package io.gravitee.gateway.handlers.api.security;
 
 import io.gravitee.definition.model.Api;
+import io.gravitee.gateway.api.service.SubscriptionService;
 import io.gravitee.gateway.security.core.AuthenticationHandler;
 import io.gravitee.gateway.security.core.AuthenticationHandlerEnhancer;
-import io.gravitee.repository.management.api.SubscriptionRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -33,13 +33,13 @@ public class PlanBasedAuthenticationHandlerEnhancer implements AuthenticationHan
 
     private final Logger logger = LoggerFactory.getLogger(PlanBasedAuthenticationHandlerEnhancer.class);
 
-    protected SubscriptionRepository subscriptionRepository;
+    protected SubscriptionService subscriptionService;
 
     private final Api api;
 
-    public PlanBasedAuthenticationHandlerEnhancer(Api api, SubscriptionRepository subscriptionRepository) {
+    public PlanBasedAuthenticationHandlerEnhancer(Api api, SubscriptionService subscriptionService) {
         this.api = api;
-        this.subscriptionRepository = subscriptionRepository;
+        this.subscriptionService = subscriptionService;
     }
 
     @Override
@@ -66,9 +66,9 @@ public class PlanBasedAuthenticationHandlerEnhancer implements AuthenticationHan
                         );
 
                         if ("api_key".equals(provider.name())) {
-                            providers.add(new ApiKeyPlanBasedAuthenticationHandler(provider, plan));
+                            providers.add(new ApiKeyPlanBasedAuthenticationHandler(provider, plan, subscriptionService));
                         } else if ("jwt".equals(provider.name())) {
-                            providers.add(new JwtPlanBasedAuthenticationHandler(provider, plan, subscriptionRepository));
+                            providers.add(new JwtPlanBasedAuthenticationHandler(provider, plan, subscriptionService));
                         } else {
                             providers.add(new DefaultPlanBasedAuthenticationHandler(provider, plan));
                         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/security/ApiKeyPlanBasedAuthenticationHandlerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/security/ApiKeyPlanBasedAuthenticationHandlerTest.java
@@ -23,94 +23,174 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import io.gravitee.definition.model.Plan;
+import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.service.ApiKey;
+import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.api.service.SubscriptionService;
 import io.gravitee.gateway.security.core.AuthenticationContext;
 import io.gravitee.gateway.security.core.AuthenticationHandler;
+import java.util.Optional;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
+@RunWith(MockitoJUnitRunner.class)
 public class ApiKeyPlanBasedAuthenticationHandlerTest {
 
     private static final String APIKEY_CONTEXT_ATTRIBUTE = "apikey";
+
+    @InjectMocks
     private ApiKeyPlanBasedAuthenticationHandler apiKeyPlanBasedAuthenticationHandler;
+
+    @Mock
+    private SubscriptionService subscriptionService;
+
+    @Mock
+    private AuthenticationHandler authenticationHandler;
+
+    @Mock
+    private Plan plan;
+
+    @Mock
+    private AuthenticationContext authenticationContext;
+
+    @Mock
+    private ApiKey apiKey;
+
+    @Mock
+    private Subscription subscription;
 
     @Test
     public void shouldNotHandle() {
-        AuthenticationHandler handler = mock(AuthenticationHandler.class);
-        Plan plan = mock(Plan.class);
-        apiKeyPlanBasedAuthenticationHandler = new ApiKeyPlanBasedAuthenticationHandler(handler, plan);
-        AuthenticationContext context = mock(AuthenticationContext.class);
-        when(handler.canHandle(any())).thenReturn(false);
+        apiKeyPlanBasedAuthenticationHandler = new ApiKeyPlanBasedAuthenticationHandler(authenticationHandler, plan, subscriptionService);
+        when(authenticationHandler.canHandle(any())).thenReturn(false);
 
-        boolean canHandle = apiKeyPlanBasedAuthenticationHandler.canHandle(context);
+        boolean canHandle = apiKeyPlanBasedAuthenticationHandler.canHandle(authenticationContext);
 
         assertFalse(canHandle);
-        verify(context, never()).get(APIKEY_CONTEXT_ATTRIBUTE);
+        verify(authenticationContext, never()).get(APIKEY_CONTEXT_ATTRIBUTE);
         verify(plan, never()).getId();
     }
 
     @Test
     public void shouldNotHandle_ifKeyNotFound() {
-        AuthenticationHandler handler = mock(AuthenticationHandler.class);
-        Plan plan = mock(Plan.class);
-        apiKeyPlanBasedAuthenticationHandler = new ApiKeyPlanBasedAuthenticationHandler(handler, plan);
-        AuthenticationContext context = mock(AuthenticationContext.class);
-        when(handler.canHandle(any())).thenReturn(true);
+        apiKeyPlanBasedAuthenticationHandler = new ApiKeyPlanBasedAuthenticationHandler(authenticationHandler, plan, subscriptionService);
+        when(authenticationHandler.canHandle(any())).thenReturn(true);
 
-        when(context.contains(APIKEY_CONTEXT_ATTRIBUTE)).thenReturn(true);
-        when(context.get(APIKEY_CONTEXT_ATTRIBUTE)).thenReturn(empty());
+        when(authenticationContext.contains(APIKEY_CONTEXT_ATTRIBUTE)).thenReturn(true);
+        when(authenticationContext.get(APIKEY_CONTEXT_ATTRIBUTE)).thenReturn(empty());
 
-        boolean canHandle = apiKeyPlanBasedAuthenticationHandler.canHandle(context);
+        boolean canHandle = apiKeyPlanBasedAuthenticationHandler.canHandle(authenticationContext);
 
         assertFalse(canHandle);
-        verify(context, times(1)).get(APIKEY_CONTEXT_ATTRIBUTE);
+        verify(authenticationContext, times(1)).get(APIKEY_CONTEXT_ATTRIBUTE);
         verify(plan, never()).getId();
     }
 
     @Test
-    public void shouldHandle_ifKeyFoundAndPlanMatch() {
-        AuthenticationHandler handler = mock(AuthenticationHandler.class);
-        Plan plan = mock(Plan.class);
+    public void shouldNotHandle_ifKeyFoundAndPlanNotMatch() {
         when(plan.getId()).thenReturn("planId");
-        apiKeyPlanBasedAuthenticationHandler = new ApiKeyPlanBasedAuthenticationHandler(handler, plan);
-        AuthenticationContext context = mock(AuthenticationContext.class);
-        when(handler.canHandle(any())).thenReturn(true);
-        ApiKey key = mock(ApiKey.class);
+        apiKeyPlanBasedAuthenticationHandler = new ApiKeyPlanBasedAuthenticationHandler(authenticationHandler, plan, subscriptionService);
+        when(authenticationHandler.canHandle(any())).thenReturn(true);
 
-        when(context.contains(APIKEY_CONTEXT_ATTRIBUTE)).thenReturn(true);
-        when(context.get(APIKEY_CONTEXT_ATTRIBUTE)).thenReturn((of(key)));
+        when(authenticationContext.contains(APIKEY_CONTEXT_ATTRIBUTE)).thenReturn(true);
+        when(authenticationContext.get(APIKEY_CONTEXT_ATTRIBUTE)).thenReturn((of(apiKey)));
 
-        when(key.getPlan()).thenReturn("planId");
+        when(apiKey.getPlan()).thenReturn("planId2");
 
-        boolean canHandle = apiKeyPlanBasedAuthenticationHandler.canHandle(context);
+        boolean canHandle = apiKeyPlanBasedAuthenticationHandler.canHandle(authenticationContext);
 
-        assertTrue(canHandle);
-        verify(context, times(1)).get(APIKEY_CONTEXT_ATTRIBUTE);
+        assertFalse(canHandle);
+        verify(authenticationContext, times(1)).get(APIKEY_CONTEXT_ATTRIBUTE);
         verify(plan, times(1)).getId();
     }
 
     @Test
-    public void shouldNotHandle_ifKeyFoundAndPlanNotMatch() {
-        AuthenticationHandler handler = mock(AuthenticationHandler.class);
-        Plan plan = mock(Plan.class);
+    public void shouldNotHandle_ifKeyFoundAndPlanMatchAndNoSubscription() {
         when(plan.getId()).thenReturn("planId");
-        apiKeyPlanBasedAuthenticationHandler = new ApiKeyPlanBasedAuthenticationHandler(handler, plan);
-        AuthenticationContext context = mock(AuthenticationContext.class);
-        when(handler.canHandle(any())).thenReturn(true);
-        ApiKey key = mock(ApiKey.class);
+        when(plan.getApi()).thenReturn("apiId");
+        when(apiKey.getPlan()).thenReturn("planId");
+        when(apiKey.getKey()).thenReturn("api-key");
 
-        when(context.contains(APIKEY_CONTEXT_ATTRIBUTE)).thenReturn(true);
-        when(context.get(APIKEY_CONTEXT_ATTRIBUTE)).thenReturn((of(key)));
+        apiKeyPlanBasedAuthenticationHandler = new ApiKeyPlanBasedAuthenticationHandler(authenticationHandler, plan, subscriptionService);
+        when(authenticationHandler.canHandle(any())).thenReturn(true);
 
-        when(key.getPlan()).thenReturn("planId2");
+        when(authenticationContext.contains(APIKEY_CONTEXT_ATTRIBUTE)).thenReturn(true);
+        when(authenticationContext.get(APIKEY_CONTEXT_ATTRIBUTE)).thenReturn((of(apiKey)));
 
-        boolean canHandle = apiKeyPlanBasedAuthenticationHandler.canHandle(context);
+        boolean canHandle = apiKeyPlanBasedAuthenticationHandler.canHandle(authenticationContext);
 
         assertFalse(canHandle);
-        verify(context, times(1)).get(APIKEY_CONTEXT_ATTRIBUTE);
-        verify(plan, times(1)).getId();
+        verify(authenticationContext, times(1)).get(APIKEY_CONTEXT_ATTRIBUTE);
+        verify(subscriptionService, times(1))
+            .getByApiAndSecurityToken(
+                eq("apiId"),
+                argThat(s -> "API_KEY".equals(s.getTokenType()) && "api-key".equals(s.getTokenValue())),
+                eq("planId")
+            );
+    }
+
+    @Test
+    public void shouldNotHandle_ifKeyFoundAndPlanMatchAndSubscriptionWithInvalidTime() {
+        when(plan.getId()).thenReturn("planId");
+        when(plan.getApi()).thenReturn("apiId");
+        when(apiKey.getPlan()).thenReturn("planId");
+        when(apiKey.getKey()).thenReturn("api-key");
+
+        apiKeyPlanBasedAuthenticationHandler = new ApiKeyPlanBasedAuthenticationHandler(authenticationHandler, plan, subscriptionService);
+        when(authenticationHandler.canHandle(any())).thenReturn(true);
+        when(authenticationContext.request()).thenReturn(mock(Request.class));
+
+        when(authenticationContext.contains(APIKEY_CONTEXT_ATTRIBUTE)).thenReturn(true);
+        when(authenticationContext.get(APIKEY_CONTEXT_ATTRIBUTE)).thenReturn((of(apiKey)));
+
+        when(
+            subscriptionService.getByApiAndSecurityToken(
+                eq("apiId"),
+                argThat(s -> "API_KEY".equals(s.getTokenType()) && "api-key".equals(s.getTokenValue())),
+                eq("planId")
+            )
+        )
+            .thenReturn(Optional.of(subscription));
+        when(subscription.isTimeValid(anyLong())).thenReturn(false);
+
+        boolean canHandle = apiKeyPlanBasedAuthenticationHandler.canHandle(authenticationContext);
+
+        assertFalse(canHandle);
+    }
+
+    @Test
+    public void shouldHandle_ifKeyFoundAndPlanMatchAndSubscriptionWithValidTime() {
+        when(plan.getId()).thenReturn("planId");
+        when(plan.getApi()).thenReturn("apiId");
+        when(apiKey.getPlan()).thenReturn("planId");
+        when(apiKey.getKey()).thenReturn("api-key");
+
+        apiKeyPlanBasedAuthenticationHandler = new ApiKeyPlanBasedAuthenticationHandler(authenticationHandler, plan, subscriptionService);
+        when(authenticationHandler.canHandle(any())).thenReturn(true);
+        when(authenticationContext.request()).thenReturn(mock(Request.class));
+
+        when(authenticationContext.contains(APIKEY_CONTEXT_ATTRIBUTE)).thenReturn(true);
+        when(authenticationContext.get(APIKEY_CONTEXT_ATTRIBUTE)).thenReturn((of(apiKey)));
+
+        when(
+            subscriptionService.getByApiAndSecurityToken(
+                eq("apiId"),
+                argThat(s -> "API_KEY".equals(s.getTokenType()) && "api-key".equals(s.getTokenValue())),
+                eq("planId")
+            )
+        )
+            .thenReturn(Optional.of(subscription));
+        when(subscription.isTimeValid(anyLong())).thenReturn(true);
+
+        boolean canHandle = apiKeyPlanBasedAuthenticationHandler.canHandle(authenticationContext);
+
+        assertTrue(canHandle);
     }
 }


### PR DESCRIPTION
**Description**

feat: improve authentication workflow of subscription based plans

Plan based authentication handlers have to use the SubscriptionService of the gateway api, instead of SubscriptionRepositoryWrappers which has been removed.

ApiKey plans based authentication handler can now retrieve subscription and check its validity.

**Issue**

https://github.com/gravitee-io/issues/issues/8168
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/feat-v3plansonmaster-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fgesyoohac.chromatic.com)
<!-- Storybook placeholder end -->
<!-- E2E Coverage placeholder -->
---
### 🧪 End-to-End Coverage

| INSTRUCTIONS | BRANCHES |
| :----------: | :------: |
|   37% | 22%   |

A more detailed report has been uploaded to [circleci](https://output.circle-artifacts.com/output/job/b3bd2ee9-ee42-444e-9487-bafc25f0c10b/artifacts/0/gravitee-apim-e2e/jacoco/reports/index.html)
<!-- E2E Coverage placeholder end -->
