### PR TITLE
Allow to use another registry in Docker quick setups

### DIFF
--- a/docker/quick-setup/consul-service-discovery/docker-compose.yml
+++ b/docker/quick-setup/consul-service-discovery/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       - storage
 
   gateway:
-    image: graviteeio/apim-gateway:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_VERSION:-latest}
     container_name: gio_apim_gateway
     restart: always
     ports:
@@ -94,7 +94,7 @@ services:
       - frontend
 
   management_api:
-    image: graviteeio/apim-management-api:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-api:${APIM_VERSION:-latest}
     container_name: gio_apim_management_api
     restart: always
     ports:
@@ -115,7 +115,7 @@ services:
       - frontend
 
   management_ui:
-    image: graviteeio/apim-management-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-ui:${APIM_VERSION:-latest}
     container_name: gio_apim_management_ui
     restart: always
     ports:
@@ -130,7 +130,7 @@ services:
       - frontend
 
   portal_ui:
-    image: graviteeio/apim-portal-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-portal-ui:${APIM_VERSION:-latest}
     container_name: gio_apim_portal_ui
     restart: always
     ports:

--- a/docker/quick-setup/ee-with-alert-engine/docker-compose.yml
+++ b/docker/quick-setup/ee-with-alert-engine/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       - ./.license:/opt/graviteeio-alert-engine/license
 
   gateway:
-    image: graviteeio/apim-gateway:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_VERSION:-latest}
     container_name: gio_apim_gateway
     restart: always
     ports:
@@ -95,7 +95,7 @@ services:
       - frontend
 
   management_api:
-    image: graviteeio/apim-management-api:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-api:${APIM_VERSION:-latest}
     container_name: gio_apim_management_api
     restart: always
     ports:
@@ -125,7 +125,7 @@ services:
       - frontend
 
   management_ui:
-    image: graviteeio/apim-management-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-ui:${APIM_VERSION:-latest}
     container_name: gio_apim_management_ui
     restart: always
     ports:
@@ -140,7 +140,7 @@ services:
       - frontend
 
   portal_ui:
-    image: graviteeio/apim-portal-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-portal-ui:${APIM_VERSION:-latest}
     container_name: gio_apim_portal_ui
     restart: always
     ports:

--- a/docker/quick-setup/gateway-http-bridge-repository-postgresql-heartbeat/README.md
+++ b/docker/quick-setup/gateway-http-bridge-repository-postgresql-heartbeat/README.md
@@ -23,16 +23,16 @@ You can download one here: https://jdbc.postgresql.org/download.html
 
 `APIM_VERSION={APIM_VERSION} docker-compose up -d ` 
 
-To be sure to fetch last version of images, you can do
-`export APIM_VERSION={APIM_VERSION} && docker-compose down -v && docker-compose pull && docker-compose up`
+To be sure to fetch last version of images, you can do `export APIM_VERSION={APIM_VERSION} && docker-compose down -v && docker-compose pull && docker-compose up`.
+To target non stable images use: `APIM_REGISTRY=graviteeio.azurecr.io`
 
 If you want to add `i` instances of gateway_client
-You can run `docker-compose up scale gateway_client={i} -d`
+You can run `docker-compose up --scale gateway_client={i} -d`
 
 On Osx, you have to add the instances one by one, otherwise you will get a port binding error.
 For example, if you need to start 3 instances;
-```
+```shell
 docker-compose up -d
