### PR TITLE
[Console] Migrate API Proxy deployments screen

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/proxy/apis.proxy.route.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/apis.proxy.route.ts
@@ -106,6 +106,19 @@ function apisProxyRouterConfig($stateProvider) {
         },
       },
     })
+    .state('management.apis.detail.proxy.ng-deployments', {
+      url: '/ng-deployments',
+      component: 'ngApiProxyDeployments',
+      data: {
+        useAngularMaterial: true,
+        perms: {
+          only: ['api-definition-r'],
+        },
+        docs: {
+          page: 'management-api-proxy',
+        },
+      },
+    })
     .state('management.apis.detail.proxy.failover', {
       url: '/failover',
       template: require('./backend/failover/apiProxyFailover.html'),

--- a/gravitee-apim-console-webui/src/management/api/proxy/cors/api-proxy-cors.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/cors/api-proxy-cors.component.ts
@@ -23,6 +23,7 @@ import { catchError, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { UIRouterStateParams } from '../../../../ajs-upgraded-providers';
 import { ApiService } from '../../../../services-ngx/api.service';
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
 import { CorsUtil } from '../../../../shared/utils';
 
 @Component({
@@ -45,6 +46,7 @@ export class ApiProxyCorsComponent implements OnInit, OnDestroy {
     @Inject(UIRouterStateParams) private readonly ajsStateParams,
     private readonly apiService: ApiService,
     private readonly snackBarService: SnackBarService,
+    private readonly permissionService: GioPermissionService,
   ) {}
 
   ngOnInit(): void {
@@ -57,7 +59,7 @@ export class ApiProxyCorsComponent implements OnInit, OnDestroy {
             enabled: false,
           };
 
-          const isReadOnly = api.origin === 'kubernetes';
+          const isReadOnly = !this.permissionService.hasAnyMatching(['api-definition-u']) || api.origin === 'kubernetes';
           const isCorsDisabled = isReadOnly || !cors.enabled;
 
           this.corsForm = new FormGroup({

--- a/gravitee-apim-console-webui/src/management/api/proxy/deployments/api-proxy-deployments.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/deployments/api-proxy-deployments.component.html
@@ -1,0 +1,18 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+🚧

--- a/gravitee-apim-console-webui/src/management/api/proxy/deployments/api-proxy-deployments.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/deployments/api-proxy-deployments.component.html
@@ -15,4 +15,21 @@
     limitations under the License.
 
 -->
-🚧
+<h1>Deployments</h1>
+
+<form *ngIf="deploymentsForm" [formGroup]="deploymentsForm" autocomplete="off" gioFormFocusInvalid>
+  <mat-card>
+    <p>Use sharding tags to control where the API must be deployed.</p>
+
+    <mat-form-field class="deployments-card__form-field" appearance="fill">
+      <mat-label>Sharding tags</mat-label>
+      <mat-select formControlName="tags" multiple>
+        <mat-option *ngFor="let tag of shardingTags" [value]="tag.id"
+          >{{ tag.name }}<span *ngIf="tag.description"> - {{ tag.description }}</span></mat-option
+        >
+      </mat-select>
+    </mat-form-field>
+  </mat-card>
+</form>
+
+<gio-save-bar [form]="deploymentsForm" [formInitialValues]="initialDeploymentsFormValue" (submitted)="onSubmit()"></gio-save-bar>

--- a/gravitee-apim-console-webui/src/management/api/proxy/deployments/api-proxy-deployments.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/proxy/deployments/api-proxy-deployments.component.scss
@@ -1,0 +1,5 @@
+@use '../../../../scss/gio-layout' as gio-layout;
+
+:host {
+  @include gio-layout.gio-responsive-content-container;
+}

--- a/gravitee-apim-console-webui/src/management/api/proxy/deployments/api-proxy-deployments.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/proxy/deployments/api-proxy-deployments.component.scss
@@ -3,3 +3,9 @@
 :host {
   @include gio-layout.gio-responsive-content-container;
 }
+
+.deployments-card {
+  &__form-field {
+    width: 100%;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/proxy/deployments/api-proxy-deployments.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/deployments/api-proxy-deployments.component.spec.ts
@@ -106,6 +106,22 @@ describe('ApiProxyDeploymentsComponent', () => {
     httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.org.baseURL}/configuration/tags`, method: 'GET' });
   });
 
+  it('should disable field when origin is kubernetes', async () => {
+    const api = fakeApi({
+      id: API_ID,
+      tags: ['tag2'],
+      origin: 'kubernetes',
+    });
+    expectApiGetRequest(api);
+    expectTagGetRequest([fakeTag({ id: 'tag1', name: 'tag1' })]);
+
+    const saveBar = await loader.getHarness(GioSaveBarHarness);
+    expect(await saveBar.isVisible()).toBe(false);
+
+    const tagsInput = await loader.getHarness(MatSelectHarness.with({ selector: '[formControlName="tags"]' }));
+    expect(await tagsInput.isDisabled()).toEqual(true);
+  });
+
   function expectApiGetRequest(api: Api) {
     httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/apis/${api.id}`, method: 'GET' }).flush(api);
     fixture.detectChanges();

--- a/gravitee-apim-console-webui/src/management/api/proxy/deployments/api-proxy-deployments.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/deployments/api-proxy-deployments.component.spec.ts
@@ -16,36 +16,103 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpTestingController } from '@angular/common/http/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { GioSaveBarHarness } from '@gravitee/ui-particles-angular';
+import { MatSelectHarness } from '@angular/material/select/testing';
+import { MatSnackBarHarness } from '@angular/material/snack-bar/testing';
 
 import { ApiProxyDeploymentsModule } from './api-proxy-deployments.module';
 import { ApiProxyDeploymentsComponent } from './api-proxy-deployments.component';
 
-import { GioHttpTestingModule } from '../../../../shared/testing';
+import { CONSTANTS_TESTING, GioHttpTestingModule } from '../../../../shared/testing';
+import { UIRouterStateParams, CurrentUserService } from '../../../../ajs-upgraded-providers';
+import { User } from '../../../../entities/user';
+import { Api } from '../../../../entities/api';
+import { fakeTag } from '../../../../entities/tag/tag.fixture';
+import { Tag } from '../../../../entities/tag/tag';
+import { fakeApi } from '../../../../entities/api/Api.fixture';
 
 describe('ApiProxyDeploymentsComponent', () => {
+  const API_ID = 'apiId';
+
   let fixture: ComponentFixture<ApiProxyDeploymentsComponent>;
-  let component: ApiProxyDeploymentsComponent;
+  let loader: HarnessLoader;
+  let rootLoader: HarnessLoader;
   let httpTestingController: HttpTestingController;
+
+  const currentUser = new User();
+  currentUser.userPermissions = ['api-definition-u'];
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, GioHttpTestingModule, ApiProxyDeploymentsModule],
+      providers: [
+        { provide: UIRouterStateParams, useValue: { apiId: API_ID } },
+        { provide: CurrentUserService, useValue: { currentUser } },
+      ],
     });
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ApiProxyDeploymentsComponent);
-    component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
 
     httpTestingController = TestBed.inject(HttpTestingController);
     fixture.detectChanges();
   });
 
-  it('should work', async () => {
-    expect(component).toBeTruthy();
-  });
-
   afterEach(() => {
     httpTestingController.verify();
   });
+
+  it('should update deployment', async () => {
+    const api = fakeApi({
+      id: API_ID,
+      tags: ['tag2'],
+    });
+    expectApiGetRequest(api);
+    expectTagGetRequest([
+      fakeTag({ id: 'tag1', name: 'tag1' }),
+      fakeTag({ id: 'tag2', name: 'tag2' }),
+      fakeTag({ id: 'tag3', name: 'tag3' }),
+    ]);
+
+    const saveBar = await loader.getHarness(GioSaveBarHarness);
+    expect(await saveBar.isVisible()).toBe(false);
+
+    const tagsInput = await loader.getHarness(MatSelectHarness.with({ selector: '[formControlName="tags"]' }));
+    expect(await tagsInput.isDisabled()).toEqual(false);
+
+    await tagsInput.clickOptions({ text: /tag1/ });
+    await tagsInput.clickOptions({ text: /tag2/ });
+    await tagsInput.clickOptions({ text: /tag3/ });
+
+    const saveButton = await loader.getHarness(GioSaveBarHarness);
+    await saveButton.clickSubmit();
+
+    // Expect fetch api and update
+    expectApiGetRequest(api);
+    const req = httpTestingController.expectOne({ method: 'PUT', url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}` });
+    expect(req.request.body.tags).toStrictEqual(['tag1', 'tag3']);
+    req.flush(api);
+
+    const snackBars = await rootLoader.getAllHarnesses(MatSnackBarHarness);
+    expect(snackBars.length).toBe(1);
+
+    // No flush to stop on new call of ngOnInit
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/apis/${api.id}`, method: 'GET' });
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.org.baseURL}/configuration/tags`, method: 'GET' });
+  });
+
+  function expectApiGetRequest(api: Api) {
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/apis/${api.id}`, method: 'GET' }).flush(api);
+    fixture.detectChanges();
+  }
+
+  function expectTagGetRequest(tags: Tag[]) {
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.org.baseURL}/configuration/tags`, method: 'GET' }).flush(tags);
+    fixture.detectChanges();
+  }
 });

--- a/gravitee-apim-console-webui/src/management/api/proxy/deployments/api-proxy-deployments.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/deployments/api-proxy-deployments.component.spec.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+
+import { ApiProxyDeploymentsModule } from './api-proxy-deployments.module';
+import { ApiProxyDeploymentsComponent } from './api-proxy-deployments.component';
+
+import { GioHttpTestingModule } from '../../../../shared/testing';
+
+describe('ApiProxyDeploymentsComponent', () => {
+  let fixture: ComponentFixture<ApiProxyDeploymentsComponent>;
+  let component: ApiProxyDeploymentsComponent;
+  let httpTestingController: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, GioHttpTestingModule, ApiProxyDeploymentsModule],
+    });
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ApiProxyDeploymentsComponent);
+    component = fixture.componentInstance;
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+  });
+
+  it('should work', async () => {
+    expect(component).toBeTruthy();
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/proxy/deployments/api-proxy-deployments.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/deployments/api-proxy-deployments.component.ts
@@ -13,8 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, OnDestroy, OnInit } from '@angular/core';
-import { Subject } from 'rxjs';
+import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import { FormGroup, FormControl } from '@angular/forms';
+import { combineLatest, EMPTY, Subject } from 'rxjs';
+import { catchError, switchMap, takeUntil, tap } from 'rxjs/operators';
+
+import { UIRouterStateParams } from '../../../../ajs-upgraded-providers';
+import { Tag } from '../../../../entities/tag/tag';
+import { ApiService } from '../../../../services-ngx/api.service';
+import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
+import { TagService } from '../../../../services-ngx/tag.service';
+import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
 
 @Component({
   selector: 'api-proxy-deployments',
@@ -24,12 +33,58 @@ import { Subject } from 'rxjs';
 export class ApiProxyDeploymentsComponent implements OnInit, OnDestroy {
   private unsubscribe$: Subject<boolean> = new Subject<boolean>();
 
-  constructor() {}
+  public shardingTags: Tag[];
+  public deploymentsForm: FormGroup;
+  public initialDeploymentsFormValue: unknown;
 
-  ngOnInit(): void {}
+  constructor(
+    @Inject(UIRouterStateParams) private readonly ajsStateParams,
+    private readonly apiService: ApiService,
+    private readonly tagService: TagService,
+    private readonly snackBarService: SnackBarService,
+    private readonly permissionService: GioPermissionService,
+  ) {}
+
+  ngOnInit(): void {
+    combineLatest([this.apiService.get(this.ajsStateParams.apiId), this.tagService.list()])
+      .pipe(
+        takeUntil(this.unsubscribe$),
+        tap(([api, shardingTags]) => {
+          this.shardingTags = shardingTags;
+
+          const isReadOnly = !this.permissionService.hasAnyMatching(['api-definition-u']);
+
+          this.deploymentsForm = new FormGroup({
+            tags: new FormControl({
+              value: api.tags ?? [],
+              disabled: isReadOnly,
+            }),
+          });
+
+          this.initialDeploymentsFormValue = this.deploymentsForm.getRawValue();
+        }),
+      )
+      .subscribe();
+  }
 
   ngOnDestroy() {
     this.unsubscribe$.next(true);
     this.unsubscribe$.unsubscribe();
+  }
+
+  onSubmit() {
+    return this.apiService
+      .get(this.ajsStateParams.apiId)
+      .pipe(
+        takeUntil(this.unsubscribe$),
+        switchMap((api) => this.apiService.update({ ...api, tags: this.deploymentsForm.get('tags').value ?? [] })),
+        tap(() => this.snackBarService.success('Configuration successfully saved!')),
+        catchError(({ error }) => {
+          this.snackBarService.error(error.message);
+          return EMPTY;
+        }),
+        tap(() => this.ngOnInit()),
+      )
+      .subscribe();
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/proxy/deployments/api-proxy-deployments.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/deployments/api-proxy-deployments.component.ts
@@ -52,7 +52,7 @@ export class ApiProxyDeploymentsComponent implements OnInit, OnDestroy {
         tap(([api, shardingTags]) => {
           this.shardingTags = shardingTags;
 
-          const isReadOnly = !this.permissionService.hasAnyMatching(['api-definition-u']);
+          const isReadOnly = !this.permissionService.hasAnyMatching(['api-definition-u']) || api.origin === 'kubernetes';
 
           this.deploymentsForm = new FormGroup({
             tags: new FormControl({

--- a/gravitee-apim-console-webui/src/management/api/proxy/deployments/api-proxy-deployments.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/deployments/api-proxy-deployments.component.ts
@@ -13,14 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Subject } from 'rxjs';
 
-import { NgModule } from '@angular/core';
-
-import { ApiProxyCorsModule } from './cors/api-proxy-cors.module';
-import { ApiProxyDeploymentsModule } from './deployments/api-proxy-deployments.module';
-import { ApiProxyEntrypointsModule } from './entrypoints/api-proxy-entrypoints.module';
-
-@NgModule({
-  imports: [ApiProxyEntrypointsModule, ApiProxyCorsModule, ApiProxyDeploymentsModule],
+@Component({
+  selector: 'api-proxy-deployments',
+  template: require('./api-proxy-deployments.component.html'),
+  styles: [require('./api-proxy-deployments.component.scss')],
 })
-export class ApiProxyModule {}
+export class ApiProxyDeploymentsComponent implements OnInit, OnDestroy {
+  private unsubscribe$: Subject<boolean> = new Subject<boolean>();
+
+  constructor() {}
+
+  ngOnInit(): void {}
+
+  ngOnDestroy() {
+    this.unsubscribe$.next(true);
+    this.unsubscribe$.unsubscribe();
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/proxy/deployments/api-proxy-deployments.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/deployments/api-proxy-deployments.module.ts
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
+import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
-import { ApiProxyCorsModule } from './cors/api-proxy-cors.module';
-import { ApiProxyDeploymentsModule } from './deployments/api-proxy-deployments.module';
-import { ApiProxyEntrypointsModule } from './entrypoints/api-proxy-entrypoints.module';
+import { ApiProxyDeploymentsComponent } from './api-proxy-deployments.component';
 
 @NgModule({
-  imports: [ApiProxyEntrypointsModule, ApiProxyCorsModule, ApiProxyDeploymentsModule],
+  declarations: [ApiProxyDeploymentsComponent],
+  exports: [ApiProxyDeploymentsComponent],
+  imports: [CommonModule],
 })
-export class ApiProxyModule {}
+export class ApiProxyDeploymentsModule {}

--- a/gravitee-apim-console-webui/src/management/api/proxy/deployments/api-proxy-deployments.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/deployments/api-proxy-deployments.module.ts
@@ -16,12 +16,32 @@
 
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { GioSaveBarModule } from '@gravitee/ui-particles-angular';
 
 import { ApiProxyDeploymentsComponent } from './api-proxy-deployments.component';
+
+import { GioFormFocusInvalidModule } from '../../../../shared/components/gio-form-focus-first-invalid/gio-form-focus-first-invalid.module';
 
 @NgModule({
   declarations: [ApiProxyDeploymentsComponent],
   exports: [ApiProxyDeploymentsComponent],
-  imports: [CommonModule],
+  imports: [
+    CommonModule,
+
+    ReactiveFormsModule,
+
+    MatFormFieldModule,
+    MatSelectModule,
+    MatCardModule,
+    MatSnackBarModule,
+
+    GioSaveBarModule,
+    GioFormFocusInvalidModule,
+  ],
 })
 export class ApiProxyDeploymentsModule {}

--- a/gravitee-apim-console-webui/src/management/management.module.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/management.module.ajs.ts
@@ -549,6 +549,7 @@ import { ApiProxyEntrypointsComponent } from './api/proxy/entrypoints/api-proxy-
 import { ApiProxyEntrypointsContextPathComponent } from './api/proxy/entrypoints/context-path/api-proxy-entrypoints-context-path.component';
 import { ApiProxyEntrypointsVirtualHostComponent } from './api/proxy/entrypoints/virtual-host/api-proxy-entrypoints-virtual-host.component';
 import { ApiProxyCorsComponent } from './api/proxy/cors/api-proxy-cors.component';
+import { ApiProxyDeploymentsComponent } from './api/proxy/deployments/api-proxy-deployments.component';
 
 (<any>window).moment = moment;
 require('angular-moment-picker');
@@ -682,6 +683,7 @@ graviteeManagementModule.directive(
   downgradeComponent({ component: ApiProxyEntrypointsVirtualHostComponent }),
 );
 graviteeManagementModule.directive('ngApiProxyCors', downgradeComponent({ component: ApiProxyCorsComponent }));
+graviteeManagementModule.directive('ngApiProxyDeployments', downgradeComponent({ component: ApiProxyDeploymentsComponent }));
 
 // Pendo Analytics
 graviteeManagementModule.factory('ngGioPendoService', downgradeInjectable(GioPendoService));


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8141

## Description

Migrate API Proxy deployments screen

## Additional context
Before: 
![image](https://user-images.githubusercontent.com/4974420/189401232-60375343-a4b3-48d2-b995-4a59b5d81d0e.png)


Next :
![image](https://user-images.githubusercontent.com/4974420/189401185-ae2f85ff-808a-45bd-b1db-c4a7af71a6b8.png)

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8141-migrate-proxy-deployments/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qvxciezdac.chromatic.com)
<!-- Storybook placeholder end -->
