### PR TITLE
fix: make debug mode works in hybrid installation

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/spring/SyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/spring/SyncConfiguration.java
@@ -15,16 +15,20 @@
  */
 package io.gravitee.gateway.services.sync.spring;
 
+import io.gravitee.common.event.EventManager;
 import io.gravitee.gateway.services.sync.SyncManager;
 import io.gravitee.gateway.services.sync.cache.configuration.LocalCacheConfiguration;
 import io.gravitee.gateway.services.sync.healthcheck.ApiSyncProbe;
 import io.gravitee.gateway.services.sync.synchronizer.*;
+import io.gravitee.node.api.Node;
 import io.gravitee.node.api.cache.CacheManager;
+import io.gravitee.plugin.core.api.PluginRegistry;
 import io.reactivex.annotations.NonNull;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -39,6 +43,18 @@ import org.springframework.context.annotation.Import;
 public class SyncConfiguration {
 
     public static final int PARALLELISM = Runtime.getRuntime().availableProcessors() * 2;
+
+    @Autowired
+    private EventManager eventManager;
+
+    @Autowired
+    private Node node;
+
+    @Autowired
+    private PluginRegistry pluginRegistry;
+
+    @Autowired
+    private io.gravitee.node.api.configuration.Configuration configuration;
 
     @Bean
     public SyncManager syncManager() {
@@ -75,7 +91,7 @@ public class SyncConfiguration {
 
     @Bean
     public DebugApiSynchronizer debugApiSynchronizer() {
-        return new DebugApiSynchronizer();
+        return new DebugApiSynchronizer(eventManager, pluginRegistry, configuration, node);
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/DebugApiSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/DebugApiSynchronizer.java
@@ -22,6 +22,9 @@ import io.gravitee.common.event.EventManager;
 import io.gravitee.gateway.reactor.ReactorEvent;
 import io.gravitee.gateway.reactor.impl.ReactableWrapper;
 import io.gravitee.node.api.Node;
+import io.gravitee.node.api.configuration.Configuration;
+import io.gravitee.plugin.core.api.Plugin;
+import io.gravitee.plugin.core.api.PluginRegistry;
 import io.gravitee.repository.management.api.search.EventCriteria;
 import io.gravitee.repository.management.model.ApiDebugStatus;
 import io.gravitee.repository.management.model.Event;
@@ -39,36 +42,44 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class DebugApiSynchronizer extends AbstractSynchronizer {
 
     private final Logger logger = LoggerFactory.getLogger(DebugApiSynchronizer.class);
+    private final EventManager eventManager;
+    private final Node node;
+    private final boolean isDebugModeAvailable;
 
-    @Autowired
-    private EventManager eventManager;
+    public DebugApiSynchronizer(EventManager eventManager, PluginRegistry pluginRegistry, Configuration configuration, Node node) {
+        this.eventManager = eventManager;
+        this.node = node;
 
-    @Autowired
-    private Node node;
+        this.isDebugModeAvailable =
+            pluginRegistry.plugins().stream().map(Plugin::id).anyMatch("gateway-debug"::equalsIgnoreCase) &&
+            configuration.getProperty("gravitee.services.gateway-debug.enabled", Boolean.class);
+    }
 
     @Override
     public void synchronize(Long lastRefreshAt, Long nextLastRefreshAt, List<String> environments) {
-        final long start = System.currentTimeMillis();
-        if (lastRefreshAt != -1) {
-            EventCriteria.Builder criteriaBuilder = new EventCriteria.Builder()
-                .types(EventType.DEBUG_API)
-                .property(Event.EventProperties.API_DEBUG_STATUS.getValue(), ApiDebugStatus.TO_DEBUG.name())
-                .from(lastRefreshAt == null ? 0 : lastRefreshAt - TIMEFRAME_BEFORE_DELAY)
-                .to(nextLastRefreshAt == null ? 0 : nextLastRefreshAt + TIMEFRAME_AFTER_DELAY)
-                .environments(environments);
+        if (isDebugModeAvailable) {
+            final long start = System.currentTimeMillis();
+            if (lastRefreshAt != -1) {
+                EventCriteria.Builder criteriaBuilder = new EventCriteria.Builder()
+                    .types(EventType.DEBUG_API)
+                    .property(Event.EventProperties.API_DEBUG_STATUS.getValue(), ApiDebugStatus.TO_DEBUG.name())
+                    .from(lastRefreshAt == null ? 0 : lastRefreshAt - TIMEFRAME_BEFORE_DELAY)
+                    .to(nextLastRefreshAt == null ? 0 : nextLastRefreshAt + TIMEFRAME_AFTER_DELAY)
+                    .environments(environments);
 
-            List<String> events = eventRepository
-                .search(criteriaBuilder.build())
-                .stream()
-                .filter(event -> node.id().equals(event.getProperties().get(Event.EventProperties.GATEWAY_ID.getValue())))
-                .map(
-                    event -> {
-                        eventManager.publishEvent(ReactorEvent.DEBUG, new ReactableWrapper(event));
-                        return event.getId();
-                    }
-                )
-                .collect(Collectors.toList());
-            logger.debug("{} debug apis synchronized in {}ms", events.size(), (System.currentTimeMillis() - start));
+                List<String> events = eventRepository
+                    .search(criteriaBuilder.build())
+                    .stream()
+                    .filter(event -> node.id().equals(event.getProperties().get(Event.EventProperties.GATEWAY_ID.getValue())))
+                    .map(
+                        event -> {
+                            eventManager.publishEvent(ReactorEvent.DEBUG, new ReactableWrapper(event));
+                            return event.getId();
+                        }
+                    )
+                    .collect(Collectors.toList());
+                logger.debug("{} debug apis synchronized in {}ms", events.size(), (System.currentTimeMillis() - start));
+            }
         }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/DebugApiSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/DebugApiSynchronizerTest.java
@@ -24,6 +24,11 @@ import io.gravitee.gateway.reactor.ReactorEvent;
 import io.gravitee.gateway.reactor.impl.ReactableWrapper;
 import io.gravitee.gateway.services.sync.builder.RepositoryApiBuilder;
 import io.gravitee.node.api.Node;
+import io.gravitee.node.api.configuration.Configuration;
+import io.gravitee.plugin.core.api.Plugin;
+import io.gravitee.plugin.core.api.PluginRegistry;
+import io.gravitee.plugin.core.internal.PluginDependencyImpl;
+import io.gravitee.plugin.core.internal.PluginImpl;
 import io.gravitee.repository.management.api.EventRepository;
 import io.gravitee.repository.management.model.*;
 import java.util.*;
@@ -47,8 +52,7 @@ public class DebugApiSynchronizerTest extends TestCase {
 
     private static final String GATEWAY_ID = "gateway-id";
 
-    @InjectMocks
-    private DebugApiSynchronizer debugApiSynchronizer = new DebugApiSynchronizer();
+    private DebugApiSynchronizer debugApiSynchronizer;
 
     @Mock
     private EventRepository eventRepository;
@@ -59,10 +63,23 @@ public class DebugApiSynchronizerTest extends TestCase {
     @Mock
     private Node node;
 
+    @Mock
+    private PluginRegistry pluginRegistry;
+
+    @Mock
+    private Configuration configuration;
+
     static final List<String> ENVIRONMENTS = Arrays.asList("DEFAULT", "OTHER_ENV");
 
     @Before
     public void setup() {
+        Plugin debugPlugin = mock(Plugin.class);
+        when(debugPlugin.id()).thenReturn("gateway-debug");
+        when(pluginRegistry.plugins()).thenReturn((Collection) List.of(debugPlugin));
+        when(configuration.getProperty("gravitee.services.gateway-debug.enabled", Boolean.class)).thenReturn(true);
+
+        debugApiSynchronizer = new DebugApiSynchronizer(eventManager, pluginRegistry, configuration, node);
+        debugApiSynchronizer.eventRepository = eventRepository;
         debugApiSynchronizer.setExecutor(Executors.newFixedThreadPool(1));
         when(node.id()).thenReturn(GATEWAY_ID);
     }
@@ -97,6 +114,28 @@ public class DebugApiSynchronizerTest extends TestCase {
         debugApiSynchronizer.synchronize(System.currentTimeMillis() - 5000, System.currentTimeMillis(), ENVIRONMENTS);
 
         verify(eventManager, times(1)).publishEvent(eq(ReactorEvent.DEBUG), any(ReactableWrapper.class));
+    }
+
+    @Test
+    public void shouldNotSyncIfDebugModeServiceIsDisabled() {
+        when(configuration.getProperty("gravitee.services.gateway-debug.enabled", Boolean.class)).thenReturn(false);
+        debugApiSynchronizer = new DebugApiSynchronizer(eventManager, pluginRegistry, configuration, node);
+
+        debugApiSynchronizer.synchronize(System.currentTimeMillis() - 5000, System.currentTimeMillis(), ENVIRONMENTS);
+
+        verify(eventRepository, never()).search(any());
+        verify(eventManager, never()).publishEvent(eq(ReactorEvent.DEBUG), any(ReactableWrapper.class));
+    }
+
+    @Test
+    public void shouldNotSyncIfDebugModePluginIsAbsent() {
+        when(pluginRegistry.plugins()).thenReturn((Collection) List.of());
+        debugApiSynchronizer = new DebugApiSynchronizer(eventManager, pluginRegistry, configuration, node);
+
+        debugApiSynchronizer.synchronize(System.currentTimeMillis() - 5000, System.currentTimeMillis(), ENVIRONMENTS);
+
+        verify(eventRepository, never()).search(any());
+        verify(eventManager, never()).publishEvent(eq(ReactorEvent.DEBUG), any(ReactableWrapper.class));
     }
 
     private Event mockEvent(final Api api, EventType eventType) {

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpEventRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpEventRepository.java
@@ -36,8 +36,13 @@ import org.springframework.stereotype.Component;
 public class HttpEventRepository extends AbstractRepository implements EventRepository {
 
     @Override
-    public Optional<Event> findById(String s) throws TechnicalException {
-        throw new IllegalStateException();
+    public Optional<Event> findById(String eventId) throws TechnicalException {
+        try {
+            return blockingGet(get("/event" + eventId, BodyCodecs.optional(Event.class)).send()).payload();
+        } catch (TechnicalException te) {
+            // Ensure that an exception is thrown and managed by the caller
+            throw new IllegalStateException(te);
+        }
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/BridgeService.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/BridgeService.java
@@ -150,6 +150,7 @@ public class BridgeService extends AbstractService {
             bridgeRouter.post("/events/_searchLatest").handler(eventsHandler::searchLatest);
             bridgeRouter.post("/events").handler(eventsHandler::create);
             bridgeRouter.put("/events/:eventId").handler(eventsHandler::update);
+            bridgeRouter.get("/events/:eventId").handler(eventsHandler::findById);
 
             // Dictionaries handler
             DictionariesHandler dictionariesHandler = new DictionariesHandler();

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/EventsHandler.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/EventsHandler.java
@@ -19,6 +19,7 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.EventRepository;
 import io.gravitee.repository.management.api.search.EventCriteria;
 import io.gravitee.repository.management.api.search.builder.PageableBuilder;
+import io.gravitee.repository.management.model.Environment;
 import io.gravitee.repository.management.model.Event;
 import io.gravitee.repository.management.model.EventType;
 import io.vertx.core.AsyncResult;
@@ -28,6 +29,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -168,6 +170,24 @@ public class EventsHandler extends AbstractHandler {
                     }
                 },
                 (Handler<AsyncResult<Event>>) event -> handleResponse(ctx, event)
+            );
+    }
+
+    public void findById(RoutingContext ctx) {
+        final String idParam = ctx.request().getParam("eventId");
+
+        ctx
+            .vertx()
+            .executeBlocking(
+                (Handler<Promise<Optional<Event>>>) promise -> {
+                    try {
+                        promise.complete(eventRepository.findById(idParam));
+                    } catch (Exception ex) {
+                        LOGGER.error("Unable to find event by id {}", idParam, ex);
+                        promise.fail(ex);
+                    }
+                },
+                event -> handleResponse(ctx, event)
             );
     }
 


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8373

## Description

First, there is an improvement, we only synchronize if the plugin is present and the debug service is enabled.
It could have been done directly in the SyncManager, but I did not want to pollute it. Happy to discuss that topic.

Second commit is about the fix itself, the HTTP repositories where not implemented for `eventRepository.findById` request, meaning the debug mode were not able to get and then save the completion event



<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8373-debug-mode-bridge/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-prygjxexdf.chromatic.com)
<!-- Storybook placeholder end -->
