### PR TITLE
fix(ui): remove relative base href

### DIFF
--- a/docker/quick-setup/nginx/docker-compose.yml
+++ b/docker/quick-setup/nginx/docker-compose.yml
@@ -120,6 +120,7 @@ services:
       - management_api
     environment:
       - MGMT_API_URL=/management/organizations/DEFAULT/environments/DEFAULT/
+      - CONSOLE_BASE_HREF=/console/
     volumes:
       - ./.logs/apim-management-ui:/var/log/nginx
     networks:

--- a/gravitee-apim-console-webui/docker/config/templates/default.conf.tmpl
+++ b/gravitee-apim-console-webui/docker/config/templates/default.conf.tmpl
@@ -24,6 +24,8 @@ server {
     location / {
         try_files $uri $uri/ =404;
         root /usr/share/nginx/html;
+        sub_filter '<base href="/"' '<base href="{{ getenv "CONSOLE_BASE_HREF" "/" }}"';
+        sub_filter_once on;
     }
 
     # redirect server error pages to the static page /50x.html

--- a/gravitee-apim-console-webui/src/index.html
+++ b/gravitee-apim-console-webui/src/index.html
@@ -19,7 +19,7 @@
 <html class="bootstrap">
   <head>
     <meta charset="utf-8" />
-    <base href="./" />
+    <base href="/" />
     <title ng-bind="consoleTitle"></title>
     <meta name="description" content="" />
     <meta name="viewport" content="width=device-width" />

--- a/gravitee-apim-portal-webui/docker/config/templates/default.conf.tmpl
+++ b/gravitee-apim-portal-webui/docker/config/templates/default.conf.tmpl
@@ -23,7 +23,7 @@ server {
     location / {
         try_files $uri$args $uri$args/ $uri $uri/ /index.html =404;
         root /usr/share/nginx/html;
-        sub_filter '<base href="./"' '<base href="{{ getenv "PORTAL_BASE_HREF" "/" }}"';
+        sub_filter '<base href="/"' '<base href="{{ getenv "PORTAL_BASE_HREF" "/" }}"';
         sub_filter_once on;
     }
 

--- a/gravitee-apim-portal-webui/src/index.html
+++ b/gravitee-apim-portal-webui/src/index.html
@@ -20,7 +20,7 @@
   <head>
     <meta charset="utf-8" />
     <title>Gravitee.io Portail</title>
-    <base href="./" />
+    <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <script src="webcomponents/webcomponents-loader.js"></script>
     <script src="@asciidoctor/asciidoctor.js"></script>


### PR DESCRIPTION

## Issue
https://github.com/gravitee-io/issues/issues/8518

## Description

prefer use of `PORTAL_BASE_HREF` env variable to replace `<base href="/"'`

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8518-base-href/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-olqdhhfkyz.chromatic.com)
<!-- Storybook placeholder end -->
