### PR TITLE
test(message): adapt test according to the new message identifier

### DIFF
--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/v4/v4-sse-entrypoint-to-mock-endpoint.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/v4/v4-sse-entrypoint-to-mock-endpoint.spec.ts
@@ -118,13 +118,16 @@ describeIfJupiter('Gateway V4 - SSE entrypoint to mock endpoint', () => {
       const messages = [];
       await fetchEventSourceGateway({ contextPath: `/${contextPath}` }, (ev) => {
         if (!ev.retry) {
-          messages.push(ev.data);
+          messages.push(ev);
         }
       });
       expect(messages).toHaveLength(3);
-      expect(messages[0]).toBe('e2e test message 0');
-      expect(messages[1]).toBe('e2e test message 1');
-      expect(messages[2]).toBe('e2e test message 2');
+      expect(messages[0].id).toBe('0');
+      expect(messages[0].data).toBe('e2e test message');
+      expect(messages[1].id).toBe('1');
+      expect(messages[1].data).toBe('e2e test message');
+      expect(messages[2].id).toBe('2');
+      expect(messages[2].data).toBe('e2e test message');
     });
 
     afterAll(async () => {
@@ -141,14 +144,18 @@ describeIfJupiter('Gateway V4 - SSE entrypoint to mock endpoint', () => {
       const messages = [];
       await fetchEventSourceGateway({ contextPath: `/${contextPath}` }, (ev) => {
         if (!ev.retry) {
-          messages.push(ev.data);
+          messages.push(ev);
         }
       });
       expect(messages).toHaveLength(4);
-      expect(messages[0]).toBe('e2e test message from group configuration 0');
-      expect(messages[1]).toBe('e2e test message from group configuration 1');
-      expect(messages[2]).toBe('e2e test message from group configuration 2');
-      expect(messages[3]).toBe('e2e test message from group configuration 3');
+      expect(messages[0].id).toBe('0');
+      expect(messages[0].data).toBe('e2e test message from group configuration');
+      expect(messages[1].id).toBe('1');
+      expect(messages[1].data).toBe('e2e test message from group configuration');
+      expect(messages[2].id).toBe('2');
+      expect(messages[2].data).toBe('e2e test message from group configuration');
+      expect(messages[3].id).toBe('3');
+      expect(messages[3].data).toBe('e2e test message from group configuration');
     });
 
     afterAll(async () => {


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/XXXXX

## Description

A small description of what you did in that PR.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-e2e-identifier-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tweyrzijeo.chromatic.com)
<!-- Storybook placeholder end -->
<!-- E2E Coverage placeholder -->
---
### 🧪 End-to-End Coverage

| INSTRUCTIONS | BRANCHES |
| :----------: | :------: |
|   37% | 22%   |

A more detailed report has been uploaded to [circleci](https://output.circle-artifacts.com/output/job/9853811b-8288-473f-ba58-efe92e2d66eb/artifacts/0/gravitee-apim-e2e/jacoco/reports/index.html)
<!-- E2E Coverage placeholder end -->
