### PR TITLE
chore: use stable version of gravitee-kubernetes-mapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <gravitee-resource-cache-provider-api.version>1.3.0</gravitee-resource-cache-provider-api.version>
         <gravitee-resource-oauth2-provider-api.version>1.3.0</gravitee-resource-oauth2-provider-api.version>
         <gravitee-service-discovery-api.version>1.1.1</gravitee-service-discovery-api.version>
-        <gravitee-kubernetes-mapper.version>0.4.0-SNAPSHOT</gravitee-kubernetes-mapper.version>
+        <gravitee-kubernetes-mapper.version>0.4.0</gravitee-kubernetes-mapper.version>
         <!-- Other dependencies version -->
         <asm.version>9.2</asm.version>
         <batik-transcoder.version>1.14</batik-transcoder.version>


### PR DESCRIPTION

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/chore-gravitee-kubernetes-version/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kynsegimjm.chromatic.com)
<!-- Storybook placeholder end -->
