### PR TITLE
fix: apikey plan selection jupiter mode

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -66,7 +66,7 @@
         <gravitee-policy-json-xml.version>1.1.1</gravitee-policy-json-xml.version>
         <gravitee-policy-jws.version>1.3.2</gravitee-policy-jws.version>
         <gravitee-policy-jwt.version>2.4.0</gravitee-policy-jwt.version>
-        <gravitee-policy-keyless.version>1.8.0</gravitee-policy-keyless.version>
+        <gravitee-policy-keyless.version>1.8.1</gravitee-policy-keyless.version>
         <gravitee-policy-latency.version>1.4.0</gravitee-policy-latency.version>
         <gravitee-policy-metrics-reporter.version>2.0.0</gravitee-policy-metrics-reporter.version>
         <gravitee-policy-mock.version>1.13.0</gravitee-policy-mock.version>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/security/SecurityChain.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/security/SecurityChain.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.jupiter.handlers.api.security;
 
 import static io.gravitee.common.http.HttpStatusCode.UNAUTHORIZED_401;
 import static io.gravitee.gateway.jupiter.api.context.InternalContextAttributes.ATTR_INTERNAL_FLOW_STAGE;
+import static io.gravitee.gateway.jupiter.api.context.InternalContextAttributes.ATTR_INTERNAL_SECURITY_TOKEN;
 import static io.reactivex.Completable.defer;
 
 import io.gravitee.definition.model.Api;
