### PR TITLE
fix: do not serialize flows for api v1 exports

### DIFF
--- a/gravitee-apim-e2e/api-test/src/export/api-export.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/export/api-export.spec.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { APIsApi } from '@management-apis/APIsApi';
+import { forManagementAsAdminUser } from '@client-conf/*';
+import { afterAll, beforeAll, describe, expect } from '@jest/globals';
+import { ApisFaker } from '@management-fakers/ApisFaker';
+import { ApiEntity } from '@management-models/ApiEntity';
+import { noContent, succeed } from '@lib/jest-utils';
+import { NewApiEntityFlowModeEnum } from '@management-models/NewApiEntity';
+import { Flow } from '@management-models/Flow';
+import { ConsumerConsumerTypeEnum } from '@management-models/Consumer';
+import { PathOperatorOperatorEnum } from '@management-models/PathOperator';
+
+const orgId = 'DEFAULT';
+const envId = 'DEFAULT';
+const apisResourceAdmin = new APIsApi(forManagementAsAdminUser());
+
+let userApi: ApiEntity;
+
+describe('API - Exports', () => {
+  describe('Export path based api from current version to 3.0 to 3.6 version and import it', () => {
+    let importedApi: ApiEntity;
+    beforeAll(async () => {
+      userApi = await apisResourceAdmin.createApi({
+        orgId,
+        envId,
+        newApiEntity: ApisFaker.newApi({ paths: ['/'], gravitee: '1.0.0' }),
+      });
+    });
+
+    it('should export the api without flow', async () => {
+      const exportedApi = JSON.parse(
+        await succeed(apisResourceAdmin.exportApiDefinitionRaw({ api: userApi.id, envId, orgId, version: '3.0' })),
+      );
+      expect(exportedApi).toBeTruthy();
+      expect(exportedApi).not.toHaveProperty('flows');
+      expect(exportedApi).toHaveProperty('paths');
+
+      await noContent(apisResourceAdmin.deleteApiRaw({ orgId, envId, api: userApi.id }));
+
+      importedApi = await succeed(apisResourceAdmin.importApiDefinitionRaw({ orgId, envId, body: exportedApi }));
+      expect(importedApi).toBeTruthy();
+      expect(importedApi.crossId).toStrictEqual(exportedApi.crossId);
+      expect(importedApi.flows).toHaveLength(0);
+      expect(importedApi.paths).toMatchObject({ '/': [] });
+      expect(importedApi.gravitee).toStrictEqual(exportedApi.gravitee);
+    });
+
+    afterEach(async () => {
+      await apisResourceAdmin.deleteApi({ orgId, envId, api: importedApi.id });
+    });
+  });
+
+  describe('Export flow based api from current version to 3.0 to 3.6 and import it', () => {
+    const flow: Flow = {
+      condition: '',
+      consumers: [{ consumerId: 'Consumer#1', consumerType: ConsumerConsumerTypeEnum.TAG }],
+      enabled: true,
+      methods: [],
+      name: 'Flow',
+      path_operator: { operator: PathOperatorOperatorEnum.STARTSWITH, path: '' },
+      post: [],
+      pre: [],
+    };
+    const exportedFlow = { ...flow, 'path-operator': flow.path_operator, path_operator: undefined };
+    let importedApi: ApiEntity;
+
+    beforeAll(async () => {
+      userApi = await apisResourceAdmin.createApi({
+        orgId,
+        envId,
+        newApiEntity: ApisFaker.newApi({
+          gravitee: '2.0.0',
+          flows: [flow],
+          flow_mode: NewApiEntityFlowModeEnum.BESTMATCH,
+        }),
+      });
+    });
+
+    it('should export the api without flow', async () => {
+      const exportedApi = JSON.parse(
+        await succeed(apisResourceAdmin.exportApiDefinitionRaw({ api: userApi.id, envId, orgId, version: '3.0' })),
+      );
+      expect(exportedApi).toBeTruthy();
+      expect(exportedApi).toHaveProperty('flows');
+      expect(exportedApi.flows).toHaveLength(1);
+      expect(exportedApi.flows[0]).toEqual(exportedFlow);
+      expect(exportedApi).not.toHaveProperty('paths');
+
+      await noContent(apisResourceAdmin.deleteApiRaw({ orgId, envId, api: userApi.id }));
+
+      importedApi = await succeed(apisResourceAdmin.importApiDefinitionRaw({ orgId, envId, body: exportedApi }));
+      expect(importedApi).toBeTruthy();
+      expect(importedApi.crossId).toStrictEqual(exportedApi.crossId);
+      expect(exportedApi.flows).toHaveLength(1);
+      expect(exportedApi.flows[0]).toEqual(exportedFlow);
+      expect(importedApi.gravitee).toStrictEqual(exportedApi.gravitee);
+    });
+
+    afterAll(async () => {
+      await apisResourceAdmin.deleteApi({ orgId, envId, api: importedApi.id });
+    });
+  });
+});

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/api/ApiSerializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/api/ApiSerializer.java
@@ -20,6 +20,7 @@ import static java.util.Collections.emptyList;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.definition.model.Rule;
 import io.gravitee.definition.model.plugins.resources.Resource;
@@ -107,12 +108,19 @@ public abstract class ApiSerializer extends StdSerializer<ApiEntity> {
         if (apiEntity.getPicture() != null) {
             jsonGenerator.writeObjectField("picture", apiEntity.getPicture());
         }
-        if (apiEntity.getPaths() != null) {
-            jsonGenerator.writeObjectFieldStart("paths");
-            for (Map.Entry<String, List<Rule>> entry : apiEntity.getPaths().entrySet()) {
-                jsonGenerator.writeObjectField(entry.getKey(), entry.getValue());
+
+        if (DefinitionVersion.V1.getLabel().equals(apiEntity.getGraviteeDefinitionVersion())) {
+            if (apiEntity.getPaths() != null) {
+                jsonGenerator.writeObjectFieldStart("paths");
+                for (Map.Entry<String, List<Rule>> entry : apiEntity.getPaths().entrySet()) {
+                    jsonGenerator.writeObjectField(entry.getKey(), entry.getValue());
+                }
+                jsonGenerator.writeEndObject();
             }
-            jsonGenerator.writeEndObject();
+        } else if (DefinitionVersion.V2.getLabel().equals(apiEntity.getGraviteeDefinitionVersion())) {
+            if (apiEntity.getFlows() != null) {
+                jsonGenerator.writeObjectField("flows", apiEntity.getFlows());
+            }
         }
 
         if (apiEntity.getGraviteeDefinitionVersion() != null) {
@@ -121,10 +129,6 @@ public abstract class ApiSerializer extends StdSerializer<ApiEntity> {
 
         if (apiEntity.getFlowMode() != null) {
             jsonGenerator.writeObjectField("flow_mode", apiEntity.getFlowMode().toString().toUpperCase());
-        }
-
-        if (apiEntity.getFlows() != null) {
-            jsonGenerator.writeObjectField("flows", apiEntity.getFlows());
         }
 
         if (apiEntity.getServices() != null && !apiEntity.getServices().isEmpty()) {


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8365

**Description**

Remove ``paths`` attribute from Api model during serialization when the definition version equals v2 .
Remove ``Flows`` attribute from Api model during serialization when the definition version equals v1 .

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/issues-8365-import-path-based-api/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
