### PR TITLE
sort chart legend items by name

### DIFF
--- a/gravitee-apim-console-webui/src/components/widget/line/widget-chart-line.component.ts
+++ b/gravitee-apim-console-webui/src/components/widget/line/widget-chart-line.component.ts
@@ -65,11 +65,15 @@ const WidgetChartLineComponent: ng.IComponentOptions = {
       const timestamp = data.timestamp;
       this.events = data.events && data.events.content;
 
+      const orderedBucketNames = [];
+
       data.values.forEach((value, idx) => {
         let label = this.parent.widget.chart.labels ? this.parent.widget.chart.labels[idx] : '';
 
         if (value.buckets.length === 0) {
           const bucketCount = (data.timestamp.to - data.timestamp.from) / data.timestamp.interval;
+
+          orderedBucketNames.push(label);
 
           this.series.values.push({
             name: label,
@@ -97,8 +101,11 @@ const WidgetChartLineComponent: ng.IComponentOptions = {
                 label = value.metadata[bucket.name].name;
               }
 
+              const valueName = isFieldRequest ? bucket.name : label;
+              orderedBucketNames.push(valueName);
+
               this.series.values.push({
-                name: isFieldRequest ? bucket.name : label,
+                name: valueName,
                 data: bucket.data,
                 labelPrefix: isFieldRequest ? label : '',
                 id: bucket.name,
@@ -106,7 +113,12 @@ const WidgetChartLineComponent: ng.IComponentOptions = {
               });
             }
           });
+          orderedBucketNames.sort();
         }
+      });
+
+      this.series.values.forEach((value) => {
+        value.legendIndex = orderedBucketNames.indexOf(value.name);
       });
 
       this.options = {


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8497

## Description

Use the `legendIndex` attribute in the series sent to highcharts.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8497-order-chart-legend-by-name/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kchxoehped.chromatic.com)
<!-- Storybook placeholder end -->
