### PR TITLE
fix: exclude unsupported fields from crd export

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/kubernetes/v1alpha1/ApiDefinitionResource.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/kubernetes/v1alpha1/ApiDefinitionResource.java
@@ -37,10 +37,12 @@ public class ApiDefinitionResource extends CustomResource<ObjectNode> {
         "pages",
         "metadata",
         "createdAt",
-        "updatedAt"
+        "updatedAt",
+        "picture",
+        "apiMedia"
     );
 
-    private static final List<String> UNSUPPORTED_PLAN_FIELDS = List.of("created_at", "updated_at");
+    private static final List<String> UNSUPPORTED_PLAN_FIELDS = List.of("created_at", "updated_at", "published_at");
 
     private static final String PLANS_FIELD = "plans";
 

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/kubernetes/v1alpha1/ApiDefinitionResourceTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/kubernetes/v1alpha1/ApiDefinitionResourceTest.java
@@ -39,12 +39,15 @@ public class ApiDefinitionResourceTest {
         assertFalse(resource.getSpec().has("metadata"));
         assertFalse(resource.getSpec().has("pages"));
         assertFalse(resource.getSpec().has("members"));
+        assertFalse(resource.getSpec().has("picture"));
+        assertFalse(resource.getSpec().has("apiMedia"));
 
         ArrayNode plans = (ArrayNode) resource.getSpec().get("plans");
 
         JsonNode plan = plans.iterator().next();
         assertFalse(plan.has("created_at"));
         assertFalse(plan.has("updated_at"));
+        assertFalse(resource.getSpec().has("published_at"));
     }
 
     private ObjectNode readDefinition() throws Exception {

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/test/resources/io/gravitee/definition/model/kubernetes/v1alpha1/api-definition.json
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/test/resources/io/gravitee/definition/model/kubernetes/v1alpha1/api-definition.json
@@ -11,6 +11,20 @@
   "createdAt": 1661848370924,
   "resources": [],
   "properties": [],
+  "picture": "L1VzZXJzL2Fjb3JkaWVyL0Rvd25sb2Fkcy9BdmF0YXItUHJvZmlsZS5wbmcK",
+  "apiMedia": [
+    {
+      "id": "7b5c71f5-5a83-4e59-9c71-f55a83be5945",
+      "hash": "573BBD2EC55AA637D539C3D0D18A25C6",
+      "type": "image",
+      "subType": "png",
+      "fileName": "Avatar-Profile.png",
+      "createAt": 1662974642783,
+      "size": 25721,
+      "data": "iVBORw0KGgoAAAANSUhEUgAAAgAAAAIACAYAAAD0eNT6AABkQElEQVR42ux9B3hUVfr+uO7",
+      "mimeType": "image/png"
+    }
+  ],
   "members": [
     {
       "source": "memory",
@@ -36,7 +50,8 @@
       "excludedAccessControls": false,
       "accessControls": [],
       "api": "f8216fd9-92e0-4008-a16f-d992e0e00860",
-      "attached_media": []
+      "attached_media": [],
+      "published_at": 1662559764415
     }
   ],
   "plans": [


### PR DESCRIPTION
see https://github.com/gravitee-io/issues/issues/8143

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/gko-fix-export/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dhvzrxfdah.chromatic.com)
<!-- Storybook placeholder end -->
