### PR TITLE
Debug Mode: Display Query params as table instead of string 

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-inspector/policy-studio-debug-inspector.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-inspector/policy-studio-debug-inspector.component.spec.ts
@@ -58,9 +58,12 @@ describe('PolicyStudioDebugInspectorComponent', () => {
     expect(treeNodes[0].children[0].name).toEqual('Method');
     expect(treeNodes[0].children[0].type).toBeUndefined();
     expect(treeNodes[0].children[0].children.length).toEqual(1);
-    expect(treeNodes[0].children[1].name).toEqual('Path');
+    expect(treeNodes[0].children[1].name).toEqual('Query params');
     expect(treeNodes[0].children[1].type).toBeUndefined();
-    expect(treeNodes[0].children[1].children[0].type).toEqual('text');
+    expect(treeNodes[0].children[1].children[0].type).toEqual('table');
+    expect(treeNodes[0].children[2].name).toEqual('Path');
+    expect(treeNodes[0].children[2].type).toBeUndefined();
+    expect(treeNodes[0].children[2].children[0].type).toEqual('text');
     expect(treeNodes[1].name).toEqual('HTTP headers');
     expect(treeNodes[1].children[0].type).toEqual('table');
     expect(treeNodes[1].children[0].input).toBeDefined();

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-inspector/policy-studio-debug-inspector.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-inspector/policy-studio-debug-inspector.component.ts
@@ -43,7 +43,7 @@ interface NodeContainerElement {
 const HTTP_PROPERTIES_NODES: Record<string, NodeContainerElement> = {
   parameters: {
     name: 'Query params',
-    type: 'text',
+    type: 'table',
   },
   pathParameters: {
     name: 'Path params',

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/debug/models/DebugStep.fixture.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/debug/models/DebugStep.fixture.ts
@@ -43,6 +43,9 @@ export function fakeRequestDebugStep(attributes?: Partial<RequestPolicyDebugStep
         retrievePetSize: 'false',
         defaultPetName: 'Bobby',
       },
+      parameters: {
+        query: 'queryValue',
+      },
       method: 'GET',
       path: '/fake/api',
     },


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7779

**Description**

Display Query params as table instead of string 


**Screenshots**

Before:
![image](https://user-images.githubusercontent.com/4112568/188827791-8b9b590c-717f-4d05-8108-c4436e7dfdd3.png)


After:
![image](https://user-images.githubusercontent.com/4112568/188827765-7976b088-685a-4f90-a36b-2dda41888b35.png)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/7779-fix-query-params-in-debug-mode/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xouqodlkft.chromatic.com)
<!-- Storybook placeholder end -->
