### PR TITLE
chore: restore javadoc generation, solving lombok incompatibilities

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1208,7 +1208,7 @@ jobs:
             - run:
                   name: Maven deploy to Gravitee's private Artifactory
                   command: |
-                      mvn --settings .gravitee.settings.xml -B -U -P all-modules,gio-artifactory-release,gio-release clean deploy -DskipTests=true -Dskip.validation -T 4 --no-transfer-progress -Dmaven.javadoc.skip=true
+                      mvn --settings .gravitee.settings.xml -B -U -P all-modules,gio-artifactory-release,gio-release clean deploy -DskipTests=true -Dskip.validation -T 4 --no-transfer-progress
             - save-maven-job-cache:
                   jobName: backend-build-and-publish-artifactory
 

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/DefinitionVersion.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/DefinitionVersion.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -29,7 +28,6 @@ import lombok.RequiredArgsConstructor;
  * @author GraviteeSource Team
  */
 @RequiredArgsConstructor
-@Getter(onMethod_ = @JsonValue)
 public enum DefinitionVersion {
     @JsonEnumDefaultValue
     V1("1.0.0"),
@@ -59,5 +57,11 @@ public enum DefinitionVersion {
     @SuppressWarnings("java:S5361")
     public Integer asInteger() {
         return Integer.valueOf(label.replaceAll("\\.", ""));
+    }
+
+    // @JsonValue on the getter instead of attribute makes enum values relevant in generated openapi file
+    @JsonValue
+    public String getLabel() {
+        return label;
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/flow/selector/Selector.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/flow/selector/Selector.java
@@ -15,9 +15,7 @@
  */
 package io.gravitee.definition.model.v4.flow.selector;
 
-import static io.gravitee.definition.model.v4.flow.selector.Selector.CHANNEL_LABEL;
-import static io.gravitee.definition.model.v4.flow.selector.Selector.CONDITION_LABEL;
-import static io.gravitee.definition.model.v4.flow.selector.Selector.HTTP_LABEL;
+import static io.gravitee.definition.model.v4.flow.selector.Selector.*;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -30,7 +28,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import lombok.experimental.FieldNameConstants;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -42,8 +39,7 @@ import lombok.experimental.FieldNameConstants;
 @Setter
 @ToString
 @EqualsAndHashCode
-@FieldNameConstants
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = Selector.Fields.type)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type")
 @JsonSubTypes(
     {
         @JsonSubTypes.Type(value = HttpSelector.class, name = HTTP_LABEL),

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/listener/Listener.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/listener/Listener.java
@@ -15,9 +15,7 @@
  */
 package io.gravitee.definition.model.v4.listener;
 
-import static io.gravitee.definition.model.v4.listener.Listener.HTTP_LABEL;
-import static io.gravitee.definition.model.v4.listener.Listener.SUBSCRIPTION_LABEL;
-import static io.gravitee.definition.model.v4.listener.Listener.TCP_LABEL;
+import static io.gravitee.definition.model.v4.listener.Listener.*;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -32,8 +30,11 @@ import java.io.Serializable;
 import java.util.List;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
-import lombok.*;
-import lombok.experimental.FieldNameConstants;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -44,8 +45,7 @@ import lombok.experimental.FieldNameConstants;
 @Setter
 @ToString
 @EqualsAndHashCode
-@FieldNameConstants
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = Listener.Fields.type)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type")
 @JsonSubTypes(
     {
         @JsonSubTypes.Type(value = HttpListener.class, name = HTTP_LABEL),

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/flow/selector/FlowSelector.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/flow/selector/FlowSelector.java
@@ -24,7 +24,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import lombok.experimental.FieldNameConstants;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -36,9 +35,8 @@ import lombok.experimental.FieldNameConstants;
 @Setter
 @ToString
 @EqualsAndHashCode
-@FieldNameConstants
 // Require only for tests
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = FlowSelector.Fields.type)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type")
 @JsonSubTypes(
     {
         @JsonSubTypes.Type(value = FlowHttpSelector.class, name = "HTTP"),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/plan/PlanSecurityType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/plan/PlanSecurityType.java
@@ -26,7 +26,7 @@ import lombok.RequiredArgsConstructor;
  * @author GraviteeSource Team
  */
 @RequiredArgsConstructor
-@Getter(onMethod_ = @JsonValue)
+@Getter
 @Schema(enumAsRef = true, name = "PlanSecurityTypeV4")
 public enum PlanSecurityType {
     /**
@@ -67,7 +67,6 @@ public enum PlanSecurityType {
         SUBSCRIPTION
     );
 
-    @JsonValue
     private final String label;
 
     public static PlanSecurityType valueOfLabel(final String label) {
@@ -83,5 +82,11 @@ public enum PlanSecurityType {
             return planSecurityType;
         }
         return null;
+    }
+
+    // @JsonValue on the getter instead of attribute makes enum values relevant in generated openapi file
+    @JsonValue
+    public String getLabel() {
+        return label;
     }
 }


### PR DESCRIPTION
**Description**

Javadoc generation was failing due to some incompatibilities with lombok.

This fixes solve those incompatibilities, and restores javadoc generation :
- Stop using 'onMethod_' attribute of lombok getters manually : write the getter instead
- Stop using constant generated by lombok's FieldNameConstants annotation in JsonTypeInfo : use the string value instead

**Issue**

https://github.com/gravitee-io/issues/issues/8408
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-lombokvsjavadoc/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
