### PR TITLE
refactor: add margin on api list icons

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
@@ -73,7 +73,12 @@
           size="20"
           svgIcon="gio:kubernetes"
         ></mat-icon>
-        <span *ngIf="element.workflowBadge" [ngClass]="element.workflowBadge.class" class="states__api-workflow-badge">
+        <span
+          *ngIf="element.workflowBadge"
+          [ngClass]="element.workflowBadge.class"
+          class="states__api-workflow-badge"
+          [matTooltip]="element.workflowBadge.text"
+        >
           {{ element.workflowBadge.text }}
         </span>
       </td>

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.scss
@@ -44,6 +44,10 @@
   padding: 0 4px;
   white-space: nowrap;
 
+  .mat-icon {
+    margin: 0 4px;
+  }
+
   .states {
     &__api-started {
       color: mat.get-color-from-palette(gio.$mat-success-palette, 'default');


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8142

**Description**

Add margin on icons

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/issues-8142-add-icon-spaces/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-upzcggnkhn.chromatic.com)
<!-- Storybook placeholder end -->

<img width="1788" alt="Screenshot 2022-09-02 at 14 15 55" src="https://user-images.githubusercontent.com/25704259/188140884-025bb2ae-ecda-469d-8931-4a1171b4ca13.png">