@@ -102,6 +103,7 @@ public class SecurityChain implements Hookable<SecurityPlanHook> {
                         .any(Boolean::booleanValue)
                         .flatMapCompletable(
                             securityHandled -> {
+                                ctx.removeInternalAttribute(ATTR_INTERNAL_SECURITY_TOKEN);
                                 if (Boolean.FALSE.equals(securityHandled)) {
                                     return ctx.interruptWith(
                                         new ExecutionFailure(UNAUTHORIZED_401).key(PLAN_UNRESOLVABLE).message(UNAUTHORIZED_MESSAGE)

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/security/plan/SecurityPlan.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/security/plan/SecurityPlan.java
@@ -19,6 +19,7 @@ import static io.gravitee.gateway.jupiter.api.context.ContextAttributes.ATTR_API
 import static io.gravitee.gateway.jupiter.api.context.ContextAttributes.ATTR_APPLICATION;
 import static io.gravitee.gateway.jupiter.api.context.ContextAttributes.ATTR_PLAN;
 import static io.gravitee.gateway.jupiter.api.context.ContextAttributes.ATTR_SUBSCRIPTION_ID;
+import static io.gravitee.gateway.jupiter.api.context.InternalContextAttributes.ATTR_INTERNAL_SECURITY_TOKEN;
 
 import io.gravitee.gateway.api.service.Subscription;
 import io.gravitee.gateway.api.service.SubscriptionService;
@@ -78,6 +79,7 @@ public class SecurityPlan {
     public Single<Boolean> canExecute(HttpExecutionContext ctx) {
         return policy
             .extractSecurityToken(ctx)
+            .doOnSuccess(securityToken -> ctx.setInternalAttribute(ATTR_INTERNAL_SECURITY_TOKEN, securityToken))
             .flatMap(
                 securityToken ->
                     matchSelectionRule(ctx)

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/security/SecurityChainTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/security/SecurityChainTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.jupiter.handlers.api.security;
 
+import static io.gravitee.gateway.jupiter.api.context.InternalContextAttributes.ATTR_INTERNAL_SECURITY_TOKEN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -28,6 +29,7 @@ import io.gravitee.gateway.jupiter.api.ExecutionPhase;
 import io.gravitee.gateway.jupiter.api.context.ExecutionContext;
 import io.gravitee.gateway.jupiter.api.policy.SecurityPolicy;
 import io.gravitee.gateway.jupiter.api.policy.SecurityToken;
+import io.gravitee.gateway.jupiter.handlers.api.security.plan.SecurityPlan;
 import io.gravitee.gateway.jupiter.policy.PolicyManager;
 import io.reactivex.Completable;
 import io.reactivex.Maybe;
@@ -80,6 +82,7 @@ class SecurityChainTest {
         final TestObserver<Void> obs = cut.execute(ctx).test();
 
         obs.assertResult();
+        verify(ctx, times(1)).removeInternalAttribute(ATTR_INTERNAL_SECURITY_TOKEN);
     }
 
     @Test
@@ -105,6 +108,7 @@ class SecurityChainTest {
         obs.assertResult();
         verify(policy2).order();
         verifyNoMoreInteractions(policy2);
+        verify(ctx, times(1)).removeInternalAttribute(ATTR_INTERNAL_SECURITY_TOKEN);
     }
 
     @Test
@@ -131,6 +135,7 @@ class SecurityChainTest {
         verify(policy1).order();
         verify(policy2).order();
         verifyNoMoreInteractions(policy1, policy2);
+        verify(ctx, never()).removeInternalAttribute(ATTR_INTERNAL_SECURITY_TOKEN);
     }
 
     @Test
@@ -143,6 +148,7 @@ class SecurityChainTest {
 
         obs.assertError(Throwable.class);
         verifyUnauthorized();
+        verify(ctx, times(1)).removeInternalAttribute(ATTR_INTERNAL_SECURITY_TOKEN);
     }
 
     @Test
@@ -167,6 +173,7 @@ class SecurityChainTest {
 
         obs.assertError(Throwable.class);
         verifyUnauthorized();
+        verify(ctx, times(1)).removeInternalAttribute(ATTR_INTERNAL_SECURITY_TOKEN);
     }
 
     private void verifyUnauthorized() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/security/plan/SecurityPlanTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/security/plan/SecurityPlanTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.jupiter.handlers.api.security.plan;
 
+import static io.gravitee.gateway.jupiter.api.context.InternalContextAttributes.ATTR_INTERNAL_SECURITY_TOKEN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -33,6 +34,7 @@ import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.observers.TestObserver;
 import java.util.Optional;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -83,6 +85,7 @@ class SecurityPlanTest {
         final TestObserver<Boolean> obs = cut.canExecute(ctx).test();
 
         obs.assertResult(true);
+        verify(ctx, times(1)).setInternalAttribute(eq(ATTR_INTERNAL_SECURITY_TOKEN), any());
     }
 
     @Test
@@ -96,6 +99,7 @@ class SecurityPlanTest {
         final TestObserver<Boolean> obs = cut.canExecute(ctx).test();
 
         obs.assertResult(true);
+        verify(ctx, times(1)).setInternalAttribute(eq(ATTR_INTERNAL_SECURITY_TOKEN), any());
     }
 
     @Test
@@ -109,6 +113,7 @@ class SecurityPlanTest {
         final TestObserver<Boolean> obs = cut.canExecute(ctx).test();
 
         obs.assertResult(true);
+        verify(ctx, times(1)).setInternalAttribute(eq(ATTR_INTERNAL_SECURITY_TOKEN), any());
     }
 
     @Test
@@ -122,6 +127,7 @@ class SecurityPlanTest {
         final TestObserver<Boolean> obs = cut.canExecute(ctx).test();
 
         obs.assertResult(false);
+        verify(ctx, times(1)).setInternalAttribute(eq(ATTR_INTERNAL_SECURITY_TOKEN), any());
     }
 
     @Test
@@ -132,6 +138,7 @@ class SecurityPlanTest {
         final TestObserver<Boolean> obs = cut.canExecute(ctx).test();
 
         obs.assertResult(false);
+        verify(ctx, never()).setInternalAttribute(eq(ATTR_INTERNAL_SECURITY_TOKEN), any());
     }
 
     @Test
@@ -150,6 +157,7 @@ class SecurityPlanTest {
 
         verify(subscriptionService).getByApiAndSecurityToken(API_ID, securityToken, PLAN_ID);
         obs.assertResult(false);
+        verify(ctx, times(1)).setInternalAttribute(eq(ATTR_INTERNAL_SECURITY_TOKEN), any());
     }
 
     @Test
@@ -170,6 +178,7 @@ class SecurityPlanTest {
 
         verify(subscriptionService).getByApiAndSecurityToken(API_ID, securityToken, PLAN_ID);
         obs.assertResult(false);
+        verify(ctx, times(1)).setInternalAttribute(eq(ATTR_INTERNAL_SECURITY_TOKEN), any());
     }
 
     @Test
@@ -193,6 +202,7 @@ class SecurityPlanTest {
 
         verify(subscriptionService).getByApiAndSecurityToken(API_ID, securityToken, PLAN_ID);
         obs.assertResult(false);
+        verify(ctx, times(1)).setInternalAttribute(eq(ATTR_INTERNAL_SECURITY_TOKEN), any());
     }
 
     @Test
@@ -216,6 +226,7 @@ class SecurityPlanTest {
 
         verify(subscriptionService).getByApiAndSecurityToken(API_ID, securityToken, PLAN_ID);
         obs.assertResult(true);
+        verify(ctx, times(1)).setInternalAttribute(eq(ATTR_INTERNAL_SECURITY_TOKEN), any());
     }
 
     @Test
@@ -233,6 +244,7 @@ class SecurityPlanTest {
         final TestObserver<Boolean> obs = cut.canExecute(ctx).test();
 
         obs.assertResult(false);
+        verify(ctx, times(1)).setInternalAttribute(eq(ATTR_INTERNAL_SECURITY_TOKEN), any());
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <gravitee-connector-api.version>1.1.4</gravitee-connector-api.version>
         <gravitee-expression-language.version>1.11.2</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>1.44.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.44.1</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>1.25.0</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8498


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/issues-8498-jupiter-apikey-fallback/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
