### PR TITLE
test: fix endpoint rule handler and dynamic properties updater tests

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/pom.xml
@@ -94,14 +94,14 @@
 
         <dependency>
             <groupId>io.vertx</groupId>
-            <artifactId>vertx-unit</artifactId>
+            <artifactId>vertx-junit5</artifactId>
             <scope>test</scope>
         </dependency>
 
         <!-- HTTP mock -->
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
+            <artifactId>wiremock-jre8</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -111,7 +111,6 @@
             <classifier>${os.detected.classifier}</classifier>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleHandler.java
@@ -24,7 +24,6 @@ import io.gravitee.definition.model.Endpoint;
 import io.gravitee.el.TemplateEngine;
 import io.gravitee.el.exceptions.ExpressionEvaluationException;
 import io.gravitee.gateway.api.http.HttpHeaders;
-import io.gravitee.gateway.core.endpoint.EndpointException;
 import io.gravitee.gateway.http.vertx.VertxHttpHeaders;
 import io.gravitee.gateway.services.healthcheck.EndpointRule;
 import io.gravitee.gateway.services.healthcheck.EndpointStatusDecorator;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/test/java/io/gravitee/gateway/services/healthcheck/http/ManagedEndpointRuleHandlerOpenSslTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/test/java/io/gravitee/gateway/services/healthcheck/http/ManagedEndpointRuleHandlerOpenSslTest.java
@@ -15,14 +15,14 @@
  */
 package io.gravitee.gateway.services.healthcheck.http;
 
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.junit.runner.RunWith;
+import io.vertx.junit5.VertxExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-@RunWith(VertxUnitRunner.class)
+@ExtendWith(VertxExtension.class)
 public class ManagedEndpointRuleHandlerOpenSslTest extends AbstractManagedEndpointRuleHandlerTest {
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/test/java/io/gravitee/gateway/services/healthcheck/http/ManagedEndpointRuleHandlerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/test/java/io/gravitee/gateway/services/healthcheck/http/ManagedEndpointRuleHandlerTest.java
@@ -15,14 +15,14 @@
  */
 package io.gravitee.gateway.services.healthcheck.http;
 
-import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.junit.runner.RunWith;
+import io.vertx.junit5.VertxExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-@RunWith(VertxUnitRunner.class)
+@ExtendWith(VertxExtension.class)
 public class ManagedEndpointRuleHandlerTest extends AbstractManagedEndpointRuleHandlerTest {
 
     @Override

--- a/gravitee-apim-gateway/pom.xml
+++ b/gravitee-apim-gateway/pom.xml
@@ -86,6 +86,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/7970

## Description

In DynamicPropertyUpdaterTest.java we mock the provider and return a completed futur instead of an supplyAsync. It allow us to keep testing everything in the ``handle`` → ``.whenComplete( ... )``

In AbstractManagedEndpointRuleHandlerTest.java we migrate the test to junit 5 and increase the time before the next request using the endpoint rule cron expression. It allow us to avoid Timeout exception [here](https://github.com/gravitee-io/gravitee-api-management/blob/6e586c030d3c1e45715cc99d08d3257f661e481e/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleHandler.java#L250)
``HttpEndpointRuleHandler`` → ``createHttpClientOptions`` → ``.setConnectTimeout((int) Math.min(getDelayMillis(), endpoint.getHttpClientOptions().getConnectTimeout())``


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/test-flaky-test-junit-5/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fedbeiitid.chromatic.com)
<!-- Storybook placeholder end -->
