### PR TITLE
[Console] Start Migration of api proxy entrypoints

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/proxy/api-proxy.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/api-proxy.module.ts
@@ -13,12 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { NgModule } from '@angular/core';
 
-import { ApiListModule } from './list/api-list.module';
-import { ApiProxyModule } from './proxy/api-proxy.module';
+import { NgModule } from '@angular/core';
+import { ApiProxyEntrypointsModule } from './entrypoints/api-proxy-entrypoints.module';
 
 @NgModule({
-  imports: [ApiListModule, ApiProxyModule],
+  imports: [ApiProxyEntrypointsModule],
 })
-export class ApisModule {}
+export class ApiProxyModule {}

--- a/gravitee-apim-console-webui/src/management/api/proxy/api-proxy.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/api-proxy.module.ts
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import { NgModule } from "@angular/core";
+import { NgModule } from '@angular/core';
 
-import { ApiProxyEntrypointsModule } from "./entrypoints/api-proxy-entrypoints.module";
-
+import { ApiProxyEntrypointsModule } from './entrypoints/api-proxy-entrypoints.module';
 
 @NgModule({
   imports: [ApiProxyEntrypointsModule],

--- a/gravitee-apim-console-webui/src/management/api/proxy/api-proxy.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/api-proxy.module.ts
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-import { NgModule } from '@angular/core';
-import { ApiProxyEntrypointsModule } from './entrypoints/api-proxy-entrypoints.module';
+import { NgModule } from "@angular/core";
+
+import { ApiProxyEntrypointsModule } from "./entrypoints/api-proxy-entrypoints.module";
+
 
 @NgModule({
   imports: [ApiProxyEntrypointsModule],

--- a/gravitee-apim-console-webui/src/management/api/proxy/apiProxy.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/apiProxy.controller.ts
@@ -387,7 +387,7 @@ class ApiProxyController {
   initDomainRestrictions(data: any) {
     const domainPattern = '((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+';
 
-    this.domainRestrictions = data.domainRestrictions;
+    this.domainRestrictions = ['domain.restriction1.io', 'domain.restriction2.io'] ?? data.domainRestrictions;
 
     if (this.domainRestrictions === undefined) {
       this.domainRestrictions = [];

--- a/gravitee-apim-console-webui/src/management/api/proxy/apis.proxy.route.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/apis.proxy.route.ts
@@ -52,6 +52,19 @@ function apisProxyRouterConfig($stateProvider) {
         },
       },
     })
+    .state('management.apis.detail.proxy.ng-entrypoints', {
+      url: '/ng-proxy',
+      component: 'ngApiProxyEntrypoints',
+      data: {
+        useAngularMaterial: true,
+        perms: {
+          only: ['api-definition-r', 'api-health-r'],
+        },
+        docs: {
+          page: 'management-api-proxy',
+        },
+      },
+    })
     .state('management.apis.detail.proxy.cors', {
       url: '/cors',
       template: require('./general/apiProxyCORS.html'),

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.html
@@ -1,0 +1,18 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+🚧

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.html
@@ -38,6 +38,7 @@
   <api-proxy-entrypoints-virtual-host
     *ngIf="virtualHostModeEnabled"
     [apiProxy]="apiProxy"
+    [domainRestrictions]="domainRestrictions"
     (apiProxySubmit)="onSubmit($event)"
   ></api-proxy-entrypoints-virtual-host>
 </ng-container>

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.html
@@ -28,24 +28,16 @@
   </button>
 </div>
 
-<form *ngIf="entrypointsForm" [formGroup]="entrypointsForm" (ngSubmit)="onSubmit()" autocomplete="off" gioFormFocusInvalid>
-<mat-card class="form-card">
-    <mat-form-field appearance="fill" class="form-card__context-path-field">
-      <mat-label>Gateway context-path</mat-label>
-      <input matInput formControlName="contextPath" />
-      <mat-hint
-        >Path where API is exposed, must start with a '/' and must contain any letter, capitalize letter, number, dash or
-        underscore.</mat-hint
-      >
-      <mat-error *ngIf="entrypointsForm.get('contextPath').hasError('required')">Context path is required.</mat-error>
-      <mat-error *ngIf="entrypointsForm.get('contextPath').hasError('minlength')"
-        >Context path has to be more than 3 characters long.</mat-error
-      >
-      <mat-error *ngIf="entrypointsForm.get('contextPath').hasError('pattern')"
-        >Context path is not valid (must start with a '/' and must contain any letter, capitalize letter, number, dash or underscore).</mat-error
-      >
-    </mat-form-field>
-</mat-card>
+<ng-container *ngIf="apiProxy">
+  <api-proxy-entrypoints-context-path
+    *ngIf="!virtualHostModeEnabled"
+    [apiProxy]="apiProxy"
+    (apiProxySubmit)="onSubmit($event)"
+  ></api-proxy-entrypoints-context-path>
 
-<gio-save-bar [form]="entrypointsForm" [formInitialValues]="initialEntrypointsFormValue"> </gio-save-bar>
-</form>
+  <api-proxy-entrypoints-virtual-host
+    *ngIf="virtualHostModeEnabled"
+    [apiProxy]="apiProxy"
+    (apiProxySubmit)="onSubmit($event)"
+  ></api-proxy-entrypoints-virtual-host>
+</ng-container>

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.html
@@ -15,4 +15,37 @@
     limitations under the License.
 
 -->
-🚧
+<div class="title">
+  <h1>Entrypoints</h1>
+  <button
+    (click)="switchVirtualHostMode()"
+    mat-raised-button
+    color="primary"
+    aria-label="add-api"
+    *gioPermission="{ anyOf: ['api-definition-u'] }"
+  >
+    {{ virtualHostModeEnabled ? 'Switch to context-path mode' : 'Switch to virtual-hosts mode' }}
+  </button>
+</div>
+
+<form *ngIf="entrypointsForm" [formGroup]="entrypointsForm" (ngSubmit)="onSubmit()" autocomplete="off" gioFormFocusInvalid>
+<mat-card class="form-card">
+    <mat-form-field appearance="fill" class="form-card__context-path-field">
+      <mat-label>Gateway context-path</mat-label>
+      <input matInput formControlName="contextPath" />
+      <mat-hint
+        >Path where API is exposed, must start with a '/' and must contain any letter, capitalize letter, number, dash or
+        underscore.</mat-hint
+      >
+      <mat-error *ngIf="entrypointsForm.get('contextPath').hasError('required')">Context path is required.</mat-error>
+      <mat-error *ngIf="entrypointsForm.get('contextPath').hasError('minlength')"
+        >Context path has to be more than 3 characters long.</mat-error
+      >
+      <mat-error *ngIf="entrypointsForm.get('contextPath').hasError('pattern')"
+        >Context path is not valid (must start with a '/' and must contain any letter, capitalize letter, number, dash or underscore).</mat-error
+      >
+    </mat-form-field>
+</mat-card>
+
+<gio-save-bar [form]="entrypointsForm" [formInitialValues]="initialEntrypointsFormValue"> </gio-save-bar>
+</form>

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.scss
@@ -5,7 +5,6 @@
   overflow: visible;
 }
 
-
 .title {
   display: flex;
   align-items: center;
@@ -14,13 +13,5 @@
 
   h1 {
     margin-bottom: 0;
-  }
-}
-
-
-.form-card {
-  &__context-path-field {
-    width: 100%;
-    padding-bottom: 32px;
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.scss
@@ -1,0 +1,8 @@
+@use '../../../../scss/gio-layout' as gio-layout;
+
+:host {
+  @include gio-layout.gio-responsive-content-container;
+}
+
+.api-proxy-entrypoints {
+}

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.scss
@@ -2,7 +2,25 @@
 
 :host {
   @include gio-layout.gio-responsive-content-container;
+  overflow: visible;
 }
 
-.api-proxy-entrypoints {
+
+.title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+
+  h1 {
+    margin-bottom: 0;
+  }
+}
+
+
+.form-card {
+  &__context-path-field {
+    width: 100%;
+    padding-bottom: 32px;
+  }
 }

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.spec.ts
@@ -16,36 +16,79 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpTestingController } from '@angular/common/http/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+import { GioSaveBarHarness } from '@gravitee/ui-particles-angular';
 
 import { ApiProxyEntrypointsModule } from './api-proxy-entrypoints.module';
 import { ApiProxyEntrypointsComponent } from './api-proxy-entrypoints.component';
 
-import { GioHttpTestingModule } from '../../../../shared/testing';
+import { CONSTANTS_TESTING, GioHttpTestingModule } from '../../../../shared/testing';
+import { fakeApi } from '../../../../entities/api/Api.fixture';
+import { Api } from '../../../../entities/api';
+import { CurrentUserService, UIRouterStateParams } from '../../../../ajs-upgraded-providers';
+import { User } from '../../../../entities/user';
+
 
 describe('ApiProxyEntrypointsComponent', () => {
   let fixture: ComponentFixture<ApiProxyEntrypointsComponent>;
-  let component: ApiProxyEntrypointsComponent;
+  let loader: HarnessLoader;
   let httpTestingController: HttpTestingController;
+
+  const currentUser = new User();
+  currentUser.userPermissions = ['api-definition-u', 'api-gateway_definition-u'];
+
+  const API_ID= "apiId"
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, GioHttpTestingModule, ApiProxyEntrypointsModule],
+      providers: [
+        { provide: UIRouterStateParams, useValue: { apiId: API_ID } },
+        { provide: CurrentUserService, useValue: { currentUser } },
+      ],
     });
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ApiProxyEntrypointsComponent);
-    component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
 
     httpTestingController = TestBed.inject(HttpTestingController);
     fixture.detectChanges();
   });
 
-  it('should work', async () => {
-    expect(component).toBeTruthy();
+  it('should update context-path', async () => {
+    
+    const api = fakeApi({ id: API_ID, proxy: { virtual_hosts: [{ path: '/path' }] } });
+    expectApiGetRequest(api);
+
+    const saveBar = await loader.getHarness(GioSaveBarHarness);
+    expect(await saveBar.isVisible()).toBe(false);
+    
+    const contextPathInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=contextPath]' }));
+    expect(await contextPathInput.isDisabled()).toEqual(false);
+    expect(await contextPathInput.getValue()).toEqual('/path');
+
+    await contextPathInput.setValue('/new-path');
+
+    expect(await saveBar.isSubmitButtonInvalid()).toEqual(false);
+    await saveBar.clickSubmit();
+
+    // Expect fetch api get and update proxy
+    expectApiGetRequest(api);
+    const req = httpTestingController.expectOne({ method: 'PUT', url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}` });
+    expect(req.request.body.proxy.virtual_hosts).toEqual([{ path: '/new-path' }]);
+
   });
 
   afterEach(() => {
     httpTestingController.verify();
   });
+
+  function expectApiGetRequest(api: Api) {
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/apis/${api.id}`, method: 'GET' }).flush(api);
+    fixture.detectChanges();
+  }
 });

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.spec.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+
+import { ApiProxyEntrypointsModule } from './api-proxy-entrypoints.module';
+import { ApiProxyEntrypointsComponent } from './api-proxy-entrypoints.component';
+
+import { GioHttpTestingModule } from '../../../../shared/testing';
+
+describe('ApiProxyEntrypointsComponent', () => {
+  let fixture: ComponentFixture<ApiProxyEntrypointsComponent>;
+  let component: ApiProxyEntrypointsComponent;
+  let httpTestingController: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, GioHttpTestingModule, ApiProxyEntrypointsModule],
+    });
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ApiProxyEntrypointsComponent);
+    component = fixture.componentInstance;
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+  });
+
+  it('should work', async () => {
+    expect(component).toBeTruthy();
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.spec.ts
@@ -30,7 +30,6 @@ import { Api } from '../../../../entities/api';
 import { CurrentUserService, UIRouterStateParams } from '../../../../ajs-upgraded-providers';
 import { User } from '../../../../entities/user';
 
-
 describe('ApiProxyEntrypointsComponent', () => {
   let fixture: ComponentFixture<ApiProxyEntrypointsComponent>;
   let loader: HarnessLoader;
@@ -39,7 +38,7 @@ describe('ApiProxyEntrypointsComponent', () => {
   const currentUser = new User();
   currentUser.userPermissions = ['api-definition-u', 'api-gateway_definition-u'];
 
-  const API_ID= "apiId"
+  const API_ID = 'apiId';
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -60,13 +59,12 @@ describe('ApiProxyEntrypointsComponent', () => {
   });
 
   it('should update context-path', async () => {
-    
     const api = fakeApi({ id: API_ID, proxy: { virtual_hosts: [{ path: '/path' }] } });
     expectApiGetRequest(api);
 
     const saveBar = await loader.getHarness(GioSaveBarHarness);
     expect(await saveBar.isVisible()).toBe(false);
-    
+
     const contextPathInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=contextPath]' }));
     expect(await contextPathInput.isDisabled()).toEqual(false);
     expect(await contextPathInput.getValue()).toEqual('/path');
@@ -80,7 +78,6 @@ describe('ApiProxyEntrypointsComponent', () => {
     expectApiGetRequest(api);
     const req = httpTestingController.expectOne({ method: 'PUT', url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}` });
     expect(req.request.body.proxy.virtual_hosts).toEqual([{ path: '/new-path' }]);
-
   });
 
   afterEach(() => {

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.spec.ts
@@ -29,10 +29,16 @@ import { fakeApi } from '../../../../entities/api/Api.fixture';
 import { Api } from '../../../../entities/api';
 import { CurrentUserService, UIRouterStateParams } from '../../../../ajs-upgraded-providers';
 import { User } from '../../../../entities/user';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { Environment } from '../../../../entities/environment/environment';
+import { fakeEnvironment } from '../../../../entities/environment/environment.fixture';
+import { MatDialogHarness } from '@angular/material/dialog/testing';
+import { InteractivityChecker } from '@angular/cdk/a11y';
 
 describe('ApiProxyEntrypointsComponent', () => {
   let fixture: ComponentFixture<ApiProxyEntrypointsComponent>;
   let loader: HarnessLoader;
+  let rootLoader: HarnessLoader;
   let httpTestingController: HttpTestingController;
 
   const currentUser = new User();
@@ -47,45 +53,95 @@ describe('ApiProxyEntrypointsComponent', () => {
         { provide: UIRouterStateParams, useValue: { apiId: API_ID } },
         { provide: CurrentUserService, useValue: { currentUser } },
       ],
+    }).overrideProvider(InteractivityChecker, {
+      useValue: {
+        isFocusable: () => true, // This traps focus checks and so avoid warnings when dealing with
+      },
     });
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ApiProxyEntrypointsComponent);
     loader = TestbedHarnessEnvironment.loader(fixture);
+    rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
 
     httpTestingController = TestBed.inject(HttpTestingController);
     fixture.detectChanges();
-  });
-
-  it('should update context-path', async () => {
-    const api = fakeApi({ id: API_ID, proxy: { virtual_hosts: [{ path: '/path' }] } });
-    expectApiGetRequest(api);
-
-    const saveBar = await loader.getHarness(GioSaveBarHarness);
-    expect(await saveBar.isVisible()).toBe(false);
-
-    const contextPathInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=contextPath]' }));
-    expect(await contextPathInput.isDisabled()).toEqual(false);
-    expect(await contextPathInput.getValue()).toEqual('/path');
-
-    await contextPathInput.setValue('/new-path');
-
-    expect(await saveBar.isSubmitButtonInvalid()).toEqual(false);
-    await saveBar.clickSubmit();
-
-    // Expect fetch api get and update proxy
-    expectApiGetRequest(api);
-    const req = httpTestingController.expectOne({ method: 'PUT', url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}` });
-    expect(req.request.body.proxy.virtual_hosts).toEqual([{ path: '/new-path' }]);
   });
 
   afterEach(() => {
     httpTestingController.verify();
   });
 
+  describe('context-path mode', () => {
+    beforeEach(() => {
+      exceptEnvironmentGetRequest(fakeEnvironment());
+    });
+
+    it('should update context-path', async () => {
+      const api = fakeApi({ id: API_ID, proxy: { virtual_hosts: [{ path: '/path' }] } });
+      expectApiGetRequest(api);
+
+      const saveBar = await loader.getHarness(GioSaveBarHarness);
+      expect(await saveBar.isVisible()).toBe(false);
+
+      const contextPathInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=contextPath]' }));
+      expect(await contextPathInput.isDisabled()).toEqual(false);
+      expect(await contextPathInput.getValue()).toEqual('/path');
+
+      await contextPathInput.setValue('/new-path');
+
+      expect(await saveBar.isSubmitButtonInvalid()).toEqual(false);
+      await saveBar.clickSubmit();
+
+      // Expect fetch api get and update proxy
+      expectApiGetRequest(api);
+      const req = httpTestingController.expectOne({ method: 'PUT', url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}` });
+      expect(req.request.body.proxy.virtual_hosts).toEqual([{ path: '/new-path' }]);
+    });
+
+    it('should switch to virtual-host mode', async () => {
+      expectApiGetRequest(fakeApi({ id: API_ID }));
+
+      const switchButton = await loader.getHarness(MatButtonHarness.with({ text: 'Switch to virtual-hosts mode' }));
+      await switchButton.click();
+
+      expect(await switchButton.getText()).toEqual('Switch to context-path mode');
+    });
+  });
+
+  describe('virtual-host mode', () => {
+    beforeEach(() => {
+      exceptEnvironmentGetRequest(fakeEnvironment());
+    });
+
+    it('should switch to context-path mode', async () => {
+      const api = fakeApi({ id: API_ID, proxy: { virtual_hosts: [{ path: '/path-foo', host: 'host' }, { path: '/path-bar' }] } });
+      expectApiGetRequest(api);
+
+      const switchButton = await loader.getHarness(MatButtonHarness.with({ text: 'Switch to context-path mode' }));
+      await switchButton.click();
+
+      const confirmDialog = await rootLoader.getHarness(MatDialogHarness.with({ selector: '#switchContextPathConfirmDialog' }));
+      const confirmDialogSwitchButton = await confirmDialog.getHarness(MatButtonHarness.with({ text: 'Switch' }));
+      await confirmDialogSwitchButton.click();
+
+      expect(await switchButton.getText()).toEqual('Switch to virtual-hosts mode');
+
+      // Expect fetch api get and update proxy
+      expectApiGetRequest(api);
+      const req = httpTestingController.expectOne({ method: 'PUT', url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}` });
+      expect(req.request.body.proxy.virtual_hosts).toEqual([{ path: '/path-foo' }]);
+    });
+  });
+
   function expectApiGetRequest(api: Api) {
     httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/apis/${api.id}`, method: 'GET' }).flush(api);
+    fixture.detectChanges();
+  }
+
+  function exceptEnvironmentGetRequest(environment: Environment) {
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}`, method: 'GET' }).flush(environment);
     fixture.detectChanges();
   }
 });

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.ts
@@ -13,12 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { NgModule } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Subject } from 'rxjs';
 
