### PR TITLE
Revert "chore(ci): generate APIM e2e tests sdk on each PR and fail if uncommited changes"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -513,7 +513,6 @@ jobs:
                   root: ./
                   paths:
                       - ./gravitee-*/*/target/*
-                      - ./gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/target/classes/console-openapi.*
                       - ./rest-api-docker-context
                       - ./gateway-docker-context
 
@@ -735,38 +734,6 @@ jobs:
                       docker push ${GATEWAY_PRIVATE_IMAGE_TAG}
                       docker logout graviteeio.azurecr.io
             - notify-on-failure
-
-    e2e-generate-sdk:
-      executor:
-        name: openjdk
-        with_node: true
-        class: small
-      steps:
-        - checkout
-        - webui-install:
-            apim-ui-project: gravitee-apim-e2e
-        - attach_workspace:
-            at: .
-        - run:
-            name: Generate e2e tests SDK
-            command: |
-              npm run update:sdk:management
-              npm run update:sdk:portal
-            working_directory: gravitee-apim-e2e
-        - run:
-            name: Check e2e tests SDK changes
-            command: |
-              if [[ `git status lib --porcelain` ]]; then
-                echo "AIM E2E tests SDK has some uncommitted changes."
-                echo "Please regenerate it, commit the changes, and ensure the e2e tests are still running."
-                echo ""
-                echo "Commands to regenerate SDKs, to run under the gravitee-apim-e2e folder :"
-                echo "- npm run update:sdk:management"
-                echo "- npm run update:sdk:portal"
-                exit 1
-              fi
-            working_directory: gravitee-apim-e2e
-        - notify-on-failure
 
     e2e-lint-build:
         executor:
@@ -2025,17 +1992,12 @@ workflows:
                           only:
                               - master
                               - /^\d+\.\d+\.x$/
-            - e2e-generate-sdk:
-                  name: Generate e2e tests SDK
-                  context: cicd-orchestrator
-                  requires:
-                    - setup
-                    - build
+            # To be modified when testing strategy will be defined
             - e2e-lint-build:
                   name: Lint & Build APIM e2e
                   context: cicd-orchestrator
                   requires:
-                      - Generate e2e tests SDK
+                      - setup
             - e2e-test:
                   context: cicd-orchestrator
                   name: Test APIM E2E - << matrix.execution_mode >> - << matrix.database >>


### PR DESCRIPTION
This reverts commit efd05173b56cf9f28bed29cc03f3931f5ef8b36d.

## Issue

https://github.com/gravitee-io/issues/issues/8374
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/revert-ci-tests-sdk/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gstgdqtlzc.chromatic.com)
<!-- Storybook placeholder end -->
