### PR TITLE
fix: handle HTTP trailers in jupiter gateway fixes GRPC calls

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/adapter/invoker/FlowableProxyResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/adapter/invoker/FlowableProxyResponse.java
@@ -41,14 +41,22 @@ public class FlowableProxyResponse extends Flowable<Buffer> {
 
     private Subscription subscription;
     private Subscriber<? super Buffer> subscriber;
+    private Runnable onComplete;
 
-    public void initialize(HttpExecutionContext ctx, ProxyConnection connection, ProxyResponse proxyResponse) {
+    public FlowableProxyResponse initialize(HttpExecutionContext ctx, ProxyConnection connection, ProxyResponse proxyResponse) {
         this.ctx = ctx;
         this.connection = connection;
         this.proxyResponse = proxyResponse;
 
         // Always start by pausing the response.
         pauseProxyResponse();
+
+        return this;
+    }
+
+    public FlowableProxyResponse doOnComplete(Runnable onComplete) {
+        this.onComplete = onComplete;
+        return this;
     }
 
     private void release() {
@@ -105,6 +113,9 @@ public class FlowableProxyResponse extends Flowable<Buffer> {
 
     private void handleEnd() {
         release();
+        if (onComplete != null) {
+            onComplete.run();
+        }
         subscriber.onComplete();
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/adapter/invoker/FlowableProxyResponseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/adapter/invoker/FlowableProxyResponseTest.java
@@ -131,6 +131,20 @@ class FlowableProxyResponseTest {
     }
 
     @Test
+    public void shouldCompleteAndCallOnComplete() {
+        Runnable onComplete = mock(Runnable.class);
+        cut.doOnComplete(onComplete);
+
+        final TestSubscriber<Buffer> obs = cut.test();
+        verify(proxyResponse).endHandler(endHandlerCaptor.capture());
+        endHandlerCaptor.getValue().handle(null);
+
+        obs.assertComplete();
+        verify(onComplete).run();
+        verifyNoMoreInteractions(onComplete);
+    }
+
+    @Test
     public void shouldCompleteReceiveProxyResponseWithBackPressure() {
         final AtomicInteger chunkCount = new AtomicInteger(0);
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -456,8 +456,6 @@
                                 <gravitee.api.jupiterMode.default>always</gravitee.api.jupiterMode.default>
                             </environmentVariables>
                             <excludes>
-                                <!-- TODO: https://github.com/gravitee-io/issues/issues/8083 -->
-                                <exclude>**/Grpc*Test.java</exclude>
                                 <!-- TODO: https://github.com/gravitee-io/issues/issues/8075 -->
                                 <exclude>**/ClientConnectionResponseTemplateTest.java</exclude>
                             </excludes>


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8083

## Description

GRPC calls through jupiter gateway were failing cause HTTP trailers were not in the response.
This fix makes ConnectionHandlerAdapter get trailers from proxyResponse and copy them to the response.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-jupitergrpc/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-utfsfssdfn.chromatic.com)
<!-- Storybook placeholder end -->
