### PR TITLE
feat: turn V4 EndpointGroup configuration to a json object

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/endpointgroup/EndpointGroup.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/endpointgroup/EndpointGroup.java
@@ -17,6 +17,8 @@ package io.gravitee.definition.model.v4.endpointgroup;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRawValue;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.definition.model.v4.endpointgroup.loadbalancer.LoadBalancer;
 import io.gravitee.definition.model.v4.endpointgroup.service.EndpointGroupServices;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -24,7 +26,6 @@ import java.io.Serializable;
 import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotEmpty;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -51,10 +52,23 @@ public class EndpointGroup implements Serializable {
 
     private LoadBalancer loadBalancer;
 
+    @Schema(implementation = Object.class)
+    @JsonRawValue
     private String sharedConfiguration;
 
     @Valid
     private List<Endpoint> endpoints;
 
     private EndpointGroupServices services;
+
+    @JsonSetter
+    public void setSharedConfiguration(final JsonNode configuration) {
+        if (configuration != null) {
+            this.sharedConfiguration = configuration.toString();
+        }
+    }
+
+    public void setSharedConfiguration(final String sharedConfiguration) {
+        this.sharedConfiguration = sharedConfiguration;
+    }
 }

--- a/gravitee-apim-e2e/lib/management-webclient-sdk/src/lib/models/EndpointGroupV4.ts
+++ b/gravitee-apim-e2e/lib/management-webclient-sdk/src/lib/models/EndpointGroupV4.ts
@@ -63,10 +63,10 @@ export interface EndpointGroupV4 {
     services?: EndpointGroupServicesV4;
     /**
      * 
-     * @type {string}
+     * @type {any}
      * @memberof EndpointGroupV4
      */
-    sharedConfiguration?: string;
+    sharedConfiguration?: any;
     /**
      * 
      * @type {string}


### PR DESCRIPTION
feat: turn V4 EndpointGroup configuration to a json object

V4 EndpointGroup configuration was a raw string containing json ;
This turns it to a json object instead.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/feat-endpointgroupsharedconfig/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ocszeandtv.chromatic.com)
<!-- Storybook placeholder end -->
