### PR TITLE
fix: broken property access from k8s configmap/secret via RBAC 

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/spring/RestManagementConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/spring/RestManagementConfiguration.java
@@ -19,44 +19,17 @@ import io.gravitee.el.ExpressionLanguageInitializer;
 import io.gravitee.plugin.core.spring.PluginConfiguration;
 import io.gravitee.rest.api.idp.core.spring.IdentityProviderPluginConfiguration;
 import io.gravitee.rest.api.service.spring.ServiceConfiguration;
-import java.util.Properties;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
-import org.springframework.core.env.Environment;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
 @Configuration
-@Import({ PropertiesConfiguration.class, PluginConfiguration.class, ServiceConfiguration.class, IdentityProviderPluginConfiguration.class })
+@Import({ PluginConfiguration.class, ServiceConfiguration.class, IdentityProviderPluginConfiguration.class })
 public class RestManagementConfiguration {
-
-    @Bean
-    public static PropertySourcesPlaceholderConfigurer properties(@Qualifier("graviteeProperties") Properties graviteeProperties) {
-        PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer = new PropertySourcesPlaceholderConfigurer();
-        propertySourcesPlaceholderConfigurer.setProperties(graviteeProperties);
-        propertySourcesPlaceholderConfigurer.setIgnoreUnresolvablePlaceholders(true);
-
-        return propertySourcesPlaceholderConfigurer;
-    }
-
-    @Bean
-    public static EnvironmentBeanFactoryPostProcessor environmentBeanFactoryPostProcessor() {
-        return new EnvironmentBeanFactoryPostProcessor();
-    }
-
-    @Bean
-    public static PropertySourceBeanProcessor propertySourceBeanProcessor(
-        @Qualifier("graviteeProperties") Properties graviteeProperties,
-        Environment environment
-    ) {
-        // Using this we are now able to use {@link org.springframework.core.env.Environment} in Spring beans
-        return new PropertySourceBeanProcessor(graviteeProperties, environment);
-    }
 
     @Bean
     public ExpressionLanguageInitializer expressionLanguageInitializer() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/spring/RestPortalConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/spring/RestPortalConfiguration.java
@@ -19,14 +19,9 @@ import io.gravitee.plugin.core.spring.PluginConfiguration;
 import io.gravitee.rest.api.idp.core.spring.IdentityProviderPluginConfiguration;
 import io.gravitee.rest.api.portal.security.SecurityPortalConfiguration;
 import io.gravitee.rest.api.service.spring.ServiceConfiguration;
-import java.util.Properties;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
-import org.springframework.core.env.Environment;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -35,36 +30,6 @@ import org.springframework.core.env.Environment;
 @Configuration
 @ComponentScan({ "io.gravitee.rest.api.portal.rest.mapper" })
 @Import(
-    {
-        PropertiesConfiguration.class,
-        PluginConfiguration.class,
-        ServiceConfiguration.class,
-        SecurityPortalConfiguration.class,
-        IdentityProviderPluginConfiguration.class,
-    }
+    { PluginConfiguration.class, ServiceConfiguration.class, SecurityPortalConfiguration.class, IdentityProviderPluginConfiguration.class }
 )
-public class RestPortalConfiguration {
-
-    @Bean
-    public static PropertySourcesPlaceholderConfigurer properties(@Qualifier("graviteeProperties") Properties graviteeProperties) {
-        PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer = new PropertySourcesPlaceholderConfigurer();
-        propertySourcesPlaceholderConfigurer.setProperties(graviteeProperties);
-        propertySourcesPlaceholderConfigurer.setIgnoreUnresolvablePlaceholders(true);
-
-        return propertySourcesPlaceholderConfigurer;
-    }
-
-    @Bean
-    public static EnvironmentBeanFactoryPostProcessor environmentBeanFactoryPostProcessor() {
-        return new EnvironmentBeanFactoryPostProcessor();
-    }
-
-    @Bean
-    public static PropertySourceBeanProcessor propertySourceBeanProcessor(
-        @Qualifier("graviteeProperties") Properties graviteeProperties,
-        Environment environment
-    ) {
-        // Using this we are now able to use {@link org.springframework.core.env.Environment} in Spring beans
-        return new PropertySourceBeanProcessor(graviteeProperties, environment);
-    }
-}
+public class RestPortalConfiguration {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/bin/gravitee
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/bin/gravitee
@@ -28,9 +28,9 @@ fi
 
 # Searching for configuration 
 GRAVITEE_OPTS=""
-if [ -f "/etc/gravitee-management/gravitee.yml" ]
+if [ -f "/opt/graviteeio-management-api/config/gravitee.yml" ]
 then
-	GRAVITEE_OPTS="-Dgravitee.conf=/etc/gravitee-management/gravitee.yml"
+	GRAVITEE_OPTS="-Dgravitee.conf=/opt/graviteeio-management-api/config/gravitee.yml"
 fi
 
 # Setup GRAVITEE_HOME


### PR DESCRIPTION
fix: broken property access from k8s configmap/secret via RBAC  in gravitee-apim-rest-api-standalone-container

## Issue

https://github.com/gravitee-io/issues/issues/8095

## Description

remove duplicated/overwriting spring property handling, fix path for loading gravitee.yml in container 

