### PR TITLE
doc: update readme with -- typo in commands

### DIFF
--- a/release/README.adoc
+++ b/release/README.adoc
@@ -47,11 +47,11 @@ When it's done, run 'npm run nexus_sync -- --version=3.15.11'
 
 Here are the steps to run to fully release APIM (Releasing 3.15.11, in the following example):
 
-1. `npm run release -- --version=3.15.11`
-2. `npm run package_zip -- --version=3.15.11`:
-3. `npm run docker_rpms -- --version=3.15.11`: You can also provide the `--latest` parameter to flag the image as `latest`.
-4. `npm run changelog -- --version=3.15.11`
-5. `npm run nexus_sync -- --version=3.15.11`
+1. `npm run release \-- --version=3.15.11`
+2. `npm run package_zip \-- --version=3.15.11`
+3. `npm run docker_rpms \-- --version=3.15.11`: You can also provide the `--latest` parameter to flag the image as `latest`.
+4. `npm run changelog \-- --version=3.15.11`
+5. `npm run nexus_sync \-- --version=3.15.11`
 
 == 🧪 Handle pre-version releases
 


### PR DESCRIPTION
## Description

Escape the -- to be able to copy past commands from the readme

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/update-release-readme/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
