### PR TITLE
fix: vertx timers memory leak

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/logging/LoggableClientResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/logging/LoggableClientResponse.java
@@ -65,15 +65,27 @@ public class LoggableClientResponse implements Response {
     }
 
     @Override
+    public void end() {
+        response.end();
+    }
+
+    @Override
+    public void end(Buffer buffer) {
+        response.end(buffer);
+    }
+
+    @Override
     public Response status(int statusCode) {
         log.setClientResponse(new io.gravitee.reporter.api.common.Response(statusCode));
-        return response.status(statusCode);
+        response.status(statusCode);
+        return this;
     }
 
     @Override
     public Response endHandler(Handler<Void> endHandler) {
         writeClientResponseLog(buffer);
-        return response.endHandler(endHandler);
+        response.endHandler(endHandler);
+        return this;
     }
 
     private void writeClientResponseLog(Buffer buffer) {
@@ -101,7 +113,8 @@ public class LoggableClientResponse implements Response {
 
     @Override
     public Response reason(String reason) {
-        return response.reason(reason);
+        response.reason(reason);
+        return this;
     }
 
     @Override
@@ -121,7 +134,8 @@ public class LoggableClientResponse implements Response {
 
     @Override
     public Response writeCustomFrame(HttpFrame frame) {
-        return response.writeCustomFrame(frame);
+        response.writeCustomFrame(frame);
+        return this;
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/TimeoutServerResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/TimeoutServerResponse.java
@@ -43,7 +43,8 @@ public class TimeoutServerResponse implements Response {
 
     @Override
     public Response status(int i) {
-        return response.status(i);
+        response.status(i);
+        return this;
     }
 
     @Override
@@ -58,7 +59,8 @@ public class TimeoutServerResponse implements Response {
 
     @Override
     public Response reason(String reason) {
-        return response.reason(reason);
+        response.reason(reason);
+        return this;
     }
 
     @Override
@@ -97,7 +99,8 @@ public class TimeoutServerResponse implements Response {
 
     @Override
     public Response endHandler(Handler<Void> endHandler) {
-        return response.endHandler(endHandler);
+        response.endHandler(endHandler);
+        return this;
     }
 
     private void release() {
@@ -116,6 +119,7 @@ public class TimeoutServerResponse implements Response {
 
     @Override
     public Response writeCustomFrame(HttpFrame frame) {
-        return response.writeCustomFrame(frame);
+        response.writeCustomFrame(frame);
+        return this;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttp2ServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttp2ServerRequest.java
@@ -50,7 +50,7 @@ public class VertxHttp2ServerRequest extends VertxHttpServerRequest {
     }
 
     @Override
-    public Response create() {
+    public Response createResponse() {
         return new VertxHttp2ServerResponse(this);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpServerRequest.java
@@ -29,10 +29,8 @@ import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.api.http2.HttpFrame;
 import io.gravitee.gateway.api.ws.WebSocket;
 import io.gravitee.reporter.api.http.Metrics;
-import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.net.SocketAddress;
-import java.util.Map;
 import javax.net.ssl.SSLSession;
 
 /**
@@ -265,7 +263,7 @@ public class VertxHttpServerRequest implements Request {
         return serverRequest;
     }
 
-    public Response create() {
+    public Response createResponse() {
         return new VertxHttpServerResponse(this);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/grpc/VertxGrpcServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/grpc/VertxGrpcServerRequest.java
@@ -31,7 +31,7 @@ public class VertxGrpcServerRequest extends VertxHttp2ServerRequest {
     }
 
     @Override
-    public Response create() {
+    public Response createResponse() {
         return new VertxGrpcServerResponse(this);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/ws/VertxWebSocketServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/ws/VertxWebSocketServerRequest.java
@@ -56,7 +56,7 @@ public class VertxWebSocketServerRequest extends VertxHttpServerRequest {
     }
 
     @Override
-    public Response create() {
+    public Response createResponse() {
         return new VertxWebSocketServerResponse(this);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/DefaultHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/DefaultHttpRequestDispatcher.java
@@ -18,14 +18,12 @@ package io.gravitee.gateway.jupiter.reactor;
 import io.gravitee.common.http.IdGenerator;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.definition.model.ExecutionMode;
-import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.api.context.SimpleExecutionContext;
 import io.gravitee.gateway.api.handler.Handler;
 import io.gravitee.gateway.core.component.ComponentProvider;
 import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.env.HttpRequestTimeoutConfiguration;
 import io.gravitee.gateway.http.utils.WebSocketUtils;
-import io.gravitee.gateway.http.vertx.TimeoutServerResponse;
 import io.gravitee.gateway.http.vertx.VertxHttp2ServerRequest;
 import io.gravitee.gateway.http.vertx.grpc.VertxGrpcServerRequest;
 import io.gravitee.gateway.http.vertx.ws.VertxWebSocketServerRequest;
@@ -302,7 +300,7 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
         HttpServerRequest httpServerRequest,
         io.gravitee.gateway.http.vertx.VertxHttpServerRequest request
     ) {
-        SimpleExecutionContext simpleExecutionContext = new SimpleExecutionContext(request, request.create());
+        SimpleExecutionContext simpleExecutionContext = new SimpleExecutionContext(request, request.createResponse());
 
         if (httpRequestTimeoutConfiguration.getHttpRequestTimeout() > 0 && !isV3WebSocket(httpServerRequest)) {
             final long vertxTimerId = vertx.setTimer(

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/vertx/VertxDebugReactorHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/vertx/VertxDebugReactorHandler.java
@@ -54,7 +54,7 @@ public class VertxDebugReactorHandler implements Handler<HttpServerRequest> {
 
         request = new VertxHttpServerRequestDebugDecorator(request, idGenerator);
 
-        route(request, request.create());
+        route(request, request.createResponse());
     }
 
     protected void route(final Request request, final Response response) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/vertx/VertxHttpServerRequestDebugDecorator.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/vertx/VertxHttpServerRequestDebugDecorator.java
@@ -29,7 +29,7 @@ public class VertxHttpServerRequestDebugDecorator extends VertxHttpServerRequest
     }
 
     @Override
-    public Response create() {
+    public Response createResponse() {
         return new VertxHttpServerResponseDebugDecorator(delegate);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/jupiter/debug/reactor/DebugHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/jupiter/debug/reactor/DebugHttpRequestDispatcher.java
@@ -81,9 +81,4 @@ public class DebugHttpRequestDispatcher extends DefaultHttpRequestDispatcher {
         io.gravitee.gateway.http.vertx.VertxHttpServerRequest v3Request = super.createV3Request(httpServerRequest, idGenerator);
         return new VertxHttpServerRequestDebugDecorator(v3Request, idGenerator);
     }
-
-    @Override
-    protected Response createV3TimeoutResponse(Vertx vertx, io.gravitee.gateway.http.vertx.VertxHttpServerRequest request, long timeoutId) {
-        return new TimeoutServerResponseDebugDecorator(vertx, request.create(), timeoutId);
-    }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxReactorHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxReactorHandler.java
@@ -63,7 +63,7 @@ public class VertxReactorHandler implements Handler<HttpServerRequest> {
             request = new VertxHttpServerRequest(httpServerRequest, idGenerator);
         }
 
-        route(request, request.create());
+        route(request, request.createResponse());
     }
 
     protected void route(final Request request, final Response response) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/ws/VertxWebSocketReactorHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/ws/VertxWebSocketReactorHandler.java
@@ -45,7 +45,7 @@ public class VertxWebSocketReactorHandler extends VertxReactorHandler {
     public void handle(HttpServerRequest httpServerRequest) {
         if (isWebSocket(httpServerRequest)) {
             VertxHttpServerRequest request = new VertxWebSocketServerRequest(httpServerRequest, idGenerator);
-            super.route(request, request.create());
+            super.route(request, request.createResponse());
         } else {
             super.handle(httpServerRequest);
         }


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/8196

In some scenarios, vertx timers were created without being canceled properly, cause TimeoutServerResponse.release() was never called.
That led to memory leaks.

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-timeoutvertxtimer/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jtboeikemy.chromatic.com)
<!-- Storybook placeholder end -->
