### PR TITLE
test: deprecate api and test portal and api

### DIFF
--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/general/deprecate-api-and-test-the-portal-and-api.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/general/deprecate-api-and-test-the-portal-and-api.spec.ts
@@ -13,8 +13,96 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { describe } from '@jest/globals';
+import { APIsApi } from '@gravitee/management-webclient-sdk/src/lib/apis/APIsApi';
+import { forManagementAsApiUser, forPortalAsApiUser } from '@gravitee/utils/configuration';
+import { afterAll, beforeAll, describe, expect } from '@jest/globals';
+import { fail, succeed } from '@lib/jest-utils';
+import { ApisFaker } from '@gravitee/fixtures/management/ApisFaker';
+import { ApiEntity } from '@gravitee/management-webclient-sdk/src/lib/models/ApiEntity';
+import { PlansFaker } from '@gravitee/fixtures/management/PlansFaker';
+import { LifecycleAction } from '@gravitee/management-webclient-sdk/src/lib/models/LifecycleAction';
+import { PlanStatus } from '@gravitee/management-webclient-sdk/src/lib/models/PlanStatus';
+import { fetchGatewaySuccess } from '@gravitee/utils/gateway';
+import { teardownApisAndApplications } from '@gravitee/utils/management';
+import { ApiLifecycleState, UpdateApiEntityFromJSON, Visibility } from '@gravitee/management-webclient-sdk/src/lib/models';
+import { ApiApi } from '@gravitee/portal-webclient-sdk/src/lib';
+
+const orgId = 'DEFAULT';
+const envId = 'DEFAULT';
+const apisResourceAsPublisher = new APIsApi(forManagementAsApiUser());
+const portalApiResourceAsPublisher = new ApiApi(forPortalAsApiUser());
 
 describe('Deprecate API and test the portal and API', () => {
-  test.skip('To complete', async () => {});
+  let createdApi: ApiEntity;
+
+  beforeAll(async () => {
+    // create an API with a published free plan
+    createdApi = await succeed(
+      apisResourceAsPublisher.importApiDefinitionRaw({
+        envId,
+        orgId,
+        body: ApisFaker.apiImport({
+          plans: [PlansFaker.plan({ status: PlanStatus.PUBLISHED })],
+        }),
+      }),
+    );
+
+    // start API
+    await apisResourceAsPublisher.doApiLifecycleAction({
+      envId,
+      orgId,
+      api: createdApi.id,
+      action: LifecycleAction.START,
+    });
+
+    // make sure API endpoint is working
+    await fetchGatewaySuccess({ contextPath: createdApi.context_path }).then((res) => res.json());
+
+    // publish API
+    await apisResourceAsPublisher.updateApi({
+      api: createdApi.id,
+      updateApiEntity: UpdateApiEntityFromJSON({
+        ...createdApi,
+        lifecycle_state: ApiLifecycleState.PUBLISHED,
+        visibility: Visibility.PUBLIC,
+      }),
+      orgId,
+      envId,
+    });
+
+    // make sure API can be found in the portal
+    await portalApiResourceAsPublisher.getApiByApiId({ apiId: createdApi.id });
+
+    // deprecate the API
+    await apisResourceAsPublisher.updateApi({
+      envId,
+      orgId,
+      api: createdApi.id,
+      updateApiEntity: {
+        lifecycle_state: ApiLifecycleState.DEPRECATED,
+        description: createdApi.description,
+        name: createdApi.name,
+        proxy: createdApi.proxy,
+        version: createdApi.version,
+        visibility: createdApi.visibility,
+      },
+    });
+  });
+
+  test('Should be able to connect to deprecated API', async () => {
+    await fetchGatewaySuccess({ contextPath: createdApi.context_path }).then((res) => res.json());
+  });
+
+  test('Should find deprecated API in management console', async () => {
+    let responseApi = await succeed(apisResourceAsPublisher.getApiRaw({ orgId, envId, api: createdApi.id }));
+    expect(responseApi.lifecycle_state).toEqual(ApiLifecycleState.DEPRECATED);
+  });
+
+  test('Should fail to find deprecated API in portal', async () => {
+    await fail(portalApiResourceAsPublisher.getApiByApiId({ apiId: createdApi.id }), 404);
+  });
+
+  afterAll(async () => {
+    await teardownApisAndApplications(orgId, envId, [createdApi.id]);
+  });
 });


### PR DESCRIPTION
## Description
This use-case test does the following:

### Test preparation
- create an API with a published free plan
- start, publish & connect to API endpoint
- deprecates API

### Tests
Make sure ...
- ... it's possible to connect to deprecated API
- ... one can find deprecated API in management console
- ... deprecated API in not available in the portal

gravitee-io/issues#8100
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/test-8100-deprecate-api-and-test-portal-and-api-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lsfiwmhwcn.chromatic.com)
<!-- Storybook placeholder end -->
<!-- E2E Coverage placeholder -->
---
### 🧪 End-to-End Coverage

| INSTRUCTIONS | BRANCHES |
| :----------: | :------: |
|   37% | 22%   |

A more detailed report has been uploaded to [circleci](https://output.circle-artifacts.com/output/job/07b735f4-bbcc-4821-8508-6aeca5c291c5/artifacts/0/gravitee-apim-e2e/jacoco/reports/index.html)
<!-- E2E Coverage placeholder end -->
