### PR TITLE
Use worker for bridge server handlers

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/BridgeService.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/BridgeService.java
@@ -23,6 +23,7 @@ import io.gravitee.repository.bridge.server.handler.*;
 import io.gravitee.repository.bridge.server.http.configuration.HttpServerConfiguration;
 import io.gravitee.repository.bridge.server.version.VersionHandler;
 import io.vertx.core.Vertx;
+import io.vertx.core.WorkerExecutor;
 import io.vertx.core.json.jackson.DatabindCodec;
 import io.vertx.ext.auth.authentication.AuthenticationProvider;
 import io.vertx.ext.web.Router;
@@ -66,6 +67,10 @@ public class BridgeService extends AbstractService {
 
     @Autowired
     private HttpServerConfiguration httpServerConfiguration;
+
+    @Autowired
+    @Qualifier("bridgeWorkerExecutor")
+    private WorkerExecutor bridgeWorkerExecutor;
 
     @Override
     protected void doStart() throws Exception {
@@ -194,6 +199,7 @@ public class BridgeService extends AbstractService {
     protected void doStop() throws Exception {
         super.doStop();
 
+        bridgeWorkerExecutor.close(event -> LOGGER.debug("WorkerExecutor for bridge has been closed"));
         httpServer.close(event -> LOGGER.info("HTTP server for bridge has been stopped"));
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/BridgeService.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/BridgeService.java
@@ -120,34 +120,34 @@ public class BridgeService extends AbstractService {
             bridgeRouter.get("/").handler(rootHandler);
 
             // APIs handler
-            ApisHandler apisHandler = new ApisHandler();
+            ApisHandler apisHandler = new ApisHandler(bridgeWorkerExecutor);
             applicationContext.getAutowireCapableBeanFactory().autowireBean(apisHandler);
             bridgeRouter.get("/apis").handler(apisHandler::search);
             bridgeRouter.get("/apis/:apiId").handler(apisHandler::findById);
 
             // API Plans handler
-            ApiPlansHandler apiPlansHandler = new ApiPlansHandler();
+            ApiPlansHandler apiPlansHandler = new ApiPlansHandler(bridgeWorkerExecutor);
             applicationContext.getAutowireCapableBeanFactory().autowireBean(apiPlansHandler);
             bridgeRouter.get("/apis/:apiId/plans").handler(apiPlansHandler::handle);
 
             // Plans handler
-            PlansHandler plansHandler = new PlansHandler();
+            PlansHandler plansHandler = new PlansHandler(bridgeWorkerExecutor);
             applicationContext.getAutowireCapableBeanFactory().autowireBean(plansHandler);
             bridgeRouter.post("/plans").handler(plansHandler::handle);
 
             // API Keys handler
-            ApiKeysHandler apiKeysHandler = new ApiKeysHandler();
+            ApiKeysHandler apiKeysHandler = new ApiKeysHandler(bridgeWorkerExecutor);
             applicationContext.getAutowireCapableBeanFactory().autowireBean(apiKeysHandler);
             bridgeRouter.post("/keys/_search").handler(apiKeysHandler::findByCriteria);
             bridgeRouter.get("/apis/:apiId/keys/:key").handler(apiKeysHandler::findByKeyAndApi);
 
             // Subscriptions handler
-            SubscriptionsHandler subscriptionsHandler = new SubscriptionsHandler();
+            SubscriptionsHandler subscriptionsHandler = new SubscriptionsHandler(bridgeWorkerExecutor);
             applicationContext.getAutowireCapableBeanFactory().autowireBean(subscriptionsHandler);
             bridgeRouter.post("/subscriptions/_search").handler(subscriptionsHandler::search);
 
             // Events handler
-            EventsHandler eventsHandler = new EventsHandler();
+            EventsHandler eventsHandler = new EventsHandler(bridgeWorkerExecutor);
             applicationContext.getAutowireCapableBeanFactory().autowireBean(eventsHandler);
             bridgeRouter.post("/events/_search").handler(eventsHandler::search);
             bridgeRouter.post("/events/_searchLatest").handler(eventsHandler::searchLatest);
@@ -155,19 +155,19 @@ public class BridgeService extends AbstractService {
             bridgeRouter.put("/events/:eventId").handler(eventsHandler::update);
 
             // Dictionaries handler
-            DictionariesHandler dictionariesHandler = new DictionariesHandler();
+            DictionariesHandler dictionariesHandler = new DictionariesHandler(bridgeWorkerExecutor);
             applicationContext.getAutowireCapableBeanFactory().autowireBean(dictionariesHandler);
             bridgeRouter.get("/dictionaries").handler(dictionariesHandler::find);
 
             // Node Monitoring handler
-            NodeMonitoringHandler nodeMonitoringHandler = new NodeMonitoringHandler();
+            NodeMonitoringHandler nodeMonitoringHandler = new NodeMonitoringHandler(bridgeWorkerExecutor);
             applicationContext.getAutowireCapableBeanFactory().autowireBean(nodeMonitoringHandler);
             bridgeRouter.post("/node/monitoring").handler(nodeMonitoringHandler::create);
             bridgeRouter.put("/node/monitoring").handler(nodeMonitoringHandler::update);
             bridgeRouter.get("/node/monitoring").handler(nodeMonitoringHandler::findByNodeIdAndType);
 
             // Environments handler
-            EnvironmentsHandler environmentsHandler = new EnvironmentsHandler();
+            EnvironmentsHandler environmentsHandler = new EnvironmentsHandler(bridgeWorkerExecutor);
             applicationContext.getAutowireCapableBeanFactory().autowireBean(environmentsHandler);
             bridgeRouter.get("/environments").handler(environmentsHandler::findAll);
             bridgeRouter.get("/environments/_byOrganizationId").handler(environmentsHandler::findByOrganizationId);
@@ -175,14 +175,14 @@ public class BridgeService extends AbstractService {
             bridgeRouter.get("/environments/:environmentId").handler(environmentsHandler::findById);
 
             // Organizations handler
-            OrganizationsHandler organizationsHandler = new OrganizationsHandler();
+            OrganizationsHandler organizationsHandler = new OrganizationsHandler(bridgeWorkerExecutor);
             applicationContext.getAutowireCapableBeanFactory().autowireBean(organizationsHandler);
             bridgeRouter.get("/organizations").handler(organizationsHandler::findAll);
             bridgeRouter.get("/organizations/_byHrids").handler(organizationsHandler::findByHrids);
             bridgeRouter.get("/organizations/:organizationId").handler(organizationsHandler::findById);
 
             // Installation handler
-            InstallationHandler installationHandler = new InstallationHandler();
+            InstallationHandler installationHandler = new InstallationHandler(bridgeWorkerExecutor);
             applicationContext.getAutowireCapableBeanFactory().autowireBean(installationHandler);
             bridgeRouter.get("/installation").handler(installationHandler::find);
         }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/AbstractHandler.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/AbstractHandler.java
@@ -22,6 +22,7 @@ import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.http.MediaType;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.WorkerExecutor;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.jackson.DatabindCodec;
 import io.vertx.ext.web.RoutingContext;
@@ -42,6 +43,11 @@ import org.springframework.util.StringUtils;
 public abstract class AbstractHandler {
 
     protected final Logger LOGGER = LoggerFactory.getLogger(this.getClass());
+    protected WorkerExecutor bridgeWorkerExecutor;
+
+    protected AbstractHandler(WorkerExecutor bridgeWorkerExecutor) {
+        this.bridgeWorkerExecutor = bridgeWorkerExecutor;
+    }
 
     protected <T> void handleResponse(final RoutingContext ctx, AsyncResult<T> result) {
         final HttpServerResponse response = ctx.response();

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/ApiKeysHandler.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/ApiKeysHandler.java
@@ -59,6 +59,7 @@ public class ApiKeysHandler extends AbstractHandler {
                     promise.fail(te);
                 }
             },
+            false,
             (Handler<AsyncResult<List<ApiKey>>>) result -> handleResponse(ctx, result)
         );
     }
@@ -76,6 +77,7 @@ public class ApiKeysHandler extends AbstractHandler {
                     promise.fail(te);
                 }
             },
+            false,
             (Handler<AsyncResult<Optional<ApiKey>>>) result -> handleResponse(ctx, result)
         );
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/ApiKeysHandler.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/ApiKeysHandler.java
@@ -18,10 +18,10 @@ package io.gravitee.repository.bridge.server.handler;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.api.search.ApiKeyCriteria;
-import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.ApiKey;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
+import io.vertx.core.WorkerExecutor;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
@@ -40,44 +40,44 @@ public class ApiKeysHandler extends AbstractHandler {
     @Autowired
     private ApiKeyRepository apiKeyRepository;
 
+    public ApiKeysHandler(WorkerExecutor bridgeWorkerExecutor) {
+        super(bridgeWorkerExecutor);
+    }
+
     public void findByCriteria(RoutingContext ctx) {
         final JsonObject searchPayload = ctx.getBodyAsJson();
 
         // Parse criteria
         final ApiKeyCriteria apiKeyCriteria = readCriteria(searchPayload);
 
-        ctx
-            .vertx()
-            .executeBlocking(
-                promise -> {
-                    try {
-                        promise.complete(apiKeyRepository.findByCriteria(apiKeyCriteria));
-                    } catch (TechnicalException te) {
-                        LOGGER.error("Unable to search for API Keys", te);
-                        promise.fail(te);
-                    }
-                },
-                (Handler<AsyncResult<List<ApiKey>>>) result -> handleResponse(ctx, result)
-            );
+        bridgeWorkerExecutor.executeBlocking(
+            promise -> {
+                try {
+                    promise.complete(apiKeyRepository.findByCriteria(apiKeyCriteria));
+                } catch (TechnicalException te) {
+                    LOGGER.error("Unable to search for API Keys", te);
+                    promise.fail(te);
+                }
+            },
+            (Handler<AsyncResult<List<ApiKey>>>) result -> handleResponse(ctx, result)
+        );
     }
 
     public void findByKeyAndApi(RoutingContext ctx) {
         final String apiId = ctx.request().getParam("apiId");
         final String key = ctx.request().getParam("key");
 
-        ctx
-            .vertx()
-            .executeBlocking(
-                promise -> {
-                    try {
-                        promise.complete(apiKeyRepository.findByKeyAndApi(key, apiId));
-                    } catch (TechnicalException te) {
-                        LOGGER.error("Unable to find the API Key", te);
-                        promise.fail(te);
-                    }
-                },
-                (Handler<AsyncResult<Optional<ApiKey>>>) result -> handleResponse(ctx, result)
-            );
+        bridgeWorkerExecutor.executeBlocking(
+            promise -> {
+                try {
+                    promise.complete(apiKeyRepository.findByKeyAndApi(key, apiId));
+                } catch (TechnicalException te) {
+                    LOGGER.error("Unable to find the API Key", te);
+                    promise.fail(te);
+                }
+            },
+            (Handler<AsyncResult<Optional<ApiKey>>>) result -> handleResponse(ctx, result)
+        );
     }
 
     private ApiKeyCriteria readCriteria(JsonObject payload) {

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/ApiPlansHandler.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/ApiPlansHandler.java
@@ -50,6 +50,7 @@ public class ApiPlansHandler extends AbstractHandler {
                     promise.fail(te);
                 }
             },
+            false,
             (Handler<AsyncResult<Set<Plan>>>) result -> handleResponse(ctx, result)
         );
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/ApiPlansHandler.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/ApiPlansHandler.java
@@ -20,6 +20,7 @@ import io.gravitee.repository.management.api.PlanRepository;
 import io.gravitee.repository.management.model.Plan;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
+import io.vertx.core.WorkerExecutor;
 import io.vertx.ext.web.RoutingContext;
 import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,21 +34,23 @@ public class ApiPlansHandler extends AbstractHandler {
     @Autowired
     private PlanRepository planRepository;
 
+    public ApiPlansHandler(WorkerExecutor bridgeWorkerExecutor) {
+        super(bridgeWorkerExecutor);
+    }
+
     public void handle(RoutingContext ctx) {
         final String sApi = ctx.request().getParam("apiId");
 
-        ctx
-            .vertx()
-            .executeBlocking(
-                promise -> {
-                    try {
-                        promise.complete(planRepository.findByApi(sApi));
-                    } catch (TechnicalException te) {
-                        LOGGER.error("Unable to get plans for an API", te);
-                        promise.fail(te);
-                    }
-                },
-                (Handler<AsyncResult<Set<Plan>>>) result -> handleResponse(ctx, result)
-            );
+        bridgeWorkerExecutor.executeBlocking(
+            promise -> {
+                try {
+                    promise.complete(planRepository.findByApi(sApi));
+                } catch (TechnicalException te) {
+                    LOGGER.error("Unable to get plans for an API", te);
+                    promise.fail(te);
+                }
+            },
+            (Handler<AsyncResult<Set<Plan>>>) result -> handleResponse(ctx, result)
+        );
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/ApisHandler.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/ApisHandler.java
@@ -61,6 +61,7 @@ public class ApisHandler extends AbstractHandler {
                     promise.fail(te);
                 }
             },
+            false,
             (Handler<AsyncResult<Collection<Api>>>) result -> handleResponse(ctx, result)
         );
     }
@@ -77,6 +78,7 @@ public class ApisHandler extends AbstractHandler {
                     promise.fail(te);
                 }
             },
+            false,
             (Handler<AsyncResult<Optional<Api>>>) result -> handleResponse(ctx, result)
         );
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/ApisHandler.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/ApisHandler.java
@@ -21,6 +21,7 @@ import io.gravitee.repository.management.api.search.ApiFieldExclusionFilter;
 import io.gravitee.repository.management.model.Api;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
