### PR TITLE
fix: remove typo for information

### DIFF
--- a/gravitee-apim-console-webui/docs/management-configuration-apiportalheader.md
+++ b/gravitee-apim-console-webui/docs/management-configuration-apiportalheader.md
@@ -1,4 +1,4 @@
-# API Portal Informations
+# API Portal Information
 
 Add a list of name/value to display in the API aside.
 The name could be used as is, or could be a translated key.

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-inspector/policy-studio-debug-inspector-table/policy-studio-debug-inspector-table.component.html
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-inspector/policy-studio-debug-inspector-table/policy-studio-debug-inspector-table.component.html
@@ -15,7 +15,7 @@
     limitations under the License.
 
 -->
-<table class="gio-table-light" attr.aria-label="Debug informations for {{ name }}">
+<table class="gio-table-light" attr.aria-label="Debug information for {{ name }}">
   <thead>
     <tr>
       <th>key</th>

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-inspector/policy-studio-debug-inspector-text/policy-studio-debug-inspector-text.component.html
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/debug/components/policy-studio-debug-inspector/policy-studio-debug-inspector-text/policy-studio-debug-inspector-text.component.html
@@ -15,7 +15,7 @@
     limitations under the License.
 
 -->
-<table class="gio-table-light" attr.aria-label="Debug informations for {{ name }}">
+<table class="gio-table-light" attr.aria-label="Debug information for {{ name }}">
   <tbody>
     <tr [ngClass]="this.diffClass">
       <td class="input">

--- a/gravitee-apim-console-webui/src/management/configuration/api-portal-header/api-portal-header.html
+++ b/gravitee-apim-console-webui/src/management/configuration/api-portal-header/api-portal-header.html
@@ -16,11 +16,11 @@
 
 -->
 <div class="gv-forms" layout="column">
-  <h1>API Portal Informations</h1>
+  <h1>API Portal Information</h1>
   <div class="gv-form">
     <h2></h2>
     <div class="gv-form-content" layout="column">
-      <h3>Add extra informations</h3>
+      <h3>Add extra information</h3>
       <md-input-container class="gv-input-container-dense">
         <md-checkbox
           ng-model="$ctrl.settings.portal.apis.apiHeaderShowTags.enabled"
@@ -48,7 +48,7 @@
         </md-checkbox>
       </md-input-container>
 
-      <h3>Configure the informations list</h3>
+      <h3>Configure the information list</h3>
       <md-table-container>
         <table md-table class="gv-table-dense">
           <thead md-head>

--- a/gravitee-apim-console-webui/src/management/configuration/settings.html
+++ b/gravitee-apim-console-webui/src/management/configuration/settings.html
@@ -43,7 +43,7 @@
           <a class="execute" ui-sref="{{$ctrl.settingsMenu.analytics.goTo}}">Analytics</a>
         </li>
         <li class="iterable-item" ng-if="$ctrl.settingsMenu.apiPortalHeader.perm" ui-sref-active="aui-nav-selected">
-          <a class="execute" ui-sref="{{$ctrl.settingsMenu.apiPortalHeader.goTo}}">API Portal Informations</a>
+          <a class="execute" ui-sref="{{$ctrl.settingsMenu.apiPortalHeader.goTo}}">API Portal Information</a>
         </li>
         <li
           class="iterable-item"

--- a/gravitee-apim-console-webui/src/management/instances/details/environment/instance-environment.html
+++ b/gravitee-apim-console-webui/src/management/instances/details/environment/instance-environment.html
@@ -17,7 +17,7 @@
 -->
 <div class="gravitee-instances-container">
   <div class="gravitee-instances-content">
-    <div class="gravitee-instances-table-title"><ng-md-icon icon="info_outline"></ng-md-icon> Informations</div>
+    <div class="gravitee-instances-table-title"><ng-md-icon icon="info_outline"></ng-md-icon> Information</div>
     <md-table-container>
       <table md-table>
         <tbody md-body>


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/7683

## Description

Remove `S` from `informationS`
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-typo-information-7683/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-thbfklxjwj.chromatic.com)
<!-- Storybook placeholder end -->