-import { ApiListModule } from './list/api-list.module';
-import { ApiProxyModule } from './proxy/api-proxy.module';
-
-@NgModule({
-  imports: [ApiListModule, ApiProxyModule],
+@Component({
+  selector: 'api-proxy-entrypoints',
+  template: require('./api-proxy-entrypoints.component.html'),
+  styles: [require('./api-proxy-entrypoints.component.scss')],
 })
-export class ApisModule {}
+export class ApiProxyEntrypointsComponent implements OnInit, OnDestroy {
+  private unsubscribe$: Subject<boolean> = new Subject<boolean>();
+
+  constructor() {}
+
+  ngOnInit(): void {}
+
+  ngOnDestroy() {
+    this.unsubscribe$.next(true);
+    this.unsubscribe$.unsubscribe();
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.module.ts
@@ -22,13 +22,15 @@ import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { GioConfirmDialogModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatTableModule } from '@angular/material/table';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 
+import { ApiProxyEntrypointsVirtualHostComponent } from './virtual-host/api-proxy-entrypoints-virtual-host.component';
+import { ApiProxyEntrypointsContextPathComponent } from './context-path/api-proxy-entrypoints-context-path.component';
 import { ApiProxyEntrypointsComponent } from './api-proxy-entrypoints.component';
 
 import { GioPermissionModule } from '../../../../shared/components/gio-permission/gio-permission.module';
-import { ApiProxyEntrypointsContextPathComponent } from './context-path/api-proxy-entrypoints-context-path.component';
-import { ApiProxyEntrypointsVirtualHostComponent } from './virtual-host/api-proxy-entrypoints-virtual-host.component';
-import { MatDialogModule } from '@angular/material/dialog';
 
 @NgModule({
   declarations: [ApiProxyEntrypointsComponent, ApiProxyEntrypointsContextPathComponent, ApiProxyEntrypointsVirtualHostComponent],
@@ -41,6 +43,8 @@ import { MatDialogModule } from '@angular/material/dialog';
     MatInputModule,
     MatCardModule,
     MatDialogModule,
+    MatTableModule,
+    MatCheckboxModule,
     GioPermissionModule,
     GioSaveBarModule,
     GioConfirmDialogModule,

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.module.ts
@@ -16,14 +16,30 @@
 
 import { CommonModule } from "@angular/common";
 import { NgModule } from "@angular/core";
+import { ReactiveFormsModule } from "@angular/forms";
+import { MatButtonModule } from "@angular/material/button";
+import { MatCardModule } from "@angular/material/card";
+import { MatFormFieldModule } from "@angular/material/form-field";
+import { MatInputModule } from "@angular/material/input";
+import { GioSaveBarModule } from "@gravitee/ui-particles-angular";
 
 import { ApiProxyEntrypointsComponent } from "./api-proxy-entrypoints.component";
+
+import { GioPermissionModule } from "../../../../shared/components/gio-permission/gio-permission.module";
+
 
 @NgModule({
   declarations: [ApiProxyEntrypointsComponent],
   exports: [ApiProxyEntrypointsComponent],
   imports: [
     CommonModule,
+    ReactiveFormsModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatCardModule,
+    GioPermissionModule,
+    GioSaveBarModule,
   ],
 })
 export class ApiProxyEntrypointsModule {}

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.module.ts
@@ -21,13 +21,14 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
-import { GioSaveBarModule } from '@gravitee/ui-particles-angular';
+import { GioConfirmDialogModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
 
 import { ApiProxyEntrypointsComponent } from './api-proxy-entrypoints.component';
 
 import { GioPermissionModule } from '../../../../shared/components/gio-permission/gio-permission.module';
 import { ApiProxyEntrypointsContextPathComponent } from './context-path/api-proxy-entrypoints-context-path.component';
 import { ApiProxyEntrypointsVirtualHostComponent } from './virtual-host/api-proxy-entrypoints-virtual-host.component';
+import { MatDialogModule } from '@angular/material/dialog';
 
 @NgModule({
   declarations: [ApiProxyEntrypointsComponent, ApiProxyEntrypointsContextPathComponent, ApiProxyEntrypointsVirtualHostComponent],
@@ -39,8 +40,10 @@ import { ApiProxyEntrypointsVirtualHostComponent } from './virtual-host/api-prox
     MatFormFieldModule,
     MatInputModule,
     MatCardModule,
+    MatDialogModule,
     GioPermissionModule,
     GioSaveBarModule,
+    GioConfirmDialogModule,
   ],
 })
 export class ApiProxyEntrypointsModule {}

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.module.ts
@@ -14,22 +14,23 @@
  * limitations under the License.
  */
 
-import { CommonModule } from "@angular/common";
-import { NgModule } from "@angular/core";
-import { ReactiveFormsModule } from "@angular/forms";
-import { MatButtonModule } from "@angular/material/button";
-import { MatCardModule } from "@angular/material/card";
-import { MatFormFieldModule } from "@angular/material/form-field";
-import { MatInputModule } from "@angular/material/input";
-import { GioSaveBarModule } from "@gravitee/ui-particles-angular";
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { GioSaveBarModule } from '@gravitee/ui-particles-angular';
 
-import { ApiProxyEntrypointsComponent } from "./api-proxy-entrypoints.component";
+import { ApiProxyEntrypointsComponent } from './api-proxy-entrypoints.component';
 
-import { GioPermissionModule } from "../../../../shared/components/gio-permission/gio-permission.module";
-
+import { GioPermissionModule } from '../../../../shared/components/gio-permission/gio-permission.module';
+import { ApiProxyEntrypointsContextPathComponent } from './context-path/api-proxy-entrypoints-context-path.component';
+import { ApiProxyEntrypointsVirtualHostComponent } from './virtual-host/api-proxy-entrypoints-virtual-host.component';
 
 @NgModule({
-  declarations: [ApiProxyEntrypointsComponent],
+  declarations: [ApiProxyEntrypointsComponent, ApiProxyEntrypointsContextPathComponent, ApiProxyEntrypointsVirtualHostComponent],
   exports: [ApiProxyEntrypointsComponent],
   imports: [
     CommonModule,

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.module.ts
@@ -13,12 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { NgModule } from '@angular/core';
 
-import { ApiListModule } from './list/api-list.module';
-import { ApiProxyModule } from './proxy/api-proxy.module';
+import { CommonModule } from "@angular/common";
+import { NgModule } from "@angular/core";
+
+import { ApiProxyEntrypointsComponent } from "./api-proxy-entrypoints.component";
 
 @NgModule({
-  imports: [ApiListModule, ApiProxyModule],
+  declarations: [ApiProxyEntrypointsComponent],
+  exports: [ApiProxyEntrypointsComponent],
+  imports: [
+    CommonModule,
+  ],
 })
-export class ApisModule {}
+export class ApiProxyEntrypointsModule {}

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/context-path/api-proxy-entrypoints-context-path.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/context-path/api-proxy-entrypoints-context-path.component.html
@@ -1,0 +1,39 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<form *ngIf="entrypointsForm" [formGroup]="entrypointsForm" (ngSubmit)="onSubmit()" autocomplete="off" gioFormFocusInvalid>
+  <mat-card *ngIf="!virtualHostModeEnabled" class="form-card">
+    <mat-form-field appearance="fill" class="form-card__context-path-field">
+      <mat-label>Gateway context-path</mat-label>
+      <input matInput formControlName="contextPath" />
+      <mat-hint
+        >Path where API is exposed, must start with a '/' and must contain any letter, capitalize letter, number, dash or
+        underscore.</mat-hint
+      >
+      <mat-error *ngIf="entrypointsForm.get('contextPath').hasError('required')">Context path is required.</mat-error>
+      <mat-error *ngIf="entrypointsForm.get('contextPath').hasError('minlength')"
+        >Context path has to be more than 3 characters long.</mat-error
+      >
+      <mat-error *ngIf="entrypointsForm.get('contextPath').hasError('pattern')"
+        >Context path is not valid (must start with a '/' and must contain any letter, capitalize letter, number, dash or
+        underscore).</mat-error
+      >
+    </mat-form-field>
+  </mat-card>
+
+  <gio-save-bar [form]="entrypointsForm" [formInitialValues]="initialEntrypointsFormValue"> </gio-save-bar>
+</form>

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/context-path/api-proxy-entrypoints-context-path.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/context-path/api-proxy-entrypoints-context-path.component.scss
@@ -1,0 +1,6 @@
+.form-card {
+  &__context-path-field {
+    width: 100%;
+    padding-bottom: 32px;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/context-path/api-proxy-entrypoints-context-path.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/context-path/api-proxy-entrypoints-context-path.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 
 import { Api } from '../../../../../entities/api';

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/context-path/api-proxy-entrypoints-context-path.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/context-path/api-proxy-entrypoints-context-path.component.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+
+import { Api } from '../../../../../entities/api';
+import { GioPermissionService } from '../../../../../shared/components/gio-permission/gio-permission.service';
+
+@Component({
+  selector: 'api-proxy-entrypoints-context-path',
+  template: require('./api-proxy-entrypoints-context-path.component.html'),
+  styles: [require('./api-proxy-entrypoints-context-path.component.scss')],
+})
+export class ApiProxyEntrypointsContextPathComponent implements OnChanges {
+  @Input()
+  apiProxy: Api['proxy'];
+
+  @Output()
+  public apiProxySubmit = new EventEmitter<Api['proxy']>();
+
+  public entrypointsForm: FormGroup;
+  public initialEntrypointsFormValue: unknown;
+
+  constructor(private readonly permissionService: GioPermissionService) {}
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.apiProxy) {
+      this.initForm(this.apiProxy);
+    }
+  }
+
+  onSubmit() {
+    this.apiProxySubmit.emit({ ...this.apiProxy, virtual_hosts: [{ path: this.entrypointsForm.value.contextPath }] });
+  }
+
+  private initForm(apiProxy: Api['proxy']) {
+    this.entrypointsForm = new FormGroup({
+      contextPath: new FormControl(
+        {
+          value: apiProxy.virtual_hosts[0].path,
+          disabled: !this.permissionService.hasAnyMatching(['api-definition-u', 'api-gateway_definition-u']),
+        },
+        [Validators.required, Validators.minLength(3), Validators.pattern(/^\/[/.a-zA-Z0-9-_]+$/)],
+      ),
+    });
+    this.initialEntrypointsFormValue = this.entrypointsForm.getRawValue();
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/virtual-host/api-proxy-entrypoints-virtual-host.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/virtual-host/api-proxy-entrypoints-virtual-host.component.html
@@ -1,0 +1,23 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<form *ngIf="entrypointsForm" [formGroup]="entrypointsForm" (ngSubmit)="onSubmit()" autocomplete="off" gioFormFocusInvalid>
+  <mat-card> TODO </mat-card>
+
+  <gio-save-bar [form]="entrypointsForm" [formInitialValues]="initialEntrypointsFormValue"> </gio-save-bar>
+</form>

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/virtual-host/api-proxy-entrypoints-virtual-host.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/virtual-host/api-proxy-entrypoints-virtual-host.component.html
@@ -16,8 +16,73 @@
 
 -->
 
-<form *ngIf="entrypointsForm" [formGroup]="entrypointsForm" (ngSubmit)="onSubmit()" autocomplete="off" gioFormFocusInvalid>
-  <mat-card> TODO </mat-card>
+<form *ngIf="virtualHostsFormArray" [formGroup]="virtualHostsFormArray" (ngSubmit)="onSubmit()" autocomplete="off" gioFormFocusInvalid>
+  <mat-card>
+    <table
+      mat-table
+      [dataSource]="virtualHostsFormArray.controls"
+      class="virtual-host__table"
+      id="virtualHostsTable"
+      aria-label="Virtual hosts table"
+    >
+      <!-- Host Column -->
+      <ng-container matColumnDef="host">
+        <th mat-header-cell *matHeaderCellDef id="host" width="25%">Host</th>
+        <td mat-cell *matCellDef="let element">
+          <mat-form-field appearance="fill" class="virtual-host__table__host-field">
+            <mat-label>Listening host</mat-label>
+            <input matInput [formControl]="element.controls.host" />
+            <mat-hint>Host which must be set into the HTTP request to access this entrypoint.</mat-hint>
+            <mat-error *ngIf="element.controls.path.hasError('required')">Listening host is required.</mat-error>
+            <mat-error *ngIf="element.controls.path.hasError('pattern')">Listening host is not valid.</mat-error>
+          </mat-form-field>
+        </td>
+      </ng-container>
+      <!-- Path Column -->
+      <ng-container matColumnDef="path">
+        <th mat-header-cell *matHeaderCellDef id="path" width="25%">Path</th>
+        <td mat-cell *matCellDef="let element">
+          <mat-form-field appearance="fill" class="virtual-host__table__path-field">
+            <mat-label>Listening Path</mat-label>
+            <input matInput [formControl]="element.controls.path" />
+            <mat-hint
+              >Path where API is exposed, must start with a '/' and must contain any letter, capitalize letter, number, dash or
+              underscore.</mat-hint
+            >
+            <mat-error *ngIf="element.controls.path.hasError('required')">Listening path is required.</mat-error>
+            <mat-error *ngIf="element.controls.path.hasError('pattern')"
+              >Listening path is not valid (must start with a '/' and must contain any letter, capitalize letter, number, dash or
+              underscore).</mat-error
+            >
+          </mat-form-field>
+        </td>
+      </ng-container>
+      <!-- Override Column -->
+      <ng-container matColumnDef="override_entrypoint">
+        <th mat-header-cell *matHeaderCellDef id="override_entrypoint" width="25%">Override</th>
+        <td mat-cell *matCellDef="let element">
+          <mat-checkbox [formControl]="element.controls.override_entrypoint" aria-label="Override entrypoint"
+            >Override entrypoint
+          </mat-checkbox>
 
-  <gio-save-bar [form]="entrypointsForm" [formInitialValues]="initialEntrypointsFormValue"> </gio-save-bar>
+          <div class="mat-small">Useful to override entrypoint with the virtual host on the portal.</div>
+        </td>
+      </ng-container>
+      <!-- Remove Column -->
+      <ng-container matColumnDef="remove">
+        <th mat-header-cell *matHeaderCellDef id="remove" width="1%"></th>
+        <td mat-cell *matCellDef="let element">X</td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="virtualHostsTableDisplayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: virtualHostsTableDisplayedColumns"></tr>
+
+      <!-- Row shown when there is no data -->
+      <tr class="mat-row" *matNoDataRow>
+        <td class="mat-cell" [attr.colspan]="virtualHostsTableDisplayedColumns.length">No audit</td>
+      </tr>
+    </table>
+  </mat-card>
+
+  <gio-save-bar [form]="virtualHostsFormArray" [formInitialValues]="initialVirtualHostsFormValue"> </gio-save-bar>
 </form>

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/virtual-host/api-proxy-entrypoints-virtual-host.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/virtual-host/api-proxy-entrypoints-virtual-host.component.scss
@@ -1,0 +1,12 @@
+.virtual-host__table {
+  .mat-column-host,
+  .mat-column-path,
+  .mat-column-override_entrypoint {
+    padding: 4px 8px 40px 8px;
+  }
+
+  &__path-field,
+  &__host-field {
+    width: 100%;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/virtual-host/api-proxy-entrypoints-virtual-host.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/virtual-host/api-proxy-entrypoints-virtual-host.component.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+
+import { Api } from '../../../../../entities/api';
+import { GioPermissionService } from '../../../../../shared/components/gio-permission/gio-permission.service';
+
+@Component({
+  selector: 'api-proxy-entrypoints-virtual-host',
+  template: require('./api-proxy-entrypoints-virtual-host.component.html'),
+  styles: [require('./api-proxy-entrypoints-virtual-host.component.scss')],
+})
+export class ApiProxyEntrypointsVirtualHostComponent implements OnChanges {
+  @Input()
+  apiProxy: Api['proxy'];
+
+  @Output()
+  public apiProxySubmit = new EventEmitter<Api['proxy']>();
+
+  public entrypointsForm: FormGroup;
+  public initialEntrypointsFormValue: unknown;
+
+  constructor(private readonly permissionService: GioPermissionService) {}
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.apiProxy) {
+      this.initForm(this.apiProxy);
+    }
+  }
+
+  onSubmit() {
+    // TODO
+  }
+
+  private initForm(apiProxy: Api['proxy']) {
+    // TODO
+  }
+}

--- a/gravitee-apim-console-webui/src/management/management.module.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/management.module.ajs.ts
@@ -546,6 +546,8 @@ import { EnvAuditComponent } from './audit/env-audit.component';
 import { EnvApplicationListComponent } from './application/list/env-application-list.component';
 import { ApiListComponent } from './api/list/api-list.component';
 import { ApiProxyEntrypointsComponent } from './api/proxy/entrypoints/api-proxy-entrypoints.component';
+import { ApiProxyEntrypointsContextPathComponent } from './api/proxy/entrypoints/context-path/api-proxy-entrypoints-context-path.component';
+import { ApiProxyEntrypointsVirtualHostComponent } from './api/proxy/entrypoints/virtual-host/api-proxy-entrypoints-virtual-host.component';
 
 (<any>window).moment = moment;
 require('angular-moment-picker');
@@ -670,6 +672,14 @@ graviteeManagementModule.run(runBlock);
 // Apis
 graviteeManagementModule.directive('ngApiList', downgradeComponent({ component: ApiListComponent }));
 graviteeManagementModule.directive('ngApiProxyEntrypoints', downgradeComponent({ component: ApiProxyEntrypointsComponent }));
+graviteeManagementModule.directive(
+  'ngApiProxyEntrypointsContextPath',
+  downgradeComponent({ component: ApiProxyEntrypointsContextPathComponent }),
+);
+graviteeManagementModule.directive(
+  'ngApiProxyEntrypointsVirtualHost',
+  downgradeComponent({ component: ApiProxyEntrypointsVirtualHostComponent }),
+);
 
 // Pendo Analytics
 graviteeManagementModule.factory('ngGioPendoService', downgradeInjectable(GioPendoService));

--- a/gravitee-apim-console-webui/src/management/management.module.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/management.module.ajs.ts
@@ -545,6 +545,7 @@ import { OrgSettingsAuditComponent } from '../organization/configuration/audit/o
 import { EnvAuditComponent } from './audit/env-audit.component';
 import { EnvApplicationListComponent } from './application/list/env-application-list.component';
 import { ApiListComponent } from './api/list/api-list.component';
+import { ApiProxyEntrypointsComponent } from './api/proxy/entrypoints/api-proxy-entrypoints.component';
 
 (<any>window).moment = moment;
 require('angular-moment-picker');
@@ -668,6 +669,7 @@ graviteeManagementModule.run(runBlock);
 
 // Apis
 graviteeManagementModule.directive('ngApiList', downgradeComponent({ component: ApiListComponent }));
+graviteeManagementModule.directive('ngApiProxyEntrypoints', downgradeComponent({ component: ApiProxyEntrypointsComponent }));
 
 // Pendo Analytics
 graviteeManagementModule.factory('ngGioPendoService', downgradeInjectable(GioPendoService));

--- a/gravitee-apim-console-webui/src/services-ngx/api.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api.service.spec.ts
@@ -43,15 +43,15 @@ describe('ApiService', () => {
 
   describe('get', () => {
     it('should call the API', (done) => {
-      const apiName = 'fox';
+      const apiId = 'fox';
       const mockApi = fakeApi();
 
-      apiService.get(apiName).subscribe((response) => {
+      apiService.get(apiId).subscribe((response) => {
         expect(response).toMatchObject(mockApi);
         done();
       });
 
-      const req = httpTestingController.expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.env.baseURL}/apis/${apiName}` });
+      const req = httpTestingController.expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.env.baseURL}/apis/${apiId}` });
 
       req.flush(mockApi);
     });

--- a/gravitee-apim-console-webui/src/services-ngx/api.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api.service.ts
@@ -28,8 +28,8 @@ import { PagedResult } from '../entities/pagedResult';
 export class ApiService {
   constructor(private readonly http: HttpClient, @Inject('Constants') private readonly constants: Constants) {}
 
-  get(name: string): Observable<Api> {
-    return this.http.get<Api>(`${this.constants.env.baseURL}/apis/${name}`);
+  get(apiId: string): Observable<Api> {
+    return this.http.get<Api>(`${this.constants.env.baseURL}/apis/${apiId}`);
   }
 
   getFlowSchemaForm(): Observable<FlowSchema> {

--- a/gravitee-apim-console-webui/src/services-ngx/environment.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/environment.service.spec.ts
@@ -50,6 +50,24 @@ describe('EnvironmentService', () => {
     });
   });
 
+  describe('getCurrent', () => {
+    it('should call the API', (done) => {
+      const environment = fakeEnvironment();
+
+      environmentService.getCurrent().subscribe((env) => {
+        expect(env).toMatchObject(environment);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: CONSTANTS_TESTING.env.baseURL,
+        method: 'GET',
+      });
+
+      req.flush(environment);
+    });
+  });
+
   afterEach(() => {
     httpTestingController.verify();
   });

--- a/gravitee-apim-console-webui/src/services-ngx/environment.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/environment.service.ts
@@ -29,4 +29,8 @@ export class EnvironmentService {
   list(): Observable<Environment[]> {
     return this.http.get<Environment[]>(`${this.constants.org.baseURL}/environments`);
   }
+
+  getCurrent(): Observable<Environment> {
+    return this.http.get<Environment>(this.constants.env.baseURL);
+  }
 }


### PR DESCRIPTION
**Issue**
https://github.com/gravitee-io/issues/issues/8141

**Description**
Start migration of api proxy entrypoints screen
- init component
- impl contrxt-patn mode
- start impl for vritual-hosts mode 


In next PR : 

- impl dynamic table in vritual-hosts mode 
- add pattern validation for vritual-hosts host filed with domain restriction
- replace legacy screen 

**Additional context**

Previous :
<img width="1538" alt="image" src="https://user-images.githubusercontent.com/4974420/188881324-363e8f2f-898f-4e41-907b-ed11f8f207c6.png">

<img width="1178" alt="image" src="https://user-images.githubusercontent.com/4974420/188881407-31224a41-def3-406c-99d5-2561c4196577.png">

Next :

<img width="1543" alt="image" src="https://user-images.githubusercontent.com/4974420/188881507-da3ed2e5-1e9b-4272-a51a-726f152b05d3.png">

<img width="1540" alt="image" src="https://user-images.githubusercontent.com/4974420/188881567-e819e129-f09c-4b5b-b4cd-43bdc16bf699.png">






<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8141-migrate-proxy-entrypoints/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fuvjunxnbd.chromatic.com)
<!-- Storybook placeholder end -->
