### PR TITLE
test: add API properties and use them

### DIFF
--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/properties/add-properties-and-use-them.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/properties/add-properties-and-use-them.spec.ts
@@ -13,8 +13,135 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { describe } from '@jest/globals';
+import { afterAll, beforeAll, describe, expect, test } from '@jest/globals';
+import { succeed } from '@lib/jest-utils';
+import { APIsApi } from '@gravitee/management-webclient-sdk/src/lib/apis/APIsApi';
+import { ApisFaker } from '@gravitee/fixtures/management/ApisFaker';
+import { PlansFaker } from '@gravitee/fixtures/management/PlansFaker';
+import { LifecycleAction } from '@gravitee/management-webclient-sdk/src/lib/models/LifecycleAction';
+import { forManagementAsApiUser } from '@gravitee/utils/configuration';
+import {
+  ApiEntity,
+  PathOperatorOperatorEnum,
+  PlanSecurityType,
+  PlanStatus,
+  UpdateApiEntityFromJSON,
+} from '@gravitee/management-webclient-sdk/src/lib/models';
+import { teardownApisAndApplications } from '@gravitee/utils/management';
+import { PropertyEntity } from '@model/apis';
+import { fetchGatewaySuccess } from '@gravitee/utils/gateway';
+
+const orgId = 'DEFAULT';
+const envId = 'DEFAULT';
+const apisManagementApiAsApiUser = new APIsApi(forManagementAsApiUser());
 
 describe('Add properties and use them', () => {
-  test.skip('To complete', async () => {});
+  let createdApi: ApiEntity;
+
+  beforeAll(async () => {
+    // create APIs with a published keyless plan and mock policy
+    createdApi = await apisManagementApiAsApiUser.importApiDefinition({
+      envId,
+      orgId,
+      body: ApisFaker.apiImport({
+        plans: [
+          PlansFaker.plan({
+            security: PlanSecurityType.KEY_LESS,
+            status: PlanStatus.PUBLISHED,
+            flows: [
+              {
+                name: '',
+                path_operator: {
+                  path: '/',
+                  operator: PathOperatorOperatorEnum.STARTS_WITH,
+                },
+                condition: '',
+                consumers: [],
+                methods: [],
+                pre: [
+                  {
+                    name: 'Mock',
+                    description: '',
+                    enabled: true,
+                    policy: 'mock',
+                    configuration: {
+                      content: '{ "key_1": "{#properties[\'key_1\']}", "encryptedKey": "{#properties[\'encryptedKey\']}" }',
+                      status: '200',
+                    },
+                  },
+                ],
+                post: [],
+                enabled: true,
+              },
+            ],
+          }),
+        ],
+      }),
+    });
+
+    // start it
+    await apisManagementApiAsApiUser.doApiLifecycleAction({
+      envId,
+      orgId,
+      api: createdApi.id,
+      action: LifecycleAction.START,
+    });
+  });
+
+  test('should set API property', async () => {
+    const newProperties: PropertyEntity[] = [
+      {
+        key: 'key_1',
+        value: 'abc',
+        encrypted: false,
+        dynamic: false,
+        encryptable: false,
+      },
+      {
+        key: 'encryptedKey',
+        value: 'secretKeyValue',
+        encrypted: true,
+        dynamic: false,
+        encryptable: false,
+      },
+    ];
+
+    const updateApiEntity = UpdateApiEntityFromJSON({
+      ...createdApi,
+      properties: newProperties,
+    });
+
+    const updatedApi = await succeed(
+      apisManagementApiAsApiUser.updateApiRaw({
+        api: createdApi.id,
+        updateApiEntity,
+        orgId,
+        envId,
+      }),
+    );
+
+    await succeed(apisManagementApiAsApiUser.deployApiRaw({ orgId, envId, api: updatedApi.id }));
+    expect(updatedApi.properties).toMatchObject([
+      { key: 'key_1', value: 'abc' },
+      { key: 'encryptedKey', value: 'secretKeyValue' },
+    ]);
+  });
+
+  test('should be able to use encrypted and unencrypted properties inside a policy', async () => {
+    const response = await fetchGatewaySuccess({
+      contextPath: createdApi.context_path,
+      expectedResponseValidator: async (response) => {
+        const body = await response.json();
+        expect(body).toEqual({
+          key_1: 'abc',
+          encryptedKey: 'secretKeyValue',
+        });
+        return true;
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await teardownApisAndApplications(orgId, envId, [createdApi.id]);
+  });
 });


### PR DESCRIPTION
## Description
Use-case test to make sure we can add properties to an API and use them (e.g. in policies).

An API with keyless plan and mock policy is created, some properties (encrypted & unencrypted) are added and a connection test makes sure that these properties are used by the mock policy.


gravitee-io/issues#8060

<!-- E2E Coverage placeholder -->
---
### 🧪 End-to-End Coverage

| INSTRUCTIONS | BRANCHES |
| :----------: | :------: |
|   37% | 22%   |

A more detailed report has been uploaded to [circleci](https://output.circle-artifacts.com/output/job/16aed434-ff6b-4b29-8b79-b9288f6629ac/artifacts/0/gravitee-apim-e2e/jacoco/reports/index.html)
<!-- E2E Coverage placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/test-8060-add-properties-and-use-them-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hdwmrpvsus.chromatic.com)
<!-- Storybook placeholder end -->
