### PR TITLE
Improve console subscription screen

### DIFF
--- a/gravitee-apim-console-webui/src/management/application/applications.route.ts
+++ b/gravitee-apim-console-webui/src/management/application/applications.route.ts
@@ -17,7 +17,6 @@ import { StateParams, StateService } from '@uirouter/core';
 import * as _ from 'lodash';
 
 import { ApplicationType } from '../../entities/application';
-import { ApiService } from '../../services/api.service';
 import ApplicationService from '../../services/application.service';
 import ApplicationTypesService from '../../services/applicationTypes.service';
 import EnvironmentService from '../../services/environment.service';
@@ -301,7 +300,6 @@ function applicationsConfig($stateProvider) {
       url: '/subscribe',
       component: 'applicationSubscribe',
       resolve: {
-        apis: (ApiService: ApiService) => ApiService.list(null, true).then((response) => response.data),
         groups: (GroupService: GroupService) => GroupService.list().then((response) => response.data),
         subscriptions: ($stateParams, ApplicationService: ApplicationService) =>
           ApplicationService.listSubscriptions($stateParams.applicationId, '?expand=security').then((response) => response.data),

--- a/gravitee-apim-console-webui/src/management/application/details/subscribe/application-subscribe.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscribe/application-subscribe.controller.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import * as _ from 'lodash';
+import { IHttpPromise } from 'angular';
 
 import { ApiService } from '../../../../services/api.service';
 import ApplicationService from '../../../../services/application.service';
@@ -49,6 +50,9 @@ class ApplicationSubscribeController {
 
   async $onInit() {
     const subscriptionsByAPI = _.groupBy(this.subscriptions.data, 'api');
+
+    this.apis = (await this.ApiService.list(null, true, null, null, null, Object.keys(subscriptionsByAPI))).data;
+
     _.forEach(subscriptionsByAPI, (subscriptions, api) => {
       this.subscribedAPIs.push(
         _.merge(_.find(this.apis, { id: api }), {
@@ -61,6 +65,10 @@ class ApplicationSubscribeController {
     });
 
     this.subscribedPlans = _.map(this.subscriptions.data, 'plan');
+  }
+
+  searchApiByName(searchText): IHttpPromise<any> {
+    return this.ApiService.searchApis(searchText, 1, 'name').then((response) => response.data.data);
   }
 
   onSelectAPI(api) {

--- a/gravitee-apim-console-webui/src/management/application/details/subscribe/application-subscribe.html
+++ b/gravitee-apim-console-webui/src/management/application/details/subscribe/application-subscribe.html
@@ -23,13 +23,13 @@
       <md-autocomplete
         class="application-subscribe__content__api-selector-container__selector"
         md-input-id="new-view-apis-autocomplete-id"
-        md-search-text="$ctrl.filterAPI"
+        md-search-text="searchText"
         md-selected-item-change="$ctrl.onSelectAPI(api)"
-        md-items="api in $ctrl.apis | filter:$ctrl.filterAPI"
+        md-items="api in $ctrl.searchApiByName(searchText)"
         md-item-text="api.name"
-        placeholder="Select an API to subscribe"
+        placeholder="Search and select an API to subscribe | name:'My api *' | ownerName:admin"
         md-autofocus="false"
-        md-min-length="0"
+        md-min-length="3"
         md-no-cache="true"
         md-menu-class="autocomplete-custom-template"
       >
@@ -40,7 +40,7 @@
             </div>
           </md-list-item>
         </md-item-template>
-        <md-not-found> No API matching "{{$ctrl.filterAPI}}" were found. </md-not-found>
+        <md-not-found> No API matching "{{searchText}}" were found. </md-not-found>
       </md-autocomplete>
     </div>
     <div class="gv-forms application-subscribe__content__subscribed-api">

--- a/gravitee-apim-console-webui/src/services/api.service.ts
+++ b/gravitee-apim-console-webui/src/services/api.service.ts
@@ -124,7 +124,7 @@ export class ApiService {
     return this.Constants.env.settings.analytics.clientTimeout as number;
   }
 
-  list(category?: string, portal?: boolean, page?: any, order?: string, opts?: any): IHttpPromise<any> {
+  list(category?: string, portal?: boolean, page?: any, order?: string, opts?: any, ids?: string[]): IHttpPromise<any> {
     let url = `${this.Constants.env.baseURL}/apis/`;
 
     // Fallback to paginated list if a page parameter is provided.
@@ -138,6 +138,7 @@ export class ApiService {
       portal: portal,
       page: page,
       order: order,
+      ids: ids,
     };
 
     return this.$http.get(url, opts);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
@@ -116,8 +116,8 @@ public class ApisResource extends AbstractResource {
         )
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
-    public Collection<ApiListItem> getApis(@BeanParam final ApisParam apisParam) {
-        return getApis(apisParam, null).getData();
+    public Collection<ApiListItem> getApis(@BeanParam final ApisParam apisParam, @QueryParam("ids") final List<String> ids) {
+        return getApis(apisParam, ids, null).getData();
     }
 
     @GET
@@ -134,9 +134,16 @@ public class ApisResource extends AbstractResource {
         content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ApiListItemPagedResult.class))
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
-    public ApiListItemPagedResult getApis(@BeanParam final ApisParam apisParam, @Valid @BeanParam Pageable pageable) {
+    public ApiListItemPagedResult getApis(
+        @BeanParam final ApisParam apisParam,
+        @QueryParam("ids") final List<String> ids,
+        @Valid @BeanParam Pageable pageable
+    ) {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         final ApiQuery apiQuery = new ApiQuery();
+        if (ids != null && !ids.isEmpty()) {
+            apiQuery.setIds(ids);
+        }
         if (apisParam.getGroup() != null) {
             apiQuery.setGroups(singletonList(apisParam.getGroup()));
         }


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8496

## Description

When a user try to subscribe to an API from an application (in the console), we first load all the available APIs. Then we can filter this list with an autocomplete input.

As it is not a good idea to fetch all the APIs in one call, This PR change the behaviour of the feature:

- When a user clicks on "Subscribe to APIs", he is redirected to the right screen wiuthout waiting for APIs to be loaded.
- On init, we only load APIs already subscribed by the current application
- The autocomplete form now uses the same search method as the main APIs page, and allow the user to use query like "name:..."

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8496-improve-console-subscription-screen/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rxdydtfcdm.chromatic.com)
<!-- Storybook placeholder end -->
