### PR TITLE
Update links to API Designer 

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation/api-creation-get-started.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/api-creation-get-started.component.spec.ts
@@ -70,7 +70,7 @@ describe('ApiCreationGetStartedComponent', () => {
       initConfigureTestingModule(currentUser);
     });
 
-    it('should use the cockpit link', async () => {
+    it('should use the cockpit link if installation registered', async () => {
       httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/installation`).flush(
         fakeInstallation({
           cockpitURL: 'https://cockpit.gravitee.io',
@@ -79,17 +79,21 @@ describe('ApiCreationGetStartedComponent', () => {
           },
         }),
       );
-      expect(component.cockpitLink).toEqual('https://cockpit.gravitee.io');
+      expect(component.cockpitLink).toEqual(
+        'https://cockpit.gravitee.io?utm_source=apim&utm_medium=InApp&utm_campaign=api_designer&utm_term=registered',
+      );
     });
 
-    it('should use the gravitee.io link', async () => {
+    it('should always use the cockpit.gravitee.io link even if installation not registered', async () => {
       httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/installation`).flush(
         fakeInstallation({
           cockpitURL: 'https://cockpit.gravitee.io',
           additionalInformation: {},
         }),
       );
-      expect(component.cockpitLink).toEqual('https://www.gravitee.io/platform/api-designer?utm_source=apim');
+      expect(component.cockpitLink).toEqual(
+        'https://cockpit.gravitee.io?utm_source=apim&utm_medium=InApp&utm_campaign=api_designer&utm_term=not_registered',
+      );
     });
 
     it('should go to api creation wizard', async () => {
@@ -112,10 +116,12 @@ describe('ApiCreationGetStartedComponent', () => {
       initConfigureTestingModule(currentUser);
     });
 
-    it('should use the gravitee.io link', async () => {
+    it('should always use the cockpit.gravitee.io link even if no right to access the installation', async () => {
       httpTestingController.expectNone(`${CONSTANTS_TESTING.org.baseURL}/installation`);
 
-      expect(component.cockpitLink).toEqual('https://www.gravitee.io/platform/api-designer?utm_source=apim');
+      expect(component.cockpitLink).toEqual(
+        'https://cockpit.gravitee.io?utm_source=apim&utm_medium=InApp&utm_campaign=api_designer&utm_term=not_registered',
+      );
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/api/creation/api-creation-get-started.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/api-creation-get-started.component.ts
@@ -20,6 +20,7 @@ import { takeUntil, tap } from 'rxjs/operators';
 import { of, Subject } from 'rxjs';
 
 import { UIRouterState } from '../../../ajs-upgraded-providers';
+import { CockpitService, UtmCampaign } from '../../../services-ngx/cockpit.service';
 import { Constants } from '../../../entities/Constants';
 import { InstallationService } from '../../../services-ngx/installation.service';
 import { Installation } from '../../../entities/installation/installation';
@@ -46,6 +47,7 @@ export class ApiCreationGetStartedComponent implements OnInit, OnDestroy {
   constructor(
     @Inject(UIRouterState) private readonly ajsState: StateService,
     @Inject('Constants') private readonly constants: Constants,
+    private readonly cockpitService: CockpitService,
     private readonly installationService: InstallationService,
     private readonly permissionService: GioPermissionService,
   ) {}
@@ -78,10 +80,16 @@ export class ApiCreationGetStartedComponent implements OnInit, OnDestroy {
   }
 
   private getCockpitLink(installation?: Installation): string {
+    let cockpitURL;
+    let cockpitInstallationStatus;
     if (installation?.additionalInformation.COCKPIT_INSTALLATION_STATUS === 'ACCEPTED') {
-      return installation.cockpitURL;
+      cockpitURL = installation.cockpitURL;
+      cockpitInstallationStatus = 'ACCEPTED';
     } else {
-      return 'https://www.gravitee.io/platform/api-designer?utm_source=apim';
+      cockpitURL = 'https://cockpit.gravitee.io';
+      cockpitInstallationStatus = undefined;
     }
+
+    return this.cockpitService.addQueryParamsForAnalytics(cockpitURL, UtmCampaign.API_DESIGNER, cockpitInstallationStatus);
   }
 }

--- a/gravitee-apim-console-webui/src/services-ngx/cockpit.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/cockpit.service.spec.ts
@@ -37,6 +37,24 @@ describe('CockpitService', () => {
     done();
   });
 
+  it('should configure URL with API_DESIGNER campaign and ACCEPTED installation status', (done) => {
+    const enhancedURL = cockpitService.addQueryParamsForAnalytics(COCKPIT_URL, UtmCampaign.API_DESIGNER, 'ACCEPTED');
+    expect(enhancedURL).toEqual(`${COCKPIT_URL}?utm_source=apim&utm_medium=InApp&utm_campaign=api_designer&utm_term=registered`);
+    done();
+  });
+
+  it('should configure URL with API_DESIGNER campaign and no installation status', (done) => {
+    const enhancedURL = cockpitService.addQueryParamsForAnalytics(COCKPIT_URL, UtmCampaign.API_DESIGNER);
+    expect(enhancedURL).toEqual(`${COCKPIT_URL}?utm_source=apim&utm_medium=InApp&utm_campaign=api_designer&utm_term=not_registered`);
+    done();
+  });
+
+  it('should configure URL with API_DESIGNER campaign and not ACCEPTED installation status', (done) => {
+    const enhancedURL = cockpitService.addQueryParamsForAnalytics(COCKPIT_URL, UtmCampaign.API_DESIGNER, 'unknown_status');
+    expect(enhancedURL).toEqual(`${COCKPIT_URL}?utm_source=apim&utm_medium=InApp&utm_campaign=api_designer&utm_term=not_registered`);
+    done();
+  });
+
   it('should configure URL with DiscoverCockpit campaign and PENDING installation status', (done) => {
     const enhancedURL = cockpitService.addQueryParamsForAnalytics(COCKPIT_URL, UtmCampaign.DISCOVER_COCKPIT, 'PENDING');
     expect(enhancedURL).toEqual(`${COCKPIT_URL}?utm_source=apim&utm_medium=InApp&utm_campaign=discover_cockpit&utm_term=pending`);

--- a/gravitee-apim-console-webui/src/services-ngx/cockpit.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/cockpit.service.ts
@@ -17,6 +17,7 @@
 import { Injectable } from '@angular/core';
 
 export enum UtmCampaign {
+  API_DESIGNER = 'api_designer',
   API_PROMOTION = 'api_promotion',
   DISCOVER_COCKPIT = 'discover_cockpit',
 }
@@ -40,7 +41,7 @@ export class CockpitService {
     enhancedCockpitUrl += `&utm_campaign=${utmCampaign}`;
 
     // if DISCOVER_COCKPIT, add cockpit installation status
-    if (utmCampaign === UtmCampaign.DISCOVER_COCKPIT) {
+    if (utmCampaign === UtmCampaign.DISCOVER_COCKPIT || utmCampaign === UtmCampaign.API_DESIGNER) {
       const utmTerm = this.computeCockpitStatusForQueryParam(cockpitInstallationStatus);
       enhancedCockpitUrl += `&utm_term=${utmTerm}`;
     }


### PR DESCRIPTION
## Issues

gravitee-io/issues#8334
gravitee-io/issues#8485

## Description

- Add query parameters for pendo analytics
- Always redirect to https://cockpit.gravitee.io
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-piiqjgxahb.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8334-links-analytics-improvements/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