+import io.vertx.core.WorkerExecutor;
 import io.vertx.ext.web.RoutingContext;
 import java.util.Collection;
 import java.util.Optional;
@@ -35,6 +36,10 @@ public class ApisHandler extends AbstractHandler {
     @Autowired
     private ApiRepository apiRepository;
 
+    public ApisHandler(WorkerExecutor bridgeWorkerExecutor) {
+        super(bridgeWorkerExecutor);
+    }
+
     public void search(RoutingContext ctx) {
         final boolean excludeDefinition = Boolean.parseBoolean(ctx.request().getParam("excludeDefinition"));
         final boolean excludePicture = Boolean.parseBoolean(ctx.request().getParam("excludePicture"));
@@ -47,36 +52,32 @@ public class ApisHandler extends AbstractHandler {
             builder.excludePicture();
         }
 
-        ctx
-            .vertx()
-            .executeBlocking(
-                promise -> {
-                    try {
-                        promise.complete(apiRepository.search(null, builder.build()));
-                    } catch (Exception te) {
-                        LOGGER.error("Unable to search for APIs", te);
-                        promise.fail(te);
-                    }
-                },
-                (Handler<AsyncResult<Collection<Api>>>) result -> handleResponse(ctx, result)
-            );
+        bridgeWorkerExecutor.executeBlocking(
+            promise -> {
+                try {
+                    promise.complete(apiRepository.search(null, builder.build()));
+                } catch (Exception te) {
+                    LOGGER.error("Unable to search for APIs", te);
+                    promise.fail(te);
+                }
+            },
+            (Handler<AsyncResult<Collection<Api>>>) result -> handleResponse(ctx, result)
+        );
     }
 
     public void findById(RoutingContext ctx) {
         final String sApi = ctx.request().getParam("apiId");
 
-        ctx
-            .vertx()
-            .executeBlocking(
-                promise -> {
-                    try {
-                        promise.complete(apiRepository.findById(sApi));
-                    } catch (TechnicalException te) {
-                        LOGGER.error("Unable to find an API", te);
-                        promise.fail(te);
-                    }
-                },
-                (Handler<AsyncResult<Optional<Api>>>) result -> handleResponse(ctx, result)
-            );
+        bridgeWorkerExecutor.executeBlocking(
+            promise -> {
+                try {
+                    promise.complete(apiRepository.findById(sApi));
+                } catch (TechnicalException te) {
+                    LOGGER.error("Unable to find an API", te);
+                    promise.fail(te);
+                }
+            },
+            (Handler<AsyncResult<Optional<Api>>>) result -> handleResponse(ctx, result)
+        );
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/DictionariesHandler.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/DictionariesHandler.java
@@ -61,6 +61,7 @@ public class DictionariesHandler extends AbstractHandler {
                     promise.fail(ex);
                 }
             },
+            false,
             event -> handleResponse(ctx, event)
         );
     }
