### PR TITLE
try again and again to fix websockets flakys test

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/AbstractWebSocketGatewayTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/AbstractWebSocketGatewayTest.java
@@ -25,6 +25,8 @@ import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServer;
+import java.io.IOException;
+import java.net.ServerSocket;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -78,7 +80,9 @@ public abstract class AbstractWebSocketGatewayTest extends AbstractGatewayTest {
             }
         );
 
-        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+            logger.warn("Unable to close http client and server");
+        }
     }
 
     /**
@@ -102,6 +106,14 @@ public abstract class AbstractWebSocketGatewayTest extends AbstractGatewayTest {
                     endpoints.iterator().next().setTarget(getApiEndpointTarget());
                 }
             }
+        }
+    }
+
+    static int getFreePort() {
+        try (ServerSocket serverSocket = new ServerSocket(0)) {
+            return serverSocket.getLocalPort();
+        } catch (IOException e) {
+            return -1;
         }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketAcceptTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketAcceptTest.java
@@ -35,7 +35,7 @@ import org.junit.rules.TestRule;
 @ApiDescriptor("/io/gravitee/gateway/standalone/websocket/teams.json")
 public class WebsocketAcceptTest extends AbstractWebSocketGatewayTest {
 
-    private static final Integer WEBSOCKET_PORT = 16665;
+    private static final Integer WEBSOCKET_PORT = getFreePort();
 
     @Override
     protected String getApiEndpointTarget() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketBidirectionalTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketBidirectionalTest.java
@@ -41,7 +41,7 @@ import org.junit.rules.TestRule;
 @ApiDescriptor("/io/gravitee/gateway/standalone/websocket/teams.json")
 public class WebsocketBidirectionalTest extends AbstractWebSocketGatewayTest {
 
-    private static final Integer WEBSOCKET_PORT = 16666;
+    private static final Integer WEBSOCKET_PORT = getFreePort();
 
     @Override
     protected String getApiEndpointTarget() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketCloseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketCloseTest.java
@@ -34,7 +34,7 @@ import org.junit.rules.TestRule;
 @ApiDescriptor("/io/gravitee/gateway/standalone/websocket/teams.json")
 public class WebsocketCloseTest extends AbstractWebSocketGatewayTest {
 
-    private static final Integer WEBSOCKET_PORT = 16667;
+    private static final Integer WEBSOCKET_PORT = getFreePort();
 
     @Override
     protected String getApiEndpointTarget() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketHeadersTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketHeadersTest.java
@@ -37,7 +37,7 @@ import org.junit.rules.TestRule;
 @ApiDescriptor("/io/gravitee/gateway/standalone/websocket/teams.json")
 public class WebsocketHeadersTest extends AbstractWebSocketGatewayTest {
 
-    private static final Integer WEBSOCKET_PORT = 16668;
+    private static final Integer WEBSOCKET_PORT = getFreePort();
 
     @Override
     protected String getApiEndpointTarget() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketPingFrameTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketPingFrameTest.java
@@ -36,7 +36,7 @@ import org.junit.rules.TestRule;
 @ApiDescriptor("/io/gravitee/gateway/standalone/websocket/teams.json")
 public class WebsocketPingFrameTest extends AbstractWebSocketGatewayTest {
 
-    private static final Integer WEBSOCKET_PORT = 16669;
+    private static final Integer WEBSOCKET_PORT = getFreePort();
 
     @Override
     protected String getApiEndpointTarget() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketRejectTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/websocket/WebsocketRejectTest.java
@@ -32,7 +32,7 @@ import org.junit.rules.TestRule;
 @ApiDescriptor("/io/gravitee/gateway/standalone/websocket/teams.json")
 public class WebsocketRejectTest extends AbstractWebSocketGatewayTest {
 
-    private static final Integer WEBSOCKET_PORT = 16661;
+    private static final Integer WEBSOCKET_PORT = getFreePort();
 
     @Override
     protected String getApiEndpointTarget() {


### PR DESCRIPTION
**Issue**

N/A

**Description**

Generate a random port instead of fixed one
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/websocket-flakys-again/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cddlievyof.chromatic.com)
<!-- Storybook placeholder end -->
