### PR TITLE
Fix/endpoint rule handler timeout exceptions

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleHandler.java
@@ -48,6 +48,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Date;
 import java.util.Iterator;
+import java.util.concurrent.TimeoutException;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -218,7 +219,7 @@ public abstract class EndpointRuleHandler<T extends Endpoint> implements Handler
                     request.setUri(hcRequestUri.toString());
 
                     if (requestPreparationEvent.failed()) {
-                        reportThrowable(requestPreparationEvent.cause(), step, healthBuilder, startTime, request, httpClient);
+                        reportThrowable(requestPreparationEvent.cause(), step, healthBuilder, startTime, request);
                     } else {
                         healthRequest.response(
                             healthRequestEvent -> {
@@ -246,14 +247,15 @@ public abstract class EndpointRuleHandler<T extends Endpoint> implements Handler
                                         throwable -> logger.error("An error has occurred during Health check response handler", throwable)
                                     );
                                 } else {
-                                    logger.error("An error has occurred during Health check response handler", healthRequestEvent.cause());
+                                    logger.error("An error has occurred during Health check request", healthRequestEvent.cause());
+                                    reportThrowable(healthRequestEvent.cause(), step, healthBuilder, startTime, request);
                                 }
                             }
                         );
 
                         healthRequest.exceptionHandler(
                             throwable -> {
-                                reportThrowable(throwable, step, healthBuilder, startTime, request, httpClient);
+                                reportThrowable(throwable, step, healthBuilder, startTime, request);
                             }
                         );
 
@@ -277,8 +279,7 @@ public abstract class EndpointRuleHandler<T extends Endpoint> implements Handler
         io.gravitee.definition.model.services.healthcheck.Step step,
         EndpointStatus.Builder healthBuilder,
         long startTime,
-        Request request,
-        HttpClient httpClient
+        Request request
     ) {
         long endTime = currentTimeMillis();
         Step failingStep = buildFailingStep(step, startTime, endTime, request, throwable);
@@ -344,7 +345,7 @@ public abstract class EndpointRuleHandler<T extends Endpoint> implements Handler
             request.setHeaders(getHttpHeaders(step));
         }
 
-        if (throwable instanceof ConnectTimeoutException) {
+        if (throwable instanceof ConnectTimeoutException || throwable instanceof TimeoutException) {
             stepBuilder.fail(throwable.getMessage());
             healthResponse.setStatus(HttpStatusCode.GATEWAY_TIMEOUT_504);
         } else {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/DebugApiSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/DebugApiSynchronizer.java
@@ -52,7 +52,7 @@ public class DebugApiSynchronizer extends AbstractSynchronizer {
 
         this.isDebugModeAvailable =
             pluginRegistry.plugins().stream().map(Plugin::id).anyMatch("gateway-debug"::equalsIgnoreCase) &&
-            configuration.getProperty("gravitee.services.gateway-debug.enabled", Boolean.class);
+            configuration.getProperty("gravitee.services.gateway-debug.enabled", Boolean.class, true);
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/DebugApiSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/DebugApiSynchronizerTest.java
@@ -76,7 +76,7 @@ public class DebugApiSynchronizerTest extends TestCase {
         Plugin debugPlugin = mock(Plugin.class);
         when(debugPlugin.id()).thenReturn("gateway-debug");
         when(pluginRegistry.plugins()).thenReturn((Collection) List.of(debugPlugin));
-        when(configuration.getProperty("gravitee.services.gateway-debug.enabled", Boolean.class)).thenReturn(true);
+        when(configuration.getProperty("gravitee.services.gateway-debug.enabled", Boolean.class, true)).thenReturn(true);
 
         debugApiSynchronizer = new DebugApiSynchronizer(eventManager, pluginRegistry, configuration, node);
         debugApiSynchronizer.eventRepository = eventRepository;
@@ -118,7 +118,7 @@ public class DebugApiSynchronizerTest extends TestCase {
 
     @Test
     public void shouldNotSyncIfDebugModeServiceIsDisabled() {
-        when(configuration.getProperty("gravitee.services.gateway-debug.enabled", Boolean.class)).thenReturn(false);
+        when(configuration.getProperty("gravitee.services.gateway-debug.enabled", Boolean.class, true)).thenReturn(false);
         debugApiSynchronizer = new DebugApiSynchronizer(eventManager, pluginRegistry, configuration, node);
 
         debugApiSynchronizer.synchronize(System.currentTimeMillis() - 5000, System.currentTimeMillis(), ENVIRONMENTS);


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8429

## Description

Add default value on debug mode enabled
Handle timeout on health check request
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-endpoint-rule-handler-timeout-exceptions-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bfommebnen.chromatic.com)
<!-- Storybook placeholder end -->