@@ -75,6 +76,7 @@ public class DictionariesHandler extends AbstractHandler {
                     promise.fail(te);
                 }
             },
+            false,
             (Handler<AsyncResult<Set<Dictionary>>>) result -> handleResponse(ctx, result)
         );
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/DictionariesHandler.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/DictionariesHandler.java
@@ -21,6 +21,7 @@ import io.gravitee.repository.management.model.Dictionary;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
+import io.vertx.core.WorkerExecutor;
 import io.vertx.ext.web.RoutingContext;
 import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,6 +36,10 @@ public class DictionariesHandler extends AbstractHandler {
     @Autowired
     private DictionaryRepository dictionaryRepository;
 
+    public DictionariesHandler(WorkerExecutor bridgeWorkerExecutor) {
+        super(bridgeWorkerExecutor);
+    }
+
     public void find(RoutingContext ctx) {
         final String environementsIdsParam = ctx.request().getParam("environmentsIds");
         if (StringUtils.isEmpty(environementsIdsParam)) {
@@ -47,34 +52,30 @@ public class DictionariesHandler extends AbstractHandler {
     private void findAllByEnvironment(RoutingContext ctx, String environementsIdsParam) {
         final Set<String> environments = readListParam(environementsIdsParam);
 
-        ctx
-            .vertx()
-            .executeBlocking(
-                (Handler<Promise<Set<Dictionary>>>) promise -> {
-                    try {
-                        promise.complete(dictionaryRepository.findAllByEnvironments(environments));
-                    } catch (Exception ex) {
-                        LOGGER.error("Unable to search for dictionaries", ex);
-                        promise.fail(ex);
-                    }
-                },
-                event -> handleResponse(ctx, event)
-            );
+        bridgeWorkerExecutor.executeBlocking(
+            (Handler<Promise<Set<Dictionary>>>) promise -> {
+                try {
+                    promise.complete(dictionaryRepository.findAllByEnvironments(environments));
+                } catch (Exception ex) {
+                    LOGGER.error("Unable to search for dictionaries", ex);
+                    promise.fail(ex);
+                }
+            },
+            event -> handleResponse(ctx, event)
+        );
     }
 
     private void findAll(RoutingContext ctx) {
-        ctx
-            .vertx()
-            .executeBlocking(
-                promise -> {
-                    try {
-                        promise.complete(dictionaryRepository.findAll());
-                    } catch (TechnicalException te) {
-                        LOGGER.error("Unable to get dictionaries", te);
-                        promise.fail(te);
-                    }
-                },
-                (Handler<AsyncResult<Set<Dictionary>>>) result -> handleResponse(ctx, result)
-            );
+        bridgeWorkerExecutor.executeBlocking(
+            promise -> {
+                try {
+                    promise.complete(dictionaryRepository.findAll());
+                } catch (TechnicalException te) {
+                    LOGGER.error("Unable to get dictionaries", te);
+                    promise.fail(te);
+                }
+            },
+            (Handler<AsyncResult<Set<Dictionary>>>) result -> handleResponse(ctx, result)
+        );
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/EnvironmentsHandler.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/EnvironmentsHandler.java
@@ -19,6 +19,7 @@ import io.gravitee.repository.management.api.EnvironmentRepository;
 import io.gravitee.repository.management.model.Environment;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
+import io.vertx.core.WorkerExecutor;
 import io.vertx.ext.web.RoutingContext;
 import java.util.Collection;
 import java.util.Optional;
@@ -34,6 +35,10 @@ public class EnvironmentsHandler extends AbstractHandler {
     @Autowired
     private EnvironmentRepository environmentRepository;
 
+    public EnvironmentsHandler(WorkerExecutor bridgeWorkerExecutor) {
+        super(bridgeWorkerExecutor);
+    }
+
     public void findByOrganizationsAndHrids(RoutingContext ctx) {
         final String organizationsIdsParam = ctx.request().getParam("organizationsIds");
         final String hridsParam = ctx.request().getParam("hrids");
@@ -41,70 +46,62 @@ public class EnvironmentsHandler extends AbstractHandler {
         final Set<String> organizationsIds = readListParam(organizationsIdsParam);
         final Set<String> hrids = readListParam(hridsParam);
 
-        ctx
-            .vertx()
-            .executeBlocking(
-                (Handler<Promise<Set<Environment>>>) promise -> {
-                    try {
-                        promise.complete(environmentRepository.findByOrganizationsAndHrids(organizationsIds, hrids));
-                    } catch (Exception ex) {
-                        LOGGER.error("Unable to search for environments", ex);
-                        promise.fail(ex);
-                    }
-                },
-                event -> handleResponse(ctx, event)
-            );
+        bridgeWorkerExecutor.executeBlocking(
+            (Handler<Promise<Set<Environment>>>) promise -> {
+                try {
+                    promise.complete(environmentRepository.findByOrganizationsAndHrids(organizationsIds, hrids));
+                } catch (Exception ex) {
+                    LOGGER.error("Unable to search for environments", ex);
+                    promise.fail(ex);
+                }
+            },
+            event -> handleResponse(ctx, event)
+        );
     }
 
     public void findAll(RoutingContext ctx) {
-        ctx
-            .vertx()
-            .executeBlocking(
-                (Handler<Promise<Collection<Environment>>>) promise -> {
-                    try {
-                        promise.complete(environmentRepository.findAll());
-                    } catch (Exception ex) {
-                        LOGGER.error("Unable to search for environments", ex);
-                        promise.fail(ex);
-                    }
-                },
-                event -> handleResponse(ctx, event)
-            );
+        bridgeWorkerExecutor.executeBlocking(
+            (Handler<Promise<Collection<Environment>>>) promise -> {
+                try {
+                    promise.complete(environmentRepository.findAll());
+                } catch (Exception ex) {
+                    LOGGER.error("Unable to search for environments", ex);
+                    promise.fail(ex);
+                }
+            },
+            event -> handleResponse(ctx, event)
+        );
     }
 
     public void findById(RoutingContext ctx) {
         final String idParam = ctx.request().getParam("environmentId");
 
-        ctx
-            .vertx()
-            .executeBlocking(
-                (Handler<Promise<Optional<Environment>>>) promise -> {
-                    try {
-                        promise.complete(environmentRepository.findById(idParam));
-                    } catch (Exception ex) {
-                        LOGGER.error("Unable to find environment by id {}", idParam, ex);
-                        promise.fail(ex);
-                    }
-                },
-                event -> handleResponse(ctx, event)
-            );
+        bridgeWorkerExecutor.executeBlocking(
+            (Handler<Promise<Optional<Environment>>>) promise -> {
+                try {
+                    promise.complete(environmentRepository.findById(idParam));
+                } catch (Exception ex) {
+                    LOGGER.error("Unable to find environment by id {}", idParam, ex);
+                    promise.fail(ex);
+                }
+            },
+            event -> handleResponse(ctx, event)
+        );
     }
 
     public void findByOrganizationId(RoutingContext ctx) {
         final String organizationIdParam = ctx.request().getParam("organizationId");
 
-        ctx
-            .vertx()
-            .executeBlocking(
-                (Handler<Promise<Set<Environment>>>) promise -> {
-                    try {
-                        promise.complete(environmentRepository.findByOrganization(organizationIdParam));
-                    } catch (Exception ex) {
-                        LOGGER.error("Unable to search for environments by organizationId {}", organizationIdParam, ex);
-                        promise.fail(ex);
-                    }
-                },
-                event -> handleResponse(ctx, event)
-            );
+        bridgeWorkerExecutor.executeBlocking(
+            (Handler<Promise<Set<Environment>>>) promise -> {
+                try {
+                    promise.complete(environmentRepository.findByOrganization(organizationIdParam));
+                } catch (Exception ex) {
+                    LOGGER.error("Unable to search for environments by organizationId {}", organizationIdParam, ex);
+                    promise.fail(ex);
+                }
+            },
+            event -> handleResponse(ctx, event)
+        );
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/EnvironmentsHandler.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/EnvironmentsHandler.java
@@ -55,6 +55,7 @@ public class EnvironmentsHandler extends AbstractHandler {
                     promise.fail(ex);
                 }
             },
+            false,
             event -> handleResponse(ctx, event)
         );
     }
@@ -69,6 +70,7 @@ public class EnvironmentsHandler extends AbstractHandler {
                     promise.fail(ex);
                 }
             },
+            false,
             event -> handleResponse(ctx, event)
         );
     }
@@ -85,6 +87,7 @@ public class EnvironmentsHandler extends AbstractHandler {
                     promise.fail(ex);
                 }
             },
+            false,
             event -> handleResponse(ctx, event)
         );
     }
