### PR TITLE
fix: include context path when evaluating platform path condition

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/main/java/io/gravitee/gateway/flow/condition/evaluation/PathBasedConditionEvaluator.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/main/java/io/gravitee/gateway/flow/condition/evaluation/PathBasedConditionEvaluator.java
@@ -39,13 +39,22 @@ public class PathBasedConditionEvaluator implements ConditionEvaluator<Flow> {
 
     private final Map<String, Pattern> cache = new ConcurrentHashMap<>();
 
+    private final boolean stripContextPath;
+
+    public PathBasedConditionEvaluator() {
+        this(true);
+    }
+
+    public PathBasedConditionEvaluator(boolean stripContextPath) {
+        this.stripContextPath = stripContextPath;
+    }
+
     @Override
     public boolean evaluate(ExecutionContext context, Flow flow) {
         Pattern pattern = cache.computeIfAbsent(flow.getPath(), this::transform);
+        String path = stripContextPath ? context.request().pathInfo() : context.request().path();
 
-        return (flow.getOperator() == Operator.EQUALS)
-            ? pattern.matcher(context.request().pathInfo()).matches()
-            : pattern.matcher(context.request().pathInfo()).lookingAt();
+        return (flow.getOperator() == Operator.EQUALS) ? pattern.matcher(path).matches() : pattern.matcher(path).lookingAt();
     }
 
     private Pattern transform(String path) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/flow/PathBasedConditionEvaluatorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/flow/PathBasedConditionEvaluatorTest.java
@@ -17,7 +17,7 @@ package io.gravitee.gateway.flow;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.definition.model.flow.Operator;
@@ -151,5 +151,17 @@ public class PathBasedConditionEvaluatorTest {
         when(flow.getPath()).thenReturn("/my/:param");
 
         assertTrue(evaluator.evaluate(context, flow));
+    }
+
+    @Test
+    public void shouldUseFullRequestPath() {
+        PathBasedConditionEvaluator platformLevelEvaluator = new PathBasedConditionEvaluator(false);
+
+        when(request.path()).thenReturn("/my/path");
+        when(flow.getOperator()).thenReturn(Operator.EQUALS);
+        when(flow.getPath()).thenReturn("/my/path");
+
+        verify(request, never()).pathInfo();
+        assertTrue(platformLevelEvaluator.evaluate(context, flow));
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-platform/src/main/java/io/gravitee/gateway/platform/OrganizationFlowResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-platform/src/main/java/io/gravitee/gateway/platform/OrganizationFlowResolver.java
@@ -39,7 +39,7 @@ public class OrganizationFlowResolver extends ConditionalFlowResolver {
         super(
             new CompositeConditionEvaluator(
                 new HttpMethodConditionEvaluator(),
-                new PathBasedConditionEvaluator(),
+                new PathBasedConditionEvaluator(false),
                 new ExpressionLanguageFlowConditionEvaluator()
             )
         );


### PR DESCRIPTION
see https://github.com/gravitee-io/issues/issues/8302
see https://graviteecommunity.atlassian.net/browse/APIM-76


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kbdmzentmr.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/8302-platform-policy/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
