### PR TITLE
add Content Security Policies in default nginx configuration

### DIFF
--- a/gravitee-apim-console-webui/docker/config/templates/default.conf.tmpl
+++ b/gravitee-apim-console-webui/docker/config/templates/default.conf.tmpl
@@ -4,6 +4,7 @@ server {
     server_name {{ getenv "SERVER_NAME" "_" }};
 
     add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header Content-Security-Policy "frame-ancestors 'self';" always;
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Content-Type-Options nosniff;
     add_header X-Permitted-Cross-Domain-Policies none;

--- a/gravitee-apim-portal-webui/docker/config/templates/default.conf.tmpl
+++ b/gravitee-apim-portal-webui/docker/config/templates/default.conf.tmpl
@@ -3,6 +3,9 @@ server {
     listen {{ getenv "HTTPS_PORT" "8443" }};
     server_name {{ getenv "SERVER_NAME" "_" }};
 
+  {{- if eq (getenv "FRAME_PROTECTION_ENABLED" "true") "true" }}
+    add_header Content-Security-Policy "frame-ancestors {{ getenv "ALLOWED_FRAME_ANCESTOR_URLS" "'self'" }};" always;
+  {{- end }}
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Content-Type-Options nosniff;
     add_header X-Permitted-Cross-Domain-Policies none;


### PR DESCRIPTION
## Issue

N/A

## Description
add Content Security Policies in default nginx configuration for console and portal

breaking change: by default the portal is no more displayable in the console because of the CSP header. See upgrade guide 3.19.0 for workaround
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/improve-ui-security/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ndibnjkpfv.chromatic.com)
<!-- Storybook placeholder end -->
