### PR TITLE
Improve VersionUtils to be able to parse non stable versions

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/pom.xml
@@ -87,6 +87,11 @@
             <artifactId>vertx-unit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/utils/VersionUtils.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/utils/VersionUtils.java
@@ -24,7 +24,11 @@ import java.util.regex.Pattern;
  */
 public class VersionUtils {
 
-    private static final Pattern VERSION_PATTERN = Pattern.compile("([0-9]+)\\.([0-9]+)\\.([0-9]+)(-SNAPSHOT)?");
+    private VersionUtils() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    private static final Pattern VERSION_PATTERN = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)(-.*)?");
 
     public static Version parse(String input) {
         Matcher matcher = VERSION_PATTERN.matcher(input);

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/test/java/io/gravitee/repository/bridge/server/utils/VersionUtilsTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/test/java/io/gravitee/repository/bridge/server/utils/VersionUtilsTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.bridge.server.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class VersionUtilsTest {
+
+    private static Stream<String> validVersions() {
+        return Stream.of(
+            "1.2.3",
+            "1.2.3-SNAPSHOT",
+            "1.2.3-alpha.1",
+            "1.2.3-alpha.1-SNAPSHOT",
+            "1.2.3-beta.1",
+            "1.2.3-beta.1-SNAPSHOT",
+            "1.2.3-rc.1",
+            "1.2.3-rc.1-SNAPSHOT"
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("validVersions")
+    void parseValidVersion(String expression) {
+        VersionUtils.Version version = VersionUtils.parse(expression);
+        assertNotNull(version);
+        assertEquals(1, version.major());
+        assertEquals(2, version.minor());
+        assertEquals(3, version.patch());
+    }
+
+    private static Stream<String> invalidVersions() {
+        return Stream.of("1.2", "1.2.SNAPSHOT", "1.2.3test");
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidVersions")
+    void parseInvalidVersion(String expression) {
+        VersionUtils.Version version = VersionUtils.parse(expression);
+        assertNull(version);
+    }
+}


### PR DESCRIPTION
## Issue

NA

## Description

Improve VersionUtils to be able to parse non stable versions
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-version-parsing/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cqkyayxbdz.chromatic.com)
<!-- Storybook placeholder end -->
