### PR TITLE
package endpoints & entrypoints when releasing

### DIFF
--- a/release/ci-steps/package-bundles.mjs
+++ b/release/ci-steps/package-bundles.mjs
@@ -235,17 +235,23 @@ await within(async () => {
   await $`rm -rf graviteeio-full-${releasingVersion}`;
 });
 
-console.log(chalk.blue(`Step 8: Packaging - Plugins / All Repositories`));
-const repositoriesPluginDir = `./dist/plugins/repositories`;
-await $`rm -rf ${repositoriesPluginDir} && mkdir -p ${repositoriesPluginDir}`;
+console.log(chalk.blue(`Step 8: Packaging - Plugins / Repositories`));
+const packagePlugins = async (pluginsDir, pluginsGroupId) => {
+  await $`rm -rf ${pluginsDir} && mkdir -p ${pluginsDir}`;
 
-await Promise.all(
-  allDependencies
-    .filter((d) => d.groupId.startsWith('io.gravitee.apim.repository'))
-    .map(async ({ fileName, artifactId }) => {
-      await $`mkdir -p  ${repositoriesPluginDir}/${artifactId} && cp ${fileName} ${repositoriesPluginDir}/${artifactId}/`;
-      await createFileSum(`${repositoriesPluginDir}/${artifactId}/${fileName}`);
-    }),
-);
+  await Promise.all(
+    allDependencies
+      .filter((d) => d.groupId.startsWith(pluginsGroupId))
+      .map(async ({ fileName, artifactId }) => {
+        await $`mkdir -p  ${pluginsDir}/${artifactId} && cp ${fileName} ${pluginsDir}/${artifactId}/`;
+        await createFileSum(`${pluginsDir}/${artifactId}/${fileName}`);
+      }),
+  );
+};
+
+// Repositories
+await packagePlugins('./dist/plugins/repositories', 'io.gravitee.apim.repository');
+await packagePlugins('./dist/plugins/endpoints', 'io.gravitee.apim.plugin.endpoint');
+await packagePlugins('./dist/plugins/entrypoints', 'io.gravitee.apim.plugin.entrypoint');
 
 console.log(chalk.magenta(`📦 The package is ready!`));

--- a/release/package-lock.json
+++ b/release/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "dotenv": "^16.0.1",
         "xml2json": "^0.12.0",
-        "zx": "^7.0.7"
+        "zx": "^7.0.8"
       },
       "devDependencies": {
         "prettier": "2.5.1"

--- a/release/package.json
+++ b/release/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "dotenv": "^16.0.1",
     "xml2json": "^0.12.0",
-    "zx": "^7.0.7"
+    "zx": "^7.0.8"
   },
   "scripts": {
     "prettier": "prettier --check \"**/*.{js,mjs,json}\"",

--- a/release/steps/5-nexus_sync.mjs
+++ b/release/steps/5-nexus_sync.mjs
@@ -2,7 +2,7 @@
 
 import { checkToken } from '../helpers/circleci-helper.mjs';
 import { computeVersion, extractVersion } from '../helpers/version-helper.mjs';
-import { isDryRun } from "../helpers/option-helper.mjs";
+import { isDryRun } from '../helpers/option-helper.mjs';
 
 await checkToken();
 


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8509

## Description

- update zx to 7.0.8
- apply prettier
- package endpoints & entrypoints when packaging everything before sending to S3
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8509-adapt-packaging-scripts-for-endpoint-and-entrypoint-plu/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-afihkhflck.chromatic.com)
<!-- Storybook placeholder end -->
