### PR TITLE
Remove relative base href - 3.15.x

### DIFF
--- a/docker/quick-setup/nginx/docker-compose.yml
+++ b/docker/quick-setup/nginx/docker-compose.yml
@@ -120,6 +120,7 @@ services:
       - management_api
     environment:
       - MGMT_API_URL=/console/api/organizations/DEFAULT/environments/DEFAULT/
+      - CONSOLE_BASE_HREF=/console/
     volumes:
       - ./.logs/apim-management-ui:/var/log/nginx
     networks:

--- a/gravitee-apim-console-webui/docker/config/templates/default.conf.tmpl
+++ b/gravitee-apim-console-webui/docker/config/templates/default.conf.tmpl
@@ -19,6 +19,8 @@ server {
     location / {
         try_files $uri $uri/ =404;
         root /usr/share/nginx/html;
+        sub_filter '<base href="/"' '<base href="{{ getenv "CONSOLE_BASE_HREF" "/" }}"';
+        sub_filter_once on;
     }
 
     # redirect server error pages to the static page /50x.html

--- a/gravitee-apim-console-webui/src/index.html
+++ b/gravitee-apim-console-webui/src/index.html
@@ -19,6 +19,7 @@
 <html class="bootstrap">
   <head>
     <meta charset="utf-8" />
+    <base href="/" />
     <title ng-bind="consoleTitle"></title>
     <meta name="description" content="" />
     <meta name="viewport" content="width=device-width" />


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8518

## Description

Introduce `CONSOLE_BASE_HREF` env variable to have the same behavior as the Portal
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-otmuocuigc.chromatic.com)
<!-- Storybook placeholder end -->
