### PR TITLE
fix: configure kubernetes synchronizer to watch All or specifiec name…

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/kubernetes/KubernetesSyncServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/kubernetes/KubernetesSyncServiceTest.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.kubernetes;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.definition.model.Api;
+import io.gravitee.gateway.services.sync.synchronizer.ApiSynchronizer;
+import io.gravitee.kubernetes.client.KubernetesClient;
+import io.gravitee.kubernetes.client.model.v1.ConfigMap;
+import io.gravitee.kubernetes.client.model.v1.Event;
+import io.gravitee.kubernetes.client.model.v1.ObjectMeta;
+import io.gravitee.kubernetes.client.model.v1.Watchable;
+import io.reactivex.rxjava3.core.Flowable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class KubernetesSyncServiceTest {
+
+    @InjectMocks
+    private KubernetesSyncService cut;
+
+    @Mock
+    private KubernetesClient kubernetesClient;
+
+    @Mock
+    private ApiSynchronizer apiSynchronizer;
+
+    @Mock
+    private ObjectMapper mapper;
+
+    @Before
+    public void setUp() throws Exception {
+        cut = new KubernetesSyncService(kubernetesClient, apiSynchronizer);
+        cut.setMapper(mapper);
+    }
+
+    @Test
+    public void watchAllNamespaces() throws Exception {
+        cut.setNamespaces(new String[] { "ALL" });
+
+        CountDownLatch latch = new CountDownLatch(3);
+        when(kubernetesClient.watch(any())).thenReturn(mockFlowableEvents());
+
+        Api api = new Api();
+        api.setId(UUID.randomUUID().toString());
+        when(mapper.readValue("test", Api.class)).thenReturn(api);
+        when(apiSynchronizer.processApiEvents(any()))
+            .then(
+                (Answer<Flowable<String>>) invocation -> {
+                    latch.countDown();
+                    return Flowable.just(api.getId());
+                }
+            );
+
+        cut.doStart();
+
+        latch.await();
+        verify(apiSynchronizer, times(3)).processApiEvents(any());
+    }
+
+    @Test
+    public void watchGivenNamespaces() throws Exception {
+        cut.setNamespaces(new String[] { "default", "dev" });
+
+        CountDownLatch latch = new CountDownLatch(3);
+        when(kubernetesClient.watch(any())).thenReturn(mockFlowableEvents());
+
+        Api api = new Api();
+        api.setId(UUID.randomUUID().toString());
+        when(mapper.readValue("test", Api.class)).thenReturn(api);
+        when(apiSynchronizer.processApiEvents(any()))
+            .then(
+                (Answer<Flowable<String>>) invocation -> {
+                    latch.countDown();
+                    return Flowable.just(api.getId());
+                }
+            );
+
+        cut.doStart();
+
+        latch.await(1000L, TimeUnit.MILLISECONDS);
+        verify(apiSynchronizer, times(2)).processApiEvents(any());
+    }
+
+    private Flowable<Event<? extends Watchable>> mockFlowableEvents() {
+        ObjectMeta objectMeta1 = new ObjectMeta();
+        objectMeta1.setName("service1");
+        objectMeta1.setNamespace("default");
+        ObjectMeta objectMeta2 = new ObjectMeta();
+        objectMeta2.setName("service2");
+        objectMeta2.setNamespace("dev");
+        ObjectMeta objectMeta3 = new ObjectMeta();
+        objectMeta3.setName("service3");
+        objectMeta3.setNamespace("test");
+
+        Map<String, String> data = new HashMap<>();
+        data.put(KubernetesSyncService.DATA_DEFINITION, "test");
+
+        ConfigMap configMap1 = new ConfigMap("v1", null, data, true, "ConfigMap", objectMeta1);
+        ConfigMap configMap2 = new ConfigMap("v1", null, data, true, "ConfigMap", objectMeta2);
+        ConfigMap configMap3 = new ConfigMap("v1", null, data, true, "ConfigMap", objectMeta3);
+
+        return Flowable.just(mockEvent(configMap1), mockEvent(configMap2), mockEvent(configMap3));
+    }
+
+    private Event<ConfigMap> mockEvent(ConfigMap configMap) {
+        Event<ConfigMap> event = new Event<>();
+        event.setType("ADD");
+        event.setObject(configMap);
+
+        return event;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -262,6 +262,13 @@ services:
      # This sync service requires to install Gravitee Kubernetes Operator
 #    kubernetes:
 #      enabled: false
+      # by default only the current namespace that the Gateway is running will be watched but you can watch "ALL" or a list
+      # of comma seprated namespaces "ns1,ns2,ns3" or an array of namespaces
+#      namespaces: 
+#        - ALL 
+#        - ns1
+#        - ns2
+#        - ns3
 
   # Local registry service.
   # This registry is used to load API Definition with json format from the file system. By doing so, you do not need


### PR DESCRIPTION
## Description
At the moment Kubernetes synchroniser is watching all namespaces and there is no way to configure it. This PR will make the synchronizer to only watch to the current namespace that the Gateway is running inside it by default but the user can change this behaviour by setting the 'namespace' attribute. 
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/kubeernetes-sync/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rqqphvpgnq.chromatic.com)
<!-- Storybook placeholder end -->
