### PR TITLE
refactor: brigde worker executor

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/EventsHandler.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-server/src/main/java/io/gravitee/repository/bridge/server/handler/EventsHandler.java
@@ -109,6 +109,7 @@ public class EventsHandler extends AbstractHandler {
                     promise.fail(ex);
                 }
             },
+            false,
             event -> handleResponse(ctx, event)
         );
     }
@@ -149,6 +150,7 @@ public class EventsHandler extends AbstractHandler {
                     promise.fail(ex);
                 }
             },
+            false,
             (Handler<AsyncResult<Event>>) event -> handleResponse(ctx, event)
         );
     }
@@ -164,25 +166,25 @@ public class EventsHandler extends AbstractHandler {
                     promise.fail(ex);
                 }
             },
+            false,
             (Handler<AsyncResult<Event>>) event -> handleResponse(ctx, event)
         );
     }
 
     public void createOrPatch(RoutingContext ctx) {
-        ctx
-            .vertx()
-            .executeBlocking(
-                promise -> {
-                    try {
-                        Event event = ctx.getBodyAsJson().mapTo(Event.class);
-                        promise.complete(eventRepository.createOrPatch(event));
-                    } catch (Exception ex) {
-                        LOGGER.error("Unable to create or update an event", ex);
-                        promise.fail(ex);
-                    }
-                },
-                (Handler<AsyncResult<Event>>) event -> handleResponse(ctx, event)
-            );
+        bridgeWorkerExecutor.executeBlocking(
+            promise -> {
+                try {
+                    Event event = ctx.getBodyAsJson().mapTo(Event.class);
+                    promise.complete(eventRepository.createOrPatch(event));
+                } catch (Exception ex) {
+                    LOGGER.error("Unable to create or update an event", ex);
+                    promise.fail(ex);
+                }
+            },
+            false,
+            (Handler<AsyncResult<Event>>) event -> handleResponse(ctx, event)
+        );
     }
 
     private EventCriteria readCriteria(JsonObject payload) {


### PR DESCRIPTION
## Description

Following [this pull request ](https://github.com/gravitee-io/gravitee-api-management/pull/2464/files) and some merge of the 3.10 in 3.15 we discovered that this improvement has not been applied everywhere. It's certainly due to a merge without conflicts.
Here is a small pr to use the bridge worker executor everywhere.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-natpefpmgx.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/refactor-brigde-worker-executor/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
