### PR TITLE
Improve API subscriptions page loading time

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/portal/apis.portal.route.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/apis.portal.route.ts
@@ -170,9 +170,6 @@ function apisPortalRouterConfig($stateProvider) {
           return ApiService.getSubscriptions($stateParams.apiId, query).then((response) => response.data);
         },
 
-        subscribers: ($stateParams, ApiService: ApiService) =>
-          ApiService.getSubscribers($stateParams.apiId).then((response) => response.data),
-
         plans: ($stateParams, ApiService: ApiService) => ApiService.getApiPlans($stateParams.apiId).then((response) => response.data),
       },
       data: {

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/subscriptions.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/subscriptions.component.ts
@@ -313,7 +313,7 @@ const ApiSubscriptionsComponent: ng.IComponentOptions = {
     }
 
     applicationSearchTermSearch() {
-      this.ApiService.getSubscribers(this.api.id, this.applicationSearchTerm, 1, 40).then((response) => {
+      this.ApiService.getSubscribers(this.api.id, this.applicationSearchTerm, 1, 40, ['owner']).then((response) => {
         this.subscribers = response.data;
       });
       this.retrieveSelectedApplications();

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/subscriptions.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/subscriptions.component.ts
@@ -42,12 +42,12 @@ const ApiSubscriptionsComponent: ng.IComponentOptions = {
     api: '<',
     plans: '<',
     subscriptions: '<',
-    subscribers: '<',
   },
   template: require('./subscriptions.html'),
   controller: class {
     private subscriptions: PagedResult;
     private api: any;
+    private subscribers: any = null;
 
     private query: SubscriptionQuery = new SubscriptionQuery();
 
@@ -102,6 +102,10 @@ const ApiSubscriptionsComponent: ng.IComponentOptions = {
 
     $onInit() {
       this.getSubscriptionAnalytics();
+
+      this.ApiService.getSubscribers(this.api.id).then((response) => {
+        this.subscribers = response.data
+      })
     }
 
     onPaginate(page) {

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/subscriptions.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/subscriptions.component.ts
@@ -48,6 +48,7 @@ const ApiSubscriptionsComponent: ng.IComponentOptions = {
     private subscriptions: PagedResult;
     private api: any;
     private subscribers: any = null;
+    private subscribersSelected: any = null;
 
     private query: SubscriptionQuery = new SubscriptionQuery();
 
@@ -60,6 +61,8 @@ const ApiSubscriptionsComponent: ng.IComponentOptions = {
     };
 
     private subscriptionsFiltersForm: any;
+
+    private applicationSearchTerm: string;
 
     constructor(
       private ApiService: ApiService,
@@ -103,9 +106,7 @@ const ApiSubscriptionsComponent: ng.IComponentOptions = {
     $onInit() {
       this.getSubscriptionAnalytics();
 
-      this.ApiService.getSubscribers(this.api.id).then((response) => {
-        this.subscribers = response.data
-      })
+      this.retrieveSelectedApplications();
     }
 
     onPaginate(page) {
@@ -309,6 +310,26 @@ const ApiSubscriptionsComponent: ng.IComponentOptions = {
 
     get allowsSharedApiKeys(): boolean {
       return this.Constants.env?.settings?.plan?.security?.sharedApiKey?.enabled;
+    }
+
+    applicationSearchTermSearch() {
+      this.ApiService.getSubscribers(this.api.id, this.applicationSearchTerm, 1, 40).then((response) => {
+        this.subscribers = response.data;
+      });
+      this.retrieveSelectedApplications();
+    }
+
+    private retrieveSelectedApplications() {
+      const selectedApplications = this.query.applications;
+      if (selectedApplications && selectedApplications.length > 0) {
+        this.ApplicationService.list(null, null, 'active', selectedApplications).then((response) => {
+          this.subscribersSelected = response.data;
+        });
+      }
+    }
+
+    clearApplicationSearchTerm() {
+      this.applicationSearchTerm = '';
     }
   },
 };

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/subscriptions.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/subscriptions.html
@@ -32,6 +32,7 @@
             <md-input-container class="md-block" flex-gt-sm flex="20">
               <label>Application</label>
               <md-select ng-model="$ctrl.query.applications" placeholder="Applications" multiple>
+                <md-option ng-if="$ctrl.subscribers === null" disabled>Loading...</md-option>
                 <md-option ng-value="subscriber.id" ng-repeat="subscriber in $ctrl.subscribers track by subscriber.id"
                   >{{ subscriber.name }}</md-option
                 >

--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/subscriptions.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/subscriptions.html
@@ -31,11 +31,33 @@
             </md-input-container>
             <md-input-container class="md-block" flex-gt-sm flex="20">
               <label>Application</label>
-              <md-select ng-model="$ctrl.query.applications" placeholder="Applications" multiple>
+              <md-select
+                ng-model="$ctrl.query.applications"
+                data-md-container-class="selectdemoSelectHeader"
+                md-on-open="$ctrl.applicationSearchTermSearch()"
+                placeholder="Applications"
+                multiple
+              >
+                <md-select-header class="demo-select-header">
+                  <input
+                    ng-model="$ctrl.applicationSearchTerm"
+                    ng-change="$ctrl.applicationSearchTermSearch()"
+                    ng-keydown="$event.stopPropagation()"
+                    type="search"
+                    placeholder="Search applications."
+                    class="demo-header-searchbox md-text"
+                  />
+                </md-select-header>
+
                 <md-option ng-if="$ctrl.subscribers === null" disabled>Loading...</md-option>
                 <md-option ng-value="subscriber.id" ng-repeat="subscriber in $ctrl.subscribers track by subscriber.id"
                   >{{ subscriber.name }}</md-option
                 >
+                <md-optgroup ng-if="$ctrl.subscribersSelected && $ctrl.subscribersSelected.length > 0" label="Selected">
+                  <md-option ng-value="subscriber.id" ng-repeat="subscriber in $ctrl.subscribersSelected track by subscriber.id"
+                    >{{ subscriber.name }}</md-option
+                  >
+                </md-optgroup>
               </md-select>
             </md-input-container>
             <md-input-container class="md-block" flex-gt-sm flex="20">

--- a/gravitee-apim-console-webui/src/services/api.service.ts
+++ b/gravitee-apim-console-webui/src/services/api.service.ts
@@ -469,8 +469,19 @@ export class ApiService {
     return this.$http.get(req, { timeout: 30000 });
   }
 
-  getSubscribers(apiId: string): IHttpPromise<any> {
-    return this.$http.get(`${this.Constants.env.baseURL}/apis/${apiId}/subscribers`);
+  getSubscribers(apiId: string, query?: string, page?: number, size?: number): IHttpPromise<any> {
+    const queryParams: string[] = [];
+    if (query) {
+      queryParams.push(`query=${query}`);
+    }
+    if (page) {
+      queryParams.push(`page=${page}`);
+    }
+    if (size) {
+      queryParams.push(`size=${size}`);
+    }
+
+    return this.$http.get(`${this.Constants.env.baseURL}/apis/${apiId}/subscribers${queryParams ? '?' + queryParams.join('&') : ''}`);
   }
 
   getSubscription(apiId, subscriptionId): IHttpPromise<any> {

--- a/gravitee-apim-console-webui/src/services/api.service.ts
+++ b/gravitee-apim-console-webui/src/services/api.service.ts
@@ -16,6 +16,8 @@
 import { IHttpPromise, IHttpService, IRootScopeService } from 'angular';
 import { clone } from 'lodash';
 
+import { ApplicationExcludeFilter } from './application.service';
+
 import { Constants } from '../entities/Constants';
 import { PagedResult } from '../entities/pagedResult';
 
@@ -469,7 +471,7 @@ export class ApiService {
     return this.$http.get(req, { timeout: 30000 });
   }
 
-  getSubscribers(apiId: string, query?: string, page?: number, size?: number): IHttpPromise<any> {
+  getSubscribers(apiId: string, query?: string, page?: number, size?: number, exclude: ApplicationExcludeFilter[] = []): IHttpPromise<any> {
     const queryParams: string[] = [];
     if (query) {
       queryParams.push(`query=${query}`);
@@ -480,7 +482,9 @@ export class ApiService {
     if (size) {
       queryParams.push(`size=${size}`);
     }
-
+    if (exclude && exclude.length > 0) {
+      queryParams.push(exclude.map((filter) => `exclude=${filter}`).join('&'));
+    }
     return this.$http.get(`${this.Constants.env.baseURL}/apis/${apiId}/subscribers${queryParams ? '?' + queryParams.join('&') : ''}`);
   }
 

--- a/gravitee-apim-console-webui/src/services/application.service.ts
+++ b/gravitee-apim-console-webui/src/services/application.service.ts
@@ -35,7 +35,7 @@ interface IMembership {
   role: string;
 }
 
-type ApplicationExcludeFilter = 'owner' | 'picture';
+export type ApplicationExcludeFilter = 'owner' | 'picture';
 
 class ApplicationService {
   constructor(private $http: ng.IHttpService, private Constants) {

--- a/gravitee-apim-console-webui/src/services/application.service.ts
+++ b/gravitee-apim-console-webui/src/services/application.service.ts
@@ -70,18 +70,21 @@ class ApplicationService {
     return this.$http.post(`${this.applicationURL(applicationId)}` + '/members/transfer_ownership', ownership);
   }
 
-  list(exclude: ApplicationExcludeFilter[] = [], query = '', status = 'active'): ng.IHttpPromise<any> {
+  list(exclude: ApplicationExcludeFilter[] = [], query = '', status = 'active', ids?: string[]): ng.IHttpPromise<any> {
     let url = `${this.Constants.env.baseURL}/applications/?status=${status}`;
 
-    if (query.trim() !== '') {
+    if (query && query.trim() !== '') {
       url += `&query=${query}`;
     }
 
-    if (exclude.length > 0) {
+    if (ids) {
+      url += '&' + ids.map((i) => `ids=${i}`).join('&');
+    }
+
+    if (exclude && exclude.length > 0) {
       const excludeFilters = exclude.map((filter) => `exclude=${filter}`).join('&');
       url += `&${excludeFilters}`;
     }
-
     return this.$http.get(url);
   }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/SubscriptionCriteria.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/SubscriptionCriteria.java
@@ -29,6 +29,8 @@ import java.util.Objects;
  */
 public class SubscriptionCriteria {
 
+    private final Collection<String> ids;
+
     private final Collection<String> apis;
 
     private final Collection<String> plans;
@@ -48,6 +50,7 @@ public class SubscriptionCriteria {
     SubscriptionCriteria(SubscriptionCriteria.Builder builder) {
         this.from = builder.from;
         this.to = builder.to;
+        this.ids = builder.ids;
         this.apis = builder.apis;
         this.plans = builder.plans;
         this.applications = builder.applications;
@@ -56,6 +59,10 @@ public class SubscriptionCriteria {
         this.endingAtAfter = builder.endingAtAfter;
         this.endingAtBefore = builder.endingAtBefore;
         this.planSecurityTypes = builder.planSecurityTypes;
+    }
+
+    public Collection<String> getIds() {
+        return ids;
     }
 
     public Collection<String> getApis() {
@@ -110,6 +117,7 @@ public class SubscriptionCriteria {
             to == that.to &&
             endingAtAfter == that.endingAtAfter &&
             endingAtBefore == that.endingAtBefore &&
+            Objects.equals(ids, that.ids) &&
             Objects.equals(apis, that.apis) &&
             Objects.equals(plans, that.plans) &&
             Objects.equals(statuses, that.statuses) &&
@@ -120,10 +128,12 @@ public class SubscriptionCriteria {
 
     @Override
     public int hashCode() {
-        return Objects.hash(apis, plans, statuses, applications, from, to, endingAtAfter, endingAtBefore, planSecurityTypes);
+        return Objects.hash(ids, apis, plans, statuses, applications, from, to, endingAtAfter, endingAtBefore, planSecurityTypes);
     }
 
     public static class Builder {
+
+        private Collection<String> ids;
 
         private Collection<String> apis;
 
@@ -148,6 +158,11 @@ public class SubscriptionCriteria {
 
         public SubscriptionCriteria.Builder to(long to) {
             this.to = to;
+            return this;
+        }
+
+        public SubscriptionCriteria.Builder ids(Collection<String> ids) {
+            this.ids = ids;
             return this;
         }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcSubscriptionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcSubscriptionRepository.java
@@ -196,10 +196,9 @@ public class JdbcSubscriptionRepository extends JdbcAbstractCrudRepository<Subsc
         started = addStringsWhereClause(criteria.getPlans(), "s." + escapeReservedWord("plan"), argsList, builder, started);
         started = addStringsWhereClause(criteria.getApplications(), "s.application", argsList, builder, started);
         started = addStringsWhereClause(criteria.getApis(), "s.api", argsList, builder, started);
+        started = addStringsWhereClause(criteria.getIds(), "s.id", argsList, builder, started);
 
-        if (!isEmpty(criteria.getStatuses())) {
-            addStringsWhereClause(criteria.getStatuses(), "s.status", argsList, builder, started);
-        }
+        addStringsWhereClause(criteria.getStatuses(), "s.status", argsList, builder, started);
 
         builder.append(" order by s.created_at desc ");
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/common/MongoFactory.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/common/MongoFactory.java
@@ -142,6 +142,9 @@ public class MongoFactory implements FactoryBean<MongoClient> {
         boolean sslEnabled = readPropertyValue(propertyPrefix + "sslEnabled", Boolean.class, false);
         sslBuilder.enabled(sslEnabled);
 
+        boolean sslInvalidHostNameAllowed = readPropertyValue(propertyPrefix + "sslInvalidHostNameAllowed", Boolean.class, false);
+        sslBuilder.invalidHostNameAllowed(sslInvalidHostNameAllowed);
+
         if (sslEnabled) {
             try {
                 String tlsProtocol = readPropertyValue(propertyPrefix + "tlsProtocol", String.class, "TLS");

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/create-index.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/create-index.js
@@ -34,6 +34,7 @@ db.getCollection(`${prefix}plans`).reIndex();
 db.getCollection(`${prefix}subscriptions`).dropIndexes();
 db.getCollection(`${prefix}subscriptions`).createIndex( { "plan" : 1 }, { "name": "p1" } );
 db.getCollection(`${prefix}subscriptions`).createIndex( { "application" : 1 }, { "name": "a1" } );
+db.getCollection(`${prefix}subscriptions`).createIndex( { "createdAt" : -1 }, { "name": "c-1" } );
 db.getCollection(`${prefix}subscriptions`).reIndex();
 
 // "keys" collection

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/common/MongoFactoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/common/MongoFactoryTest.java
@@ -193,11 +193,13 @@ public class MongoFactoryTest {
 
         assertThat(sslSettings).isNotNull();
         assertThat(sslSettings.isEnabled()).isFalse();
+        assertThat(sslSettings.isInvalidHostNameAllowed()).isFalse();
     }
 
     @Test
     public void buildSslSettingsShouldReturnSettingsConfiguredWithProperties() {
         environment.setProperty(PROPERTY_PREFIX + "sslEnabled", "true");
+        environment.setProperty(PROPERTY_PREFIX + "sslInvalidHostNameAllowed", "true");
         environment.setProperty(PROPERTY_PREFIX + "truststore.path", this.getClass().getResource("/ca-truststore.jks").getPath());
         environment.setProperty(PROPERTY_PREFIX + "truststore.password", "truststore-secret");
         environment.setProperty(PROPERTY_PREFIX + "truststore.type", "jks");
@@ -210,6 +212,7 @@ public class MongoFactoryTest {
 
         assertThat(sslSettings).isNotNull();
         assertThat(sslSettings.isEnabled()).isTrue();
+        assertThat(sslSettings.isInvalidHostNameAllowed()).isTrue();
         assertThat(sslSettings.getContext().getProtocol()).isEqualTo("TLS");
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/SubscriptionRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/SubscriptionRepositoryTest.java
@@ -111,6 +111,29 @@ public class SubscriptionRepositoryTest extends AbstractRepositoryTest {
     }
 
     @Test
+    public void shouldFindByIds() throws TechnicalException {
+        List<Subscription> subscriptions =
+            this.subscriptionRepository.search(new SubscriptionCriteria.Builder().ids(List.of("sub1", "sub3", "sub4")).build());
+
+        assertNotNull(subscriptions);
+        assertFalse(subscriptions.isEmpty());
+        assertEquals("Subscriptions size", 3, subscriptions.size());
+        final Iterator<Subscription> iterator = subscriptions.iterator();
+        assertEquals("Subscription id", "sub3", iterator.next().getId());
+        assertEquals("Subscription id", "sub4", iterator.next().getId());
+        assertEquals("Subscription id", "sub1", iterator.next().getId());
+    }
+
+    @Test
+    public void shoulNotFindByIds() throws TechnicalException {
+        List<Subscription> subscriptions =
+            this.subscriptionRepository.search(new SubscriptionCriteria.Builder().ids(singleton("unknown-subscription")).build());
+
+        assertNotNull(subscriptions);
+        assertTrue(subscriptions.isEmpty());
+    }
+
+    @Test
     public void shouldFindById() throws TechnicalException {
         Optional<Subscription> optionalSubscription = this.subscriptionRepository.findById("sub1");
 

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/SubscriptionRepositoryMock.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/SubscriptionRepositoryMock.java
@@ -87,6 +87,11 @@ public class SubscriptionRepositoryMock extends AbstractRepositoryMock<Subscript
         when(subscriptionRepository.search(new SubscriptionCriteria.Builder().applications(singleton("unknown-app")).build()))
             .thenReturn(Collections.emptyList());
 
+        when(subscriptionRepository.search(new SubscriptionCriteria.Builder().ids(List.of("sub1", "sub3", "sub4")).build()))
+            .thenReturn(asList(sub3, sub4, sub1));
+        when(subscriptionRepository.search(new SubscriptionCriteria.Builder().ids(singleton("unknown-subscription")).build()))
+            .thenReturn(Collections.emptyList());
+
         when(subscriptionRepository.findById("sub1")).thenReturn(of(sub1));
         when(subscriptionRepository.findById("unknown-sub")).thenReturn(empty());
         when(subscriptionRepository.findById("sub2")).thenReturn(empty());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscribersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscribersResource.java
@@ -21,6 +21,7 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.management.rest.model.Pageable;
 import io.gravitee.rest.api.model.SubscriptionEntity;
+import io.gravitee.rest.api.model.application.ApplicationExcludeFilter;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.model.application.ApplicationQuery;
 import io.gravitee.rest.api.model.common.Sortable;
@@ -91,7 +92,11 @@ public class ApiSubscribersResource extends AbstractResource {
         )
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
-    public Collection<ApplicationListItem> getApiSubscribers(@QueryParam("query") final String query, @Valid @BeanParam Pageable pageable) {
+    public Collection<ApplicationListItem> getApiSubscribers(
+        @QueryParam("query") final String query,
+        @QueryParam("exclude") final List<ApplicationExcludeFilter> exclude,
+        @Valid @BeanParam Pageable pageable
+    ) {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         if (
             !hasPermission(executionContext, RolePermission.API_SUBSCRIPTION, api, RolePermissionAction.READ) &&
@@ -109,6 +114,9 @@ public class ApiSubscribersResource extends AbstractResource {
         Set<String> applicationIds = subscriptions.stream().map(SubscriptionEntity::getApplication).collect(Collectors.toSet());
 
         ApplicationQuery applicationQuery = new ApplicationQuery();
+        if (exclude != null && !exclude.isEmpty()) {
+            applicationQuery.setExcludeFilters(exclude);
+        }
         applicationQuery.setIds(applicationIds);
         if (query != null && !query.isEmpty()) {
             applicationQuery.setName(query);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscribersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscribersResource.java
@@ -19,9 +19,8 @@ import static io.gravitee.rest.api.model.SubscriptionStatus.*;
 
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.common.http.MediaType;
-import io.gravitee.rest.api.model.ApplicationEntity;
+import io.gravitee.rest.api.management.rest.model.Pageable;
 import io.gravitee.rest.api.model.SubscriptionEntity;
-import io.gravitee.rest.api.model.SubscriptionStatus;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.model.application.ApplicationQuery;
 import io.gravitee.rest.api.model.common.Sortable;
@@ -46,11 +45,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.inject.Inject;
+import javax.validation.Valid;
+import javax.ws.rs.BeanParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.container.ResourceContext;
 import javax.ws.rs.core.Context;
 
@@ -90,7 +91,7 @@ public class ApiSubscribersResource extends AbstractResource {
         )
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
-    public Collection<ApplicationListItem> getApiSubscribers() {
+    public Collection<ApplicationListItem> getApiSubscribers(@QueryParam("query") final String query, @Valid @BeanParam Pageable pageable) {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         if (
             !hasPermission(executionContext, RolePermission.API_SUBSCRIPTION, api, RolePermissionAction.READ) &&
@@ -109,6 +110,9 @@ public class ApiSubscribersResource extends AbstractResource {
 
         ApplicationQuery applicationQuery = new ApplicationQuery();
         applicationQuery.setIds(applicationIds);
+        if (query != null && !query.isEmpty()) {
+            applicationQuery.setName(query);
+        }
 
         Sortable sortable = new SortableImpl("name", true);
 
@@ -116,7 +120,7 @@ public class ApiSubscribersResource extends AbstractResource {
             executionContext,
             applicationQuery,
             sortable,
-            null
+            pageable.toPageable()
         );
 
         if (subscribersApplicationPage == null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationsResource.java
@@ -41,10 +41,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.validation.Valid;
@@ -94,10 +91,11 @@ public class ApplicationsResource extends AbstractResource {
         @QueryParam("group") final String group,
         @QueryParam("query") final String query,
         @QueryParam("status") @DefaultValue("ACTIVE") final String status,
+        @QueryParam("ids") final List<String> ids,
         @QueryParam("exclude") List<ApplicationExcludeFilter> excludeFilters
     ) {
         ApplicationsOrderParam applicationsOrderParam = new ApplicationsOrderParam("ARCHIVED".equals(status) ? "updated_at" : "name");
-        return this.getApplicationsPaged(group, query, status, applicationsOrderParam, null, excludeFilters).getData();
+        return this.getApplicationsPaged(group, query, status, ids, applicationsOrderParam, null, excludeFilters).getData();
     }
 
     @GET
@@ -120,6 +118,7 @@ public class ApplicationsResource extends AbstractResource {
         @QueryParam("group") final String group,
         @QueryParam("query") final String query,
         @QueryParam("status") @DefaultValue("ACTIVE") final String status,
+        @QueryParam("ids") final List<String> ids,
         @Parameter(
             name = "order",
             schema = @Schema(
@@ -142,6 +141,10 @@ public class ApplicationsResource extends AbstractResource {
             applicationQuery.setGroups(Set.of(group));
         }
         applicationQuery.setName(query);
+
+        if (ids != null && !ids.isEmpty()) {
+            applicationQuery.setIds(new HashSet<>(ids));
+        }
 
         if (!isAdmin()) {
             applicationQuery.setUser(getAuthenticatedUser());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiSubscribersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiSubscribersResourceTest.java
@@ -107,7 +107,7 @@ public class ApiSubscribersResourceTest extends AbstractResourceTest {
                 eq(GraviteeContext.getExecutionContext()),
                 argThat(q -> q.getIds().containsAll(Arrays.asList("A", "B", "C"))),
                 eq(new SortableImpl("name", true)),
-                eq(null)
+                argThat(pageable -> pageable.getPageNumber() == 1 && pageable.getPageSize() == 20)
             );
 
         final Response response = envTarget(API_ID).path("subscribers").request().get();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiSubscribersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiSubscribersResourceTest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource;
+
+import static io.gravitee.common.http.HttpStatusCode.NOT_FOUND_404;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.rest.api.model.ApplicationEntity;
+import io.gravitee.rest.api.model.PrimaryOwnerEntity;
+import io.gravitee.rest.api.model.SubscriptionEntity;
+import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.model.analytics.TopHitsAnalytics;
+import io.gravitee.rest.api.model.analytics.query.GroupByQuery;
+import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.model.application.ApplicationListItem;
+import io.gravitee.rest.api.model.common.SortableImpl;
+import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.io.IOException;
+import java.util.*;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Response;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+/**
+ * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ApiSubscribersResourceTest extends AbstractResourceTest {
+
+    private static final String API_ID = "my-api";
+
+    @Override
+    protected String contextPath() {
+        return "apis/" + API_ID + "";
+    }
+
+    @Before
+    public void init() throws IOException {
+        reset(apiKeyService, subscriptionService, applicationService);
+        GraviteeContext.cleanContext();
+
+        ApiEntity mockApi = new ApiEntity();
+        mockApi.setId(API_ID);
+        UserEntity user = new UserEntity();
+        user.setId(USER_NAME);
+        PrimaryOwnerEntity primaryOwner = new PrimaryOwnerEntity(user);
+        mockApi.setPrimaryOwner(primaryOwner);
+        Set<ApiEntity> mockApis = new HashSet<>(Arrays.asList(mockApi));
+        doReturn(mockApis)
+            .when(apiService)
+            .findPublishedByUser(eq(GraviteeContext.getExecutionContext()), any(), argThat(q -> singletonList(API_ID).equals(q.getIds())));
+    }
+
+    @After
+    public void tearDown() {
+        GraviteeContext.cleanContext();
+    }
+
+    @Test
+    public void shouldGetApiSubscribers() {
+        SubscriptionEntity subA1 = new SubscriptionEntity();
+        subA1.setApplication("A");
+        subA1.setApi(API_ID);
+        SubscriptionEntity subB1 = new SubscriptionEntity();
+        subB1.setApplication("B");
+        subB1.setApi(API_ID);
+        SubscriptionEntity subC1 = new SubscriptionEntity();
+        subC1.setApplication("C");
+        subC1.setApi(API_ID);
+        doReturn(Arrays.asList(subB1, subC1, subA1)).when(subscriptionService).search(eq(GraviteeContext.getExecutionContext()), any());
+
+        ApplicationListItem appA = new ApplicationListItem();
+        appA.setId("A");
+        ApplicationListItem appB = new ApplicationListItem();
+        appB.setId("B");
+        ApplicationListItem appC = new ApplicationListItem();
+        appC.setId("C");
+        Page<ApplicationListItem> applications = new Page(Arrays.asList(appA, appB, appC), 1, 10, 42);
+
+        doReturn(applications)
+            .when(applicationService)
+            .search(
+                eq(GraviteeContext.getExecutionContext()),
+                argThat(q -> q.getIds().containsAll(Arrays.asList("A", "B", "C"))),
+                eq(new SortableImpl("name", true)),
+                eq(null)
+            );
+
+        final Response response = envTarget(API_ID).path("subscribers").request().get();
+        assertEquals(OK_200, response.getStatus());
+
+        final Collection<ApplicationListItem> applicationsResponse = response.readEntity(new GenericType<>() {});
+        assertNotNull(applicationsResponse);
+        assertEquals(3, applicationsResponse.size());
+    }
+
+    @Test
+    public void shouldGetNoSubscribers() {
+        doReturn(Collections.emptyList()).when(subscriptionService).search(eq(GraviteeContext.getExecutionContext()), any());
+
+        final Response response = envTarget(API_ID).path("subscribers").request().get();
+        assertEquals(OK_200, response.getStatus());
+
+        final Collection<ApplicationListItem> applicationsResponse = response.readEntity(new GenericType<>() {});
+        assertNotNull(applicationsResponse);
+        assertEquals(0, applicationsResponse.size());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/application/ApplicationListItem.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/application/ApplicationListItem.java
@@ -83,6 +83,9 @@ public class ApplicationListItem {
     @Schema(description = "The API key mode used for this application.")
     private ApiKeyMode apiKeyMode;
 
+    @JsonProperty("disable_membership_notifications")
+    private boolean disableMembershipNotifications;
+
     public String getId() {
         return id;
     }
@@ -209,6 +212,18 @@ public class ApplicationListItem {
 
     public void setApiKeyMode(ApiKeyMode apiKeyMode) {
         this.apiKeyMode = apiKeyMode;
+    }
+
+    public boolean hasApiKeySharedMode() {
+        return apiKeyMode == ApiKeyMode.SHARED;
+    }
+
+    public boolean isDisableMembershipNotifications() {
+        return disableMembershipNotifications;
+    }
+
+    public void setDisableMembershipNotifications(boolean disableMembershipNotifications) {
+        this.disableMembershipNotifications = disableMembershipNotifications;
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiSubscribersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiSubscribersResource.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.portal.rest.resource;
 
+import io.gravitee.common.data.domain.Page;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.model.SubscriptionStatus;
@@ -23,6 +24,9 @@ import io.gravitee.rest.api.model.analytics.query.GroupByQuery;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.api.ApiQuery;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
+import io.gravitee.rest.api.model.application.ApplicationQuery;
+import io.gravitee.rest.api.model.common.Sortable;
+import io.gravitee.rest.api.model.common.SortableImpl;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.portal.rest.mapper.ApplicationMapper;
 import io.gravitee.rest.api.portal.rest.model.Application;
@@ -90,14 +94,32 @@ public class ApiSubscribersResource extends AbstractResource {
             Map<String, Long> nbHitsByApp = getNbHitsByApplication(apiId);
 
             Collection<SubscriptionEntity> subscriptions = subscriptionService.search(executionContext, subscriptionQuery);
-            List<Application> subscribersApplication = subscriptions
+
+            Set<String> applicationIds = subscriptions.stream().map(SubscriptionEntity::getApplication).collect(Collectors.toSet());
+
+            ApplicationQuery applicationQuery = new ApplicationQuery();
+            applicationQuery.setIds(applicationIds);
+
+            Sortable sortable = new SortableImpl("name", true);
+
+            Page<ApplicationListItem> subscribersApplicationPage = applicationService.search(
+                executionContext,
+                applicationQuery,
+                sortable,
+                null
+            );
+
+            if (subscribersApplicationPage == null) {
+                return createListResponse(executionContext, Collections.emptyList(), paginationParam);
+            }
+
+            List<Application> subscribersApplication = subscribersApplicationPage
+                .getContent()
                 .stream()
-                .map(SubscriptionEntity::getApplication)
-                .distinct()
-                .map(application -> applicationService.findById(executionContext, application))
                 .map(application -> applicationMapper.convert(executionContext, application, uriInfo))
                 .sorted((o1, o2) -> compareApp(nbHitsByApp, o1, o2))
                 .collect(Collectors.toList());
+
             return createListResponse(executionContext, subscribersApplication, paginationParam);
         }
         throw new ApiNotFoundException(apiId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiSubscribersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiSubscribersResourceTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doReturn;
 
+import io.gravitee.common.data.domain.Page;
 import io.gravitee.rest.api.model.ApplicationEntity;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.SubscriptionEntity;
@@ -31,6 +32,7 @@ import io.gravitee.rest.api.model.analytics.TopHitsAnalytics;
 import io.gravitee.rest.api.model.analytics.query.GroupByQuery;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
+import io.gravitee.rest.api.model.common.SortableImpl;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.portal.rest.model.Application;
 import io.gravitee.rest.api.portal.rest.model.ApplicationsResponse;
@@ -118,20 +120,32 @@ public class ApiSubscribersResourceTest extends AbstractResourceTest {
         subC1.setApi(API);
         doReturn(Arrays.asList(subB1, subC1, subA1)).when(subscriptionService).search(eq(GraviteeContext.getExecutionContext()), any());
 
-        ApplicationEntity appA = new ApplicationEntity();
+        ApplicationListItem appA = new ApplicationListItem();
         appA.setId("A");
-        doReturn(appA).when(applicationService).findById(GraviteeContext.getExecutionContext(), "A");
-        doReturn(new Application().id("A")).when(applicationMapper).convert(eq(GraviteeContext.getExecutionContext()), eq(appA), any());
-
-        ApplicationEntity appB = new ApplicationEntity();
+        ApplicationListItem appB = new ApplicationListItem();
         appB.setId("B");
-        doReturn(appB).when(applicationService).findById(GraviteeContext.getExecutionContext(), "B");
-        doReturn(new Application().id("B")).when(applicationMapper).convert(eq(GraviteeContext.getExecutionContext()), eq(appB), any());
-
-        ApplicationEntity appC = new ApplicationEntity();
+        ApplicationListItem appC = new ApplicationListItem();
         appC.setId("C");
-        doReturn(appC).when(applicationService).findById(GraviteeContext.getExecutionContext(), "C");
-        doReturn(new Application().id("C")).when(applicationMapper).convert(eq(GraviteeContext.getExecutionContext()), eq(appC), any());
+        Page<ApplicationListItem> applications = new Page(Arrays.asList(appA, appB, appC), 1, 10, 2);
+        doReturn(applications)
+            .when(applicationService)
+            .search(
+                eq(GraviteeContext.getExecutionContext()),
+                argThat(q -> q.getIds().containsAll(Arrays.asList("A", "B", "C"))),
+                eq(new SortableImpl("name", true)),
+                eq(null)
+            );
+        doReturn(new Application().id("A").name("A"))
+            .when(applicationMapper)
+            .convert(eq(GraviteeContext.getExecutionContext()), eq(appA), any());
+
+        doReturn(new Application().id("B").name("B"))
+            .when(applicationMapper)
+            .convert(eq(GraviteeContext.getExecutionContext()), eq(appB), any());
+
+        doReturn(new Application().id("C").name("C"))
+            .when(applicationMapper)
+            .convert(eq(GraviteeContext.getExecutionContext()), eq(appC), any());
 
         final Response response = target(API).path("subscribers").request().get();
         assertEquals(OK_200, response.getStatus());
@@ -165,26 +179,32 @@ public class ApiSubscribersResourceTest extends AbstractResourceTest {
         subC1.setApi(API);
         doReturn(Arrays.asList(subB1, subC1, subA1)).when(subscriptionService).search(eq(GraviteeContext.getExecutionContext()), any());
 
-        ApplicationEntity appA = new ApplicationEntity();
+        ApplicationListItem appA = new ApplicationListItem();
         appA.setId("A");
         appA.setName("A");
-        doReturn(appA).when(applicationService).findById(GraviteeContext.getExecutionContext(), "A");
+        ApplicationListItem appB = new ApplicationListItem();
+        appB.setId("B");
+        appB.setName("B");
+        ApplicationListItem appC = new ApplicationListItem();
+        appC.setId("C");
+        appC.setName("C");
+        Page<ApplicationListItem> applications = new Page(Arrays.asList(appA, appB, appC), 1, 10, 2);
+        doReturn(applications)
+            .when(applicationService)
+            .search(
+                eq(GraviteeContext.getExecutionContext()),
+                argThat(q -> q.getIds().containsAll(Arrays.asList("A", "B", "C"))),
+                eq(new SortableImpl("name", true)),
+                eq(null)
+            );
         doReturn(new Application().id("A").name("A"))
             .when(applicationMapper)
             .convert(eq(GraviteeContext.getExecutionContext()), eq(appA), any());
 
-        ApplicationEntity appB = new ApplicationEntity();
-        appB.setId("B");
-        appB.setName("B");
-        doReturn(appB).when(applicationService).findById(GraviteeContext.getExecutionContext(), "B");
         doReturn(new Application().id("B").name("B"))
             .when(applicationMapper)
             .convert(eq(GraviteeContext.getExecutionContext()), eq(appB), any());
 
-        ApplicationEntity appC = new ApplicationEntity();
-        appC.setId("C");
-        appC.setName("C");
-        doReturn(appC).when(applicationService).findById(GraviteeContext.getExecutionContext(), "C");
         doReturn(new Application().id("C").name("C"))
             .when(applicationMapper)
             .convert(eq(GraviteeContext.getExecutionContext()), eq(appC), any());
@@ -229,14 +249,20 @@ public class ApiSubscribersResourceTest extends AbstractResourceTest {
         subC1.setApi(API);
         doReturn(Arrays.asList(subA1, subC1)).when(subscriptionService).search(eq(GraviteeContext.getExecutionContext()), any());
 
-        ApplicationEntity appA = new ApplicationEntity();
+        ApplicationListItem appA = new ApplicationListItem();
         appA.setId("A");
-        doReturn(appA).when(applicationService).findById(GraviteeContext.getExecutionContext(), "A");
-        doReturn(new Application().id("A")).when(applicationMapper).convert(eq(GraviteeContext.getExecutionContext()), eq(appA), any());
-
-        ApplicationEntity appC = new ApplicationEntity();
+        ApplicationListItem appC = new ApplicationListItem();
         appC.setId("C");
-        doReturn(appC).when(applicationService).findById(GraviteeContext.getExecutionContext(), "C");
+        Page<ApplicationListItem> applications = new Page(Arrays.asList(appA, appC), 1, 10, 2);
+        doReturn(applications)
+            .when(applicationService)
+            .search(
+                eq(GraviteeContext.getExecutionContext()),
+                argThat(q -> q.getIds().containsAll(Arrays.asList("A", "C"))),
+                eq(new SortableImpl("name", true)),
+                eq(null)
+            );
+        doReturn(new Application().id("A")).when(applicationMapper).convert(eq(GraviteeContext.getExecutionContext()), eq(appA), any());
         doReturn(new Application().id("C")).when(applicationMapper).convert(eq(GraviteeContext.getExecutionContext()), eq(appC), any());
 
         ApplicationListItem appLIA = new ApplicationListItem();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -918,6 +918,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                     item.setStatus(application.getStatus().name());
                     item.setPicture(application.getPicture());
                     item.setBackground(application.getBackground());
+                    item.setDisableMembershipNotifications(application.isDisableMembershipNotifications());
                     return item;
                 }
             )
@@ -967,6 +968,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                     item.setPicture(applicationEntity.getPicture());
                     item.setBackground(applicationEntity.getBackground());
                     item.setApiKeyMode(applicationEntity.getApiKeyMode());
+                    item.setDisableMembershipNotifications(applicationEntity.isDisableMembershipNotifications());
 
                     final Application app = applications
                         .stream()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -157,6 +157,7 @@ management:
 
 ## SSL settings
 #    sslEnabled:                  # mongodb ssl mode (default false)
+#    sslInvalidHostNameAllowed:   # mongodb ssl allow invalid host name (default false)
 #    tlsProtocol:                 # protocol to use when connecting to the mongodb instance (when sslEnabled is true, default TLS)
 #    keystore:
 #      path:                      # Path to the keystore (when sslEnabled is true, default null)


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8421

## Description

In the console
- call subscribers list only when user clicks in the application input
- limit the number of subscribers retrieved to 40
- allow to filter subscribers by name

In the API:
- use pagination to retrieve subscribers
- use search method with multiple ids instead of multiple times `findById`
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8421-improve-api-subscriptions-page-loading/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tkaadcmusi.chromatic.com)
<!-- Storybook placeholder end -->
