### PR TITLE
feat(message): add identifier on message

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/sme/SseEntrypointIntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/sme/SseEntrypointIntegrationTest.java
@@ -128,8 +128,8 @@ class SseEntrypointIntegrationTest extends AbstractGatewayTest {
     private void assertOnChunk(Buffer chunk, int messageNumber) {
         final String[] splitMessage = chunk.toString().split("\n");
         assertThat(splitMessage).hasSize(3);
-        assertThat(splitMessage[0]).startsWith("id: ");
+        assertThat(splitMessage[0]).startsWith("id: " + messageNumber);
         assertThat(splitMessage[1]).isEqualTo("event: message");
-        assertThat(splitMessage[2]).isEqualTo("data: Mock data " + messageNumber);
+        assertThat(splitMessage[2]).isEqualTo("data: Mock data");
     }
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mock/src/main/java/io/gravitee/plugin/endpoint/mock/MockEndpointConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mock/src/main/java/io/gravitee/plugin/endpoint/mock/MockEndpointConnector.java
@@ -62,8 +62,7 @@ public class MockEndpointConnector implements EndpointAsyncConnector {
     private Flowable<Message> generateMessageFlow() {
         Flowable<Message> messageFlow = Flowable
             .interval(configuration.getMessageInterval(), TimeUnit.MILLISECONDS)
-            .map(value -> configuration.getMessageContent() + " " + value)
-            .map(DefaultMessage::new);
+            .map(value -> new DefaultMessage(configuration.getMessageContent()).id(Long.toString(value)));
         if (configuration.getMessageCount() != null) {
             return messageFlow.limit(configuration.getMessageCount());
         }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mock/src/test/java/io/gravitee/plugin/endpoint/mock/MockEndpointConnectorTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mock/src/test/java/io/gravitee/plugin/endpoint/mock/MockEndpointConnectorTest.java
@@ -44,6 +44,9 @@ class MockEndpointConnectorTest {
     private static final String MESSAGE_TO_LOG = "message to log";
     private final MockEndpointConnectorConfiguration configuration = new MockEndpointConnectorConfiguration();
 
+    @Mock
+    Logger logger;
+
     @InjectMocks
     private MockEndpointConnector mockEndpointConnector;
 
@@ -55,9 +58,6 @@ class MockEndpointConnectorTest {
 
     @Mock
     private Response response;
-
-    @Mock
-    Logger logger;
 
     @BeforeEach
     public void setup() {
@@ -84,9 +84,9 @@ class MockEndpointConnectorTest {
             .test()
             .awaitCount(3)
             .assertValueCount(3)
-            .assertValueAt(0, message -> message.content().toString().equals("test mock endpoint 0"))
-            .assertValueAt(1, message -> message.content().toString().equals("test mock endpoint 1"))
-            .assertValueAt(2, message -> message.content().toString().equals("test mock endpoint 2"));
+            .assertValueAt(0, message -> message.content().toString().equals("test mock endpoint") && message.id().equals("0"))
+            .assertValueAt(1, message -> message.content().toString().equals("test mock endpoint") && message.id().equals("1"))
+            .assertValueAt(2, message -> message.content().toString().equals("test mock endpoint") && message.id().equals("2"));
 
         verify(logger).info("Received message:\n" + MESSAGE_TO_LOG);
     }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/test/java/io/gravitee/plugin/entrypoint/http/post/HttpPostEntrypointConnectorTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/test/java/io/gravitee/plugin/entrypoint/http/post/HttpPostEntrypointConnectorTest.java
@@ -86,7 +86,10 @@ class HttpPostEntrypointConnectorTest {
         when(mockExecutionContext.request()).thenReturn(dummyMessageRequest);
         httpPostEntrypointConnector.handleRequest(mockExecutionContext).test().assertComplete();
 
-        dummyMessageRequest.messages().test().assertValue(message -> "bodyContent".equals(message.content().toString()));
+        dummyMessageRequest
+            .messages()
+            .test()
+            .assertValue(message -> "bodyContent".equals(message.content().toString()) && message.id() != null);
     }
 
     @Test

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-sse/src/main/java/io/gravitee/plugin/entrypoint/sse/SseEntrypointConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-sse/src/main/java/io/gravitee/plugin/entrypoint/sse/SseEntrypointConnector.java
@@ -114,7 +114,7 @@ public class SseEntrypointConnector implements EntrypointAsyncConnector {
                                     Buffer.buffer(
                                         SseEvent
                                             .builder()
-                                            .id(UUID.randomUUID().toString())
+                                            .id(message.id())
                                             .event("message")
                                             .data(message.content().getBytes())
                                             .comments(comments)

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <gravitee-connector-api.version>1.1.4</gravitee-connector-api.version>
         <gravitee-expression-language.version>1.11.0</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>1.45.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.46.0</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>1.25.0</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>


### PR DESCRIPTION
  - Kafka now set the id based on record information

**Issue**

https://github.com/gravitee-io/issues/issues/8262

**Description**

Adding id on message and implement id generation on kafka endpoint.
Id is by default generated from UUID.random()


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8262-identify-message/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jkpipksbyc.chromatic.com)
<!-- Storybook placeholder end -->
