### PR TITLE
feat: handle stop on entrypoint connector

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/jupiter/core/v4/entrypoint/DefaultEntrypointConnectorResolverTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/jupiter/core/v4/entrypoint/DefaultEntrypointConnectorResolverTest.java
@@ -47,6 +47,7 @@ class DefaultEntrypointConnectorResolverTest {
 
     protected static final String ENTRYPOINT_TYPE = "test";
     protected static final String ENTRYPOINT_CONFIG = "{ \"config\": \"something\"}";
+    protected static final String MOCK_EXCEPTION = "Mock exception";
 
     @Mock
     private ExecutionContext ctx;
@@ -157,6 +158,98 @@ class DefaultEntrypointConnectorResolverTest {
         final EntrypointConnector resolvedEntrypointConnector = cut.resolve(ctx);
 
         assertNull(resolvedEntrypointConnector);
+    }
+
+    @Test
+    void shouldPreStopEntrypointConnectors() throws Exception {
+        final Api api = buildApi();
+        api.getListeners().get(0).getEntrypoints().add(buildEntrypoint());
+
+        final EntrypointConnector entrypointConnector1 = mock(EntrypointConnector.class);
+        final EntrypointConnector entrypointConnector2 = mock(EntrypointConnector.class);
+        final EntrypointConnector entrypointConnector3 = mock(EntrypointConnector.class);
+
+        when(connectorFactory.createConnector(ENTRYPOINT_CONFIG))
+            .thenReturn(entrypointConnector1)
+            .thenReturn(entrypointConnector2)
+            .thenReturn(entrypointConnector3);
+
+        final DefaultEntrypointConnectorResolver cut = new DefaultEntrypointConnectorResolver(api, pluginManager);
+        cut.preStop();
+
+        verify(entrypointConnector1).preStop();
+        verify(entrypointConnector2).preStop();
+        verify(entrypointConnector3).preStop();
+    }
+
+    @Test
+    void shouldIgnoreErrorWhenPreStopEntrypointConnectors() throws Exception {
+        final Api api = buildApi();
+        api.getListeners().get(0).getEntrypoints().add(buildEntrypoint());
+
+        final EntrypointConnector entrypointConnector1 = mock(EntrypointConnector.class);
+        final EntrypointConnector entrypointConnector2 = mock(EntrypointConnector.class);
+        final EntrypointConnector entrypointConnector3 = mock(EntrypointConnector.class);
+
+        when(entrypointConnector2.preStop()).thenThrow(new Exception(MOCK_EXCEPTION));
+
+        when(connectorFactory.createConnector(ENTRYPOINT_CONFIG))
+            .thenReturn(entrypointConnector1)
+            .thenReturn(entrypointConnector2)
+            .thenReturn(entrypointConnector3);
+
+        final DefaultEntrypointConnectorResolver cut = new DefaultEntrypointConnectorResolver(api, pluginManager);
+        cut.preStop();
+
+        verify(entrypointConnector1).preStop();
+        verify(entrypointConnector2).preStop();
+        verify(entrypointConnector3).preStop();
+    }
+
+    @Test
+    void shouldStopEntrypointConnectors() throws Exception {
+        final Api api = buildApi();
+        api.getListeners().get(0).getEntrypoints().add(buildEntrypoint());
+
+        final EntrypointConnector entrypointConnector1 = mock(EntrypointConnector.class);
+        final EntrypointConnector entrypointConnector2 = mock(EntrypointConnector.class);
+        final EntrypointConnector entrypointConnector3 = mock(EntrypointConnector.class);
+
+        when(connectorFactory.createConnector(ENTRYPOINT_CONFIG))
+            .thenReturn(entrypointConnector1)
+            .thenReturn(entrypointConnector2)
+            .thenReturn(entrypointConnector3);
+
+        final DefaultEntrypointConnectorResolver cut = new DefaultEntrypointConnectorResolver(api, pluginManager);
+        cut.stop();
+
+        verify(entrypointConnector1).stop();
+        verify(entrypointConnector2).stop();
+        verify(entrypointConnector3).stop();
+    }
+
+    @Test
+    void shouldIgnoreErrorWhenStopEntrypointConnectors() throws Exception {
+        final Api api = buildApi();
+        api.getListeners().get(0).getEntrypoints().add(buildEntrypoint());
+
+        final EntrypointConnector entrypointConnector1 = mock(EntrypointConnector.class);
+        final EntrypointConnector entrypointConnector2 = mock(EntrypointConnector.class);
+        final EntrypointConnector entrypointConnector3 = mock(EntrypointConnector.class);
+
+        when(entrypointConnector2.stop()).thenThrow(new Exception(MOCK_EXCEPTION));
+
+        when(connectorFactory.createConnector(ENTRYPOINT_CONFIG))
+            .thenReturn(entrypointConnector1)
+            .thenReturn(entrypointConnector2)
+            .thenReturn(entrypointConnector3);
+
+        final DefaultEntrypointConnectorResolver cut = new DefaultEntrypointConnectorResolver(api, pluginManager);
+        cut.stop();
+
+        verify(entrypointConnector1).stop();
+        verify(entrypointConnector2).stop();
+        verify(entrypointConnector3).stop();
     }
 
     private Api buildApi() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
@@ -226,6 +226,7 @@ public class ApiHandlerConfiguration {
         return new AsyncReactorFactory(
             applicationContext,
             configuration,
+            node,
             policyFactory,
             entrypointConnectorPluginManager,
             endpointConnectorPluginManager,

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/v4/AsyncReactorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/v4/AsyncReactorFactory.java
@@ -46,6 +46,7 @@ import io.gravitee.gateway.resource.ResourceConfigurationFactory;
 import io.gravitee.gateway.resource.ResourceLifecycleManager;
 import io.gravitee.gateway.resource.internal.ResourceConfigurationFactoryImpl;
 import io.gravitee.gateway.resource.internal.ResourceManagerImpl;
+import io.gravitee.node.api.Node;
 import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.plugin.core.api.ConfigurablePluginManager;
 import io.gravitee.plugin.endpoint.EndpointConnectorPluginManager;
@@ -68,6 +69,7 @@ public class AsyncReactorFactory implements ReactorFactory<Api> {
 
     protected final ApplicationContext applicationContext;
     protected final Configuration configuration;
+    private final Node node;
     protected final PolicyFactory policyFactory;
     protected final EntrypointConnectorPluginManager entrypointConnectorPluginManager;
     protected final EndpointConnectorPluginManager endpointConnectorPluginManager;
@@ -82,6 +84,7 @@ public class AsyncReactorFactory implements ReactorFactory<Api> {
     public AsyncReactorFactory(
         final ApplicationContext applicationContext,
         final Configuration configuration,
+        final Node node,
         final PolicyFactory policyFactory,
         final EntrypointConnectorPluginManager entrypointConnectorPluginManager,
         final EndpointConnectorPluginManager endpointConnectorPluginManager,
@@ -94,6 +97,7 @@ public class AsyncReactorFactory implements ReactorFactory<Api> {
     ) {
         this.applicationContext = applicationContext;
         this.configuration = configuration;
+        this.node = node;
         this.policyFactory = policyFactory;
         this.entrypointConnectorPluginManager = entrypointConnectorPluginManager;
         this.endpointConnectorPluginManager = endpointConnectorPluginManager;
@@ -187,10 +191,13 @@ public class AsyncReactorFactory implements ReactorFactory<Api> {
                     policyManager,
                     new DefaultEntrypointConnectorResolver(api.getDefinition(), entrypointConnectorPluginManager),
                     new EndpointInvoker(new DefaultEndpointConnectorResolver(api.getDefinition(), endpointConnectorPluginManager)),
+                    resourceLifecycleManager,
                     apiProcessorChainFactory,
                     apiMessageProcessorChainFactory,
                     flowChainFactory,
-                    v4FlowChainFactory
+                    v4FlowChainFactory,
+                    configuration,
+                    node
                 );
             }
         } catch (Exception ex) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/v4/AsyncReactorFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/v4/AsyncReactorFactoryTest.java
@@ -53,7 +53,7 @@ public class AsyncReactorFactoryTest {
     public void init() {
         lenient().when(api.getDefinition()).thenReturn(definition);
 
-        factory = new AsyncReactorFactory(null, null, null, null, null, null, null, null, null, null, null);
+        factory = new AsyncReactorFactory(null, null, null, null, null, null, null, null, null, null, null, null);
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/handler/context/AbstractExecutionContext.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/handler/context/AbstractExecutionContext.java
@@ -157,7 +157,7 @@ abstract class AbstractExecutionContext<RQ extends Request, RS extends Response>
             templateContext.setVariable(HttpExecutionContext.TEMPLATE_ATTRIBUTE_CONTEXT, new EvaluableExecutionContext(this));
 
             if (templateVariableProviders != null) {
-                templateVariableProviders.forEach(templateVariableProvider -> templateVariableProvider.provide(this));
+                templateVariableProviders.forEach(templateVariableProvider -> templateVariableProvider.provide((ExecutionContext) this));
             }
         }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/impl/DefaultReactorHandlerRegistry.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/impl/DefaultReactorHandlerRegistry.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.reactor.handler.impl;
 
+import io.gravitee.common.service.AbstractService;
 import io.gravitee.gateway.jupiter.reactor.v4.reactor.ReactorFactoryManager;
 import io.gravitee.gateway.reactor.Reactable;
 import io.gravitee.gateway.reactor.handler.Acceptor;

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-handler/src/test/java/io/gravitee/plugin/endpoint/internal/fake/FakeEndpointConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-handler/src/test/java/io/gravitee/plugin/endpoint/internal/fake/FakeEndpointConnector.java
@@ -15,9 +15,12 @@
  */
 package io.gravitee.plugin.endpoint.internal.fake;
 
+import io.gravitee.common.component.Lifecycle;
 import io.gravitee.gateway.jupiter.api.ApiType;
 import io.gravitee.gateway.jupiter.api.ConnectorMode;
+import io.gravitee.gateway.jupiter.api.connector.Connector;
 import io.gravitee.gateway.jupiter.api.connector.endpoint.EndpointConnector;
+import io.gravitee.gateway.jupiter.api.connector.endpoint.async.EndpointAsyncConnector;
 import io.gravitee.gateway.jupiter.api.context.ExecutionContext;
 import io.reactivex.Completable;
 import java.util.Set;
@@ -29,7 +32,7 @@ import lombok.Getter;
  */
 @Builder
 @Getter
-public class FakeEndpointConnector implements EndpointConnector {
+public class FakeEndpointConnector extends EndpointAsyncConnector {
 
     static final ApiType SUPPORTED_API = ApiType.SYNC;
     static final Set<ConnectorMode> SUPPORTED_MODES = Set.of(ConnectorMode.REQUEST_RESPONSE);
@@ -52,7 +55,12 @@ public class FakeEndpointConnector implements EndpointConnector {
     }
 
     @Override
-    public Completable connect(ExecutionContext executionContext) {
+    protected Completable subscribe(ExecutionContext ctx) {
+        return Completable.complete();
+    }
+
+    @Override
+    protected Completable publish(ExecutionContext ctx) {
         return Completable.complete();
     }
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mock/src/main/java/io/gravitee/plugin/endpoint/mock/MockEndpointConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mock/src/main/java/io/gravitee/plugin/endpoint/mock/MockEndpointConnector.java
@@ -26,12 +26,8 @@ import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.Maybe;
 import java.util.Set;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeUnit;
 import lombok.AllArgsConstructor;
-import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import lombok.extern.slf4j.Slf4j;
 
 /**

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mock/src/test/java/io/gravitee/plugin/endpoint/mock/MockEndpointConnectorTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mock/src/test/java/io/gravitee/plugin/endpoint/mock/MockEndpointConnectorTest.java
@@ -18,9 +18,7 @@ package io.gravitee.plugin.endpoint.mock;
 import static io.gravitee.gateway.jupiter.api.context.InternalContextAttributes.ATTR_INTERNAL_ENTRYPOINT_CONNECTOR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import io.gravitee.gateway.jupiter.api.ApiType;
 import io.gravitee.gateway.jupiter.api.ConnectorMode;
@@ -62,11 +60,11 @@ class MockEndpointConnectorTest {
     private static final String MESSAGE_TO_LOG = "message to log";
     private final MockEndpointConnectorConfiguration configuration = new MockEndpointConnectorConfiguration();
 
-    @Mock
-    Logger logger;
+    @Mock(name = "io.gravitee.plugin.endpoint.mock.MockEndpointConnector")
+    Logger log;
 
     @InjectMocks
-    private MockEndpointConnector mockEndpointConnector;
+    private MockEndpointConnector cut;
 
     @Mock
     private ExecutionContext ctx;
@@ -84,7 +82,7 @@ class MockEndpointConnectorTest {
     public void setup() {
         configuration.setMessageInterval(100L);
         configuration.setMessageContent(MESSAGE_CONTENT);
-        mockEndpointConnector = new MockEndpointConnector(configuration);
+        cut = new MockEndpointConnector(configuration);
         lenient().when(request.onMessage(any())).thenReturn(Completable.complete());
 
         lenient().when(ctx.request()).thenReturn(request);
@@ -95,35 +93,35 @@ class MockEndpointConnectorTest {
 
     @Test
     void shouldIdReturnMock() {
-        assertThat(mockEndpointConnector.id()).isEqualTo("mock");
+        assertThat(cut.id()).isEqualTo("mock");
     }
 
     @Test
     void shouldSupportAsyncApi() {
-        assertThat(mockEndpointConnector.supportedApi()).isEqualTo(ApiType.ASYNC);
+        assertThat(cut.supportedApi()).isEqualTo(ApiType.ASYNC);
     }
 
     @Test
     void shouldSupportPublishAndSubscribeModes() {
-        assertThat(mockEndpointConnector.supportedModes()).containsOnly(ConnectorMode.PUBLISH, ConnectorMode.SUBSCRIBE);
+        assertThat(cut.supportedModes()).containsOnly(ConnectorMode.PUBLISH, ConnectorMode.SUBSCRIBE);
     }
 
     @Test
     @DisplayName("Should receive messages")
     void shouldLogRequestMessagesFlow() {
-        mockEndpointConnector.connect(ctx).test().assertComplete();
+        cut.connect(ctx).test().assertComplete();
 
         ArgumentCaptor<Function<Message, Maybe<Message>>> messagesCaptor = ArgumentCaptor.forClass(Function.class);
 
         verify(request).onMessage(messagesCaptor.capture());
         messagesCaptor.getValue().apply(new DefaultMessage(MESSAGE_TO_LOG)).test().assertComplete();
-        verify(logger).info("Received message: {}", MESSAGE_TO_LOG);
+        verify(log).info("Received message: {}", MESSAGE_TO_LOG);
     }
 
     @Test
     @DisplayName("Should generate messages flow")
     void shouldGenerateMessagesFlow() {
-        mockEndpointConnector.connect(ctx).test().assertComplete();
+        cut.connect(ctx).test().assertComplete();
 
         ArgumentCaptor<Flowable<Message>> messagesCaptor = ArgumentCaptor.forClass(Flowable.class);
         verify(response).messages(messagesCaptor.capture());
@@ -144,7 +142,7 @@ class MockEndpointConnectorTest {
     void shouldGenerateLimitedMessagesFlowFromConfiguration() throws InterruptedException {
         configuration.setMessageCount(5);
 
-        mockEndpointConnector.connect(ctx).test().assertComplete();
+        cut.connect(ctx).test().assertComplete();
 
         ArgumentCaptor<Flowable<Message>> messagesCaptor = ArgumentCaptor.forClass(Flowable.class);
         verify(response).messages(messagesCaptor.capture());
@@ -160,7 +158,7 @@ class MockEndpointConnectorTest {
         when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_MESSAGES_RESUME_LASTID)).thenReturn(null);
         when(request.onMessage(any())).thenReturn(Completable.complete());
 
-        mockEndpointConnector.connect(ctx).test().assertComplete();
+        cut.connect(ctx).test().assertComplete();
 
         ArgumentCaptor<Flowable<Message>> messagesCaptor = ArgumentCaptor.forClass(Flowable.class);
         verify(response).messages(messagesCaptor.capture());
@@ -180,7 +178,7 @@ class MockEndpointConnectorTest {
         when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_MESSAGES_RESUME_LASTID)).thenReturn(null);
         when(request.onMessage(any())).thenReturn(Completable.complete());
 
-        mockEndpointConnector.connect(ctx).test().assertComplete();
+        cut.connect(ctx).test().assertComplete();
 
         ArgumentCaptor<Flowable<Message>> messagesCaptor = ArgumentCaptor.forClass(Flowable.class);
         verify(response).messages(messagesCaptor.capture());
@@ -196,7 +194,7 @@ class MockEndpointConnectorTest {
         when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_MESSAGES_RESUME_LASTID)).thenReturn(null);
         when(request.onMessage(any())).thenReturn(Completable.complete());
 
-        mockEndpointConnector.connect(ctx).test().assertComplete();
+        cut.connect(ctx).test().assertComplete();
 
         ArgumentCaptor<Flowable<Message>> messagesCaptor = ArgumentCaptor.forClass(Flowable.class);
         verify(response).messages(messagesCaptor.capture());
@@ -213,7 +211,7 @@ class MockEndpointConnectorTest {
         when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_MESSAGES_RESUME_LASTID)).thenReturn("1");
         when(request.onMessage(any())).thenReturn(Completable.complete());
 
-        mockEndpointConnector.connect(ctx).test().assertComplete();
+        cut.connect(ctx).test().assertComplete();
 
         ArgumentCaptor<Flowable<Message>> messagesCaptor = ArgumentCaptor.forClass(Flowable.class);
         verify(response).messages(messagesCaptor.capture());

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-sse/pom.xml
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-sse/pom.xml
@@ -74,6 +74,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-websocket/src/main/java/io/gravitee/plugin/entrypoint/websocket/WebSocketCloseStatus.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-websocket/src/main/java/io/gravitee/plugin/entrypoint/websocket/WebSocketCloseStatus.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.entrypoint.websocket;
+
+import static io.netty.util.internal.ObjectUtil.checkNotNull;
+
+/**
+ * WebSocket close status (copied from vertx).
+ */
+public final class WebSocketCloseStatus {
+
+    public static final WebSocketCloseStatus NORMAL_CLOSURE = new WebSocketCloseStatus(1000, "Bye");
+
+    public static final WebSocketCloseStatus ENDPOINT_UNAVAILABLE = new WebSocketCloseStatus(1001, "Endpoint unavailable");
+
+    public static final WebSocketCloseStatus PROTOCOL_ERROR = new WebSocketCloseStatus(1002, "Protocol error");
+
+    public static final WebSocketCloseStatus INVALID_MESSAGE_TYPE = new WebSocketCloseStatus(1003, "Invalid message type");
+
+    public static final WebSocketCloseStatus INVALID_PAYLOAD_DATA = new WebSocketCloseStatus(1007, "Invalid payload data");
+
+    public static final WebSocketCloseStatus POLICY_VIOLATION = new WebSocketCloseStatus(1008, "Policy violation");
+
+    public static final WebSocketCloseStatus MESSAGE_TOO_BIG = new WebSocketCloseStatus(1009, "Message too big");
+
+    public static final WebSocketCloseStatus MANDATORY_EXTENSION = new WebSocketCloseStatus(1010, "Mandatory extension");
+
+    public static final WebSocketCloseStatus SERVER_ERROR = new WebSocketCloseStatus(1011, "Server error");
+
+    public static final WebSocketCloseStatus SERVICE_RESTART = new WebSocketCloseStatus(1012, "Service Restart");
+
+    public static final WebSocketCloseStatus TRY_AGAIN_LATER = new WebSocketCloseStatus(1013, "Try Again Later");
+
+    public static final WebSocketCloseStatus BAD_GATEWAY = new WebSocketCloseStatus(1014, "Bad Gateway");
+
+    public static final WebSocketCloseStatus EMPTY = new WebSocketCloseStatus(1005, "Empty");
+
+    public static final WebSocketCloseStatus ABNORMAL_CLOSURE = new WebSocketCloseStatus(1006, "Abnormal closure");
+
+    public static final WebSocketCloseStatus TLS_HANDSHAKE_FAILED = new WebSocketCloseStatus(1015, "TLS handshake failed");
+
+    private final int statusCode;
+    private final String reasonText;
+
+    private WebSocketCloseStatus(int statusCode, String reasonText) {
+        this.statusCode = statusCode;
+        this.reasonText = checkNotNull(reasonText, "reasonText");
+    }
+
+    public int code() {
+        return statusCode;
+    }
+
+    public String reasonText() {
+        return reasonText;
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-websocket/src/main/java/io/gravitee/plugin/entrypoint/websocket/WebSocketException.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-websocket/src/main/java/io/gravitee/plugin/entrypoint/websocket/WebSocketException.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.entrypoint.websocket;
+
+import lombok.Getter;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Getter
+public class WebSocketException extends Exception {
+
+    private final WebSocketCloseStatus closeStatus;
+    private final String error;
+
+    public WebSocketException(WebSocketCloseStatus closeStatus, String error) {
+        this.closeStatus = closeStatus;
+        this.error = error;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <gravitee-bom.version>2.6</gravitee-bom.version>
         <gravitee-alert-api.version>1.9.1</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>1.12.0</gravitee-cockpit-api.version>
-        <gravitee-common.version>1.27.0</gravitee-common.version>
+        <gravitee-common.version>1.28.0</gravitee-common.version>
         <gravitee-connector-api.version>1.1.4</gravitee-connector-api.version>
         <gravitee-expression-language.version>1.11.0</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-92

## Description

When a client is consuming an async api and that api is redeployed, we need to close the connection properly so the client application is informed that it needs to reconnect to continue the consumption of messages.

The behavior will mainly depends on the type of entrypoint and cannot be limited to an http status code as, most of the time, the response headers are already sent and the messages are produced in a streaming fashion way. Here is a summary:

- http-get: the response is returned with an error block indicating the api is redeploying.
- http-post: as there is no expected response, nothing particular is expected
- sse: a final error message is sent indicating the api is redeploying
- websocket: the connection is closed with a 1013 (try again later) status
- webhook: stops sending message to http webhook (kept simple for now but it will change when the subscription lifecycle will be well handled).
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-92-entrypoint-lifecycle-stop/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xedfjlkagl.chromatic.com)
<!-- Storybook placeholder end -->