@@ -101,6 +104,7 @@ public class EnvironmentsHandler extends AbstractHandler {
                     promise.fail(ex);
                 }
             },
+            false,
             event -> handleResponse(ctx, event)
         );
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/EventsHandler.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/EventsHandler.java
@@ -73,6 +73,7 @@ public class EventsHandler extends AbstractHandler {
                         promise.fail(ex);
                     }
                 },
+                false,
                 (Handler<AsyncResult<Page<Event>>>) event -> handleResponse(ctx, event)
             );
         } else {
@@ -85,6 +86,7 @@ public class EventsHandler extends AbstractHandler {
                         promise.fail(ex);
                     }
                 },
+                false,
                 event -> handleResponse(ctx, event)
             );
         }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/InstallationHandler.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/InstallationHandler.java
@@ -19,6 +19,7 @@ import io.gravitee.repository.management.api.InstallationRepository;
 import io.gravitee.repository.management.model.Installation;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
+import io.vertx.core.WorkerExecutor;
 import io.vertx.ext.web.RoutingContext;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,19 +33,21 @@ public class InstallationHandler extends AbstractHandler {
     @Autowired
     private InstallationRepository installationRepository;
 
+    public InstallationHandler(WorkerExecutor bridgeWorkerExecutor) {
+        super(bridgeWorkerExecutor);
+    }
+
     public void find(RoutingContext ctx) {
-        ctx
-            .vertx()
-            .executeBlocking(
-                (Handler<Promise<Optional<Installation>>>) promise -> {
-                    try {
-                        promise.complete(installationRepository.find());
-                    } catch (Exception ex) {
-                        LOGGER.error("Unable to search for installation", ex);
-                        promise.fail(ex);
-                    }
-                },
-                event -> handleResponse(ctx, event)
-            );
+        bridgeWorkerExecutor.executeBlocking(
+            (Handler<Promise<Optional<Installation>>>) promise -> {
+                try {
+                    promise.complete(installationRepository.find());
+                } catch (Exception ex) {
+                    LOGGER.error("Unable to search for installation", ex);
+                    promise.fail(ex);
+                }
+            },
+            event -> handleResponse(ctx, event)
+        );
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/InstallationHandler.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/InstallationHandler.java
@@ -47,6 +47,7 @@ public class InstallationHandler extends AbstractHandler {
                     promise.fail(ex);
                 }
             },
+            false,
             event -> handleResponse(ctx, event)
         );
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/NodeMonitoringHandler.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/NodeMonitoringHandler.java
@@ -56,6 +56,7 @@ public class NodeMonitoringHandler extends AbstractHandler {
                     promise.fail(ex);
                 }
             },
