### PR TITLE
fix: increased timeout to fix flaky ui-api-list test

### DIFF
--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-list.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-list.spec.ts
@@ -24,11 +24,11 @@ describe('API List feature', () => {
   });
 
   it(`Visit Home board`, () => {
-    cy.visit(Cypress.env('managementUI'));
+    cy.visit(Cypress.env('managementUI'), { timeout: 10000 });
     cy.contains('Home board');
   });
 
-  xit(`Visit Search Apis`, () => {
-    cy.visit(`${Cypress.env('managementUI')}/#!/environments/DEFAULT/apis/`);
+  it(`Visit Search Apis`, () => {
+    cy.visit(`${Cypress.env('managementUI')}/#!/environments/DEFAULT/apis/`, { timeout: 10000 });
   });
 });


### PR DESCRIPTION
## Description
This test failed sometimes due to timeout issue. It used the default timeout of 4s. 
In this change that value was increased to 10s.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-flaky-test-in-ui-api-list-test-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-aosbkswzrl.chromatic.com)
<!-- Storybook placeholder end -->
<!-- E2E Coverage placeholder -->
---
### 🧪 End-to-End Coverage

| INSTRUCTIONS | BRANCHES |
| :----------: | :------: |
|   37% | 22%   |

A more detailed report has been uploaded to [circleci](https://output.circle-artifacts.com/output/job/d034e65e-434d-48a6-ae8f-3a37de864107/artifacts/0/gravitee-apim-e2e/jacoco/reports/index.html)
<!-- E2E Coverage placeholder end -->
