### PR TITLE
fix: do not serialize flows for api v1 exports

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/api/ApiSerializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/api/ApiSerializer.java
@@ -20,6 +20,7 @@ import static java.util.Collections.emptyList;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.Rule;
 import io.gravitee.definition.model.plugins.resources.Resource;
 import io.gravitee.rest.api.model.*;
@@ -81,12 +82,19 @@ public abstract class ApiSerializer extends StdSerializer<ApiEntity> {
         if (apiEntity.getPicture() != null) {
             jsonGenerator.writeObjectField("picture", apiEntity.getPicture());
         }
-        if (apiEntity.getPaths() != null) {
-            jsonGenerator.writeObjectFieldStart("paths");
-            for (Map.Entry<String, List<Rule>> entry : apiEntity.getPaths().entrySet()) {
-                jsonGenerator.writeObjectField(entry.getKey(), entry.getValue());
+
+        if (DefinitionVersion.V1.getLabel().equals(apiEntity.getGraviteeDefinitionVersion())) {
+            if (apiEntity.getPaths() != null) {
+                jsonGenerator.writeObjectFieldStart("paths");
+                for (Map.Entry<String, List<Rule>> entry : apiEntity.getPaths().entrySet()) {
+                    jsonGenerator.writeObjectField(entry.getKey(), entry.getValue());
+                }
+                jsonGenerator.writeEndObject();
             }
-            jsonGenerator.writeEndObject();
+        } else {
+            if (apiEntity.getFlows() != null) {
+                jsonGenerator.writeObjectField("flows", apiEntity.getFlows());
+            }
         }
 
         if (apiEntity.getGraviteeDefinitionVersion() != null) {
@@ -95,10 +103,6 @@ public abstract class ApiSerializer extends StdSerializer<ApiEntity> {
 
         if (apiEntity.getFlowMode() != null) {
             jsonGenerator.writeObjectField("flow_mode", apiEntity.getFlowMode().toString().toUpperCase());
-        }
-
-        if (apiEntity.getFlows() != null) {
-            jsonGenerator.writeObjectField("flows", apiEntity.getFlows());
         }
 
         if (apiEntity.getServices() != null && !apiEntity.getServices().isEmpty()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_EnumValueWittenLowercaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_EnumValueWittenLowercaseTest.java
@@ -55,12 +55,47 @@ public class ApiService_EnumValueWittenLowercaseTest {
     }
 
     @Test
-    public void shouldConvertAsJsonForExportWithUppercaseEnum() throws IOException {
+    public void shouldConvertAsJsonForV2ExportWithUppercaseEnum() throws IOException {
         ApiEntity apiEntity = new ApiEntity();
         apiEntity.setId(API_ID);
         apiEntity.setName("test");
         apiEntity.setDescription("Gravitee.io");
         apiEntity.setVisibility(Visibility.PUBLIC);
+        apiEntity.setGraviteeDefinitionVersion("2.0.0");
+
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put(ApiSerializer.METADATA_EXPORT_VERSION, ApiSerializer.Version.DEFAULT.getVersion());
+        metadata.put(
+            ApiSerializer.METADATA_FILTERED_FIELDS_LIST,
+            Arrays.asList("groups", "members", "pages", "plans", "metadata", "media")
+        );
+        apiEntity.setMetadata(metadata);
+
+        String result = objectMapper.writeValueAsString(apiEntity);
+        assertThat(result)
+            .isEqualTo(
+                "{\n" +
+                "  \"name\" : \"test\",\n" +
+                "  \"description\" : \"Gravitee.io\",\n" +
+                "  \"visibility\" : \"PUBLIC\",\n" +
+                "  \"flows\" : [ ],\n" +
+                "  \"gravitee\" : \"2.0.0\",\n" +
+                "  \"resources\" : [ ],\n" +
+                "  \"properties\" : [ ],\n" +
+                "  \"id\" : \"id-api\",\n" +
+                "  \"path_mappings\" : [ ]\n" +
+                "}"
+            );
+    }
+
+    @Test
+    public void shouldConvertAsJsonForV1ExportWithUppercaseEnum() throws IOException {
+        ApiEntity apiEntity = new ApiEntity();
+        apiEntity.setId(API_ID);
+        apiEntity.setName("test");
+        apiEntity.setDescription("Gravitee.io");
+        apiEntity.setVisibility(Visibility.PUBLIC);
+        apiEntity.setGraviteeDefinitionVersion("1.0.0");
 
         Map<String, Object> metadata = new HashMap<>();
         metadata.put(ApiSerializer.METADATA_EXPORT_VERSION, ApiSerializer.Version.DEFAULT.getVersion());
@@ -78,7 +113,7 @@ public class ApiService_EnumValueWittenLowercaseTest {
                 "  \"description\" : \"Gravitee.io\",\n" +
                 "  \"visibility\" : \"PUBLIC\",\n" +
                 "  \"paths\" : { },\n" +
-                "  \"flows\" : [ ],\n" +
+                "  \"gravitee\" : \"1.0.0\",\n" +
                 "  \"resources\" : [ ],\n" +
                 "  \"properties\" : [ ],\n" +
                 "  \"id\" : \"id-api\",\n" +
@@ -111,6 +146,7 @@ public class ApiService_EnumValueWittenLowercaseTest {
             "  \"description\" : \"Gravitee.io\",\n" +
             "  \"visibility\" : \"PUBLIC\",\n" +
             "  \"paths\" : { },\n" +
+            "  \"gravitee\" : \"1.0.0\",\n" +
             "  \"resources\" : [ ],\n" +
             "  \"path_mappings\" : [ ]\n" +
             "}";


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8365

**Description**

Backport this fix ( https://github.com/gravitee-io/gravitee-api-management/pull/2418 ) to 3.15 
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vuhatqrpfr.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/issues-8365-import-path-based-api-315x-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
