### PR TITLE
[Management] API read-only if managed by CRD - Part 2

### DIFF
--- a/gravitee-apim-console-webui/.eslintrc.js
+++ b/gravitee-apim-console-webui/.eslintrc.js
@@ -45,7 +45,14 @@ module.exports = {
     'no-prototype-builtins': 'warn',
     'no-cond-assign': 'warn',
     '@typescript-eslint/ban-types': 'error',
-    '@typescript-eslint/no-unused-vars': 'error',
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+      },
+    ],
     '@typescript-eslint/ban-ts-comment': 'warn',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',

--- a/gravitee-apim-console-webui/src/management/api/proxy/apiProxy.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/apiProxy.controller.ts
@@ -387,7 +387,7 @@ class ApiProxyController {
   initDomainRestrictions(data: any) {
     const domainPattern = '((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+';
 
-    this.domainRestrictions = ['domain.restriction1.io', 'domain.restriction2.io'] ?? data.domainRestrictions;
+    this.domainRestrictions = data.domainRestrictions;
 
     if (this.domainRestrictions === undefined) {
       this.domainRestrictions = [];

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.html
@@ -18,11 +18,10 @@
 <div class="title">
   <h1>Entrypoints</h1>
   <button
+    *gioPermission="{ anyOf: ['api-definition-u'] }"
     (click)="switchVirtualHostMode()"
     mat-raised-button
     color="primary"
-    aria-label="add-api"
-    *gioPermission="{ anyOf: ['api-definition-u'] }"
   >
     {{ virtualHostModeEnabled ? 'Switch to context-path mode' : 'Switch to virtual-hosts mode' }}
   </button>

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.html
@@ -17,12 +17,7 @@
 -->
 <div class="title">
   <h1>Entrypoints</h1>
-  <button
-    *gioPermission="{ anyOf: ['api-definition-u'] }"
-    (click)="switchVirtualHostMode()"
-    mat-raised-button
-    color="primary"
-  >
+  <button *ngIf="!isReadOnly" (click)="switchVirtualHostMode()" mat-raised-button color="primary">
     {{ virtualHostModeEnabled ? 'Switch to context-path mode' : 'Switch to virtual-hosts mode' }}
   </button>
 </div>
@@ -30,12 +25,14 @@
 <ng-container *ngIf="apiProxy">
   <api-proxy-entrypoints-context-path
     *ngIf="!virtualHostModeEnabled"
+    [readOnly]="isReadOnly"
     [apiProxy]="apiProxy"
     (apiProxySubmit)="onSubmit($event)"
   ></api-proxy-entrypoints-context-path>
 
   <api-proxy-entrypoints-virtual-host
     *ngIf="virtualHostModeEnabled"
+    [readOnly]="isReadOnly"
     [apiProxy]="apiProxy"
     [domainRestrictions]="domainRestrictions"
     (apiProxySubmit)="onSubmit($event)"

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.spec.ts
@@ -104,6 +104,17 @@ describe('ApiProxyEntrypointsComponent', () => {
       expect(req.request.body.proxy.virtual_hosts).toEqual([{ path: '/new-path' }]);
     });
 
+    it('should disable field when origin is kubernetes', async () => {
+      const api = fakeApi({ id: API_ID, proxy: { virtual_hosts: [{ path: '/path' }] }, origin: 'kubernetes' });
+      expectApiGetRequest(api);
+
+      const saveBar = await loader.getHarness(GioSaveBarHarness);
+      expect(await saveBar.isVisible()).toBe(false);
+
+      const contextPathInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName=contextPath]' }));
+      expect(await contextPathInput.isDisabled()).toEqual(true);
+    });
+
     it('should switch to virtual-host mode', async () => {
       expectApiGetRequest(fakeApi({ id: API_ID }));
 

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.ts
@@ -23,6 +23,7 @@ import { UIRouterStateParams } from '../../../../ajs-upgraded-providers';
 import { Api } from '../../../../entities/api';
 import { ApiService } from '../../../../services-ngx/api.service';
 import { EnvironmentService } from '../../../../services-ngx/environment.service';
+import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
 
 @Component({
   selector: 'api-proxy-entrypoints',
@@ -36,12 +37,14 @@ export class ApiProxyEntrypointsComponent implements OnInit, OnDestroy {
   public domainRestrictions: string[] = [];
 
   public apiProxy: Api['proxy'];
+  public isReadOnly = false;
 
   constructor(
     @Inject(UIRouterStateParams) private readonly ajsStateParams,
     private readonly apiService: ApiService,
     private readonly environmentService: EnvironmentService,
     private readonly matDialog: MatDialog,
+    private readonly permissionService: GioPermissionService,
   ) {}
 
   ngOnInit(): void {
@@ -52,11 +55,14 @@ export class ApiProxyEntrypointsComponent implements OnInit, OnDestroy {
           this.apiProxy = api.proxy;
 
           this.virtualHostModeEnabled =
-            api.proxy.virtual_hosts.length > 1 ||
+            api.proxy?.virtual_hosts?.length > 1 ||
             api.proxy.virtual_hosts[0].host !== undefined ||
-            environment.domainRestrictions.length > 0;
+            environment.domainRestrictions?.length > 0;
 
-          this.domainRestrictions = environment.domainRestrictions || [];
+          this.domainRestrictions = environment.domainRestrictions ?? [];
+
+          this.isReadOnly =
+            !this.permissionService.hasAnyMatching(['api-definition-u', 'api-gateway_definition-u']) || api.origin === 'kubernetes';
         }),
       )
       .subscribe();

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.ts
@@ -16,6 +16,7 @@
 import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { GioConfirmDialogComponent, GioConfirmDialogData } from '@gravitee/ui-particles-angular';
+import { get, isEmpty, isNil } from 'lodash';
 import { combineLatest, Subject } from 'rxjs';
 import { switchMap, takeUntil, tap } from 'rxjs/operators';
 
@@ -54,10 +55,11 @@ export class ApiProxyEntrypointsComponent implements OnInit, OnDestroy {
         tap(([api, environment]) => {
           this.apiProxy = api.proxy;
 
+          // virtual host mode is enabled if there domain restrictions or if there is more than one virtual host or if the first virtual host has a host
           this.virtualHostModeEnabled =
-            api.proxy?.virtual_hosts?.length > 1 ||
-            api.proxy.virtual_hosts[0].host !== undefined ||
-            environment.domainRestrictions?.length > 0;
+            !isEmpty(environment.domainRestrictions) ||
+            get(api, 'proxy.virtual_hosts', []) > 1 ||
+            !isNil(get(api, 'proxy.virtual_hosts[0].host', null));
 
           this.domainRestrictions = environment.domainRestrictions ?? [];
 

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.ts
@@ -17,13 +17,14 @@ import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { GioConfirmDialogComponent, GioConfirmDialogData } from '@gravitee/ui-particles-angular';
 import { get, isEmpty, isNil } from 'lodash';
-import { combineLatest, Subject } from 'rxjs';
-import { switchMap, takeUntil, tap } from 'rxjs/operators';
+import { combineLatest, EMPTY, Subject } from 'rxjs';
+import { catchError, switchMap, takeUntil, tap } from 'rxjs/operators';
 
 import { UIRouterStateParams } from '../../../../ajs-upgraded-providers';
 import { Api } from '../../../../entities/api';
 import { ApiService } from '../../../../services-ngx/api.service';
 import { EnvironmentService } from '../../../../services-ngx/environment.service';
+import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
 
 @Component({
@@ -46,6 +47,7 @@ export class ApiProxyEntrypointsComponent implements OnInit, OnDestroy {
     private readonly environmentService: EnvironmentService,
     private readonly matDialog: MatDialog,
     private readonly permissionService: GioPermissionService,
+    private readonly snackBarService: SnackBarService,
   ) {}
 
   ngOnInit(): void {
@@ -82,6 +84,11 @@ export class ApiProxyEntrypointsComponent implements OnInit, OnDestroy {
         takeUntil(this.unsubscribe$),
         switchMap((api) => this.apiService.update({ ...api, proxy: apiProxy })),
         tap((api) => (this.apiProxy = api.proxy)),
+        tap(() => this.snackBarService.success('Configuration successfully saved!')),
+        catchError(({ error }) => {
+          this.snackBarService.error(error.message);
+          return EMPTY;
+        }),
       )
       .subscribe();
   }

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.module.ts
@@ -21,7 +21,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
-import { GioConfirmDialogModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
+import { GioConfirmDialogModule, GioIconsModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatTableModule } from '@angular/material/table';
 import { MatCheckboxModule } from '@angular/material/checkbox';
@@ -49,6 +49,7 @@ import { GioFormFocusInvalidModule } from '../../../../shared/components/gio-for
     GioPermissionModule,
     GioSaveBarModule,
     GioConfirmDialogModule,
+    GioIconsModule,
     GioFormFocusInvalidModule,
   ],
 })

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.module.ts
@@ -25,6 +25,7 @@ import { GioConfirmDialogModule, GioIconsModule, GioSaveBarModule } from '@gravi
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatTableModule } from '@angular/material/table';
 import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
 
 import { ApiProxyEntrypointsVirtualHostComponent } from './virtual-host/api-proxy-entrypoints-virtual-host.component';
 import { ApiProxyEntrypointsContextPathComponent } from './context-path/api-proxy-entrypoints-context-path.component';
@@ -46,6 +47,7 @@ import { GioFormFocusInvalidModule } from '../../../../shared/components/gio-for
     MatDialogModule,
     MatTableModule,
     MatCheckboxModule,
+    MatAutocompleteModule,
     GioPermissionModule,
     GioSaveBarModule,
     GioConfirmDialogModule,

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.module.ts
@@ -31,6 +31,7 @@ import { ApiProxyEntrypointsContextPathComponent } from './context-path/api-prox
 import { ApiProxyEntrypointsComponent } from './api-proxy-entrypoints.component';
 
 import { GioPermissionModule } from '../../../../shared/components/gio-permission/gio-permission.module';
+import { GioFormFocusInvalidModule } from '../../../../shared/components/gio-form-focus-first-invalid/gio-form-focus-first-invalid.module';
 
 @NgModule({
   declarations: [ApiProxyEntrypointsComponent, ApiProxyEntrypointsContextPathComponent, ApiProxyEntrypointsVirtualHostComponent],
@@ -48,6 +49,7 @@ import { GioPermissionModule } from '../../../../shared/components/gio-permissio
     GioPermissionModule,
     GioSaveBarModule,
     GioConfirmDialogModule,
+    GioFormFocusInvalidModule,
   ],
 })
 export class ApiProxyEntrypointsModule {}

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.module.ts
@@ -26,6 +26,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { MatTableModule } from '@angular/material/table';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 import { ApiProxyEntrypointsVirtualHostComponent } from './virtual-host/api-proxy-entrypoints-virtual-host.component';
 import { ApiProxyEntrypointsContextPathComponent } from './context-path/api-proxy-entrypoints-context-path.component';
@@ -48,6 +49,7 @@ import { GioFormFocusInvalidModule } from '../../../../shared/components/gio-for
     MatTableModule,
     MatCheckboxModule,
     MatAutocompleteModule,
+    MatSnackBarModule,
     GioPermissionModule,
     GioSaveBarModule,
     GioConfirmDialogModule,

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/context-path/api-proxy-entrypoints-context-path.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/context-path/api-proxy-entrypoints-context-path.component.html
@@ -15,7 +15,7 @@
     limitations under the License.
 
 -->
-<form *ngIf="entrypointsForm" [formGroup]="entrypointsForm" (ngSubmit)="onSubmit()" autocomplete="off" gioFormFocusInvalid>
+<form *ngIf="entrypointsForm" [formGroup]="entrypointsForm" autocomplete="off" gioFormFocusInvalid>
   <mat-card *ngIf="!virtualHostModeEnabled" class="form-card">
     <mat-form-field appearance="fill" class="form-card__context-path-field">
       <mat-label>Gateway context-path</mat-label>
@@ -35,5 +35,5 @@
     </mat-form-field>
   </mat-card>
 
-  <gio-save-bar [form]="entrypointsForm" [formInitialValues]="initialEntrypointsFormValue"> </gio-save-bar>
+  <gio-save-bar [form]="entrypointsForm" [formInitialValues]="initialEntrypointsFormValue" (submitted)="onSubmit()"></gio-save-bar>
 </form>

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/context-path/api-proxy-entrypoints-context-path.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/context-path/api-proxy-entrypoints-context-path.component.ts
@@ -17,7 +17,6 @@ import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 
 import { Api } from '../../../../../entities/api';
-import { GioPermissionService } from '../../../../../shared/components/gio-permission/gio-permission.service';
 
 @Component({
   selector: 'api-proxy-entrypoints-context-path',
@@ -25,6 +24,9 @@ import { GioPermissionService } from '../../../../../shared/components/gio-permi
   styles: [require('./api-proxy-entrypoints-context-path.component.scss')],
 })
 export class ApiProxyEntrypointsContextPathComponent implements OnChanges {
+  @Input()
+  readOnly: boolean;
+
   @Input()
   apiProxy: Api['proxy'];
 
@@ -34,10 +36,8 @@ export class ApiProxyEntrypointsContextPathComponent implements OnChanges {
   public entrypointsForm: FormGroup;
   public initialEntrypointsFormValue: unknown;
 
-  constructor(private readonly permissionService: GioPermissionService) {}
-
   ngOnChanges(changes: SimpleChanges) {
-    if (changes.apiProxy) {
+    if (changes.apiProxy || changes.readOnly) {
       this.initForm(this.apiProxy);
     }
   }
@@ -51,7 +51,7 @@ export class ApiProxyEntrypointsContextPathComponent implements OnChanges {
       contextPath: new FormControl(
         {
           value: apiProxy.virtual_hosts[0].path,
-          disabled: !this.permissionService.hasAnyMatching(['api-definition-u', 'api-gateway_definition-u']),
+          disabled: this.readOnly,
         },
         [Validators.required, Validators.minLength(3), Validators.pattern(/^\/[/.a-zA-Z0-9-_]+$/)],
       ),

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/virtual-host/api-proxy-entrypoints-virtual-host.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/virtual-host/api-proxy-entrypoints-virtual-host.component.html
@@ -16,7 +16,7 @@
 
 -->
 
-<form *ngIf="virtualHostsFormArray" [formGroup]="virtualHostsFormArray" (ngSubmit)="onSubmit()" autocomplete="off" gioFormFocusInvalid>
+<form *ngIf="virtualHostsFormArray" [formGroup]="virtualHostsFormArray" autocomplete="off" gioFormFocusInvalid>
   <mat-card>
     <table
       mat-table
@@ -84,5 +84,5 @@
     </table>
   </mat-card>
 
-  <gio-save-bar [form]="virtualHostsFormArray" [formInitialValues]="initialVirtualHostsFormValue"> </gio-save-bar>
+  <gio-save-bar [form]="virtualHostsFormArray" [formInitialValues]="initialVirtualHostsFormValue" (submitted)="onSubmit()"></gio-save-bar>
 </form>

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/virtual-host/api-proxy-entrypoints-virtual-host.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/virtual-host/api-proxy-entrypoints-virtual-host.component.html
@@ -114,5 +114,5 @@
     </table>
   </mat-card>
 
-  <gio-save-bar [form]="virtualHostsFormArray" [formInitialValues]="initialVirtualHostsFormValue" (submitted)="onSubmit()"></gio-save-bar>
+  <gio-save-bar [form]="virtualHostsFormArray" (submitted)="onSubmit()" (resetClicked)="onResetClicked()"></gio-save-bar>
 </form>

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/virtual-host/api-proxy-entrypoints-virtual-host.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/virtual-host/api-proxy-entrypoints-virtual-host.component.html
@@ -18,9 +18,17 @@
 
 <form *ngIf="virtualHostsFormArray" [formGroup]="virtualHostsFormArray" autocomplete="off" gioFormFocusInvalid>
   <mat-card>
+    <div class="virtual-host__header">
+      <span>Use virtual-host to define on which entrypoint your API can be reached depending on host. </span>
+
+      <button mat-raised-button type="button" (click)="onAddVirtualHost()" color="primary">
+        <mat-icon svgIcon="gio:plus"></mat-icon> Add virtual-host
+      </button>
+    </div>
+
     <table
       mat-table
-      [dataSource]="virtualHostsFormArray.controls"
+      [dataSource]="virtualHostsTableData"
       class="virtual-host__table"
       id="virtualHostsTable"
       aria-label="Virtual hosts table"
@@ -71,7 +79,11 @@
       <!-- Remove Column -->
       <ng-container matColumnDef="remove">
         <th mat-header-cell *matHeaderCellDef id="remove" width="1%"></th>
-        <td mat-cell *matCellDef="let element">X</td>
+        <td mat-cell *matCellDef="let element; let i = index;">
+          <button (click)="onDeleteVirtualHostClicked(i)" mat-icon-button aria-label="Button to delete a virtual host">
+            <mat-icon svgIcon="gio:trash"></mat-icon>
+          </button>
+        </td>
       </ng-container>
 
       <tr mat-header-row *matHeaderRowDef="virtualHostsTableDisplayedColumns"></tr>
@@ -79,7 +91,7 @@
 
       <!-- Row shown when there is no data -->
       <tr class="mat-row" *matNoDataRow>
-        <td class="mat-cell" [attr.colspan]="virtualHostsTableDisplayedColumns.length">No audit</td>
+        <td class="mat-cell" [attr.colspan]="virtualHostsTableDisplayedColumns.length">No entrypoints</td>
       </tr>
     </table>
   </mat-card>

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/virtual-host/api-proxy-entrypoints-virtual-host.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/virtual-host/api-proxy-entrypoints-virtual-host.component.html
@@ -39,10 +39,28 @@
         <td mat-cell *matCellDef="let element">
           <mat-form-field appearance="fill" class="virtual-host__table__host-field">
             <mat-label>Listening host</mat-label>
-            <input matInput [formControl]="element.controls.host" />
+            <input #hostInput matInput [formControl]="element.controls.host" [matAutocomplete]="hostAuto" />
+
+            <!-- Config Autocomplete to only select domain with input value -->
+            <mat-autocomplete #hostAuto="matAutocomplete">
+              <mat-option
+                *ngFor="let domain of domainRestrictions"
+                [value]="hostInput.value"
+                (click)="element.controls.hostDomain.setValue(domain)"
+              >
+                {{ hostInput.value + '.' + domain }}
+              </mat-option>
+            </mat-autocomplete>
+
+            <span matSuffix
+              ><em>{{ element.controls.hostDomain.value }}</em></span
+            >
+
             <mat-hint>Host which must be set into the HTTP request to access this entrypoint.</mat-hint>
-            <mat-error *ngIf="element.controls.path.hasError('required')">Listening host is required.</mat-error>
-            <mat-error *ngIf="element.controls.path.hasError('pattern')">Listening host is not valid.</mat-error>
+            <mat-error *ngIf="element.controls.host.hasError('required')">Listening host is required.</mat-error>
+            <mat-error *ngIf="element.controls.host.hasError('host')"
+              >Listening host is not valid (must end with one of restriction domain).</mat-error
+            >
           </mat-form-field>
         </td>
       </ng-container>
@@ -79,7 +97,7 @@
       <!-- Remove Column -->
       <ng-container matColumnDef="remove">
         <th mat-header-cell *matHeaderCellDef id="remove" width="1%"></th>
-        <td mat-cell *matCellDef="let element; let i = index;">
+        <td mat-cell *matCellDef="let element; let i = index">
           <button (click)="onDeleteVirtualHostClicked(i)" mat-icon-button aria-label="Button to delete a virtual host">
             <mat-icon svgIcon="gio:trash"></mat-icon>
           </button>

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/virtual-host/api-proxy-entrypoints-virtual-host.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/virtual-host/api-proxy-entrypoints-virtual-host.component.scss
@@ -1,12 +1,23 @@
-.virtual-host__table {
-  .mat-column-host,
-  .mat-column-path,
-  .mat-column-override_entrypoint {
-    padding: 4px 8px 40px 8px;
+.virtual-host {
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-bottom: 24px;
   }
 
-  &__path-field,
-  &__host-field {
-    width: 100%;
+  &__table {
+    .mat-row {
+      .mat-column-host,
+      .mat-column-path,
+      .mat-column-override_entrypoint {
+        padding: 8px 8px 40px 8px;
+      }
+    }
+
+    &__path-field,
+    &__host-field {
+      width: 100%;
+    }
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/virtual-host/api-proxy-entrypoints-virtual-host.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/virtual-host/api-proxy-entrypoints-virtual-host.component.ts
@@ -18,14 +18,15 @@ import { AbstractControl, FormArray, FormControl, FormGroup, ValidationErrors, V
 import { escapeRegExp, isEmpty } from 'lodash';
 
 import { Api } from '../../../../../entities/api';
-import { GioPermissionService } from '../../../../../shared/components/gio-permission/gio-permission.service';
-
 @Component({
   selector: 'api-proxy-entrypoints-virtual-host',
   template: require('./api-proxy-entrypoints-virtual-host.component.html'),
   styles: [require('./api-proxy-entrypoints-virtual-host.component.scss')],
 })
 export class ApiProxyEntrypointsVirtualHostComponent implements OnChanges {
+  @Input()
+  readOnly: boolean;
+
   @Input()
   apiProxy: Api['proxy'];
 
@@ -46,10 +47,8 @@ export class ApiProxyEntrypointsVirtualHostComponent implements OnChanges {
 
   public hostPattern: string;
 
-  constructor(private readonly permissionService: GioPermissionService) {}
-
   ngOnChanges(changes: SimpleChanges) {
-    if (changes.apiProxy) {
+    if (changes.apiProxy || changes.readOnly) {
       this.initForm(this.apiProxy);
     }
   }
@@ -90,27 +89,27 @@ export class ApiProxyEntrypointsVirtualHostComponent implements OnChanges {
       host: new FormControl(
         {
           value: hostObj.host ?? '',
-          disabled: !this.permissionService.hasAnyMatching(['api-definition-u', 'api-gateway_definition-u']),
+          disabled: this.readOnly,
         },
         [Validators.required, hostValidator(this.domainRestrictions)],
       ),
       hostDomain: new FormControl(
         {
           value: hostObj.hostDomain ?? '',
-          disabled: !this.permissionService.hasAnyMatching(['api-definition-u', 'api-gateway_definition-u']),
+          disabled: this.readOnly,
         },
         [hostValidator(this.domainRestrictions)],
       ),
       path: new FormControl(
         {
           value: virtualHost?.path ?? '',
-          disabled: !this.permissionService.hasAnyMatching(['api-definition-u', 'api-gateway_definition-u']),
+          disabled: this.readOnly,
         },
         [Validators.required, Validators.pattern(/^\/[/.a-zA-Z0-9-_]*$/)],
       ),
       override_entrypoint: new FormControl({
         value: virtualHost?.override_entrypoint ?? false,
-        disabled: !this.permissionService.hasAnyMatching(['api-definition-u', 'api-gateway_definition-u']),
+        disabled: this.readOnly,
       }),
     });
   }

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/virtual-host/api-proxy-entrypoints-virtual-host.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/virtual-host/api-proxy-entrypoints-virtual-host.component.ts
@@ -43,7 +43,6 @@ export class ApiProxyEntrypointsVirtualHostComponent implements OnChanges {
     return [...(this.virtualHostsFormArray?.controls ?? [])];
   }
   public virtualHostsTableDisplayedColumns = ['host', 'path', 'override_entrypoint', 'remove'];
-  public initialVirtualHostsFormValue: unknown;
 
   public hostPattern: string;
 
@@ -76,10 +75,13 @@ export class ApiProxyEntrypointsVirtualHostComponent implements OnChanges {
     this.virtualHostsFormArray.markAsDirty();
   }
 
+  onResetClicked() {
+    // Nedded to re init all form controls
+    this.initForm(this.apiProxy);
+  }
+
   private initForm(apiProxy: Api['proxy']) {
     this.virtualHostsFormArray = new FormArray([...apiProxy.virtual_hosts.map((virtualHost) => this.newVirtualHostFormGroup(virtualHost))]);
-
-    this.initialVirtualHostsFormValue = this.virtualHostsFormArray.getRawValue();
   }
 
   private newVirtualHostFormGroup(virtualHost?: Api['proxy']['virtual_hosts'][number]) {

--- a/gravitee-apim-console-webui/src/shared/components/gio-form-color-input/gio-form-color-input.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-form-color-input/gio-form-color-input.component.ts
@@ -228,7 +228,7 @@ export class GioFormColorInputComponent implements MatFormFieldControl<Color>, C
   }
 
   // From ControlValueAccessor interface
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   onContainerClick(_event: MouseEvent): void {}
 
   // From ControlValueAccessor interface

--- a/gravitee-apim-console-webui/src/shared/components/gio-form-focus-first-invalid/gio-form-focus-first-invalid.directive.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-form-focus-first-invalid/gio-form-focus-first-invalid.directive.ts
@@ -24,7 +24,11 @@ export class GioFormFocusInvalidDirective {
   @HostListener('submit')
   onFormSubmit() {
     try {
-      const invalidControl = this.renderer.selectRootElement('.ng-invalid[formControlName]', true);
+      const invalidControl = this.renderer.selectRootElement(
+        '.ng-invalid[formControlName],input.ng-invalid,mat-select.ng-invalid,textarea.ng-invalid',
+        true,
+      );
+
       if (invalidControl) {
         invalidControl.scrollIntoView({ behavior: 'smooth', block: 'center' });
       }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/8141

**Description**

Next to this [PR](https://github.com/gravitee-io/gravitee-api-management/pull/2430)

- impl dynamic table in vritual-hosts mode 
- add pattern validation for vritual-hosts host filed with domain restriction
- disabled fom when origin is not management

**Additional context**
![image](https://user-images.githubusercontent.com/4974420/189065654-9fc69467-73a0-4517-9293-5e2a76ad04bf.png)

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8141-migrate-proxy-entrypoints-p2/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zzqywfkjxu.chromatic.com)
<!-- Storybook placeholder end -->