-docker-compose up scale gateway_client=2 -d
-docker-compose up scale gateway_client=3 -d
+docker-compose up --scale gateway_client=2 -d
+docker-compose up --scale gateway_client=3 -d
 ```

--- a/docker/quick-setup/gateway-http-bridge-repository-postgresql-heartbeat/docker-compose.yml
+++ b/docker/quick-setup/gateway-http-bridge-repository-postgresql-heartbeat/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       - storage
 
   gateway_server:
-    image: graviteeio/apim-gateway:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_VERSION:-latest}
     restart: always
     ports:
       - "18092:18092"
@@ -108,7 +108,7 @@ services:
       - frontend
 
   gateway_client:
-    image: graviteeio/apim-gateway:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_VERSION:-latest}
     restart: always
     ports:
       - "8075-8082:8082"
@@ -142,7 +142,7 @@ services:
       - frontend
 
   management_api:
-    image: graviteeio/apim-management-api:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-api:${APIM_VERSION:-latest}
     restart: always
     ports:
       - "8083:8083"
@@ -166,7 +166,7 @@ services:
       - frontend
 
   management_ui:
-    image: graviteeio/apim-management-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-ui:${APIM_VERSION:-latest}
     restart: always
     ports:
       - "8084:8080"
@@ -180,7 +180,7 @@ services:
       - frontend
 
   portal_ui:
-    image: graviteeio/apim-portal-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-portal-ui:${APIM_VERSION:-latest}
     restart: always
     ports:
       - "8085:8080"

--- a/docker/quick-setup/gateway-http-bridge-repository/docker-compose.yml
+++ b/docker/quick-setup/gateway-http-bridge-repository/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       - storage
 
   gateway_server:
-    image: graviteeio/apim-gateway:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_VERSION:-latest}
     container_name: gio_apim_gateway_server
     restart: always
     ports:
@@ -86,7 +86,7 @@ services:
       - frontend
 
   gateway_client:
-    image: graviteeio/apim-gateway:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_VERSION:-latest}
     container_name: gio_apim_gateway_client
     restart: always
     ports:
@@ -113,7 +113,7 @@ services:
       - frontend
 
   management_api:
-    image: graviteeio/apim-management-api:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-api:${APIM_VERSION:-latest}
     container_name: gio_apim_management_api
     restart: always
     ports:
@@ -134,7 +134,7 @@ services:
       - frontend
 
   management_ui:
-    image: graviteeio/apim-management-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-ui:${APIM_VERSION:-latest}
     container_name: gio_apim_management_ui
     restart: always
     ports:
@@ -149,7 +149,7 @@ services:
       - frontend
 
   portal_ui:
-    image: graviteeio/apim-portal-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-portal-ui:${APIM_VERSION:-latest}
     container_name: gio_apim_portal_ui
     restart: always
     ports:

--- a/docker/quick-setup/https-gateway/docker-compose.yml
+++ b/docker/quick-setup/https-gateway/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       - storage
 
   gateway:
-    image: graviteeio/apim-gateway:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_VERSION:-latest}
     container_name: gio_apim_https_gateway
     restart: always
     ports:
@@ -89,7 +89,7 @@ services:
       - frontend
 
   management_api:
-    image: graviteeio/apim-management-api:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-api:${APIM_VERSION:-latest}
     container_name: gio_apim_management_api
     restart: always
     ports:
@@ -110,7 +110,7 @@ services:
       - frontend
 
   management_ui:
-    image: graviteeio/apim-management-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-ui:${APIM_VERSION:-latest}
     container_name: gio_apim_management_ui
     restart: always
     ports:
@@ -125,7 +125,7 @@ services:
       - frontend
 
   portal_ui:
-    image: graviteeio/apim-portal-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-portal-ui:${APIM_VERSION:-latest}
     container_name: gio_apim_portal_ui
     restart: always
     ports:

--- a/docker/quick-setup/keycloak/docker-compose.yml
+++ b/docker/quick-setup/keycloak/docker-compose.yml
@@ -89,7 +89,7 @@ services:
       - storage
 
   gateway:
-    image: graviteeio/apim-gateway:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_VERSION:-latest}
     restart: always
     ports:
       - "8082:8082"
@@ -113,7 +113,7 @@ services:
       - frontend
 
   management_api:
-    image: graviteeio/apim-management-api:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-api:${APIM_VERSION:-latest}
     restart: always
     ports:
       - "8083:8083"
@@ -154,7 +154,7 @@ services:
       - frontend
 
   management_ui:
-    image: graviteeio/apim-management-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-ui:${APIM_VERSION:-latest}
     restart: always
     ports:
       - "8084:8080"
@@ -168,7 +168,7 @@ services:
       - frontend
 
   portal_ui:
-    image: graviteeio/apim-portal-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-portal-ui:${APIM_VERSION:-latest}
     restart: always
     ports:
       - "8085:8080"

--- a/docker/quick-setup/mongodb/docker-compose.yml
+++ b/docker/quick-setup/mongodb/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       - storage
 
   gateway:
-    image: graviteeio/apim-gateway:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_VERSION:-latest}
     container_name: gio_apim_gateway
     restart: always
     ports:
@@ -80,7 +80,7 @@ services:
       - frontend
 
   management_api:
-    image: graviteeio/apim-management-api:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-api:${APIM_VERSION:-latest}
     container_name: gio_apim_management_api
     restart: always
     ports:
@@ -101,7 +101,7 @@ services:
       - frontend
 
   management_ui:
-    image: graviteeio/apim-management-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-ui:${APIM_VERSION:-latest}
     container_name: gio_apim_management_ui
     restart: always
     ports:
@@ -116,7 +116,7 @@ services:
       - frontend
 
   portal_ui:
-    image: graviteeio/apim-portal-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-portal-ui:${APIM_VERSION:-latest}
     container_name: gio_apim_portal_ui
     restart: always
     ports:

--- a/docker/quick-setup/nginx/docker-compose.yml
+++ b/docker/quick-setup/nginx/docker-compose.yml
@@ -74,7 +74,7 @@ services:
       - storage
 
   gateway:
-    image: graviteeio/apim-gateway:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_VERSION:-latest}
     container_name: gio_apim_gateway
     restart: always
     depends_on:
@@ -91,7 +91,7 @@ services:
       - frontend
 
   management_api:
-    image: graviteeio/apim-management-api:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-api:${APIM_VERSION:-latest}
     container_name: gio_apim_management_api
     restart: always
     links:
@@ -113,7 +113,7 @@ services:
       - frontend
 
   management_ui:
-    image: graviteeio/apim-management-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-ui:${APIM_VERSION:-latest}
     container_name: gio_apim_management_ui
     restart: always
     depends_on:
@@ -126,7 +126,7 @@ services:
       - frontend
 
   portal_ui:
-    image: graviteeio/apim-portal-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-portal-ui:${APIM_VERSION:-latest}
     container_name: gio_apim_portal_ui
     restart: always
     depends_on:

--- a/docker/quick-setup/opensearch/docker-compose.yml
+++ b/docker/quick-setup/opensearch/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       - storage
 
   gateway:
-    image: graviteeio/apim-gateway:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_VERSION:-latest}
     container_name: gio_apim_gateway
     restart: always
     ports:
@@ -81,7 +81,7 @@ services:
       - frontend
 
   management_api:
-    image: graviteeio/apim-management-api:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-api:${APIM_VERSION:-latest}
     container_name: gio_apim_management_api
     restart: always
     ports:
@@ -104,7 +104,7 @@ services:
       - frontend
 
   management_ui:
-    image: graviteeio/apim-management-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-ui:${APIM_VERSION:-latest}
     container_name: gio_apim_management_ui
     restart: always
     ports:
@@ -119,7 +119,7 @@ services:
       - frontend
 
   portal_ui:
-    image: graviteeio/apim-portal-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-portal-ui:${APIM_VERSION:-latest}
     container_name: gio_apim_portal_ui
     restart: always
     ports:

--- a/docker/quick-setup/opentracing-jaeger/docker-compose.yml
+++ b/docker/quick-setup/opentracing-jaeger/docker-compose.yml
@@ -80,7 +80,7 @@ services:
       - jaeger
 
   gateway:
-    image: graviteeio/apim-gateway:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_VERSION:-latest}
     container_name: gio_apim_gateway
     restart: always
     ports:
@@ -110,7 +110,7 @@ services:
       - jaeger
 
   management_api:
-    image: graviteeio/apim-management-api:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-api:${APIM_VERSION:-latest}
     container_name: gio_apim_management_api
     restart: always
     ports:
@@ -131,7 +131,7 @@ services:
       - frontend
 
   management_ui:
-    image: graviteeio/apim-management-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-ui:${APIM_VERSION:-latest}
     container_name: gio_apim_management_ui
     restart: always
     ports:
@@ -146,7 +146,7 @@ services:
       - frontend
 
   portal_ui:
-    image: graviteeio/apim-portal-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-portal-ui:${APIM_VERSION:-latest}
     container_name: gio_apim_portal_ui
     restart: always
     ports:

--- a/docker/quick-setup/postgresql/docker-compose.yml
+++ b/docker/quick-setup/postgresql/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       - storage
 
   gateway:
-    image: graviteeio/apim-gateway:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_VERSION:-latest}
     container_name: apim-qs-psql-gateway
     restart: always
     ports:
@@ -101,7 +101,7 @@ services:
       - frontend
 
   management_api:
-    image: graviteeio/apim-management-api:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-api:${APIM_VERSION:-latest}
     container_name: apim-qs-psql-management_api
     restart: always
     ports:
@@ -126,7 +126,7 @@ services:
       - frontend
 
   management_ui:
-    image: graviteeio/apim-management-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-ui:${APIM_VERSION:-latest}
     container_name: apim-qs-psql-console_ui
     restart: always
     ports:
@@ -141,7 +141,7 @@ services:
       - frontend
 
   portal_ui:
-    image: graviteeio/apim-portal-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-portal-ui:${APIM_VERSION:-latest}
     container_name: apim-qs-psql-portal_ui
     restart: always
     ports:

--- a/docker/quick-setup/prometheus/docker-compose.yml
+++ b/docker/quick-setup/prometheus/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       - prometheus
 
   gateway:
-    image: graviteeio/apim-gateway:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_VERSION:-latest}
     container_name: gio_apim_gateway
     restart: always
     ports:
@@ -100,7 +100,7 @@ services:
       - prometheus
 
   management_api:
-    image: graviteeio/apim-management-api:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-api:${APIM_VERSION:-latest}
     container_name: gio_apim_management_api
     restart: always
     ports:
@@ -121,7 +121,7 @@ services:
       - frontend
 
   management_ui:
-    image: graviteeio/apim-management-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-ui:${APIM_VERSION:-latest}
     container_name: gio_apim_management_ui
     restart: always
     ports:
@@ -136,7 +136,7 @@ services:
       - frontend
 
   portal_ui:
-    image: graviteeio/apim-portal-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-portal-ui:${APIM_VERSION:-latest}
     container_name: gio_apim_portal_ui
     restart: always
     ports:

--- a/docker/quick-setup/redis-rate-limit/docker-compose.yml
+++ b/docker/quick-setup/redis-rate-limit/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       - data-redis-client:/db
 
   gateway:
-    image: graviteeio/apim-gateway:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_VERSION:-latest}
     container_name: gio_apim_gateway
     restart: always
     ports:
@@ -113,7 +113,7 @@ services:
       - frontend
 
   management_api:
-    image: graviteeio/apim-management-api:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-api:${APIM_VERSION:-latest}
     container_name: gio_apim_management_api
     restart: always
     ports:
@@ -134,7 +134,7 @@ services:
       - frontend
 
   management_ui:
-    image: graviteeio/apim-management-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-ui:${APIM_VERSION:-latest}
     container_name: gio_apim_management_ui
     restart: always
     ports:
@@ -149,7 +149,7 @@ services:
       - frontend
 
   portal_ui:
-    image: graviteeio/apim-portal-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-portal-ui:${APIM_VERSION:-latest}
     container_name: gio_apim_portal_ui
     restart: always
     ports:

--- a/docker/quick-setup/tags-internal-external/docker-compose.yml
+++ b/docker/quick-setup/tags-internal-external/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       - storage
 
   gateway_internal:
-    image: graviteeio/apim-gateway:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_VERSION:-latest}
     container_name: gio_apim_gateway_internal
     restart: always
     ports:
@@ -81,7 +81,7 @@ services:
       - frontend
 
   gateway_external:
-    image: graviteeio/apim-gateway:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-gateway:${APIM_VERSION:-latest}
     container_name: gio_apim_gateway_external
     restart: always
     ports:
@@ -101,7 +101,7 @@ services:
       - frontend
 
   management_api:
-    image: graviteeio/apim-management-api:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-api:${APIM_VERSION:-latest}
     container_name: gio_apim_management_api
     restart: always
     ports:
@@ -122,7 +122,7 @@ services:
       - frontend
 
   management_ui:
-    image: graviteeio/apim-management-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-management-ui:${APIM_VERSION:-latest}
     container_name: gio_apim_management_ui
     restart: always
     ports:
@@ -137,7 +137,7 @@ services:
       - frontend
 
   portal_ui:
-    image: graviteeio/apim-portal-ui:${APIM_VERSION:-latest}
+    image: ${APIM_REGISTRY:-graviteeio}/apim-portal-ui:${APIM_VERSION:-latest}
     container_name: gio_apim_portal_ui
     restart: always
     ports:


### PR DESCRIPTION
**Issue**

NA

**Description**

Being able to run APIM in different contexts with the Docker quick setups is excellent. Still, we were restricted to the officially released version as all the images were pulled from DockerHub. 
This PR allows the use of another repository by providing it as an environment variable, for instance: `APIM_REGISTRY=graviteeio.azurecr.io`
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/improve-docker-quick-setup/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hgdtcwsqtp.chromatic.com)
<!-- Storybook placeholder end -->
