### PR TITLE
remove kafka endpoint from default bundle

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -70,7 +70,7 @@
         <gravitee-policy-latency.version>1.4.0</gravitee-policy-latency.version>
         <gravitee-policy-metrics-reporter.version>2.0.0</gravitee-policy-metrics-reporter.version>
         <gravitee-policy-mock.version>1.13.0</gravitee-policy-mock.version>
-	<gravitee-policy-oauth2.version>1.23.0</gravitee-policy-oauth2.version>
+        <gravitee-policy-oauth2.version>1.23.0</gravitee-policy-oauth2.version>
         <gravitee-policy-openid-connect-userinfo.version>1.5.2</gravitee-policy-openid-connect-userinfo.version>
         <gravitee-policy-override-http-method.version>1.3.0</gravitee-policy-override-http-method.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->
@@ -167,13 +167,6 @@
         <dependency>
             <groupId>io.gravitee.apim.plugin.endpoint</groupId>
             <artifactId>gravitee-apim-plugin-endpoint-mock</artifactId>
-            <version>${project.version}</version>
-            <scope>runtime</scope>
-            <type>zip</type>
-        </dependency>
-        <dependency>
-            <groupId>io.gravitee.apim.plugin.endpoint</groupId>
-            <artifactId>gravitee-apim-plugin-endpoint-kafka</artifactId>
             <version>${project.version}</version>
             <scope>runtime</scope>
             <type>zip</type>
@@ -731,6 +724,14 @@
                     <version>${gravitee-connector-kafka.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
+                </dependency>
+                <!-- Endpoints -->
+                <dependency>
+                    <groupId>io.gravitee.apim.plugin.endpoint</groupId>
+                    <artifactId>gravitee-apim-plugin-endpoint-kafka</artifactId>
+                    <version>${project.version}</version>
+                    <scope>runtime</scope>
+                    <type>zip</type>
                 </dependency>
                 <!-- Policies -->
                 <dependency>


### PR DESCRIPTION
## Issue

N/A

## Description

Remove kafka endpoint from default bundle to save 31MB on the final bundle size.
Will probably be reintroduced in 3.20 with size improvement and a clear communication to users.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/remove-kafka-endpoint-from-final-bundle/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-utlxviepld.chromatic.com)
<!-- Storybook placeholder end -->
