### PR TITLE
fix(portal): display step to accept General Condition when subscribing

### DIFF
--- a/gravitee-apim-portal-webui/src/app/pages/api/api-subscribe/api-subscribe.component.html
+++ b/gravitee-apim-portal-webui/src/app/pages/api/api-subscribe/api-subscribe.component.html
@@ -31,8 +31,8 @@
         'step-content': true,
         one: this.currentStep === 1,
         two: this.currentStep === 2,
-        three: this.canConfigureSharedApiKey() && this.currentStep === 3,
-        four: (this.canConfigureSharedApiKey() && this.currentStep === 4) || (!this.canConfigureSharedApiKey() && this.currentStep === 3)
+        three: this.canDisplayApiKeyModeStep() && this.currentStep === 3,
+        four: (this.canDisplayApiKeyModeStep() && this.currentStep === 4) || (!this.canDisplayApiKeyModeStep() && this.currentStep === 3)
       }"
     >
       <form [formGroup]="subscribeForm">

--- a/gravitee-apim-portal-webui/src/app/pages/api/api-subscribe/api-subscribe.component.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/api/api-subscribe/api-subscribe.component.ts
@@ -259,7 +259,7 @@ export class ApiSubscribeComponent implements OnInit {
       })
       .slice(0, this.isKeyLess() ? 1 : this._allSteps.length);
 
-    if (!this.canDisplayApiKeyModeStep()) {
+    if (this.canConfigureSharedApiKey() && !this.canDisplayApiKeyModeStep()) {
       this.steps.splice(2, 1);
     }
   }
@@ -350,9 +350,6 @@ export class ApiSubscribeComponent implements OnInit {
     if (this.canNext()) {
       this.currentStep += 1;
     }
-    if (!this.canDisplayApiKeyModeStep() && this.currentStep === 3) {
-      this.currentStep += 1;
-    }
   }
 
   canNext() {
@@ -366,9 +363,6 @@ export class ApiSubscribeComponent implements OnInit {
   onPrevious() {
     this.hasSubscriptionError = false;
     this.currentStep -= 1;
-    if (!this.canDisplayApiKeyModeStep() && this.currentStep === 3) {
-      this.currentStep -= 1;
-    }
   }
 
   hasPlans() {
@@ -661,7 +655,7 @@ export class ApiSubscribeComponent implements OnInit {
     return this.configurationService.hasFeature(FeatureEnum.applicationCreation);
   }
 
-  canConfigureSharedApiKey() {
+  private canConfigureSharedApiKey() {
     return this.configurationService.hasFeature(FeatureEnum.sharedApiKey);
   }
 


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8442

## Description

From my understanding, the conditions are used in the `onNext` and `onPrevious` and should be replicated on the HTML, see https://github.com/gravitee-io/gravitee-api-management/blob/05e258965f85a2f9da53c17afb32d94a1d6dfc93/gravitee-apim-portal-webui/src/app/pages/api/api-subscribe/api-subscribe.component.ts#L353
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8442-fix-general-condition-display/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-trbscmdxqr.chromatic.com)
<!-- Storybook placeholder end -->