+            false,
             (Handler<AsyncResult<Monitoring>>) event -> handleResponse(ctx, event)
         );
     }
@@ -79,6 +80,7 @@ public class NodeMonitoringHandler extends AbstractHandler {
                     promise.fail(ex);
                 }
             },
+            false,
             (Handler<AsyncResult<Monitoring>>) event -> handleResponse(ctx, event)
         );
     }
@@ -102,6 +104,7 @@ public class NodeMonitoringHandler extends AbstractHandler {
                     promise.fail(ex);
                 }
             },
+            false,
             (Handler<AsyncResult<Optional<Monitoring>>>) event -> handleResponse(ctx, event)
         );
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/NodeMonitoringHandler.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/NodeMonitoringHandler.java
@@ -19,6 +19,7 @@ import io.gravitee.node.api.Monitoring;
 import io.gravitee.node.api.NodeMonitoringRepository;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
+import io.vertx.core.WorkerExecutor;
 import io.vertx.ext.web.RoutingContext;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,78 +33,76 @@ public class NodeMonitoringHandler extends AbstractHandler {
     @Autowired
     private NodeMonitoringRepository nodeMonitoringRepository;
 
+    public NodeMonitoringHandler(WorkerExecutor bridgeWorkerExecutor) {
+        super(bridgeWorkerExecutor);
+    }
+
     public void create(RoutingContext ctx) {
-        ctx
-            .vertx()
-            .executeBlocking(
-                promise -> {
-                    try {
-                        Monitoring monitoring = ctx.getBodyAsJson().mapTo(Monitoring.class);
-                        nodeMonitoringRepository
-                            .create(monitoring)
-                            .subscribe(
-                                promise::complete,
-                                throwable -> {
-                                    LOGGER.error("Unable to create a node monitoring", throwable);
-                                    promise.fail(throwable);
-                                }
-                            );
-                    } catch (Exception ex) {
-                        LOGGER.error("Unable to create a node monitoring", ex);
-                        promise.fail(ex);
-                    }
-                },
-                (Handler<AsyncResult<Monitoring>>) event -> handleResponse(ctx, event)
-            );
+        bridgeWorkerExecutor.executeBlocking(
+            promise -> {
+                try {
+                    Monitoring monitoring = ctx.getBodyAsJson().mapTo(Monitoring.class);
+                    nodeMonitoringRepository
+                        .create(monitoring)
+                        .subscribe(
+                            promise::complete,
+                            throwable -> {
+                                LOGGER.error("Unable to create a node monitoring", throwable);
+                                promise.fail(throwable);
+                            }
+                        );
+                } catch (Exception ex) {
+                    LOGGER.error("Unable to create a node monitoring", ex);
+                    promise.fail(ex);
+                }
+            },
+            (Handler<AsyncResult<Monitoring>>) event -> handleResponse(ctx, event)
+        );
     }
 
     public void update(RoutingContext ctx) {
-        ctx
-            .vertx()
-            .executeBlocking(
-                promise -> {
-                    try {
-                        Monitoring monitoring = ctx.getBodyAsJson().mapTo(Monitoring.class);
-                        nodeMonitoringRepository
-                            .update(monitoring)
-                            .subscribe(
-                                promise::complete,
-                                throwable -> {
-                                    LOGGER.error("Unable to update a node monitoring", throwable);
-                                    promise.fail(throwable);
-                                }
-                            );
-                    } catch (Exception ex) {
-                        LOGGER.error("Unable to update a node monitoring", ex);
-                        promise.fail(ex);
-                    }
-                },
-                (Handler<AsyncResult<Monitoring>>) event -> handleResponse(ctx, event)
-            );
+        bridgeWorkerExecutor.executeBlocking(
+            promise -> {
+                try {
+                    Monitoring monitoring = ctx.getBodyAsJson().mapTo(Monitoring.class);
+                    nodeMonitoringRepository
+                        .update(monitoring)
+                        .subscribe(
+                            promise::complete,
+                            throwable -> {
+                                LOGGER.error("Unable to update a node monitoring", throwable);
+                                promise.fail(throwable);
+                            }
+                        );
+                } catch (Exception ex) {
+                    LOGGER.error("Unable to update a node monitoring", ex);
+                    promise.fail(ex);
+                }
+            },
+            (Handler<AsyncResult<Monitoring>>) event -> handleResponse(ctx, event)
+        );
     }
 
     public void findByNodeIdAndType(RoutingContext ctx) {
-        ctx
-            .vertx()
-            .executeBlocking(
-                promise -> {
-                    try {
-                        nodeMonitoringRepository
-                            .findByNodeIdAndType(ctx.request().getParam("nodeId"), ctx.request().getParam("type"))
-                            .subscribe(
-                                monitoring -> promise.complete(Optional.of(monitoring)),
-                                throwable -> {
-                                    LOGGER.error("Unable to find a node monitoring by type and ID", throwable);
-                                    promise.fail(throwable);
-                                },
-                                () -> promise.complete(Optional.empty())
-                            );
-                    } catch (Exception ex) {
-                        LOGGER.error("Unable to find a node monitoring by type and ID", ex);
-                        promise.fail(ex);
-                    }
-                },
-                (Handler<AsyncResult<Optional<Monitoring>>>) event -> handleResponse(ctx, event)
-            );
+        bridgeWorkerExecutor.executeBlocking(
+            promise -> {
+                try {
+                    nodeMonitoringRepository
+                        .findByNodeIdAndType(ctx.request().getParam("nodeId"), ctx.request().getParam("type"))
+                        .subscribe(
+                            monitoring -> promise.complete(Optional.of(monitoring)),
+                            throwable -> {
+                                LOGGER.error("Unable to find a node monitoring by type and ID", throwable);
+                                promise.fail(throwable);
+                            },
+                            () -> promise.complete(Optional.empty())
+                        );
+                } catch (Exception ex) {
+                    LOGGER.error("Unable to find a node monitoring by type and ID", ex);
+                    promise.fail(ex);
+                }
+            },
+            (Handler<AsyncResult<Optional<Monitoring>>>) event -> handleResponse(ctx, event)
+        );
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/OrganizationsHandler.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/OrganizationsHandler.java
@@ -53,6 +53,7 @@ public class OrganizationsHandler extends AbstractHandler {
                     promise.fail(ex);
                 }
             },
+            false,
             event -> handleResponse(ctx, event)
         );
     }
