### PR TITLE
ci: move changelog generation in apim

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,7 +326,7 @@ commands:
 parameters:
     gio_action:
         type: enum
-        enum: [release, package_bundle, nexus_staging, pull_requests, build_rpm_&_docker_images]
+        enum: [release, package_bundle, nexus_staging, pull_requests, build_rpm_&_docker_images, changelog_apim]
         default: pull_requests
     dry_run:
         type: boolean
@@ -340,6 +340,10 @@ parameters:
         default: ""
         type: string
         description: "Version of APIM to be used in docker images"
+    gio_milestone_version:
+      type: string
+      default: $GIO_MILESTONE_VERSION
+      description: "The Gravitee.io Milestone version https://github.com/gravitee-io/issues/milestones for which we want to generate Changelog"
 
 jobs:
     setup:
@@ -1772,6 +1776,54 @@ jobs:
                                 --acl public-read
                             from: ./release/.tmp/<< pipeline.parameters.graviteeio_version >>/dist
                             to: "s3://gravitee-releases-downloads/graviteeio-apim"
+    changelog_apim:
+      docker:
+        - image: groovy:jdk11
+          user: root
+      resource_class: small
+      environment:
+        MILESTONE_VERSION: << pipeline.parameters.gio_milestone_version >>
+      steps:
+        - checkout
+        - keeper/env-export:
+            secret-url: keeper://IZd-yvsMopfQEa_0j1SDvg/field/login
+            var-name: GIT_USER_NAME
+        - keeper/env-export:
+            secret-url: keeper://IZd-yvsMopfQEa_0j1SDvg/custom_field/email
+            var-name: GIT_USER_EMAIL
+        - keeper/env-export:
+            secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+            var-name: GITHUB_TOKEN
+        - add_ssh_keys:
+            fingerprints:
+              - "ac:88:23:8f:c6:0f:7d:f0:fc:df:73:20:34:56:02:6c"
+        - run:
+            name: Git config
+            command: |
+              apt-get -y update
+              apt-get -y install git
+              git config --global user.name "${GIT_USER_NAME}"
+              git config --global user.email "${GIT_USER_EMAIL}"
+        - gh/setup
+        - run:
+            name: "Generate Changelog for Gravitee.io APIM"
+            command: groovy -DMILESTONE_VERSION="$MILESTONE_VERSION" .circleci/githubChangelogGenerator.groovy
+        - run:
+            name: "Commit Changelog and open a PR on the repository"
+            command: |
+              # Sanitize MILESTONE_VERSION
+              MILESTONE_VERSION_SANITIZED=$(echo ${MILESTONE_VERSION} | sed -e 's/[^a-zA-Z0-9]//g')
+
+              # Create a branch for the changelog PR
+              git checkout -b "changelog_apim_pr_${MILESTONE_VERSION_SANITIZED}"
+
+              # Commit the changelog
+              git add ./release/changelog/CHANGELOG*.adoc
+              git commit -m "Generate changelog for version ${MILESTONE_VERSION}"
+
+              # Push the branch and open a PR
+              git push --set-upstream origin "changelog_apim_pr_${MILESTONE_VERSION_SANITIZED}"
+              gh pr create --title "Changelog for ${MILESTONE_VERSION}" --body "Generate changelog for version ${MILESTONE_VERSION}" --reviewer "@gravitee-io/apim"
 
 workflows:
     pull_requests:
@@ -2180,3 +2232,10 @@ workflows:
                   matrix:
                       parameters:
                           version: ["3", "4", "5"]
+
+    changelog_apim:
+      when:
+        equal: [ changelog_apim, << pipeline.parameters.gio_action >> ]
+      jobs:
+        - changelog_apim:
+            context: cicd-orchestrator

--- a/.circleci/githubChangelogGenerator.groovy
+++ b/.circleci/githubChangelogGenerator.groovy
@@ -1,0 +1,155 @@
+import groovy.json.JsonSlurper
+
+
+String header = '# Change Log\n\n'
+
+def milestoneVersion = System.getProperties().getProperty('MILESTONE_VERSION')
+def changelogFile = './release/changelog/CHANGELOG-v3.adoc'
+def repo = 'issues'
+println 'milestoneVersion' + milestoneVersion
+
+def version = milestoneVersion.split(' - ')
+def component = version[0]
+def majorVersion = version[1].substring(0, 1) as Integer
+
+def originChangelog
+if (component == 'APIM') {
+    header += 'For upgrade instructions, please refer to https://docs.gravitee.io/apim/' + majorVersion + '.x/apim_installguide_migration.html[APIM Migration Guide]\n\n'
+    header += '*Important:* If you plan to skip versions when you upgrade, ensure that you read the version-specific upgrade notes for each intermediate version. You may be required to perform manual actions as part of the upgrade.\n\n'
+}
+
+originChangelog = readFile(changelogFile).replace(header, '')
+
+String changelog = header
+
+// get milestones from version
+List milestones = new ArrayList()
+
+for (int i = 1; i <= 150; i++) {
+    def pageMilestones = new JsonSlurper().parseText(
+            new URL('https://gh.gravitee.io/repos/gravitee-io/' + repo + '/milestones?state=closed&page=' + i).text)
+    if (!pageMilestones) {
+        break
+    }
+    milestones.addAll(pageMilestones)
+}
+
+def milestone = milestones.find { it.title == milestoneVersion }
+
+if (milestone) {
+    int milestoneNumber = milestone.number
+
+    String milestoneDate = milestone.closed_at
+
+    println 'Generating changelog for version ' + milestoneVersion + ' / milestone ' + milestoneNumber + '...'
+
+    List issues = new ArrayList()
+
+    for (int i = 1; i <= 100; i++) {
+        def pageIssues = new JsonSlurper().parseText(
+                new URL('https://gh.gravitee.io/repos/gravitee-io/' + repo + '/issues?state=closed&milestone=' + milestoneNumber + '&page=' + i).text)
+        if (!pageIssues) {
+            break
+        }
+        issues.addAll(pageIssues)
+    }
+
+    // exclusion of duplicates and technicals
+    issues = issues.findAll {
+        !it.labels.name.contains('type: duplicate') && !it.labels.name.contains('type: technical')
+    }
+
+    println issues.size + ' issues found'
+
+    if (repo == 'issues') {
+        changelog += '\n== https://github.com/gravitee-io/issues/milestone/' + milestoneNumber + '?closed=1[' + milestoneVersion + ' (' + milestoneDate.substring(0, 10) + ')]\n'
+    } else {
+        changelog += '\n== ' + milestoneVersion + ' (' + milestoneDate.substring(0, 10) + ')\n'
+    }
+
+
+    // Bug Fixes part
+    changelog += generateChangelogPart(issues, 'Bug fixes', 'type: bug', repo)
+
+    // Features part
+    changelog += generateChangelogPart(issues, 'Features', 'type: feature', repo)
+
+    // Improvements part
+    changelog += generateChangelogPart(issues, 'Improvements', 'type: enhancement', repo)
+
+    changelog += System.getProperty("line.separator") + ' '
+
+    changelog += System.getProperty("line.separator") + ' '
+
+    changelog += System.getProperty("line.separator")
+
+    changelog += originChangelog
+
+    writeFile file: changelogFile, text: changelog
+} else {
+    println 'Unknown version ' + milestoneVersion
+}
+
+private String generateChangelogPart(issues, String changelogPartTitle, String type, String repo) {
+    String changelog = ''
+
+    // filter type
+    issues = issues.findAll { it.labels.name.contains(type) }
+
+    println issues.size + ' issues found for the type ' + type
+
+    if (issues) {
+        changelog += '\n=== ' + changelogPartTitle + '\n'
+        // group by domain (portal, gateway...)
+        Map<String, List> domainIssues = new LinkedHashMap<String, List>()
+        for (int i = 0; i < issues.size(); i++) {
+            def matcher = issues[i].title =~ '^\\[((\\w|-|_)+)\\]'
+            String domain = matcher.size() == 0 ? 'General' : matcher[0][1].capitalize()
+
+            List listIssues = domainIssues.get(domain)
+
+            if (listIssues == null) {
+                listIssues = new ArrayList()
+            }
+            listIssues.add(issues[i])
+
+            domainIssues.put(domain, listIssues)
+        }
+
+        domainIssues = domainIssues.sort()
+
+        for (domainIssue in domainIssues.entrySet()) {
+            changelog += '\n*_' + domainIssue.key + '_*\n\n'
+
+            def iss = domainIssue.value
+            List titles = new LinkedList()
+            for (int j = 0; j < iss.size(); j++) {
+                def title = iss[j].title
+                if (iss[j].title.indexOf(']') > 0) {
+                    title = title.substring(iss[j].title.indexOf(']') + 1)
+                }
+
+                if (repo == 'issues') {
+                    titles.add('- ' + title.trim().replace(': ', '').capitalize() + ' ' + iss[j].html_url + '[#' + iss[j].number + ']\n')
+                } else {
+                    titles.add('- ' + title.trim().replace(': ', '').capitalize() + '\n')
+                }
+            }
+            titles = titles.sort()
+
+            for (int j = 0; j < titles.size(); j++) {
+                changelog += titles[j]
+            }
+        }
+    }
+    return changelog
+}
+
+private static String readFile(String fileName) {
+    return new File(fileName).text
+}
+
+private static void writeFile(object) {
+    String file = object.file
+    new File(file).text = object.text
+}

--- a/release/changelog/CHANGELOG-v3.adoc
+++ b/release/changelog/CHANGELOG-v3.adoc
@@ -1,0 +1,4091 @@
+# Change Log
+
+For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim_installguide_migration.html[APIM Migration Guide]
+
+*Important:* If you plan to skip versions when you upgrade, ensure that you read the version-specific upgrade notes for each intermediate version. You may be required to perform manual actions as part of the upgrade.
+
+
+== https://github.com/gravitee-io/issues/milestone/575?closed=1[APIM - 3.15.13 (2022-07-27)]
+
+=== Bug fixes
+
+*_APIM_*
+
+- In version 3.15.9 the display of healthcheck logs is broken https://github.com/gravitee-io/issues/issues/7841[#7841]
+
+*_Gateway_*
+
+- [expression-language] String Condition Evaluator not work as expected https://github.com/gravitee-io/issues/issues/8153[#8153]
+
+*_General_*
+
+- Improve email template sanitization https://github.com/gravitee-io/issues/issues/8093[#8093]
+
+*_Reporters_*
+
+- RetainDays configuration of file reporter is inaccurate https://github.com/gravitee-io/issues/issues/8090[#8090]
+
+ 
+ 
+
+== https://github.com/gravitee-io/issues/milestone/574?closed=1[APIM - 3.18.3 (2022-07-20)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Handle Pendo ApiKey with correct attribute in `gravitee.yaml` https://github.com/gravitee-io/issues/issues/8155[#8155]
+- Mongodb migrations scripts fails https://github.com/gravitee-io/issues/issues/8147[#8147]
+- Management API fails to start if API without primary https://github.com/gravitee-io/issues/issues/8130[#8130]
+
+ 
+ 
+
+== https://github.com/gravitee-io/issues/milestone/573?closed=1[APIM - 3.10.18 (2022-07-20)]
+
+=== Bug fixes
+
+*_Console_*
+
+- Listening host in virtual-host mode is changed to 'null' when saving https://github.com/gravitee-io/issues/issues/7856[#7856]
+
+*_Management_*
+
+- Application update removes Oauth client data if DCR unreachable https://github.com/gravitee-io/issues/issues/7953[#7953]
+- Fixed API import process failing when creating member roles https://github.com/gravitee-io/issues/issues/7822[#7822]
+- Subscription created without API Key https://github.com/gravitee-io/issues/issues/7332[#7332]
+- Fixed the display of healthcheck logs (backport of 3.15) https://github.com/gravitee-io/issues/issues/8107[#8107]
+ 
+ 
+
+== https://github.com/gravitee-io/issues/milestone/571?closed=1[APIM - 3.18.2 (2022-07-15)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Can't login when using JDBC database https://github.com/gravitee-io/issues/issues/8110[#8110]
+
+ 
+ 
+
+== https://github.com/gravitee-io/issues/milestone/564?closed=1[APIM - 3.18.1 (2022-07-08)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- file reporter log files are not created https://github.com/gravitee-io/issues/issues/8065[#8065]
+
+*_General_*
+
+- Update build version number of Console and Portal https://github.com/gravitee-io/issues/issues/8072[#8072]
+
+*_Portal_*
+
+- OpenAPI specification of the Portal API not available https://github.com/gravitee-io/issues/issues/8074[#8074]
+
+ 
+ 
+
+== https://github.com/gravitee-io/issues/milestone/565?closed=1[APIM - 3.15.12 (2022-07-08)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Log file are not created https://github.com/gravitee-io/issues/issues/8064[#8064]
+
+ 
+ 
+== https://github.com/gravitee-io/issues/milestone/519?closed=1[APIM - 3.18.0 (2022-07-07)]
+
+=== Bug fixes
+
+*_Console_*
+
+- Remove the horizontal scroll bar in the markdown creation page https://github.com/gravitee-io/issues/issues/5119[#5119]
+- Wrong example when generating Personal Access Token https://github.com/gravitee-io/issues/issues/5271[#5271]
+- Not_equals alert filter displays an empty list https://github.com/gravitee-io/issues/issues/7489[#7489]
+- Icons not rendering with custom nginx configuration https://github.com/gravitee-io/issues/issues/7569[#7569]
+
+*_General_*
+
+- Merge 3.17.2 into master https://github.com/gravitee-io/issues/issues/7617[#7617]
+
+*_Management_*
+
+- DCR providers should be scoped by org https://github.com/gravitee-io/issues/issues/6604[#6604]
+- One shot upgraders run on each APIM startup with cockpit https://github.com/gravitee-io/issues/issues/7450[#7450]
+- OpenApi files are never updated https://github.com/gravitee-io/issues/issues/7631[#7631]
+
+*_Policies_*
+
+- Retry Policy: cancel timeout response, manage lastResponse counter and tests https://github.com/gravitee-io/issues/issues/7747[#7747]
+- Data Logging Masking: fix some bugs https://github.com/gravitee-io/issues/issues/7758[#7758]
+
+=== Features
+
+*_Console_*
+
+- Promote API Designer https://github.com/gravitee-io/issues/issues/7645[#7645]
+- Add Pendo analytics tool https://github.com/gravitee-io/issues/issues/7781[#7781]
+
+*_General_*
+
+- Support of RHEL8 https://github.com/gravitee-io/issues/issues/7208[#7208]
+
+*_Management_*
+
+- Partial update - PATCH method on Import API https://github.com/gravitee-io/issues/issues/7443[#7443]
+- Add page to display organization Audit https://github.com/gravitee-io/issues/issues/7536[#7536]
+
+*_Policies_*
+
+- Transform-Header: Define headers based on the request or on the response payload https://github.com/gravitee-io/issues/issues/7359[#7359]
+- Circuit Breaker: Write documentation for policy https://github.com/gravitee-io/issues/issues/7756[#7756]
+
+=== Improvements
+
+*_Console_*
+
+- API properties header title change https://github.com/gravitee-io/issues/issues/6065[#6065]
+- Add Conditional icon in legend https://github.com/gravitee-io/issues/issues/7457[#7457]
+
+*_General_*
+
+- Mutualize System proxy configuration https://github.com/gravitee-io/issues/issues/7739[#7739]
+
+*_Portal_*
+
+- Migrate to last Angular version https://github.com/gravitee-io/issues/issues/6666[#6666]
+
+ 
+ 
+
+== https://github.com/gravitee-io/issues/milestone/562?closed=1[APIM - 3.17.4 (2022-07-05)]
+
+=== Bug fixes
+
+*_APIM_*
+
+- API alerts do not show in analytics https://github.com/gravitee-io/issues/issues/7480[#7480]
+
+*_General_*
+
+- Merge 3.16.5 in 3.17.x https://github.com/gravitee-io/issues/issues/7787[#7787]
+
+ 
+ 
+
+== https://github.com/gravitee-io/issues/milestone/560?closed=1[APIM - 3.16.5 (2022-07-04)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.15.10 in 3.16.x https://github.com/gravitee-io/issues/issues/7868[#7868]
+- Merge 3.15.11 in 3.16.x https://github.com/gravitee-io/issues/issues/7961[#7961]
+
+ 
+ 
+
+== https://github.com/gravitee-io/issues/milestone/561?closed=1[APIM - 3.15.11 (2022-07-01)]
+
+=== Bug fixes
+
+*_APIM_*
+
+- Not able to fully import an API, issue related to the default page (System Folder) https://github.com/gravitee-io/issues/issues/7876[#7876]
+
+*_General_*
+
+- Portal - Filtering by a certain Category on All APIs page will return all existing APIs https://github.com/gravitee-io/issues/issues/7201[#7201]
+
+*_Management_*
+
+- Healthcheck is failing to report in ES due to issue on headers. https://github.com/gravitee-io/issues/issues/7930[#7930]
+
+ 
+ 
+
+== https://github.com/gravitee-io/issues/milestone/559?closed=1[APIM - 3.15.10 (2022-06-28)]
+
+=== Bug fixes
+
+*_APIM_*
+
+- ApiPrimaryOwner property of a group disappears when the group is updated through console/api call https://github.com/gravitee-io/issues/issues/7448[#7448]
+- CORS no longer read only if configured in .yml file https://github.com/gravitee-io/issues/issues/7326[#7326]
+
+*_APIM-EL_*
+
+- ExpesionLanguage query used to work but it no longer does in newer versions. https://github.com/gravitee-io/issues/issues/7754[#7754]
+
+*_Gateway_*
+
+- 503 errors may occur when redeploying an api https://github.com/gravitee-io/issues/issues/6948[#6948]
+- API  gateway_ip:18082/_node/apis/api.id not working, return 500 error https://github.com/gravitee-io/issues/issues/7287[#7287]
+- Gateway does not start if openssl is enabled https://github.com/gravitee-io/issues/issues/7742[#7742]
+- Handle client side sse connection close https://github.com/gravitee-io/issues/issues/7573[#7573]
+
+*_General_*
+
+- 500 error when accessing user api details in organization settings category issue on JDBC https://github.com/gravitee-io/issues/issues/7882[#7882]
+- APIM Connection with Google connect fails https://github.com/gravitee-io/issues/issues/7743[#7743]
+- Groovy policy error on HTTP headers (backport of 3.17) https://github.com/gravitee-io/issues/issues/7811[#7811]
+- HTTP headers breaking changes from 3.15 https://github.com/gravitee-io/issues/issues/7812[#7812]
+- Merge 3.10.17 in 3.15.x https://github.com/gravitee-io/issues/issues/7867[#7867]
+
+*_Management_*
+
+- Service discovery Healthcheck isn't working https://github.com/gravitee-io/issues/issues/7533[#7533]
+
+*_Policy_*
+
+- Cache Policy cache not cleared/refreshed after Time to Live https://github.com/gravitee-io/issues/issues/7740[#7740]
+
+*_Reporter_*
+
+- File reporter log files are missing headers details https://github.com/gravitee-io/issues/issues/7741[#7741]
+
+ 
+ 
+
+== https://github.com/gravitee-io/issues/milestone/558?closed=1[APIM - 3.10.17 (2022-06-24)]
+
+=== Bug fixes
+
+*_Console_*
+
+- BestMatch Flow mode does not work for Platform flow https://github.com/gravitee-io/issues/issues/7625[#7625]
+
+*_Gateway_*
+
+- Service Discovery error when configured with more than one API https://github.com/gravitee-io/issues/issues/7821[#7821]
+
+*_General_*
+
+- Update Logback library https://github.com/gravitee-io/issues/issues/7837[#7837]
+
+*_Management_*
+
+- Can Transfer Ownership via cURL or Postman where there is no Primary Owner in the Group. https://github.com/gravitee-io/issues/issues/6994[#6994]
+- Regression in API imports https://github.com/gravitee-io/issues/issues/7807[#7807]
+
+*_Repository_*
+
+- [JDBC] Api disappears for all users including org admin when group default role is changed to non primary_owner https://github.com/gravitee-io/issues/issues/7428[#7428]
+
+ 
+ 
+
+== https://github.com/gravitee-io/issues/milestone/556?closed=1[APIM - 3.10.16 (2022-06-13)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Filter disabled flows and flows steps https://github.com/gravitee-io/issues/issues/7794[#7794]
+- Hazelcast is referring to a queue but get a topic https://github.com/gravitee-io/issues/issues/7681[#7681]
+- Headers are not forwarded to websocket upstream https://github.com/gravitee-io/issues/issues/7750[#7750]
+- OOM when heartbeat event can't be delivered https://github.com/gravitee-io/issues/issues/7806[#7806]
+- OOM in case of Connect timeouts in health-check https://github.com/gravitee-io/issues/issues/7709[#7709]
+- Max logging size must accept smaller size than MB https://github.com/gravitee-io/issues/issues/7761[#7761]
+- ElasticSearch indexing data is getting out of bounds on Server Sent Event APIs (api-response-time) https://github.com/gravitee-io/issues/issues/7094[#7094]
+
+*_Repositories_*
+
+- Switch implementation to IO thread https://github.com/gravitee-io/issues/issues/7682[#7682]
+
+ 
+ 
+
+== https://github.com/gravitee-io/issues/milestone/551?closed=1[APIM - 3.15.9 (2022-06-01)]
+
+=== Bug fixes
+
+*_APIM_*
+
+- Errors while creating Platform Policies. https://github.com/gravitee-io/issues/issues/7547[#7547]
+- Transfer ownership option is not available to in memory org admin (in memory admin) if primary owner is another user. https://github.com/gravitee-io/issues/issues/7430[#7430]
+
+*_Console_*
+
+- APIs not showing on a selected user page when the group they are in is updated. https://github.com/gravitee-io/issues/issues/7285[#7285]
+- Platform Policies/Flow->Save button stays enabled even after saving the flow https://github.com/gravitee-io/issues/issues/7651[#7651]
+
+*_General_*
+
+- Cannot connect to APIM from Cockpit https://github.com/gravitee-io/issues/issues/7773[#7773]
+- Error NullPointerException when executing code in Javascript policy On-request content script https://github.com/gravitee-io/issues/issues/7179[#7179]
+- Merge 3.10.15 in 3.15.x https://github.com/gravitee-io/issues/issues/7749[#7749]
+
+*_Management_*
+
+- Auto fetch of documentation is not working https://github.com/gravitee-io/issues/issues/7589[#7589]
+- Dynamic properties API out of sync https://github.com/gravitee-io/issues/issues/7269[#7269]
+- When dynamic properties are triggered to update, the API status change to out of sync and the front ask for deploy. https://github.com/gravitee-io/issues/issues/5245[#5245]
+- [RepositoryJDBC] Error when trying to create flow with policy on organization level https://github.com/gravitee-io/issues/issues/7399[#7399]
+
+*_Portal_*
+
+- How to disable metrics on the APIM Portal? https://github.com/gravitee-io/issues/issues/7231[#7231]
+
+ 
+ 
+
+== https://github.com/gravitee-io/issues/milestone/550?closed=1[APIM - 3.10.15 (2022-05-25)]
+
+=== Bug fixes
+
+*_Console_*
+
+- Alert not correctly displayed/saved https://github.com/gravitee-io/issues/issues/6705[#6705]
+- An organization user (and environnement admin) can't delete a dictionary he has created https://github.com/gravitee-io/issues/issues/6556[#6556]
+- Count function, when saving alert, not saved properly https://github.com/gravitee-io/issues/issues/7279[#7279]
+- Error in console when opening APIM Console https://github.com/gravitee-io/issues/issues/7737[#7737]
+- Padding issue on content of some Console screen https://github.com/gravitee-io/issues/issues/7738[#7738]
+
+*_Gateway_*
+
+- Connexion not closed with Server Sent Event APIs https://github.com/gravitee-io/issues/issues/7093[#7093]
+- Elasticsearch ilm index_mode is missing rollover_alias and first index is not created https://github.com/gravitee-io/issues/issues/7110[#7110]
+- First dynamic dictionary start causes an IllegalArgumentException on the gateway https://github.com/gravitee-io/issues/issues/6044[#6044]
+
+*_General_*
+
+- Error when importing an API without logging on an env with `Logging audit events` activated https://github.com/gravitee-io/issues/issues/7612[#7612]
+
+*_Management_*
+
+- Allow to use System Proxy on Generic Oauth2 resource as already present for AM resource https://github.com/gravitee-io/issues/issues/7258[#7258]
+- Can't update a dynamic dictionary https://github.com/gravitee-io/issues/issues/6043[#6043]
+- Cannot import APi with primary owner  of type group and empty members list in group mode https://github.com/gravitee-io/issues/issues/6808[#6808]
+- Dynamic Property does not get updated after it was created https://github.com/gravitee-io/issues/issues/7684[#7684]
+- Error while deleting a user https://github.com/gravitee-io/issues/issues/7613[#7613]
+- Fix EnvironmentNotFoundException for task https://github.com/gravitee-io/issues/issues/7635[#7635]
+- Issue when deleting the properties of a dictionary https://github.com/gravitee-io/issues/issues/6996[#6996]
+- Logging condition with timestamp returns status 500 https://github.com/gravitee-io/issues/issues/7367[#7367]
+- Wrong log audit date for refresh dictionary events https://github.com/gravitee-io/issues/issues/6045[#6045]
+
+*_Portal_*
+
+- Delete/remove member button does not work https://github.com/gravitee-io/issues/issues/7241[#7241]
+- Unable to reply to a rating https://github.com/gravitee-io/issues/issues/6869[#6869]
+
+=== Improvements
+
+*_Management_*
+
+- Add Secure Flag by default on each cookie https://github.com/gravitee-io/issues/issues/7725[#7725]
+
+ 
+ 
+
+== https://github.com/gravitee-io/issues/milestone/546?closed=1[APIM - 3.17.3 (2022-05-12)]
+
+=== Bug fixes
+
+*_General_*
+
+- Cannot connect to APIM from Cockpit https://github.com/gravitee-io/issues/issues/7649[#7649]
+
+*_Management_*
+
+- Mongodb queries fail when encountering a document with a field set to `undefined` https://github.com/gravitee-io/issues/issues/7610[#7610]
+
+ 
+ 
+
+== https://github.com/gravitee-io/issues/milestone/545?closed=1[APIM - 3.17.2 (2022-05-03)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.16.4 in 3.17.x https://github.com/gravitee-io/issues/issues/7615[#7615]
+
+ 
+ 
+
+== https://github.com/gravitee-io/issues/milestone/543?closed=1[APIM - 3.16.4 (2022-04-29)]
+
+=== Bug fixes
+
+*_General_*
+
+- 500 Internal Server Error when using Transform Headers policy in combination with API-Key validationkey https://github.com/gravitee-io/issues/issues/7499[#7499]
+- Merge 3.15.8 in 3.16.x https://github.com/gravitee-io/issues/issues/7585[#7585]
+
+*_Management_*
+
+- Backport #7450 on 3.16 One shot upgraders run on each APIM startup with cockpit https://github.com/gravitee-io/issues/issues/7452[#7452]
+
+ 
+ 
+
+== https://github.com/gravitee-io/issues/milestone/542?closed=1[APIM - 3.15.8 (2022-04-27)]
+
+=== Bug fixes
+
+*_APIM_*
+
+- Policies (or flow) are getting ignored when best match is used in flow mode https://github.com/gravitee-io/issues/issues/7472[#7472]
+
+*_Gateway_*
+
+- Analytics in UI stopped working after updating gateway to version 3.15.5 https://github.com/gravitee-io/issues/issues/7288[#7288]
+- Conditional logging on Application prevents to display API logs https://github.com/gravitee-io/issues/issues/7329[#7329]
+
+*_General_*
+
+- Merge 3.10.14 in 3.15.x https://github.com/gravitee-io/issues/issues/7570[#7570]
+
+*_Management_*
+
+- Backport #7450 on 3.15 One shot upgraders run on each APIM startup with cockpit https://github.com/gravitee-io/issues/issues/7453[#7453]
+
+*_Migration_*
+
+- Null pointer exception for old started gateways https://github.com/gravitee-io/issues/issues/7277[#7277]
+
+=== Improvements
+
+*_Upgrader_*
+
+- Deploy APIs that gets out of sync by upgrader https://github.com/gravitee-io/issues/issues/7511[#7511]
+
+ 
+ 
+
+== https://github.com/gravitee-io/issues/milestone/541?closed=1[APIM - 3.10.14 (2022-04-21)]
+
+=== Bug fixes
+
+*_APIM_*
+
+- All APIs in the Console that do not have Group/s as direct members have all Groups in Members. Only with Postgresql. https://github.com/gravitee-io/issues/issues/7429[#7429]
+
+*_General_*
+
+- Backport of #7489 in 3.10.x https://github.com/gravitee-io/issues/issues/7490[#7490]
+- When filtering through the logs, showing results as the maximum alows, and no other pages even though there are more results https://github.com/gravitee-io/issues/issues/6913[#6913]
+
+*_Management_*
+
+- Alerts are not scoped to environment https://github.com/gravitee-io/issues/issues/6079[#6079]
+- Backport #7450 on 3.10 One shot upgraders run on each APIM startup with cockpit https://github.com/gravitee-io/issues/issues/7454[#7454]
+- Org. admin is not allowed to transfer API ownership https://github.com/gravitee-io/issues/issues/7395[#7395]
+
+*_Repository_*
+
+- MongoDB with self-signed SSL certificate https://github.com/gravitee-io/issues/issues/7539[#7539]
+
+=== Improvements
+
+*_General_*
+
+- Set Version V3_X by default on creation form https://github.com/gravitee-io/issues/issues/6454[#6454]
+
+ 
+ 
+
+== https://github.com/gravitee-io/issues/milestone/534?closed=1[APIM - 3.17.1 (2022-04-07)]
+
+=== Bug fixes
+
+*_General_*
+
+- $facet operator not supported in documentDB causes errors in 3.17.0 https://github.com/gravitee-io/issues/issues/7422[#7422]
+- Merge 3.16.3 in 3.17.x https://github.com/gravitee-io/issues/issues/7442[#7442]
+
+*_Management_*
+
+- Backport #7450 on 3.17 One shot upgraders run on each APIM startup with cockpit https://github.com/gravitee-io/issues/issues/7451[#7451]
+- Java heap space when requesting the OpenAPI specification https://github.com/gravitee-io/issues/issues/7460[#7460]
+- Platform Flows deleted after a restart when connected to Cockpit https://github.com/gravitee-io/issues/issues/7421[#7421]
+
+ 
+ 
+
+== https://github.com/gravitee-io/issues/milestone/536?closed=1[APIM - 3.16.3 (2022-04-04)]
+
+=== Bug fixes
+
+*_General_*
+
+- Content policies returning null stream not displayed in debug mode https://github.com/gravitee-io/issues/issues/7396[#7396]
+- Merge 3.15.7 in 3.16.x https://github.com/gravitee-io/issues/issues/7441[#7441]
+
+ 
+ 
+
+== https://github.com/gravitee-io/issues/milestone/535?closed=1[APIM - 3.15.7 (2022-04-04)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.10.13 https://github.com/gravitee-io/issues/issues/7444[#7444]
+
+*_APIM_*
+
+- Content not read from JKS and PKCS12 Certificates(Binary Content) in Group Endpoint Configuration https://github.com/gravitee-io/issues/issues/7405[#7405]
+
+*_Data-masking-policy_*
+
+- Data masking policy at platform level is not masking data https://github.com/gravitee-io/issues/issues/7022[#7022]
+
+*_Management_*
+
+- "Host" header not overwritten if redefined in Endpoint configuration https://github.com/gravitee-io/issues/issues/7007[#7007]
+
+ 
+ 
+
+== https://github.com/gravitee-io/issues/milestone/531?closed=1[APIM - 3.10.13 (2022-04-01)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Best match doesn't match any flow https://github.com/gravitee-io/issues/issues/7412[#7412]
+
+*_Management_*
+
+- Platform Flows deleted after a restart when connected to cockpit https://github.com/gravitee-io/issues/issues/7423[#7423]
+
+=== Features
+
+*_Policy_*
+
+- Prevent following policies to reach endpoint when input is invalid: JSON Validation, JSON Threat Protection, XML Threat Protection and Regex Threat Protection https://github.com/gravitee-io/issues/issues/7301[#7301]  
+ 
+
+== https://github.com/gravitee-io/issues/milestone/508?closed=1[APIM - 3.17.0 (2022-03-29)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.16.1 https://github.com/gravitee-io/issues/issues/7268[#7268]
+- Merge 3.16.2 https://github.com/gravitee-io/issues/issues/7402[#7402]
+
+*_Console_*
+
+- In Debug mode (fka Try-It), request does not return the good path https://github.com/gravitee-io/issues/issues/7220[#7220]
+
+=== Features
+
+*_Console_*
+
+* Debug mode:
+** Dynamic table for request headers https://github.com/gravitee-io/issues/issues/7149[#7149]
+** Quick access timeline https://github.com/gravitee-io/issues/issues/6767[#6767]
+** Allow use of user context-path https://github.com/gravitee-io/issues/issues/7072[#7072]
+** View API call metrics https://github.com/gravitee-io/issues/issues/7111[#7111]
+** View condition applied on a policy https://github.com/gravitee-io/issues/issues/7226[#7226]
+** View if a policy is set at platform or API level https://github.com/gravitee-io/issues/issues/7183[#7183]
+
+* Shared API Key:
+** Toggle Shared API Key mode in settings https://github.com/gravitee-io/issues/issues/6990[#6990]
+** Manage Shared API Key at application level (https://github.com/gravitee-io/issues/issues/6798[#6798], https://github.com/gravitee-io/issues/issues/6801[#6801], https://github.com/gravitee-io/issues/issues/6800[#6800], https://github.com/gravitee-io/issues/issues/6804[#6804], https://github.com/gravitee-io/issues/issues/6796[#6796], https://github.com/gravitee-io/issues/issues/6797[#6797], https://github.com/gravitee-io/issues/issues/7192[#7192], https://github.com/gravitee-io/issues/issues/6795[#6795])
+** Choose Shared API-Key mode at application level https://github.com/gravitee-io/issues/issues/6793[#6793]
+** De-correlate API-Key and Subscription lifecycle https://github.com/gravitee-io/issues/issues/7266[#7266]
+** Prevent Shared API-key Key revocation at API Level https://github.com/gravitee-io/issues/issues/6799[#6799]
+** View subscriptions for a Shared-API Key https://github.com/gravitee-io/issues/issues/6794[#6794]
+
+
+*_Policy_*
+
+- Define headers based on the request or on the response payload https://github.com/gravitee-io/issues/issues/7358[#7358]
+
+*_Portal_*
+
+* Shared API Key:
+** Manage a shared API Key https://github.com/gravitee-io/issues/issues/6819[#6819]
+** Use a shared API Key (https://github.com/gravitee-io/issues/issues/6816[#6816], https://github.com/gravitee-io/issues/issues/6817[#6817], https://github.com/gravitee-io/issues/issues/6818[#6818])
+
+=== Improvements
+
+*_Management_*
+
+- Migrate management API documentation from openAPI V2 (aka swagger) to v3 https://github.com/gravitee-io/issues/issues/6224[#6224]
+
+ 
+ 
+
+== https://github.com/gravitee-io/issues/milestone/530?closed=1[APIM - 3.16.2 (2022-03-28)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.15.6 in 3.16.x https://github.com/gravitee-io/issues/issues/7388[#7388]
+- Platform policies not executed in multi environments context https://github.com/gravitee-io/issues/issues/7379[#7379]
+
+=== Features
+
+*_Policy_*
+
+- Define headers based on the request or on the response payload https://github.com/gravitee-io/issues/issues/7333[#7333]
+
+- Prevent following policies to reach endpoint when input is invalid: JSON Validation, JSON Threat Protection, XML Threat Protection and Regex Threat Protection https://github.com/gravitee-io/issues/issues/7301[#7301] 
+ 
+
+== https://github.com/gravitee-io/issues/milestone/529?closed=1[APIM - 3.15.6 (2022-03-24)]
+
+=== Bug fixes
+
+*_Console_*
+
+- Contextual Docs no longer works https://github.com/gravitee-io/issues/issues/7323[#7323]
+- Secondary endpoint feature not working/switching if the Health-check is down on the primary endpoint. https://github.com/gravitee-io/issues/issues/7135[#7135]
+
+*_Gateway_*
+
+- Gateway only keeps last set-Cookie header from backend response even with different cookie-names https://github.com/gravitee-io/issues/issues/7325[#7325]
+
+*_General_*
+
+- Dictionaries no longer work in expressions https://github.com/gravitee-io/issues/issues/7303[#7303]
+- Javascript policy input box is only showing a few lines and not the whole code https://github.com/gravitee-io/issues/issues/7028[#7028]
+- Json is only partially visible in editor under API Documentaiton https://github.com/gravitee-io/issues/issues/7116[#7116]
+- Let the API Owner choose the Accept-Encoding https://github.com/gravitee-io/issues/issues/6967[#6967]
+- Merge 3.10.12 in 3.15.x https://github.com/gravitee-io/issues/issues/7363[#7363]
+- Support DocumentDB index name constraints https://github.com/gravitee-io/issues/issues/7134[#7134]
+
+*_Management_*
+
+- Application subscriptions API keys buttons are not visible https://github.com/gravitee-io/issues/issues/7273[#7273]
+
+*_Policy Groovy_*
+
+- Cannot iterate on Map with entry and trim on GStringImpl https://github.com/gravitee-io/issues/issues/7302[#7302]
+
+*_Policy JavaScript_*
+
+- Allows to break request/response on content phase https://github.com/gravitee-io/issues/issues/7173[#7173]
+
+
+== https://github.com/gravitee-io/issues/milestone/528?closed=1[APIM - 3.10.12 (2022-03-22)]
+
+=== Bug fixes
+
+*_APIM_*
+
+- Events not being displayed correctly https://github.com/gravitee-io/issues/issues/7300[#7300]
+
+*_Console_*
+
+- Can't access a newly created API with import https://github.com/gravitee-io/issues/issues/7216[#7216]
+- Condition Logging on API is not displayed after saving https://github.com/gravitee-io/issues/issues/6978[#6978]
+
+*_Gateway_*
+
+- Best Match flow mode doesn't execute the best matching flow https://github.com/gravitee-io/issues/issues/6654[#6654]
+
+*_Gateway-api_*
+
+- Bad behavior on TransformationException if no policyChain https://github.com/gravitee-io/issues/issues/7130[#7130]
+
+*_General_*
+
+- Let the API Owner choose the Accept-Encoding https://github.com/gravitee-io/issues/issues/7181[#7181]
+
+*_Helm_*
+
+- Api template doesn't support opening of service core port https://github.com/gravitee-io/issues/issues/6895[#6895]
+
+*_Management_*
+
+- Notify API Consumers contact too many people https://github.com/gravitee-io/issues/issues/7213[#7213]
+
+*_Metrics-reporter-policy_*
+
+- Metrics reporting not done at the good time (backport 7194 in 3.10.x) https://github.com/gravitee-io/issues/issues/7196[#7196]
+
+*_Policy_*
+
+- Policy-ssl-enforcementsupport x509 attributes https://github.com/gravitee-io/issues/issues/7276[#7276]
+
+ 
+ 
+
+== https://github.com/gravitee-io/issues/milestone/525?closed=1[APIM - 3.16.1 (2022-03-09)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.15.4 in 3.16.x https://github.com/gravitee-io/issues/issues/7224[#7224]
+- Merge 3.15.5 in 3.16.x https://github.com/gravitee-io/issues/issues/7265[#7265]
+
+*_Management_*
+
+- Policy studio - Save reload the page https://github.com/gravitee-io/issues/issues/7238[#7238]
+
+ 
+ 
+
+== https://github.com/gravitee-io/issues/milestone/524?closed=1[APIM - 3.15.5 (2022-03-09)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Health check does not pull out unhealthy endpoints https://github.com/gravitee-io/issues/issues/7250[#7250]
+
+ 
+ 
+
+
+ 
+ 
+
+== https://github.com/gravitee-io/issues/milestone/523?closed=1[APIM - 3.15.4 (2022-03-07)]
+
+=== Bug fixes
+
+*_APIM_*
+
+- Condition generated automatically when maximum time limit is set in API logging does not work https://github.com/gravitee-io/issues/issues/7205[#7205]
+- [policy-basic-authentication] Error message is received when using basic authentication policy https://github.com/gravitee-io/issues/issues/7198[#7198]
+
+*_General_*
+
+- Merge 3.14.1 in 3.15.x https://github.com/gravitee-io/issues/issues/7162[#7162]
+
+*_Management_*
+
+- OAS - servers without basepath make import fail https://github.com/gravitee-io/issues/issues/7227[#7227]
+
+*_Metrics-reporter-policy_*
+
+- Metrics reporting not done at the good time https://github.com/gravitee-io/issues/issues/7194[#7194]
+
+*_Resource-cache-redis_*
+
+- User cannot save configuration https://github.com/gravitee-io/issues/issues/7172[#7172]
+
+=== Features
+
+*_Expression-language_*
+
+- Improve map access with dot https://github.com/gravitee-io/issues/issues/7228[#7228]
+
+ 
+== https://github.com/gravitee-io/issues/milestone/522?closed=1[APIM - 3.14.1 (2022-03-03)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Error when discovery service creates new endpoints https://github.com/gravitee-io/issues/issues/6727[#6727]
+- Javascript Policy returns 500 OK in case of failure https://github.com/gravitee-io/issues/issues/6831[#6831]
+
+*_General_*
+
+- Environment variables GRAVITEE_PLUGINS_PATH_X are not working for gateway service https://github.com/gravitee-io/issues/issues/6909[#6909]
+- Merge 3.10.11 in 3.14.x https://github.com/gravitee-io/issues/issues/7160[#7160]
+
+
+== https://github.com/gravitee-io/issues/milestone/493?closed=1[APIM - 3.16.0 (2022-02-28)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Platform policies should not be executed first on response https://github.com/gravitee-io/issues/issues/7138[#7138]
+
+*_General_*
+
+- Login redirection is sometimes not working https://github.com/gravitee-io/issues/issues/7141[#7141]
+
+=== Features
+
+*_General_*
+
+- Add crossId, identifying entities across environments https://github.com/gravitee-io/issues/issues/7003[#7003]
+- Enhance ci/cd url with crossId https://github.com/gravitee-io/issues/issues/7084[#7084]
+- Debug mode https://github.com/gravitee-io/issues/issues/6760[#6760]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/517?closed=1[APIM - 3.10.11 (2022-02-25)]
+
+=== Bug fixes
+
+*_Console_*
+
+- Not full log message is displayed in logs while the full one is received. https://github.com/gravitee-io/issues/issues/7017[#7017]
+- User Information - Label display problem https://github.com/gravitee-io/issues/issues/5625[#5625]
+
+*_Gateway_*
+
+- Http requestTimeout prevents the gateway to log Analytics https://github.com/gravitee-io/issues/issues/6961[#6961]
+- Platform policies should not be executed first on response (Backport #7138 in 3.10.x) https://github.com/gravitee-io/issues/issues/7143[#7143]
+
+*_General_*
+
+- API Primary Owner role check https://github.com/gravitee-io/issues/issues/6360[#6360]
+- Anchor links are not working anymore in AsciiDoc files https://github.com/gravitee-io/issues/issues/6952[#6952]
+- Merge 3.5.29 in 3.10.x https://github.com/gravitee-io/issues/issues/6974[#6974]
+- Merge 3.5.30 in 3.10.x
+- Not able to publish documentation in APIM Portal in a desired order https://github.com/gravitee-io/issues/issues/6652[#6652]
+
+*_Management_*
+
+- Checking "Show the URL to download the content" in the swagger documentation generates and error https://github.com/gravitee-io/issues/issues/6713[#6713]
+
+*_Node_*
+
+- Node_health metric returns null values in 3.10 https://github.com/gravitee-io/issues/issues/6924[#6924]
+
+*_Repository_*
+
+- Fix invalid SQL syntax when finding alert triggers https://github.com/gravitee-io/issues/issues/7163[#7163]
+
+=== Features
+
+*_Alert_*
+
+- Alert per endpoint when healthcheck status change https://github.com/gravitee-io/issues/issues/6728[#6728]
+
+=== Improvements
+
+*_Management_*
+
+- Support OpenSearch https://github.com/gravitee-io/issues/issues/6890[#6890]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/515?closed=1[APIM - 3.5.30 (2022-02-25)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Improve personal token matching performance https://github.com/gravitee-io/issues/issues/7187[#7187]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/507?closed=1[APIM - 3.15.3 (2022-02-07)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Error on API deployment on environment without HrId https://github.com/gravitee-io/issues/issues/7053[#7053]
+
+*_Management_*
+
+- Image not found when sending a email https://github.com/gravitee-io/issues/issues/7057[#7057]
+- Can't get API plans on JDBC when API has no category https://github.com/gravitee-io/issues/issues/7060[#7060]
+- SQL error on subscription with PostgreSQL or MsSql https://github.com/gravitee-io/issues/issues/7051[#7051]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/506?closed=1[APIM - 3.15.2 (2022-02-03)]
+
+=== Bug fixes
+
+*_Platform_*
+
+- IllegalArgumentException unsupported cipher suite when enforcing tls protocols https://github.com/gravitee-io/issues/issues/7038[#7038]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/504?closed=1[APIM - 3.15.1 (2022-01-31)]
+
+=== Bug fixes
+
+*_Management_*
+
+- [policy] Rest-to-Soap doesn't work anymore https://github.com/gravitee-io/issues/issues/7025[#7025]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/350?closed=1[APIM - 3.15.0 (2022-01-27)]
+
+=== Bug fixes
+
+*_General_*
+
+- Raise error if update API try to update an existing plan belonging to another API https://github.com/gravitee-io/issues/issues/6693[#6693]
+- Use provided page ID when updating API https://github.com/gravitee-io/issues/issues/6694[#6694]
+- Kubernetes certificate not working with kubernetes >= 1.20 https://github.com/gravitee-io/issues/issues/6906[#6906]
+
+=== Features
+
+*_Gateway_*
+
+- Performances improvements https://github.com/gravitee-io/issues/issues/6492[#6492]
+
+*_General_*
+
+- API Path-based creation deprecation https://github.com/gravitee-io/issues/issues/6377[#6377]
+
+*_Platform_*
+
+- Update Dockerfile for java 17 support https://github.com/gravitee-io/issues/issues/6930[#6930]
+- Support for Java 17 runtime https://github.com/gravitee-io/issues/issues/6708[#6708]
+
+*_Policies Management_*
+
+- Conditional policies https://github.com/gravitee-io/issues/issues/6629[#6629]
+- Add a condition for execution https://github.com/gravitee-io/issues/issues/6614[#6614]
+- View if a policy is conditional https://github.com/gravitee-io/issues/issues/6615[#6615]
+- View if a flow is conditional https://github.com/gravitee-io/issues/issues/6626[#6626]
+
+*_Portal alerts_*
+
+- Add a description field for alert https://github.com/gravitee-io/issues/issues/6803[#6803]
+- Allow alert configuration by API https://github.com/gravitee-io/issues/issues/6702[#6702]
+- Allow alert notification via webhook https://github.com/gravitee-io/issues/issues/6703[#6703]
+
+== https://github.com/gravitee-io/issues/milestone/498?closed=1[APIM - 3.5.29 (2022-01-19)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Starting is very slow when there is a lot of events in database https://github.com/gravitee-io/issues/issues/6955[#6955]
+- [bridge] Bridge repository client is not backward compatible https://github.com/gravitee-io/issues/issues/6884[#6884]
+
+*_Management_*
+
+- Deleted dynamic dictionary is never undeployed https://github.com/gravitee-io/issues/issues/6870[#6870]
+- Path-mapping import is failing https://github.com/gravitee-io/issues/issues/6856[#6856]
+- When importing an API through file or URL path-mapping for analytics are not created. https://github.com/gravitee-io/issues/issues/6723[#6723]
+- [design studio] Conflict with keyboard shortcuts https://github.com/gravitee-io/issues/issues/6935[#6935]
+
+=== Improvements
+
+*_Management_*
+
+- Support OpenSearch https://github.com/gravitee-io/issues/issues/6889[#6889]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/496?closed=1[APIM - 3.10.10 (2022-01-14)]
+
+=== Bug fixes
+
+*_Console_*
+
+- Transfer Group Primary Ownership https://github.com/gravitee-io/issues/issues/6359[#6359]
+
+*_General_*
+
+- Merge 3.5.28 in 3.10.x https://github.com/gravitee-io/issues/issues/6874[#6874]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/372?closed=1[APIM - 3.14.0 (2022-01-12)]
+
+=== Bug fixes
+
+*_Console_*
+
+- Alerts page documentation is not properly displayed https://github.com/gravitee-io/issues/issues/6680[#6680]
+
+*_Gateway_*
+
+- Vhost mode does not work with HTTP/2 https://github.com/gravitee-io/issues/issues/6574[#6574]
+- [perf] Some ignored metrics are no longer ignored https://github.com/gravitee-io/issues/issues/6555[#6555]
+
+*_General_*
+
+- Merge 3.13.2 into master https://github.com/gravitee-io/issues/issues/6749[#6749]
+
+=== Features
+
+*_Console_*
+
+- View domain used by application https://github.com/gravitee-io/issues/issues/6384[#6384]
+
+*_Management_*
+
+- Add a domain field for application creation https://github.com/gravitee-io/issues/issues/6383[#6383]
+- Generate a group token https://github.com/gravitee-io/issues/issues/6210[#6210]
+- [Analytics] OpenSearch support https://github.com/gravitee-io/issues/issues/6423[#6423]
+- [CICD] Access token management by administrator https://github.com/gravitee-io/issues/issues/6468[#6468]
+- [CICD] Creation of service account https://github.com/gravitee-io/issues/issues/6467[#6467]
+
+*_Portal_*
+
+- Possibilty to disable promoted card on page list https://github.com/gravitee-io/issues/issues/6472[#6472]
+
+=== Improvements
+
+*_Elasticsearch-reporter_*
+
+- Enable default plugins for all ES versions, and allow disabling them from configuration https://github.com/gravitee-io/issues/issues/6683[#6683]
+
+*_Gateway_*
+
+- Add support of native OpenSSL on http connector https://github.com/gravitee-io/issues/issues/6561[#6561]
+
+*_Portal_*
+
+- API Card - Add OwnerName info https://github.com/gravitee-io/issues/issues/6485[#6485]
+- Application page list pagination https://github.com/gravitee-io/issues/issues/6665[#6665]
+- Direct Search from the API Info https://github.com/gravitee-io/issues/issues/6486[#6486]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/494?closed=1[APIM - 3.5.28 (2022-01-06)]
+
+=== Bug fixes
+
+*_Console_*
+
+- Creating simultaneous changes in dictionaries(one user, two tabs) overwrites the changes in one or the other. https://github.com/gravitee-io/issues/issues/6750[#6750]
+- Expression language completion isn't usable with code editor https://github.com/gravitee-io/issues/issues/6577[#6577]
+- When you check/activate HTTP Proxy with System Proxy in Endpoint configuration, Save button goes grey. https://github.com/gravitee-io/issues/issues/6619[#6619]
+- Wrong Units for Request/Response Content length in Analytics Dashboards https://github.com/gravitee-io/issues/issues/5706[#5706]
+
+*_Management_*
+
+- Stop/start of dynamic dictionaries do not get redeployed on gateways https://github.com/gravitee-io/issues/issues/6847[#6847]
+
+*_Portal_*
+
+- Documentation Page cannot handle lots of menu options https://github.com/gravitee-io/issues/issues/6618[#6618]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/488?closed=1[APIM - 3.13.3 (2021-12-29)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.12.6 in 3.13.x https://github.com/gravitee-io/issues/issues/6806[#6806]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/487?closed=1[APIM - 3.12.6 (2021-12-24)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.10.9 in 3.12.x https://github.com/gravitee-io/issues/issues/6805[#6805]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/486?closed=1[APIM - 3.10.9 (2021-12-23)]
+
+=== Bug fixes
+
+*_Console_*
+
+- Login Error after password reset https://github.com/gravitee-io/issues/issues/6488[#6488]
+- Resource can not be saved after being updated https://github.com/gravitee-io/issues/issues/6781[#6781]
+
+*_General_*
+
+- Merge 3.5.26 in 3.10.x https://github.com/gravitee-io/issues/issues/6756[#6756]
+- Merge 3.5.27 in 3.10.x https://github.com/gravitee-io/issues/issues/6789[#6789]
+
+*_Management_*
+
+- Healthcheck scheduled every seconds instead of configured value after import https://github.com/gravitee-io/issues/issues/6775[#6775]
+
+*_Portal_*
+
+- Jump to anchors in Markdown documents does not work - Syntax bug https://github.com/gravitee-io/issues/issues/6659[#6659]
+
+=== Improvements
+
+*_Reporter_*
+
+- [elasticsearch] Backport #6683 on 3.10 ES plugins management https://github.com/gravitee-io/issues/issues/6710[#6710]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/485?closed=1[APIM - 3.5.27 (2021-12-21)]
+
+=== Bug fixes
+
+*_Console_*
+
+- Design studioselecting policies are pushing the menu right side https://github.com/gravitee-io/issues/issues/5242[#5242]
+
+*_Gateway_*
+
+- System proxy is not managed for health-check https://github.com/gravitee-io/issues/issues/6731[#6731]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/484?closed=1[APIM - 3.5.26 (2021-12-17)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Executable jar start with an error https://github.com/gravitee-io/issues/issues/6733[#6733]
+- [policy] retry policy may cause OOM https://github.com/gravitee-io/issues/issues/6684[#6684]
+
+*_Portal_*
+
+- Different representation of date format in 'Try it out" swagger admin console/dev portal https://github.com/gravitee-io/issues/issues/6506[#6506]
+- When login is required on portal, an error is displayed https://github.com/gravitee-io/issues/issues/5727[#5727]
+
+=== Features
+
+*_Gateway_*
+
+- Shutdown gracefully https://github.com/gravitee-io/issues/issues/6722[#6722]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/474?closed=1[APIM - 3.13.2 (2021-12-15)]
+
+=== Bug fixes
+
+*_Connector_*
+
+- [kafka] Improve assignment and seeking https://github.com/gravitee-io/issues/issues/6686[#6686]
+
+*_Console_*
+
+- Analytics/metrics are no more present if index_per_typetrue with ES 5.x https://github.com/gravitee-io/issues/issues/6630[#6630]
+- Can't configure healthcheck on an old API https://github.com/gravitee-io/issues/issues/6736[#6736]
+
+*_Gateway_*
+
+- Executable jar start with an error https://github.com/gravitee-io/issues/issues/6732[#6732]
+
+*_General_*
+
+- Merge 3.12.5 in 3.13.x https://github.com/gravitee-io/issues/issues/6704[#6704]
+
+*_Management_*
+
+- HealthCheck does not take into account Proxy settings https://github.com/gravitee-io/issues/issues/6698[#6698]
+
+*_Policy_*
+
+- [groovy] Groovy  scripts fails to resolve method even if whitelisted https://github.com/gravitee-io/issues/issues/6681[#6681]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/473?closed=1[APIM - 3.12.5 (2021-12-10)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- OpenTracing hanging gateway https://github.com/gravitee-io/issues/issues/6366[#6366]
+
+*_General_*
+
+- Merge 3.10.8 into 3.12.x https://github.com/gravitee-io/issues/issues/6701[#6701]
+
+*_Management_*
+
+- Fetching Documentation Page from external source (GitHub/Gitlab) return 401 or 404 https://github.com/gravitee-io/issues/issues/6331[#6331]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/472?closed=1[APIM - 3.10.8 (2021-12-08)]
+
+=== Bug fixes
+
+*_Console_*
+
+- API Logs - Consumer response is no longer displayed https://github.com/gravitee-io/issues/issues/6596[#6596]
+- Error log on delete action https://github.com/gravitee-io/issues/issues/6583[#6583]
+
+*_General_*
+
+- Merge 3.5.24 into 3.10.x https://github.com/gravitee-io/issues/issues/6611[#6611]
+- Merge 3.5.25 in 3.10.x https://github.com/gravitee-io/issues/issues/6687[#6687]
+
+*_Management_*
+
+- Fix plans inconsistencies in database https://github.com/gravitee-io/issues/issues/6586[#6586]
+- Rollback introduces duplicated plans https://github.com/gravitee-io/issues/issues/6595[#6595]
+
+*_Portal_*
+
+- "page not found" after Google authentication https://github.com/gravitee-io/issues/issues/6235[#6235]
+- Error message on login page https://github.com/gravitee-io/issues/issues/6203[#6203]
+- Subscriptions menu should not be displayed if user does not have access rights on Applications subscriptions https://github.com/gravitee-io/issues/issues/6021[#6021]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/471?closed=1[APIM - 3.5.25 (2021-12-06)]
+
+=== Bug fixes
+
+*_Console_*
+
+- API:ALERT:read permission doesn't activate API alert detail https://github.com/gravitee-io/issues/issues/5974[#5974]
+
+*_Gateway_*
+
+- Api HealthCheck of endpoints consume too much resources https://github.com/gravitee-io/issues/issues/6658[#6658]
+- EndpointHealthcheckService not ready when Api sync starts https://github.com/gravitee-io/issues/issues/6657[#6657]
+- Heartbeat may cause infinite loop and server crash under certain circumptances https://github.com/gravitee-io/issues/issues/6655[#6655]
+- Make entrypoints concurrently available https://github.com/gravitee-io/issues/issues/6656[#6656]
+- [perf] ensure ClassLoaders are well released after api undeploy https://github.com/gravitee-io/issues/issues/6678[#6678]
+
+*_Management_*
+
+- Handle null value when getting instances https://github.com/gravitee-io/issues/issues/6639[#6639]
+- Search API should keep the search score order https://github.com/gravitee-io/issues/issues/5744[#5744]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/475?closed=1[APIM - 3.13.1 (2021-11-26)]
+
+=== Bug fixes
+
+*_Console_*
+
+- Cannot configure healthcheck at API Level https://github.com/gravitee-io/issues/issues/6569[#6569]
+
+*_General_*
+
+- Merge 3.12.4 in 3.13.x https://github.com/gravitee-io/issues/issues/6606[#6606]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/469?closed=1[APIM - 3.5.24 (2021-11-23)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Inconsistent entrypoint resolution may cause 500 errors https://github.com/gravitee-io/issues/issues/6543[#6543]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/466?closed=1[APIM - 3.12.4 (2021-11-22)]
+
+=== Bug fixes
+
+*_Console_*
+
+- Organization Roles - Member list is empty https://github.com/gravitee-io/issues/issues/6527[#6527]
+
+*_General_*
+
+- Merge 3.10.7 in 3.12.x https://github.com/gravitee-io/issues/issues/6603[#6603]
+
+*_Management_*
+
+- "Role not found" exception when importing an API to a new environment https://github.com/gravitee-io/issues/issues/6448[#6448]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/465?closed=1[APIM - 3.10.7 (2021-11-22)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- API call always returns 500 internal error after redeploy https://github.com/gravitee-io/issues/issues/6601[#6601]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/356?closed=1[APIM - 3.13.0 (2021-11-19)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.12.2 https://github.com/gravitee-io/issues/issues/6557[#6557]
+- Merge 3.12.3 https://github.com/gravitee-io/issues/issues/6594[#6594]
+
+*_Management_*
+
+- Fix Jetty's class loader https://github.com/gravitee-io/issues/issues/6495[#6495]
+
+=== Features
+
+*_Console_*
+
+- Display excluded groups in plans https://github.com/gravitee-io/issues/issues/5259[#5259]
+- Support webhook on API update event https://github.com/gravitee-io/issues/issues/5426[#5426]
+
+*_Management_*
+
+- Service Management Ecosystem (SME): API HTTP Connector Integration https://github.com/gravitee-io/issues/issues/6132[#6132]
+- Service Management Ecosystem (SME): Kafka connector _(available next week)_ https://github.com/gravitee-io/issues/issues/6133[#6133]
+
+*_Portal_*
+
+- Add an API search bar in the portal homepage https://github.com/gravitee-io/issues/issues/5323[#5323]
+
+=== Improvements
+
+*_Policy_*
+
+- JWT-PolicyCache management improvements https://github.com/gravitee-io/issues/issues/6046[#6046]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/463?closed=1[APIM - 3.12.3 (2021-11-18)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.10.6 in 3.12.x https://github.com/gravitee-io/issues/issues/6593[#6593]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/457?closed=1[APIM - 3.10.6 (2021-11-18)]
+
+=== Bug fixes
+
+*_Console_*
+
+- Not possible to change the logs configuration https://github.com/gravitee-io/issues/issues/6282[#6282]
+
+*_General_*
+
+- Merge 3.5.23 in 3.10.x https://github.com/gravitee-io/issues/issues/6576[#6576]
+
+*_Management_*
+
+- Plan is duplicated when importing an api with one plan https://github.com/gravitee-io/issues/issues/6042[#6042]
+
+*_Reporter-file_*
+
+- Monitor logs (node-*) get empty if output is set to elasticsearch https://github.com/gravitee-io/issues/issues/6564[#6564]
+
+=== Improvements
+
+*_Console_*
+
+- [alerts] Add HTTP_SIGNATURE_INVALID_SIGNATURE to api metrics list https://github.com/gravitee-io/issues/issues/6462[#6462]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/458?closed=1[APIM - 3.5.23 (2021-11-17)]
+
+=== Bug fixes
+
+*_Console_*
+
+- API search doesn't return all expected results https://github.com/gravitee-io/issues/issues/6565[#6565]
+- Signup not possible on console using JDBC https://github.com/gravitee-io/issues/issues/6330[#6330]
+
+*_Gateway_*
+
+- Avoid 404 and 500 error during api redeploy or stop https://github.com/gravitee-io/issues/issues/6553[#6553]
+- ILM managed indice are not handled by elasticsearch reporter https://github.com/gravitee-io/issues/issues/6507[#6507]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/449?closed=1[APIM - 3.12.2 (2021-11-12)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.11.3 in 3.12.x https://github.com/gravitee-io/issues/issues/6511[#6511]
+
+=== Improvements
+
+*_Console_*
+
+- Customize HTTP_SIGNATURE_INVALID_SIGNATURE response template https://github.com/gravitee-io/issues/issues/6320[#6320]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/448?closed=1[APIM - 3.11.3 (2021-11-12)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.10.4 in 3.11.x https://github.com/gravitee-io/issues/issues/6512[#6512]
+- Merge 3.10.5 in 3.11.x https://github.com/gravitee-io/issues/issues/6548[#6548]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/447?closed=1[APIM - 3.10.5 (2021-11-10)]
+
+=== Bug fixes
+
+*_Console_*
+
+- Policy - Pressing tab in EL fields add a transparent \t https://github.com/gravitee-io/issues/issues/6534[#6534]
+
+*_Gateway_*
+
+- Cannot use JWT multiple plans https://github.com/gravitee-io/issues/issues/6529[#6529]
+- Inconsistent entrypoint resolution may cause 500 errors https://github.com/gravitee-io/issues/issues/6544[#6544]
+- Irrelevant bean injection warning for apis with health check https://github.com/gravitee-io/issues/issues/6105[#6105]
+- Sync probe ends with an exception when calling /_node/sync https://github.com/gravitee-io/issues/issues/6541[#6541]
+
+*_Policy_*
+
+- [geoip-filtering] Upgrade for APIM >= 3.10 https://github.com/gravitee-io/issues/issues/6531[#6531]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/453?closed=1[APIM - 3.5.22 (2021-11-10)]
+
+=== Bug fixes
+
+*_Console_*
+
+- Design studio - Policy disappear after save https://github.com/gravitee-io/issues/issues/6517[#6517]
+- Plan level policies are not displayed in the history https://github.com/gravitee-io/issues/issues/6524[#6524]
+- Policy - Pressing tab in EL fields add a transparent \t https://github.com/gravitee-io/issues/issues/6533[#6533]
+- Policy Mock unexpected behavior https://github.com/gravitee-io/issues/issues/6438[#6438]
+
+*_Gateway_*
+
+- Cannot use JWT multiple plans https://github.com/gravitee-io/issues/issues/6528[#6528]
+- Inconsistent entrypoint resolution may cause 500 errors https://github.com/gravitee-io/issues/issues/6543[#6543]
+- Sync probe ends with an exception when calling /_node/sync https://github.com/gravitee-io/issues/issues/6539[#6539]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/430?closed=1[APIM - 3.10.4 (2021-11-05)]
+
+=== Bug fixes
+
+*_Console_*
+
+- Documentation page configuration imported from external source can not be edited https://github.com/gravitee-io/issues/issues/6149[#6149]
+- Organization Settings get reinitialized after changing Authentication configuration. https://github.com/gravitee-io/issues/issues/6114[#6114]
+- Portal Settings get reinitialized after changing Portal Authentication configuration https://github.com/gravitee-io/issues/issues/6154[#6154]
+- Quality Metrics lost after upgrade https://github.com/gravitee-io/issues/issues/6290[#6290]
+- Reset button in settings does not work https://github.com/gravitee-io/issues/issues/6497[#6497]
+
+*_Gateway_*
+
+- Can not start gateway if Hazelcast ratelimt enabled java.lang.ClassNotFoundExceptioncom.hazelcast.core.IMap https://github.com/gravitee-io/issues/issues/6117[#6117]
+- Health-check stops working after gateway is stopped/started. https://github.com/gravitee-io/issues/issues/6306[#6306]
+- Unable to start gateway when activating TLS and HTTP/2 https://github.com/gravitee-io/issues/issues/6232[#6232]
+- [policy] fix license management of data-logging-masking and assign-metrics policies https://github.com/gravitee-io/issues/issues/6435[#6435]
+
+*_General_*
+
+- Backport #6101 in 3.10.x https://github.com/gravitee-io/issues/issues/6279[#6279]
+- Backport 6173 in 3.10.x https://github.com/gravitee-io/issues/issues/6174[#6174]
+- Backport of #5966 in 3.10.x https://github.com/gravitee-io/issues/issues/6085[#6085]
+- Merge 3.5.21 into 3.10.4 https://github.com/gravitee-io/issues/issues/6496[#6496]
+
+*_Management_*
+
+- Error when creating an alert with system email notification https://github.com/gravitee-io/issues/issues/6231[#6231]
+- Swagger description of APIM Console API is empty https://github.com/gravitee-io/issues/issues/6494[#6494]
+
+*_Policy_*
+
+- [data-logging-masking] datas are no longer masked https://github.com/gravitee-io/issues/issues/6122[#6122]
+
+*_Portal_*
+
+- Filters on path on the logs in APIM Portal do not work. https://github.com/gravitee-io/issues/issues/6238[#6238]
+
+*_Repository_*
+
+- [sqlserver] Rest API database setup https://github.com/gravitee-io/issues/issues/6447[#6447]
+
+=== Improvements
+
+*_Console_*
+
+- Enable/Disable API Status dashboard https://github.com/gravitee-io/issues/issues/6365[#6365]
+
+*_Management_*
+
+- Customize HTTP SIGNATURE response template https://github.com/gravitee-io/issues/issues/6319[#6319]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/442?closed=1[APIM - 3.5.21 (2021-11-02)]
+
+=== Bug fixes
+
+*_Console_*
+
+- 500 error when importing definition of an API, null pointer exception https://github.com/gravitee-io/issues/issues/6052[#6052]
+- Change button labels (dashboard types) on Settings > Analytics page https://github.com/gravitee-io/issues/issues/6363[#6363]
+- Deleted plan is not removed from design studio https://github.com/gravitee-io/issues/issues/5942[#5942]
+- Documentation page configuration imported from external source can not be edited https://github.com/gravitee-io/issues/issues/6461[#6461]
+- Top failed APIs shows 100% Failed on 200 status in Application Analytics https://github.com/gravitee-io/issues/issues/5703[#5703]
+
+=== Improvements
+
+*_Gateway_*
+
+- Provide information for accurate Kubernetes Probes support https://github.com/gravitee-io/issues/issues/6455[#6455]
+
+*_Policy_*
+
+- Print more accurate logs in case of invalid configuration https://github.com/gravitee-io/issues/issues/6479[#6479]
+
+*_Reporter_*
+
+- Improve reporters performances https://github.com/gravitee-io/issues/issues/6430[#6430]
+
+*_Repository_*
+
+- Optimize mongodb searchLatest events https://github.com/gravitee-io/issues/issues/6481[#6481]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/435?closed=1[APIM - 3.12.1 (2021-10-25)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.11.2 https://github.com/gravitee-io/issues/issues/6451[#6451]
+
+*_Portal_*
+
+- APIKey isn't the right one https://github.com/gravitee-io/issues/issues/6413[#6413]
+
+*_Repository_*
+
+- [sqlserver] Rest API database setup https://github.com/gravitee-io/issues/issues/6453[#6453]
+
+
+== https://github.com/gravitee-io/issues/milestone/438?closed=1[APIM - 3.11.2 (2021-10-25)]
+
+=== Bug fixes
+
+*_Repository_*
+
+- [jdbc] APIs are not loaded at gateway startup after migration https://github.com/gravitee-io/issues/issues/6449[#6449]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/426?closed=1[APIM - 3.5.20 (2021-10-14)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+ - Fix JWT and OAuth2 plans https://github.com/gravitee-io/issues/issues/6391[#6391]
+
+== https://github.com/gravitee-io/issues/milestone/413?closed=1[APIM - 3.5.19 (2021-10-07)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Backport of https://github.com/gravitee-io/issues/issues/5649[#5649] : Heartbeat stops after 1h https://github.com/gravitee-io/issues/issues/6183[#6183]
+- Wrong settings for SyncService https://github.com/gravitee-io/issues/issues/5977[#5977]
+- [sync] In case of dictionary sync issue, APIs are fully resync https://github.com/gravitee-io/issues/issues/6301[#6301]
+- [sync] Sync process is trying to deploy APIs twice https://github.com/gravitee-io/issues/issues/6300[#6300]
+
+*_General_*
+
+- Backport of https://github.com/gravitee-io/issues/issues/5966[#5966] : Node stop event are not well propagated when node is stopped https://github.com/gravitee-io/issues/issues/6084[#6084]
+- Backport of https://github.com/gravitee-io/issues/issues/5982[#5982] : JSON Threat Protection Policy : unable to adjust default values https://github.com/gravitee-io/issues/issues/5983[#5983]
+
+*_Management_*
+
+- Application Dashboard inconsistent filtering on "Top Failed" widget https://github.com/gravitee-io/issues/issues/5771[#5771]
+- Plans get lost when imported with different user with admin rights https://github.com/gravitee-io/issues/issues/6008[#6008]
+- Reorder issue on PageServiceImpl.java https://github.com/gravitee-io/issues/issues/5931[#5931]
+- SMTP TLS negotiation error https://github.com/gravitee-io/issues/issues/6101[#6101]
+- SQL error when trying to search application to subscribe with https://github.com/gravitee-io/issues/issues/5812[#5812]
+- User can list all applications without permissions https://github.com/gravitee-io/issues/issues/6307[#6307]
+- [repository] missing mongodb index makes impossible to start management api https://github.com/gravitee-io/issues/issues/5995[#5995]
+
+*_Policy_*
+
+- [json threat] - MAX JSON Array size issue not taken into account https://github.com/gravitee-io/issues/issues/6050[#6050]
+- [ratelimit] Error 429 is being returned while using two Rate Limit Policies. https://github.com/gravitee-io/issues/issues/6218[#6218]
+- [ratelimit] Redis AsyncRateLimitRepositoryError NumberFormatExceptionnull https://github.com/gravitee-io/issues/issues/5988[#5988]
+
+*_Portal_*
+
+- API name not displayed correctly when multiple labels https://github.com/gravitee-io/issues/issues/5761[#5761]
+- Long paths/names are not well displayed in Analytics and Logs widgets https://github.com/gravitee-io/issues/issues/5767[#5767]
+- Scopes (Available Authorizations) can't be displayed in API Documentation (swagger) https://github.com/gravitee-io/issues/issues/5661[#5661]
+
+=== Features
+
+*_Management_*
+
+- Search for users by Id from /management/organizations/{orgId}/environments/{envId}/search/users  endpoint https://github.com/gravitee-io/issues/issues/5855[#5855]
+
+=== Improvements
+
+*_Management_*
+
+- Allow spaces in the declaration of dictionaries, at the dynamic routing level https://github.com/gravitee-io/issues/issues/5938[#5938]
+- Startup performance improvements https://github.com/gravitee-io/issues/issues/6066[#6066]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/352?closed=1[APIM - 3.12.0 (2021-09-30)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.11.1 https://github.com/gravitee-io/issues/issues/6240[#6240]
+
+*_Repository_*
+
+- [mongo] Wrong total number of elements in paginated search https://github.com/gravitee-io/issues/issues/6173[#6173]
+
+=== Features
+
+*_Gateway_*
+
+- Update Gateway API to add an access to the SSLSession https://github.com/gravitee-io/issues/issues/5322[#5322]
+
+*_Platform_*
+
+- Handle duplicate API keys https://github.com/gravitee-io/issues/issues/6006[#6006]
+
+*_Policy_*
+
+- [generate-http-signature] Genrate HTTP Signature policy https://github.com/gravitee-io/issues/issues/4899[#4899]
+
+*_Portal_*
+
+- Advanced search on APIs https://github.com/gravitee-io/issues/issues/2839[#2839]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/422?closed=1[APIM - 3.11.1 (2021-09-22)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Try It Mode -  Number of instances provided should be set https://github.com/gravitee-io/issues/issues/6073[#6073]
+- Try It Mode - issues if api has health check configured https://github.com/gravitee-io/issues/issues/6069[#6069]
+- Try It Mode - issues with configuration https://github.com/gravitee-io/issues/issues/6072[#6072]
+
+*_General_*
+
+- Merge 3.10.1 https://github.com/gravitee-io/issues/issues/6056[#6056]
+- Merge 3.10.2 https://github.com/gravitee-io/issues/issues/6217[#6217]
+- Merge 3.10.3 https://github.com/gravitee-io/issues/issues/6219[#6219]
+
+=== Improvements
+
+*_Management_*
+
+- Try It Mode - check api configuration when requesting debug https://github.com/gravitee-io/issues/issues/6017[#6017]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/429?closed=1[APIM - 3.10.3 (2021-09-17)]
+
+=== Bug fixes
+
+*_Platform_*
+
+- Fix APIM Dockerfile https://github.com/gravitee-io/issues/issues/6206[#6206]
+
+== https://github.com/gravitee-io/issues/milestone/421?closed=1[APIM - 3.10.2 (2021-09-17)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- [oauth-am-resource] memory leak https://github.com/gravitee-io/issues/issues/6119[#6119]
+
+*_Management_*
+
+- Add missing script and missing documentation https://github.com/gravitee-io/issues/issues/6142[#6142]
+
+*_Repository_*
+
+- [rate-limit] redis health check throws an exception https://github.com/gravitee-io/issues/issues/6111[#6111]
+
+*_Resource-oauth2-provider_*
+
+- Exceptions occur when two many concurrent requests are made https://github.com/gravitee-io/issues/issues/6176[#6176]
+
+=== Improvements
+
+*_Platform_*
+
+- Upgrade Docker Images https://github.com/gravitee-io/issues/issues/6139[#6139]
+- Update APIM dependencies https://github.com/gravitee-io/issues/issues/6152[#6152]
+
+== https://github.com/gravitee-io/issues/milestone/419?closed=1[APIM - 3.10.1 (2021-09-06)]
+
+=== Bug fixes
+
+*_Console_*
+
+- Logo disappeared after migration to 3.10 https://github.com/gravitee-io/issues/issues/6038[#6038]
+- Metrics of instances are not displayed https://github.com/gravitee-io/issues/issues/6039[#6039]
+- Pending Tasks are visible to any users in the Console https://github.com/gravitee-io/issues/issues/6036[#6036]
+- Portal Settings get reinitialized after changes https://github.com/gravitee-io/issues/issues/6009[#6009]
+- [3.10.0] "Authentication button color" set in Console OIDC Authentication Settings not propagated to Portal https://github.com/gravitee-io/issues/issues/6010[#6010]
+
+*_Gateway_*
+
+- Enabling prometheus Metrics gives java.lang.ClassNotFoundExceptionorg.LatencyUtils.PauseDetector https://github.com/gravitee-io/issues/issues/5996[#5996]
+
+*_General_*
+
+- Cannot access API as a User https://github.com/gravitee-io/issues/issues/6033[#6033]
+- Merge 3.9.4 https://github.com/gravitee-io/issues/issues/5945[#5945]
+
+*_Management_*
+
+- Enable to sync APIs due to NPE https://github.com/gravitee-io/issues/issues/5980[#5980]
+
+*_Platform_*
+
+- El expression request.method leads to an InvocationTargetException https://github.com/gravitee-io/issues/issues/6051[#6051]
+
+=== Features
+
+*_Reporter_*
+
+- Add the ability to filter or rename properties / fields https://github.com/gravitee-io/issues/issues/5831[#5831]
+
+=== Improvements
+
+*_Gateway_*
+
+- Enhance certificate management in keystore to enable to differenciate certificates per domain https://github.com/gravitee-io/issues/issues/5894[#5894]
+- Resource hogging when using many certificates in keystore https://github.com/gravitee-io/issues/issues/5895[#5895]
+
+*_Management_*
+
+- Set spring security dependencies as provided in IDP plugins https://github.com/gravitee-io/issues/issues/5947[#5947]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/333?closed=1[APIM - 3.11.0 (2021-08-31)]
+
+=== Bug fixes
+
+*_General_*
+
+- OAuth2 plan parsing must accept tokens other than JWT (example 1) https://github.com/gravitee-io/issues/issues/5828[#5828]
+- OAuth2 plan parsing must accept tokens other than JWT (example 2) https://github.com/gravitee-io/issues/issues/5829[#5829]
+- The "Access control" tab of a documentation page does not return the correct list of roles https://github.com/gravitee-io/issues/issues/5789[#5789]
+
+*_Management_*
+
+- Logging is enabled on the wrong api https://github.com/gravitee-io/issues/issues/5991[#5991]
+
+=== Features
+
+*_General_*
+
+- Add `Try it` in Design Studio https://github.com/gravitee-io/issues/issues/5901[#5901]
+- Define the request https://github.com/gravitee-io/issues/issues/5804[#5804]
+- Display the response https://github.com/gravitee-io/issues/issues/5805[#5805]
+- Encrypt API properties https://github.com/gravitee-io/issues/issues/5638[#5638]
+- Javascript policy https://github.com/gravitee-io/issues/issues/5948[#5948]
+- Write documentation with AsyncAPI https://github.com/gravitee-io/issues/issues/5575[#5575]
+
+*_Policy_*
+
+- [gravitee-policy-callout-http] fire & forget mode https://github.com/gravitee-io/issues/issues/5972[#5972]
+
+=== Improvements
+
+*_Policy-groovy_*
+
+- Improve form https://github.com/gravitee-io/issues/issues/6027[#6027]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/416?closed=1[APIM - 3.9.4 (2021-08-23)]
+
+=== Bug fixes
+
+*_Console_*
+
+- Probem on registration of the proxy conf https://github.com/gravitee-io/issues/issues/5896[#5896]
+
+*_General_*
+
+- Merge 3.8.7 https://github.com/gravitee-io/issues/issues/5944[#5944]
+
+*_Management_*
+
+- JSON Threat Protection Policy unable to adjust default values https://github.com/gravitee-io/issues/issues/5982[#5982]
+
+*_Ratelimit_*
+
+- Rate limiting not working with Redis https://github.com/gravitee-io/issues/issues/5882[#5882]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/414?closed=1[APIM - 3.8.7 (2021-08-12)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.5.18 https://github.com/gravitee-io/issues/issues/5943[#5943]
+
+*_Management_*
+
+- Error while importing a file https://github.com/gravitee-io/issues/issues/5933[#5933]
+- Metadata of type URL do not support all characters https://github.com/gravitee-io/issues/issues/5964[#5964]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/409?closed=1[APIM - 3.5.18 (2021-08-04)]
+
+=== Bug fixes
+
+*_Definition_*
+
+- Virtual host with '/' is not saved https://github.com/gravitee-io/issues/issues/5859[#5859]
+
+*_Gateway_*
+
+- Sync process optimisations https://github.com/gravitee-io/issues/issues/5615[#5615]
+- Upgrade dependency for AE 1.3.3 plugin https://github.com/gravitee-io/issues/issues/5890[#5890]
+
+*_Management_*
+
+- "order" field of Plans get reseted when imported from 3.5.x to 3.8.x https://github.com/gravitee-io/issues/issues/5696[#5696]
+- Allow to specify multiple roles to map with ldap idp https://github.com/gravitee-io/issues/issues/5619[#5619]
+- Check plan policy configuration https://github.com/gravitee-io/issues/issues/5952[#5952]
+- Flows property not accepted in request payload for Update Plan https://github.com/gravitee-io/issues/issues/5694[#5694]
+- Plan Flows get lost on updating an API with an existing API definition (updateApiWithDefinition) https://github.com/gravitee-io/issues/issues/5820[#5820]
+- [analytics] "Display percentage" is never checked https://github.com/gravitee-io/issues/issues/5495[#5495]
+- [github idp] user without space in their username fail to authenticate https://github.com/gravitee-io/issues/issues/5507[#5507]
+
+*_Policy-ratelimit_*
+
+- Unable to use quota notification.properties https://github.com/gravitee-io/issues/issues/5834[#5834]
+
+*_Reporter-file_*
+
+- [reporter-tcp] manage user-agent in the elasticsearch output https://github.com/gravitee-io/issues/issues/5893[#5893]
+
+=== Improvements
+
+*_General_*
+
+- Add the created_at value in the Get API definition response https://github.com/gravitee-io/issues/issues/5455[#5455]
+
+*_Management_*
+
+- Re-enable "retainDays" configuration in file-reporter plugin https://github.com/gravitee-io/issues/issues/5463[#5463]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/243?closed=1[APIM - 3.10.0 (2021-08-03)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Heartbeat stops after 1h https://github.com/gravitee-io/issues/issues/5649[#5649]
+- [apim] gRPC in Server streaming mode the call is never close https://github.com/gravitee-io/issues/issues/5494[#5494]
+
+*_General_*
+
+- Lost documentation pages when duplicating an API https://github.com/gravitee-io/issues/issues/5849[#5849]
+- Merge 3.9.2 https://github.com/gravitee-io/issues/issues/5814[#5814]
+- Merge 3.9.3 https://github.com/gravitee-io/issues/issues/5818[#5818]
+
+*_Management_*
+
+- Error while importing a file https://github.com/gravitee-io/issues/issues/5932[#5932]
+- Not redirect to dashboard when click on gravitee logo https://github.com/gravitee-io/issues/issues/5768[#5768]
+
+=== Features
+
+*_Gateway_*
+
+- OpenTracing support https://github.com/gravitee-io/issues/issues/1581[#1581]
+
+*_General_*
+
+- API Promotion https://github.com/gravitee-io/issues/issues/5530[#5530]
+- Accepting/Rejecting an API promotion request https://github.com/gravitee-io/issues/issues/5528[#5528]
+- Handle `groups` during API Promotion https://github.com/gravitee-io/issues/issues/5844[#5844]
+- Handle `pages` during API Promotion https://github.com/gravitee-io/issues/issues/5841[#5841]
+- Handle `plans` during API Promotion https://github.com/gravitee-io/issues/issues/5842[#5842]
+- Logging events for API promotion https://github.com/gravitee-io/issues/issues/5531[#5531]
+- Making requests for API promotion https://github.com/gravitee-io/issues/issues/5526[#5526]
+- Managing in progress API promotion requests https://github.com/gravitee-io/issues/issues/5746[#5746]
+- Support Redis for cache resource https://github.com/gravitee-io/issues/issues/5712[#5712]
+- Viewing tasks for API promotion requests https://github.com/gravitee-io/issues/issues/5527[#5527]
+
+*_Management_*
+
+- Allows to use Expression Language in health check configuration https://github.com/gravitee-io/issues/issues/4943[#4943]
+- Manage AsciiDoc pages https://github.com/gravitee-io/issues/issues/4717[#4717]
+- Notify consumer before the expiration of its subscription https://github.com/gravitee-io/issues/issues/3887[#3887]
+
+*_Policy_*
+
+- [groovy] add XML support https://github.com/gravitee-io/issues/issues/5891[#5891]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/410?closed=1[APIM - 3.9.3 (2021-07-16)]
+
+=== Bug fixes
+
+*_General_*
+
+- APIM Console Plan creation with Rate Limiting causes an exception https://github.com/gravitee-io/issues/issues/5833[#5833]
+- Merge 3.8.6 https://github.com/gravitee-io/issues/issues/5817[#5817]
+- The GW instance is no longer displayed on the nightly https://github.com/gravitee-io/issues/issues/5782[#5782]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/408?closed=1[APIM - 3.8.6 (2021-07-16)]
+
+=== Bug fixes
+
+*_General_*
+
+- GetGroupMembers align documentation vs real output https://github.com/gravitee-io/issues/issues/5614[#5614]
+- Merge 3.5.17 https://github.com/gravitee-io/issues/issues/5816[#5816]
+
+=== Features
+
+*_Gateway_*
+
+- [response template] add a GATEWAY_TIMEOUT response template https://github.com/gravitee-io/issues/issues/5501[#5501]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/404?closed=1[APIM - 3.5.17 (2021-07-06)]
+
+=== Bug fixes
+
+*_General_*
+
+- Backport 5756 https://github.com/gravitee-io/issues/issues/5757[#5757]
+
+*_Management_*
+
+- Strange UI behaviour in the console https://github.com/gravitee-io/issues/issues/5807[#5807]
+- [alerting] When creating "Alert on the health status of the node", CREATE button is disabled https://github.com/gravitee-io/issues/issues/5808[#5808]
+
+*_Managment_*
+
+- API Analytics response payload not displayed, fails with javascript error e.getTextArea is not a function https://github.com/gravitee-io/issues/issues/5364[#5364]
+
+*_Policy_*
+
+- Allow array.length with groovy sandbox https://github.com/gravitee-io/issues/issues/5557[#5557]
+- [transform headers] support null in arrays https://github.com/gravitee-io/issues/issues/5778[#5778]
+
+=== Features
+
+*_Resource_*
+
+- [auth-provider] Support HTTP-based authentication provider https://github.com/gravitee-io/issues/issues/5737[#5737]
+
+=== Improvements
+
+*_Policy_*
+
+- [basic-authentication] Manage async auth providers https://github.com/gravitee-io/issues/issues/5733[#5733]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/400?closed=1[APIM - 3.9.2 (2021-06-29)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.8.4 https://github.com/gravitee-io/issues/issues/5721[#5721]
+- Merge 3.8.5 https://github.com/gravitee-io/issues/issues/5793[#5793]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/398?closed=1[APIM - 3.8.5 (2021-06-29)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.5.15 https://github.com/gravitee-io/issues/issues/5740[#5740]
+- Merge 3.5.16 https://github.com/gravitee-io/issues/issues/5758[#5758]
+
+*_Management_*
+
+- API_REVIEW_* Audit Event filters are missing in the scrolling list (API and Global Levels) https://github.com/gravitee-io/issues/issues/5673[#5673]
+- Redirection problem when connecting to console from cockpit https://github.com/gravitee-io/issues/issues/5785[#5785]
+- Roles initialized to default after removing a role mapping configuration https://github.com/gravitee-io/issues/issues/5756[#5756]
+- Subscription approval link not correct https://github.com/gravitee-io/issues/issues/5724[#5724]
+
+*_Reporter_*
+
+- Bad timestamp format by reporters https://github.com/gravitee-io/issues/issues/5707[#5707]
+- [file] NPEs thrown in log https://github.com/gravitee-io/issues/issues/5668[#5668]
+
+*_Resource-cache_*
+
+- Error when redeploy an api https://github.com/gravitee-io/issues/issues/5671[#5671]
+
+=== Improvements
+
+*_Helm_*
+
+- Adapt liveness probe of the gateway to check API synchronization https://github.com/gravitee-io/issues/issues/5734[#5734]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/401?closed=1[APIM - 3.5.16 (2021-06-18)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- API health check is duplicating slash in some case https://github.com/gravitee-io/issues/issues/5752[#5752]
+
+*_Portal_*
+
+- Login issue on the portal https://github.com/gravitee-io/issues/issues/5748[#5748]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/396?closed=1[APIM - 3.5.15 (2021-06-17)]
+
+=== Bug fixes
+
+*_Console_*
+
+- Allow to disable "maintenance" mode https://github.com/gravitee-io/issues/issues/5731[#5731]
+- CORS settings doesn't display https://github.com/gravitee-io/issues/issues/5729[#5729]
+
+*_Gateway_*
+
+- Unable to establish websocket connection using Firefox https://github.com/gravitee-io/issues/issues/5722[#5722]
+
+*_General_*
+
+- Backport #5632 https://github.com/gravitee-io/issues/issues/5697[#5697]
+- Check consistency of Plans on API update https://github.com/gravitee-io/issues/issues/5718[#5718]
+
+*_Management_*
+
+- Can not Auto-fetch Documentation Page from an external source https://github.com/gravitee-io/issues/issues/5699[#5699]
+- Inconsistent Sharding Tags behavior compared to the documentation https://github.com/gravitee-io/issues/issues/5600[#5600]
+- Newsletter subscribe link not working anymore https://github.com/gravitee-io/issues/issues/5720[#5720]
+
+=== Features
+
+*_Policy_*
+
+- [Http Signature] Support non quoted String in the signature https://github.com/gravitee-io/issues/issues/5684[#5684]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/391?closed=1[APIM - 3.8.4 (2021-06-14)]
+
+=== Bug fixes
+
+*_General_*
+
+- Backport #5649 https://github.com/gravitee-io/issues/issues/5704[#5704]
+- Merge 3.5.13 https://github.com/gravitee-io/issues/issues/5690[#5690]
+- Merge 3.5.14 https://github.com/gravitee-io/issues/issues/5698[#5698]
+
+*_Management_*
+
+- Categories order field not set at creation https://github.com/gravitee-io/issues/issues/5632[#5632]
+
+*_Resource-cache_*
+
+- Error when redeploy an api https://github.com/gravitee-io/issues/issues/5671[#5671]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/399?closed=1[APIM - 3.9.1 (2021-06-12)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Loss of data when migrating on 3.9.0 for jdbc users https://github.com/gravitee-io/issues/issues/5711[#5711]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/393?closed=1[APIM - 3.5.14 (2021-06-09)]
+
+=== Bug fixes
+
+*_General_*
+
+- Group/role mapping lost after OIDC login https://github.com/gravitee-io/issues/issues/5686[#5686]
+
+*_Management_*
+
+- Allow to specify multiple roles to map with ldap idp https://github.com/gravitee-io/issues/issues/5619[#5619]
+- Gravitee_http_cors_alloworigin environment variable setting not reflected in UI https://github.com/gravitee-io/issues/issues/5583[#5583]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/242?closed=1[APIM - 3.9.0 (2021-06-08)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.8.1 https://github.com/gravitee-io/issues/issues/5497[#5497]
+- Merge 3.8.2 https://github.com/gravitee-io/issues/issues/5554[#5554]
+- Merge 3.8.3 https://github.com/gravitee-io/issues/issues/5634[#5634]
+
+*_Management_*
+
+- Cannot ask for review anymore https://github.com/gravitee-io/issues/issues/5558[#5558]
+- Cannot publish / unpublish a page with a link https://github.com/gravitee-io/issues/issues/5559[#5559]
+- Check existance of confirmUrl https://github.com/gravitee-io/issues/issues/5567[#5567]
+- Error when updating user's avatar https://github.com/gravitee-io/issues/issues/5533[#5533]
+- [gateway] reintroduce serializers/deserializers on gravitee-definition https://github.com/gravitee-io/issues/issues/5642[#5642]
+
+=== Features
+
+*_Console_*
+
+- Custom templates for alert notifications (HTTP Status Code and Average Response Time) https://github.com/gravitee-io/issues/issues/5481[#5481]
+
+*_Gateway_*
+
+- Allow to associate a gateway to a specific environment https://github.com/gravitee-io/issues/issues/5357[#5357]
+- Platform policies https://github.com/gravitee-io/issues/issues/4460[#4460]
+
+*_Management_*
+
+- Allow an API Publisher to push API Metrics to a specific target https://github.com/gravitee-io/issues/issues/5349[#5349]
+- Configure an alert on a timeframe https://github.com/gravitee-io/issues/issues/4894[#4894]
+
+*_Portal_*
+
+- Allow to define alerts for a consumer https://github.com/gravitee-io/issues/issues/5341[#5341]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/386?closed=1[APIM - 3.5.13 (2021-06-04)]
+
+=== Bug fixes
+
+*_General_*
+
+- Backport #5621 https://github.com/gravitee-io/issues/issues/5633[#5633]
+- Default_api_logo.png can not be overriden https://github.com/gravitee-io/issues/issues/5524[#5524]
+- Merge 3.0.17 https://github.com/gravitee-io/issues/issues/5647[#5647]
+
+*_Helm_*
+
+- Cannot disable the Alert Engine connector https://github.com/gravitee-io/issues/issues/5662[#5662]
+
+*_Management_*
+
+- CORS Access-Control-Allow-Origin regex fails on pattern as ".*.mydomain.com" https://github.com/gravitee-io/issues/issues/5611[#5611]
+- Cannot update Quality Rules https://github.com/gravitee-io/issues/issues/5626[#5626]
+- Invalid logout url construction with external OIDC Provider https://github.com/gravitee-io/issues/issues/5593[#5593]
+- Plan Flows get lost when re-importing API from a swagger/oas3 specification https://github.com/gravitee-io/issues/issues/5651[#5651]
+- Policies on path are not updated when updating an API with swagger https://github.com/gravitee-io/issues/issues/4970[#4970]
+- Unable to use default image on API https://github.com/gravitee-io/issues/issues/5303[#5303]
+
+*_Management-api_*
+
+- Unable to change admin password with the environment variables in Openshift https://github.com/gravitee-io/issues/issues/2680[#2680]
+
+*_Portal_*
+
+- Do not display "Create an Application" in Portal if user has insufficient privileges https://github.com/gravitee-io/issues/issues/5403[#5403]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/387?closed=1[APIM - 3.8.3 (2021-05-26)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.7.4 https://github.com/gravitee-io/issues/issues/5602[#5602]
+
+*_Management-ui_*
+
+- Loss of path when OIDC logout process https://github.com/gravitee-io/issues/issues/5621[#5621]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/365?closed=1[APIM - 3.0.17 (2021-05-20)]
+
+=== Bug fixes
+
+*_General_*
+
+- Backport #5468 https://github.com/gravitee-io/issues/issues/5503[#5503]
+- Backport #5517 https://github.com/gravitee-io/issues/issues/5534[#5534]
+- The API footer overlap the redoc documentation https://github.com/gravitee-io/issues/issues/5597[#5597]
+
+*_Management_*
+
+- Update start date label for audit logs https://github.com/gravitee-io/issues/issues/5256[#5256]
+- User search is not accurate https://github.com/gravitee-io/issues/issues/5150[#5150]
+
+*_Portal_*
+
+- "information" is singular https://github.com/gravitee-io/issues/issues/5595[#5595]
+- Unable to create an App from the portal https://github.com/gravitee-io/issues/issues/5563[#5563]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/388?closed=1[APIM - 3.7.4 (2021-05-22)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.5.12 https://github.com/gravitee-io/issues/issues/5601[#5601]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/384?closed=1[APIM - 3.5.12 (2021-05-18)]
+
+=== Bug fixes
+
+*_General_*
+
+- Backport #5558 https://github.com/gravitee-io/issues/issues/5568[#5568]
+- Backport #5564 https://github.com/gravitee-io/issues/issues/5590[#5590]
+- Backport #5567 https://github.com/gravitee-io/issues/issues/5589[#5589]
+- Default_api_logo.png can not be overriden https://github.com/gravitee-io/issues/issues/5524[#5524]
+
+*_IdentityProvider_*
+
+- Not default role when user created with external IDP https://github.com/gravitee-io/issues/issues/5561[#5561]
+
+*_Management_*
+
+- Disabling Newsletter does not disable bottom right Pop-in https://github.com/gravitee-io/issues/issues/5502[#5502]
+
+=== Improvements
+
+*_Elasticsearch_*
+
+- Do not include date as part of the index name for ILM managed indices https://github.com/gravitee-io/issues/issues/5551[#5551]
+
+*_General_*
+
+- Add postman for /applications?query=A accessible to unauthorized users https://github.com/gravitee-io/issues/issues/5535[#5535]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/383?closed=1[APIM - 3.8.2 (2021-05-14)]
+
+=== Bug fixes
+
+*_General_*
+
+- Backport #5559 https://github.com/gravitee-io/issues/issues/5569[#5569]
+- Backport 5533 https://github.com/gravitee-io/issues/issues/5552[#5552]
+- Merge 3.7.3 https://github.com/gravitee-io/issues/issues/5553[#5553]
+
+*_Management_*
+
+- Missing plan selection rule for V2 Definition APIs https://github.com/gravitee-io/issues/issues/5564[#5564]
+
+*_Management-ui_*
+
+- As a user I should see user assigned to the group without refreshing the page https://github.com/gravitee-io/issues/issues/5401[#5401]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/381?closed=1[APIM - 3.7.3 (2021-05-12)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.5.11 https://github.com/gravitee-io/issues/issues/5541[#5541]
+
+*_Management_*
+
+- API Health-check screen is broken https://github.com/gravitee-io/issues/issues/5511[#5511]
+- Environment permission is needed to display the api events in analytics https://github.com/gravitee-io/issues/issues/5473[#5473]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/376?closed=1[APIM - 3.5.11 (2021-05-07)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- File descriptors exhaustion on POST method with form-data inputfile https://github.com/gravitee-io/issues/issues/5517[#5517]
+- Issue when flushing inbound request queue on an already ended request https://github.com/gravitee-io/issues/issues/5539[#5539]
+
+*_General_*
+
+- Backport #5468 https://github.com/gravitee-io/issues/issues/5504[#5504]
+- CVE#2168 https://github.com/gravitee-io/issues/issues/5450[#5450]
+
+*_Management_*
+
+- /applications?query=A accessible to unauthorized users https://github.com/gravitee-io/issues/issues/5518[#5518]
+- A Membership for member USER and ref GROUP already exists. https://github.com/gravitee-io/issues/issues/5413[#5413]
+- API logs and permissions https://github.com/gravitee-io/issues/issues/5412[#5412]
+- Get an API by its context-path doesn't seem to work on latest version https://github.com/gravitee-io/issues/issues/5298[#5298]
+- Make /portal protected by authentication https://github.com/gravitee-io/issues/issues/5435[#5435]
+- Plan id not preserved on API import https://github.com/gravitee-io/issues/issues/5489[#5489]
+- [healthcheck] add a query parameter in the path without / https://github.com/gravitee-io/issues/issues/5433[#5433]
+
+*_Portal_*
+
+- Do not display "Create an Application" in Portal if user has insufficient privileges https://github.com/gravitee-io/issues/issues/5403[#5403]
+
+*_Reporter_*
+
+- [file] OOM when flush takes a long time https://github.com/gravitee-io/issues/issues/5515[#5515]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/378?closed=1[APIM - 3.8.1 (2021-04-28)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.7.2 https://github.com/gravitee-io/issues/issues/5467[#5467]
+
+=== Features
+
+*_General_*
+
+- APIM dependencies upgrade https://github.com/gravitee-io/issues/issues/5471[#5471]
+- EE docker image jdk upgrade openjdk11:jre-11.0.10_9-alpine https://github.com/gravitee-io/issues/issues/5472[#5472]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/371?closed=1[APIM - 3.7.2 (2021-04-23)]
+
+=== Bug fixes
+
+*_General_*
+
+- Backport #5416 https://github.com/gravitee-io/issues/issues/5421[#5421]
+- Merge 3.5.10 https://github.com/gravitee-io/issues/issues/5466[#5466]
+- Merge 3.6.3 https://github.com/gravitee-io/issues/issues/5446[#5446]
+
+=== Improvements
+
+*_Management_*
+
+- Default Schema is now set to "public" for jdbc https://github.com/gravitee-io/issues/issues/5468[#5468]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/364?closed=1[APIM - 3.5.10 (2021-04-21)]
+
+=== Bug fixes
+
+*_General_*
+
+- API Design Cannot save and deploy policy more than once https://github.com/gravitee-io/issues/issues/5336[#5336]
+- Backport #5159 https://github.com/gravitee-io/issues/issues/5381[#5381]
+- CVE#2168 https://github.com/gravitee-io/issues/issues/5450[#5450]
+- CVE#2169 https://github.com/gravitee-io/issues/issues/5451[#5451]
+
+*_Management_*
+
+- 502 response received on health-check timeout https://github.com/gravitee-io/issues/issues/5342[#5342]
+- A Membership for member USER and ref GROUP already exists. https://github.com/gravitee-io/issues/issues/5413[#5413]
+- Health availability is KO when HC is disabled on a specific endpoint https://github.com/gravitee-io/issues/issues/5365[#5365]
+- Health-check details Response colors to be consistent with colors in the Platform logs https://github.com/gravitee-io/issues/issues/5309[#5309]
+- Improve the user account screen https://github.com/gravitee-io/issues/issues/5376[#5376]
+- Nullpointer exception on OIDC provider login after migration from 1.30 https://github.com/gravitee-io/issues/issues/5410[#5410]
+- Policies configuration form not well displayed https://github.com/gravitee-io/issues/issues/5351[#5351]
+- Search criteria and table offset get lost when clicking 'back to Health-check' https://github.com/gravitee-io/issues/issues/5302[#5302]
+- [portal] unable to logout with OIDC provider https://github.com/gravitee-io/issues/issues/5247[#5247]
+
+*_Managment_*
+
+- API Analytics response payload not displayed, fails with javascript error e.getTextArea is not a function https://github.com/gravitee-io/issues/issues/5364[#5364]
+
+*_Portal_*
+
+- AddressException when trying to submit a Ticket with custom "from" configuration that contains <> https://github.com/gravitee-io/issues/issues/5352[#5352]
+- Documentation pages not displayed (imported from 1.30) https://github.com/gravitee-io/issues/issues/5192[#5192]
+- Inconsistent display in Portal search box https://github.com/gravitee-io/issues/issues/5160[#5160]
+
+=== Features
+
+*_Management_*
+
+- Add icon on policies https://github.com/gravitee-io/issues/issues/5399[#5399]
+
+=== Improvements
+
+*_Management_*
+
+- Allows to sort the logs by API response time https://github.com/gravitee-io/issues/issues/3391[#3391]
+- Naming confusion between path authorizations and resource filtering https://github.com/gravitee-io/issues/issues/5464[#5464]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/241?closed=1[APIM - 3.8.0 (2021-04-16)]
+
+=== Bug fixes
+
+*_Management_*
+
+- API creation and permissions https://github.com/gravitee-io/issues/issues/5416[#5416]
+
+=== Features
+
+*_Gateway_*
+
+- Readiness vs Liveness https://github.com/gravitee-io/issues/issues/4902[#4902]
+- Resource information in health API https://github.com/gravitee-io/issues/issues/4903[#4903]
+
+*_Management_*
+
+- Allow to navigate to previous / next log https://github.com/gravitee-io/issues/issues/4871[#4871]
+- Allows to restore an archived application https://github.com/gravitee-io/issues/issues/4453[#4453]
+- Contact subscribers as an API publisher https://github.com/gravitee-io/issues/issues/4896[#4896]
+- Dashboard of all alerts https://github.com/gravitee-io/issues/issues/4892[#4892]
+- Display groups in user account information https://github.com/gravitee-io/issues/issues/4870[#4870]
+- Private page https://github.com/gravitee-io/issues/issues/4893[#4893]
+- Traffic shadowing https://github.com/gravitee-io/issues/issues/5186[#5186]
+
+*_Policy_*
+
+- [jwt] Allows to configure the client id claims https://github.com/gravitee-io/issues/issues/4900[#4900]
+
+*_Portal_*
+
+- Allows to change favicon https://github.com/gravitee-io/issues/issues/4855[#4855]
+- Override the main sentence in the homepage https://github.com/gravitee-io/issues/issues/4856[#4856]
+
+=== Improvements
+
+*_Gateway_*
+
+- Allow to filter probes on health resource https://github.com/gravitee-io/issues/issues/5236[#5236]
+
+*_Management_*
+
+- Add ACL on the custom links https://github.com/gravitee-io/issues/issues/4563[#4563]
+- [portal] Update ui-component library to 2.3.1 https://github.com/gravitee-io/issues/issues/5389[#5389]
+
+*_Policy_*
+
+- Endpoint reference from policy https://github.com/gravitee-io/issues/issues/5268[#5268]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/370?closed=1[APIM - 3.6.3 (2021-04-15)]
+
+=== Bug fixes
+
+*_Cockpit_*
+
+- Backport #5170 (delete installation) https://github.com/gravitee-io/issues/issues/5430[#5430]
+
+*_Management_*
+
+- Cannot login with new users with newsletter https://github.com/gravitee-io/issues/issues/5423[#5423]
+
+=== Features
+
+*_General_*
+
+- New http-signature policy with support for base64 encoding https://github.com/gravitee-io/issues/issues/5408[#5408]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/363?closed=1[APIM - 3.7.1 (2021-04-10)]
+
+=== Bug fixes
+
+*_General_*
+
+- . This error mainly occurs when the policy is linked to a missing resource, for example a cache or an oauth2 resource. Please check your policy configuration!" https://github.com/gravitee-io/issues/issues/5354[#5354]
+- Merge 3.6.2 https://github.com/gravitee-io/issues/issues/5360[#5360]
+
+
+
+
+== https://github.com/gravitee-io/issues/milestone/358?closed=1[APIM - 3.6.2 (2021-04-06)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.5.9 https://github.com/gravitee-io/issues/issues/5326[#5326]
+
+*_Management_*
+
+- As a simple USER I can see the Analytics dashboard but I have a permission error https://github.com/gravitee-io/issues/issues/5251[#5251]
+- In a multi env context search of APIs is not working well https://github.com/gravitee-io/issues/issues/5296[#5296]
+- Portal authentication settings has disappeared https://github.com/gravitee-io/issues/issues/5278[#5278]
+- Unable to save an api Cron expression must consist of 6 fields (found 0 in \"\") https://github.com/gravitee-io/issues/issues/5118[#5118]
+- User pre-registration does not work with an OIDC provider https://github.com/gravitee-io/issues/issues/5159[#5159]
+
+*_Portal_*
+
+- Example and schema imported from swagger document not displayed in portal https://github.com/gravitee-io/issues/issues/5202[#5202]
+
+== https://github.com/gravitee-io/issues/milestone/361?closed=1[APIM - 3.5.9 (2021-03-30)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.0.16 https://github.com/gravitee-io/issues/issues/5299[#5299]
+- ResonseContainer Annotation does not work for `Page` and `PagedResult` https://github.com/gravitee-io/issues/issues/5289[#5289]
+
+*_Management_*
+
+- Dates are not updated when create/update a category https://github.com/gravitee-io/issues/issues/5275[#5275]
+- JWT Plan - resolver param using JWKS URL with EL get unresolved (Error 404) https://github.com/gravitee-io/issues/issues/5206[#5206]
+- Minimum limit on IDP name is too short https://github.com/gravitee-io/issues/issues/5297[#5297]
+- Unable to subscribe to public apis from an application https://github.com/gravitee-io/issues/issues/5223[#5223]
+- [portal] Groups get lost while changing the Application image in Portal https://github.com/gravitee-io/issues/issues/5274[#5274]
+- [portal] unable to logout with OIDC provider https://github.com/gravitee-io/issues/issues/5247[#5247]
+
+*_Repository_*
+
+- [jdbc] Make the repositories transactional https://github.com/gravitee-io/issues/issues/5284[#5284]
+
+=== Improvements
+
+*_Management_*
+
+- Dynamic newsletter taglines https://github.com/gravitee-io/issues/issues/5269[#5269]
+
+== https://github.com/gravitee-io/issues/milestone/337?closed=1[APIM - 3.0.16 (2021-03-24)]
+
+=== Bug fixes
+
+*_Console_*
+
+- User can not access application analytics https://github.com/gravitee-io/issues/issues/4843[#4843]
+
+*_General_*
+
+- Merge 1.30.30 https://github.com/gravitee-io/issues/issues/4962[#4962]
+- Merge 1.30.31 https://github.com/gravitee-io/issues/issues/5288[#5288]
+
+*_Management_*
+
+- Client side code injection https://github.com/gravitee-io/issues/issues/5031[#5031]
+- Do not use system proxy by default for OAuth authentication https://github.com/gravitee-io/issues/issues/5281[#5281]
+- Enable to search APIs https://github.com/gravitee-io/issues/issues/5043[#5043]
+- Event type button in dashboards are too big https://github.com/gravitee-io/issues/issues/4983[#4983]
+
+*_Oauth2_*
+
+- Oauth2 Authentication of API Portal and API Management have not the same behavior https://github.com/gravitee-io/issues/issues/4058[#4058]
+
+*_Policy_*
+
+- [assign-content] Template Injection https://github.com/gravitee-io/issues/issues/5033[#5033]
+
+*_Portal_*
+
+- Do not display the "add application members" section if the current user has not the permission https://github.com/gravitee-io/issues/issues/4635[#4635]
+
+=== Improvements
+
+*_Management_*
+
+- Access-Control-Allow-Origin regex fail and do not conform with rfc6454 and rfc3986 https://github.com/gravitee-io/issues/issues/4796[#4796]
+
+*_Repository_*
+
+- [jdbc] Add ability to set db schema name https://github.com/gravitee-io/issues/issues/4940[#4940]
+
+== https://github.com/gravitee-io/issues/milestone/240?closed=1[APIM - 3.7.0 (2021-03-23)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.6.1 https://github.com/gravitee-io/issues/issues/5273[#5273]
+
+=== Features
+
+*_Management_*
+
+- Define Group as Primary Owner of an API https://github.com/gravitee-io/issues/issues/5016[#5016]
+- Global markdown template pages https://github.com/gravitee-io/issues/issues/4465[#4465]
+- Searchable Metadata https://github.com/gravitee-io/issues/issues/5017[#5017]
+
+*_Policy_*
+
+- [cache] Support of cache replication across an APIM cluster https://github.com/gravitee-io/issues/issues/599[#599]
+- [oauth2] Add a cache at the policy level https://github.com/gravitee-io/issues/issues/2298[#2298]
+
+*_Repository_*
+
+- Allows to define a prefix for collections / tables https://github.com/gravitee-io/issues/issues/4715[#4715]
+
+=== Improvements
+
+*_Gateway_*
+
+- Add the libraries to allow to write application logs in JSON by changing the logback configuration https://github.com/gravitee-io/issues/issues/5139[#5139]
+
+*_Reporter_*
+
+- Metrics do not expose timestamp for formatters https://github.com/gravitee-io/issues/issues/5097[#5097]
+
+*_Resource_*
+
+- [cache] Allows to limit the cache usage at the platform level https://github.com/gravitee-io/issues/issues/4455[#4455]
+
+== https://github.com/gravitee-io/issues/milestone/348?closed=1[APIM - 3.6.1 (2021-03-19)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.5.5 https://github.com/gravitee-io/issues/issues/5246[#5246]
+- Merge 3.5.6 https://github.com/gravitee-io/issues/issues/5248[#5248]
+- Merge 3.5.7 https://github.com/gravitee-io/issues/issues/5249[#5249]
+- Merge 3.5.8 https://github.com/gravitee-io/issues/issues/5264[#5264]
+- Migration from 3.5.x to 3.6.x fails with MySQL https://github.com/gravitee-io/issues/issues/5175[#5175]
+
+*_Management_*
+
+- Error when trying to log in using an OpenIDConnect Provider https://github.com/gravitee-io/issues/issues/5144[#5144]
+- [multi-org] Allow to change the current organization in the console https://github.com/gravitee-io/issues/issues/5044[#5044]
+
+*_Policy_*
+
+- [hmac]Error 500 on HMAC Http Signature policy https://github.com/gravitee-io/issues/issues/5180[#5180]
+
+*_Portal_*
+
+- Fix the api subscription screen https://github.com/gravitee-io/issues/issues/5103[#5103]
+
+== https://github.com/gravitee-io/issues/milestone/355?closed=1[APIM - 3.5.8 (2021-03-18)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Cannot create dynamic properties https://github.com/gravitee-io/issues/issues/5230[#5230]
+- I18n base path reference is incorrect https://github.com/gravitee-io/issues/issues/5240[#5240]
+- Quality metrics not shown in APIs main page https://github.com/gravitee-io/issues/issues/5238[#5238]
+- Using the right naming convention https://github.com/gravitee-io/issues/issues/5235[#5235]
+- [portal] image media uri is not right https://github.com/gravitee-io/issues/issues/5244[#5244]
+
+*_Policy_*
+
+- [rest-to-soap] Can not use query parameters from SOAP envelope template https://github.com/gravitee-io/issues/issues/5209[#5209]
+
+*_Portal_*
+
+- Application menus are not correctly displayed https://github.com/gravitee-io/issues/issues/5207[#5207]
+- Cannot read menu entries when is in a sticky mode https://github.com/gravitee-io/issues/issues/5233[#5233]
+- Dasboard list have wrong style https://github.com/gravitee-io/issues/issues/5121[#5121]
+- Display type selector cannot be seen well https://github.com/gravitee-io/issues/issues/5234[#5234]
+
+*_Repository_*
+
+- [http] Improve server to execute repository requests https://github.com/gravitee-io/issues/issues/5203[#5203]
+- [http] Remove strong constraint on client / server version https://github.com/gravitee-io/issues/issues/5204[#5204]
+
+== https://github.com/gravitee-io/issues/milestone/353?closed=1[APIM - 3.5.7 (2021-03-11)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Cannot delete a deprecated API anymore https://github.com/gravitee-io/issues/issues/5113[#5113]
+- Some API Logging settings get lost after saving https://github.com/gravitee-io/issues/issues/5164[#5164]
+
+*_Reporter_*
+
+- [tcp | file] Monitor elasticsearch output contains a wrong id value https://github.com/gravitee-io/issues/issues/5181[#5181]
+- [tcp] Reporter must be disabled by default https://github.com/gravitee-io/issues/issues/5183[#5183]
+
+=== Improvements
+
+*_Gateway_*
+
+- Add SNI support https://github.com/gravitee-io/issues/issues/5194[#5194]
+- Heartbeat is storing unlimited events which may cause OOM https://github.com/gravitee-io/issues/issues/5191[#5191]
+
+== https://github.com/gravitee-io/issues/milestone/349?closed=1[APIM - 3.5.6 (2021-03-09)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Can't access a group page if too many users https://github.com/gravitee-io/issues/issues/5083[#5083]
+- Closed plans are visible in the design studio https://github.com/gravitee-io/issues/issues/5122[#5122]
+
+*_Portal_*
+
+- Permissions issue when accessing category documentation https://github.com/gravitee-io/issues/issues/5114[#5114]
+
+*_Repository_*
+
+- [bridge] Unable to retrieve subscriptions for some APIs https://github.com/gravitee-io/issues/issues/5176[#5176]
+
+=== Features
+
+*_Repository_*
+
+- [bridge] Add support for HTTP/S proxy https://github.com/gravitee-io/issues/issues/5178[#5178]
+
+=== Improvements
+
+*_Management_*
+
+- Improve /apis performance https://github.com/gravitee-io/issues/issues/5045[#5045]
+
+== https://github.com/gravitee-io/issues/milestone/344?closed=1[APIM - 3.5.5 (2021-02-24)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- [hc] handle DAYS time unit https://github.com/gravitee-io/issues/issues/5085[#5085]
+
+*_Management_*
+
+- A user should only see APIs it can manage https://github.com/gravitee-io/issues/issues/5096[#5096]
+- EL inputs should be in single line mode https://github.com/gravitee-io/issues/issues/5086[#5086]
+- Handle default value during policy schema validation https://github.com/gravitee-io/issues/issues/5095[#5095]
+- Missing response templates when creating or updating a plan https://github.com/gravitee-io/issues/issues/5110[#5110]
+- User not found when looking for subscriptions https://github.com/gravitee-io/issues/issues/5091[#5091]
+
+*_Policy_*
+
+- [circuit-breaker] Use the correct types in the UI form https://github.com/gravitee-io/issues/issues/5116[#5116]
+
+*_Portal_*
+
+- Css issue when displaying my subscriptions https://github.com/gravitee-io/issues/issues/5094[#5094]
+
+=== Improvements
+
+*_Management-ui_*
+
+- Hide swagger authorization button if try it option is disabled https://github.com/gravitee-io/issues/issues/5100[#5100]
+
+== https://github.com/gravitee-io/issues/milestone/239?closed=1[APIM - 3.6.0 (2021-02-18)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.5.2 https://github.com/gravitee-io/issues/issues/4961[#4961]
+- Merge 3.5.3 https://github.com/gravitee-io/issues/issues/5025[#5025]
+- Merge 3.5.4 https://github.com/gravitee-io/issues/issues/5084[#5084]
+
+=== Features
+
+*_Management_*
+
+- Advanced API logging configuration https://github.com/gravitee-io/issues/issues/4745[#4745]
+- Associate a label to an API deployment https://github.com/gravitee-io/issues/issues/4742[#4742]
+- Be able to enable / disable health-check during some periods https://github.com/gravitee-io/issues/issues/4043[#4043]
+- Cockpit authentication support https://github.com/gravitee-io/issues/issues/4522[#4522]
+- Console dashboard page https://github.com/gravitee-io/issues/issues/4747[#4747]
+- Define HTTP verb for dynamic properties and dictionaries https://github.com/gravitee-io/issues/issues/4746[#4746]
+- Display deployments markups on analytics charts https://github.com/gravitee-io/issues/issues/4743[#4743]
+- Improve logging configuration for GDPR compliance https://github.com/gravitee-io/issues/issues/3919[#3919]
+- Manage Cockpit installation registration https://github.com/gravitee-io/issues/issues/4766[#4766]
+- Move organization & environment creation to command handler https://github.com/gravitee-io/issues/issues/4287[#4287]
+- Policy studio history preview https://github.com/gravitee-io/issues/issues/4749[#4749]
+- Propagate installation events to APIM https://github.com/gravitee-io/issues/issues/4945[#4945]
+- Status page for endpoints based on HC https://github.com/gravitee-io/issues/issues/4750[#4750]
+- [multi-env] Display current environment id in the console URL https://github.com/gravitee-io/issues/issues/4778[#4778]
+
+*_Policy_*
+
+- [assign-metrics] Allows to add some custom metrics in analytics https://github.com/gravitee-io/issues/issues/4769[#4769]
+- [hmac] Enable HMAC authentication https://github.com/gravitee-io/issues/issues/4813[#4813]
+
+*_Reporter_*
+
+- [elasticsearch] Auto-enable geo-ip, user-agent when Elasticsearch >= 7.x https://github.com/gravitee-io/issues/issues/4744[#4744]
+
+=== Improvements
+
+*_Analytics_*
+
+- Improve Log detail view https://github.com/gravitee-io/issues/issues/4815[#4815]
+
+*_Identity-providers_*
+
+- [multi-env] Adapt role mapping screen for multi-environment https://github.com/gravitee-io/issues/issues/4803[#4803]
+
+*_Management_*
+
+- Add more configuration options on dynamic dictionaries / properties https://github.com/gravitee-io/issues/issues/4447[#4447]
+- Allows to select groups while creating an API https://github.com/gravitee-io/issues/issues/4449[#4449]
+- [multi-env] Handle environment switching https://github.com/gravitee-io/issues/issues/4777[#4777]
+- [multi-env] Handle user without environments permissions https://github.com/gravitee-io/issues/issues/4774[#4774]
+- [multi-env]Default application creation https://github.com/gravitee-io/issues/issues/4776[#4776]
+
+*_Policy_*
+
+- [json-xml] Allows to transform a JSON to a XML https://github.com/gravitee-io/issues/issues/4561[#4561]
+
+*_Portal_*
+
+- Display the category selected to navigate to the current API page https://github.com/gravitee-io/issues/issues/4466[#4466]
+- EN typo https://github.com/gravitee-io/issues/issues/4857[#4857]
+
+== https://github.com/gravitee-io/issues/milestone/342?closed=1[APIM - 3.5.4 (2021-02-15)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Policies are executed following wrong order for response stream policy flow https://github.com/gravitee-io/issues/issues/5054[#5054]
+- [healthcheck] Exception on HC request should return a 502 instead of 503 https://github.com/gravitee-io/issues/issues/5059[#5059]
+
+*_General_*
+
+- Backport #4653 https://github.com/gravitee-io/issues/issues/5076[#5076]
+
+*_Management_*
+
+- Enable to search APIs https://github.com/gravitee-io/issues/issues/5080[#5080]
+- Unable to delete a metadata when I delete an API https://github.com/gravitee-io/issues/issues/5000[#5000]
+- [policy-studio] Impossible to scroll on code field when have long text https://github.com/gravitee-io/issues/issues/5060[#5060]
+
+*_Management-api_*
+
+- Do not expose sensitive information from settings endpoint https://github.com/gravitee-io/issues/issues/5034[#5034]
+
+*_Management-ui_*
+
+- Calendar widget is not accurate https://github.com/gravitee-io/issues/issues/5027[#5027]
+
+*_Policy_*
+
+- [groovy] add documentation in the studio https://github.com/gravitee-io/issues/issues/5077[#5077]
+- [groovy] unable to whitelist array.getAt https://github.com/gravitee-io/issues/issues/5075[#5075]
+
+*_Repository_*
+
+- [mongodb] Unable to save dictionary with properties containing a dot https://github.com/gravitee-io/issues/issues/5072[#5072]
+
+=== Improvements
+
+*_General_*
+
+- Missing id_token_hint on logout endpoint https://github.com/gravitee-io/issues/issues/4975[#4975]
+
+== https://github.com/gravitee-io/issues/milestone/339?closed=1[APIM - 3.5.3 (2021-02-06)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Problem with the execution order of the policies of a response flow https://github.com/gravitee-io/issues/issues/4973[#4973]
+
+*_General_*
+
+- Merge 3.4.3 https://github.com/gravitee-io/issues/issues/5001[#5001]
+
+*_Management_*
+
+- Cannot deploy APIs with configured HTTP headers at the endpoint level or health check https://github.com/gravitee-io/issues/issues/4963[#4963]
+- Manage WSDL imports when creating or updating an API https://github.com/gravitee-io/issues/issues/4976[#4976]
+- Policies on path are not updated when updating an API with swagger https://github.com/gravitee-io/issues/issues/4970[#4970]
+- SecurityDefinition is missing when migrating API from v1 to v2 definition https://github.com/gravitee-io/issues/issues/4979[#4979]
+
+== https://github.com/gravitee-io/issues/milestone/327?closed=1[APIM - 3.4.3 (2021-02-01)]
+
+=== Bug fixes
+
+*_General_*
+
+- Backport #4592 to 3.4.x https://github.com/gravitee-io/issues/issues/4864[#4864]
+- Backport #4797 to 3.4.x https://github.com/gravitee-io/issues/issues/4800[#4800]
+- Backport 4761 https://github.com/gravitee-io/issues/issues/4783[#4783]
+- Client ID and Client Secret are not shown in developer portal https://github.com/gravitee-io/issues/issues/4779[#4779]
+- Merge 3.0.14 https://github.com/gravitee-io/issues/issues/4853[#4853]
+- Merge 3.0.15 https://github.com/gravitee-io/issues/issues/4923[#4923]
+
+*_Management_*
+
+- A new invited user does not have environment role https://github.com/gravitee-io/issues/issues/4833[#4833]
+- Dictionary start/stop API fails in case of empty Accept header https://github.com/gravitee-io/issues/issues/4740[#4740]
+- Duplicate pages when importing an API https://github.com/gravitee-io/issues/issues/4944[#4944]
+- Fix swagger documentation https://github.com/gravitee-io/issues/issues/4726[#4726]
+- Improve attach media feature https://github.com/gravitee-io/issues/issues/4702[#4702]
+- Manage rights on the plans displayed on the policy studio https://github.com/gravitee-io/issues/issues/4770[#4770]
+- OpenAPI with external $ref is not well parsed https://github.com/gravitee-io/issues/issues/4967[#4967]
+- Swagger type is not sync with API model https://github.com/gravitee-io/issues/issues/4788[#4788]
+- [studio] scope is not automaticaly selected https://github.com/gravitee-io/issues/issues/4801[#4801]
+
+*_Portal_*
+
+- Enable to subscribe to a jwt plan with an app with a client_id https://github.com/gravitee-io/issues/issues/4724[#4724]
+- Has invalid dates when viewing a pending subscription https://github.com/gravitee-io/issues/issues/4873[#4873]
+
+=== Improvements
+
+*_Gateway_*
+
+- Allow to use the system proxy for the endpoint health check https://github.com/gravitee-io/issues/issues/4627[#4627]
+
+*_Management_*
+
+- Handle input type password in schema form https://github.com/gravitee-io/issues/issues/4701[#4701]
+
+*_Repository_*
+
+- [mongodb] Improve 3.4.0 update script https://github.com/gravitee-io/issues/issues/4881[#4881]
+
+== https://github.com/gravitee-io/issues/milestone/334?closed=1[APIM - 3.5.2 (2021-01-22)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- PathParametersIndexProcessor error for specific request pathInfo https://github.com/gravitee-io/issues/issues/4960[#4960]
+
+*_Management_*
+
+- Disable default username / password for SMTP https://github.com/gravitee-io/issues/issues/4913[#4913]
+- Error when trying to access Design menu with new design studio and without admin rights https://github.com/gravitee-io/issues/issues/4925[#4925]
+- Social authentication is not working anymore https://github.com/gravitee-io/issues/issues/4937[#4937]
+
+*_Policy_*
+
+- [ip-filtering] Empty IPs can be defined as part of whitelist / blacklist https://github.com/gravitee-io/issues/issues/4912[#4912]
+- [rest-to-soap] do not override request path info https://github.com/gravitee-io/issues/issues/4860[#4860]
+
+*_Repository_*
+
+- [elasticsearch] Retry is not working in case of non 2xx status code https://github.com/gravitee-io/issues/issues/4919[#4919]
+
+=== Improvements
+
+*_Management_*
+
+- Newsletter improvment https://github.com/gravitee-io/issues/issues/4692[#4692]
+- Social idp are not enabled after creation https://github.com/gravitee-io/issues/issues/4956[#4956]
+
+*_Portal_*
+
+- Align delete link in aside box https://github.com/gravitee-io/issues/issues/4926[#4926]
+
+== https://github.com/gravitee-io/issues/milestone/329?closed=1[APIM - 3.0.15 (2021-01-18)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Add HTTP proxy configuration for the OAuth2AuthenticationResource https://github.com/gravitee-io/issues/issues/4398[#4398]
+- I18n error on console start in production mode https://github.com/gravitee-io/issues/issues/4878[#4878]
+- Input not disable for application group https://github.com/gravitee-io/issues/issues/4710[#4710]
+- Unable to finalize user invitation https://github.com/gravitee-io/issues/issues/4858[#4858]
+
+*_Repository_*
+
+- [jdbc] Cannot remove a group anymore in some case https://github.com/gravitee-io/issues/issues/4785[#4785]
+
+=== Improvements
+
+*_Resource_*
+
+- [am] Add trailing slash to the URL automatically https://github.com/gravitee-io/issues/issues/4907[#4907]
+
+== https://github.com/gravitee-io/issues/milestone/324?closed=1[APIM - 3.5.1 (2021-01-13)]
+
+=== Bug fixes
+
+*_Console_*
+
+- Contextual documentation `management-configuration-identityproviders.md` is missing https://github.com/gravitee-io/issues/issues/4890[#4890]
+- Revoked apikey can not be reactived https://github.com/gravitee-io/issues/issues/4850[#4850]
+
+*_Gateway_*
+
+- ALPN is enabled by default if ssl is disabled https://github.com/gravitee-io/issues/issues/4887[#4887]
+
+*_Management_*
+
+- Mails are not sent anymore with authenticated smtp https://github.com/gravitee-io/issues/issues/4904[#4904]
+- Missing environment id when fetching current user tasks https://github.com/gravitee-io/issues/issues/4862[#4862]
+- Swagger parsing with fully resolve mode may result in OOM https://github.com/gravitee-io/issues/issues/4906[#4906]
+- WSDL import generate wrong scope for `xml-to-json` policy https://github.com/gravitee-io/issues/issues/4879[#4879]
+
+*_Ui_*
+
+- Alert menu does not appears anymore at API level https://github.com/gravitee-io/issues/issues/4908[#4908]
+
+=== Improvements
+
+*_Policy_*
+
+- [Retry] Use Expression Language Editor in schema-form https://github.com/gravitee-io/issues/issues/4844[#4844]
+
+== https://github.com/gravitee-io/issues/milestone/316?closed=1[APIM - 3.0.14 (2020-12-28)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Unable to disable websockets support https://github.com/gravitee-io/issues/issues/4476[#4476]
+- Unable to establish websocket connection https://github.com/gravitee-io/issues/issues/4768[#4768]
+
+*_General_*
+
+- Backport #4798 to 3.0.x https://github.com/gravitee-io/issues/issues/4846[#4846]
+- Backport #4825 to 3.0.x https://github.com/gravitee-io/issues/issues/4826[#4826]
+- Backport 4669 to 3.0.x https://github.com/gravitee-io/issues/issues/4670[#4670]
+- Backport 4678 https://github.com/gravitee-io/issues/issues/4679[#4679]
+- Backport 4680 https://github.com/gravitee-io/issues/issues/4681[#4681]
+- Backport 4823 to 3.0.x https://github.com/gravitee-io/issues/issues/4824[#4824]
+- Inconsistent synchronization between portal and management ui when using OIDC https://github.com/gravitee-io/issues/issues/4532[#4532]
+- Merge 1.30.29 https://github.com/gravitee-io/issues/issues/4794[#4794]
+
+*_Management_*
+
+- API import not working with a documentation fetcher from a future version (configuration not compatible) https://github.com/gravitee-io/issues/issues/4806[#4806]
+- Add HTTP proxy configuration for the AMAuthenticationResource https://github.com/gravitee-io/issues/issues/4832[#4832]
+- Cannot define a scope on Authentication creation but only on update https://github.com/gravitee-io/issues/issues/4684[#4684]
+- Closing a subscription with an expiry date is still active https://github.com/gravitee-io/issues/issues/4799[#4799]
+- Hits by country not well sorted https://github.com/gravitee-io/issues/issues/4668[#4668]
+- Markdown generation issue with too big images https://github.com/gravitee-io/issues/issues/4810[#4810]
+
+*_Portal_*
+
+- Do not display error when metrics cannot be retrieved on an application https://github.com/gravitee-io/issues/issues/4677[#4677]
+- Link to an unpublished API should not be display in subscriptions https://github.com/gravitee-io/issues/issues/4836[#4836]
+- User without rights on Applications should not see the menu and be able to browse the dashboard https://github.com/gravitee-io/issues/issues/4675[#4675]
+
+=== Improvements
+
+*_Management_*
+
+- Update user profile information https://github.com/gravitee-io/issues/issues/4618[#4618]
+
+== https://github.com/gravitee-io/issues/milestone/238?closed=1[APIM - 3.5.0 (2020-12-23)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Avoid usage of URI.create to handle properly path and query parameters with special caracters https://github.com/gravitee-io/issues/issues/4837[#4837]
+
+*_General_*
+
+- Merge 3.4.1 https://github.com/gravitee-io/issues/issues/4775[#4775]
+- Merge 3.4.2 https://github.com/gravitee-io/issues/issues/4790[#4790]
+- Report bug 4756 to master https://github.com/gravitee-io/issues/issues/4757[#4757]
+
+*_Identity-providers_*
+
+- Can't sign in on console with an IDP that is not enabled for portal https://github.com/gravitee-io/issues/issues/4797[#4797]
+
+*_Management_*
+
+- An api-key can not be reactivated for a closed plan https://github.com/gravitee-io/issues/issues/4798[#4798]
+- Cannot change an existing plan to add restrictions https://github.com/gravitee-io/issues/issues/4761[#4761]
+- Environment Role is not being set with Role Mapping https://github.com/gravitee-io/issues/issues/4762[#4762]
+
+*_Policy_*
+
+- [CalloutHttp] variables should be optional https://github.com/gravitee-io/issues/issues/4818[#4818]
+
+*_Portal_*
+
+- 404 when filtering on all APIs https://github.com/gravitee-io/issues/issues/4823[#4823]
+- Missing one API when filtering by category https://github.com/gravitee-io/issues/issues/4825[#4825]
+
+=== Features
+
+*_Gateway_*
+
+- Fine-grained conditional policies https://github.com/gravitee-io/issues/issues/60[#60]
+- Handle best match on the policy flows https://github.com/gravitee-io/issues/issues/4598[#4598]
+
+*_Management_*
+
+- Allows to migrate from policy studio v1 to v2 https://github.com/gravitee-io/issues/issues/4589[#4589]
+- Default response template per API https://github.com/gravitee-io/issues/issues/4464[#4464]
+
+*_Policy_*
+
+- Retry policy https://github.com/gravitee-io/issues/issues/4802[#4802]
+
+=== Improvements
+
+*_Gateway_*
+
+- Support for cipher suites configuration https://github.com/gravitee-io/issues/issues/4541[#4541]
+
+*_General_*
+
+- Change the subject of emails about adding members https://github.com/gravitee-io/issues/issues/4809[#4809]
+
+*_Management_*
+
+- Better handling of settings (report #4787) https://github.com/gravitee-io/issues/issues/4804[#4804]
+- Make APIM Console multi-env ready https://github.com/gravitee-io/issues/issues/4151[#4151]
+- Multi tenancy parameters - implementation https://github.com/gravitee-io/issues/issues/4642[#4642]
+
+*_Policies_*
+
+- Update documentation https://github.com/gravitee-io/issues/issues/4831[#4831]
+
+*_Repository_*
+
+- [redis] Add support for Redis Sentinel https://github.com/gravitee-io/issues/issues/79[#79]
+
+== https://github.com/gravitee-io/issues/milestone/321?closed=1[APIM - 3.4.2 (2020-12-13)]
+
+=== Bug fixes
+
+*_General_*
+
+- Backport 4762 to 3.4.x https://github.com/gravitee-io/issues/issues/4780[#4780]
+
+*_Management_*
+
+- Wrong email template when resetting a password https://github.com/gravitee-io/issues/issues/4756[#4756]
+
+=== Improvements
+
+*_Management_*
+
+- Better handling of settings https://github.com/gravitee-io/issues/issues/4787[#4787]
+
+== https://github.com/gravitee-io/issues/milestone/317?closed=1[APIM - 3.4.1 (2020-12-08)]
+
+=== Bug fixes
+
+*_Management_*
+
+- API importing block is too small and does not scroll https://github.com/gravitee-io/issues/issues/4723[#4723]
+- Cannot create a plan with rate limiting restriction on an API created with the new design studio https://github.com/gravitee-io/issues/issues/4700[#4700]
+- Cannot save good script values on Grooy policy with policy-studio https://github.com/gravitee-io/issues/issues/4712[#4712]
+- Create or Update API with duplicated label fails with SQLIntegrityConstraintViolationException https://github.com/gravitee-io/issues/issues/4704[#4704]
+- Ignore missing properties when updating settings. https://github.com/gravitee-io/issues/issues/4682[#4682]
+- Not able to define mock body with policy studio https://github.com/gravitee-io/issues/issues/4665[#4665]
+- Sometimes APIs are not well deployed in gateway https://github.com/gravitee-io/issues/issues/4707[#4707]
+- Wrong format of securitydefinition when create a plan https://github.com/gravitee-io/issues/issues/4714[#4714]
+- [policy-validate-request] unable to create a complex validation https://github.com/gravitee-io/issues/issues/4722[#4722]
+
+*_Portal_*
+
+- Media links are not well computed https://github.com/gravitee-io/issues/issues/4669[#4669]
+
+== https://github.com/gravitee-io/issues/milestone/309?closed=1[APIM - 3.3.4 (2020-12-01)]
+
+=== Bug fixes
+
+*_General_*
+
+- Backport #4655 to 3.3.x https://github.com/gravitee-io/issues/issues/4657[#4657]
+- Backport 4578 https://github.com/gravitee-io/issues/issues/4608[#4608]
+- Backport 4591 https://github.com/gravitee-io/issues/issues/4607[#4607]
+- Backport 4620 and 4669 to 3.3.x https://github.com/gravitee-io/issues/issues/4630[#4630]
+- Backport 4634 to 3.3.x https://github.com/gravitee-io/issues/issues/4636[#4636]
+- Merge 3.2.3 https://github.com/gravitee-io/issues/issues/4676[#4676]
+
+*_Portal_*
+
+- Example cURL not displayed for an unpublished API on subscriptions https://github.com/gravitee-io/issues/issues/4680[#4680]
+
+*_Reporter_*
+
+- [elasticsearch] Template mapping of log is incorrect with ES 7.x https://github.com/gravitee-io/issues/issues/4685[#4685]
+
+*_Repository_*
+
+- [jdbc] Simple user without groups can see all the applications https://github.com/gravitee-io/issues/issues/4678[#4678]
+
+=== Improvements
+
+*_Management_*
+
+- Check that the version of the accepted CGU is the current one https://github.com/gravitee-io/issues/issues/4603[#4603]
+- Manage attached resources in API import/export https://github.com/gravitee-io/issues/issues/4315[#4315]
+
+== https://github.com/gravitee-io/issues/milestone/304?closed=1[APIM - 3.2.3 (2020-11-27)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.0.13 https://github.com/gravitee-io/issues/issues/4671[#4671]
+
+*_Management_*
+
+- Backport #4551 on 3.2.x https://github.com/gravitee-io/issues/issues/4552[#4552]
+- Cannot reorder a page anymore https://github.com/gravitee-io/issues/issues/4417[#4417]
+- Forbidden access with a Authorization bearer token https://github.com/gravitee-io/issues/issues/4440[#4440]
+- Null constraint violation with jdbc repository at startup https://github.com/gravitee-io/issues/issues/4521[#4521]
+
+== https://github.com/gravitee-io/issues/milestone/310?closed=1[APIM - 3.0.13 (2020-11-26)]
+
+=== Bug fixes
+
+*_General_*
+
+- Backport #4620 to 3.0.x https://github.com/gravitee-io/issues/issues/4629[#4629]
+- Backport 4585 https://github.com/gravitee-io/issues/issues/4606[#4606]
+- Backport 4591 to 3.0.x https://github.com/gravitee-io/issues/issues/4619[#4619]
+- Merge 1.30.26 https://github.com/gravitee-io/issues/issues/4663[#4663]
+
+*_Management_*
+
+- API not found on global dashboard when deleted https://github.com/gravitee-io/issues/issues/4573[#4573]
+- Cannot create an API and ask for review https://github.com/gravitee-io/issues/issues/4571[#4571]
+- Config file user roles are ignored when user is assigned to a group before his first login https://github.com/gravitee-io/issues/issues/4586[#4586]
+- Export logs in CSV should contain the user when it is displayed https://github.com/gravitee-io/issues/issues/4659[#4659]
+- Importing theme with images fails https://github.com/gravitee-io/issues/issues/4179[#4179]
+- Improve UI when search user to add https://github.com/gravitee-io/issues/issues/4599[#4599]
+- Location header does not contain full path to resource https://github.com/gravitee-io/issues/issues/4624[#4624]
+- Unable to delete the homepage background https://github.com/gravitee-io/issues/issues/4213[#4213]
+
+*_Portal_*
+
+- Cannot list more than 10 plans during the subscription https://github.com/gravitee-io/issues/issues/4653[#4653]
+- Cannot search on labels with some special characters https://github.com/gravitee-io/issues/issues/4661[#4661]
+- Missing X-Xsrf-Token header from the portal UI in APIM https://github.com/gravitee-io/issues/issues/4628[#4628]
+- Size list of application log is not well updated https://github.com/gravitee-io/issues/issues/4662[#4662]
+
+=== Improvements
+
+*_Management_*
+
+- Allows to export all the logs in a CSV and not only the current page https://github.com/gravitee-io/issues/issues/4664[#4664]
+
+== https://github.com/gravitee-io/issues/milestone/237?closed=1[APIM - 3.4.0 (2020-11-24)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Graceful shutdown on streamFailWith https://github.com/gravitee-io/issues/issues/4648[#4648]
+- Manage graceful shutdown for 3.x https://github.com/gravitee-io/issues/issues/4632[#4632]
+
+*_General_*
+
+- Add an API from another docker-compose stack than the Gravitee one https://github.com/gravitee-io/issues/issues/4640[#4640]
+- Typo in french portal translation when connection issues https://github.com/gravitee-io/issues/issues/4504[#4504]
+
+*_Management_*
+
+- Cannot create an API from a Gravitee.io definition anymore https://github.com/gravitee-io/issues/issues/4570[#4570]
+- Default admin can't see/go to the dashboard and settings menu https://github.com/gravitee-io/issues/issues/4591[#4591]
+- Default application is not correctly created for social / OAuth login https://github.com/gravitee-io/issues/issues/4634[#4634]
+- Impossible to move documentation page to folder https://github.com/gravitee-io/issues/issues/4655[#4655]
+- Portal and Schedulers sections appear two times in settings https://github.com/gravitee-io/issues/issues/4578[#4578]
+- Redoc is not working with a private API on dist https://github.com/gravitee-io/issues/issues/4585[#4585]
+- [quality-rules]unable to create a new quality-rule https://github.com/gravitee-io/issues/issues/4602[#4602]
+
+*_Plugin_*
+
+- Ensure plugin loading order https://github.com/gravitee-io/issues/issues/4486[#4486]
+
+*_Portal_*
+
+- Image links are broken on portal documentation https://github.com/gravitee-io/issues/issues/4620[#4620]
+
+=== Features
+
+*_Gateway_*
+
+- Forward the X-Forwarded-Prefix to the backend endpoint https://github.com/gravitee-io/issues/issues/4434[#4434]
+- Support for path-named parameters in Expression Language (EL) https://github.com/gravitee-io/issues/issues/4431[#4431]
+
+*_Management_*
+
+- Allows to manage authentication identity providers on the portal https://github.com/gravitee-io/issues/issues/3963[#3963]
+- Global reviewer https://github.com/gravitee-io/issues/issues/4436[#4436]
+- Label's dictionary https://github.com/gravitee-io/issues/issues/4437[#4437]
+- Move CORS from static to dynamic configuration https://github.com/gravitee-io/issues/issues/4432[#4432]
+- Move SMTP from static to dynamic configuration https://github.com/gravitee-io/issues/issues/4433[#4433]
+- Move notification templates in the UI https://github.com/gravitee-io/issues/issues/4297[#4297]
+- Override settings via envvars https://github.com/gravitee-io/issues/issues/4452[#4452]
+- Support tickets history https://github.com/gravitee-io/issues/issues/4435[#4435]
+- [audit] Adapt audit system to Orgs & Envs https://github.com/gravitee-io/issues/issues/3976[#3976]
+
+*_Policy_*
+
+- [api-key] Allows to define custom api-key https://github.com/gravitee-io/issues/issues/4318[#4318]
+
+*_Reporter_*
+
+- [file] File reporter to write raw data (csv format) https://github.com/gravitee-io/issues/issues/4236[#4236]
+- [tcp] Add support for a TCP reporter https://github.com/gravitee-io/issues/issues/4584[#4584]
+
+*_Repository_*
+
+- [hazelcast] Rate-limit support https://github.com/gravitee-io/issues/issues/4527[#4527]
+
+=== Improvements
+
+*_Management_*
+
+- Allows to configure statically the theme https://github.com/gravitee-io/issues/issues/4456[#4456]
+- Allows to define the background color of the login page from the theme https://github.com/gravitee-io/issues/issues/4458[#4458]
+- Improve API Quality checks display https://github.com/gravitee-io/issues/issues/3201[#3201]
+- Remove i18n support on the management UI https://github.com/gravitee-io/issues/issues/4485[#4485]
+
+*_Policy_*
+
+- [aws-lambda] Allows to extract data in execution context from payload https://github.com/gravitee-io/issues/issues/4395[#4395]
+
+== https://github.com/gravitee-io/issues/milestone/303?closed=1[APIM - 3.0.12 (2020-11-15)]
+
+=== Bug fixes
+
+*_General_*
+
+- Backport 4602 https://github.com/gravitee-io/issues/issues/4604[#4604]
+- Merge 1.30.25 https://github.com/gravitee-io/issues/issues/4610[#4610]
+
+*_Swagger_*
+
+- Only validate swagger content on create/update https://github.com/gravitee-io/issues/issues/4605[#4605]
+
+*_Ui-components_*
+
+- Double icon rendering on gv-table https://github.com/gravitee-io/issues/issues/4523[#4523]
+
+=== Improvements
+
+*_Gateway_*
+
+- HTTP code 414 (URL too long) with gateway https://github.com/gravitee-io/issues/issues/4534[#4534]
+- Support for TLS 1.3 https://github.com/gravitee-io/issues/issues/4065[#4065]
+
+== https://github.com/gravitee-io/issues/milestone/306?closed=1[APIM - 3.3.3 (2020-11-04)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Cannot update roles of a user anymore https://github.com/gravitee-io/issues/issues/4551[#4551]
+
+== https://github.com/gravitee-io/issues/milestone/305?closed=1[APIM - 3.3.2 (2020-11-03)]
+
+=== Bug fixes
+
+*_Management-ui_*
+
+- Connection pool min limit for an endpoint should be 1 and not 10 https://github.com/gravitee-io/issues/issues/4543[#4543]
+
+== https://github.com/gravitee-io/issues/milestone/292?closed=1[APIM - 3.3.1 (2020-11-03)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.2.2 https://github.com/gravitee-io/issues/issues/4559[#4559]
+
+*_Management_*
+
+- Impossible to create Cache Policy https://github.com/gravitee-io/issues/issues/4478[#4478]
+
+=== Improvements
+
+*_Management_*
+
+- Coherence between api import with definition and with swagger https://github.com/gravitee-io/issues/issues/4411[#4411]
+- Typo in _depreciate subpath https://github.com/gravitee-io/issues/issues/4414[#4414]
+
+== https://github.com/gravitee-io/issues/milestone/291?closed=1[APIM - 3.2.2 (2020-11-04)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.0.10 https://github.com/gravitee-io/issues/issues/4515[#4515]
+- Merge 3.0.11 https://github.com/gravitee-io/issues/issues/4558[#4558]
+- Merge 3.0.9 https://github.com/gravitee-io/issues/issues/4424[#4424]
+
+*_Management_*
+
+- Missing description in operation response when import WSDL https://github.com/gravitee-io/issues/issues/4416[#4416]
+
+== https://github.com/gravitee-io/issues/milestone/301?closed=1[APIM - 3.0.11 (2020-10-31)]
+
+=== Bug fixes
+
+*_Jdbc-repository_*
+
+- Liquibase checksum fail when migrating from 3.0.6 to 3.0.7 https://github.com/gravitee-io/issues/issues/4526[#4526]
+
+=== Improvements
+
+*_Gateway_*
+
+- Allowing constructors in expression language https://github.com/gravitee-io/issues/issues/4514[#4514]
+
+== https://github.com/gravitee-io/issues/milestone/294?closed=1[APIM - 3.0.10 (2020-10-27)]
+
+=== Bug fixes
+
+*_General_*
+
+- Create dedicated resource to change user password https://github.com/gravitee-io/issues/issues/4480[#4480]
+- Ensure bad response are considered as errors https://github.com/gravitee-io/issues/issues/4513[#4513]
+- Merge 1.30.24 https://github.com/gravitee-io/issues/issues/4491[#4491]
+- Missing mapping for orgId and envId in swagger definition generated for management Rest-API https://github.com/gravitee-io/issues/issues/4394[#4394]
+
+*_Management_*
+
+- As standard user i see an administration link on portal UI https://github.com/gravitee-io/issues/issues/4399[#4399]
+- Change background color for theme logo https://github.com/gravitee-io/issues/issues/4444[#4444]
+- Error while searching through LDAP to transfer application https://github.com/gravitee-io/issues/issues/4441[#4441]
+- Improve the force login feature https://github.com/gravitee-io/issues/issues/4412[#4412]
+- Removing a user from a role, removes the user from all roles of the scope https://github.com/gravitee-io/issues/issues/4501[#4501]
+- Resetting password from Portal UI should not invalidate password https://github.com/gravitee-io/issues/issues/4410[#4410]
+
+*_Portal_*
+
+- Anchor links not working correctly https://github.com/gravitee-io/issues/issues/2161[#2161]
+- Code preview display as block for inline code https://github.com/gravitee-io/issues/issues/4404[#4404]
+- Display of a large API name broken on a table list https://github.com/gravitee-io/issues/issues/4035[#4035]
+- Version too large in the dashboard's subscriptions https://github.com/gravitee-io/issues/issues/4461[#4461]
+
+*_Repository_*
+
+- [http-bridge] Gateway does not resync (gateway-bridge-http) after network issue https://github.com/gravitee-io/issues/issues/4505[#4505]
+
+=== Improvements
+
+*_Portal_*
+
+- Allows to get the portal's version https://github.com/gravitee-io/issues/issues/4459[#4459]
+- Hide empty categories https://github.com/gravitee-io/issues/issues/4477[#4477]
+
+== https://github.com/gravitee-io/issues/milestone/236?closed=1[APIM - 3.3.0 (2020-10-15)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.2.1 https://github.com/gravitee-io/issues/issues/4385[#4385]
+
+*_Management_*
+
+- Import of OpenAPI/Swagger containing path definition with parentheses and url parameters failed https://github.com/gravitee-io/issues/issues/4336[#4336]
+
+*_Policy_*
+
+- [json-validation] Scope Enum modification https://github.com/gravitee-io/issues/issues/4420[#4420]
+
+*_Portal_*
+
+- Fix typo in EN https://github.com/gravitee-io/issues/issues/4379[#4379]
+
+=== Features
+
+*_Management_*
+
+- Support for custom Swagger tags to define API's information https://github.com/gravitee-io/issues/issues/4295[#4295]
+- [identity-provider]Users and IdentityProviders can only be attached to an organization https://github.com/gravitee-io/issues/issues/3973[#3973]
+
+*_Policy_*
+
+- AWS Lambda Function https://github.com/gravitee-io/issues/issues/4276[#4276]
+- [json-validation] Integration with swagger / OpenAPI https://github.com/gravitee-io/issues/issues/4293[#4293]
+- [spike-arrest] Protect backend against overload https://github.com/gravitee-io/issues/issues/4296[#4296]
+- [xml-validation] Integration with swagger / OpenAPI https://github.com/gravitee-io/issues/issues/4294[#4294]
+
+== https://github.com/gravitee-io/issues/milestone/287?closed=1[APIM - 3.0.9 (2020-10-09)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 1.30.22 https://github.com/gravitee-io/issues/issues/4346[#4346]
+- Merge 1.30.23 https://github.com/gravitee-io/issues/issues/4390[#4390]
+
+*_Management_*
+
+- Blank page when selecting multiple times the setting menu https://github.com/gravitee-io/issues/issues/4392[#4392]
+- Error popup after a login with an OIDC provider https://github.com/gravitee-io/issues/issues/4290[#4290]
+- Import of an existing api fail since 3.2 https://github.com/gravitee-io/issues/issues/4397[#4397]
+
+*_Migration_*
+
+- Duplicate memberships after v3 migration https://github.com/gravitee-io/issues/issues/4382[#4382]
+
+*_Portal_*
+
+- Align EN translations for rating https://github.com/gravitee-io/issues/issues/4388[#4388]
+- Cannot display payloads on a log https://github.com/gravitee-io/issues/issues/4048[#4048]
+- Fix typo in EN https://github.com/gravitee-io/issues/issues/4383[#4383]
+- In Prod mode, folders in documentation can not be expanded https://github.com/gravitee-io/issues/issues/4275[#4275]
+- Log's title truncated https://github.com/gravitee-io/issues/issues/4054[#4054]
+- Redoc does not use gateway url but portal url https://github.com/gravitee-io/issues/issues/4389[#4389]
+- Remove the useless portal title from settings https://github.com/gravitee-io/issues/issues/4370[#4370]
+
+*_Repository_*
+
+- [jdbc] Startup repository error when using MySQL 8.0.15 plugin/driver https://github.com/gravitee-io/issues/issues/4255[#4255]
+
+=== Features
+
+*_Management_*
+
+- Remove the Application picture https://github.com/gravitee-io/issues/issues/4316[#4316]
+
+=== Improvements
+
+*_Management_*
+
+- Improve canReadAPI method https://github.com/gravitee-io/issues/issues/4401[#4401]
+
+*_Management-api_*
+
+- Create Subscription not returning subscription keys https://github.com/gravitee-io/issues/issues/4171[#4171]
+
+== https://github.com/gravitee-io/issues/milestone/286?closed=1[APIM - 3.2.1 (2020-10-01)]
+
+=== Bug fixes
+
+*_Policy_*
+
+- [ipfiltering] Socket leak with DNS resolution https://github.com/gravitee-io/issues/issues/4362[#4362]
+- [quota] Inconsistent body for Quota at V3.2 https://github.com/gravitee-io/issues/issues/4345[#4345]
+
+== https://github.com/gravitee-io/issues/milestone/234?closed=1[APIM - 3.2.0 (2020-09-22)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.1.3 https://github.com/gravitee-io/issues/issues/4261[#4261]
+- Merge 3.1.4 https://github.com/gravitee-io/issues/issues/4299[#4299]
+
+*_Reporter_*
+
+- [elasticsearch] invalid default value for ILM lifecycle property name https://github.com/gravitee-io/issues/issues/4303[#4303]
+
+=== Features
+
+*_Fetcher_*
+
+- Add a cron task to fetch the documentation https://github.com/gravitee-io/issues/issues/3196[#3196]
+
+*_Management_*
+
+- Associate assets to a page https://github.com/gravitee-io/issues/issues/4066[#4066]
+- Associate page to a category https://github.com/gravitee-io/issues/issues/4067[#4067]
+- Custom user fields https://github.com/gravitee-io/issues/issues/4070[#4070]
+- General Conditions of use (when subscribing to a plan) https://github.com/gravitee-io/issues/issues/4068[#4068]
+- Process to validate an account (registration) https://github.com/gravitee-io/issues/issues/4069[#4069]
+
+*_Management-api_*
+
+- Create api from a WSDL https://github.com/gravitee-io/issues/issues/322[#322]
+
+*_Policy_*
+
+- WS-Security based authentication https://github.com/gravitee-io/issues/issues/4247[#4247]
+- [basic-auth] Protect api w/ simple basic auth https://github.com/gravitee-io/issues/issues/689[#689]
+- [rate-limit] Increase configurability of the rate-limit policy https://github.com/gravitee-io/issues/issues/4128[#4128]
+
+*_Portal_*
+
+- Add versioning on documentation pages https://github.com/gravitee-io/issues/issues/146[#146]
+- Allows to link pages in markdown https://github.com/gravitee-io/issues/issues/4072[#4072]
+
+*_Resource_*
+
+- [auth-provider] Provide user attributes https://github.com/gravitee-io/issues/issues/4281[#4281]
+
+=== Improvements
+
+*_Management_*
+
+- Enable / disable swagger's rendering editor https://github.com/gravitee-io/issues/issues/4055[#4055]
+- Enable logging without condition https://github.com/gravitee-io/issues/issues/2778[#2778]
+
+*_Management-ui_*
+
+- Provide more logs about CORS issue https://github.com/gravitee-io/issues/issues/4231[#4231]
+- Show API status icons on API portal page https://github.com/gravitee-io/issues/issues/4229[#4229]
+
+== https://github.com/gravitee-io/issues/milestone/281?closed=1[APIM - 3.1.4 (2020-09-16)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- NPE on windows environment when using alerting https://github.com/gravitee-io/issues/issues/4240[#4240]
+
+*_General_*
+
+- Merge 3.0.8 https://github.com/gravitee-io/issues/issues/4286[#4286]
+
+*_Management-api_*
+
+- Inconsistent behavior of Gravitee https://github.com/gravitee-io/issues/issues/4130[#4130]
+
+*_Portal_*
+
+- Unable to logout when using AM IDP https://github.com/gravitee-io/issues/issues/4215[#4215]
+
+*_Repository_*
+
+- [jdbc] Impossible to delete a group https://github.com/gravitee-io/issues/issues/4234[#4234]
+
+== https://github.com/gravitee-io/issues/milestone/280?closed=1[APIM - 3.0.8 (2020-09-15)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 1.30.20 https://github.com/gravitee-io/issues/issues/4259[#4259]
+- Merge 1.30.21 https://github.com/gravitee-io/issues/issues/4282[#4282]
+
+*_Management_*
+
+- All user invitations are made for the idp "gravitee" https://github.com/gravitee-io/issues/issues/4226[#4226]
+- Cannot save an API with health check inheritance https://github.com/gravitee-io/issues/issues/4251[#4251]
+- When we import an api, documentation is brokeninternal link, image, order of appearance https://github.com/gravitee-io/issues/issues/4149[#4149]
+
+*_Repository_*
+
+- [jdbc] Cannot update custom roles https://github.com/gravitee-io/issues/issues/4258[#4258]
+- [mongodb]index script contains an error on memberships https://github.com/gravitee-io/issues/issues/4233[#4233]
+
+== https://github.com/gravitee-io/issues/milestone/274?closed=1[APIM - 3.1.3 (2020-09-02)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Improve websocket continuation support https://github.com/gravitee-io/issues/issues/4220[#4220]
+
+*_General_*
+
+- Merge 3.0.7 https://github.com/gravitee-io/issues/issues/4194[#4194]
+- Requests seems stuck when enabling restrictions (Quota or Rate limiting) on a plan https://github.com/gravitee-io/issues/issues/4175[#4175]
+
+*_Management_*
+
+- NPE on login if user has no first connection information https://github.com/gravitee-io/issues/issues/4196[#4196]
+- Not able to set default API / application role with JDBC repository https://github.com/gravitee-io/issues/issues/4214[#4214]
+
+*_Portal_*
+
+- An error occurred during the subscription for an OAuth 2 Plan https://github.com/gravitee-io/issues/issues/4195[#4195]
+- Unable to logout when using AM IDP https://github.com/gravitee-io/issues/issues/4215[#4215]
+
+== https://github.com/gravitee-io/issues/milestone/270?closed=1[APIM - 3.0.7 (2020-08-19)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- APIM gateway 3.0.4 -> 3.0.6 causes WARN  No plan has been selected and apis does not work https://github.com/gravitee-io/issues/issues/4169[#4169]
+
+*_General_*
+
+- Merge 1.30.17 https://github.com/gravitee-io/issues/issues/4157[#4157]
+- Merge 1.30.18 https://github.com/gravitee-io/issues/issues/4163[#4163]
+- Merge 1.30.19 https://github.com/gravitee-io/issues/issues/4181[#4181]
+
+*_Management_*
+
+- Make markdown documentation visually similar to the one present in version 1.30 https://github.com/gravitee-io/issues/issues/4147[#4147]
+- Members inherited from group doesn't work on 3.1.1 and 3.0.6 https://github.com/gravitee-io/issues/issues/4154[#4154]
+
+*_Portal_*
+
+- Application's metadata management https://github.com/gravitee-io/issues/issues/4089[#4089]
+
+=== Improvements
+
+*_Management_*
+
+- Use URLs of the portal and management from settings https://github.com/gravitee-io/issues/issues/4144[#4144]
+
+== https://github.com/gravitee-io/issues/milestone/266?closed=1[APIM - 3.1.2 (2020-08-04)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Disable logging activity https://github.com/gravitee-io/issues/issues/4131[#4131]
+
+*_General_*
+
+- Merge 3.0.6 https://github.com/gravitee-io/issues/issues/4142[#4142]
+
+*_Management_*
+
+- Allows to export from 3.1 to 3.0 also with grpc endpoints https://github.com/gravitee-io/issues/issues/4098[#4098]
+
+*_Policy_*
+
+- [rest-to-soap] Can not save the form after updating prefill soap envelope in some case https://github.com/gravitee-io/issues/issues/4087[#4087]
+
+=== Improvements
+
+*_Management_*
+
+- Allows a user to subscribe to the newsletter after first login https://github.com/gravitee-io/issues/issues/4096[#4096]
+
+*_Service-discovery_*
+
+- Consul.io MTLS support https://github.com/gravitee-io/issues/issues/4116[#4116]
+
+== https://github.com/gravitee-io/issues/milestone/267?closed=1[APIM - 3.0.6 (2020-07-30)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 1.30.16 https://github.com/gravitee-io/issues/issues/4132[#4132]
+
+*_Portal_*
+
+- Confirmation message when deleting a member is not well displayed https://github.com/gravitee-io/issues/issues/4140[#4140]
+- Copy to sender not work in user contact form https://github.com/gravitee-io/issues/issues/4136[#4136]
+
+== https://github.com/gravitee-io/issues/milestone/265?closed=1[APIM - 3.1.1 (2020-07-20)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Bad merge with 1.30.14 https://github.com/gravitee-io/issues/issues/4121[#4121]
+
+*_Management_*
+
+- Node cannot start on an empty database in some context https://github.com/gravitee-io/issues/issues/4118[#4118]
+
+== https://github.com/gravitee-io/issues/milestone/217?closed=1[APIM - 3.1.0 (2020-07-17)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 3.0.4 https://github.com/gravitee-io/issues/issues/4042[#4042]
+
+=== Features
+
+*_Gateway_*
+
+- Support zone in order to group analytics https://github.com/gravitee-io/issues/issues/3858[#3858]
+- Use backup endpoints as secondary choice https://github.com/gravitee-io/issues/issues/3877[#3877]
+
+*_Policy_*
+
+- Json Threat Protection policy https://github.com/gravitee-io/issues/issues/3950[#3950]
+- Regex Threat Protection Policy https://github.com/gravitee-io/issues/issues/3949[#3949]
+- Xml Threat Protection Policy https://github.com/gravitee-io/issues/issues/3951[#3951]
+- [ip-filtering] Add DNS resolution option for host filtering https://github.com/gravitee-io/issues/issues/3880[#3880]
+
+=== Improvements
+
+*_Gateway_*
+
+- Accept backends/entrypoints supporting only HTTP/2 https://github.com/gravitee-io/issues/issues/3105[#3105]
+
+*_Policy_*
+
+- [request-validation] support for type "ENUM" https://github.com/gravitee-io/issues/issues/3556[#3556]
+
+*_Portal_*
+
+- Allows to define a background on the APIs/Apps/Categories headers https://github.com/gravitee-io/issues/issues/3761[#3761]
+
+== https://github.com/gravitee-io/issues/milestone/263?closed=1[APIM - 3.0.5 (2020-07-17)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Websocket and stompgetting "Error during WebSocket handshakeSent non-empty 'Sec-WebSocket-Protocol' header but no response was received" https://github.com/gravitee-io/issues/issues/4060[#4060]
+
+*_General_*
+
+- Merge 1.30.15 https://github.com/gravitee-io/issues/issues/4083[#4083]
+
+*_Management_*
+
+- HtmlSanitizer can sometimes generate an error when creating or updating a markdown page https://github.com/gravitee-io/issues/issues/4077[#4077]
+- Incorrect audit when deleting a portal page https://github.com/gravitee-io/issues/issues/4099[#4099]
+- Sometimes social login is not working https://github.com/gravitee-io/issues/issues/4088[#4088]
+
+*_Portal_*
+
+- Application image not well displayed if too large in last step of application creation https://github.com/gravitee-io/issues/issues/4063[#4063]
+- Wrong table headers in last step of application creation https://github.com/gravitee-io/issues/issues/4057[#4057]
+
+== https://github.com/gravitee-io/issues/milestone/259?closed=1[APIM - 3.0.4 (2020-07-01)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 1.30.13 https://github.com/gravitee-io/issues/issues/4026[#4026]
+- Merge 1.30.14 https://github.com/gravitee-io/issues/issues/4027[#4027]
+
+*_Management_*
+
+- Cannot save API in some case with http headers https://github.com/gravitee-io/issues/issues/4001[#4001]
+- Configuration of logging don't work https://github.com/gravitee-io/issues/issues/4021[#4021]
+- Exported APIs to 1.x version incorrect https://github.com/gravitee-io/issues/issues/3996[#3996]
+- Geo map is not displayed https://github.com/gravitee-io/issues/issues/4007[#4007]
+
+*_Management-ui_*
+
+- Checkbox "override entrypoint" is very big in api virtualhost mode https://github.com/gravitee-io/issues/issues/3999[#3999]
+
+*_Platform_*
+
+- EL sandbox is not well instantiated https://github.com/gravitee-io/issues/issues/4003[#4003]
+
+*_Portal_*
+
+- Cannot list my subscriptions in some cases https://github.com/gravitee-io/issues/issues/3994[#3994]
+- Configure the baseUrl on default distribution config https://github.com/gravitee-io/issues/issues/4005[#4005]
+- Try it with oauth2 is not working when the UI is served with a base path https://github.com/gravitee-io/issues/issues/4038[#4038]
+- With different basePath sends redirect request for openid without the basePath https://github.com/gravitee-io/issues/issues/3993[#3993]
+
+*_Repository_*
+
+- [jdbc] Increase the client id to allow 128 characters https://github.com/gravitee-io/issues/issues/4040[#4040]
+
+=== Improvements
+
+*_Portal_*
+
+- Adapt configuration to be more consistant with the mgmt config https://github.com/gravitee-io/issues/issues/3968[#3968]
+
+== https://github.com/gravitee-io/issues/milestone/256?closed=1[APIM - 3.0.3 (2020-06-18)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 1.30.12 https://github.com/gravitee-io/issues/issues/3971[#3971]
+
+*_Portal_*
+
+- A simple user without permissions on API plan read get an exception on subscription https://github.com/gravitee-io/issues/issues/3953[#3953]
+- Better handling of logos with a large width https://github.com/gravitee-io/issues/issues/3892[#3892]
+- Pagination is broken when browsing APIs https://github.com/gravitee-io/issues/issues/3960[#3960]
+- The subscribe button should not disappear on scroll https://github.com/gravitee-io/issues/issues/3955[#3955]
+- Unable to get plans list for subscriptions https://github.com/gravitee-io/issues/issues/3914[#3914]
+
+*_Repository_*
+
+- [jdbc] When opening portal as not logged in user, getting browser error https://github.com/gravitee-io/issues/issues/3913[#3913]
+- [jdbc] in apim 3 requires super user privilege to gravitee user in postgresql https://github.com/gravitee-io/issues/issues/3909[#3909]
+- [jdbc] upgraded users should be linked to an ORGANIZATION https://github.com/gravitee-io/issues/issues/3912[#3912]
+
+=== Features
+
+*_Management_*
+
+- Support for redirection after authentication https://github.com/gravitee-io/issues/issues/3857[#3857]
+
+== https://github.com/gravitee-io/issues/milestone/232?closed=1[APIM - 3.0.2 (2020-06-03)]
+
+=== Bug fixes
+
+*_General_*
+
+- APIM3.0.1 Portal-UI uri baseurl not configurable https://github.com/gravitee-io/issues/issues/3883[#3883]
+- Merge 1.30.11 https://github.com/gravitee-io/issues/issues/3890[#3890]
+- Update in FROM clause Error in MySQL environment when use gravitee-repository-jdbc-3.0.0 https://github.com/gravitee-io/issues/issues/3853[#3853]
+
+*_Management-api_*
+
+- ID is sent on create View and this cause error https://github.com/gravitee-io/issues/issues/3882[#3882]
+
+*_Portal_*
+
+- Access URL not well displayed when too long https://github.com/gravitee-io/issues/issues/3898[#3898]
+- Application default icon is not well generated in subscriptions lists https://github.com/gravitee-io/issues/issues/3847[#3847]
+- Console error when trying to rate an API https://github.com/gravitee-io/issues/issues/3902[#3902]
+- Error message on application creation & api subscription https://github.com/gravitee-io/issues/issues/3875[#3875]
+- On the dashboard, the version of API is not well displayed with a large API name https://github.com/gravitee-io/issues/issues/3832[#3832]
+- Should not be able to subscribe to a JWT API without a client id https://github.com/gravitee-io/issues/issues/3874[#3874]
+- Sometimes my subscriptions are not well displayed on hover https://github.com/gravitee-io/issues/issues/3804[#3804]
+- Tags and views are not displayed anymore on cards when not configured in API's aside https://github.com/gravitee-io/issues/issues/3897[#3897]
+- The error message is not displayed until we click https://github.com/gravitee-io/issues/issues/3817[#3817]
+
+=== Improvements
+
+*_Management_*
+
+- Better handling of read access on API's items https://github.com/gravitee-io/issues/issues/3886[#3886]
+- Change the wording of the views to categories https://github.com/gravitee-io/issues/issues/3843[#3843]
+
+*_Portal_*
+
+- Enable to click on a tag displayed on a card https://github.com/gravitee-io/issues/issues/3842[#3842]
+
+== https://github.com/gravitee-io/issues/milestone/203?closed=1[APIM - 3.0.1 (2020-05-26)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Default admin can't go to the dashboard and settings menu https://github.com/gravitee-io/issues/issues/3834[#3834]
+- Unable to create a folder in TopFooter system folder https://github.com/gravitee-io/issues/issues/3825[#3825]
+
+*_Portal_*
+
+- Api rating issues https://github.com/gravitee-io/issues/issues/3824[#3824]
+- Link in aside reloads all the application https://github.com/gravitee-io/issues/issues/3810[#3810]
+- Swagger OAuth integration https://github.com/gravitee-io/issues/issues/3813[#3813]
+- Take care of defined properties to display API's aside https://github.com/gravitee-io/issues/issues/3812[#3812]
+- Unpublished pages are displayed on API's documentation https://github.com/gravitee-io/issues/issues/3837[#3837]
+- Use the color defined on the identity providers display on the login https://github.com/gravitee-io/issues/issues/3811[#3811]
+- When creating view the picture is broken https://github.com/gravitee-io/issues/issues/3841[#3841]
+- When forceLogin is enabled, we cannot register anymore https://github.com/gravitee-io/issues/issues/3845[#3845]
+
+== https://github.com/gravitee-io/issues/milestone/187?closed=1[APIM - 3.0.0 (2020-05-20)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge 1.30.x https://github.com/gravitee-io/issues/issues/3392[#3392]
+
+*_Management_*
+
+- Empty mode is not well displayed on Gateway Instances screen https://github.com/gravitee-io/issues/issues/3739[#3739]
+- User/avatar should return 200 with no body when user doesn't have avatar https://github.com/gravitee-io/issues/issues/3330[#3330]
+
+*_Portal_*
+
+- Display labels on API cards https://github.com/gravitee-io/issues/issues/3116[#3116]
+
+=== Features
+
+*_Gateway_*
+
+- Remove the legacy mode for url encoding https://github.com/gravitee-io/issues/issues/2634[#2634]
+
+*_Management_*
+
+- I18n for documentation https://github.com/gravitee-io/issues/issues/3071[#3071]
+- [multi-env] Adapt memberships scopes and permissions to multi-env https://github.com/gravitee-io/issues/issues/3206[#3206]
+
+*_Multi-env_*
+
+- Add organization feature https://github.com/gravitee-io/issues/issues/3182[#3182]
+
+*_Portal_*
+
+- Add a link to admin in user menu https://github.com/gravitee-io/issues/issues/3109[#3109]
+- Add message for Cookies https://github.com/gravitee-io/issues/issues/2956[#2956]
+- Add the possibility to comment / rate an API https://github.com/gravitee-io/issues/issues/3061[#3061]
+- Allow a user to change his avatar https://github.com/gravitee-io/issues/issues/2806[#2806]
+- Allow a user to consult analytics of an application https://github.com/gravitee-io/issues/issues/2804[#2804]
+- Allow a user to consult logs of an application https://github.com/gravitee-io/issues/issues/2805[#2805]
+- Allow a user to consult subscriptions of an application https://github.com/gravitee-io/issues/issues/3114[#3114]
+- Allow a user to consult/edit global settings of an application https://github.com/gravitee-io/issues/issues/2799[#2799]
+- Allow a user to consult/edit members of an application https://github.com/gravitee-io/issues/issues/2803[#2803]
+- Allow a user to create an application https://github.com/gravitee-io/issues/issues/2798[#2798]
+- Allow a user to reset his password https://github.com/gravitee-io/issues/issues/2822[#2822]
+- Allow a user to subscribe to notifications on an application https://github.com/gravitee-io/issues/issues/3115[#3115]
+- Allow users to subscribe to newsletters https://github.com/gravitee-io/issues/issues/3420[#3420]
+- Allows to consult a subscription https://github.com/gravitee-io/issues/issues/3108[#3108]
+- Generate a custom default icon for user/apis/application https://github.com/gravitee-io/issues/issues/2853[#2853]
+- Integrate Google Analytics https://github.com/gravitee-io/issues/issues/3344[#3344]
+
+=== Improvements
+
+*_Platform_*
+
+- Update v3 configuration https://github.com/gravitee-io/issues/issues/3668[#3668]
+
+*_Portal_*
+
+- Add a 404 page https://github.com/gravitee-io/issues/issues/2991[#2991]
+- Generate dist on the root https://github.com/gravitee-io/issues/issues/3737[#3737]
+- Keep API display preference to the user https://github.com/gravitee-io/issues/issues/3110[#3110]
+- Work on route transition animations https://github.com/gravitee-io/issues/issues/3010[#3010]
+- Work on scroll to top strategy router navigation https://github.com/gravitee-io/issues/issues/3012[#3012]

--- a/release/changelog/CHANGELOG.adoc
+++ b/release/changelog/CHANGELOG.adoc
@@ -1,0 +1,6061 @@
+# Change Log
+
+For upgrade instructions, please refer to https://docs.gravitee.io/apim/1.x/apim_installguide_migration.html[APIM Migration Guide]
+
+*Important:* If you plan to skip versions when you upgrade, ensure that you read the version-specific upgrade notes for each intermediate version. You may be required to perform manual actions as part of the upgrade.
+
+
+== https://github.com/gravitee-io/issues/milestone/336?closed=1[APIM - 1.30.31 (2021-02-07)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Cannot use OAuth 2.0/JWT multiple plans https://github.com/gravitee-io/issues/issues/4931[#4931]
+
+*_Management_*
+
+- Metadata cannot be deleted when value is too long https://github.com/gravitee-io/issues/issues/3266[#3266]
+
+*_Repository_*
+
+- [elasticsearch] Retry is not working in case of non 2xx status code https://github.com/gravitee-io/issues/issues/4977[#4977]
+
+== https://github.com/gravitee-io/issues/milestone/326?closed=1[APIM - 1.30.30 (2021-01-14)]
+
+=== Bug fixes
+
+*_Console_*
+
+- Error JS on APIs list screen https://github.com/gravitee-io/issues/issues/4840[#4840]
+
+*_Gateway_*
+
+- Better handling of multiple OAuth2/JWT plans with a single subscription https://github.com/gravitee-io/issues/issues/4817[#4817]
+
+*_General_*
+
+- Backport #4534 https://github.com/gravitee-io/issues/issues/4865[#4865]
+
+*_Management_*
+
+- APIs confusion when performing particular manipulations on analytics https://github.com/gravitee-io/issues/issues/4560[#4560]
+- Api-key can not be reactivate for a closed plan https://github.com/gravitee-io/issues/issues/4889[#4889]
+- Disable import button while importing https://github.com/gravitee-io/issues/issues/4795[#4795]
+- Use api permissions instead of env one for alert https://github.com/gravitee-io/issues/issues/4877[#4877]
+
+=== Improvements
+
+*_Management_*
+
+- Multiple emails sent to subscriber (Application) if email notif enabled https://github.com/gravitee-io/issues/issues/4822[#4822]
+
+== https://github.com/gravitee-io/issues/milestone/322?closed=1[APIM - 1.30.29 (2020-12-14)]
+
+=== Bug fixes
+
+*_General_*
+
+- Backport #4659 https://github.com/gravitee-io/issues/issues/4753[#4753]
+
+*_Management_*
+
+- Admin user can not subscribe to plan associated to specific groups https://github.com/gravitee-io/issues/issues/4720[#4720]
+- Empty user page https://github.com/gravitee-io/issues/issues/4752[#4752]
+
+*_Policy_*
+
+- [jwt] add api id into the logging MDC https://github.com/gravitee-io/issues/issues/4782[#4782]
+
+*_Reporter_*
+
+- [elasticsearch] Limit of total fields on logs index can sometimes be reached https://github.com/gravitee-io/issues/issues/4566[#4566]
+
+=== Improvements
+
+*_Gateway_*
+
+- [failover] add API ID in case of failure https://github.com/gravitee-io/issues/issues/4738[#4738]
+
+*_Management_*
+
+- Exposing APIs from multiple entrypoints for the same tag https://github.com/gravitee-io/issues/issues/4713[#4713]
+
+== https://github.com/gravitee-io/issues/milestone/319?closed=1[APIM - 1.30.28 (2020-12-02)]
+
+=== Bug fixes
+
+*_Management_*
+
+- We should inform than a subscription is paused and not avoid to close the plan https://github.com/gravitee-io/issues/issues/4688[#4688]
+
+=== Improvements
+
+*_Management_*
+
+- Dynamic dictionary updates ignored when it is started https://github.com/gravitee-io/issues/issues/4535[#4535]
+
+*_Resource_*
+
+- [oauth2] Hide client id / secret in the configuration https://github.com/gravitee-io/issues/issues/4673[#4673]
+
+== https://github.com/gravitee-io/issues/milestone/313?closed=1[APIM - 1.30.27 (2020-11-30)]
+
+=== Bug fixes
+
+*_General_*
+
+- Backport 4661 https://github.com/gravitee-io/issues/issues/4683[#4683]
+- Backport 4685 https://github.com/gravitee-io/issues/issues/4686[#4686]
+
+=== Improvements
+
+*_General_*
+
+- Backport 4664 https://github.com/gravitee-io/issues/issues/4666[#4666]
+
+== https://github.com/gravitee-io/issues/milestone/311?closed=1[APIM - 1.30.26 (2020-11-24)]
+
+=== Bug fixes
+
+*_General_*
+
+- Backport 4513 https://github.com/gravitee-io/issues/issues/4614[#4614]
+- Backport 4640 https://github.com/gravitee-io/issues/issues/4654[#4654]
+
+*_Management_*
+
+- We must not close an API plan if there are some paused subscriptions https://github.com/gravitee-io/issues/issues/4626[#4626]
+
+*_Reporter_*
+
+- [elasticsearch] listen for events after error https://github.com/gravitee-io/issues/issues/4612[#4612]
+
+=== Improvements
+
+*_Elasticsearch_*
+
+- Add settings to search indexing slow log https://github.com/gravitee-io/issues/issues/4615[#4615]
+
+== https://github.com/gravitee-io/issues/milestone/295?closed=1[APIM - 1.30.25 (2020-11-14)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Assign-Content policy duplicates content when failover is activated on endpoint https://github.com/gravitee-io/issues/issues/4557[#4557]
+
+*_General_*
+
+- Backport #4570 https://github.com/gravitee-io/issues/issues/4600[#4600]
+
+*_Management_*
+
+- Add help for configuring alert rules https://github.com/gravitee-io/issues/issues/4443[#4443]
+- Cannot filter on a status code in analytics https://github.com/gravitee-io/issues/issues/4554[#4554]
+- Dictionary property not well refreshed when updating a value https://github.com/gravitee-io/issues/issues/4545[#4545]
+- Do not reduce the menu automatically while browsing settings https://github.com/gravitee-io/issues/issues/4536[#4536]
+- Impossible to sort the properties in the dictionaries https://github.com/gravitee-io/issues/issues/4540[#4540]
+- Patch section in audit log not fully displayed https://github.com/gravitee-io/issues/issues/4473[#4473]
+- Polling configuration is lost when disabling and saving dynamic properties on API https://github.com/gravitee-io/issues/issues/4547[#4547]
+- [logs] elasticsearch query special characters are not escaped https://github.com/gravitee-io/issues/issues/4518[#4518]
+
+*_Reporter_*
+
+- [elasticsearch] Invalid mapping for index request for ES6 https://github.com/gravitee-io/issues/issues/4482[#4482]
+- [elasticsearch] Logging not working on proxy only mode https://github.com/gravitee-io/issues/issues/4537[#4537]
+
+*_Resource_*
+
+- [am] Missing version 3.x in the list https://github.com/gravitee-io/issues/issues/4538[#4538]
+
+*_Swagger_*
+
+- Only validate swagger content on create/update https://github.com/gravitee-io/issues/issues/4506[#4506]
+
+=== Improvements
+
+*_Elasticsearch_*
+
+- Add settings to search slow log https://github.com/gravitee-io/issues/issues/4524[#4524]
+
+*_Management_*
+
+- Allows to be alerted when no event during a period https://github.com/gravitee-io/issues/issues/4445[#4445]
+
+== https://github.com/gravitee-io/issues/milestone/293?closed=1[APIM - 1.30.24 (2020-10-16)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Add coherency between list applications and get application settings https://github.com/gravitee-io/issues/issues/4469[#4469]
+- Alert's template must be considered as enabled https://github.com/gravitee-io/issues/issues/4374[#4374]
+- Do not send emails to an unresolved expression https://github.com/gravitee-io/issues/issues/4403[#4403]
+- Select box truncated under firefox https://github.com/gravitee-io/issues/issues/4288[#4288]
+
+*_Policy_*
+
+- [resource-filtering] Handle also the case when the method not match https://github.com/gravitee-io/issues/issues/4454[#4454]
+
+*_Portal_*
+
+- Links to published API gallery pages redirects anonymous users to the login page https://github.com/gravitee-io/issues/issues/4402[#4402]
+
+*_Swagger_*
+
+- Error in swagger Management API some array items type https://github.com/gravitee-io/issues/issues/4405[#4405]
+
+=== Improvements
+
+*_Management_*
+
+- Audit API review actions https://github.com/gravitee-io/issues/issues/4462[#4462]
+- Be notified when my subscription is accepted https://github.com/gravitee-io/issues/issues/3920[#3920]
+- Set the default time range to the last 5 minutes in analytics https://github.com/gravitee-io/issues/issues/4463[#4463]
+
+*_Policy_*
+
+- [callout] Allow to use the system proxy https://github.com/gravitee-io/issues/issues/4448[#4448]
+
+== https://github.com/gravitee-io/issues/milestone/289?closed=1[APIM - 1.30.23 (2020-10-06)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Alert's template must be considered as enabled https://github.com/gravitee-io/issues/issues/4374[#4374]
+- Display swagger / OAI errors to the console's user and API caller https://github.com/gravitee-io/issues/issues/4349[#4349]
+- Do not add additional parenthesis on logging configuration https://github.com/gravitee-io/issues/issues/4377[#4377]
+- Missing API id when defining alert notification with ${api.id} https://github.com/gravitee-io/issues/issues/4364[#4364]
+- Reorder application's apikey https://github.com/gravitee-io/issues/issues/4357[#4357]
+
+*_Management-api_*
+
+- Closing and deletion of API in quick succession leads to unauthorized 401 error https://github.com/gravitee-io/issues/issues/4338[#4338]
+
+*_Management-ui_*
+
+- Angularjs error on cors settings screen https://github.com/gravitee-io/issues/issues/4253[#4253]
+
+*_Notifier_*
+
+- [email] Allows to completely disable TLS https://github.com/gravitee-io/issues/issues/4348[#4348]
+- [webhook] Add some logs when the webhook is successfully sent or not https://github.com/gravitee-io/issues/issues/4347[#4347]
+
+*_Policy_*
+
+- [jwt] request hang if an exception is thrown https://github.com/gravitee-io/issues/issues/4372[#4372]
+
+*_Portal_*
+
+- Links to open API's redirects to the login page https://github.com/gravitee-io/issues/issues/3721[#3721]
+
+*_Reporter_*
+
+- [elasticsearch] Disable health check when the reporter / repository is disabled https://github.com/gravitee-io/issues/issues/4350[#4350]
+
+=== Improvements
+
+*_Management_*
+
+- Post a page content without having to stringify the content. https://github.com/gravitee-io/issues/issues/4365[#4365]
+
+*_Policy_*
+
+- [jwt] Add the api_id to the log output for debugging purpose https://github.com/gravitee-io/issues/issues/4351[#4351]
+
+== https://github.com/gravitee-io/issues/milestone/285?closed=1[APIM - 1.30.22 (2020-09-25)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Avoid the downtime when redeploying an API https://github.com/gravitee-io/issues/issues/4320[#4320]
+
+*_General_*
+
+- Unable to show/edit group even if user has all GROUP permissions https://github.com/gravitee-io/issues/issues/4285[#4285]
+
+*_Management_*
+
+- Do not add same acknowledgments for a node https://github.com/gravitee-io/issues/issues/4327[#4327]
+- Do not display idp identifier on user pre-creation when no idps https://github.com/gravitee-io/issues/issues/4279[#4279]
+- Expose API metadata in alert notification templates https://github.com/gravitee-io/issues/issues/4334[#4334]
+- Permissions are not the same between Basic and Bearer https://github.com/gravitee-io/issues/issues/2353[#2353]
+- Target is not readable on the audit screen in some cases https://github.com/gravitee-io/issues/issues/4291[#4291]
+- User authorities should be retrieved when using personal token security filter https://github.com/gravitee-io/issues/issues/4289[#4289]
+
+*_Notifier_*
+
+- [email] Subject prefix is not used https://github.com/gravitee-io/issues/issues/4333[#4333]
+
+*_Policy_*
+
+- [callout] exit on error option should be apply for connectivity issue https://github.com/gravitee-io/issues/issues/4301[#4301]
+
+*_Reporter_*
+
+- [elasticsearch] invalid default value for ILM lifecycle property name https://github.com/gravitee-io/issues/issues/4303[#4303]
+
+*_Reporters_*
+
+- [elasticsearch] Load balancing is not well done on runtime https://github.com/gravitee-io/issues/issues/4321[#4321]
+
+=== Features
+
+*_Management_*
+
+- Remove the API / View / Application / User picture https://github.com/gravitee-io/issues/issues/4268[#4268]
+
+=== Improvements
+
+*_Management_*
+
+- Add more information to the user profile https://github.com/gravitee-io/issues/issues/4300[#4300]
+- [swagger] add api information in log for parsing exception https://github.com/gravitee-io/issues/issues/4197[#4197]
+
+*_Policy_*
+
+- [callout] Access request / response properties for onRequest and onResponse https://github.com/gravitee-io/issues/issues/4277[#4277]
+
+== https://github.com/gravitee-io/issues/milestone/279?closed=1[APIM - 1.30.21 (2020-09-14)]
+
+=== Bug fixes
+
+*_Alerts_*
+
+- Handle default values for notifiers configuration https://github.com/gravitee-io/issues/issues/4248[#4248]
+
+*_Gateway_*
+
+- ConcurrentModificationException when parallel access https://github.com/gravitee-io/issues/issues/4221[#4221]
+
+*_Management_*
+
+- Add image popup in markdown editor is broken https://github.com/gravitee-io/issues/issues/4249[#4249]
+- After creating a role, we should be redirected on it https://github.com/gravitee-io/issues/issues/3584[#3584]
+- Do not display a gauge when no health check value https://github.com/gravitee-io/issues/issues/4230[#4230]
+- Infinite scroll not working on APIs on high resolution https://github.com/gravitee-io/issues/issues/3591[#3591]
+- Member's list component seems broken https://github.com/gravitee-io/issues/issues/3650[#3650]
+- Mocks are not based anymore on examples https://github.com/gravitee-io/issues/issues/3334[#3334]
+- Release memory correctly in case of error in dynamic properties / dictionaries https://github.com/gravitee-io/issues/issues/4244[#4244]
+- [analytics] Path mappings not correctly detected https://github.com/gravitee-io/issues/issues/4216[#4216]
+
+*_Management-api_*
+
+- Missing PORTAL.USER_CREATED.yml file https://github.com/gravitee-io/issues/issues/3168[#3168]
+- NullPointerException on CORS https://github.com/gravitee-io/issues/issues/4252[#4252]
+- Typo in OAI documentation https://github.com/gravitee-io/issues/issues/4232[#4232]
+
+=== Features
+
+*_Management_*
+
+- Allows to a publisher to enable an expired API key https://github.com/gravitee-io/issues/issues/4227[#4227]
+
+=== Improvements
+
+*_Gateway_*
+
+- Allow to use the system proxy for an endpoint https://github.com/gravitee-io/issues/issues/4256[#4256]
+
+*_Management_*
+
+- Allow a user to delete his own account https://github.com/gravitee-io/issues/issues/4250[#4250]
+
+*_Policy_*
+
+- [jwt] Use JWKS behind an HTTP proxy https://github.com/gravitee-io/issues/issues/4254[#4254]
+
+== https://github.com/gravitee-io/issues/milestone/277?closed=1[APIM - 1.30.20 (2020-08-28)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Weighted load-balancing algorithm are not always refreshed https://github.com/gravitee-io/issues/issues/4208[#4208]
+
+*_Management_*
+
+- Identity provider group mapping is not updated when a group is deleted https://github.com/gravitee-io/issues/issues/4201[#4201]
+- NPE when deleting a group https://github.com/gravitee-io/issues/issues/4200[#4200]
+
+*_Management-api_*
+
+- String parse issue https://github.com/gravitee-io/issues/issues/4204[#4204]
+
+*_Policy_*
+
+- [callout] Failed to create SSL connection https://github.com/gravitee-io/issues/issues/4191[#4191]
+
+=== Improvements
+
+*_Elasticsearch_*
+
+- [ILM] support Open Distro ISM API https://github.com/gravitee-io/issues/issues/4190[#4190]
+
+*_Gateway_*
+
+- Reorder transaction and traceparent processor to use traceparent as the transactionid https://github.com/gravitee-io/issues/issues/4212[#4212]
+
+*_Management_*
+
+- [swagger] add api information in log for parsing exception https://github.com/gravitee-io/issues/issues/4197[#4197]
+
+*_Management-ui_*
+
+- Apply pattern validator for CORS allow origin field https://github.com/gravitee-io/issues/issues/4202[#4202]
+- [alert] Define health-check rule's template https://github.com/gravitee-io/issues/issues/4210[#4210]
+
+== https://github.com/gravitee-io/issues/milestone/272?closed=1[APIM - 1.30.19 (2020-08-12)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Add API information on HC logs https://github.com/gravitee-io/issues/issues/4160[#4160]
+
+*_Management_*
+
+- Add consistency on field properties in EL https://github.com/gravitee-io/issues/issues/4162[#4162]
+- Useless stacktrace when a document cannot be indexed https://github.com/gravitee-io/issues/issues/4164[#4164]
+
+*_Reporter_*
+
+- [elasticsearch] Index proxy-latency https://github.com/gravitee-io/issues/issues/4165[#4165]
+
+*_Service-discovery_*
+
+- [consul] Discovery is not working on a group which is not the first https://github.com/gravitee-io/issues/issues/4155[#4155]
+
+=== Improvements
+
+*_Management_*
+
+- Provide the capability to expand list of subscriptions with api keys https://github.com/gravitee-io/issues/issues/4167[#4167]
+
+*_Reporter_*
+
+- [elasticsearch] Allows to configure custom regexes on the user agent processor https://github.com/gravitee-io/issues/issues/4170[#4170]
+
+== https://github.com/gravitee-io/issues/milestone/271?closed=1[APIM - 1.30.18 (2020-08-05)]
+
+=== Bug fixes
+
+*_Reporter_*
+
+- [elasticsearch] Template mapping for user_agent https://github.com/gravitee-io/issues/issues/4138[#4138]
+- [elasticsearch] UserAgent empty value can't be indexed anymore https://github.com/gravitee-io/issues/issues/4139[#4139]
+
+== https://github.com/gravitee-io/issues/milestone/268?closed=1[APIM - 1.30.17 (2020-07-31)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Concurrency issue with gateway processors https://github.com/gravitee-io/issues/issues/4146[#4146]
+
+*_Management_*
+
+- Copy to sender not working anymore when creating a ticket https://github.com/gravitee-io/issues/issues/4141[#4141]
+- When a group is deleted, it's not removed from APIs https://github.com/gravitee-io/issues/issues/4143[#4143]
+
+=== Improvements
+
+*_Management_*
+
+- Disable the sending of the e-mail notifications which occur when I assign an user as member of a Group, Api or Application https://github.com/gravitee-io/issues/issues/4134[#4134]
+- Provide more information about the application on subscription screen https://github.com/gravitee-io/issues/issues/3965[#3965]
+
+== https://github.com/gravitee-io/issues/milestone/264?closed=1[APIM - 1.30.16 (2020-07-25)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Cannot deprecate an API when contains a plan in staging state https://github.com/gravitee-io/issues/issues/4112[#4112]
+- Do not display unknown instances after a configured time parameter https://github.com/gravitee-io/issues/issues/4100[#4100]
+- Sometimes "400 - Invalid Image Format" when updating a picture https://github.com/gravitee-io/issues/issues/4086[#4086]
+- Use "Reply-To" instead of from when sending support email https://github.com/gravitee-io/issues/issues/4105[#4105]
+- When the property info is missing in a OAI file, there is no log https://github.com/gravitee-io/issues/issues/4129[#4129]
+
+*_Policy_*
+
+- [request-validation] handle empty query parameters https://github.com/gravitee-io/issues/issues/4111[#4111]
+
+*_Reporter_*
+
+- [elasticsearch] Escape invalid characters before to index data https://github.com/gravitee-io/issues/issues/4126[#4126]
+
+=== Improvements
+
+*_Gateway_*
+
+- Traceparent support https://github.com/gravitee-io/issues/issues/4122[#4122]
+
+*_Management_*
+
+- Improve audit to display more information / context https://github.com/gravitee-io/issues/issues/3876[#3876]
+
+== https://github.com/gravitee-io/issues/milestone/261?closed=1[APIM - 1.30.15 (2020-07-08)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Rate-limiting issue when policies are run on preflight-request https://github.com/gravitee-io/issues/issues/4044[#4044]
+
+*_Management_*
+
+- Typo in healthcheck metrics https://github.com/gravitee-io/issues/issues/4025[#4025]
+
+*_Management-ui_*
+
+- [analytics] Filtering by host doesn't work when host contains ':' https://github.com/gravitee-io/issues/issues/4049[#4049]
+
+== https://github.com/gravitee-io/issues/milestone/260?closed=1[APIM - 1.30.14 (2020-06-27)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Allows to filter alerts on health check status https://github.com/gravitee-io/issues/issues/4019[#4019]
+- Bad template used when a subscription is approved https://github.com/gravitee-io/issues/issues/4014[#4014]
+- Better handling of indexation of searchable data https://github.com/gravitee-io/issues/issues/4012[#4012]
+- Breaking change with virtual_hosts https://github.com/gravitee-io/issues/issues/4013[#4013]
+- Documentation is missing for the application metadata https://github.com/gravitee-io/issues/issues/4015[#4015]
+- Error while removing an API with an alert trigger configured when alerting is disabled https://github.com/gravitee-io/issues/issues/4008[#4008]
+- Export in uppercase for backward compatibility and accept to import in case insensitive https://github.com/gravitee-io/issues/issues/4023[#4023]
+- Plan cannot be subscribed in some case https://github.com/gravitee-io/issues/issues/4024[#4024]
+
+=== Features
+
+*_Gateway_*
+
+- Execute API policies on a preflight-request https://github.com/gravitee-io/issues/issues/3964[#3964]
+
+*_Management_*
+
+- API Alert template https://github.com/gravitee-io/issues/issues/3970[#3970]
+
+=== Improvements
+
+*_Management_*
+
+- Allows to refresh the alerts history with a button https://github.com/gravitee-io/issues/issues/4017[#4017]
+- Allows to search / register user on OIDC provider https://github.com/gravitee-io/issues/issues/3904[#3904]
+
+*_Repository_*
+
+- [redis] Support Redis SSL connections https://github.com/gravitee-io/issues/issues/4010[#4010]
+
+== https://github.com/gravitee-io/issues/milestone/235?closed=1[APIM - 1.30.13 (2020-06-20)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- [HC] handle response exception https://github.com/gravitee-io/issues/issues/3979[#3979]
+
+*_Management_*
+
+- Attach base64 image to email templates https://github.com/gravitee-io/issues/issues/3988[#3988]
+- Error on application audit log https://github.com/gravitee-io/issues/issues/3991[#3991]
+- Timeout to display API list (non admin user) https://github.com/gravitee-io/issues/issues/3957[#3957]
+- Unable to set default roles on group https://github.com/gravitee-io/issues/issues/3992[#3992]
+- [alert] Not able to save notifications in some case https://github.com/gravitee-io/issues/issues/3972[#3972]
+
+*_Portal_*
+
+- Bad format when swagger in yaml format is indented with tabs instead of spaces https://github.com/gravitee-io/issues/issues/3982[#3982]
+
+=== Features
+
+*_Management_*
+
+- Add custom info to applications https://github.com/gravitee-io/issues/issues/3058[#3058]
+
+=== Improvements
+
+*_Gateway_*
+
+- Allows to pass a request id in outgoing headers https://github.com/gravitee-io/issues/issues/3974[#3974]
+
+== https://github.com/gravitee-io/issues/milestone/253?closed=1[APIM - 1.30.12 (2020-06-16)]
+
+=== Bug fixes
+
+*_Discovery_*
+
+- [eureka] failed to load spring context https://github.com/gravitee-io/issues/issues/3929[#3929]
+
+*_Gateway_*
+
+- Hardcoded content-type text/plain in NotFoundProcessor https://github.com/gravitee-io/issues/issues/3639[#3639]
+- If policy in chain fail, than following policies will be execute https://github.com/gravitee-io/issues/issues/3599[#3599]
+- Reporter may throw a NullPointerException https://github.com/gravitee-io/issues/issues/3888[#3888]
+
+*_Management_*
+
+- Export CSV is not working anymore on subscriptions https://github.com/gravitee-io/issues/issues/3642[#3642]
+- Markdown editor broken https://github.com/gravitee-io/issues/issues/3946[#3946]
+- [documentation] can't fetch API Documentation since Gitlab 12.9 https://github.com/gravitee-io/issues/issues/3677[#3677]
+
+*_Reporter_*
+
+- [file] Gateway seems to fail to load FileReporter plugin https://github.com/gravitee-io/issues/issues/3915[#3915]
+
+=== Features
+
+*_Elasticsearch_*
+
+- Ability to add proxy for ES HTTP client https://github.com/gravitee-io/issues/issues/3354[#3354]
+
+*_Management_*
+
+- Provide an access token to the management-api for each API for CI/CD purposes https://github.com/gravitee-io/issues/issues/2749[#2749]
+
+=== Improvements
+
+*_Gateway_*
+
+- Allow API logging for unknown / CORS request https://github.com/gravitee-io/issues/issues/3891[#3891]
+
+*_Management_*
+
+- Add primary-owner to alert commands https://github.com/gravitee-io/issues/issues/3942[#3942]
+- Display the URI instead of the path in logs page and file export https://github.com/gravitee-io/issues/issues/3393[#3393]
+- Logsadd a field to search on remote-ip https://github.com/gravitee-io/issues/issues/3879[#3879]
+
+*_Notifier_*
+
+- [email] Support for EL in 'from' https://github.com/gravitee-io/issues/issues/3944[#3944]
+
+*_Policy_*
+
+- [jwt] Support more key format https://github.com/gravitee-io/issues/issues/3930[#3930]
+- [request-validation] Date format validator https://github.com/gravitee-io/issues/issues/3896[#3896]
+
+== https://github.com/gravitee-io/issues/milestone/226?closed=1[APIM - 1.25.26 (2020-06-01)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Handle unknown X-Forwarded-For headers https://github.com/gravitee-io/issues/issues/3863[#3863]
+
+*_Management_*
+
+- Import not possible when a closed plan has the same name than an active one https://github.com/gravitee-io/issues/issues/3680[#3680]
+
+== https://github.com/gravitee-io/issues/milestone/227?closed=1[APIM - 1.30.11 (2020-06-01)]
+
+=== Bug fixes
+
+*_Elasticsearch_*
+
+- Unable to run health-check query ES7.x https://github.com/gravitee-io/issues/issues/3864[#3864]
+
+*_Gateway_*
+
+- Rate-limit probe should not share a common identifier https://github.com/gravitee-io/issues/issues/3867[#3867]
+- Upgrade jetty ALPN java agent https://github.com/gravitee-io/issues/issues/3862[#3862]
+
+*_General_*
+
+- The LinkedCaseInsensitiveMap is not well implemented https://github.com/gravitee-io/issues/issues/3830[#3830]
+
+*_Management_*
+
+- Filters are not working on the same widget https://github.com/gravitee-io/issues/issues/3866[#3866]
+- Group notification on each login when dynamic mapping is enabled with OIDC https://github.com/gravitee-io/issues/issues/3860[#3860]
+- NPE when login with GitHub Account without an email https://github.com/gravitee-io/issues/issues/3738[#3738]
+
+*_Management-api_*
+
+- Management-api 1.30.10 fails to start https://github.com/gravitee-io/issues/issues/3820[#3820]
+
+*_Management-ui_*
+
+- Health-check widgets are well refreshed https://github.com/gravitee-io/issues/issues/3865[#3865]
+
+*_Policy_*
+
+- [rate-limit] Inaccurate rate with small window (<= 1s) https://github.com/gravitee-io/issues/issues/3884[#3884]
+
+*_Portal_*
+
+- Timeout to display the gallery with a lot of APIs https://github.com/gravitee-io/issues/issues/3881[#3881]
+
+*_Service-discovery_*
+
+- EndpointGroupLifecycleManager - NullPointerExceptionno null host accepted https://github.com/gravitee-io/issues/issues/3814[#3814]
+
+=== Features
+
+*_Alert_*
+
+- Provide API / APP / User info to alert-engine https://github.com/gravitee-io/issues/issues/3754[#3754]
+
+=== Improvements
+
+*_Gateway_*
+
+- Support regex to CORS allowed origins https://github.com/gravitee-io/issues/issues/3840[#3840]
+
+*_Reporter_*
+
+- [elasticsearch] Change the default value for the number of shards https://github.com/gravitee-io/issues/issues/3855[#3855]
+
+== https://github.com/gravitee-io/issues/milestone/224?closed=1[APIM - 1.30.10 (2020-05-07)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Load API definition with lower-case enum https://github.com/gravitee-io/issues/issues/3682[#3682]
+
+*_Management-api_*
+
+- Do not search user using email domain https://github.com/gravitee-io/issues/issues/3665[#3665]
+- Fix user registration https://github.com/gravitee-io/issues/issues/3656[#3656]
+- X-Forwarded-Host overwrites default port https://github.com/gravitee-io/issues/issues/3641[#3641]
+
+*_Management-ui_*
+
+- Fallback to default theme if custom does not exist https://github.com/gravitee-io/issues/issues/3658[#3658]
+
+=== Improvements
+
+*_Gateway_*
+
+- Save my memory footprintavoid to duplicate API's properties https://github.com/gravitee-io/issues/issues/3683[#3683]
+
+*_Management_*
+
+- Export API with enum value in lowercase https://github.com/gravitee-io/issues/issues/3406[#3406]
+- Import API security plan value lowercase https://github.com/gravitee-io/issues/issues/3402[#3402]
+
+*_Management-api_*
+
+- Allow to optionally enable csrf https://github.com/gravitee-io/issues/issues/3663[#3663]
+- Improve api data filtering https://github.com/gravitee-io/issues/issues/3644[#3644]
+
+*_Platform_*
+
+- [node] Technical API _node/configuration end-point doesn't resolve env variables https://github.com/gravitee-io/issues/issues/3419[#3419]
+
+== https://github.com/gravitee-io/issues/milestone/221?closed=1[APIM - 1.25.25 (2020-04-27)]
+
+=== Bug fixes
+
+*_Backport_*
+
+- #3409 https://github.com/gravitee-io/issues/issues/3443[#3443]
+
+*_Gateway_*
+
+- Handle X-Forwarded-For IPv6 format header https://github.com/gravitee-io/issues/issues/3444[#3444]
+- [request-validation] constraint parameter with EL value is initialized only once https://github.com/gravitee-io/issues/issues/3621[#3621]
+
+*_Management_*
+
+- Unexpected error occurred in scheduled task. io.gravitee.management.service.exceptions.PageNotFoundException https://github.com/gravitee-io/issues/issues/3574[#3574]
+
+*_Repository_*
+
+- [jdbc] Duplicated APIs are returned by the search in some cases https://github.com/gravitee-io/issues/issues/3619[#3619]
+- [jdbc] Fail to save a Client registration config https://github.com/gravitee-io/issues/issues/3617[#3617]
+
+=== Improvements
+
+*_Gateway_*
+
+- Add PLAN_UNRESOLVABLE policy chain error key if no plan has been selected https://github.com/gravitee-io/issues/issues/3513[#3513]
+
+== https://github.com/gravitee-io/issues/milestone/222?closed=1[APIM - 1.30.9 (2020-04-24)]
+
+=== Bug fixes
+
+*_Alert_*
+
+- Upgrade alert-api dependency https://github.com/gravitee-io/issues/issues/3499[#3499]
+
+*_Gateway_*
+
+- Paused apikey subscriptions still works https://github.com/gravitee-io/issues/issues/3520[#3520]
+
+*_Management_*
+
+- Allows to override virtual host with entrypoints https://github.com/gravitee-io/issues/issues/3626[#3626]
+- Default `all` view has no key https://github.com/gravitee-io/issues/issues/3636[#3636]
+- Enable to connect a new user if simpleApp is disabled and default app is enabled https://github.com/gravitee-io/issues/issues/3523[#3523]
+- Filters are not correctly synched https://github.com/gravitee-io/issues/issues/3445[#3445]
+- Keep the swagger documentation when you update an API from a swagger file https://github.com/gravitee-io/issues/issues/3518[#3518]
+- Oidc "emailRequired" is not mapped https://github.com/gravitee-io/issues/issues/3597[#3597]
+- Searching for subscriptions with api-key does not work if there are many applications https://github.com/gravitee-io/issues/issues/3346[#3346]
+- [alert] metrics are the same for request or node https://github.com/gravitee-io/issues/issues/3514[#3514]
+
+*_Reporter_*
+
+- [elasticsearch] Bulk indexer continue to process data in case of error https://github.com/gravitee-io/issues/issues/3630[#3630]
+
+=== Improvements
+
+*_Management-api_*
+
+- Groups mapping for OAuth2 users are never refreshed https://github.com/gravitee-io/issues/issues/1698[#1698]
+
+*_Policy_*
+
+- [callout-http] Add support for OnRequestContent / OnResponseContent https://github.com/gravitee-io/issues/issues/3628[#3628]
+
+== https://github.com/gravitee-io/issues/milestone/220?closed=1[APIM - 1.30.8 (2020-04-06)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge release 1.25.24 https://github.com/gravitee-io/issues/issues/3425[#3425]
+
+*_Management_*
+
+- Error on top path column name https://github.com/gravitee-io/issues/issues/3411[#3411]
+- Metadata are not well imported while creating or updating an API https://github.com/gravitee-io/issues/issues/3409[#3409]
+- Unable to filter analytics on paths https://github.com/gravitee-io/issues/issues/3410[#3410]
+
+*_Management-ui_*
+
+- Login button is disabled with credentials settled by browser https://github.com/gravitee-io/issues/issues/3355[#3355]
+
+*_Portal_*
+
+- Entrypoints are incorrect in case of virtual hosting configuration https://github.com/gravitee-io/issues/issues/3404[#3404]
+
+=== Improvements
+
+*_Gateway_*
+
+- Get calls with Content-Type https://github.com/gravitee-io/issues/issues/3426[#3426]
+
+== https://github.com/gravitee-io/issues/milestone/215?closed=1[APIM - 1.25.24 (2020-04-04)]
+
+=== Bug fixes
+
+*_Management_*
+
+- (+) button override clickable elements https://github.com/gravitee-io/issues/issues/3081[#3081]
+- Move all JUL logs to SLF4J https://github.com/gravitee-io/issues/issues/3360[#3360]
+- Support email message is displaying html elements https://github.com/gravitee-io/issues/issues/3398[#3398]
+
+== https://github.com/gravitee-io/issues/milestone/218?closed=1[APIM - 1.30.7 (2020-03-31)]
+
+=== Bug fixes
+
+*_Node_*
+
+- Health-check is returning 500 when healthy https://github.com/gravitee-io/issues/issues/3400[#3400]
+
+== https://github.com/gravitee-io/issues/milestone/212?closed=1[APIM - 1.30.6 (2020-03-27)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge release 1.25.23 https://github.com/gravitee-io/issues/issues/3337[#3337]
+
+*_Management_*
+
+- API Quality is equals to 1% with no validated rules https://github.com/gravitee-io/issues/issues/3325[#3325]
+- Allows to define all policies at the plan's level https://github.com/gravitee-io/issues/issues/3280[#3280]
+- Direct members permissions are not well merged with group permissions https://github.com/gravitee-io/issues/issues/3315[#3315]
+- Unable to resume a subscription https://github.com/gravitee-io/issues/issues/3362[#3362]
+- Use the correct log lever for errors on token exchange https://github.com/gravitee-io/issues/issues/3267[#3267]
+- [analytics] keep order for data table widget https://github.com/gravitee-io/issues/issues/3350[#3350]
+- [dcr] Unable to change app info with using DCR https://github.com/gravitee-io/issues/issues/3180[#3180]
+- [documentation] unable to navigate inside subfolders https://github.com/gravitee-io/issues/issues/3375[#3375]
+- [fetcher] wrong credentials after setting fetcher configuration https://github.com/gravitee-io/issues/issues/3342[#3342]
+
+*_Management-api_*
+
+- Breaking change with virtual_hosts https://github.com/gravitee-io/issues/issues/3356[#3356]
+
+*_Management-ui_*
+
+- Bad ES syntax https://github.com/gravitee-io/issues/issues/3369[#3369]
+- Cannot view API response template key with read-only user role https://github.com/gravitee-io/issues/issues/3331[#3331]
+- Logs show Delete API / Application instead of Unknown https://github.com/gravitee-io/issues/issues/3349[#3349]
+- [analytics] cannot filter on unknown application https://github.com/gravitee-io/issues/issues/3345[#3345]
+
+*_Oauth2_*
+
+- Log in when behind a loadbalancer isn't always working https://github.com/gravitee-io/issues/issues/3329[#3329]
+
+*_Policy_*
+
+- [jwt] Bearer token_type is not case-insensitive https://github.com/gravitee-io/issues/issues/3250[#3250]
+
+*_Portal_*
+
+- When updating the view name, the label is not correct on the API's cards https://github.com/gravitee-io/issues/issues/3279[#3279]
+
+=== Features
+
+*_Policy_*
+
+- Create a policy from a swagger descriptor https://github.com/gravitee-io/issues/issues/3298[#3298]
+
+=== Improvements
+
+*_Alert_*
+
+- Add alert events based on node health-check https://github.com/gravitee-io/issues/issues/3118[#3118]
+
+*_Expression-language_*
+
+- Add support of XPath for internal expression language https://github.com/gravitee-io/issues/issues/3211[#3211]
+
+*_Management_*
+
+- Keep history of alert's notifications https://github.com/gravitee-io/issues/issues/3185[#3185]
+- Option to include API's path to Swagger server https://github.com/gravitee-io/issues/issues/3359[#3359]
+- Setup API alert from platform settings https://github.com/gravitee-io/issues/issues/3335[#3335]
+- Swagger servers based on API entrypoints https://github.com/gravitee-io/issues/issues/3277[#3277]
+
+*_Management-ui_*
+
+- Add more response-time filters to search for logs https://github.com/gravitee-io/issues/issues/3358[#3358]
+
+*_Policy_*
+
+- [generate-jwt] The header x5c is not available in policy https://github.com/gravitee-io/issues/issues/2999[#2999]
+- [ssl-enforcement] Manage multiple RFC for subject format https://github.com/gravitee-io/issues/issues/3321[#3321]
+
+*_Service-discovery_*
+
+- Consul service discovery plugin doesn't have a way of knowing whether it's SSL https://github.com/gravitee-io/issues/issues/3294[#3294]
+
+== https://github.com/gravitee-io/issues/milestone/210?closed=1[APIM - 1.25.23 (2020-03-11)]
+
+=== Bug fixes
+
+*_General_*
+
+- Backport issue #3264 https://github.com/gravitee-io/issues/issues/3265[#3265]
+
+*_Management_*
+
+- API metadata are not exported https://github.com/gravitee-io/issues/issues/3314[#3314]
+- InMemory users with empty firstname/lastname are displayed as 'null' https://github.com/gravitee-io/issues/issues/3313[#3313]
+- Make clearer the group's selection on a plan or a page https://github.com/gravitee-io/issues/issues/3281[#3281]
+- Manual unlocking of detailed logging limitation https://github.com/gravitee-io/issues/issues/3282[#3282]
+- Some users are wrongly flagged as primary owners https://github.com/gravitee-io/issues/issues/3273[#3273]
+- Wildcard logs search in the "path" field is not working anymore https://github.com/gravitee-io/issues/issues/3256[#3256]
+
+*_Management-ui_*
+
+- Entry Point API Portal headers are truncated https://github.com/gravitee-io/issues/issues/3312[#3312]
+- Unable to save view settings after updating only the visibility https://github.com/gravitee-io/issues/issues/3255[#3255]
+
+*_Policy_*
+
+- [rate-limit] ConcurrentModificationException with async mode https://github.com/gravitee-io/issues/issues/3311[#3311]
+
+*_Repository_*
+
+- [jdbc] Database objects missing when initially starting management api https://github.com/gravitee-io/issues/issues/3272[#3272]
+
+=== Improvements
+
+*_Management_*
+
+- Improve our rest-api documentation https://github.com/gravitee-io/issues/issues/3230[#3230]
+
+== https://github.com/gravitee-io/issues/milestone/211?closed=1[APIM - 1.30.5 (2020-02-27)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Fail to parse Swagger page with dynamic freemarker values https://github.com/gravitee-io/issues/issues/3259[#3259]
+- Metadata cannot be deleted when value is too long https://github.com/gravitee-io/issues/issues/3266[#3266]
+- Paging functionality of widgets in the dashboards not working https://github.com/gravitee-io/issues/issues/3263[#3263]
+
+*_Management-ui_*
+
+- Missing API Entry Points header https://github.com/gravitee-io/issues/issues/3260[#3260]
+
+*_Policy_*
+
+- [oauth2] User is not logged anymore https://github.com/gravitee-io/issues/issues/3264[#3264]
+
+=== Features
+
+*_Management_*
+
+- Platform logs https://github.com/gravitee-io/issues/issues/3233[#3233]
+
+== https://github.com/gravitee-io/issues/milestone/208?closed=1[APIM - 1.30.4 (2020-02-24)]
+
+=== Bug fixes
+
+*_Analytics_*
+
+- Cors request considered as "Deleted Application" https://github.com/gravitee-io/issues/issues/3228[#3228]
+- Unable to filter on unknown application from dashboard https://github.com/gravitee-io/issues/issues/3226[#3226]
+
+*_Gateway_*
+
+- Calls with a wrong context path have a status code 0 in platform analytics https://github.com/gravitee-io/issues/issues/3216[#3216]
+
+*_General_*
+
+- Merge release 1.25.22 https://github.com/gravitee-io/issues/issues/3247[#3247]
+
+*_Management_*
+
+- Unable to update api-key plan https://github.com/gravitee-io/issues/issues/3242[#3242]
+- Widget timeline does not display the API names correctly https://github.com/gravitee-io/issues/issues/3205[#3205]
+
+=== Features
+
+*_Management_*
+
+- A swagger page must contains the entrypoints depending on sharding-tags https://github.com/gravitee-io/issues/issues/3246[#3246]
+
+=== Improvements
+
+*_Analytics_*
+
+- Log unknown path for unknown APIs https://github.com/gravitee-io/issues/issues/3195[#3195]
+
+== https://github.com/gravitee-io/issues/milestone/207?closed=1[APIM - 1.25.22 (2020-02-20)]
+
+=== Bug fixes
+
+*_Elasticsearch_*
+
+- Cannot index a cpu loadaverage as long https://github.com/gravitee-io/issues/issues/2692[#2692]
+
+*_Gateway_*
+
+- [response template] multiple "Accept" header is not supported https://github.com/gravitee-io/issues/issues/3212[#3212]
+
+*_Management_*
+
+- Better display on tooltip when too much data to display on a line chart https://github.com/gravitee-io/issues/issues/3244[#3244]
+- Group permissions inheritance https://github.com/gravitee-io/issues/issues/3238[#3238]
+- Typo on configuration of HTTP proxy https://github.com/gravitee-io/issues/issues/3221[#3221]
+- When creating group boolean parameters were ignored https://github.com/gravitee-io/issues/issues/3171[#3171]
+
+*_Management-ui_*
+
+- Scrollbar-x is blocked on data table widget https://github.com/gravitee-io/issues/issues/3243[#3243]
+
+*_Policy_*
+
+- [callout] Add expression language support in error response body https://github.com/gravitee-io/issues/issues/3188[#3188]
+- [jwt] End user is not logged when a policy fail https://github.com/gravitee-io/issues/issues/3189[#3189]
+- [rbac] Strict mode must not check the role from the source https://github.com/gravitee-io/issues/issues/3220[#3220]
+
+*_Portal_*
+
+- Redirect to a given page after an oauth authentication https://github.com/gravitee-io/issues/issues/3231[#3231]
+- The navbar disappeared when scrolling down the page https://github.com/gravitee-io/issues/issues/1823[#1823]
+
+*_Repository_*
+
+- [mongodb] Upgrade to latest 3.x version of the driver. https://github.com/gravitee-io/issues/issues/3235[#3235]
+
+=== Improvements
+
+*_Management_*
+
+- Add a badge for primary_owner user https://github.com/gravitee-io/issues/issues/3245[#3245]
+- Do not allow to click on "delete user" if he's PRIMARY_OWNER https://github.com/gravitee-io/issues/issues/2425[#2425]
+- Rework the gateway monitoring screen to manage large set of data https://github.com/gravitee-io/issues/issues/3222[#3222]
+- [idp] Add firstname and lastname support for inmemory users https://github.com/gravitee-io/issues/issues/3234[#3234]
+
+*_Management-ui_*
+
+- Associate sharding tags / entrypoints in the API portal header https://github.com/gravitee-io/issues/issues/3239[#3239]
+
+== https://github.com/gravitee-io/issues/milestone/205?closed=1[APIM - 1.30.3 (2020-02-09)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Some calls are reported with a negative response time https://github.com/gravitee-io/issues/issues/3191[#3191]
+
+*_General_*
+
+- Allows to override the claim to read for the log of the end user not released in 1.30.x https://github.com/gravitee-io/issues/issues/3120[#3120]
+- Merge release 1.25.21 https://github.com/gravitee-io/issues/issues/3210[#3210]
+
+*_Management_*
+
+- Analytic widgets with latency displayed hits instead of latency https://github.com/gravitee-io/issues/issues/3041[#3041]
+- As a non admin I want to create portal documentation https://github.com/gravitee-io/issues/issues/3174[#3174]
+- Do not display "Duplicate API" if you're not allowed to create an API https://github.com/gravitee-io/issues/issues/3175[#3175]
+
+*_Management-ui_*
+
+- Not able to save after removing an alert notification https://github.com/gravitee-io/issues/issues/3162[#3162]
+
+*_Portal_*
+
+- Unable to reset user password from link https://github.com/gravitee-io/issues/issues/2957[#2957]
+
+=== Features
+
+*_Alert_*
+
+- Add processor to customize event's properties https://github.com/gravitee-io/issues/issues/3187[#3187]
+
+*_Policy_*
+
+- New SSL Enforcement policy https://github.com/gravitee-io/issues/issues/3159[#3159]
+
+=== Improvements
+
+*_Analytics_*
+
+- Add remote-address in analytics fields https://github.com/gravitee-io/issues/issues/3121[#3121]
+
+*_Gateway_*
+
+- Better support of inbound mutual SSL authentication https://github.com/gravitee-io/issues/issues/3160[#3160]
+
+*_Management_*
+
+- Upgrade node/npm modules https://github.com/gravitee-io/issues/issues/3207[#3207]
+
+*_Policy_*
+
+- [json-validation] enabling response scope for gravitee-policy-json-validation https://github.com/gravitee-io/issues/issues/2825[#2825]
+
+== https://github.com/gravitee-io/issues/milestone/202?closed=1[APIM - 1.25.21 (2020-01-30)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Closed oauth subscriptions continue to work https://github.com/gravitee-io/issues/issues/3112[#3112]
+
+*_Management_*
+
+- An apikey cannot ended after subscription https://github.com/gravitee-io/issues/issues/3153[#3153]
+- Error trying to import API with primary owner without email https://github.com/gravitee-io/issues/issues/3104[#3104]
+- Manage import/export Api documentation with folders https://github.com/gravitee-io/issues/issues/3129[#3129]
+- The configuration of an email on a user (in memory) does not work https://github.com/gravitee-io/issues/issues/3103[#3103]
+
+*_Policy_*
+
+- [transform query params] Could not merge params https://github.com/gravitee-io/issues/issues/3158[#3158]
+
+*_Repository_*
+
+- [mongodb] Connection leak https://github.com/gravitee-io/issues/issues/3169[#3169]
+
+=== Features
+
+*_Management_*
+
+- Add a "Maintenance Mode" status in the rest-api https://github.com/gravitee-io/issues/issues/3124[#3124]
+
+=== Improvements
+
+*_Analytics_*
+
+- Be more specific between response time and latency https://github.com/gravitee-io/issues/issues/3113[#3113]
+- Display the complete request on the application side https://github.com/gravitee-io/issues/issues/3107[#3107]
+
+*_Management_*
+
+- Allow api owner to update the souscription end date https://github.com/gravitee-io/issues/issues/3149[#3149]
+- Be more helpful in the CORS description https://github.com/gravitee-io/issues/issues/3133[#3133]
+- [fetcher] Do not retrieve personal token https://github.com/gravitee-io/issues/issues/3082[#3082]
+- [user] synchronize user informations on login. https://github.com/gravitee-io/issues/issues/2592[#2592]
+
+*_Policy_*
+
+- [resource-filtering] backport #1271 https://github.com/gravitee-io/issues/issues/3164[#3164]
+
+*_Repository_*
+
+- [jdbc] Add option to disable Liquibase during startup of a node https://github.com/gravitee-io/issues/issues/3170[#3170]
+
+== https://github.com/gravitee-io/issues/milestone/201?closed=1[APIM - 1.25.20 (2020-01-17)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Error[failed to parse field [api-response-time] of type [integer] https://github.com/gravitee-io/issues/issues/2989[#2989]
+
+== https://github.com/gravitee-io/issues/milestone/197?closed=1[APIM - 1.30.2 (2020-01-15)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge release 1.25.18 https://github.com/gravitee-io/issues/issues/3090[#3090]
+- Merge release 1.25.19 https://github.com/gravitee-io/issues/issues/3099[#3099]
+
+*_Management_*
+
+- Cannot remove an item on the widget status (pie) https://github.com/gravitee-io/issues/issues/3089[#3089]
+
+*_Policy_*
+
+- [resource-filtering] always fails if multiple resources are configured https://github.com/gravitee-io/issues/issues/3060[#3060]
+
+=== Improvements
+
+*_Gateway_*
+
+- Remove log activity for HTTP client https://github.com/gravitee-io/issues/issues/3056[#3056]
+
+*_Management_*
+
+- Make case-insensitive enum when api is imported https://github.com/gravitee-io/issues/issues/2995[#2995]
+
+== https://github.com/gravitee-io/issues/milestone/199?closed=1[APIM - 1.25.19 (2020-01-15)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Do not log stream event requests https://github.com/gravitee-io/issues/issues/2976[#2976]
+- [bridge] Thread blocked with prometheus https://github.com/gravitee-io/issues/issues/3091[#3091]
+
+*_Management_*
+
+- [logs] Unable to search for transaction-id with : https://github.com/gravitee-io/issues/issues/3070[#3070]
+
+*_Repository_*
+
+- [bridge] events search parameters are not well mapped https://github.com/gravitee-io/issues/issues/3095[#3095]
+- [bridge] throw exception if the client http request fails https://github.com/gravitee-io/issues/issues/3096[#3096]
+
+== https://github.com/gravitee-io/issues/milestone/195?closed=1[APIM - 1.25.18 (2020-01-11)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- The max size configuration of reporters is not well handled https://github.com/gravitee-io/issues/issues/3005[#3005]
+
+*_General_*
+
+- Wrong comment syntax in .bat file https://github.com/gravitee-io/issues/issues/3050[#3050]
+
+*_Management_*
+
+- Do not log message when a field is not mapped on an identity provider https://github.com/gravitee-io/issues/issues/3016[#3016]
+- Improve email errors management https://github.com/gravitee-io/issues/issues/3038[#3038]
+- When deleting an API, memberships and notifications should also be deleted https://github.com/gravitee-io/issues/issues/2711[#2711]
+
+*_Policy_*
+
+- [mock]  JSON schema - duplicate items on status property https://github.com/gravitee-io/issues/issues/3029[#3029]
+
+*_Portal_*
+
+- Overflow of tags and views in the api header. https://github.com/gravitee-io/issues/issues/3053[#3053]
+
+*_Repository_*
+
+- [mongodb] Performance issues when searching into audits https://github.com/gravitee-io/issues/issues/3065[#3065]
+
+=== Improvements
+
+*_Gateway_*
+
+- We should avoid to log binary content https://github.com/gravitee-io/issues/issues/3007[#3007]
+
+*_Management_*
+
+- Add a warning message if `*` is set for allowed origins of CORS https://github.com/gravitee-io/issues/issues/3055[#3055]
+- Change log level if email is disabled https://github.com/gravitee-io/issues/issues/3035[#3035]
+- Create "chips" when leaving the input https://github.com/gravitee-io/issues/issues/3062[#3062]
+- Logs configuratorgenerate a more tolerant condition https://github.com/gravitee-io/issues/issues/3047[#3047]
+
+*_Management-api_*
+
+- Add EL support for the "email-support" API metadata https://github.com/gravitee-io/issues/issues/3049[#3049]
+
+== https://github.com/gravitee-io/issues/milestone/196?closed=1[APIM - 1.30.1 (2019-12-19)]
+
+=== Bug fixes
+
+*_General_*
+
+- Add option do disable log payloads indexation https://github.com/gravitee-io/issues/issues/2952[#2952]
+- Context path not used on the elasticsearch reporter https://github.com/gravitee-io/issues/issues/3030[#3030]
+- Merge release 1.25.17 https://github.com/gravitee-io/issues/issues/3042[#3042]
+- Path not used with the management bridge http https://github.com/gravitee-io/issues/issues/2992[#2992]
+
+*_Management_*
+
+- Add read permission by default on quality rules https://github.com/gravitee-io/issues/issues/2984[#2984]
+- Analytic widgets with latency displayed hits instead of latency https://github.com/gravitee-io/issues/issues/3041[#3041]
+- Analyticsunknown application always shown as deleted application https://github.com/gravitee-io/issues/issues/2987[#2987]
+- Do not allow navigation between api's and application's analytics https://github.com/gravitee-io/issues/issues/2986[#2986]
+
+*_Node_*
+
+- NodeDeployer must managed injectable fields https://github.com/gravitee-io/issues/issues/2963[#2963]
+
+*_Portal_*
+
+- Unable to reset user password from link https://github.com/gravitee-io/issues/issues/2957[#2957]
+
+=== Improvements
+
+*_Alert_*
+
+- Alerts and Notifications implements Serializable https://github.com/gravitee-io/issues/issues/2997[#2997]
+
+*_General_*
+
+- Add PKCS12 support for gateway HTTP server and management HTTP server https://github.com/gravitee-io/issues/issues/2978[#2978]
+- No trust configuration for the bridge client https://github.com/gravitee-io/issues/issues/3031[#3031]
+
+*_Policy_*
+
+- [assign-attributes] Support for on-request-content and on-response-content https://github.com/gravitee-io/issues/issues/2948[#2948]
+- [json-validation] enabling response scope for gravitee-policy-json-validation https://github.com/gravitee-io/issues/issues/2825[#2825]
+- [resource-filtering] Context-path in the pattern https://github.com/gravitee-io/issues/issues/1271[#1271]
+
+== https://github.com/gravitee-io/issues/milestone/194?closed=1[APIM - 1.25.17 (2019-12-06)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Do not log stream event requests https://github.com/gravitee-io/issues/issues/2976[#2976]
+- Request not logged when X-Forwarded-For header contains host with port number https://github.com/gravitee-io/issues/issues/2937[#2937]
+
+*_Management_*
+
+- Analyticsunknown application/api are always on top https://github.com/gravitee-io/issues/issues/2988[#2988]
+
+*_Node_*
+
+- NPE if metrics service is disabled https://github.com/gravitee-io/issues/issues/2979[#2979]
+
+=== Improvements
+
+*_Management_*
+
+- Do not log oauth mapping in error https://github.com/gravitee-io/issues/issues/2973[#2973]
+
+== https://github.com/gravitee-io/issues/milestone/186?closed=1[APIM - 1.25.16 (2019-12-04)]
+
+=== Bug fixes
+
+*_Analytics_*
+
+- Request headers with the same name are not displayed correctly https://github.com/gravitee-io/issues/issues/2890[#2890]
+
+*_Gateway_*
+
+- No path-mapping when getting 401 or 403 status code https://github.com/gravitee-io/issues/issues/2928[#2928]
+
+*_General_*
+
+- Error 400, IllegalArgumentException in dynamic routing https://github.com/gravitee-io/issues/issues/2875[#2875]
+
+*_Management_*
+
+- API events are not in the select list for logs https://github.com/gravitee-io/issues/issues/2883[#2883]
+- Add controls when creating/updating an api https://github.com/gravitee-io/issues/issues/2938[#2938]
+- Keep pagination when navigate through users https://github.com/gravitee-io/issues/issues/2897[#2897]
+- Platform dashboard rights not correctly handled for widget response status https://github.com/gravitee-io/issues/issues/2868[#2868]
+- Some settings are not save in the current session https://github.com/gravitee-io/issues/issues/2968[#2968]
+- Update page by importing a file doesn't work. https://github.com/gravitee-io/issues/issues/2896[#2896]
+- When deleting an API, its pages should be also deleted https://github.com/gravitee-io/issues/issues/2844[#2844]
+
+*_Management-api_*
+
+- View is loosing its picture when re-ordering https://github.com/gravitee-io/issues/issues/2909[#2909]
+
+*_Management-ui_*
+
+- [dictionaries] Performance issue when dictionary has a lot of properties https://github.com/gravitee-io/issues/issues/2846[#2846]
+
+*_Policy_*
+
+- [request-validation] Requests not logged with scope REQUEST-CONTENT https://github.com/gravitee-io/issues/issues/2644[#2644]
+
+*_Portal_*
+
+- API Gallerycss issue for the API logo https://github.com/gravitee-io/issues/issues/2113[#2113]
+- Blind screen when loading a documentation page https://github.com/gravitee-io/issues/issues/1968[#1968]
+
+*_Repository_*
+
+- [mongodb] Wrong default authSource https://github.com/gravitee-io/issues/issues/2905[#2905]
+
+=== Features
+
+*_Node_*
+
+- Add health data available in the prometheus endpoint https://github.com/gravitee-io/issues/issues/1958[#1958]
+
+=== Improvements
+
+*_Analytics_*
+
+- Index the remote-address on each requests https://github.com/gravitee-io/issues/issues/2895[#2895]
+
+*_Management_*
+
+- Add an header in each dynamic-properties requests https://github.com/gravitee-io/issues/issues/2854[#2854]
+
+*_Management-api_*
+
+- Improve swagger documentation for analytics https://github.com/gravitee-io/issues/issues/2914[#2914]
+
+*_Managment_*
+
+- Add group to all existing apps/apis https://github.com/gravitee-io/issues/issues/2253[#2253]
+
+*_Policy_*
+
+- [groovy] Better management of memory consumption https://github.com/gravitee-io/issues/issues/2782[#2782]
+
+== https://github.com/gravitee-io/issues/milestone/120?closed=1[APIM - 1.30.0 (2019-11-17)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- [plan] token extractor for JWT/OAuth 2.0 plan should look for token in request parameter https://github.com/gravitee-io/issues/issues/2891[#2891]
+
+*_General_*
+
+- Merge release 1.29.6 https://github.com/gravitee-io/issues/issues/2859[#2859]
+
+*_Management_*
+
+- Minor changes in multi analytics dashboard https://github.com/gravitee-io/issues/issues/2819[#2819]
+
+=== Features
+
+*_General_*
+
+- Alerting Integration https://github.com/gravitee-io/issues/issues/2777[#2777]
+
+*_Management_*
+
+- Allows to define manual rules for the reviewer which will affect the API quality https://github.com/gravitee-io/issues/issues/2601[#2601]
+- Dynamic global dashboards of analytics https://github.com/gravitee-io/issues/issues/2595[#2595]
+- Lifecycle - allows to deprecate an API https://github.com/gravitee-io/issues/issues/55[#55]
+
+*_Node_*
+
+- Provide a way to intercept node instantiation https://github.com/gravitee-io/issues/issues/2878[#2878]
+
+*_Plugin_*
+
+- Add an interceptor while deploying a plugin https://github.com/gravitee-io/issues/issues/2880[#2880]
+
+*_Portal_*
+
+- Duplicate an api to create a new version of the API https://github.com/gravitee-io/issues/issues/433[#433]
+
+=== Improvements
+
+*_Gateway_*
+
+- Notify reporters of requests to unhandled contexts https://github.com/gravitee-io/issues/issues/2625[#2625]
+
+*_Gravitee-policy-oauth2_*
+
+- Support EL in resource name https://github.com/gravitee-io/issues/issues/2629[#2629]
+
+*_Management_*
+
+- Client registration (dcr)manage software_id https://github.com/gravitee-io/issues/issues/2836[#2836]
+- [health check] The timeline in summary shouldn't be centered https://github.com/gravitee-io/issues/issues/2447[#2447]
+
+*_Policy_*
+
+- [generate-jwt] Custom claims can be only Strings https://github.com/gravitee-io/issues/issues/2850[#2850]
+- [jwt] Allows to override claim to read for the log of the end user https://github.com/gravitee-io/issues/issues/2741[#2741]
+
+== https://github.com/gravitee-io/issues/milestone/188?closed=1[APIM - 1.29.6 (2019-11-07)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Fail to translate from wss gateway to wss on endpoint sockets https://github.com/gravitee-io/issues/issues/2811[#2811]
+
+*_General_*
+
+- Merge release 1.25.15 https://github.com/gravitee-io/issues/issues/2856[#2856]
+
+*_Management_*
+
+- Can subscribe to an API with an archived application https://github.com/gravitee-io/issues/issues/2732[#2732]
+- Error on page template because of virtual hosting https://github.com/gravitee-io/issues/issues/2719[#2719]
+- WebhookNotifier doesn't support multiple languages https://github.com/gravitee-io/issues/issues/2727[#2727]
+
+*_Management-ui_*
+
+- Portal.entrypoint overriding constants.json has no effect https://github.com/gravitee-io/issues/issues/2676[#2676]
+
+=== Improvements
+
+*_Portal_*
+
+- Applications menu item visible even though no permission is granted https://github.com/gravitee-io/issues/issues/2565[#2565]
+
+== https://github.com/gravitee-io/issues/milestone/182?closed=1[APIM - 1.25.15 (2019-11-04)]
+
+=== Bug fixes
+
+*_Gravitee-policy-request-validation_*
+
+- Support order of rules https://github.com/gravitee-io/issues/issues/2666[#2666]
+
+*_Management_*
+
+- Delete button is not displayed on metadata sometimes https://github.com/gravitee-io/issues/issues/2703[#2703]
+- Read only right is not well handled on documentation page https://github.com/gravitee-io/issues/issues/2701[#2701]
+- Take care of content type on swagger/OAI specs https://github.com/gravitee-io/issues/issues/2766[#2766]
+- User management delete button is hidden on tight screen resolution https://github.com/gravitee-io/issues/issues/2821[#2821]
+- [analytics] get all HTTP response status for global dashboard https://github.com/gravitee-io/issues/issues/2813[#2813]
+
+*_Policy_*
+
+- [callout-http] Multiple headers not handled correctly in the callout response https://github.com/gravitee-io/issues/issues/2780[#2780]
+- [request-validation] Policy is writing an empty content to backend https://github.com/gravitee-io/issues/issues/2833[#2833]
+
+*_Portal_*
+
+- Redirect to login when the user token expires https://github.com/gravitee-io/issues/issues/2824[#2824]
+
+=== Improvements
+
+*_Management_*
+
+- Add a more informative message when a user close an api, an application or a plan https://github.com/gravitee-io/issues/issues/2405[#2405]
+- Analyticsmissing name for deleted plans https://github.com/gravitee-io/issues/issues/2815[#2815]
+- Increase the max length of API name https://github.com/gravitee-io/issues/issues/2800[#2800]
+- [idp] Add email support for inmemory users https://github.com/gravitee-io/issues/issues/2590[#2590]
+
+*_Notification_*
+
+- [email] use a dynamic value for the Primary Owner email https://github.com/gravitee-io/issues/issues/2831[#2831]
+
+*_Policy_*
+
+- [transform-headers] Add validation constraint on the key https://github.com/gravitee-io/issues/issues/2712[#2712]
+
+== https://github.com/gravitee-io/issues/milestone/185?closed=1[APIM - 1.29.5 (2019-10-25)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge release 1.28.6 https://github.com/gravitee-io/issues/issues/2786[#2786]
+
+== https://github.com/gravitee-io/issues/milestone/184?closed=1[APIM - 1.28.6 (2019-10-25)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge release 1.25.14 https://github.com/gravitee-io/issues/issues/2783[#2783]
+
+== https://github.com/gravitee-io/issues/milestone/172?closed=1[APIM - 1.25.14 (2019-10-22)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Errors when empty query param follows a valued query param. https://github.com/gravitee-io/issues/issues/2742[#2742]
+
+*_Management_*
+
+- After a click on an item the notification's screen is broken on Firefox https://github.com/gravitee-io/issues/issues/2704[#2704]
+- Do not display error notification when user's scheduled tasks or notifications failed https://github.com/gravitee-io/issues/issues/2689[#2689]
+- ExceptionInInitializerError while upgrading jdk to 11 https://github.com/gravitee-io/issues/issues/2481[#2481]
+- Help message in the failover configuration is wrong https://github.com/gravitee-io/issues/issues/2684[#2684]
+- Remove an api forom a view removes it for all views https://github.com/gravitee-io/issues/issues/2767[#2767]
+- Sometimes the api list is not refreshing well https://github.com/gravitee-io/issues/issues/2763[#2763]
+- The `reset` feature does not work on application's attributes and tenant configuration https://github.com/gravitee-io/issues/issues/2690[#2690]
+- The group administrator should not need the UPDATE permission https://github.com/gravitee-io/issues/issues/2708[#2708]
+- Unable to access settings for an api publisher https://github.com/gravitee-io/issues/issues/2752[#2752]
+- Unable to delete a dictionary in JDBC https://github.com/gravitee-io/issues/issues/2745[#2745]
+- When deleting an API, alerts should be also deleted https://github.com/gravitee-io/issues/issues/2306[#2306]
+- Wrong color on buttons on the deployments form https://github.com/gravitee-io/issues/issues/2729[#2729]
+
+*_Policy_*
+
+- [request-validation] email are no longer validated https://github.com/gravitee-io/issues/issues/2746[#2746]
+
+*_Repository_*
+
+- [jdbc] Upgrade schema is not working for MySQL https://github.com/gravitee-io/issues/issues/2720[#2720]
+
+=== Improvements
+
+*_Management_*
+
+- Add a confirm dialog when deleting a dictionary https://github.com/gravitee-io/issues/issues/2738[#2738]
+- Allow api/app name with one letter https://github.com/gravitee-io/issues/issues/2707[#2707]
+- Increase the http timeout during "fetch" https://github.com/gravitee-io/issues/issues/2762[#2762]
+
+*_Reporter_*
+
+- [elasticsearch] Message in request metrics should be searchable https://github.com/gravitee-io/issues/issues/2735[#2735]
+
+*_Repository_*
+
+- Retry the connection to the repository on startup https://github.com/gravitee-io/issues/issues/2693[#2693]
+
+== https://github.com/gravitee-io/issues/milestone/176?closed=1[APIM - 1.29.4 (2019-10-07)]
+
+=== Bug fixes
+
+*_Policy_*
+
+- [groovy] JSON Slurper does not work anymore within the gateway https://github.com/gravitee-io/issues/issues/2717[#2717]
+
+== https://github.com/gravitee-io/issues/milestone/175?closed=1[APIM - 1.29.3 (2019-10-03)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge release 1.28.5 https://github.com/gravitee-io/issues/issues/2702[#2702]
+
+== https://github.com/gravitee-io/issues/milestone/174?closed=1[APIM - 1.28.5 (2019-10-03)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge release 1.25.13 https://github.com/gravitee-io/issues/issues/2700[#2700]
+
+== https://github.com/gravitee-io/issues/milestone/169?closed=1[APIM - 1.25.13 (2019-10-03)]
+
+=== Bug fixes
+
+*_General_*
+
+- Upgrade vertx 3.7.1 https://github.com/gravitee-io/issues/issues/2697[#2697]
+
+== https://github.com/gravitee-io/issues/milestone/171?closed=1[APIM - 1.29.2 (2019-10-03)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge release 1.28.4 https://github.com/gravitee-io/issues/issues/2698[#2698]
+
+== https://github.com/gravitee-io/issues/milestone/170?closed=1[APIM - 1.28.4 (2019-10-02)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge release 1.25.12 https://github.com/gravitee-io/issues/issues/2696[#2696]
+
+== https://github.com/gravitee-io/issues/milestone/165?closed=1[APIM - 1.25.12 (2019-09-30)]
+
+=== Bug fixes
+
+*_Backport_*
+
+- #1599 https://github.com/gravitee-io/issues/issues/2660[#2660]
+- #1691 https://github.com/gravitee-io/issues/issues/2655[#2655]
+- #1691 https://github.com/gravitee-io/issues/issues/2658[#2658]
+- #1845 https://github.com/gravitee-io/issues/issues/2662[#2662]
+- #1856 https://github.com/gravitee-io/issues/issues/2654[#2654]
+- #2256 https://github.com/gravitee-io/issues/issues/2645[#2645]
+- #2266 https://github.com/gravitee-io/issues/issues/2657[#2657]
+- #2407 https://github.com/gravitee-io/issues/issues/2656[#2656]
+- #2435 https://github.com/gravitee-io/issues/issues/2647[#2647]
+- #2462 https://github.com/gravitee-io/issues/issues/2646[#2646]
+- #2469 https://github.com/gravitee-io/issues/issues/2648[#2648]
+- #2481 https://github.com/gravitee-io/issues/issues/2659[#2659]
+- #2548 https://github.com/gravitee-io/issues/issues/2653[#2653]
+- #2553 https://github.com/gravitee-io/issues/issues/2652[#2652]
+- #2573 https://github.com/gravitee-io/issues/issues/2651[#2651]
+- #2576 https://github.com/gravitee-io/issues/issues/2650[#2650]
+- #2596 https://github.com/gravitee-io/issues/issues/2649[#2649]
+- #946 https://github.com/gravitee-io/issues/issues/2661[#2661]
+
+*_Dictionaries_*
+
+- Can't stop a deleted dictionary https://github.com/gravitee-io/issues/issues/2663[#2663]
+
+*_Management_*
+
+- Do not save apis with regex error in path https://github.com/gravitee-io/issues/issues/2642[#2642]
+- Subscriptions failed if an app has no primary owner https://github.com/gravitee-io/issues/issues/2671[#2671]
+- [notification] remove notification when a user is deleted https://github.com/gravitee-io/issues/issues/2593[#2593]
+-  Invalid Path mappings cause management API returns 500 https://github.com/gravitee-io/issues/issues/2424[#2424]
+
+*_Policy_*
+
+- [request-validation] Requests not logged with scope REQUEST-CONTENT https://github.com/gravitee-io/issues/issues/2644[#2644]
+
+=== Improvements
+
+*_Management_*
+
+- Display the end user from the jwt policy https://github.com/gravitee-io/issues/issues/2643[#2643]
+
+*_Policy_*
+
+- [rate-limit] move to a reactive implementation https://github.com/gravitee-io/issues/issues/2570[#2570]
+
+== https://github.com/gravitee-io/issues/milestone/164?closed=1[APIM - 1.29.1 (2019-09-25)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- API Policy Path is not handled https://github.com/gravitee-io/issues/issues/2632[#2632]
+
+*_General_*
+
+- Merge release 1.28.2 https://github.com/gravitee-io/issues/issues/2639[#2639]
+
+*_Management_*
+
+- ExceptionInInitializerError while upgrading jdk to 11 https://github.com/gravitee-io/issues/issues/2481[#2481]
+- Requests per second is not displayed anymore https://github.com/gravitee-io/issues/issues/2628[#2628]
+
+*_Policy_*
+
+- [dynamic-routing] Invalid path with virtual host feature https://github.com/gravitee-io/issues/issues/2640[#2640]
+
+== https://github.com/gravitee-io/issues/milestone/168?closed=1[APIM - 1.28.3 (2019-09-20)]
+
+=== Bug fixes
+
+*_Bundle_*
+
+- Wrong version of the dynamic routing policy https://github.com/gravitee-io/issues/issues/2638[#2638]
+
+== https://github.com/gravitee-io/issues/milestone/167?closed=1[APIM - 1.28.2 (2019-09-19)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge release 1.25.11 https://github.com/gravitee-io/issues/issues/2635[#2635]
+
+== https://github.com/gravitee-io/issues/milestone/161?closed=1[APIM - 1.25.11 (2019-09-18)]
+
+=== Bug fixes
+
+*_General_*
+
+- Groovy error using context.setAttribute https://github.com/gravitee-io/issues/issues/2455[#2455]
+
+*_Management_*
+
+- Pagination size is not working anymore on subscriptions list https://github.com/gravitee-io/issues/issues/2552[#2552]
+- Read permission must be enough to see the healthcheck https://github.com/gravitee-io/issues/issues/2566[#2566]
+- Settings menu is not displaying menu elements according to set permissions https://github.com/gravitee-io/issues/issues/2555[#2555]
+- Users with read right on Entrypoints cannot list https://github.com/gravitee-io/issues/issues/2620[#2620]
+- [policies] don't fail if you create a path without a `/` https://github.com/gravitee-io/issues/issues/2609[#2609]
+
+*_Repository_*
+
+- [elasticsearch] Optimization of date histogram queries is not working on some cases https://github.com/gravitee-io/issues/issues/2503[#2503]
+
+=== Improvements
+
+*_Gateway_*
+
+- Add an option to encode outgoing request https://github.com/gravitee-io/issues/issues/2557[#2557]
+
+*_Management_*
+
+- Allow to retreive users email in search results https://github.com/gravitee-io/issues/issues/2599[#2599]
+- Hide archived applications on user administration. https://github.com/gravitee-io/issues/issues/2597[#2597]
+- [dictionaries] read only users see providers informations https://github.com/gravitee-io/issues/issues/2618[#2618]
+- [user] remove user picture on delete https://github.com/gravitee-io/issues/issues/2598[#2598]
+
+== https://github.com/gravitee-io/issues/milestone/119?closed=1[APIM - 1.29.0 (2019-09-18)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- API gateway is not forwarding HTTP/1.1 error code statustext in response header https://github.com/gravitee-io/issues/issues/2381[#2381]
+- Bad plan selection with empty query-param api-key https://github.com/gravitee-io/issues/issues/2478[#2478]
+- HTTP 500 when call API with wrong context path https://github.com/gravitee-io/issues/issues/2504[#2504]
+- Port is missing in the configuration of rate limit https://github.com/gravitee-io/issues/issues/2548[#2548]
+
+*_Management_*
+
+- API key is not logged in analytics anymore https://github.com/gravitee-io/issues/issues/2492[#2492]
+- APIM portal not sending scope as param on request to Gravitee AM configured as identity provider https://github.com/gravitee-io/issues/issues/2407[#2407]
+- Adapt width of import's modal on a small resolution screen https://github.com/gravitee-io/issues/issues/2475[#2475]
+- I can subscribe to a plan for which I do not have access https://github.com/gravitee-io/issues/issues/2573[#2573]
+- Impossible to detach an API while creating a view https://github.com/gravitee-io/issues/issues/2576[#2576]
+- Jetty server becomes unresponsive after being idle https://github.com/gravitee-io/issues/issues/2549[#2549]
+- Logging configuration filter display closed plans https://github.com/gravitee-io/issues/issues/1845[#1845]
+- Quality metric health-check should check configuration on endpoints also https://github.com/gravitee-io/issues/issues/2596[#2596]
+- Ratings do not display users 'in memory' https://github.com/gravitee-io/issues/issues/2553[#2553]
+- Redirection problem at the first refresh of a connected user when jwt secret is changed https://github.com/gravitee-io/issues/issues/1887[#1887]
+- Renew subscription also renew expired (not revoked) api keys https://github.com/gravitee-io/issues/issues/2578[#2578]
+- The copy to clipboard button of tenant is not correctly centered https://github.com/gravitee-io/issues/issues/1691[#1691]
+- When adding/updating a dictionary element, the item menu should be selected https://github.com/gravitee-io/issues/issues/1599[#1599]
+- When deleting a notification, list is not refreshed https://github.com/gravitee-io/issues/issues/1856[#1856]
+
+*_Policy_*
+
+- [dynamic-routing] EL is not supported correctly in regex pattern https://github.com/gravitee-io/issues/issues/946[#946]
+
+=== Features
+
+*_Elasticsearch_*
+
+- Elastic 7.x support https://github.com/gravitee-io/issues/issues/2165[#2165]
+
+*_Gateway_*
+
+- Route requests by header param instead of context-path https://github.com/gravitee-io/issues/issues/503[#503]
+- Virtual hosting support https://github.com/gravitee-io/issues/issues/1594[#1594]
+
+*_Management_*
+
+- Add a sparkline graph on subscriptions list https://github.com/gravitee-io/issues/issues/2497[#2497]
+- Add analytics widgets to display response times stats (avg/min/max) and number of requests per second on a given period https://github.com/gravitee-io/issues/issues/2499[#2499]
+- Allows to export subscriptions to CSV https://github.com/gravitee-io/issues/issues/2494[#2494]
+- Allows to filter logs by endpoint https://github.com/gravitee-io/issues/issues/2495[#2495]
+- Allows to search subscriptions by api key https://github.com/gravitee-io/issues/issues/2496[#2496]
+- Display client id and not token on logs for JWT/OAuth2 plans https://github.com/gravitee-io/issues/issues/2574[#2574]
+- Display top failed calls as percentage https://github.com/gravitee-io/issues/issues/2498[#2498]
+
+=== Improvements
+
+*_Gateway_*
+
+- Allow websocket support in gravitee.yml https://github.com/gravitee-io/issues/issues/2374[#2374]
+- Implement WebSocket scheme support for ws and wss https://github.com/gravitee-io/issues/issues/2255[#2255]
+- Inefficient and Arbitrary selection of API in DefaultReactorHandlerResolver https://github.com/gravitee-io/issues/issues/1445[#1445]
+- NoClassDefFoundError io/gravitee/resource/oauth2/api/OAuth2Response https://github.com/gravitee-io/issues/issues/2408[#2408]
+
+*_General_*
+
+- Management Option to disallow the api-key in query params https://github.com/gravitee-io/issues/issues/2446[#2446]
+
+*_Management_*
+
+- Ability to easily put an endpoint in backup mode https://github.com/gravitee-io/issues/issues/1890[#1890]
+- Add a header when export logs as CSV https://github.com/gravitee-io/issues/issues/2551[#2551]
+- Remove duplicate context path in definition https://github.com/gravitee-io/issues/issues/2479[#2479]
+- Resource oauth2 provider always trusts all certs and do not verify hosts https://github.com/gravitee-io/issues/issues/2584[#2584]
+- Weak SSL protocols should not be used when authenticating with OAuth2 https://github.com/gravitee-io/issues/issues/2600[#2600]
+- When searching for APIs, empty input does not trigger the search https://github.com/gravitee-io/issues/issues/2559[#2559]
+
+*_Policy_*
+
+- [callout-http] Calls are not reaching when no variable is defined https://github.com/gravitee-io/issues/issues/2383[#2383]
+
+*_Reporter_*
+
+- [elasticsearch] Deprecate version 2.X https://github.com/gravitee-io/issues/issues/2514[#2514]
+
+*_Repository_*
+
+- [elasticsearch] Display an error when a problem occurs while getting info https://github.com/gravitee-io/issues/issues/2572[#2572]
+- [reporter] [elasticsearch] SSL/TLS certificate auth https://github.com/gravitee-io/issues/issues/2508[#2508]
+
+== https://github.com/gravitee-io/issues/milestone/154?closed=1[APIM - 1.28.1 (2019-08-23)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge release 1.25.10 https://github.com/gravitee-io/issues/issues/2547[#2547]
+
+*_Management_*
+
+- Not able to create a DCR application backend_to_backend https://github.com/gravitee-io/issues/issues/2511[#2511]
+
+== https://github.com/gravitee-io/issues/milestone/158?closed=1[APIM - 1.25.10 (2019-08-21)]
+
+=== Bug fixes
+
+*_Elasticsearch_*
+
+- Cross Cluster Search does not show logs/monitoring/hc https://github.com/gravitee-io/issues/issues/2534[#2534]
+- Extended request mapping is not taken into account https://github.com/gravitee-io/issues/issues/2539[#2539]
+
+*_Management_*
+
+- Filter on hits should be based on "endpoint" field https://github.com/gravitee-io/issues/issues/2536[#2536]
+- Unable to login with an email containing a "+" https://github.com/gravitee-io/issues/issues/2519[#2519]
+- [subscriptions] keep filters and pagination https://github.com/gravitee-io/issues/issues/2421[#2421]
+
+*_Policy_*
+
+- [dynamic-routing] `:` not working in path https://github.com/gravitee-io/issues/issues/2533[#2533]
+- [request-validation] check null parameters https://github.com/gravitee-io/issues/issues/2531[#2531]
+
+*_Portal_*
+
+- Redirect user to wished url after login https://github.com/gravitee-io/issues/issues/2093[#2093]
+
+=== Improvements
+
+*_Management_*
+
+- Allow applications to close pending and paused subscriptions https://github.com/gravitee-io/issues/issues/2530[#2530]
+- Completely change the sourceId of a deleted user https://github.com/gravitee-io/issues/issues/2537[#2537]
+- [documentation] disable fetchAll when its in progress https://github.com/gravitee-io/issues/issues/2538[#2538]
+
+*_Policy_*
+
+- [generate-jwt] Optimize performances https://github.com/gravitee-io/issues/issues/2507[#2507]
+
+== https://github.com/gravitee-io/issues/milestone/159?closed=1[APIM - 1.20.19 (2019-08-21)]
+
+=== Improvements
+
+*_Identityprovider_*
+
+- [ldap] map user picture https://github.com/gravitee-io/issues/issues/2094[#2094]
+
+== https://github.com/gravitee-io/issues/milestone/155?closed=1[APIM - 1.25.9 (2019-07-23)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Application's name mustn't be empty https://github.com/gravitee-io/issues/issues/2466[#2466]
+- Close PAUSED subscriptions when closing plan https://github.com/gravitee-io/issues/issues/2484[#2484]
+
+*_Policy_*
+
+- [jwt] Header propagation must be done after token validation https://github.com/gravitee-io/issues/issues/2486[#2486]
+
+=== Features
+
+*_Reporter_*
+
+- [elasticsearch] backport #2379 https://github.com/gravitee-io/issues/issues/2489[#2489]
+
+=== Improvements
+
+*_Gateway_*
+
+- Add more logs in case of logging condition failure https://github.com/gravitee-io/issues/issues/2488[#2488]
+
+*_Policy_*
+
+- [generate-jwt] Add support for HS384 and HS512 https://github.com/gravitee-io/issues/issues/2487[#2487]
+
+== https://github.com/gravitee-io/issues/milestone/118?closed=1[APIM - 1.28.0 (2019-07-18)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Error while importing an API when no default entrypoint is defined https://github.com/gravitee-io/issues/issues/2469[#2469]
+
+*_Policy_*
+
+- [json-to-json] Jolt should not update Content-Type header https://github.com/gravitee-io/issues/issues/1024[#1024]
+
+=== Features
+
+*_Management_*
+
+- Adding a filter to set the date range in the health check screen https://github.com/gravitee-io/issues/issues/2378[#2378]
+- Import API definition via a URL https://github.com/gravitee-io/issues/issues/2377[#2377]
+- Update API with swagger / OAI https://github.com/gravitee-io/issues/issues/2376[#2376]
+
+=== Improvements
+
+*_Policy_*
+
+- [xslt] EL support for XSL stylesheet parameters https://github.com/gravitee-io/issues/issues/2393[#2393]
+
+== https://github.com/gravitee-io/issues/milestone/153?closed=1[APIM - 1.27.3 (2019-07-18)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Missing library https://github.com/gravitee-io/issues/issues/2472[#2472]
+
+== https://github.com/gravitee-io/issues/milestone/150?closed=1[APIM - 1.27.2 (2019-07-17)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Plan keyless is always evaluated even if a wrong apikey is provided https://github.com/gravitee-io/issues/issues/2444[#2444]
+
+*_Management_*
+
+- Missing OPTIONS in access-control-allow-methods https://github.com/gravitee-io/issues/issues/2435[#2435]
+
+*_Policy_*
+
+- The Ressources declared in policy on the plan not working well when multiple oauth2 plans https://github.com/gravitee-io/issues/issues/2390[#2390]
+
+*_Portal_*
+
+- Angular issue when getting entrypoints by tags https://github.com/gravitee-io/issues/issues/2462[#2462]
+
+== https://github.com/gravitee-io/issues/milestone/147?closed=1[APIM - 1.25.8 (2019-07-16)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- IllegalStateExceptionRequest already complete https://github.com/gravitee-io/issues/issues/2431[#2431]
+- NPE on DefaultPolicyManager.create https://github.com/gravitee-io/issues/issues/2441[#2441]
+- [policy-generate-jwt] add nimbus lib due to #2397 https://github.com/gravitee-io/issues/issues/2443[#2443]
+
+*_Management_*
+
+- GRAVITEE_OPTS are not used in the gravitee launcher https://github.com/gravitee-io/issues/issues/2449[#2449]
+- Some openapi cases are not working with mock https://github.com/gravitee-io/issues/issues/2467[#2467]
+- Top APIs screen is broken https://github.com/gravitee-io/issues/issues/2426[#2426]
+- [dynamic-properties] properties are not updated https://github.com/gravitee-io/issues/issues/2463[#2463]
+
+*_Portal_*
+
+- Bold titles makes the page fail https://github.com/gravitee-io/issues/issues/2442[#2442]
+
+=== Features
+
+*_Policy_*
+
+- Response content not been updated on Plan Policies https://github.com/gravitee-io/issues/issues/2043[#2043]
+- [Transform Headers] add a white list https://github.com/gravitee-io/issues/issues/2412[#2412]
+- [generate-jwt] Add support for JKS and PKCS12 https://github.com/gravitee-io/issues/issues/2427[#2427]
+
+=== Improvements
+
+*_Gateway_*
+
+- [expression language] manage null result https://github.com/gravitee-io/issues/issues/2439[#2439]
+
+== https://github.com/gravitee-io/issues/milestone/149?closed=1[APIM - 1.27.1 (2019-07-02)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge release 1.25.7 https://github.com/gravitee-io/issues/issues/2419[#2419]
+
+*_Management_*
+
+- Button of subscription should not be displayed is there is subs https://github.com/gravitee-io/issues/issues/2389[#2389]
+- Description of additional selection rule is not well readable https://github.com/gravitee-io/issues/issues/2388[#2388]
+
+*_Policy_*
+
+- [generate-jwt] unable to generate JWT https://github.com/gravitee-io/issues/issues/2397[#2397]
+
+=== Improvements
+
+*_General_*
+
+- Minor rework on geo dashboard https://github.com/gravitee-io/issues/issues/2418[#2418]
+
+== https://github.com/gravitee-io/issues/milestone/145?closed=1[APIM - 1.25.7 (2019-06-25)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Take account of  vertx thread options https://github.com/gravitee-io/issues/issues/2403[#2403]
+
+*_Management_*
+
+- Better support of swagger mock generation https://github.com/gravitee-io/issues/issues/2404[#2404]
+- Health check configuration is not working anymore https://github.com/gravitee-io/issues/issues/2399[#2399]
+- Impossible to create path mapping from swagger pages anymore https://github.com/gravitee-io/issues/issues/1935[#1935]
+- Quality rate is not refreshed on save. https://github.com/gravitee-io/issues/issues/2394[#2394]
+- Response template is not part of an API export https://github.com/gravitee-io/issues/issues/2268[#2268]
+- [documentation] Do not display issues after the document is uploaded https://github.com/gravitee-io/issues/issues/2280[#2280]
+
+*_Portal_*
+
+- CSS issue when defining a long description for a view https://github.com/gravitee-io/issues/issues/2066[#2066]
+- Header entrypoints are not displayed on the documentation and support. https://github.com/gravitee-io/issues/issues/2401[#2401]
+- No-rating link is splited when the name of the API is too short https://github.com/gravitee-io/issues/issues/2033[#2033]
+- Rating is not updated https://github.com/gravitee-io/issues/issues/1969[#1969]
+
+== https://github.com/gravitee-io/issues/milestone/117?closed=1[APIM - 1.27.0 (2019-06-19)]
+
+=== Bug fixes
+
+*_Elasticsearch_*
+
+- Error when indexing empty user-agent https://github.com/gravitee-io/issues/issues/2256[#2256]
+
+*_Fetchers_*
+
+- Gravitee-fetcher-http does not work with Envoy https://github.com/gravitee-io/issues/issues/2380[#2380]
+
+*_Gateway_*
+
+- Memory leak https://github.com/gravitee-io/issues/issues/2304[#2304]
+- Policy API is not up to date https://github.com/gravitee-io/issues/issues/2329[#2329]
+
+*_Management_*
+
+- API can not be started without being reviewed https://github.com/gravitee-io/issues/issues/2372[#2372]
+- API search is not working as expected https://github.com/gravitee-io/issues/issues/2382[#2382]
+- Lifecycle state is required when updating an API https://github.com/gravitee-io/issues/issues/2337[#2337]
+- Minor translation errors in nl & nl-be https://github.com/gravitee-io/issues/issues/2334[#2334]
+
+*_Reporter_*
+
+- [elasticsearch] Reporter should override canHandle(...) method https://github.com/gravitee-io/issues/issues/2320[#2320]
+
+=== Features
+
+*_Application_*
+
+- Renew client secret https://github.com/gravitee-io/issues/issues/2350[#2350]
+
+*_Gateway_*
+
+- Restriction of Plans by gateway https://github.com/gravitee-io/issues/issues/2219[#2219]
+
+*_Management_*
+
+- Allow developers to subscribe to multiple API plans from a single view https://github.com/gravitee-io/issues/issues/2223[#2223]
+- Allows to subscribe to multiple API plans during creation of application https://github.com/gravitee-io/issues/issues/2222[#2222]
+- Multi analytics dashboards https://github.com/gravitee-io/issues/issues/1997[#1997]
+- Selection of Plans by condition   https://github.com/gravitee-io/issues/issues/2220[#2220]
+- Support DCR client credentials https://github.com/gravitee-io/issues/issues/2226[#2226]
+
+=== Improvements
+
+*_Gateway_*
+
+- Response templates improvement https://github.com/gravitee-io/issues/issues/2208[#2208]
+
+*_Management_*
+
+- Default user mapping for OAuth 2.0 authentication https://github.com/gravitee-io/issues/issues/2170[#2170]
+- Redirect URIs not necessaries in some cases when creating applications https://github.com/gravitee-io/issues/issues/2227[#2227]
+
+*_Policy_*
+
+- [callout] Provide information to help user to define a context value https://github.com/gravitee-io/issues/issues/2364[#2364]
+- [http-callout] Response Handler https://github.com/gravitee-io/issues/issues/2258[#2258]
+
+== https://github.com/gravitee-io/issues/milestone/142?closed=1[APIM - 1.25.6 (2019-06-13)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge release 1.20.18 https://github.com/gravitee-io/issues/issues/2367[#2367]
+
+*_Management_*
+
+- (+) button not well positioned in users management https://github.com/gravitee-io/issues/issues/2316[#2316]
+- [logs] keep the pagination configuration https://github.com/gravitee-io/issues/issues/2309[#2309]
+- [plans] form is not well displayed https://github.com/gravitee-io/issues/issues/2311[#2311]
+- [plans] icons can be outside the card https://github.com/gravitee-io/issues/issues/2310[#2310]
+
+*_Management-ui_*
+
+- DocumentationEdit on github does not have correct icon https://github.com/gravitee-io/issues/issues/2038[#2038]
+
+*_Portal_*
+
+- Warn box does not have the same red color https://github.com/gravitee-io/issues/issues/2032[#2032]
+
+*_Repository_*
+
+- [bridge-http] Retry client connection until the server is available https://github.com/gravitee-io/issues/issues/2318[#2318]
+- [mongodb] Upgrade script 1.25 fails when application.metadata field does not exist https://github.com/gravitee-io/issues/issues/2331[#2331]
+
+=== Improvements
+
+*_Gateway_*
+
+- [policy] Ratelimitchange log level when using the default cache config https://github.com/gravitee-io/issues/issues/2332[#2332]
+
+*_Management_*
+
+- Do not use href on <tr> for tables https://github.com/gravitee-io/issues/issues/2314[#2314]
+
+== https://github.com/gravitee-io/issues/milestone/143?closed=1[APIM - 1.20.18 (2019-06-12)]
+
+=== Bug fixes
+
+*_Reporter_*
+
+- [elasticsearch] Thread Blocked are thrown in production https://github.com/gravitee-io/issues/issues/2363[#2363]
+
+=== Features
+
+*_General_*
+
+- Backport issue #1920 https://github.com/gravitee-io/issues/issues/2115[#2115]
+
+=== Improvements
+
+*_Management_*
+
+- [audit] when updating a parameter, do not log when nothing change https://github.com/gravitee-io/issues/issues/2100[#2100]
+
+*_Portal_*
+
+- Add more debug log in the oauth authentication https://github.com/gravitee-io/issues/issues/2352[#2352]
+
+== https://github.com/gravitee-io/issues/milestone/139?closed=1[APIM - 1.25.5 (2019-05-29)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Reduce log level when trailing slash is missing in endpoint https://github.com/gravitee-io/issues/issues/2303[#2303]
+
+*_Management_*
+
+- Add support for export API as 1.20.x https://github.com/gravitee-io/issues/issues/2293[#2293]
+- Better support of swagger mock generation. https://github.com/gravitee-io/issues/issues/2291[#2291]
+- I can create a page without the permission https://github.com/gravitee-io/issues/issues/2261[#2261]
+- Unable to search apis by context-path https://github.com/gravitee-io/issues/issues/2290[#2290]
+- [healthcheck] take into account the `From root Path` boolean when display the healthcheck summary https://github.com/gravitee-io/issues/issues/2192[#2192]
+
+*_Policy_*
+
+- [jwt] Algorithm not compatible when moving from gravitee 1.20 to 1.25 https://github.com/gravitee-io/issues/issues/2294[#2294]
+- [oauth2] Strict mode is not working when introspection response contains more scopes than required scopes https://github.com/gravitee-io/issues/issues/2295[#2295]
+
+=== Improvements
+
+*_Elasticsearch_*
+
+- Remove compile dependencies and some refactor https://github.com/gravitee-io/issues/issues/2305[#2305]
+
+*_Gateway_*
+
+- Manage errors on target endpoint https://github.com/gravitee-io/issues/issues/1653[#1653]
+
+*_Portal_*
+
+- Add an option to enable the swagger try out in anonymous mode https://github.com/gravitee-io/issues/issues/2278[#2278]
+
+== https://github.com/gravitee-io/issues/milestone/140?closed=1[APIM - 1.26.1 (2019-05-27)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge release 1.25.4 https://github.com/gravitee-io/issues/issues/2302[#2302]
+
+== https://github.com/gravitee-io/issues/milestone/137?closed=1[APIM - 1.25.4 (2019-05-24)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge release 1.20.17 https://github.com/gravitee-io/issues/issues/2292[#2292]
+
+*_Management_*
+
+- Attributes not interpreted anymore on api pages https://github.com/gravitee-io/issues/issues/2171[#2171]
+- Quality metric percentage must be rounded https://github.com/gravitee-io/issues/issues/2263[#2263]
+- Template for API's pages is not working as expected https://github.com/gravitee-io/issues/issues/2264[#2264]
+- Unable to uncheck a group in the groups menu https://github.com/gravitee-io/issues/issues/2274[#2274]
+- [logs] Endpoint is checked even if we use the mock policy https://github.com/gravitee-io/issues/issues/2269[#2269]
+
+*_Portal_*
+
+- Unable to display views picture if not admin https://github.com/gravitee-io/issues/issues/2252[#2252]
+
+=== Improvements
+
+*_Management_*
+
+- Import all endpoints from swagger/openapi https://github.com/gravitee-io/issues/issues/2241[#2241]
+- On swagger/openapi import, display the gravitee endpoints instead of the server list https://github.com/gravitee-io/issues/issues/2242[#2242]
+
+*_Policy_*
+
+- [dynamic-routing-policy] allow to not encode path https://github.com/gravitee-io/issues/issues/2239[#2239]
+
+== https://github.com/gravitee-io/issues/milestone/135?closed=1[APIM - 1.20.17 (2019-05-21)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- [logging] all requests failed if logging condition contains errors https://github.com/gravitee-io/issues/issues/2249[#2249]
+
+*_Management_*
+
+- Changes are not reseted when leaving the Settings screen https://github.com/gravitee-io/issues/issues/2265[#2265]
+- Malformed url when you come from top failed api https://github.com/gravitee-io/issues/issues/2194[#2194]
+- [analytics] Status widget does not count all the events https://github.com/gravitee-io/issues/issues/2214[#2214]
+- [healthcheck] take into account the `From root Path` boolean when display the healthcheck summary https://github.com/gravitee-io/issues/issues/2192[#2192]
+
+*_Management-ui_*
+
+- DevMode should not be used for an admin https://github.com/gravitee-io/issues/issues/2240[#2240]
+
+*_Policy_*
+
+- [url-rewriting] No response received when empty response body form the backend https://github.com/gravitee-io/issues/issues/2235[#2235]
+
+*_Portal_*
+
+- Impossible to login when login form is hidden and no idp define https://github.com/gravitee-io/issues/issues/2007[#2007]
+
+=== Improvements
+
+*_Elasticsearch_*
+
+- Simple performance improvements https://github.com/gravitee-io/issues/issues/2247[#2247]
+
+*_Management_*
+
+- Log jwt error in warning, not error https://github.com/gravitee-io/issues/issues/2121[#2121]
+
+*_Management-ui_*
+
+- Revert 'Developer Portal Only' option https://github.com/gravitee-io/issues/issues/1525[#1525]
+
+== https://github.com/gravitee-io/issues/milestone/116?closed=1[APIM - 1.26.0 (2019-05-21)]
+
+=== Features
+
+*_Gateway_*
+
+- Add a server timeout https://github.com/gravitee-io/issues/issues/1834[#1834]
+
+*_General_*
+
+- Support websocket protocol https://github.com/gravitee-io/issues/issues/1899[#1899]
+
+*_Management_*
+
+- Allows to copy request/response body on the clipboard easily https://github.com/gravitee-io/issues/issues/2052[#2052]
+- Allows to search in logs payloads https://github.com/gravitee-io/issues/issues/2053[#2053]
+- Lifecycle API https://github.com/gravitee-io/issues/issues/1996[#1996]
+
+*_Management-api_*
+
+- Allow application's primary owner to select a group https://github.com/gravitee-io/issues/issues/824[#824]
+
+*_Policy_*
+
+- Role based Access Policy https://github.com/gravitee-io/issues/issues/731[#731]
+
+=== Improvements
+
+*_Management_*
+
+- Allow a subset of application types https://github.com/gravitee-io/issues/issues/2195[#2195]
+- Dynamic client registrationsupport initial access token https://github.com/gravitee-io/issues/issues/2207[#2207]
+- Trace each authentication failure https://github.com/gravitee-io/issues/issues/2117[#2117]
+
+*_Repository_*
+
+- [mongodb] Write concern driver configuration https://github.com/gravitee-io/issues/issues/2177[#2177]
+
+== https://github.com/gravitee-io/issues/milestone/136?closed=1[APIM - 1.25.3 (2019-05-16)]
+
+=== Bug fixes
+
+*_Documentation_*
+
+- Unable to load images https://github.com/gravitee-io/issues/issues/2225[#2225]
+
+*_Gateway_*
+
+- NPE is raised in case of dynamic-routing and no endpoints available https://github.com/gravitee-io/issues/issues/2243[#2243]
+
+*_General_*
+
+- Merge release 1.20.16 https://github.com/gravitee-io/issues/issues/2230[#2230]
+
+*_Management_*
+
+- Circular bean injection https://github.com/gravitee-io/issues/issues/2238[#2238]
+- Export as CSV works only with Chrome https://github.com/gravitee-io/issues/issues/2201[#2201]
+
+*_Security_*
+
+- CVE 619 https://github.com/gravitee-io/issues/issues/2231[#2231]
+- CVE 621 https://github.com/gravitee-io/issues/issues/2232[#2232]
+- CVE 623 https://github.com/gravitee-io/issues/issues/2236[#2236]
+
+=== Features
+
+*_Gateway_*
+
+- Add more logs for "Connection was closed" exception https://github.com/gravitee-io/issues/issues/1589[#1589]
+
+=== Improvements
+
+*_Management_*
+
+- Add tooltip on the endpoints icons https://github.com/gravitee-io/issues/issues/2176[#2176]
+- Disable fetch all button if no pages to fetch https://github.com/gravitee-io/issues/issues/2172[#2172]
+
+== https://github.com/gravitee-io/issues/milestone/130?closed=1[APIM - 1.20.16 (2019-05-10)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Healthcheck fails with an empty endpoint group https://github.com/gravitee-io/issues/issues/2205[#2205]
+
+*_Management_*
+
+- Indexing datas is not synchronized beetween all management-api nodes https://github.com/gravitee-io/issues/issues/2166[#2166]
+
+*_Policy_*
+
+- [request-validation] Handle null input for regex validator https://github.com/gravitee-io/issues/issues/2157[#2157]
+
+*_Reporter_*
+
+- [elasticsearch] backport #2199 https://github.com/gravitee-io/issues/issues/2200[#2200]
+
+=== Improvements
+
+*_Idp_*
+
+- [oauth] email could be not required in cas of technical account https://github.com/gravitee-io/issues/issues/2124[#2124]
+
+*_Management_*
+
+- Add more precision when rounded the healthcheck percentage https://github.com/gravitee-io/issues/issues/2168[#2168]
+- [search] the delay between the last key pressed and the research is too short https://github.com/gravitee-io/issues/issues/2193[#2193]
+
+== https://github.com/gravitee-io/issues/milestone/133?closed=1[APIM - 1.25.2 (2019-05-09)]
+
+=== Bug fixes
+
+*_Analytics_*
+
+- Clicking on an API / application does not redirect to the API / application analytics https://github.com/gravitee-io/issues/issues/2204[#2204]
+
+*_Gateway_*
+
+- Alert engine service is not starting https://github.com/gravitee-io/issues/issues/2160[#2160]
+- Performance issues https://github.com/gravitee-io/issues/issues/2203[#2203]
+
+*_Management-ui_*
+
+- Problem displaying of contextual documentation https://github.com/gravitee-io/issues/issues/2175[#2175]
+
+== https://github.com/gravitee-io/issues/milestone/131?closed=1[APIM - 1.25.1 (2019-05-06)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Request not logged when X-Forwarded-For header contains IPv4-mapped IPv6 address https://github.com/gravitee-io/issues/issues/2186[#2186]
+
+*_Management_*
+
+- Error in audit trail when creating and deleting an application https://github.com/gravitee-io/issues/issues/2196[#2196]
+- Unable to access api with a sharding tag in certain condition https://github.com/gravitee-io/issues/issues/2191[#2191]
+- Undefined response template key when pressing enter before to select a value https://github.com/gravitee-io/issues/issues/2184[#2184]
+
+*_Management-ui_*
+
+- [health-check] No HTTP headers for request or response https://github.com/gravitee-io/issues/issues/2163[#2163]
+- [health-check] Response template is selected when viewing a single HC log https://github.com/gravitee-io/issues/issues/2162[#2162]
+
+*_Reporter_*
+
+- [elasticsearch] unable to create mapping in es5 + index per type https://github.com/gravitee-io/issues/issues/2199[#2199]
+
+=== Improvements
+
+*_Monitoring_*
+
+- Prometheus metrics configuration https://github.com/gravitee-io/issues/issues/2179[#2179]
+
+== https://github.com/gravitee-io/issues/milestone/88?closed=1[APIM - 1.25.0 (2019-04-24)]
+
+=== Bug fixes
+
+*_Analytics_*
+
+- User does not appear in logs https://github.com/gravitee-io/issues/issues/2150[#2150]
+
+*_Management_*
+
+- Portal notification of new user is missing user.username https://github.com/gravitee-io/issues/issues/2132[#2132]
+- Users connected with a social provider should get all APIs when giving ADMIN rights https://github.com/gravitee-io/issues/issues/2087[#2087]
+
+*_Policies_*
+
+- [dynamic-routing] Select a discovered endpoint https://github.com/gravitee-io/issues/issues/2155[#2155]
+
+*_Policy_*
+
+- [jwt] unable to parse RS384 SSH Given Key https://github.com/gravitee-io/issues/issues/2147[#2147]
+
+*_Repository_*
+
+- [jdbc] Update page with metadata is not working https://github.com/gravitee-io/issues/issues/2088[#2088]
+
+=== Features
+
+*_Gateway_*
+
+- Allows to define response templates per API https://github.com/gravitee-io/issues/issues/972[#972]
+
+*_Management_*
+
+- Add a button to fetch API/portal docs https://github.com/gravitee-io/issues/issues/2001[#2001]
+- Add support for Dynamic Client Registration https://github.com/gravitee-io/issues/issues/1580[#1580]
+- Allows to configure the message displayed when subscribing to an API https://github.com/gravitee-io/issues/issues/2005[#2005]
+- Allows to define permission to publish on a sharding tag https://github.com/gravitee-io/issues/issues/1995[#1995]
+- Allows to define response templates per API https://github.com/gravitee-io/issues/issues/2083[#2083]
+- Allows to export logs in a CSV file https://github.com/gravitee-io/issues/issues/2004[#2004]
+- Allows to extend ES index mapping https://github.com/gravitee-io/issues/issues/2084[#2084]
+- Change ES mapping (request) to store security type / token instead of api key https://github.com/gravitee-io/issues/issues/1994[#1994]
+- [audit] create API logging audit log https://github.com/gravitee-io/issues/issues/2103[#2103]
+
+*_Policy_*
+
+- [OIDC - UserInfo] support Expression Language for the OAuth 2.0 resource field https://github.com/gravitee-io/issues/issues/2016[#2016]
+- [api-key] Policy failures always produce json content https://github.com/gravitee-io/issues/issues/1719[#1719]
+- [validate-request] Override error message https://github.com/gravitee-io/issues/issues/1945[#1945]
+
+=== Improvements
+
+*_Idp_*
+
+- [oauth] be able to configure oauth idps by file (like in release 1.20) https://github.com/gravitee-io/issues/issues/2031[#2031]
+
+*_Management_*
+
+- Allows to define the number of logs to display per page https://github.com/gravitee-io/issues/issues/2002[#2002]
+- Allows to sort the logs by date, path, status https://github.com/gravitee-io/issues/issues/2003[#2003]
+- Hits by host in the global dashboard analytics https://github.com/gravitee-io/issues/issues/2044[#2044]
+
+*_Policy_*
+
+- [groovy] add dictionary support https://github.com/gravitee-io/issues/issues/2123[#2123]
+
+*_Repository_*
+
+- [bridge] add 1.25 compatibility https://github.com/gravitee-io/issues/issues/2148[#2148]
+- [jdbc] SQL Server support https://github.com/gravitee-io/issues/issues/1772[#1772]
+
+== https://github.com/gravitee-io/issues/milestone/127?closed=1[APIM - 1.24.1 (2019-04-11)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- No suitable driver with any JDBC driver https://github.com/gravitee-io/issues/issues/2116[#2116]
+
+*_General_*
+
+- Merge release 1.23.2 https://github.com/gravitee-io/issues/issues/2142[#2142]
+
+*_Management_*
+
+- Missing notification when a user is created https://github.com/gravitee-io/issues/issues/2143[#2143]
+- NPE in ApiPage when not authenticated https://github.com/gravitee-io/issues/issues/2108[#2108]
+- Registration not available when not logged in https://github.com/gravitee-io/issues/issues/2131[#2131]
+- [ldap] user dn is case sensitive https://github.com/gravitee-io/issues/issues/2091[#2091]
+
+*_Policy_*
+
+- [dynamic-routing]unable to select an endpoint https://github.com/gravitee-io/issues/issues/2130[#2130]
+
+*_Repository_*
+
+- [bridge] not able to use the technical api for /health https://github.com/gravitee-io/issues/issues/2125[#2125]
+
+== https://github.com/gravitee-io/issues/milestone/128?closed=1[APIM - 1.23.2 (2019-04-11)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge release 1.20.15 https://github.com/gravitee-io/issues/issues/2141[#2141]
+
+=== Improvements
+
+*_Repository_*
+
+- [redis] set pool size for test https://github.com/gravitee-io/issues/issues/2122[#2122]
+
+== https://github.com/gravitee-io/issues/milestone/125?closed=1[APIM - 1.20.15 (2019-03-29)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- OutOfMemory when scrapping metrics for Prometheus https://github.com/gravitee-io/issues/issues/2057[#2057]
+
+*_Management_*
+
+- Missing some audit event types https://github.com/gravitee-io/issues/issues/2099[#2099]
+- Old user references exists after its deletion. https://github.com/gravitee-io/issues/issues/1986[#1986]
+
+*_Portal_*
+
+- Email template not found for hook SUBSCRIPTION_REJECTED https://github.com/gravitee-io/issues/issues/2056[#2056]
+- Unable to finish registration if "Force Login" is enabled https://github.com/gravitee-io/issues/issues/2097[#2097]
+- [ldap] unable to use a complex password https://github.com/gravitee-io/issues/issues/2076[#2076]
+
+== https://github.com/gravitee-io/issues/milestone/87?closed=1[APIM - 1.24.0 (2019-03-22)]
+
+=== Bug fixes
+
+*_Expression-language_*
+
+- Jayway jsonpath lib has issue for Cache https://github.com/gravitee-io/issues/issues/1713[#1713]
+
+*_Gateway_*
+
+- Discovered endpoints are not getting properly HTTP group configuration when no endpoints are configured https://github.com/gravitee-io/issues/issues/2049[#2049]
+- Server request without body are ended even while in paused-state with Vert.x 3.6.x https://github.com/gravitee-io/issues/issues/2020[#2020]
+- The application is not settled for metrics / analytics https://github.com/gravitee-io/issues/issues/2039[#2039]
+
+*_General_*
+
+- Swagger Import Root context path not mapped correctly https://github.com/gravitee-io/issues/issues/2010[#2010]
+- Wrong openapi 3 securityScheme types when base url is set https://github.com/gravitee-io/issues/issues/2014[#2014]
+
+*_Management_*
+
+- Search users is not ordered https://github.com/gravitee-io/issues/issues/1988[#1988]
+- Service discovery configuration is lost when deleting an endpoint https://github.com/gravitee-io/issues/issues/2059[#2059]
+
+*_Portal_*
+
+- Exception when authenticating to the portal using GitHub account https://github.com/gravitee-io/issues/issues/2045[#2045]
+
+*_Reporter_*
+
+- [kafka] reporter dont work if configuration is not in  gravitee.yml https://github.com/gravitee-io/issues/issues/1803[#1803]
+- [kafka]ClassNotFoundException io.gravitee.reporter.kafka.spring.EnabledKafkaReporter https://github.com/gravitee-io/issues/issues/1805[#1805]
+
+*_Service-discovery_*
+
+- Health-check is not well started with discovered endpoints https://github.com/gravitee-io/issues/issues/2054[#2054]
+- [consul] Endpoint is not well updated when changing host or port of an existing service https://github.com/gravitee-io/issues/issues/2069[#2069]
+
+=== Features
+
+*_Gateway_*
+
+- Global logging max size body configuration https://github.com/gravitee-io/issues/issues/1891[#1891]
+
+*_General_*
+
+- JDK9 support https://github.com/gravitee-io/issues/issues/979[#979]
+
+*_Management_*
+
+- Add a timestamp and API id in the index ES log https://github.com/gravitee-io/issues/issues/1993[#1993]
+- Add an option to get hits by user agent in analytics dashboard https://github.com/gravitee-io/issues/issues/1951[#1951]
+- Allow to audit the people who consult the log detail https://github.com/gravitee-io/issues/issues/1947[#1947]
+- Allows to transfer a subscription to another plan without changing API key or token https://github.com/gravitee-io/issues/issues/1946[#1946]
+- Audit on API user from JWT https://github.com/gravitee-io/issues/issues/1948[#1948]
+- HC Availability per gateway should be displayed to admins only https://github.com/gravitee-io/issues/issues/1949[#1949]
+- User creation from management gui / management API https://github.com/gravitee-io/issues/issues/1505[#1505]
+
+*_Policy_*
+
+- [mock] Allows to use spEL in header value https://github.com/gravitee-io/issues/issues/1992[#1992]
+
+*_Service-discovery_*
+
+- [eureka] Implementation of Eureka Service Discovery plugin https://github.com/gravitee-io/issues/issues/1311[#1311]
+
+=== Improvements
+
+*_Gateway_*
+
+- Default max_header size for the gateway is not configurable https://github.com/gravitee-io/issues/issues/2037[#2037]
+- Internal refactoring https://github.com/gravitee-io/issues/issues/1744[#1744]
+- Refactor endpoint management thanks to unique reference https://github.com/gravitee-io/issues/issues/1989[#1989]
+
+*_Identity-provider_*
+
+- [ldap] use the same filter to user search and authentication https://github.com/gravitee-io/issues/issues/2026[#2026]
+
+*_Management_*
+
+- Improve log detail screen https://github.com/gravitee-io/issues/issues/1950[#1950]
+- Instances management screen not accessible sometimes https://github.com/gravitee-io/issues/issues/1908[#1908]
+- Optimizing event recuperation https://github.com/gravitee-io/issues/issues/2067[#2067]
+- Stay on the current tab when saving a page modification https://github.com/gravitee-io/issues/issues/1813[#1813]
+- [analytics] Configurable http request timeout for analytics requests https://github.com/gravitee-io/issues/issues/1920[#1920]
+
+*_Policy_*
+
+- [mock] Improve policy with body injection https://github.com/gravitee-io/issues/issues/1789[#1789]
+- [oauth2] Configure user claim for AM and Keycloak Oauth2 providers https://github.com/gravitee-io/issues/issues/2046[#2046]
+
+*_Repository_*
+
+- [jdbc] Improve performance on search events https://github.com/gravitee-io/issues/issues/1982[#1982]
+
+== https://github.com/gravitee-io/issues/milestone/124?closed=1[APIM - 1.23.1 (2019-03-16)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge release 1.22.3 https://github.com/gravitee-io/issues/issues/2048[#2048]
+
+*_Portal_*
+
+- Wrong oauth2 redirect uri https://github.com/gravitee-io/issues/issues/2011[#2011]
+
+== https://github.com/gravitee-io/issues/milestone/123?closed=1[APIM - 1.22.3 (2019-03-15)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge release 1.20.14 https://github.com/gravitee-io/issues/issues/2047[#2047]
+
+*_Management_*
+
+- CORS issues when modifying page order or publishing https://github.com/gravitee-io/issues/issues/1984[#1984]
+
+=== Improvements
+
+*_Management_*
+
+- Add a magnifying glass in the users search bar https://github.com/gravitee-io/issues/issues/1841[#1841]
+
+== https://github.com/gravitee-io/issues/milestone/121?closed=1[APIM - 1.20.14 (2019-03-15)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Could not start an api with an empty endpoint group https://github.com/gravitee-io/issues/issues/2024[#2024]
+- The last `/` of a request disappears https://github.com/gravitee-io/issues/issues/2012[#2012]
+
+*_Management_*
+
+- Do not try to import an invalid json file https://github.com/gravitee-io/issues/issues/2022[#2022]
+- Error on duplicate endpoint names when creating via API https://github.com/gravitee-io/issues/issues/2023[#2023]
+- Error while importing an API in some particular case https://github.com/gravitee-io/issues/issues/1883[#1883]
+- [analytics] top failed==top apis when a tenant is selected https://github.com/gravitee-io/issues/issues/1938[#1938]
+
+*_Portal_*
+
+- Oauth login button color is always grey. https://github.com/gravitee-io/issues/issues/2013[#2013]
+
+=== Improvements
+
+*_Management_*
+
+- Add the prometheus configuration https://github.com/gravitee-io/issues/issues/2035[#2035]
+
+*_Portal_*
+
+- Improve the search accuracy https://github.com/gravitee-io/issues/issues/1937[#1937]
+
+*_Reporter_*
+
+- Default elasticsearch configuration is not efficient https://github.com/gravitee-io/issues/issues/2019[#2019]
+
+== https://github.com/gravitee-io/issues/milestone/114?closed=1[APIM - 1.20.13 (2019-03-06)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Plans security order is not respected https://github.com/gravitee-io/issues/issues/1985[#1985]
+
+*_Management_*
+
+- Api outdated when configuring the healthcheck https://github.com/gravitee-io/issues/issues/1918[#1918]
+- Avoid duplicate name for groups and endpoints https://github.com/gravitee-io/issues/issues/1578[#1578]
+- Exclude groups in api export is not take into account. https://github.com/gravitee-io/issues/issues/1962[#1962]
+- [documentation]  unable to create a page and import content from disk https://github.com/gravitee-io/issues/issues/1940[#1940]
+- [policies]Unable to only change the method of a policy https://github.com/gravitee-io/issues/issues/1932[#1932]
+
+*_Policy_*
+
+- [cache] Required type parameter does not match the resource type https://github.com/gravitee-io/issues/issues/962[#962]
+- [dynamic-routing] Unable to handle some endpoints and url https://github.com/gravitee-io/issues/issues/1939[#1939]
+
+=== Improvements
+
+*_Management_*
+
+- Add a tooltip on the api name https://github.com/gravitee-io/issues/issues/1956[#1956]
+- Backport github fetcher https://github.com/gravitee-io/issues/issues/1942[#1942]
+- Handle 405 status code on the management api https://github.com/gravitee-io/issues/issues/1976[#1976]
+
+== https://github.com/gravitee-io/issues/milestone/86?closed=1[APIM - 1.23.0 (2019-02-25)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Impossible to save portal settings from UI https://github.com/gravitee-io/issues/issues/1941[#1941]
+- Keep http image links on emails https://github.com/gravitee-io/issues/issues/1972[#1972]
+
+*_Portal_*
+
+- Api headers name are duplicate. https://github.com/gravitee-io/issues/issues/1971[#1971]
+
+*_Repository_*
+
+- [redis] Unable to create new APIs https://github.com/gravitee-io/issues/issues/1882[#1882]
+
+=== Features
+
+*_Management_*
+
+- Add a link to the git repository defined on a documentation page https://github.com/gravitee-io/issues/issues/1825[#1825]
+- Allows to configure sharding / tenants when creating an API from scratch https://github.com/gravitee-io/issues/issues/1819[#1819]
+- Allows to create a template for HTTP configuration for endpoints discovered by Service Discovery https://github.com/gravitee-io/issues/issues/1141[#1141]
+- Create mocks in API imported from swagger/OAI https://github.com/gravitee-io/issues/issues/1567[#1567]
+- Define a picture on a portal view https://github.com/gravitee-io/issues/issues/1821[#1821]
+- Exchange JWT with API key https://github.com/gravitee-io/issues/issues/1817[#1817]
+- Fetch pages recursively https://github.com/gravitee-io/issues/issues/1565[#1565]
+- Invite a user in a group https://github.com/gravitee-io/issues/issues/1818[#1818]
+
+*_Policy_*
+
+- [assign-attribute] Add a policy assign-attribute https://github.com/gravitee-io/issues/issues/1820[#1820]
+- [callout-http] Condition to end the request https://github.com/gravitee-io/issues/issues/1904[#1904]
+- [generate-jwt] Provide a Generate JWT policy https://github.com/gravitee-io/issues/issues/1863[#1863]
+
+=== Improvements
+
+*_Expression-language_*
+
+- Performance improvements https://github.com/gravitee-io/issues/issues/1902[#1902]
+
+*_Gateway_*
+
+- Attach SSLSession to the incoming HTTP request https://github.com/gravitee-io/issues/issues/1922[#1922]
+- Performance issues when API contains lot of properties https://github.com/gravitee-io/issues/issues/1903[#1903]
+
+*_Management_*
+
+- Avoid to list all policy's schemas https://github.com/gravitee-io/issues/issues/1914[#1914]
+- Define policies at the plan level https://github.com/gravitee-io/issues/issues/1846[#1846]
+- Define trustAll for authentication providers https://github.com/gravitee-io/issues/issues/1924[#1924]
+- Select multiple conditions to send messages https://github.com/gravitee-io/issues/issues/1802[#1802]
+- We should allow to go to the next step by pressing enter on the wizard creation https://github.com/gravitee-io/issues/issues/1716[#1716]
+
+*_Policy_*
+
+- [assign-content] add EL support https://github.com/gravitee-io/issues/issues/1860[#1860]
+
+== https://github.com/gravitee-io/issues/milestone/113?closed=1[APIM - 1.22.2 (2019-02-16)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge release 1.21.5 https://github.com/gravitee-io/issues/issues/1927[#1927]
+
+*_Management_*
+
+- Swagger options should be available when importing by a swagger link https://github.com/gravitee-io/issues/issues/1906[#1906]
+
+== https://github.com/gravitee-io/issues/milestone/112?closed=1[APIM - 1.21.5 (2019-02-16)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge release 1.20.12 https://github.com/gravitee-io/issues/issues/1926[#1926]
+
+*_Policy_*
+
+- [api-key] NoSuchMethod error for an api-key with an expiredAt value https://github.com/gravitee-io/issues/issues/1888[#1888]
+
+== https://github.com/gravitee-io/issues/milestone/105?closed=1[APIM - 1.20.12 (2019-02-16)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- API Key plans are not well selected https://github.com/gravitee-io/issues/issues/1884[#1884]
+- HTTP2 requests are not well handled https://github.com/gravitee-io/issues/issues/1913[#1913]
+
+*_Management_*
+
+- Apply a default role on a group change the group attributes https://github.com/gravitee-io/issues/issues/1917[#1917]
+- Do not detect redeploy on each plan update https://github.com/gravitee-io/issues/issues/1827[#1827]
+- Email subject incorrect on new subscription (application) https://github.com/gravitee-io/issues/issues/1859[#1859]
+- Global empty date metadata cannot be overriden https://github.com/gravitee-io/issues/issues/1869[#1869]
+- Not able to create an API from a swagger from https based url https://github.com/gravitee-io/issues/issues/1897[#1897]
+- Unable to change the apikey expiration date https://github.com/gravitee-io/issues/issues/1842[#1842]
+- [analytics] unable to change the end date https://github.com/gravitee-io/issues/issues/1879[#1879]
+- [logs] api outdated when configuring a logging condition https://github.com/gravitee-io/issues/issues/1901[#1901]
+
+*_Reporter_*
+
+- [elasticsearch] Request not indexed with complex request's message https://github.com/gravitee-io/issues/issues/1021[#1021]
+
+=== Features
+
+*_Management_*
+
+- [logs] add a global max duration https://github.com/gravitee-io/issues/issues/1919[#1919]
+
+== https://github.com/gravitee-io/issues/milestone/103?closed=1[1.22.1 (2019-02-04)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- A deprecated plan is not redeploying correctly after modification https://github.com/gravitee-io/issues/issues/1857[#1857]
+
+*_Gateway-bridge_*
+
+- Add 1.22 compatibility https://github.com/gravitee-io/issues/issues/1876[#1876]
+
+*_Management_*
+
+- Message incorrect when deprecating a plan https://github.com/gravitee-io/issues/issues/1858[#1858]
+- Service discovery is not working anymore https://github.com/gravitee-io/issues/issues/1865[#1865]
+- Unable to calculate analytics when filtering by host (host:port) https://github.com/gravitee-io/issues/issues/1886[#1886]
+
+*_Portal_*
+
+- Anonymous users can not access to public APIs anymore https://github.com/gravitee-io/issues/issues/1872[#1872]
+
+=== Improvements
+
+*_General_*
+
+- Merge release 1.21.4 https://github.com/gravitee-io/issues/issues/1873[#1873]
+
+== https://github.com/gravitee-io/issues/milestone/106?closed=1[1.21.4 (2019-01-30)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge release 1.20.11 https://github.com/gravitee-io/issues/issues/1867[#1867]
+
+== https://github.com/gravitee-io/issues/milestone/104?closed=1[1.20.11 (2019-01-25)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Back-pressure for client request log not correctly handled https://github.com/gravitee-io/issues/issues/1837[#1837]
+- Error if endpoint has an empty ssl configuration https://github.com/gravitee-io/issues/issues/1838[#1838]
+
+*_General_*
+
+- Hybrid plugin / 1.20 compatibility https://github.com/gravitee-io/issues/issues/1614[#1614]
+
+*_Identityprovider_*
+
+- [ldap] LDAP authenticator is case insensitive https://github.com/gravitee-io/issues/issues/1844[#1844]
+
+*_Management_*
+
+- Qualitypages inside a folder are not taking account https://github.com/gravitee-io/issues/issues/1843[#1843]
+- Unable to create a metadata with the `date` type https://github.com/gravitee-io/issues/issues/1824[#1824]
+
+=== Improvements
+
+*_Global_*
+
+- Upgrade to Vert.x 3.5.4 https://github.com/gravitee-io/issues/issues/1839[#1839]
+
+== https://github.com/gravitee-io/issues/milestone/85?closed=1[1.22.0 (2019-01-16)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Display correctly application title when no type defined https://github.com/gravitee-io/issues/issues/1767[#1767]
+- When filtering analytics the requests contains same filters appended multiple times https://github.com/gravitee-io/issues/issues/1779[#1779]
+
+*_Portal_*
+
+- Banner of unsupported browser version is not displayed https://github.com/gravitee-io/issues/issues/1731[#1731]
+- Unable to authenticate an LDAP user https://github.com/gravitee-io/issues/issues/1782[#1782]
+
+=== Features
+
+*_Fetcher_*
+
+- Add a github fetcher https://github.com/gravitee-io/issues/issues/1750[#1750]
+
+*_Gateway_*
+
+- Allow Endpoints to Specify Header Values https://github.com/gravitee-io/issues/issues/1740[#1740]
+
+*_General_*
+
+- Service discovery plugin support https://github.com/gravitee-io/issues/issues/1701[#1701]
+
+*_Management_*
+
+- API publisher should be able to "pause" a subscription https://github.com/gravitee-io/issues/issues/1753[#1753]
+- Add a "deprecated" status for a plan https://github.com/gravitee-io/issues/issues/1762[#1762]
+- Add options when created apis from swagger https://github.com/gravitee-io/issues/issues/1566[#1566]
+- An application should be able to close a plan's subscription https://github.com/gravitee-io/issues/issues/1746[#1746]
+- Be able to differentiate analytics log which reach the target endpoint from others https://github.com/gravitee-io/issues/issues/1743[#1743]
+- Display entrypoints by API sharding tags https://github.com/gravitee-io/issues/issues/1706[#1706]
+
+=== Improvements
+
+*_Management_*
+
+- Add a "remove all" button in properties and dictionaries https://github.com/gravitee-io/issues/issues/1670[#1670]
+- Add a link to the logs config from the log screen https://github.com/gravitee-io/issues/issues/1644[#1644]
+- Add a non strict mode to valide scopes in oauth plan https://github.com/gravitee-io/issues/issues/1689[#1689]
+- Add explanation on configuration of tiles mode display https://github.com/gravitee-io/issues/issues/1822[#1822]
+- Add rollback action to the audit trail of an API https://github.com/gravitee-io/issues/issues/1658[#1658]
+- Better handling of character of escaping on analytics https://github.com/gravitee-io/issues/issues/1766[#1766]
+- Create an endpoint without trustall and trustore https://github.com/gravitee-io/issues/issues/1811[#1811]
+- Display a flag on the analytic's logs to know if the backend has been reached or not https://github.com/gravitee-io/issues/issues/1761[#1761]
+- List roles/permissions dynamically and sort alphabetically https://github.com/gravitee-io/issues/issues/1709[#1709]
+- Redesign the documentation management https://github.com/gravitee-io/issues/issues/1564[#1564]
+
+*_Policy_*
+
+- [jwt/oauth2] Add an option to not propagate the Authorization header https://github.com/gravitee-io/issues/issues/1737[#1737]
+
+*_Portal_*
+
+- Fix better management of select item in the right menu of the doc https://github.com/gravitee-io/issues/issues/1800[#1800]
+- Preserve height of APIs card https://github.com/gravitee-io/issues/issues/1796[#1796]
+
+== https://github.com/gravitee-io/issues/milestone/100?closed=1[1.21.3 (2019-01-14)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Response is handled twice https://github.com/gravitee-io/issues/issues/1732[#1732]
+
+*_General_*
+
+- Merge bugfixes from 1.20.10 https://github.com/gravitee-io/issues/issues/1814[#1814]
+
+*_Management_*
+
+- API is trying to create a new user when creating a new membership https://github.com/gravitee-io/issues/issues/1751[#1751]
+- Email subject user the user Id instead of displayname https://github.com/gravitee-io/issues/issues/1747[#1747]
+- Identity provider's description is not persisted after an update https://github.com/gravitee-io/issues/issues/1736[#1736]
+- Support for none authentification for alert default notifier https://github.com/gravitee-io/issues/issues/1793[#1793]
+- [idp] The idp type is lost on update https://github.com/gravitee-io/issues/issues/1738[#1738]
+
+*_Management-ui_*
+
+- (+) button is not well positioned https://github.com/gravitee-io/issues/issues/1754[#1754]
+- Not able to transfer ownership to in-memory user https://github.com/gravitee-io/issues/issues/1752[#1752]
+- Properties configuration or resource configuration on top of contextual documentation https://github.com/gravitee-io/issues/issues/1757[#1757]
+- Users from audit are not well displayed https://github.com/gravitee-io/issues/issues/1755[#1755]
+
+*_Repository_*
+
+- [mongodb] Alert is not correctly mapped on some cases https://github.com/gravitee-io/issues/issues/1801[#1801]
+
+=== Improvements
+
+*_Policy_*
+
+- [callout-http] Apply expression language on the URL https://github.com/gravitee-io/issues/issues/1810[#1810]
+
+== https://github.com/gravitee-io/issues/milestone/101?closed=1[1.20.10 (2019-01-14)]
+
+=== Bug fixes
+
+*_Identity-provider_*
+
+- [ldap] Complex query are not supported for authentication https://github.com/gravitee-io/issues/issues/1804[#1804]
+
+*_Management_*
+
+- Better handling of swagger descriptor with wrong format https://github.com/gravitee-io/issues/issues/1785[#1785]
+- Can not import a definition to update an API with an existing plan https://github.com/gravitee-io/issues/issues/1808[#1808]
+- Dashboard analytics is not allowing to set multiple filters https://github.com/gravitee-io/issues/issues/1780[#1780]
+- Display errors notifications correctly https://github.com/gravitee-io/issues/issues/1784[#1784]
+- New endpoints are systematically created with ssl configuration https://github.com/gravitee-io/issues/issues/1776[#1776]
+- Sometimes the tasks screen is blank https://github.com/gravitee-io/issues/issues/1760[#1760]
+- The dictionary can not be updated anymore https://github.com/gravitee-io/issues/issues/1783[#1783]
+- [ldap] User dn pattern configuration name incorrect in yml https://github.com/gravitee-io/issues/issues/1788[#1788]
+
+*_Management-ui_*
+
+- Close modal when clicking outside https://github.com/gravitee-io/issues/issues/1758[#1758]
+- Sharding tags do not appear in API history https://github.com/gravitee-io/issues/issues/1774[#1774]
+
+=== Improvements
+
+*_Management_*
+
+- Configure the root entrypoint https://github.com/gravitee-io/issues/issues/1792[#1792]
+
+== https://github.com/gravitee-io/issues/milestone/98?closed=1[1.20.9 (2018-12-22)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- 100-continue not correctly handle https://github.com/gravitee-io/issues/issues/1733[#1733]
+
+*_General_*
+
+- Technical API is not secured on sub paths https://github.com/gravitee-io/issues/issues/1759[#1759]
+
+*_Management_*
+
+- (+) button is floating if the groups management is empty https://github.com/gravitee-io/issues/issues/1765[#1765]
+- A user can see all tasks https://github.com/gravitee-io/issues/issues/1729[#1729]
+- An admin/user have a mix of permissions https://github.com/gravitee-io/issues/issues/1739[#1739]
+- No hook template for API on a closed subscription https://github.com/gravitee-io/issues/issues/1735[#1735]
+- Not able to change the weight of an endpoint https://github.com/gravitee-io/issues/issues/1749[#1749]
+
+*_Management-ui_*
+
+- Missing user name in API history https://github.com/gravitee-io/issues/issues/1764[#1764]
+- Path-mappings content should occupy the whole width https://github.com/gravitee-io/issues/issues/1756[#1756]
+
+*_Policy_*
+
+- [rate-limit] Unable to retrieve latest values of rate-limit from repository https://github.com/gravitee-io/issues/issues/1748[#1748]
+
+*_Portal_*
+
+- Use anchor in markdown pages https://github.com/gravitee-io/issues/issues/852[#852]
+
+=== Improvements
+
+*_Policy_*
+
+- [jwt] Provide more logs for an invalid JWT token https://github.com/gravitee-io/issues/issues/1768[#1768]
+
+*_Resource_*
+
+- [oauth2-generic] Default timeout https://github.com/gravitee-io/issues/issues/1728[#1728]
+
+== https://github.com/gravitee-io/issues/milestone/99?closed=1[1.21.2 (2018-12-06)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Alert should be disabled by default https://github.com/gravitee-io/issues/issues/1714[#1714]
+- Can't see current security definition for JWT plan https://github.com/gravitee-io/issues/issues/1724[#1724]
+- Imported Swagger documentation page is empty https://github.com/gravitee-io/issues/issues/1725[#1725]
+- JS error on dist https://github.com/gravitee-io/issues/issues/1720[#1720]
+- Loading spinner is not centered when searching APIs on the management part https://github.com/gravitee-io/issues/issues/1717[#1717]
+- No hook template for application on a new subscription https://github.com/gravitee-io/issues/issues/1718[#1718]
+- No security definition for plan from API wizard https://github.com/gravitee-io/issues/issues/1715[#1715]
+- Unable to map picture for user profile (IDP AM) https://github.com/gravitee-io/issues/issues/1711[#1711]
+
+=== Improvements
+
+*_Management_*
+
+- Add description for the default plugin config https://github.com/gravitee-io/issues/issues/1721[#1721]
+- Create empty data dir https://github.com/gravitee-io/issues/issues/1723[#1723]
+
+== https://github.com/gravitee-io/issues/milestone/97?closed=1[1.21.1 (2018-12-03)]
+
+=== Bug fixes
+__fixes from release 1.20.7 and 1.20.8 has been merged.__
+
+
+*_Gateway_*
+
+- [alert] Response time is not correct in the alert event https://github.com/gravitee-io/issues/issues/1702[#1702]
+
+*_Management_*
+
+- Logout URL for Gravitee.io AM is not correct https://github.com/gravitee-io/issues/issues/1704[#1704]
+
+== https://github.com/gravitee-io/issues/milestone/96?closed=1[1.20.8 (2018-12-03)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Show the right configuration in the endpoint healthcheck https://github.com/gravitee-io/issues/issues/1707[#1707]
+- The UI freeze when adding/removing a user in a role. https://github.com/gravitee-io/issues/issues/1705[#1705]
+
+== https://github.com/gravitee-io/issues/milestone/95?closed=1[1.20.7 (2018-11-29)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Do not run healthcheck if disabled https://github.com/gravitee-io/issues/issues/1697[#1697]
+
+*_Management_*
+
+- Calendar widget is displayed wrong week days on analytics filters https://github.com/gravitee-io/issues/issues/1684[#1684]
+- Danger zone is displayed to USER https://github.com/gravitee-io/issues/issues/1666[#1666]
+- Swagger import should guarantee uniqueness of endpoint group / endpoint name https://github.com/gravitee-io/issues/issues/1685[#1685]
+- Unable to map ldap group to role https://github.com/gravitee-io/issues/issues/1700[#1700]
+
+=== Improvements
+
+*_Portal_*
+
+- Add a loading spinner while searching for APIs https://github.com/gravitee-io/issues/issues/1544[#1544]
+
+== https://github.com/gravitee-io/issues/milestone/84?closed=1[1.21.0 (2018-11-28)]
+
+=== Bug fixes
+
+*_Management_*
+
+- API Key plans contain JWT securityDefinition https://github.com/gravitee-io/issues/issues/1686[#1686]
+- OAuth2AuthenticationResource doesn't distinguish users by source https://github.com/gravitee-io/issues/issues/1486[#1486]
+
+*_Resource_*
+
+- [keycloak] Typo error in access denied message https://github.com/gravitee-io/issues/issues/1667[#1667]
+
+=== Features
+
+*_Alert_*
+
+- Add a dedicated page/module to configure alerts https://github.com/gravitee-io/issues/issues/1548[#1548]
+- Alert the API owner when reaching a threshold of the configured quota https://github.com/gravitee-io/issues/issues/1551[#1551]
+
+*_General_*
+
+- Alerting https://github.com/gravitee-io/issues/issues/63[#63]
+
+*_Policy_*
+
+- [callout-http] Policy callout HTTP https://github.com/gravitee-io/issues/issues/1665[#1665]
+- [jwt] HMAC support https://github.com/gravitee-io/issues/issues/1677[#1677]
+- [jwt] OIDC discovery support https://github.com/gravitee-io/issues/issues/1673[#1673]
+
+=== Improvements
+
+*_Gateway_*
+
+- Access API version number in Expression language https://github.com/gravitee-io/issues/issues/1102[#1102]
+- Add the tenant into the execution context https://github.com/gravitee-io/issues/issues/1656[#1656]
+- Performance improvements https://github.com/gravitee-io/issues/issues/1622[#1622]
+
+*_Management_*
+
+- Add a property to a plan to ask the consumer for a message when subscribing https://github.com/gravitee-io/issues/issues/1660[#1660]
+- Add username mapping in the oauth idp https://github.com/gravitee-io/issues/issues/1370[#1370]
+- Be able to remove log condition https://github.com/gravitee-io/issues/issues/1629[#1629]
+- Configure OAuth2 authentication provider from the management-api https://github.com/gravitee-io/issues/issues/1595[#1595]
+
+*_Management-ui_*
+
+- Add animation for the contextual menu https://github.com/gravitee-io/issues/issues/1648[#1648]
+- Menu items in Settings must be ordered alphabetically https://github.com/gravitee-io/issues/issues/1596[#1596]
+
+*_Policy_*
+
+- Support EL in field "parameter" for policy "validate request" https://github.com/gravitee-io/issues/issues/1605[#1605]
+- [jwt] Moving from jjwt to nimbus https://github.com/gravitee-io/issues/issues/1672[#1672]
+- [request-validation] Validate request body https://github.com/gravitee-io/issues/issues/1654[#1654]
+
+*_Portal_*
+
+- Add animation for the portal api headers https://github.com/gravitee-io/issues/issues/1619[#1619]
+- Add language negociation to find the best translation https://github.com/gravitee-io/issues/issues/1621[#1621]
+- Allows to persist images to use it on documentation pages https://github.com/gravitee-io/issues/issues/1159[#1159]
+- Connection button must be hidden when current page is login https://github.com/gravitee-io/issues/issues/1628[#1628]
+
+*_Repository_*
+
+- [elasticsearch] Optimize cross-cluster / tenancy analytics search https://github.com/gravitee-io/issues/issues/1663[#1663]
+
+== https://github.com/gravitee-io/issues/milestone/94?closed=1[1.20.6 (2018-11-19)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Do not enable inherited HC if no inherited HC exists https://github.com/gravitee-io/issues/issues/1682[#1682]
+- Do not fail the sync process if exception thrown during HC https://github.com/gravitee-io/issues/issues/1681[#1681]
+- Endpoints are not well selected when contains whitespace character https://github.com/gravitee-io/issues/issues/1679[#1679]
+- HC is disabled even with API HC enabled after enable/disable HC at endpoint level https://github.com/gravitee-io/issues/issues/1683[#1683]
+
+*_Management_*
+
+- Log condition end date is not well managed https://github.com/gravitee-io/issues/issues/1680[#1680]
+
+== https://github.com/gravitee-io/issues/milestone/93?closed=1[1.20.5 (2018-11-15)]
+
+=== Bug fixes
+
+*_Management_*
+
+- User with LOG[READ] right is not able to access logs view https://github.com/gravitee-io/issues/issues/1659[#1659]
+
+*_Portal_*
+
+- Markdown editorstyle tag are not handled correctly https://github.com/gravitee-io/issues/issues/1671[#1671]
+
+*_Service_*
+
+- [healthcheck] Healthcheck is not running when specified at endpoint level https://github.com/gravitee-io/issues/issues/1664[#1664]
+
+== https://github.com/gravitee-io/issues/milestone/92?closed=1[1.20.4 (2018-11-08)]
+
+=== Bug fixes
+
+*_Documentation_*
+
+- [swagger] Models are not well rendered https://github.com/gravitee-io/issues/issues/1651[#1651]
+
+*_Management_*
+
+- SMTP authenticationno username / password https://github.com/gravitee-io/issues/issues/1652[#1652]
+- Search engine is case sensitive https://github.com/gravitee-io/issues/issues/1642[#1642]
+- The trash icon is hidden on chrome (users mgmt) https://github.com/gravitee-io/issues/issues/1635[#1635]
+
+*_Management-api_*
+
+- "The given id must not be null!" when setting up email notifications https://github.com/gravitee-io/issues/issues/1639[#1639]
+
+*_Management-ui_*
+
+- Error while saving an endpoint configuration https://github.com/gravitee-io/issues/issues/1647[#1647]
+
+*_Portal_*
+
+- Platform dashboardTop failed APIs does not take the query parameter into account https://github.com/gravitee-io/issues/issues/1641[#1641]
+
+=== Improvements
+
+*_Gateway_*
+
+- Upgrade the jetty-alpn-agent https://github.com/gravitee-io/issues/issues/1638[#1638]
+
+*_Management_*
+
+- Implicit trustAll for backward compatiblity https://github.com/gravitee-io/issues/issues/1646[#1646]
+
+== https://github.com/gravitee-io/issues/milestone/91?closed=1[1.20.3 (2018-10-31)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Request is hanging on preflight request https://github.com/gravitee-io/issues/issues/1634[#1634]
+
+== https://github.com/gravitee-io/issues/milestone/90?closed=1[1.20.2 (2018-10-30)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Request stream must be paused as soon as possible https://github.com/gravitee-io/issues/issues/1625[#1625]
+
+*_Management_*
+
+- Transfer ownership cause duplicate primary owner https://github.com/gravitee-io/issues/issues/1623[#1623]
+
+=== Improvements
+
+*_Gateway_*
+
+- Consider null logging condition as always true https://github.com/gravitee-io/issues/issues/1631[#1631]
+
+*_Management-api_*
+
+- Search API by exact match on name field https://github.com/gravitee-io/issues/issues/1626[#1626]
+
+== https://github.com/gravitee-io/issues/milestone/89?closed=1[1.20.1 (2018-10-26)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Stream must not be paused if response is ended before https://github.com/gravitee-io/issues/issues/1611[#1611]
+- Technical API does not expose /_node/apis anymore https://github.com/gravitee-io/issues/issues/1601[#1601]
+
+*_Identity-provider_*
+
+- [ldap] Wrong mapping https://github.com/gravitee-io/issues/issues/1587[#1587]
+
+*_Management_*
+
+- API not refreshed correctly when stopping it https://github.com/gravitee-io/issues/issues/1603[#1603]
+- API's picture reference does not take care about proto https://github.com/gravitee-io/issues/issues/1610[#1610]
+- Application permissions are not refreshed on ui https://github.com/gravitee-io/issues/issues/1535[#1535]
+- Delete button of the properties screen is not well displayed https://github.com/gravitee-io/issues/issues/1617[#1617]
+- Do not allow to add an existing members in api or apps https://github.com/gravitee-io/issues/issues/1532[#1532]
+- Forms title disappear on small screen https://github.com/gravitee-io/issues/issues/1615[#1615]
+- Hide the delete member button on application https://github.com/gravitee-io/issues/issues/1534[#1534]
+- Top APIs service is returning improper images URL. https://github.com/gravitee-io/issues/issues/1616[#1616]
+
+*_Management-api_*
+
+- Generated swagger describes date-time fields as strings, but they serialize as longs https://github.com/gravitee-io/issues/issues/1593[#1593]
+
+*_Portal_*
+
+- Keep gallery mode choice https://github.com/gravitee-io/issues/issues/1573[#1573]
+- Search subscriptions for application https://github.com/gravitee-io/issues/issues/1607[#1607]
+- Too much tasks for a user without groups https://github.com/gravitee-io/issues/issues/1590[#1590]
+
+=== Improvements
+
+*_General_*
+
+- Add a `search` button https://github.com/gravitee-io/issues/issues/1602[#1602]
+
+*_Management_*
+
+- API_PUBLISHER should have PLATFORM read right by default https://github.com/gravitee-io/issues/issues/1588[#1588]
+- No min length for application's clientId https://github.com/gravitee-io/issues/issues/1598[#1598]
+
+== https://github.com/gravitee-io/issues/milestone/75?closed=1[1.20.0 (2018-10-18)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- CORS headers are overriden by upstream headers https://github.com/gravitee-io/issues/issues/1528[#1528]
+- CORS headers must also be set in case of error (invalid security token) https://github.com/gravitee-io/issues/issues/1576[#1576]
+- Exit handler is not map properly for request chain https://github.com/gravitee-io/issues/issues/1563[#1563]
+- Gateway select first endpoint for dynamic routing https://github.com/gravitee-io/issues/issues/1515[#1515]
+- Response must be returned to the client in case of security error https://github.com/gravitee-io/issues/issues/1579[#1579]
+- Skip endpoint group without endpoints on stop https://github.com/gravitee-io/issues/issues/1572[#1572]
+- Skip the request's stream end() if we encounter a streamError https://github.com/gravitee-io/issues/issues/1569[#1569]
+- Sometimes errors occurs while reporting HC https://github.com/gravitee-io/issues/issues/1583[#1583]
+- When an API is redeployed, old handle should be remove from registry https://github.com/gravitee-io/issues/issues/1570[#1570]
+
+*_Management_*
+
+- Create empty group list on import https://github.com/gravitee-io/issues/issues/1317[#1317]
+- Error on rollback https://github.com/gravitee-io/issues/issues/1530[#1530]
+- Health check configuration of an endpoint is broken https://github.com/gravitee-io/issues/issues/1543[#1543]
+- Polling dictionnary is not stopped when the dictionnary is deleted https://github.com/gravitee-io/issues/issues/1586[#1586]
+- Wrong default search index dir https://github.com/gravitee-io/issues/issues/1562[#1562]
+
+*_Management-ui_*
+
+- CORS cant save customer Access-Control-Allow-Headers,for excample X-Gravitee-Api-Key. https://github.com/gravitee-io/issues/issues/1524[#1524]
+- Do not put application's type in title if none is set https://github.com/gravitee-io/issues/issues/1541[#1541]
+- Unable to parse log path with not encoded character https://github.com/gravitee-io/issues/issues/1527[#1527]
+
+*_Portal_*
+
+- Force login is not working as expected (always redirected to login form) https://github.com/gravitee-io/issues/issues/1542[#1542]
+- Search engine must be called also as anonymous user https://github.com/gravitee-io/issues/issues/1577[#1577]
+- Try it result of swagger is not readable as the text color is too clear https://github.com/gravitee-io/issues/issues/1582[#1582]
+
+=== Features
+
+*_Gateway_*
+
+- Identify the policy which is causing an internal server https://github.com/gravitee-io/issues/issues/1480[#1480]
+
+*_Management_*
+
+- Add a Bitbucket fetcher https://github.com/gravitee-io/issues/issues/1546[#1546]
+- Add filters for application's logs https://github.com/gravitee-io/issues/issues/1539[#1539]
+- [fetcher-gitlab] add v4 support https://github.com/gravitee-io/issues/issues/1488[#1488]
+
+*_Portal_*
+
+- Search Engine https://github.com/gravitee-io/issues/issues/1477[#1477]
+
+=== Improvements
+
+*_Analytics_*
+
+- Add Host header in ES index and analytics screen https://github.com/gravitee-io/issues/issues/1536[#1536]
+- Elasticsearch analytics requests don't hit the cache properly https://github.com/gravitee-io/issues/issues/1545[#1545]
+
+*_Gateway_*
+
+- Do not log complete stacktrace when logging condition fails https://github.com/gravitee-io/issues/issues/1568[#1568]
+- Improve support for SSL / TS and client authentication https://github.com/gravitee-io/issues/issues/1492[#1492]
+
+*_Management_*
+
+- Create empty arrays in policies configuration https://github.com/gravitee-io/issues/issues/1511[#1511]
+- Improve search engine https://github.com/gravitee-io/issues/issues/1585[#1585]
+- Improve the list of APIs https://github.com/gravitee-io/issues/issues/1483[#1483]
+- Improve the logging feature https://github.com/gravitee-io/issues/issues/1482[#1482]
+- Logs filteringadd a tenant filter https://github.com/gravitee-io/issues/issues/1538[#1538]
+- POST message https://github.com/gravitee-io/issues/issues/1526[#1526]
+- Redesign the forms https://github.com/gravitee-io/issues/issues/1481[#1481]
+- Remove configuration envvar from the environment gateway screen https://github.com/gravitee-io/issues/issues/1484[#1484]
+- [analytics] keep filters between overview and logs https://github.com/gravitee-io/issues/issues/1500[#1500]
+- [logs] improve filters https://github.com/gravitee-io/issues/issues/1501[#1501]
+
+*_Management-ui_*
+
+- Improve analytics filtering https://github.com/gravitee-io/issues/issues/1517[#1517]
+
+*_Node_*
+
+- Add a technical endpoint to retrieve the current configuration https://github.com/gravitee-io/issues/issues/1485[#1485]
+
+*_Policy_*
+
+- [request-content-limit] Request Content Limit Policy does not support transfer-encoding https://github.com/gravitee-io/issues/issues/1547[#1547]
+
+*_Portal_*
+
+- Improve the API general page https://github.com/gravitee-io/issues/issues/1479[#1479]
+- Swagger UI redirect_uri for OAuth2 authentication needs to be configured https://github.com/gravitee-io/issues/issues/1529[#1529]
+- [Doc] Add style for http verbs in the documentation page https://github.com/gravitee-io/issues/issues/1537[#1537]
+
+*_Reporter_*
+
+- [elasticsearch] Configure request timeout and use the pooled buffer https://github.com/gravitee-io/issues/issues/1508[#1508]
+
+*_Repository_*
+
+- [mongodb] Add mongodb repository TLS/SSL CA trusted compatibility https://github.com/gravitee-io/issues/issues/1460[#1460]
+
+== https://github.com/gravitee-io/issues/milestone/83?closed=1[1.19.3 (2018-09-25)]
+
+=== Features
+
+*_Management_*
+
+- Export API 'as' https://github.com/gravitee-io/issues/issues/1503[#1503]
+
+== https://github.com/gravitee-io/issues/milestone/[1.19.2 (2018-09-18)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Issue when calling SSL endpoint https://github.com/gravitee-io/issues/issues/1456[#1456]
+
+== https://github.com/gravitee-io/issues/milestone/82?closed=1[1.19.1 (2018-09-14)]
+
+=== Bug fixes
+
+*_Management_*
+
+- [message] unable to send messages https://github.com/gravitee-io/issues/issues/1499[#1499]
+
+*_Repository_*
+
+- [jdbc] Error when using mysql 8.0.11 (new keywords) https://github.com/gravitee-io/issues/issues/1498[#1498]
+
+== https://github.com/gravitee-io/issues/milestone/73?closed=1[1.19.0 (2018-09-11)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Error when path is missing in endpoint's target https://github.com/gravitee-io/issues/issues/1491[#1491]
+- Plans of the same type are mixed https://github.com/gravitee-io/issues/issues/1474[#1474]
+- Request not logged when X-Forwarded-For header contains host with port number https://github.com/gravitee-io/issues/issues/1468[#1468]
+
+*_Management_*
+
+- Button add page disappear when using back history of browser https://github.com/gravitee-io/issues/issues/1472[#1472]
+- CORS form can not be saved https://github.com/gravitee-io/issues/issues/1489[#1489]
+- Error when enabling health check https://github.com/gravitee-io/issues/issues/1467[#1467]
+- Filters should not be selectable multiple times in analytics https://github.com/gravitee-io/issues/issues/1411[#1411]
+- Unable to set the css class used in a theme https://github.com/gravitee-io/issues/issues/1454[#1454]
+- When writing first API page and refreshing the browser, the page type is lost and it's impossible to save https://github.com/gravitee-io/issues/issues/1374[#1374]
+
+*_Management-api_*
+
+- Internal Server Error when querying `/management/user` with basic auth https://github.com/gravitee-io/issues/issues/1435[#1435]
+
+*_Portal_*
+
+- Unable to reconnect a user after changing the jwtSecret https://github.com/gravitee-io/issues/issues/1471[#1471]
+
+=== Features
+
+*_Gateway_*
+
+- Add the response into the expression language engine https://github.com/gravitee-io/issues/issues/1476[#1476]
+
+*_Management_*
+
+- Add quality rating on apis https://github.com/gravitee-io/issues/issues/1403[#1403]
+- Communication by POST message https://github.com/gravitee-io/issues/issues/1402[#1402]
+- Global properties https://github.com/gravitee-io/issues/issues/1400[#1400]
+- Remove RAML support https://github.com/gravitee-io/issues/issues/1428[#1428]
+- SPEL for API endpoints https://github.com/gravitee-io/issues/issues/1401[#1401]
+- Show apps/apis for a group or a user https://github.com/gravitee-io/issues/issues/1429[#1429]
+
+*_Management-api_*
+
+- Add service to refresh pages configured with a fetcher https://github.com/gravitee-io/issues/issues/1449[#1449]
+- Using oauth scopes to assign roles in gravitee https://github.com/gravitee-io/issues/issues/1058[#1058]
+
+*_Portal_*
+
+- [analytics] Auto refresh button on dashboard and analytics page https://github.com/gravitee-io/issues/issues/1421[#1421]
+- [analytics] Refresh button on dashboard and analytics page https://github.com/gravitee-io/issues/issues/1420[#1420]
+- [documentation] Add Markdown editor https://github.com/gravitee-io/issues/issues/1425[#1425]
+- [documentation] Collapse for the folders in the documentation https://github.com/gravitee-io/issues/issues/1415[#1415]
+
+=== Improvements
+
+*_Management_*
+
+- Add a confirm dialog when deleting a notification configuration. https://github.com/gravitee-io/issues/issues/1372[#1372]
+- Default role for group members https://github.com/gravitee-io/issues/issues/1452[#1452]
+- Do not allow a read-only user to search for members https://github.com/gravitee-io/issues/issues/1391[#1391]
+- To avoid collision, we should store the bearer token on a cookie with a unique (non-standard) name https://github.com/gravitee-io/issues/issues/1470[#1470]
+- [logs] remove transactionId and requestId https://github.com/gravitee-io/issues/issues/1465[#1465]
+
+*_Management-api_*
+
+- Allow management-api to use HTTPS without HSTS header. https://github.com/gravitee-io/issues/issues/1459[#1459]
+
+*_Portal_*
+
+- API cardset a CSS class per view https://github.com/gravitee-io/issues/issues/1447[#1447]
+- Remove some roles https://github.com/gravitee-io/issues/issues/1330[#1330]
+- [analytics] Top slow and Top failed metrics will help in Application Analytics https://github.com/gravitee-io/issues/issues/1431[#1431]
+
+*_Resource_*
+
+- [am-oauth2] update OAuth2 AM resource to match the new introspection endpoint https://github.com/gravitee-io/issues/issues/1406[#1406]
+- [keycloak] Upgrade to Keycloak 4.x https://github.com/gravitee-io/issues/issues/1487[#1487]
+
+== https://github.com/gravitee-io/issues/milestone/81?closed=1[1.18.3 (2018-09-05)]
+
+=== Bug fixes
+
+*_Policy_*
+
+- [api-key] consider null as false for the "propagate api-key" configuration https://github.com/gravitee-io/issues/issues/1462[#1462]
+
+*_Portal_*
+
+- Invalid redirection when accessing a page directly from URL https://github.com/gravitee-io/issues/issues/1466[#1466]
+- User with no apis see everything https://github.com/gravitee-io/issues/issues/1463[#1463]
+
+== https://github.com/gravitee-io/issues/milestone/80?closed=1[1.15.8 (2018-08-30)]
+
+=== Bug fixes
+
+*_Portal_*
+
+- Google analytics is not working https://github.com/gravitee-io/issues/issues/1450[#1450]
+
+== https://github.com/gravitee-io/issues/milestone/76?closed=1[1.18.2 (2018-08-29)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Issue when calling SSL endpoint https://github.com/gravitee-io/issues/issues/1456[#1456]
+
+*_Portal_*
+
+- Redirections does not work well for registration/login https://github.com/gravitee-io/issues/issues/1405[#1405]
+
+== https://github.com/gravitee-io/issues/milestone/78?closed=1[1.16.5 (2018-08-16)]
+
+=== Improvements
+
+*_Analytics_*
+
+- [logs] Log detail search is done across full elasticsearch indices https://github.com/gravitee-io/issues/issues/1412[#1412]
+
+== https://github.com/gravitee-io/issues/milestone/77?closed=1[1.15.6 (2018-08-16)]
+
+=== Bug fixes
+
+*_Policy_*
+
+- [apikey] Check that the configuration is not null (backward compatibility) https://github.com/gravitee-io/issues/issues/1426[#1426]
+- [jwt] do not accept JWT token with empty signature https://github.com/gravitee-io/issues/issues/1417[#1417]
+
+*_Portal_*
+
+- Display parameter enum in swagger UI documentation pages https://github.com/gravitee-io/issues/issues/1416[#1416]
+
+== https://github.com/gravitee-io/issues/milestone/74?closed=1[1.18.1 (2018-07-26)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Api menu displays entry even if you're not authorized https://github.com/gravitee-io/issues/issues/1392[#1392]
+- Unable to configure scopes for oauth2 authentication https://github.com/gravitee-io/issues/issues/1398[#1398]
+- Unable to get apis list for a member https://github.com/gravitee-io/issues/issues/1390[#1390]
+
+== https://github.com/gravitee-io/issues/milestone/65?closed=1[1.18.0 (2018-07-11)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Handling of semicolons on request params https://github.com/gravitee-io/issues/issues/1342[#1342]
+
+*_Management_*
+
+- After importing an API and starting it, we cannot modify it without refreshing it https://github.com/gravitee-io/issues/issues/1348[#1348]
+- Creation of multiple APIs on the same context path is allowed with Swagger https://github.com/gravitee-io/issues/issues/1345[#1345]
+- Hooks notification does not work properly on support ticket without parameters https://github.com/gravitee-io/issues/issues/1358[#1358]
+- In some case, JWT plan cannot be updated https://github.com/gravitee-io/issues/issues/1286[#1286]
+- Sometimes the wizard of edit API does not pass to next step https://github.com/gravitee-io/issues/issues/1325[#1325]
+- The PNG images included in emails are not correctly mime typed https://github.com/gravitee-io/issues/issues/1357[#1357]
+- The from field of emails notifications created by social users should be set to email and not first name and last name https://github.com/gravitee-io/issues/issues/1353[#1353]
+- When adding a group, the notification says that it is removed https://github.com/gravitee-io/issues/issues/1371[#1371]
+- When connection is bad or lost the monitoring screen does not work as expected https://github.com/gravitee-io/issues/issues/1326[#1326]
+- When refreshing the api creation page, the UI try to load an API with an id `new` https://github.com/gravitee-io/issues/issues/1318[#1318]
+- When session expired the user is not correctly redirected when page is refreshed https://github.com/gravitee-io/issues/issues/1346[#1346]
+- When token is expired the management rest api returns an empty list of APIs https://github.com/gravitee-io/issues/issues/1351[#1351]
+
+*_Management-api_*
+
+- Permit access to public views https://github.com/gravitee-io/issues/issues/1369[#1369]
+
+*_Policy_*
+
+- [api-key] API Key not propagated https://github.com/gravitee-io/issues/issues/1363[#1363]
+
+*_Portal_*
+
+- Email infos are not updated when a user is logging in from ldap https://github.com/gravitee-io/issues/issues/1285[#1285]
+- Support form should be pristine after submit https://github.com/gravitee-io/issues/issues/1359[#1359]
+- The portal configuration is not overridable within an object https://github.com/gravitee-io/issues/issues/1282[#1282]
+
+*_Repository_*
+
+- [jdbc] get all notifications instead of only users notifications https://github.com/gravitee-io/issues/issues/1362[#1362]
+
+=== Features
+
+*_Gateway_*
+
+- MetricsAdd Prometheus support https://github.com/gravitee-io/issues/issues/1349[#1349]
+
+*_General_*
+
+- Repository HTTP / Bridge for Hybrid deployment https://github.com/gravitee-io/issues/issues/1344[#1344]
+
+*_Management_*
+
+- Analyticsget the top 10 of resources https://github.com/gravitee-io/issues/issues/1312[#1312]
+
+*_Management-api_*
+
+- Allows to search and filter APIs https://github.com/gravitee-io/issues/issues/561[#561]
+
+*_Policy_*
+
+- URL Rewriting https://github.com/gravitee-io/issues/issues/115[#115]
+- [json-validation] Add a json schema validation policy https://github.com/gravitee-io/issues/issues/1322[#1322]
+
+*_Portal_*
+
+- Allow API to be grouped on a single tile https://github.com/gravitee-io/issues/issues/1011[#1011]
+- Allow the user to sort the api-list by context-path https://github.com/gravitee-io/issues/issues/1156[#1156]
+- Management of second level with folder in the document menu https://github.com/gravitee-io/issues/issues/1224[#1224]
+- Swagger page enable custom option like docExpansion, show/hide URL https://github.com/gravitee-io/issues/issues/1151[#1151]
+- When creating the default application, give it the user name in place of "default app" https://github.com/gravitee-io/issues/issues/1153[#1153]
+
+*_Resource_*
+
+- [keycloak] Validate token using JWKS keys https://github.com/gravitee-io/issues/issues/1343[#1343]
+
+=== Improvements
+
+*_Gateway_*
+
+- Add AES256 ciphers for HTTP client https://github.com/gravitee-io/issues/issues/1373[#1373]
+- Improve stacktrace for port already in use for the http service https://github.com/gravitee-io/issues/issues/1354[#1354]
+- Optimize synchronization of APIs process to consume less resources (CPU, memory) https://github.com/gravitee-io/issues/issues/1367[#1367]
+- Provide the protocol scheme on the request https://github.com/gravitee-io/issues/issues/1355[#1355]
+
+*_Management_*
+
+- Implement missing notification hooks https://github.com/gravitee-io/issues/issues/1104[#1104]
+- Improve performance of start/stop API https://github.com/gravitee-io/issues/issues/1361[#1361]
+- On plan subscription, when the application is selected the plan is unchecked https://github.com/gravitee-io/issues/issues/1347[#1347]
+- When the management API is not reachable or error occurs the user is not notified https://github.com/gravitee-io/issues/issues/1365[#1365]
+
+*_Portal_*
+
+- Add a portal configuration to force user to add title and comment to rate an API https://github.com/gravitee-io/issues/issues/1364[#1364]
+- Add the i18n for brazilian portuguese https://github.com/gravitee-io/issues/issues/1333[#1333]
+- Allows to load translation for locale region https://github.com/gravitee-io/issues/issues/1337[#1337]
+- [google] GoogleAuthenticationResource userinfo endpoint url needs configuration and userInfo id issue https://github.com/gravitee-io/issues/issues/1323[#1323]
+
+*_Reporter_*
+
+- [kafka] Upgrade Kafka reporter to Vertx Kafka https://github.com/gravitee-io/issues/issues/1279[#1279]
+
+== https://github.com/gravitee-io/issues/milestone/72?closed=1[1.15.5 (2018-07-03)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Too many Response is closed logs https://github.com/gravitee-io/issues/issues/1352[#1352]
+
+*_Management_*
+
+- A user without subscriptions permissions see all tasks https://github.com/gravitee-io/issues/issues/1332[#1332]
+- Some platform analytics take into account all apis https://github.com/gravitee-io/issues/issues/1327[#1327]
+
+*_Policy_*
+
+- [JWT] When a token expire we should not log in error https://github.com/gravitee-io/issues/issues/1329[#1329]
+
+=== Improvements
+
+*_Portal_*
+
+- Add a portal configuration to force user to add title and comment to rate an API https://github.com/gravitee-io/issues/issues/1335[#1335]
+
+== https://github.com/gravitee-io/issues/milestone/64?closed=1[1.17.0 (2018-06-14)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Take care of visibility when importing an API https://github.com/gravitee-io/issues/issues/1295[#1295]
+- The portal is not accessible when the documentation URL is empty https://github.com/gravitee-io/issues/issues/1293[#1293]
+- Toggle public/private button is rollback after the save action https://github.com/gravitee-io/issues/issues/1171[#1171]
+- Typo in the portal settings https://github.com/gravitee-io/issues/issues/1301[#1301]
+- When the client id of an application is changed, its subscriptions must be updated with this new client id https://github.com/gravitee-io/issues/issues/1287[#1287]
+- When user is logged out or session is expired the UI display a blank screen https://github.com/gravitee-io/issues/issues/1303[#1303]
+- Zoom is not working correctly on HC https://github.com/gravitee-io/issues/issues/1083[#1083]
+- Do not display owner name on email https://github.com/gravitee-io/issues/issues/1280[#1280]
+
+*_Management-api_*
+
+- Better handling error when looking for APIs https://github.com/gravitee-io/issues/issues/818[#818]
+- Initializer service https://github.com/gravitee-io/issues/issues/1305[#1305]
+
+*_Portal_*
+
+- A user not authenticated cannot access to a public API https://github.com/gravitee-io/issues/issues/1309[#1309]
+- A user with role USER is not able to subscribe to an API plan https://github.com/gravitee-io/issues/issues/1297[#1297]
+- Avoid js error when user is logging out https://github.com/gravitee-io/issues/issues/1290[#1290]
+- Image is not well displayed on portal api header https://github.com/gravitee-io/issues/issues/1296[#1296]
+- Missing translations on english version https://github.com/gravitee-io/issues/issues/1294[#1294]
+- Widgets and charts are not resizing correctly https://github.com/gravitee-io/issues/issues/939[#939]
+- Social authentication does not work https://github.com/gravitee-io/issues/issues/1289[#1289]
+
+*_Gateway_*
+
+- Perform healthcheck on all available endpoints https://github.com/gravitee-io/issues/issues/1284[#1284]
+
+*_Elasticsearch_*
+
+- Impossible to generate from template /es6x/index/log.ftl https://github.com/gravitee-io/issues/issues/1270[#1270]
+
+=== Features
+
+*_Gateway_*
+
+- Group endpoints into load balancing/failover sets https://github.com/gravitee-io/issues/issues/756[#756]
+
+*_Management_*
+
+- Choose the type of security plan available https://github.com/gravitee-io/issues/issues/1242[#1242]
+- Display the status change history https://github.com/gravitee-io/issues/issues/1240[#1240]
+
+*_Portal_*
+
+- Add a `Support` link on each API https://github.com/gravitee-io/issues/issues/1241[#1241]
+
+=== Improvements
+
+*_Management_*
+
+- Add a message to explain the goal of the settings of portal api-key configuration https://github.com/gravitee-io/issues/issues/1302[#1302]
+- Add a warning if the jwt secret is the default one. https://github.com/gravitee-io/issues/issues/1269[#1269]
+- Unable to read % when it's to low https://github.com/gravitee-io/issues/issues/1304[#1304]
+
+*_Policy_*
+
+- [jwt] Using the aud field as a fallback for application reference https://github.com/gravitee-io/issues/issues/1235[#1235]
+
+*_Portal_*
+
+- Increase size of rating comment field https://github.com/gravitee-io/issues/issues/1288[#1288]
+
+== https://github.com/gravitee-io/issues/milestone/71?closed=1[1.16.4 (2018-06-13)]
+
+=== Bug fixes
+
+*_Portal_*
+
+- Social authentication does not work https://github.com/gravitee-io/issues/issues/1289[#1289]
+
+*_Elasticsearch_*
+
+- Impossible to generate from template /es6x/index/log.ftl https://github.com/gravitee-io/issues/issues/1270[#1270]
+
+*_Gateway_*
+
+- Perform healthcheck on all available endpoints https://github.com/gravitee-io/issues/issues/1284[#1284]
+
+*_Management_*
+
+- Do not display owner name on email https://github.com/gravitee-io/issues/issues/1280[#1280]
+
+=== Improvements
+
+*_Management_*
+
+- Unable to read % when it's to low https://github.com/gravitee-io/issues/issues/1304[#1304]
+
+== https://github.com/gravitee-io/issues/milestone/70?closed=1[1.15.4 (2018-06-12)]
+
+=== Bug fixes
+
+*_Elasticsearch_*
+
+- Impossible to generate from template /es6x/index/log.ftl https://github.com/gravitee-io/issues/issues/1270[#1270]
+
+*_Gateway_*
+
+- Perform healthcheck on all available endpoints https://github.com/gravitee-io/issues/issues/1284[#1284]
+
+*_Management_*
+
+- Do not display owner name on email https://github.com/gravitee-io/issues/issues/1280[#1280]
+
+=== Improvements
+
+*_Management_*
+
+- Unable to read % when it's to low https://github.com/gravitee-io/issues/issues/1304[#1304]
+
+== https://github.com/gravitee-io/issues/milestone/67?closed=1[1.16.2 (2018-05-24)]
+
+=== Bug fixes
+
+*_General_*
+
+- Merge LTS see  1.15.2 changelog for details https://github.com/gravitee-io/issues/issues/1255[#1255]
+
+== https://github.com/gravitee-io/issues/milestone/63?closed=1[1.15.2 (2018-05-23)]
+
+=== Bug fixes
+
+*_Elasticsearch_*
+
+- Top failed APIs is always empty https://github.com/gravitee-io/issues/issues/1249[#1249]
+
+*_Gateway_*
+
+- Missing trailing slash when using user-defined endpoint https://github.com/gravitee-io/issues/issues/1250[#1250]
+
+*_General_*
+
+- Importing v3.0 openAPI yaml/json is not working while creating new API. https://github.com/gravitee-io/issues/issues/1246[#1246]
+
+*_Management_*
+
+- PO role must not be available for a user in a group https://github.com/gravitee-io/issues/issues/1244[#1244]
+
+*_Management-ui_*
+
+- Endpoint's tenants are not well displayed https://github.com/gravitee-io/issues/issues/1251[#1251]
+
+=== Improvements
+
+*_Management_*
+
+- Center sidenav items https://github.com/gravitee-io/issues/issues/1245[#1245]
+
+== https://github.com/gravitee-io/issues/milestone/66?closed=1[1.16.1 (2018-05-16)]
+
+=== Bug fixes
+
+*_Management-api_*
+
+- Do not authenticate an unknown user https://github.com/gravitee-io/issues/issues/1238[#1238]
+
+=== Improvements
+
+*_Portal_*
+
+- Access or leave the login form blink effect https://github.com/gravitee-io/issues/issues/1237[#1237]
+
+== https://github.com/gravitee-io/issues/milestone/61?closed=1[1.16.0 (2018-05-10)]
+
+=== Bug fixes
+
+*_Elasticsearch_*
+
+- Healthcheck detail are empty https://github.com/gravitee-io/issues/issues/1110[#1110]
+
+*_Management_*
+
+- Add contextual doc on plan creation wizard https://github.com/gravitee-io/issues/issues/1222[#1222]
+- Display delete button of user and group management screen in low resolution https://github.com/gravitee-io/issues/issues/1223[#1223]
+- Import API does not work when LDAP is not reachable https://github.com/gravitee-io/issues/issues/1231[#1231]
+- Plan preview is not correctly displayed on low resolution https://github.com/gravitee-io/issues/issues/1221[#1221]
+- Refresh members after adding / removing a group to an API https://github.com/gravitee-io/issues/issues/1218[#1218]
+
+*_Management-api_*
+
+- Show the reason of a subscription https://github.com/gravitee-io/issues/issues/1234[#1234]
+- Sign up with NullPointerException in graviteeio-management-api-1.15.1 https://github.com/gravitee-io/issues/issues/1207[#1207]
+- User registration fails https://github.com/gravitee-io/issues/issues/1209[#1209]
+
+*_Repository_*
+
+- [jdbc] Plan security definition is not stored https://github.com/gravitee-io/issues/issues/1226[#1226]
+
+=== Features
+
+*_Elasticsearch_*
+
+- Index per type support for ES2.x and ES5.x https://github.com/gravitee-io/issues/issues/1210[#1210]
+
+*_General_*
+
+- Managementexpose the rest-api in https https://github.com/gravitee-io/issues/issues/1232[#1232]
+
+*_Management_*
+
+- Allows to reset a password of an internal user https://github.com/gravitee-io/issues/issues/1230[#1230]
+- Delegate the management of a group https://github.com/gravitee-io/issues/issues/1100[#1100]
+- Manage Portal configuration with the UI https://github.com/gravitee-io/issues/issues/1197[#1197]
+
+*_Management-api_*
+
+- Authentication token exchange https://github.com/gravitee-io/issues/issues/1228[#1228]
+
+=== Improvements
+
+*_Gateway_*
+
+- Reporting switch from LMAX disruptor to Vert.x event-bus https://github.com/gravitee-io/issues/issues/1190[#1190]
+
+*_Management_*
+
+- Disable autofill in the endpoint proxy configuration https://github.com/gravitee-io/issues/issues/916[#916]
+
+*_Management-api_*
+
+- Remove authentication by cookies https://github.com/gravitee-io/issues/issues/1191[#1191]
+
+*_Management-ui_*
+
+- Add highlight.js extension for documentation pages https://github.com/gravitee-io/issues/issues/1194[#1194]
+
+*_Repository_*
+
+- [mongodb] Add Support for MongoDB SRV Records https://github.com/gravitee-io/issues/issues/1208[#1208]
+
+== https://github.com/gravitee-io/issues/milestone/62?closed=1[1.15.1 (2018-04-10)]
+
+=== Bug fixes
+
+*_Elasticsearch_*
+
+- Group by query are limited to 20 elements only https://github.com/gravitee-io/issues/issues/1195[#1195]
+
+*_Gateway_*
+
+- Load a policy only if required https://github.com/gravitee-io/issues/issues/1199[#1199]
+- Request ends with a timeout in case of bad HTTP verb. https://github.com/gravitee-io/issues/issues/1193[#1193]
+
+*_General_*
+
+- Routing doesn't fail with non existing endpoint https://github.com/gravitee-io/issues/issues/1204[#1204]
+
+*_Management_*
+
+- I can't submit a support ticket ! https://github.com/gravitee-io/issues/issues/1202[#1202]
+- Lost labels when dynamic properties are configured https://github.com/gravitee-io/issues/issues/1200[#1200]
+
+=== Improvements
+
+*_Gateway_*
+
+- Associate preflight request (cors) to Unknown application https://github.com/gravitee-io/issues/issues/1192[#1192]
+
+== https://github.com/gravitee-io/issues/milestone/56?closed=1[1.15.0 (2018-04-04)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Clear LMAX ringbuffer when a reportable event is successfully published https://github.com/gravitee-io/issues/issues/1175[#1175]
+
+*_Management_*
+
+- Impossible to create an application with same client_id than a deleted application https://github.com/gravitee-io/issues/issues/1180[#1180]
+- Unable to change my profile avatar https://github.com/gravitee-io/issues/issues/1181[#1181]
+
+*_Reporter_*
+
+- [elasticsearch] In the analytics, the datas for geolocation by country is displayed https://github.com/gravitee-io/issues/issues/1188[#1188]
+
+=== Features
+
+*_Elasticsearch_*
+
+- Elastic 6.x support https://github.com/gravitee-io/issues/issues/1170[#1170]
+
+*_Gateway_*
+
+- Blue-green deployment https://github.com/gravitee-io/issues/issues/1052[#1052]
+
+*_Management_*
+
+- Create User management screen https://github.com/gravitee-io/issues/issues/1099[#1099]
+
+=== Improvements
+
+*_Management_*
+
+- Add a reason when an app request for a subscription https://github.com/gravitee-io/issues/issues/1098[#1098]
+- Display user name on audit screens https://github.com/gravitee-io/issues/issues/1189[#1189]
+- Forward fetcher exceptions https://github.com/gravitee-io/issues/issues/1106[#1106]
+- Refactor Configuration menu https://github.com/gravitee-io/issues/issues/1124[#1124]
+- Subscriptionsdisplay who has requested the subscription. https://github.com/gravitee-io/issues/issues/1096[#1096]
+- Swagger document should be parsed only if needed https://github.com/gravitee-io/issues/issues/1183[#1183]
+
+*_Portal_*
+
+- Add in the dashboard tenant repartition, response status, response time https://github.com/gravitee-io/issues/issues/1186[#1186]
+- Minor styling issues with swagger 3.0 https://github.com/gravitee-io/issues/issues/1178[#1178]
+- Refactor API Menu https://github.com/gravitee-io/issues/issues/1101[#1101]
+
+*_Repository_*
+
+- Add some tests on sorted page results https://github.com/gravitee-io/issues/issues/1073[#1073]
+- Redis] Allows to test on an embedded redis server https://github.com/gravitee-io/issues/issues/1164[#1164]
+
+== https://github.com/gravitee-io/issues/milestone/60?closed=1[1.14.4 (2018-03-27)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Unable to filter logs by path https://github.com/gravitee-io/issues/issues/1127[#1127]
+- Unable to lookup user with reference sometimes https://github.com/gravitee-io/issues/issues/1174[#1174]
+
+*_Repository_*
+
+- Jdbc] Membership roles not deleted when membership is deleted https://github.com/gravitee-io/issues/issues/1176[#1176]
+
+== https://github.com/gravitee-io/issues/milestone/59?closed=1[1.14.3 (2018-03-22)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- The first deployment fails sometime https://github.com/gravitee-io/issues/issues/1128[#1128]
+
+*_Management_*
+
+- Error on the first start https://github.com/gravitee-io/issues/issues/1168[#1168]
+- Reference data identifying a user is not consistent accross management API cluster https://github.com/gravitee-io/issues/issues/1133[#1133]
+- Refresh correctly API when the API picture is changed https://github.com/gravitee-io/issues/issues/1138[#1138]
+
+*_Management-api_*
+
+-  user login oauth2 map key can not be null https://github.com/gravitee-io/issues/issues/1132[#1132]
+- 404 Subscription can not be found while deleting an API https://github.com/gravitee-io/issues/issues/1143[#1143]
+
+*_Portal_*
+
+- API logos are not displayed correctly over HTTPS on apis list https://github.com/gravitee-io/issues/issues/1142[#1142]
+- Filter top APIs by user right https://github.com/gravitee-io/issues/issues/1166[#1166]
+- First portal page is not visually selected when selecting menu documentation https://github.com/gravitee-io/issues/issues/1154[#1154]
+- Swagger UI CSS incorrect and SVGs are missing https://github.com/gravitee-io/issues/issues/1121[#1121]
+
+*_Reporter_*
+
+- [elasticsearch] logging fail when header has null value https://github.com/gravitee-io/issues/issues/1140[#1140]
+
+=== Improvements
+
+*_General_*
+
+-  Add the i18n for chinese https://github.com/gravitee-io/issues/issues/1160[#1160]
+- Allow array in envvar https://github.com/gravitee-io/issues/issues/1163[#1163]
+
+*_Management_*
+
+- SwaggerParser crash when using OpenAPI 3.0 swagger https://github.com/gravitee-io/issues/issues/1117[#1117]
+
+*_Plugin_*
+
+- Add ability to extend the plugin classloader with additional dependencies https://github.com/gravitee-io/issues/issues/1137[#1137]
+
+*_Portal_*
+
+- Allows to configure home title https://github.com/gravitee-io/issues/issues/1148[#1148]
+- Better display swagger ui documentation https://github.com/gravitee-io/issues/issues/1135[#1135]
+- Upgrade swagger-ui to 3.11 version https://github.com/gravitee-io/issues/issues/1118[#1118]
+
+*_Repository_*
+
+- Jdbc] Allows to execute tests on real DBMS instead of in-memory https://github.com/gravitee-io/issues/issues/1150[#1150]
+
+== https://github.com/gravitee-io/issues/milestone/58?closed=1[1.14.2 (2018-03-06)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Do not handle stream if a streaming policy return null streamer https://github.com/gravitee-io/issues/issues/1115[#1115]
+
+*_General_*
+
+- SSL handshake failure for some urls https://github.com/gravitee-io/issues/issues/1119[#1119]
+
+*_Management_*
+
+- Double scroll when contextual documentation is displayed https://github.com/gravitee-io/issues/issues/1120[#1120]
+- Parameter [portal.top-apis] can not be found on api delete action https://github.com/gravitee-io/issues/issues/1131[#1131]
+
+*_Reporter_*
+
+- Failed to execute pipeline [gravitee_pipeline] https://github.com/gravitee-io/issues/issues/1126[#1126]
+
+=== Improvements
+
+*_General_*
+
+- Allows all envvar variations https://github.com/gravitee-io/issues/issues/1129[#1129]
+
+*_Management_*
+
+- On the notification part, "api-key" is written differently https://github.com/gravitee-io/issues/issues/1122[#1122]
+
+== https://github.com/gravitee-io/issues/milestone/57?closed=1[1.14.1 (2018-02-28)]
+
+=== Bug fixes
+
+*_Portal_*
+
+- Default avatar and logo are missing https://github.com/gravitee-io/issues/issues/1111[#1111]
+
+*_Repository_*
+
+- [elasticsearch] Blocked thread in case of ES fail https://github.com/gravitee-io/issues/issues/1112[#1112]
+
+== https://github.com/gravitee-io/issues/milestone/48?closed=1[1.14.0 (2018-02-28)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Audit / Group - user anonymisation https://github.com/gravitee-io/issues/issues/1093[#1093]
+
+*_Management-api_*
+
+- User anonymization https://github.com/gravitee-io/issues/issues/1053[#1053]
+
+*_Policy_*
+
+- [dynamic-routing] Policies rewrite '?' into '%3F' https://github.com/gravitee-io/issues/issues/1089[#1089]
+
+=== Features
+
+*_Management_*
+
+- Webhook https://github.com/gravitee-io/issues/issues/930[#930]
+
+*_Portal_*
+
+- Notification https://github.com/gravitee-io/issues/issues/929[#929]
+- Swagger UI 3 support https://github.com/gravitee-io/issues/issues/1108[#1108]
+- Top APIs configurable https://github.com/gravitee-io/issues/issues/932[#932]
+
+=== Improvements
+
+*_Gateway_*
+
+- Add routes to improve technical API for api-key refresher and subscription refresher https://github.com/gravitee-io/issues/issues/1095[#1095]
+- Manage different endpoint configuration per multi-tenant https://github.com/gravitee-io/issues/issues/1056[#1056]
+
+*_General_*
+
+- Do not treat LDAP adminLimitExceeded as an error https://github.com/gravitee-io/issues/issues/1091[#1091]
+- Improve the stars rendering for star rating https://github.com/gravitee-io/issues/issues/1109[#1109]
+
+*_Management_*
+
+- Analyticsadd informations about failed requests https://github.com/gravitee-io/issues/issues/1070[#1070]
+- Filter global dashboard with authorized API/APP https://github.com/gravitee-io/issues/issues/1072[#1072]
+
+*_Management-api_*
+
+- [ldap] Full name of LDAP users not shown if LDAP object lacks givenname/sn https://github.com/gravitee-io/issues/issues/1030[#1030]
+
+*_Management-ui_*
+
+- Improvements to OAuth integration https://github.com/gravitee-io/issues/issues/1060[#1060]
+
+*_Policy_*
+
+- Dynamic-routing] How-to remove subpath https://github.com/gravitee-io/issues/issues/1065[#1065]
+
+*_Reporter_*
+
+- Elasticsearch] refactor geoip  https://github.com/gravitee-io/issues/issues/1074[#1074]
+
+*_Service_*
+
+- Health-check] Execute health-check rule from root path https://github.com/gravitee-io/issues/issues/1078[#1078]
+
+== https://github.com/gravitee-io/issues/milestone/55?closed=1[1.13.3 (2018-02-18)]
+
+=== Bug fixes
+
+*_Reporter_*
+
+- [elasticsearch] Unable to index some logs https://github.com/gravitee-io/issues/issues/1077[#1077]
+
+*_Policy_*
+
+ - [oauth2] Policy Oauth2 should not impose client_id in the introspect body https://github.com/gravitee-io/issues/issues/1081[#1081]
+ - APIM Policy xml to json trims unknown caracters when using non UTF-8 charset https://github.com/gravitee-io/issues/issues/1085[#1085]
+
+*_Management_*
+
+- The API version is outdated and must be refreshed (current modifications will be lose) https://github.com/gravitee-io/issues/issues/1079[#1079]
+
+== https://github.com/gravitee-io/issues/milestone/54?closed=1[1.13.2 (2018-02-06)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Dynamic properties services crash when the response is an array https://github.com/gravitee-io/issues/issues/1051[#1051]
+- Unable to close a plan with only closed subscriptions https://github.com/gravitee-io/issues/issues/1067[#1067]
+
+*_Management-api_*
+
+- An other OAuth2 or JWT plan is already subscribed by the same application. https://github.com/gravitee-io/issues/issues/1062[#1062]
+
+*_Portal_*
+
+- API [undefined] error when creating new API https://github.com/gravitee-io/issues/issues/1068[#1068]
+
+=== Improvements
+
+*_Policy_*
+
+- [oauth2] Add the possibility to specify OAuth scope delimiter https://github.com/gravitee-io/issues/issues/1001[#1001]
+
+*_Repository_*
+
+- [mongodb] Missing unique index https://github.com/gravitee-io/issues/issues/1063[#1063]
+
+
+== https://github.com/gravitee-io/issues/milestone/53?closed=1[1.13.1 (2018-01-31)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Sync service is deploying all API updates after a single deployment https://github.com/gravitee-io/issues/issues/1050[#1050]
+
+*_Portal_*
+
+- CORS default values are wrong https://github.com/gravitee-io/issues/issues/1049[#1049]
+
+
+== https://github.com/gravitee-io/issues/milestone/47?closed=1[1.13.0 (2018-01-31)]
+
+=== Bug fixes
+
+*_General_*
+
+- Internal server error when the failover timeout is set to 0 https://github.com/gravitee-io/issues/issues/1038[#1038]
+- Publish planMissing redeploy sync menu  https://github.com/gravitee-io/issues/issues/1043[#1043]
+
+*_Management_*
+
+- Documentation pages order does not work correctly https://github.com/gravitee-io/issues/issues/1016[#1016]
+- Dynamic properties generate a changes if the order changes https://github.com/gravitee-io/issues/issues/942[#942]
+- Unable to scroll contextual documentation https://github.com/gravitee-io/issues/issues/1022[#1022]
+
+*_Management-api_*
+
+- User authorities / permissions not loaded with oauth / social authentication https://github.com/gravitee-io/issues/issues/1035[#1035]
+
+*_Policy_*
+
+- [jwt] authentification scheme is not checked https://github.com/gravitee-io/issues/issues/966[#966]
+
+*_Portal_*
+
+- User picture not properly handled if picture is an URL https://github.com/gravitee-io/issues/issues/1036[#1036]
+- User signup fails https://github.com/gravitee-io/issues/issues/1000[#1000]
+
+=== Features
+
+*_General_*
+
+- Choose Oauth2 on a plan https://github.com/gravitee-io/issues/issues/741[#741]
+- Override configuration with system properties or environment variables https://github.com/gravitee-io/issues/issues/1042[#1042]
+
+*_Portal_*
+
+- Allow to choose between "tiles mode" and "list mode" for the API gallery. https://github.com/gravitee-io/issues/issues/1004[#1004]
+- Task List https://github.com/gravitee-io/issues/issues/971[#971]
+
+*_Reporter_*
+
+- [elasticsearch] manage the ingest geoip processor pipeline https://github.com/gravitee-io/issues/issues/970[#970]
+
+=== Improvements
+
+*_Gateway_*
+
+- Assign ip of x-forwared-for header to remoteAddress metric https://github.com/gravitee-io/issues/issues/969[#969]
+- Performance improvements https://github.com/gravitee-io/issues/issues/1048[#1048]
+
+*_General_*
+
+- Subscription section overlaps with description section https://github.com/gravitee-io/issues/issues/1047[#1047]
+
+*_Management_*
+
+- Do not allow to add/remove the `All` view on an API. https://github.com/gravitee-io/issues/issues/1034[#1034]
+- Do not enable healthcheck by default https://github.com/gravitee-io/issues/issues/1032[#1032]
+- Handle concurrent modifications with eTag https://github.com/gravitee-io/issues/issues/999[#999]
+- Improve the http status list on log filters https://github.com/gravitee-io/issues/issues/1044[#1044]
+- Save the open/close state of the sidenav https://github.com/gravitee-io/issues/issues/1023[#1023]
+
+*_Management-api_*
+
+- Allows to configure specific CORS headers https://github.com/gravitee-io/issues/issues/160[#160]
+- Inject the subscription reject reason in the mail template https://github.com/gravitee-io/issues/issues/1033[#1033]
+- Oauth2]Update firstname and lastname https://github.com/gravitee-io/issues/issues/1020[#1020]
+- [ldap] [roles] Adding roles to users in Gravitee requires a specific design of an organizations LDAP tree https://github.com/gravitee-io/issues/issues/948[#948]
+
+*_Portal_*
+
+- Add personal css with my theme https://github.com/gravitee-io/issues/issues/963[#963]
+- Flag documents as non-published when the owner is on preview  https://github.com/gravitee-io/issues/issues/1007[#1007]
+- New markdown symbols https://github.com/gravitee-io/issues/issues/964[#964]
+- Plan description is truncated if too long https://github.com/gravitee-io/issues/issues/941[#941]
+- Save the open/close state of the new help panel on the right for a user in his browser https://github.com/gravitee-io/issues/issues/951[#951]
+- Show the owner name in the API header in place of the login https://github.com/gravitee-io/issues/issues/1003[#1003]
+- Swagger customize style https://github.com/gravitee-io/issues/issues/1028[#1028]
+
+
+== https://github.com/gravitee-io/issues/milestone/52?closed=1[1.12.5 (2018-01-18)]
+
+=== Bug fixes
+
+*_Management-api_*
+
+- [ldap] Use the identifier from LDAP instead of the one provided by the user https://github.com/gravitee-io/issues/issues/1014[#1014]
+
+*_Management-ui_*
+
+- Sometimes apis list are not well displayed https://github.com/gravitee-io/issues/issues/1010[#1010]
+
+
+== https://github.com/gravitee-io/issues/milestone/51?closed=1[1.12.4 (2018-01-11)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- ConcurrentModificationException when stopping an API https://github.com/gravitee-io/issues/issues/994[#994]
+- [endpoint-discovery] Use node address for empty service address https://github.com/gravitee-io/issues/issues/984[#984]
+- [health-check] Healthcheck service not aware of dynamic endpoints (consul.io) https://github.com/gravitee-io/issues/issues/993[#993]
+
+*_Management-api_*
+
+- Error while getting user picture https://github.com/gravitee-io/issues/issues/996[#996]
+- [dynamic-properties] Threapool mixin https://github.com/gravitee-io/issues/issues/988[#988]
+- [ldap] Use BaseDN for every LDAP requests https://github.com/gravitee-io/issues/issues/983[#983]
+
+=== Features
+
+*_Portal_*
+
+- Login onto the portal is case sensitive https://github.com/gravitee-io/issues/issues/548[#548]
+
+=== Improvements
+
+*_Elasticsearch_*
+
+- [http] Configure number of replicas or shards https://github.com/gravitee-io/issues/issues/986[#986]
+
+*_Management_*
+
+- Add more information on DynamicProperties logs https://github.com/gravitee-io/issues/issues/995[#995]
+- Improve performance to retrieve api and app list https://github.com/gravitee-io/issues/issues/992[#992]
+
+
+== https://github.com/gravitee-io/issues/milestone/50?closed=1[1.12.3 (2018-01-05)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Do not use views in the management https://github.com/gravitee-io/issues/issues/961[#961]
+- Unable to create an api from scratch with a plan https://github.com/gravitee-io/issues/issues/973[#973]
+
+*_Management-api_*
+
+- Social authentication is not working anymore https://github.com/gravitee-io/issues/issues/978[#978]
+
+*_Portal_*
+
+- Oauth2 / social authentication must be done twice https://github.com/gravitee-io/issues/issues/977[#977]
+- The api gallery is slow to display https://github.com/gravitee-io/issues/issues/976[#976]
+
+=== Improvements
+
+*_Management_*
+
+- Hidden views must be available for apis https://github.com/gravitee-io/issues/issues/960[#960]
+
+
+== https://github.com/gravitee-io/issues/milestone/49?closed=1[1.12.2 (2017-12-21)]
+
+=== Bug fixes
+
+*_Management_*
+
+- API page keep unsaved data on forms, even on navigation https://github.com/gravitee-io/issues/issues/943[#943]
+- Duplicate permissions https://github.com/gravitee-io/issues/issues/957[#957]
+- Duplicate plans & docs when import json on an existing API https://github.com/gravitee-io/issues/issues/947[#947]
+
+*_Policy_*
+
+- [groovy] No such property parameters https://github.com/gravitee-io/issues/issues/952[#952]
+
+*_Service_*
+
+- [endpoint-discovery] Use local agent address for services without address https://github.com/gravitee-io/issues/issues/953[#953]
+
+=== Improvements
+
+*_Portal_*
+
+- Force authentication to access portal https://github.com/gravitee-io/issues/issues/956[#956]
+
+
+== https://github.com/gravitee-io/issues/milestone/42?closed=1[1.12.0 (2017-12-13)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Api Keys not recognized after migration to 1.11.x https://github.com/gravitee-io/issues/issues/938[#938]
+
+*_General_*
+
+- Weird box remaining visible after canceling doc page creation https://github.com/gravitee-io/issues/issues/914[#914]
+
+*_Management_*
+
+- Proxy host and port required even if the proxy is disabled https://github.com/gravitee-io/issues/issues/917[#917]
+
+*_Management-api_*
+
+- Cannot handle metrics integer based https://github.com/gravitee-io/issues/issues/925[#925] (Thanks to https://github.com/mugues[mugues])
+- OAuth2 authentication is not working anymore https://github.com/gravitee-io/issues/issues/911[#911] (Thanks to https://github.com/yang-dw[yang-dw])
+- Thread blocked during internal health-check https://github.com/gravitee-io/issues/issues/923[#923]
+
+*_Policy_*
+
+- [Groovy] Result is not bind on the onRequest/onResponse contents scripts https://github.com/gravitee-io/issues/issues/913[#913]
+
+*_Portal_*
+
+- UI not working properly if devMode is enabled https://github.com/gravitee-io/issues/issues/919[#919]
+
+=== Features
+
+*_Gateway_*
+
+- Service Discovery for endpoints https://github.com/gravitee-io/issues/issues/843[#843]
+- Missing back-pressure handling https://github.com/gravitee-io/issues/issues/918[#918] (Thanks to https://github.com/lbovet[lbovet])
+
+*_General_*
+
+- Modify application primary owner https://github.com/gravitee-io/issues/issues/738[#738]
+- Modify primary owner API or application https://github.com/gravitee-io/issues/issues/737[#737]
+
+*_Portal_*
+
+- Add the ability to sort views https://github.com/gravitee-io/issues/issues/892[#892]
+- Endpoint health-check average availability and response time chart https://github.com/gravitee-io/issues/issues/889[#889]
+- [logs] Is there a way to filter requests in Logs screen https://github.com/gravitee-io/issues/issues/703[#703]
+
+=== Improvements
+
+*_Gateway_*
+
+- Add monitoring endpoint to technical API https://github.com/gravitee-io/issues/issues/936[#936]
+- Apply slicing windows for sync and api-keys refresh processes https://github.com/gravitee-io/issues/issues/922[#922]
+
+*_Repository_*
+
+- [mongo] Manage in the yml file the readPreference and readPrefererenceTags https://github.com/gravitee-io/issues/issues/928[#928]
+
+
+== https://github.com/gravitee-io/issues/milestone/46?closed=1[1.11.4 (2017-11-26)]
+
+=== Bug fixes
+
+*_Management-api_*
+
+- Do not stop node healthcheck in case of probe exception https://github.com/gravitee-io/issues/issues/909[#909]
+- On a fresh install, all roles are not created https://github.com/gravitee-io/issues/issues/901[#901]
+
+*_Portal_*
+
+- Auto validation swith is not well displayed https://github.com/gravitee-io/issues/issues/905[#905]
+- Constants.json properties must be optional https://github.com/gravitee-io/issues/issues/906[#906]
+
+*_Reporter_*
+
+- [elasticsearch] Freemarker template issue https://github.com/gravitee-io/issues/issues/908[#908]
+
+*_Repository_*
+
+- [elasticsearch] Search improvements for HTTP connector https://github.com/gravitee-io/issues/issues/910[#910]
+
+*_Service_*
+
+- [node-healthcheck] Internal server error https://github.com/gravitee-io/issues/issues/902[#902]
+
+
+== https://github.com/gravitee-io/issues/milestone/45?closed=1[1.11.3 (2017-11-22)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Rate-limit/quota units are not consistent between the wizard and the plan https://github.com/gravitee-io/issues/issues/897[#897]
+
+*_Management-api_*
+
+- Null pointer when getting platform audit items https://github.com/gravitee-io/issues/issues/895[#895]
+- Successful authentication event is handled twice https://github.com/gravitee-io/issues/issues/894[#894]
+- UpdatedAt property is not updated when publishing a plan https://github.com/gravitee-io/issues/issues/899[#899]
+
+*_Reporter_*
+
+- ES http plugin 401 https://github.com/gravitee-io/issues/issues/893[#893] (Thanks to https://github.com/anchsu[anchsu])
+- [repository] Elasticsearchsecurity headers not sent https://github.com/gravitee-io/issues/issues/898[#898]
+
+*_Repository_*
+
+- ES http plugin 401 https://github.com/gravitee-io/issues/issues/896[#896] (Thanks to https://github.com/anchsu[anchsu])
+
+
+== https://github.com/gravitee-io/issues/milestone/44?closed=1[1.11.1 (2017-11-16)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Selection of policy path is case sensitive https://github.com/gravitee-io/issues/issues/885[#885]
+- Send content-length header for transformable stream policy https://github.com/gravitee-io/issues/issues/884[#884]
+
+*_Management_*
+
+- Allows to create audit on initialization service with a system user https://github.com/gravitee-io/issues/issues/886[#886]
+
+*_Portal_*
+
+- Error when trying to display contextual documentation https://github.com/gravitee-io/issues/issues/888[#888]
+
+=== Improvements
+
+*_Management_*
+
+- Do not reset system permissions at each reboot https://github.com/gravitee-io/issues/issues/887[#887]
+
+
+== https://github.com/gravitee-io/issues/milestone/38?closed=1[1.11.0 (2017-11-16)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Bad timestamp for logging https://github.com/gravitee-io/issues/issues/869[#869]
+- Policy path is not well resolved with encoded URL https://github.com/gravitee-io/issues/issues/876[#876]
+- Stop technical API after services https://github.com/gravitee-io/issues/issues/883[#883]
+
+*_Identity_provider_*
+
+- [ldap] LDAP query does not filter on `user-search-base` property https://github.com/gravitee-io/issues/issues/873[#873]
+
+*_Management_*
+
+- Unable to build project under windows https://github.com/gravitee-io/issues/issues/848[#848]
+
+*_Policy_*
+
+- [cors] Preflight request hangs https://github.com/gravitee-io/issues/issues/880[#880]
+
+*_Portal_*
+
+- After installing a new version, the previous version number is displayed https://github.com/gravitee-io/issues/issues/879[#879]
+- Error popup in management-ui for non EN/FR browsers https://github.com/gravitee-io/issues/issues/652[#652]
+- Incorrect oauth2 redirect_uri if serving the application under a path https://github.com/gravitee-io/issues/issues/854[#854]
+
+*_Resource_*
+
+- [oauth2-am] Problem with absolute URL https://github.com/gravitee-io/issues/issues/858[#858]
+
+=== Features
+
+*_Management_*
+
+- Add help on each forms https://github.com/gravitee-io/issues/issues/841[#841]
+- Add the ability to close a subscription https://github.com/gravitee-io/issues/issues/856[#856]
+
+*_Management-api_*
+
+- API history / activity https://github.com/gravitee-io/issues/issues/759[#759]
+
+*_Portal_*
+
+- Add restrictions on portal documentation https://github.com/gravitee-io/issues/issues/839[#839]
+- Contextual documentation https://github.com/gravitee-io/issues/issues/859[#859]
+- Google analytics https://github.com/gravitee-io/issues/issues/842[#842]
+- Rate and comments APIs https://github.com/gravitee-io/issues/issues/840[#840]
+
+=== Improvements
+
+*_Gateway_*
+
+- Apikey refresh service looks for keyless plans. https://github.com/gravitee-io/issues/issues/862[#862]
+- Request reporter handler generates a single reportable https://github.com/gravitee-io/issues/issues/881[#881]
+
+*_Portal_*
+
+- Improve log description https://github.com/gravitee-io/issues/issues/872[#872]
+
+*_Reporter_*
+
+- [elasticsearch] HTTP support https://github.com/gravitee-io/issues/issues/861[#861]
+
+*_Repository_*
+
+- [elasticsearch] HTTP support https://github.com/gravitee-io/issues/issues/871[#871]
+
+
+== https://github.com/gravitee-io/issues/milestone/43?closed=1[1.10.5 (2017-11-16)]
+
+=== Bug fixes
+
+*_Management_*
+
+- When a subscription has an ending date, the status changes to CLOSED https://github.com/gravitee-io/issues/issues/882[#882]
+
+
+== https://github.com/gravitee-io/issues/milestone/41?closed=1[1.10.4 (2017-11-05)]
+
+=== Bug fixes
+
+*_Management-api_*
+
+- Affect default roles for OpenID connect users https://github.com/gravitee-io/issues/issues/853[#853]
+
+
+== https://github.com/gravitee-io/issues/milestone/40?closed=1[1.10.3 (2017-11-04)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Handle property reporting exception https://github.com/gravitee-io/issues/issues/867[#867]
+- [management-api] Rename 'repository' probe for node healthcheck https://github.com/gravitee-io/issues/issues/866[#866]
+
+*_Management_*
+
+- Gateway instances version is truncated https://github.com/gravitee-io/issues/issues/849[#849]
+
+*_Policy-groovy_*
+
+- Unable to add request scripts https://github.com/gravitee-io/issues/issues/868[#868]
+
+*_Portal_*
+
+- Staging plans are retrieved on public apis  https://github.com/gravitee-io/issues/issues/863[#863]
+
+*_Repository_*
+
+- Dynamodb] unable to load apikeys https://github.com/gravitee-io/issues/issues/860[#860]
+
+
+== https://github.com/gravitee-io/issues/milestone/39?closed=1[1.10.2 (2017-10-23)]
+
+=== Bug fixes
+
+*_Management-api_*
+
+- Remove subscriptions when deleting an api https://github.com/gravitee-io/issues/issues/846[#846]
+- User not found when dynamic properties is enabled on API https://github.com/gravitee-io/issues/issues/844[#844]
+
+=== Improvements
+
+*_Policy_*
+
+- [dynamic-routing] Regex does not match in case of encoded URI https://github.com/gravitee-io/issues/issues/845[#845]
+
+
+== https://github.com/gravitee-io/issues/milestone/35?closed=1[1.10.0 (2017-10-17)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Gateway must not enforce character encoding if not required https://github.com/gravitee-io/issues/issues/832[#832]
+
+*_General_*
+
+- Healthcheck probe must connect on declared host in config https://github.com/gravitee-io/issues/issues/789[#789]
+
+*_Management_*
+
+- Could not close subscriptions as Primary owner https://github.com/gravitee-io/issues/issues/834[#834]
+- Error on save of gateway endpoint https://github.com/gravitee-io/issues/issues/837[#837]
+- Error when sending email for new members https://github.com/gravitee-io/issues/issues/831[#831]
+- Sometimes some policies modifications are lost https://github.com/gravitee-io/issues/issues/838[#838]
+- Sometimes we have to click twice to access an API/application https://github.com/gravitee-io/issues/issues/790[#790]
+- Wrong name for the "new subscription" email https://github.com/gravitee-io/issues/issues/828[#828]
+
+*_Portal_*
+
+- Use firstname and lastname for each user instead of the member's ID https://github.com/gravitee-io/issues/issues/28[#28]
+
+*_Reporter_*
+
+- [elasticsearch] Unable to create index mapping https://github.com/gravitee-io/issues/issues/829[#829]
+
+=== Features
+
+*_Gateway_*
+
+- API Gateway doesn't failover for all connection failures https://github.com/gravitee-io/issues/issues/754[#754]
+- API Info Endpoint https://github.com/gravitee-io/issues/issues/723[#723]
+- Circuit-breaker support https://github.com/gravitee-io/issues/issues/786[#786]
+- Option to follow redirect https://github.com/gravitee-io/issues/issues/778[#778]
+
+*_General_*
+
+- Assign groups to user from oauth user infos on first login. https://github.com/gravitee-io/issues/issues/781[#781]
+
+*_Management-api_*
+
+- Contact screen to send an email to the support team https://github.com/gravitee-io/issues/issues/819[#819]
+- Encoding/hashing algorithm for passwords for InMemory IDP should be customizable https://github.com/gravitee-io/issues/issues/804[#804]
+- Manage CORS as an integrated feature, not an API Policy https://github.com/gravitee-io/issues/issues/825[#825]
+- Visibility of plans and documentations by groups https://github.com/gravitee-io/issues/issues/764[#764]
+
+*_Policy_*
+
+- OpenID Connect UserInfo policy https://github.com/gravitee-io/issues/issues/803[#803]
+
+*_Portal_*
+
+- Access to http dump through Log menu https://github.com/gravitee-io/issues/issues/788[#788]
+- Add a disclaimer for unsupported browser versions https://github.com/gravitee-io/issues/issues/823[#823]
+
+=== Improvements
+
+*_Gateway_*
+
+- Improve api-key refresher service https://github.com/gravitee-io/issues/issues/833[#833]
+
+*_General_*
+
+- Http core services should not enforce basic authentication https://github.com/gravitee-io/issues/issues/791[#791]
+
+*_Health-check_*
+
+- Store response body when assertion can't be validated https://github.com/gravitee-io/issues/issues/813[#813]
+
+*_Management_*
+
+- Do not round 99,999% to 100% in analytics https://github.com/gravitee-io/issues/issues/826[#826]
+- Include gateway sharding tags in instances view https://github.com/gravitee-io/issues/issues/827[#827]
+
+*_Management-api_*
+
+- JSON importadd/update members only if necessary  https://github.com/gravitee-io/issues/issues/817[#817]
+
+*_Portal_*
+
+- Display ids of sharding tags and tenant https://github.com/gravitee-io/issues/issues/490[#490]
+- Put the localhost target rest API server on the dist's constants.json https://github.com/gravitee-io/issues/issues/792[#792]
+
+*_Reporter_*
+
+- Split analytics and logs in API https://github.com/gravitee-io/issues/issues/836[#836]
+
+
+== https://github.com/gravitee-io/issues/milestone/37?closed=1[1.9.2 (2017-09-20)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Add the remote IP on the logs https://github.com/gravitee-io/issues/issues/810[#810]
+- Display expiration date on revocation's email https://github.com/gravitee-io/issues/issues/809[#809]
+- Sorting is not working on gateway endpoints https://github.com/gravitee-io/issues/issues/807[#807]
+- The default API's picture disappear on save https://github.com/gravitee-io/issues/issues/800[#800]
+- Validation's message is not the same on context-path modification and creation https://github.com/gravitee-io/issues/issues/808[#808]
+
+*_Management-api_*
+
+- Not able to transfer ownership for an API https://github.com/gravitee-io/issues/issues/805[#805]
+
+=== Improvements
+
+*_Management_*
+
+- Allows to configure the max age on the Authorization's cookie https://github.com/gravitee-io/issues/issues/811[#811]
+- Impossible to disable global HC without filling mandatory fields https://github.com/gravitee-io/issues/issues/801[#801]
+
+*_Management-ui_*
+
+- Add button to refresh health-check infos https://github.com/gravitee-io/issues/issues/812[#812]
+
+
+== https://github.com/gravitee-io/issues/milestone/36?closed=1[1.9.1 (2017-09-19)]
+
+=== Bug fixes
+
+*_General_*
+
+- Healthcheck probe must connect on declared host in config https://github.com/gravitee-io/issues/issues/789[#789]
+
+*_Management_*
+
+- Base url is not correctly overridden on swagger try it https://github.com/gravitee-io/issues/issues/787[#787]
+- Email templates issue after upgraded to APIM 1.9.0 https://github.com/gravitee-io/issues/issues/785[#785]
+- The email template is not correct for user registration https://github.com/gravitee-io/issues/issues/784[#784]
+
+*_Management-api_*
+
+- Admin rights not always checked in the same way https://github.com/gravitee-io/issues/issues/797[#797]
+
+*_Management-ui_*
+
+- API group are not well displayed in case of read-only right https://github.com/gravitee-io/issues/issues/796[#796]
+- Dynamic properties form not displayed with rate and interval https://github.com/gravitee-io/issues/issues/798[#798]
+
+*_Portal_*
+
+- Markdown page incorrect ul / li https://github.com/gravitee-io/issues/issues/794[#794]
+
+
+== https://github.com/gravitee-io/issues/milestone/29?closed=1[1.9.0 (2017-09-13)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Gateway rewrites same query parameter and keep only last one https://github.com/gravitee-io/issues/issues/720[#720]
+- Policy stream issuebackend still invoked after a streamFailWith https://github.com/gravitee-io/issues/issues/762[#762]
+- Some path are not correctly handled and policies are not correct https://github.com/gravitee-io/issues/issues/773[#773]
+
+*_Management_*
+
+- Application owners must be notify when their subscriptions are closed after the close of a plan https://github.com/gravitee-io/issues/issues/743[#743]
+
+*_Management-api_*
+
+- Unable to delete application https://github.com/gravitee-io/issues/issues/753[#753]
+- Wrong mail subject when apiKey expired https://github.com/gravitee-io/issues/issues/767[#767]
+- X-forwarded-host not properly handled when rewriting Location header https://github.com/gravitee-io/issues/issues/735[#735]
+
+*_Policy_*
+
+- [ip-filtering] Policy needs gravitee-policy-api.version to be updated https://github.com/gravitee-io/issues/issues/755[#755]
+
+*_Portal_*
+
+- API creationcontext-path does not accept underscore https://github.com/gravitee-io/issues/issues/750[#750]
+- Admin user cannot see documentation pages https://github.com/gravitee-io/issues/issues/734[#734]
+- Admin without rights https://github.com/gravitee-io/issues/issues/715[#715]
+- Authentication URL issue when using authentication provider https://github.com/gravitee-io/issues/issues/769[#769]
+- Authorization cookie not properly handled in case of cross-domain https://github.com/gravitee-io/issues/issues/771[#771]
+- Tenant not shown in endpoints table https://github.com/gravitee-io/issues/issues/760[#760]
+
+*_Repository_*
+
+- Inconsistent requirements in repository unit tests - updating item that doesn't exist in the repo https://github.com/gravitee-io/issues/issues/641[#641]
+
+*_Service_*
+
+- [node-healthcheck] Change http port strategy https://github.com/gravitee-io/issues/issues/712[#712]
+
+=== Features
+
+*_Management-api_*
+
+- Add default groups on API/Apps creation https://github.com/gravitee-io/issues/issues/763[#763]
+
+*_Policy_*
+
+- Policy to check existing param https://github.com/gravitee-io/issues/issues/650[#650]
+- [override-method] Override HTTP method https://github.com/gravitee-io/issues/issues/749[#749]
+
+*_Portal_*
+
+- Refactor group management https://github.com/gravitee-io/issues/issues/727[#727]
+
+=== Improvements
+
+*_Gateway_*
+
+- Error reporting improvement - incorrect keystore credentials for Gateway SSL config https://github.com/gravitee-io/issues/issues/733[#733]
+
+*_Management_*
+
+- Improve the email message of a subscription request https://github.com/gravitee-io/issues/issues/776[#776]
+
+*_Management-api_*
+
+- Email notification when closing a plan https://github.com/gravitee-io/issues/issues/752[#752]
+- Missing property for email subject https://github.com/gravitee-io/issues/issues/765[#765]
+
+*_Oauth2_*
+
+- Improve the Generic OAuth2 resource with appropriate param to the token introspection endpoint https://github.com/gravitee-io/issues/issues/770[#770]
+- Token introspection check active flag (rfc7662) https://github.com/gravitee-io/issues/issues/772[#772]
+
+*_Policy_*
+
+- [quota] [rate-limit] Update possible time-window for rate-limiting policies https://github.com/gravitee-io/issues/issues/744[#744]
+
+*_Portal_*
+
+- Admin must be allowed to change primary owner https://github.com/gravitee-io/issues/issues/774[#774]
+- Customize footer links https://github.com/gravitee-io/issues/issues/757[#757]
+- Include gateway version and gateway tenant in instances view https://github.com/gravitee-io/issues/issues/779[#779]
+- Sort groups by name https://github.com/gravitee-io/issues/issues/740[#740]
+
+*_Service_*
+
+- [healthcheck] Endpoint healthcheck https://github.com/gravitee-io/issues/issues/704[#704]
+
+
+== https://github.com/gravitee-io/issues/milestone/34?closed=1[1.8.4 (2017-08-23)]
+
+=== Bug fixes
+
+*_General_*
+
+- Incorrect mail content for New subscription  https://github.com/gravitee-io/issues/issues/728[#728]
+
+*_Management_*
+
+- Bad template https://github.com/gravitee-io/issues/issues/721[#721]
+
+=== Improvements
+
+*_Management_*
+
+- Improve log details on dynamic properties error https://github.com/gravitee-io/issues/issues/722[#722]
+
+*_Policy_*
+
+- Groovy] Better reporting in case of error while running groovy script https://github.com/gravitee-io/issues/issues/732[#732]
+
+
+== https://github.com/gravitee-io/issues/milestone/33?closed=1[1.8.3 (2017-07-24)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Thread deadlock https://github.com/gravitee-io/issues/issues/709[#709]
+
+*_Portal_*
+
+- APIM global logs not showing up https://github.com/gravitee-io/issues/issues/708[#708]
+- Multiple role management issues https://github.com/gravitee-io/issues/issues/707[#707]
+- Use relative path for the default user profile picture https://github.com/gravitee-io/issues/issues/705[#705]
+
+=== Improvements
+
+*_Management_*
+
+- Improve the UX when edit an API https://github.com/gravitee-io/issues/issues/694[#694]
+
+
+== https://github.com/gravitee-io/issues/milestone/32?closed=1[1.8.2 (2017-07-20)]
+
+=== Bug fixes
+
+*_Documentation_*
+
+- The documentation tab disappeared from gravitee management https://github.com/gravitee-io/issues/issues/701[#701]
+
+*_Portal_*
+
+- Problem with the alignment of APIs https://github.com/gravitee-io/issues/issues/695[#695]
+- Unable to display a public API as an unauthenticated user https://github.com/gravitee-io/issues/issues/696[#696]
+
+
+== https://github.com/gravitee-io/issues/milestone/31?closed=1[1.8.1 (2017-07-17)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Downgrade Vert.x version to 3.4.1 https://github.com/gravitee-io/issues/issues/687[#687]
+
+*_Portal_*
+
+- Could not update/delete a configuration elt (tenant/shard/views) after creation https://github.com/gravitee-io/issues/issues/690[#690]
+- Impossible to change group of application https://github.com/gravitee-io/issues/issues/527[#527]
+- [portal] Ratio of the logo https://github.com/gravitee-io/issues/issues/685[#685]
+
+=== Features
+
+*_Portal_*
+
+- Custom user Roles https://github.com/gravitee-io/issues/issues/555[#555]
+- [policy][groovy]Request attribute is of type String for onRequestContent scope https://github.com/gravitee-io/issues/issues/692[#692]
+
+=== Improvements
+
+*_Gateway_*
+
+- Check endpoint availability when using dynamic-routing policy https://github.com/gravitee-io/issues/issues/453[#453]
+
+*_Portal_*
+
+- [portal] Homepage - Display views below each API https://github.com/gravitee-io/issues/issues/686[#686]
+
+
+== https://github.com/gravitee-io/issues/milestone/24?closed=1[1.8.0 (2017-07-11)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Mixin configuration for HTTP server https://github.com/gravitee-io/issues/issues/667[#667]
+- Query parameters without key not encoded (IllegalArgumentException) https://github.com/gravitee-io/issues/issues/665[#665]
+- [healthcheck] how to detect/alert on slow backend - with healthcheck ? https://github.com/gravitee-io/issues/issues/656[#656]
+- [policy] Unrecognized field in policy configuration https://github.com/gravitee-io/issues/issues/672[#672]
+
+*_General_*
+
+- UnexpectedRollbackException when doing View Logs https://github.com/gravitee-io/issues/issues/660[#660]
+
+*_Management-api_*
+
+- Can not search for user authenticated with oauth2, google or github account https://github.com/gravitee-io/issues/issues/682[#682]
+- Picture property value for OAuth2 authentication is not well associated  https://github.com/gravitee-io/issues/issues/675[#675]
+- [dynamic-property] Properties are not injected https://github.com/gravitee-io/issues/issues/676[#676]
+
+*_Portal_*
+
+- Can't save a documentation by fetching swagger from gitlab https://github.com/gravitee-io/issues/issues/664[#664]
+- Portal is not loaded when userCreationEnabled set to false https://github.com/gravitee-io/issues/issues/655[#655]
+- Swagger not rendered with OpenAPI specification validation issues https://github.com/gravitee-io/issues/issues/668[#668]
+
+=== Features
+
+*_Gateway_*
+
+- Being able to cancel request / response while working with stream https://github.com/gravitee-io/issues/issues/657[#657]
+- HTTP/2 support https://github.com/gravitee-io/issues/issues/673[#673]
+- Move errors from the response body to the logs associated with the transaction ID https://github.com/gravitee-io/issues/issues/651[#651]
+- [management-api] Have a PID file for Gravitee processes https://github.com/gravitee-io/issues/issues/681[#681]
+- [management-api] Healthcheck https://github.com/gravitee-io/issues/issues/543[#543]
+
+=== Improvements
+
+*_Gateway_*
+
+- HTTP Serverchange the host to listen on https://github.com/gravitee-io/issues/issues/666[#666]
+- Upgrade to vert.x 3.4.2 https://github.com/gravitee-io/issues/issues/671[#671]
+
+*_Management-api_*
+
+- Performance issue when searching for users in LDAP https://github.com/gravitee-io/issues/issues/654[#654]
+
+*_Policy_*
+
+- [jwt] Public key resolver property must be mandatory https://github.com/gravitee-io/issues/issues/674[#674]
+
+*_Portal_*
+
+- API log add gateway instance https://github.com/gravitee-io/issues/issues/683[#683]
+- Default user icon must not be the same as the one used for portal logo https://github.com/gravitee-io/issues/issues/653[#653]
+- Enable Client SSL & Trust all settings UX improvements https://github.com/gravitee-io/issues/issues/663[#663]
+
+
+== https://github.com/gravitee-io/issues/milestone/23?closed=1[1.7.0 (2017-06-20)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Changing API visibility must not cause an 'out of sync' status https://github.com/gravitee-io/issues/issues/607[#607]
+- Lost some ms between each sync https://github.com/gravitee-io/issues/issues/579[#579]
+
+*_Portal_*
+
+- Error on user subscription https://github.com/gravitee-io/issues/issues/632[#632]
+- Fallback to a default language https://github.com/gravitee-io/issues/issues/604[#604]
+- Not able to update view's name / description  https://github.com/gravitee-io/issues/issues/635[#635]
+
+*_Repository_*
+
+- [elasticsearch] Healthcheck is not working for ES5.x https://github.com/gravitee-io/issues/issues/610[#610]
+- [redis] events are not well managed https://github.com/gravitee-io/issues/issues/576[#576]
+
+=== Features
+
+*_Gateway_*
+
+- Enable requests to internal endpoints to override the Host header https://github.com/gravitee-io/issues/issues/644[#644]
+- [management-api] Should be able to customize plugins work directory https://github.com/gravitee-io/issues/issues/615[#615]
+
+*_Policy_*
+
+- [jwt] Extract claims from JWT token https://github.com/gravitee-io/issues/issues/631[#631]
+
+*_Portal_*
+
+- Associate labels to an API https://github.com/gravitee-io/issues/issues/617[#617]
+- Customize the portal https://github.com/gravitee-io/issues/issues/596[#596]
+- OAuth2 authentication https://github.com/gravitee-io/issues/issues/625[#625]
+- Social authentication https://github.com/gravitee-io/issues/issues/602[#602]
+
+=== Improvements
+
+*_Gateway_*
+
+- Do not deploy an API if no published plan https://github.com/gravitee-io/issues/issues/586[#586]
+- [healthcheck] need to enable https for healthcheck https://github.com/gravitee-io/issues/issues/649[#649]
+
+*_Management-api_*
+
+- Jetty should bind to specific IP instead of 0.0.0.0 https://github.com/gravitee-io/issues/issues/621[#621]
+
+*_Portal_*
+
+- Dashboard viewadd direct link to API / application https://github.com/gravitee-io/issues/issues/645[#645]
+- Display view name on the api card https://github.com/gravitee-io/issues/issues/533[#533]
+- Override HTTP timeout for analytics https://github.com/gravitee-io/issues/issues/624[#624]
+- Show "API out of sync" when closing a plan https://github.com/gravitee-io/issues/issues/619[#619]
+
+*_Reporting_*
+
+- Associate analytics to a gateway instance https://github.com/gravitee-io/issues/issues/65[#65]
+
+
+== https://github.com/gravitee-io/issues/milestone/30?closed=1[1.6.3 (2017-06-02)]
+
+=== Bug fixes
+
+*_Policy_*
+
+- [cache] Memory consuming cache element https://github.com/gravitee-io/issues/issues/606[#606]
+
+*_Portal_*
+
+- Add multiple members to a group https://github.com/gravitee-io/issues/issues/301[#301]
+- Export definition set a wrong name https://github.com/gravitee-io/issues/issues/557[#557]
+- Metadata key should not be updatable on update https://github.com/gravitee-io/issues/issues/613[#613]
+- Need to refresh ui when adding a new endpoint on gateway configuration https://github.com/gravitee-io/issues/issues/582[#582]
+- Unknown policy https://github.com/gravitee-io/issues/issues/611[#611]
+- User not loggue can't see public api documentation https://github.com/gravitee-io/issues/issues/603[#603]
+- [policy] Updating a policy description must not generate a to_deploy event https://github.com/gravitee-io/issues/issues/154[#154]
+
+
+== https://github.com/gravitee-io/issues/milestone/28?closed=1[1.6.2 (2017-05-19)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Metadata can not be displayed well https://github.com/gravitee-io/issues/issues/594[#594]
+
+
+== https://github.com/gravitee-io/issues/milestone/27?closed=1[1.6.1 (2017-05-17)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- By default, listen for all sharding tags https://github.com/gravitee-io/issues/issues/593[#593]
+
+
+== https://github.com/gravitee-io/issues/milestone/22?closed=1[1.6.0 (2017-05-17)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- API with sharding tags are not deployed https://github.com/gravitee-io/issues/issues/581[#581]
+- After closing a plan, gateway must be refreshed https://github.com/gravitee-io/issues/issues/383[#383]
+
+*_Management_*
+
+- Error when calling the rest API service of export API https://github.com/gravitee-io/issues/issues/580[#580]
+
+*_Management-api_*
+
+- Allowed to set unknown group to an api https://github.com/gravitee-io/issues/issues/354[#354]
+- Swagger import crash https://github.com/gravitee-io/issues/issues/570[#570]
+
+*_Management-ui_*
+
+- List APIsdo not show API with `user` permission https://github.com/gravitee-io/issues/issues/589[#589]
+- No context-path for non-admin users https://github.com/gravitee-io/issues/issues/590[#590]
+
+*_Portal_*
+
+- Charts are always displayed using UTC timezone https://github.com/gravitee-io/issues/issues/587[#587]
+- Resolve superseded error from ui-router for documentation pages https://github.com/gravitee-io/issues/issues/588[#588]
+- Sync banner is not shown after plan creation https://github.com/gravitee-io/issues/issues/574[#574]
+
+=== Features
+
+*_General_*
+
+- AWS DynamoDB Repository https://github.com/gravitee-io/issues/issues/558[#558]
+
+*_Portal_*
+
+- Display a customizable endpoint for APIs https://github.com/gravitee-io/issues/issues/550[#550]
+- Metadata https://github.com/gravitee-io/issues/issues/554[#554]
+- Request / response diagnostic https://github.com/gravitee-io/issues/issues/568[#568]
+
+=== Improvements
+
+*_Plugin_*
+
+- Should be able to specify a custom folder for custom plugins https://github.com/gravitee-io/issues/issues/585[#585]
+
+*_Policy_*
+
+- [mock] Headers should not be required https://github.com/gravitee-io/issues/issues/573[#573]
+
+*_Portal_*
+
+- API header is not clear enough https://github.com/gravitee-io/issues/issues/592[#592]
+
+
+== https://github.com/gravitee-io/issues/milestone/26?closed=1[1.5.1 (2017-05-01)]
+
+=== Bug fixes
+
+*_Management-api_*
+
+- [sync] Remove check on sharding tags https://github.com/gravitee-io/issues/issues/562[#562]
+
+*_Policy_*
+
+- [oauth2] HTTPS is not well supported https://github.com/gravitee-io/issues/issues/563[#563]
+
+*_Portal_*
+
+- API is not correctly refreshed on UI https://github.com/gravitee-io/issues/issues/564[#564]
+- Context-path column empty in apis listing screen https://github.com/gravitee-io/issues/issues/551[#551]
+- Dynamic properties - missing output expected example https://github.com/gravitee-io/issues/issues/566[#566]
+- Regex deactivate the drag and drop func https://github.com/gravitee-io/issues/issues/560[#560]
+- User with `owner` role is not able to create a new documentation page https://github.com/gravitee-io/issues/issues/549[#549]
+- We cannot change the user picture anymore https://github.com/gravitee-io/issues/issues/530[#530]
+
+=== Improvements
+
+*_Gateway_*
+
+- Sync logs are very verbose with sharding tags https://github.com/gravitee-io/issues/issues/553[#553]
+
+*_Portal_*
+
+- All users must have access to api list https://github.com/gravitee-io/issues/issues/559[#559]
+
+
+== https://github.com/gravitee-io/issues/milestone/20?closed=1[1.5.0 (2017-04-19)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Endpoint configuration not correctly selected with dynamic routing https://github.com/gravitee-io/issues/issues/515[#515]
+
+*_Portal_*
+
+- Application menu disappear when login with user https://github.com/gravitee-io/issues/issues/518[#518]
+- Impossible to change group of application https://github.com/gravitee-io/issues/issues/527[#527]
+
+=== Features
+
+*_Policy_*
+
+- [api-key] Customize api-key header https://github.com/gravitee-io/issues/issues/444[#444]
+- [oauth2] Check required scopes https://github.com/gravitee-io/issues/issues/537[#537]
+
+*_Portal_*
+
+- Edit content of the api home page https://github.com/gravitee-io/issues/issues/467[#467]
+- Portal pages https://github.com/gravitee-io/issues/issues/468[#468]
+
+*_Resource_*
+
+- [oauth2] Gravitee.io AM OAuth2 resource https://github.com/gravitee-io/issues/issues/535[#535]
+
+=== Improvements
+
+*_Gateway_*
+
+- Do not check the concrete class when accessing a resource from policy  https://github.com/gravitee-io/issues/issues/532[#532]
+- Log more information in addition to stacktrace https://github.com/gravitee-io/issues/issues/528[#528]
+- Policy can send a json content for a policy failure https://github.com/gravitee-io/issues/issues/531[#531]
+- Sync service is memory and CPU consuming https://github.com/gravitee-io/issues/issues/504[#504]
+- Upgrade Vert.x to 3.4.1 https://github.com/gravitee-io/issues/issues/516[#516]
+- [health-check] Refactor service to use Vert.x instead of async-http-client https://github.com/gravitee-io/issues/issues/536[#536]
+
+*_Policy_*
+
+- [oauth2] Abstract OAuth2 resource https://github.com/gravitee-io/issues/issues/534[#534]
+
+*_Portal_*
+
+- New developer portal https://github.com/gravitee-io/issues/issues/517[#517]
+
+*_Repository_*
+
+- [mongodb] Driver upgrade https://github.com/gravitee-io/issues/issues/523[#523]
+
+
+== https://github.com/gravitee-io/issues/milestone/25?closed=1[1.4.2 (2017-03-31)]
+
+=== Bug fixes
+
+*_Portal_*
+
+- API not well refreshed when managing it  https://github.com/gravitee-io/issues/issues/519[#519]
+
+
+== https://github.com/gravitee-io/issues/milestone/21?closed=1[1.4.1 (2017-03-22)]
+
+=== Bug fixes
+
+*_Portal_*
+
+- Not able to create a new endpoint https://github.com/gravitee-io/issues/issues/507[#507]
+
+=== Improvements
+
+*_Gateway_*
+
+- Show available endpoints while deploying API https://github.com/gravitee-io/issues/issues/508[#508]
+
+
+== https://github.com/gravitee-io/issues/milestone/16?closed=1[1.4.0 (2017-03-17)]
+
+=== Bug fixes
+
+*_Management_*
+
+- Clean empty arrays in policies configuration https://github.com/gravitee-io/issues/issues/469[#469]
+
+*_Management-api_*
+
+- Create api by import file doesn't create policies https://github.com/gravitee-io/issues/issues/496[#496]
+- Failed to login via LDAP if role-mapping is set to false (default value) https://github.com/gravitee-io/issues/issues/492[#492]
+- User registration link not correct https://github.com/gravitee-io/issues/issues/487[#487]
+
+*_Policy_*
+
+- [cors] Access-Control-Allow-Methods must be returned in upper-case https://github.com/gravitee-io/issues/issues/480[#480]
+- [cors] Bad request when no Access-Control-Request-Headers specified https://github.com/gravitee-io/issues/issues/474[#474]
+- [cors] Error on call to api with policy CORS https://github.com/gravitee-io/issues/issues/464[#464]
+- [json-to-json] Error occurred while starting graviteeio-gateway in Windows 7 Env  https://github.com/gravitee-io/issues/issues/461[#461]
+
+*_Portal_*
+
+- Error on defining OAuth resource https://github.com/gravitee-io/issues/issues/484[#484]
+- Exception when sending email during user registration https://github.com/gravitee-io/issues/issues/485[#485]
+- Fix delete policy button icon width https://github.com/gravitee-io/issues/issues/497[#497]
+- Hide "Start creating an API" https://github.com/gravitee-io/issues/issues/489[#489]
+- Issues after typescript migration  https://github.com/gravitee-io/issues/issues/501[#501]
+- No error when defining duplicated endpoint's name https://github.com/gravitee-io/issues/issues/436[#436]
+- Typescript migration issues https://github.com/gravitee-io/issues/issues/493[#493]
+
+*_Repository_*
+
+- [elasticsearch] Aggregations order is not kept in ES response https://github.com/gravitee-io/issues/issues/498[#498]
+- [mongodb] Apis with same name are not correctly returned https://github.com/gravitee-io/issues/issues/500[#500]
+
+=== Features
+
+*_Portal_*
+
+- Archive an application https://github.com/gravitee-io/issues/issues/185[#185]
+
+=== Improvements
+
+*_Management-api_*
+
+- Finest configuration for SMTP server https://github.com/gravitee-io/issues/issues/488[#488]
+
+*_Policy_*
+
+- [apikey] Avoid call to repository API https://github.com/gravitee-io/issues/issues/499[#499]
+
+*_Portal_*
+
+- Tenant display in gateway settings https://github.com/gravitee-io/issues/issues/452[#452]
+
+
+== https://github.com/gravitee-io/issues/milestone/19?closed=1[1.3.3 (2017-02-17)]
+
+=== Bug fixes
+
+*_Management-api_*
+
+- API is not well-initialized after creation https://github.com/gravitee-io/issues/issues/451[#451]
+- Error 500 when creating a new API from Swagger descriptor https://github.com/gravitee-io/issues/issues/454[#454]
+
+*_Portal_*
+
+- Persistent scrollbar https://github.com/gravitee-io/issues/issues/456[#456]
+
+
+== https://github.com/gravitee-io/issues/milestone/18?closed=1[1.3.2 (2017-02-16)]
+
+=== Bug fixes
+
+*_Portal_*
+
+- Not able to save gateway configuration for an API https://github.com/gravitee-io/issues/issues/450[#450]
+
+
+== https://github.com/gravitee-io/issues/milestone/17?closed=1[1.3.1 (2017-02-15)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Sharding tags are not correctly managed https://github.com/gravitee-io/issues/issues/449[#449]
+
+
+== https://github.com/gravitee-io/issues/milestone/15?closed=1[1.3.0 (2017-02-15)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- Call API with wrong apiKey Error 500 https://github.com/gravitee-io/issues/issues/424[#424]
+
+*_General_*
+
+- Error on TransFormHeader policy https://github.com/gravitee-io/issues/issues/437[#437]
+
+*_Policy_*
+
+- [html-json] charset in content-type header https://github.com/gravitee-io/issues/issues/412[#412]
+
+*_Portal_*
+
+- Button (+) must not be present in documentation edit mode https://github.com/gravitee-io/issues/issues/417[#417]
+- Can not create custom healthceck https://github.com/gravitee-io/issues/issues/443[#443]
+- Description of the PEM certificate is misplaced https://github.com/gravitee-io/issues/issues/413[#413]
+- Documentation invisible for inherited group members https://github.com/gravitee-io/issues/issues/447[#447]
+- Enable user login and registration on development mode https://github.com/gravitee-io/issues/issues/420[#420]
+- Fields Name and Description required after 2nd creation plan https://github.com/gravitee-io/issues/issues/366[#366]
+- Name not update in the navbar https://github.com/gravitee-io/issues/issues/399[#399]
+- On the instances list screen, the filter input does not work anymore https://github.com/gravitee-io/issues/issues/448[#448]
+- Subscription of an application with a short name  https://github.com/gravitee-io/issues/issues/419[#419]
+- Top application name is incorrect for unknown application (keyless) https://github.com/gravitee-io/issues/issues/407[#407]
+
+*_Repository_*
+
+- Cassandra] Event type filtering does not work correctly when types does not exist yet in database https://github.com/gravitee-io/issues/issues/441[#441]
+
+=== Features
+
+*_Gateway_*
+
+- Multi-tenant management https://github.com/gravitee-io/issues/issues/158[#158]
+
+*_Management-api_*
+
+- Dynamic property discovery https://github.com/gravitee-io/issues/issues/353[#353]
+- Import/export api with selected informations https://github.com/gravitee-io/issues/issues/415[#415]
+
+=== Improvements
+
+*_Docs_*
+
+- Documentation about EL https://github.com/gravitee-io/issues/issues/400[#400]
+
+*_Gateway_*
+
+- Host header sent to HTTPS backend API is not accurate https://github.com/gravitee-io/issues/issues/427[#427]
+
+*_Portal_*
+
+- Analytics dashboard https://github.com/gravitee-io/issues/issues/430[#430]
+- Better representation of numbers in dashboard https://github.com/gravitee-io/issues/issues/360[#360]
+- Change label in instances information https://github.com/gravitee-io/issues/issues/421[#421]
+- Enhance create API workflow https://github.com/gravitee-io/issues/issues/418[#418]
+- Instances display https://github.com/gravitee-io/issues/issues/423[#423]
+- Modal click outside to close not homogeneous https://github.com/gravitee-io/issues/issues/431[#431]
+- New look and feel https://github.com/gravitee-io/issues/issues/440[#440]
+- Plan subscription, Application's type is missing. https://github.com/gravitee-io/issues/issues/422[#422]
+- Policy - path visibility too short https://github.com/gravitee-io/issues/issues/439[#439]
+- Remove dialog headers https://github.com/gravitee-io/issues/issues/426[#426]
+- Show more informations about user when searching API / application members https://github.com/gravitee-io/issues/issues/432[#432]
+- The application displayed on dashboard should be clickable https://github.com/gravitee-io/issues/issues/411[#411]
+- The keyless plans should not be displayed for subscriptions https://github.com/gravitee-io/issues/issues/410[#410]
+
+
+== https://github.com/gravitee-io/issues/milestone/14?closed=1[1.2.0 (2017-01-10)]
+
+=== Bug fixes
+
+*_Management-api_*
+
+- Close pending subscriptions when closing plan https://github.com/gravitee-io/issues/issues/349[#349]
+- Fix empty analytics data https://github.com/gravitee-io/issues/issues/394[#394]
+- We can create pages without type https://github.com/gravitee-io/issues/issues/351[#351]
+
+*_Policy_*
+
+- [xml-json] Remove charset in content-type header https://github.com/gravitee-io/issues/issues/391[#391]
+
+*_Portal_*
+
+- API visibility icons aren't correctly separated https://github.com/gravitee-io/issues/issues/368[#368]
+- Instance ip is not in the title anymore https://github.com/gravitee-io/issues/issues/363[#363]
+- Label pass over the switch button when not published https://github.com/gravitee-io/issues/issues/370[#370]
+- Not able to create a new path https://github.com/gravitee-io/issues/issues/373[#373]
+- Remove double 'required field' asterix https://github.com/gravitee-io/issues/issues/396[#396]
+- Resource plugins list must be dynamic https://github.com/gravitee-io/issues/issues/355[#355]
+
+=== Features
+
+*_Docs_*
+
+- Improve documentation by providing multi-pages https://github.com/gravitee-io/issues/issues/348[#348]
+
+*_Gateway_*
+
+- Provide a transformable content request builder https://github.com/gravitee-io/issues/issues/350[#350]
+
+*_General_*
+
+- Authentication method per plan https://github.com/gravitee-io/issues/issues/379[#379]
+
+*_Management-api_*
+
+- [fetcher] GitLab - access to non public project https://github.com/gravitee-io/issues/issues/326[#326]
+
+=== Improvements
+
+*_Doc_*
+
+- Write quickstart guide for 1.2.0 version https://github.com/gravitee-io/issues/issues/403[#403]
+
+*_Gateway_*
+
+- Add elasticsearch's cluster configuration in gravitee.yml https://github.com/gravitee-io/issues/issues/374[#374]
+- Inject transaction id into the response https://github.com/gravitee-io/issues/issues/401[#401](Thanks to https://github.com/lusoalex[lusoalex])
+- Make uniform streaming API  https://github.com/gravitee-io/issues/issues/356[#356]
+- Mesure the length of HTTP requests and responses https://github.com/gravitee-io/issues/issues/397[#397]
+- Rename healthcheck thread https://github.com/gravitee-io/issues/issues/361[#361]
+
+*_General_*
+
+- Optimization of data analytics transfer https://github.com/gravitee-io/issues/issues/385[#385]
+
+*_Management-api_*
+
+- Swagger descriptor is not up-to-date https://github.com/gravitee-io/issues/issues/357[#357]
+
+*_Portal_*
+
+- Allows to synchronize and zoom on analytics charts https://github.com/gravitee-io/issues/issues/384[#384]
+- Better redirection after API plan management operations https://github.com/gravitee-io/issues/issues/404[#404]
+- Better representation of numbers in dashboard https://github.com/gravitee-io/issues/issues/360[#360]
+- Replace the actual chart library by Highcharts https://github.com/gravitee-io/issues/issues/341[#341]
+
+*_Repository_*
+
+- Cassandra implementation https://github.com/gravitee-io/issues/issues/201[#201] (Thanks to https://github.com/Blake-Lead[Blake-Lead])
+- [elasticsearch] Do not check existing indices when searching ES https://github.com/gravitee-io/issues/issues/380[#380]
+
+== https://github.com/gravitee-io/issues/milestone/11?closed=1[1.1.0 (2016-11-29)]
+
+=== Bug fixes
+
+*_Management-api_*
+
+- Error when deleting a view already linked to an API https://github.com/gravitee-io/issues/issues/317[#317]
+- Send email asynchronously https://github.com/gravitee-io/issues/issues/325[#325]
+- Unable to delete API with closed plans and closed subscriptions https://github.com/gravitee-io/issues/issues/342[#342]
+
+*_Portal_*
+
+- Admin dashboard https://github.com/gravitee-io/issues/issues/290[#290]
+- Analytics API - Hit by applications not shown https://github.com/gravitee-io/issues/issues/336[#336]
+- Error when trying to subscribe to an API plan https://github.com/gravitee-io/issues/issues/296[#296]
+- Import / export an API does not work anymore https://github.com/gravitee-io/issues/issues/320[#320]
+- Not able to create a new path in API policies view https://github.com/gravitee-io/issues/issues/315[#315]
+- Sharding tagsmixin https://github.com/gravitee-io/issues/issues/340[#340]
+- Tooltip typo to edit a plan https://github.com/gravitee-io/issues/issues/309[#309]
+- Unable to subscribe to a plan https://github.com/gravitee-io/issues/issues/323[#323]
+
+=== Features
+
+*_Gateway_*
+
+- Add a transaction-id value for each request https://github.com/gravitee-io/issues/issues/307[#307]
+
+*_Management-api_*
+
+- Close a plan https://github.com/gravitee-io/issues/issues/277[#277]
+
+*_Portal_*
+
+- API publisher can add consuming application by himself (subscription). https://github.com/gravitee-io/issues/issues/114[#114]
+- Automatically show policy configuration after drag and drop https://github.com/gravitee-io/issues/issues/19[#19]
+
+***Technical***
+- http://www.leansys.fr/[Docker] Lightweight images based on alpine https://github.com/gravitee-io/issues/issues/211[#211] (Thanks to http://www.leansys.fr/[Leansys team] and https://github.com/Blake-Lead[Blake-Lead])
+
+=== Improvements
+
+***Docs***
+- Rewrite introduction and provide more inputs about API Management concepts https://github.com/gravitee-io/issues/issues/334[#334]
+
+*_Gateway_*
+
+- Compression must be enabled by default https://github.com/gravitee-io/issues/issues/343[#343]
+- SSL automatically enabled for HTTPS endpoint https://github.com/gravitee-io/issues/issues/303[#303]
+- Support for exclusion of sharding tags https://github.com/gravitee-io/issues/issues/319[#319]
+
+*_Management-api_*
+
+- Disable sending mail from the rest-api component https://github.com/gravitee-io/issues/issues/332[#332]
+
+*_Policy_*
+
+- [oauth2] Provide OAuth2 attributes through execution context https://github.com/gravitee-io/issues/issues/289[#289]
+- [transformheaders] Apply policy for requests and responses https://github.com/gravitee-io/issues/issues/321[#321]
+
+*_Portal_*
+
+- Be able to re-order API plans using drag & drop https://github.com/gravitee-io/issues/issues/308[#308]
+- Better management of sharding tags https://github.com/gravitee-io/issues/issues/318[#318]
+- Change message when there is no plan for an API https://github.com/gravitee-io/issues/issues/297[#297]
+- Change setting menu on plan screen https://github.com/gravitee-io/issues/issues/339[#339]
+- Enhance empty states https://github.com/gravitee-io/issues/issues/279[#279]
+- Prevent multiple analytics executions https://github.com/gravitee-io/issues/issues/311[#311]
+- Prevent multiple analytics executions for the admin dashboard https://github.com/gravitee-io/issues/issues/312[#312]
+
+
+== https://github.com/gravitee-io/issues/milestone/13?closed=1[1.0.2 (2016-11-07)]
+
+=== Bug fixes
+
+*_Management-api_*
+
+- API publisher cannot create a plan https://github.com/gravitee-io/issues/issues/295[#295]
+- Application's owner must see inherited members from associated group https://github.com/gravitee-io/issues/issues/302[#302]
+- Primary-owner / owner of an application not able to subscribe to a plan https://github.com/gravitee-io/issues/issues/299[#299]
+- User does not have access to published pages https://github.com/gravitee-io/issues/issues/300[#300]
+
+
+== https://github.com/gravitee-io/issues/milestone/12?closed=1[1.0.1 (2016-10-28)]
+
+=== Bug fixes
+
+*_Gateway_*
+
+- ConcurrentModificationException while stopping an API with multiple endpoints https://github.com/gravitee-io/issues/issues/286[#286]
+- NullPointerException when no underlying invoker is available https://github.com/gravitee-io/issues/issues/287[#287]
+- Stack trace in case of HTTP Client exception https://github.com/gravitee-io/issues/issues/283[#283]
+
+*_Management-api_*
+
+- Subscription service is fat https://github.com/gravitee-io/issues/issues/285[#285]
+
+*_Portal_*
+
+- Resources are not shown in plugin page https://github.com/gravitee-io/issues/issues/284[#284]
+- Wrong version number in constants.js https://github.com/gravitee-io/issues/issues/282[#282]
+
+
+== https://github.com/gravitee-io/issues/milestone/7?closed=1[1.0.0 (2016-10-25)]
+
+=== Bug fixes
+
+*_Management-api_*
+
+- Manage import/export with groups https://github.com/gravitee-io/issues/issues/275[#275]
+
+*_Portal_*
+
+- API icon disappearing sometimes https://github.com/gravitee-io/issues/issues/267[#267]
+- API properties empty mode issue https://github.com/gravitee-io/issues/issues/273[#273]
+- API sync banner size https://github.com/gravitee-io/issues/issues/271[#271]
+- Add a logo for 'resource' plugins in instance environment view https://github.com/gravitee-io/issues/issues/265[#265]
+- Bad redirection after saving a page's configuration https://github.com/gravitee-io/issues/issues/224[#224]
+- Cannot fix context-path in the wizard https://github.com/gravitee-io/issues/issues/215[#215]
+- Confirm before delete API's resources https://github.com/gravitee-io/issues/issues/268[#268]
+- Do not show views without any API https://github.com/gravitee-io/issues/issues/220[#220]
+- Manage documentation (+) button - bad position https://github.com/gravitee-io/issues/issues/225[#225]
+- Not able to rename a view in portal configuration https://github.com/gravitee-io/issues/issues/270[#270]
+- Style issues in Portal views configuration https://github.com/gravitee-io/issues/issues/269[#269]
+- Unable to import api on Firefox https://github.com/gravitee-io/issues/issues/231[#231]
+
+=== Features
+
+*_Gateway_*
+
+- Be able to configure finely HTTP / HTTPS / Proxy per endpoint https://github.com/gravitee-io/issues/issues/242[#242]
+
+*_General_*
+
+- API Plans https://github.com/gravitee-io/issues/issues/257[#257]
+
+*_Management-api_*
+
+- Create a default application during the first user connection https://github.com/gravitee-io/issues/issues/208[#208]
+- Create mail subscription templates  https://github.com/gravitee-io/issues/issues/274[#274]
+- Fine-grained rights management https://github.com/gravitee-io/issues/issues/180[#180]
+
+*_Policy_*
+
+- Resource filtering  https://github.com/gravitee-io/issues/issues/251[#251]
+
+*_Portal_*
+
+- "Portal" mode disable management features https://github.com/gravitee-io/issues/issues/181[#181]
+- Add a registration view https://github.com/gravitee-io/issues/issues/246[#246]
+- Add application analytics https://github.com/gravitee-io/issues/issues/238[#238]
+- Remove Home page https://github.com/gravitee-io/issues/issues/260[#260]
+- Show context-path of an api https://github.com/gravitee-io/issues/issues/136[#136]
+
+=== Improvements
+
+*_Gateway_*
+
+- Expression Language path params from policies https://github.com/gravitee-io/issues/issues/253[#253]
+
+*_General_*
+
+- Do not start container with plugin conflict https://github.com/gravitee-io/issues/issues/262[#262]
+- Remove views from API definition and define a dedicated field https://github.com/gravitee-io/issues/issues/272[#272]
+
+*_Policy_*
+
+- [rate-limit] Split the rate-limiting policy into two policies https://github.com/gravitee-io/issues/issues/245[#245]
+
+*_Portal_*
+
+- API analytics use application name instead of application ID https://github.com/gravitee-io/issues/issues/193[#193]
+- Change API/Application header style https://github.com/gravitee-io/issues/issues/243[#243]
+- Do not display last deployment date in header in portal mode https://github.com/gravitee-io/issues/issues/249[#249]
+- Handle empty states https://github.com/gravitee-io/issues/issues/247[#247]
+- Move view configuration in a sub menu https://github.com/gravitee-io/issues/issues/244[#244]
+- Remove api/application list page https://github.com/gravitee-io/issues/issues/266[#266]
+- Upload API icon via API header https://github.com/gravitee-io/issues/issues/263[#263]
+- Views not sorted alphabetically  https://github.com/gravitee-io/issues/issues/280[#280]
+- [analytics] Do not reload page when selecting a new timeframe https://github.com/gravitee-io/issues/issues/199[#199]
+
+*_Repository_*
+
+- Refactor how to manage memberships https://github.com/gravitee-io/issues/issues/228[#228]
+
+
+== https://github.com/gravitee-io/issues/milestone/10?closed=1[0.19.2 (2016-10-06)]
+
+=== Bug fixes
+
+- [gateway] Do not send a 'CONNECT' request when invoking HTTP uri with an HTTP proxy https://github.com/gravitee-io/issues/issues/241[#241]
+- [gateway][health-check] Health-check service does not check correct endpoints https://github.com/gravitee-io/issues/issues/240[#240]
+- [portal] Redirected to home after using the try-it feature in documentation https://github.com/gravitee-io/issues/issues/239[#239]
+- [portal] Bad SwaggerUI URL when try-it is enabled https://github.com/gravitee-io/issues/issues/221[#221]
+
+== https://github.com/gravitee-io/issues/milestone/9?closed=1[0.19.1 (2016-10-03)]
+
+=== Bug fixes
+
+- [policy] [gravitee-policy-transformqueryparams] Parameters are deleted before using them https://github.com/gravitee-io/issues/issues/236[#236]
+- [gateway] Query parameters must not be decoded https://github.com/gravitee-io/issues/issues/235[#235]
+- [policy] [gravitee-policy-transformheaders] Headers are deleted before using them https://github.com/gravitee-io/issues/issues/237[#237]
+- [portal] Small ui bug the OK popup is red https://github.com/gravitee-io/issues/issues/82[#82]
+
+=== Features
+
+- [repository] ES : select indices according to the range from query https://github.com/gravitee-io/issues/issues/217[#217]
+- [portal] Try-it for anonymous user https://github.com/gravitee-io/issues/issues/222[#222]
+- [policy] [transform-headers] Expression language in query parameters value https://github.com/gravitee-io/issues/issues/227[#227]
+- [policy] [transform-headers] Expression language in headers value https://github.com/gravitee-io/issues/issues/226[#226]
+
+== https://github.com/gravitee-io/issues/milestone/6?closed=1[0.19.0 (2016-09-07)]
+
+=== Bug fixes
+
+- [management-api] : API full descriptor must be restricted to PRIMARY_OWER and OWNER https://github.com/gravitee-io/issues/issues/202[#202]
+- [policy] [cors] NPE when handling preflight request without Access-Control-Request-Headers https://github.com/gravitee-io/issues/issues/195[#195]
+- [management-api] Unable to add a new API member https://github.com/gravitee-io/issues/issues/194[#194]
+- Optimization of APIs display with views https://github.com/gravitee-io/issues/issues/229[#229]
+
+=== Features
+
+- [portal] Change markdown JS library https://github.com/gravitee-io/issues/issues/214[#214]
+- [management-api] Dynamic documentation page's content https://github.com/gravitee-io/issues/issues/213[#213]
+- [management-api] Normalize Elasticsearch configuration https://github.com/gravitee-io/issues/issues/212[#212]
+- [magagement-api][portal] : Transfer API ownership https://github.com/gravitee-io/issues/issues/210[#210]
+- [portal] Automatically save policies with no configuration https://github.com/gravitee-io/issues/issues/209[#209]
+- [repository] Simplify Event API by preserving a single search method https://github.com/gravitee-io/issues/issues/207[#207]
+- [portal] : API list : display primary owner https://github.com/gravitee-io/issues/issues/206[#206]
+- [gateway] Multiple event-loop https://github.com/gravitee-io/issues/issues/205[#205]
+- [gateway] Enable / disable a policy in the policy chain https://github.com/gravitee-io/issues/issues/204[#204]
+- [management-api] API's owner must not be able to change context-path https://github.com/gravitee-io/issues/issues/203[#203]
+- [portal] Moving healthcheck charts to ChartJS https://github.com/gravitee-io/issues/issues/197[#197]
+- [portal] : Improve Admin dashboard https://github.com/gravitee-io/issues/issues/192[#192]
+- [management-api] generate api descriptor with swagger https://github.com/gravitee-io/issues/issues/184[#184]
+- [portal] "Try it" to test an API https://github.com/gravitee-io/issues/issues/22[#22]
+- [portal] APIs views https://github.com/gravitee-io/issues/issues/112[#112]
+- [management-ui] API picture - overlay https://github.com/gravitee-io/issues/issues/178[#178]
+- [portal] Global events history https://github.com/gravitee-io/issues/issues/113[#113]
+
+== https://github.com/gravitee-io/issues/milestone/5?closed=1[0.18.0 (2016-08-02)]
+
+=== Bug fixes
+
+- [portal] Members must not be searched or added if they already exist https://github.com/gravitee-io/issues/issues/183[#183]
+- [management-api] [portal] Security and permissions improvements https://github.com/gravitee-io/issues/issues/176[#176]
+- [policy] [mock] NullPointerException https://github.com/gravitee-io/issues/issues/172[#172]
+- [portal] Fetch an external resource to create a page https://github.com/gravitee-io/issues/issues/171[#171]
+- [management-api] Create an API from a Swagger descriptor results in NullPointerException https://github.com/gravitee-io/issues/issues/168[#168]
+
+=== Features
+
+- [portal] Create an API from a Swagger descriptor exposed through HTTP / HTTPS https://github.com/gravitee-io/issues/issues/170[#170]
+- [policy] [rest-to-soap] Add a SOAP Action attribute to invoke WS https://github.com/gravitee-io/issues/issues/177[#177]
+- [portal] Rename json file when exporting an API https://github.com/gravitee-io/issues/issues/173[#173]
+- [management-api] Full export of an API, including members, pages, ... https://github.com/gravitee-io/issues/issues/164[#164]
+- [repository] [hazelcast] Cache implementation based on Hazelcast provider https://github.com/gravitee-io/issues/issues/167[#167]
+- [policy] JWT Policy https://github.com/gravitee-io/issues/issues/46[#46]
+- [repository] Key-value repository type https://github.com/gravitee-io/issues/issues/165[#165]
+
+== https://github.com/gravitee-io/issues/milestone/8?closed=1[0.17.1 (2016-07-21)]
+
+=== Bug fixes
+
+- [gateway] Do not load useless repository (if not required by the configuration) https://github.com/gravitee-io/issues/issues/161[#161]
+- [portal] Invalid API dialog when clicking on "Create API" button https://github.com/gravitee-io/issues/issues/162[#162]
+
+== https://github.com/gravitee-io/issues/milestone/4?closed=1[0.17.0 (2016-07-20)]
+
+=== Bug fixes
+
+- [management-api] User does not have access to API even if role is settled https://github.com/gravitee-io/issues/issues/156[#156]
+- [portal] [policy] Do not update policy description when cancelling the dialog https://github.com/gravitee-io/issues/issues/153[#153]
+- [portal] LDAP admins cannot create api keys https://github.com/gravitee-io/issues/issues/151[#151]
+- [gateway] [reporter] Shutdown LMAX disruptor before reporter processors https://github.com/gravitee-io/issues/issues/131[#131]
+- [docker] Error in launch.sh https://github.com/gravitee-io/issues/issues/128[#128]
+
+=== Features
+
+- [policy] [groovy] Use codemirror for groovy scripts textarea https://github.com/gravitee-io/issues/issues/152[#152]
+- [fetcher http] test must not depend on external http server https://github.com/gravitee-io/issues/issues/150[#150]
+- [management-api] Page ids don't have to contain the page title https://github.com/gravitee-io/issues/issues/148[#148]
+- [portal] add a text-editor for webui's textarea https://github.com/gravitee-io/issues/issues/147[#147]
+- [archetype] Update dependencies version https://github.com/gravitee-io/issues/issues/144[#144]
+- [policy] [dynamic-routing] Regex naming group https://github.com/gravitee-io/issues/issues/142[#142]
+- [web-ui] [policy] Add a title and/or description in policy configuration https://github.com/gravitee-io/issues/issues/141[#141]
+- [management-api] Create an API from a Swagger descriptor https://github.com/gravitee-io/issues/issues/139[#139]
+- [reporter] Gravitee may silently drop some Reportable events https://github.com/gravitee-io/issues/issues/134[#134]
+- [gateway] Set endpoint selected by load-balancer in execution context https://github.com/gravitee-io/issues/issues/133[#133]
+- [gateway] AbstractHttpInvoker creates Regexp objects wastefully  https://github.com/gravitee-io/issues/issues/129[#129]
+- [reporter] [file] Reporter does too many unneeded memory allocations https://github.com/gravitee-io/issues/issues/127[#127]
+- [management-api] Add a developer profile to run management-api from command-line https://github.com/gravitee-io/issues/issues/126[#126]
+- [reporter] [file] Incoherent thread synchronisation https://github.com/gravitee-io/issues/issues/123[#123]
+
+== https://github.com/gravitee-io/issues/milestone/3?closed=1[0.16.0 (2016-07-05)]
+
+=== Bug fixes
+
+- [policy] [mock] Issue with special character  https://github.com/gravitee-io/issues/issues/118[#118]
+- [portal] Policy view not well refreshed https://github.com/gravitee-io/issues/issues/117[#117]
+- [management-api] spring-webmvc version mismatch  https://github.com/gravitee-io/issues/issues/116[#116]
+- [policy] [oauth2] Send a 503 status code if oauth2 server is unavailable https://github.com/gravitee-io/issues/issues/103[#103]
+- [portal] Unable to export API Definition https://github.com/gravitee-io/issues/issues/102[#102]
+- [portal] Overlap problem on resource form https://github.com/gravitee-io/issues/issues/98[#98]
+- [portal] Unable to upload a documentation file under Firefox https://github.com/gravitee-io/issues/issues/90[#90]
+- [portal] Admin user must be able to manage all APIs / Applications https://github.com/gravitee-io/issues/issues/85[#85]
+
+=== Features
+
+- [policy] [xslt] XSL stylesheet should be templatable https://github.com/gravitee-io/issues/issues/122[#122]
+- [policy] [cache] Force cache to refresh for a specific key https://github.com/gravitee-io/issues/issues/119[#119]
+- [gateway] [health-check] Default expectation https://github.com/gravitee-io/issues/issues/111[#111]
+- [gateway] Add jsonPath to expression language https://github.com/gravitee-io/issues/issues/109[#109]
+- [policy] Logging policy https://github.com/gravitee-io/issues/issues/108[#108]
+- [policy] [rest-to-soap] Use @OnRequestContent to push SOAP envelope https://github.com/gravitee-io/issues/issues/107[#107]
+- [tools] Upgrade Vagrant box for Virtualbox https://github.com/gravitee-io/issues/issues/105[#105]
+- [gateway] Upgrade to Vert.x 3.3.0 https://github.com/gravitee-io/issues/issues/104[#104]
+- [gateway] Per-api HTTP proxy settings https://github.com/gravitee-io/issues/issues/96[#96]
+- [policy] [dynamic-routing] Simplify dynamic routing policy matchers https://github.com/gravitee-io/issues/issues/94[#94]
+- [gateway] [health-check] Disable endpoint automatically https://github.com/gravitee-io/issues/issues/92[#92]
+- [gateway] [health-check] Endpoint state https://github.com/gravitee-io/issues/issues/91[#91]
+- [gateway] @OnRequestContent https://github.com/gravitee-io/issues/issues/62[#62]
+- [portal] Login page : focus on username input field. https://github.com/gravitee-io/issues/issues/14[#14]
+- [doc] move all url to https https://github.com/gravitee-io/issues/issues/3[#3]
+
+== https://github.com/gravitee-io/issues/milestone/2?closed=1[0.15.0 (2016-06-22)]
+
+=== Bug fixes
+
+- [portal] Login page: Logo not well displayed under Safari https://github.com/gravitee-io/issues/issues/81[#81]
+
+=== Features
+
+- [healthcheck] Enable / disable health-check by endpoint  https://github.com/gravitee-io/issues/issues/88[#88]
+- [policy] Dynamic routing policy https://github.com/gravitee-io/issues/issues/87[#87]
+
+== https://github.com/gravitee-io/issues/milestone/1?closed=1[0.14.1 (2016-06-21)]
+
+=== Bug fixes
+
+- [management-api] Unable to create a new API https://github.com/gravitee-io/issues/issues/84[#84]
+- [gateway] gateway cannot connect to elastic reporter https://github.com/gravitee-io/issues/issues/1[#1]
+
+=== Features
+
+- [portal] redirect user to login page when he's disconnected https://github.com/gravitee-io/issues/issues/80[#80]

--- a/release/steps/4-generate_changelog.mjs
+++ b/release/steps/4-generate_changelog.mjs
@@ -37,7 +37,7 @@ if (tagSteps !== 'y') {
   process.exit();
 }
 
-const response = await fetch('https://circleci.com/api/v2/project/gh/gravitee-io/issues/pipeline', {
+const response = await fetch('https://circleci.com/api/v2/project/gh/gravitee-io/gravitee-api-management/pipeline', {
   method: 'post',
   body: JSON.stringify(body),
   headers: {
@@ -50,7 +50,7 @@ const data = await response.json();
 
 if (response.status === 201) {
   console.log(chalk.green(`Pipeline created with number: ${data.number}`));
-  echo`Follow its progress on: https://app.circleci.com/pipelines/github/gravitee-io/issues/${data.number}`;
+  echo`Follow its progress on: https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/${data.number}`;
   console.log(chalk.greenBright(`When it's done, run 'npm run nexus_sync -- --version=${releasingVersion}'`));
 } else {
   console.log(chalk.yellow('Something went wrong'));


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8186

## Description

- [x] Move changelogs files in APIM
- [x] Move generation scripts in APIM

## Additional context

I force a changelog generation from my branch by changing the target branch in ``4-generate_changelog.mjs`` and here is the result: https://github.com/gravitee-io/gravitee-api-management/pull/2477
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/ci-changelog-in-apim/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cxzrqmriny.chromatic.com)
<!-- Storybook placeholder end -->
