### PR TITLE
Bump `gravitee-expression-language` to 1.9.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <gravitee-cockpit-api.version>1.12.0</gravitee-cockpit-api.version>
         <gravitee-common.version>1.27.0</gravitee-common.version>
         <gravitee-connector-api.version>1.1.4</gravitee-connector-api.version>
-        <gravitee-expression-language.version>1.9.5</gravitee-expression-language.version>
+        <gravitee-expression-language.version>1.9.6</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>1.34.2</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8367
https://github.com/gravitee-io/issues/issues/7894

## Description

Bump `gravitee-expression-language` to 1.9.6
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/bump-gravitee-el/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