@@ -67,6 +68,7 @@ public class OrganizationsHandler extends AbstractHandler {
                     promise.fail(ex);
                 }
             },
+            false,
             event -> handleResponse(ctx, event)
         );
     }
@@ -83,6 +85,7 @@ public class OrganizationsHandler extends AbstractHandler {
                     promise.fail(ex);
                 }
             },
+            false,
             event -> handleResponse(ctx, event)
         );
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/OrganizationsHandler.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/OrganizationsHandler.java
@@ -19,6 +19,7 @@ import io.gravitee.repository.management.api.OrganizationRepository;
 import io.gravitee.repository.management.model.Organization;
 import io.vertx.core.Handler;
 import io.vertx.core.Promise;
+import io.vertx.core.WorkerExecutor;
 import io.vertx.ext.web.RoutingContext;
 import java.util.Collection;
 import java.util.Optional;
@@ -35,56 +36,54 @@ public class OrganizationsHandler extends AbstractHandler {
     @Autowired
     private OrganizationRepository organizationRepository;
 
+    public OrganizationsHandler(WorkerExecutor bridgeWorkerExecutor) {
+        super(bridgeWorkerExecutor);
+    }
+
     public void findByHrids(RoutingContext ctx) {
         final String hridsParam = ctx.request().getParam("hrids");
         final Set<String> hrids = readListParam(hridsParam);
 
-        ctx
-            .vertx()
-            .executeBlocking(
-                (Handler<Promise<Set<Organization>>>) promise -> {
-                    try {
-                        promise.complete(organizationRepository.findByHrids(hrids));
-                    } catch (Exception ex) {
-                        LOGGER.error("Unable to search for organizations", ex);
-                        promise.fail(ex);
-                    }
-                },
-                event -> handleResponse(ctx, event)
-            );
+        bridgeWorkerExecutor.executeBlocking(
+            (Handler<Promise<Set<Organization>>>) promise -> {
+                try {
+                    promise.complete(organizationRepository.findByHrids(hrids));
+                } catch (Exception ex) {
+                    LOGGER.error("Unable to search for organizations", ex);
+                    promise.fail(ex);
+                }
+            },
+            event -> handleResponse(ctx, event)
+        );
     }
 
     public void findAll(RoutingContext ctx) {
-        ctx
-            .vertx()
-            .executeBlocking(
-                (Handler<Promise<Collection<Organization>>>) promise -> {
-                    try {
-                        promise.complete(organizationRepository.findAll());
-                    } catch (Exception ex) {
-                        LOGGER.error("Unable to search for organizations", ex);
-                        promise.fail(ex);
-                    }
-                },
-                event -> handleResponse(ctx, event)
-            );
+        bridgeWorkerExecutor.executeBlocking(
+            (Handler<Promise<Collection<Organization>>>) promise -> {
+                try {
+                    promise.complete(organizationRepository.findAll());
+                } catch (Exception ex) {
+                    LOGGER.error("Unable to search for organizations", ex);
+                    promise.fail(ex);
+                }
+            },
+            event -> handleResponse(ctx, event)
+        );
     }
 
     public void findById(RoutingContext ctx) {
         final String idParam = ctx.request().getParam("organizationId");
 
-        ctx
-            .vertx()
-            .executeBlocking(
-                (Handler<Promise<Optional<Organization>>>) promise -> {
-                    try {
-                        promise.complete(organizationRepository.findById(idParam));
-                    } catch (Exception ex) {
-                        LOGGER.error("Unable to find organization by id {}", idParam, ex);
-                        promise.fail(ex);
-                    }
-                },
-                event -> handleResponse(ctx, event)
-            );
+        bridgeWorkerExecutor.executeBlocking(
+            (Handler<Promise<Optional<Organization>>>) promise -> {
+                try {
+                    promise.complete(organizationRepository.findById(idParam));
+                } catch (Exception ex) {
+                    LOGGER.error("Unable to find organization by id {}", idParam, ex);
+                    promise.fail(ex);
+                }
+            },
+            event -> handleResponse(ctx, event)
+        );
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/PlansHandler.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/PlansHandler.java
@@ -51,6 +51,7 @@ public class PlansHandler extends AbstractHandler {
                     promise.fail(ex);
                 }
             },
+            false,
             (Handler<AsyncResult<List<Plan>>>) event -> handleResponse(ctx, event)
         );
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/PlansHandler.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/PlansHandler.java
@@ -21,6 +21,7 @@ import io.gravitee.repository.management.model.Event;
 import io.gravitee.repository.management.model.Plan;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
+import io.vertx.core.WorkerExecutor;
 import io.vertx.ext.web.RoutingContext;
 import java.util.List;
 import java.util.Set;
@@ -35,20 +36,22 @@ public class PlansHandler extends AbstractHandler {
     @Autowired
     private PlanRepository planRepository;
 
+    public PlansHandler(WorkerExecutor bridgeWorkerExecutor) {
+        super(bridgeWorkerExecutor);
+    }
+
     public void handle(RoutingContext ctx) {
-        ctx
-            .vertx()
-            .executeBlocking(
-                promise -> {
-                    try {
-                        List<String> apiIds = ctx.getBodyAsJsonArray().getList();
-                        promise.complete(planRepository.findByApis(apiIds));
-                    } catch (Exception ex) {
-                        LOGGER.error("Unable to get plans for apis", ex);
-                        promise.fail(ex);
-                    }
-                },
-                (Handler<AsyncResult<List<Plan>>>) event -> handleResponse(ctx, event)
-            );
+        bridgeWorkerExecutor.executeBlocking(
+            promise -> {
+                try {
+                    List<String> apiIds = ctx.getBodyAsJsonArray().getList();
+                    promise.complete(planRepository.findByApis(apiIds));
+                } catch (Exception ex) {
+                    LOGGER.error("Unable to get plans for apis", ex);
+                    promise.fail(ex);
+                }
+            },
+            (Handler<AsyncResult<List<Plan>>>) event -> handleResponse(ctx, event)
+        );
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/SubscriptionsHandler.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/SubscriptionsHandler.java
@@ -21,6 +21,7 @@ import io.gravitee.repository.management.api.search.SubscriptionCriteria;
 import io.gravitee.repository.management.model.Subscription;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
+import io.vertx.core.WorkerExecutor;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
@@ -38,23 +39,25 @@ public class SubscriptionsHandler extends AbstractHandler {
     @Autowired
     private SubscriptionRepository subscriptionRepository;
 
+    public SubscriptionsHandler(WorkerExecutor bridgeWorkerExecutor) {
+        super(bridgeWorkerExecutor);
+    }
+
     public void search(RoutingContext ctx) {
         final JsonObject searchPayload = ctx.getBodyAsJson();
         final SubscriptionCriteria subscriptionCriteria = readCriteria(searchPayload);
 
-        ctx
-            .vertx()
-            .executeBlocking(
-                promise -> {
-                    try {
-                        promise.complete(subscriptionRepository.search(subscriptionCriteria));
-                    } catch (TechnicalException te) {
-                        LOGGER.error("Unable to search for subscriptions", te);
-                        promise.fail(te);
-                    }
-                },
-                (Handler<AsyncResult<List<Subscription>>>) result -> handleResponse(ctx, result)
-            );
+        bridgeWorkerExecutor.executeBlocking(
+            promise -> {
+                try {
+                    promise.complete(subscriptionRepository.search(subscriptionCriteria));
+                } catch (TechnicalException te) {
+                    LOGGER.error("Unable to search for subscriptions", te);
+                    promise.fail(te);
+                }
+            },
+            (Handler<AsyncResult<List<Subscription>>>) result -> handleResponse(ctx, result)
+        );
     }
 
     private SubscriptionCriteria readCriteria(JsonObject payload) {

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/SubscriptionsHandler.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/SubscriptionsHandler.java
@@ -56,6 +56,7 @@ public class SubscriptionsHandler extends AbstractHandler {
                     promise.fail(te);
                 }
             },
+            false,
             (Handler<AsyncResult<List<Subscription>>>) result -> handleResponse(ctx, result)
         );
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/http/configuration/HttpServerConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/http/configuration/HttpServerConfiguration.java
@@ -75,6 +75,9 @@ public class HttpServerConfiguration {
     @Value("${services.bridge.http.maxChunkSize:8192}")
     private int maxChunkSize;
 
+    @Value("${services.bridge.http.workerPoolSize:-1}")
+    private int workerPoolSize;
+
     public boolean isEnabled() {
         return enabled;
     }
@@ -209,5 +212,9 @@ public class HttpServerConfiguration {
 
     public void setMaxChunkSize(int maxChunkSize) {
         this.maxChunkSize = maxChunkSize;
+    }
+
+    public int getWorkerPoolSize() {
+        return workerPoolSize;
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/http/spring/HttpServerSpringConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/http/spring/HttpServerSpringConfiguration.java
@@ -15,9 +15,12 @@
  */
 package io.gravitee.repository.bridge.server.http.spring;
 
+import static io.vertx.core.VertxOptions.DEFAULT_WORKER_POOL_SIZE;
+
 import io.gravitee.repository.bridge.server.http.auth.BasicAuthProvider;
 import io.gravitee.repository.bridge.server.http.configuration.HttpServerConfiguration;
 import io.vertx.core.Vertx;
+import io.vertx.core.WorkerExecutor;
 import io.vertx.core.http.ClientAuth;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
@@ -125,5 +128,13 @@ public class HttpServerSpringConfiguration {
     @Bean
     public HttpServerConfiguration nodeHttpServerConfiguration() {
         return new HttpServerConfiguration();
+    }
+
+    @Bean("bridgeWorkerExecutor")
+    public WorkerExecutor workerExecutor(Vertx vertx, HttpServerConfiguration httpServerConfiguration) {
+        int workerPoolSize = httpServerConfiguration.getWorkerPoolSize() > 0
+            ? httpServerConfiguration.getWorkerPoolSize()
+            : DEFAULT_WORKER_POOL_SIZE;
+        return vertx.createSharedWorkerExecutor("bridge-worker-executor", workerPoolSize);
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/test/java/io/gravitee/repository/bridge/server/handler/AbstractHandlerTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/test/java/io/gravitee/repository/bridge/server/handler/AbstractHandlerTest.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.bridge.server.handler;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import io.vertx.core.WorkerExecutor;
 import java.util.Set;
 import org.junit.Test;
 
@@ -61,5 +62,10 @@ public class AbstractHandlerTest {
         assertEquals(0, items.size());
     }
 
-    private static class TestHandler extends AbstractHandler {}
+    private static class TestHandler extends AbstractHandler {
+
+        protected TestHandler() {
+            super(null);
+        }
+    }
 }


### PR DESCRIPTION
## Description

This PR introduces a `WorkerExecutor` dedicated to Bridge handlers.
The `workerPoolSize` of this WorkerExecutor can be configured with the `services.bridge.http.workerPoolSize` property, if not set, the default value is `DEFAULT_WORKER_POOL_SIZE` (i.e. `20`).

Also, from `Vert.x in Action` book:
By default, successive `executeBlocking` operations have their results processed in the same order as the calls to `executeBlocking`. There is a variant of `executeBlocking` with an additional `boolean` parameter, and when it's set to `false`, results are made available as event-loop events as soon as they are available, regardless of the order of the `executeBlocking` calls.

`ordered` is described as this in the Javadoc:
if true then if executeBlocking is called several times on the same context, the executions for that context will be executed serially, not in parallel. if false then they will be no ordering guarantees

## Additional context

To check the result of such changes I added a 300ms timeout on all events handler methods, to simulate calls on a heavy loaded DB.
Then, I called the `_searchLatest` endpoint with a concurrency of 200 requests, doing 3000 requests, and I got the following results:

### With `ordered = true` and `maxPoolSize = 200`

Time taken for tests:   926.045 seconds

```shell
~  ab -n 3000 -c 200 -A admin:adminadmin -p data.json -T "application/json"  "http://localhost:18092/_bridge/events/_searchLatest?group=API_ID&page=0&size=10000"

This is ApacheBench, Version 2.3 <$Revision: 1879490 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost (be patient)
Completed 300 requests
Completed 600 requests
Completed 900 requests
Completed 1200 requests
Completed 1500 requests
Completed 1800 requests
Completed 2100 requests
Completed 2400 requests
Completed 2700 requests
Completed 3000 requests
Finished 3000 requests


Server Software:
Server Hostname:        localhost
Server Port:            18092

Document Path:          /_bridge/events/_searchLatest?group=API_ID&page=0&size=10000
Document Length:        2903 bytes

Concurrency Level:      200
Time taken for tests:   926.045 seconds
Complete requests:      3000
Failed requests:        0
Total transferred:      8862000 bytes
Total body sent:        732000
HTML transferred:       8709000 bytes
Requests per second:    3.24 [#/sec] (mean)
Time per request:       61736.314 [ms] (mean)
Time per request:       308.682 [ms] (mean, across all concurrent requests)
Transfer rate:          9.35 [Kbytes/sec] received
0.77 kb/s sent
10.12 kb/s total

Connection Times (ms)
min  mean[+/-sd] median   max
Connect:        0    1   1.4      0       9
Processing:   312 59665 9016.3  61738   62219
Waiting:      312 59664 9016.4  61738   62218
Total:        322 59665 9014.9  61739   62219

Percentage of the requests served within a certain time (ms)
50%  61739
66%  61804
75%  61821
80%  61829
90%  61857
95%  62132
98%  62157
99%  62175
100%  62219 (longest request)

```


### With `ordered = false` and `maxPoolSize = 20`

Time taken for tests:   46.437 seconds

```shell
~  ab -n 3000 -c 200 -A admin:adminadmin -p data.json -T "application/json"  "http://localhost:18092/_bridge/events/_searchLatest?group=API_ID&page=0&size=10000"

This is ApacheBench, Version 2.3 <$Revision: 1879490 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost (be patient)
Completed 300 requests
Completed 600 requests
Completed 900 requests
Completed 1200 requests
Completed 1500 requests
Completed 1800 requests
Completed 2100 requests
Completed 2400 requests
Completed 2700 requests
Completed 3000 requests
Finished 3000 requests


Server Software:
Server Hostname:        localhost
Server Port:            18092

Document Path:          /_bridge/events/_searchLatest?group=API_ID&page=0&size=10000
Document Length:        2903 bytes

Concurrency Level:      200
Time taken for tests:   46.437 seconds
Complete requests:      3000
Failed requests:        0
Total transferred:      8862000 bytes
Total body sent:        732000
HTML transferred:       8709000 bytes
Requests per second:    64.60 [#/sec] (mean)
Time per request:       3095.829 [ms] (mean)
Time per request:       15.479 [ms] (mean, across all concurrent requests)
Transfer rate:          186.36 [Kbytes/sec] received
15.39 kb/s sent
201.76 kb/s total

Connection Times (ms)
min  mean[+/-sd] median   max
Connect:        0    1   1.6      0      10
Processing:   312 2980 413.9   3072    3087
Waiting:      312 2980 413.9   3072    3087
Total:        322 2981 412.4   3073    3089

Percentage of the requests served within a certain time (ms)
50%   3073
66%   3075
75%   3076
80%   3076
90%   3078
95%   3080
98%   3081
99%   3083
100%   3089 (longest request)
```

### With `ordered = false` and `maxPoolSize = 200`

Time taken for tests:   5.081 seconds

```shell
 ~  ab -n 3000 -c 200 -A admin:adminadmin -p data.json -T "application/json"  "http://localhost:18092/_bridge/events/_searchLatest?group=API_ID&page=0&size=10000"

This is ApacheBench, Version 2.3 <$Revision: 1879490 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost (be patient)
Completed 300 requests
Completed 600 requests
Completed 900 requests
Completed 1200 requests
Completed 1500 requests
Completed 1800 requests
Completed 2100 requests
Completed 2400 requests
Completed 2700 requests
Completed 3000 requests
Finished 3000 requests


Server Software:
Server Hostname:        localhost
Server Port:            18092

Document Path:          /_bridge/events/_searchLatest?group=API_ID&page=0&size=10000
Document Length:        2903 bytes

Concurrency Level:      200
Time taken for tests:   5.081 seconds
Complete requests:      3000
Failed requests:        0
Total transferred:      8862000 bytes
Total body sent:        732000
HTML transferred:       8709000 bytes
Requests per second:    590.40 [#/sec] (mean)
Time per request:       338.755 [ms] (mean)
Time per request:       1.694 [ms] (mean, across all concurrent requests)
Transfer rate:          1703.16 [Kbytes/sec] received
                        140.68 kb/s sent
                        1843.84 kb/s total

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    1   1.6      0      12
Processing:   304  313  14.5    310     403
Waiting:      304  313  14.5    310     403
Total:        304  314  15.5    310     405

Percentage of the requests served within a certain time (ms)
  50%    310
  66%    311
  75%    313
  80%    314
  90%    318
  95%    345
  98%    383
  99%    394
 100%    405 (longest request)
```
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-addmglaczy.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/use-worker-for-bridge-server-handlers/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
