### PR TITLE
fix(jupiter): support large body POST with backpressure

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -47,7 +47,7 @@
         <!-- Versions of the plugins for the full distribution -->
         <!-- Management API & Gateway -->
         <gravitee-alert-engine-connectors-ws.version>1.0.0</gravitee-alert-engine-connectors-ws.version>
-        <gravitee-connector-http.version>2.0.6</gravitee-connector-http.version>
+        <gravitee-connector-http.version>2.0.7</gravitee-connector-http.version>
         <gravitee-policy-apikey.version>2.9.0</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>1.5.0</gravitee-policy-assign-attributes.version>
         <gravitee-policy-assign-content.version>1.7.0</gravitee-policy-assign-content.version>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttp2ServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttp2ServerRequest.java
@@ -43,7 +43,7 @@ public class VertxHttp2ServerRequest extends VertxHttpServerRequest {
     public Request customFrameHandler(Handler<HttpFrame> frameHandler) {
         getNativeServerRequest()
             .customFrameHandler(
-                frame -> frameHandler.handle(HttpFrame.create(frame.type(), frame.flags(), Buffer.buffer(frame.payload().getBytes())))
+                frame -> frameHandler.handle(HttpFrame.create(frame.type(), frame.flags(), Buffer.buffer(frame.payload())))
             );
 
         return this;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttp2ServerResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttp2ServerResponse.java
@@ -32,7 +32,7 @@ public class VertxHttp2ServerResponse extends VertxHttpServerResponse {
 
     @Override
     public Response writeCustomFrame(HttpFrame frame) {
-        serverResponse.writeCustomFrame(frame.type(), frame.flags(), io.vertx.core.buffer.Buffer.buffer(frame.payload().getBytes()));
+        serverResponse.writeCustomFrame(frame.type(), frame.flags(), io.vertx.core.buffer.Buffer.buffer(frame.payload().getNativeBuffer()));
 
         return this;
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpServerRequest.java
@@ -184,9 +184,9 @@ public class VertxHttpServerRequest implements Request {
     public Request bodyHandler(Handler<Buffer> bodyHandler) {
         if (!serverRequest.isEnded()) {
             serverRequest.handler(
-                event -> {
-                    bodyHandler.handle(Buffer.buffer(event.getBytes()));
-                    metrics.setRequestContentLength(metrics.getRequestContentLength() + event.length());
+                buffer -> {
+                    bodyHandler.handle(Buffer.buffer(buffer));
+                    metrics.setRequestContentLength(metrics.getRequestContentLength() + buffer.length());
                 }
             );
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpServerResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/VertxHttpServerResponse.java
@@ -103,7 +103,7 @@ public class VertxHttpServerResponse implements Response {
             }
 
             serverRequest.metrics().setResponseContentLength(serverRequest.metrics().getResponseContentLength() + chunk.length());
-            serverResponse.write(io.vertx.core.buffer.Buffer.buffer((ByteBuf) chunk.getNativeBuffer()));
+            serverResponse.write(io.vertx.core.buffer.Buffer.buffer(chunk.getNativeBuffer()));
         }
         return this;
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/ws/VertxWebSocket.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/ws/VertxWebSocket.java
@@ -76,7 +76,7 @@ class VertxWebSocket implements WebSocket {
         if (upgraded) {
             if (frame.type() == io.gravitee.gateway.api.ws.WebSocketFrame.Type.BINARY) {
                 websocket.writeFrame(
-                    io.vertx.core.http.WebSocketFrame.binaryFrame(Buffer.buffer(frame.data().getBytes()), frame.isFinal())
+                    io.vertx.core.http.WebSocketFrame.binaryFrame(Buffer.buffer(frame.data().getNativeBuffer()), frame.isFinal())
                 );
             } else if (frame.type() == io.gravitee.gateway.api.ws.WebSocketFrame.Type.TEXT) {
                 websocket.writeFrame(io.vertx.core.http.WebSocketFrame.textFrame(frame.data().toString(), frame.isFinal()));

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/ws/VertxWebSocketFrame.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/http/vertx/ws/VertxWebSocketFrame.java
@@ -46,7 +46,7 @@ class VertxWebSocketFrame implements WebSocketFrame {
 
     @Override
     public Buffer data() {
-        return Buffer.buffer(frame.binaryData().getBytes());
+        return Buffer.buffer(frame.binaryData());
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/jupiter/http/vertx/AbstractVertxServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/jupiter/http/vertx/AbstractVertxServerRequest.java
@@ -214,4 +214,20 @@ abstract class AbstractVertxServerRequest implements MutableRequest {
     public String host() {
         return this.nativeRequest.host();
     }
+
+    /**
+     * Pauses the current request.
+     * <b>WARN: use with caution</b>
+     */
+    public void pause() {
+        this.nativeRequest.pause();
+    }
+
+    /**
+     * Resumes the current request.
+     * <b>WARN: use with caution</b>
+     */
+    public void resume() {
+        this.nativeRequest.resume();
+    }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/jupiter/http/vertx/VertxHttpServerRequestTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/jupiter/http/vertx/VertxHttpServerRequestTest.java
@@ -435,6 +435,18 @@ class VertxHttpServerRequestTest {
         assertTrue(cut.isWebSocketUpgraded());
     }
 
+    @Test
+    void shouldPause() {
+        cut.pause();
+        verify(httpServerRequest).pause();
+    }
+
+    @Test
+    void shouldResume() {
+        cut.resume();
+        verify(httpServerRequest).resume();
+    }
+
     private void mockWithEmpty() {
         final Flowable<io.vertx.reactivex.core.buffer.Buffer> chunks = Flowable
             .<io.vertx.reactivex.core.buffer.Buffer>empty()

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/jupiter/policy/adapter/context/RequestAdapterTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/jupiter/policy/adapter/context/RequestAdapterTest.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.policy.adapter.context;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.gateway.jupiter.http.vertx.VertxHttpServerRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class RequestAdapterTest {
+
+    @Mock
+    private VertxHttpServerRequest request;
+
+    @Mock
+    private Runnable onResumeHandler;
+
+    @Mock
+    private Handler<Buffer> bodyHandler;
+
+    @Mock
+    private Handler<Void> endHandler;
+
+    private RequestAdapter cut;
+
+    @BeforeEach
+    void init() {
+        cut = new RequestAdapter(request);
+        cut.onResume(onResumeHandler);
+        cut.bodyHandler(bodyHandler);
+        cut.endHandler(endHandler);
+    }
+
+    @Test
+    void shouldCallOnResumeHandlerWhenResumeForTheFirstTime() {
+        cut.resume();
+        verify(onResumeHandler).run();
+    }
+
+    @Test
+    void shouldResumeRequest() {
+        // First resume calls onResume handler, any other resumes the request.
+        for (int i = 0; i < 10; i++) {
+            cut.resume();
+        }
+
+        verify(request, times(9)).resume();
+    }
+
+    @Test
+    void shouldPauseRequest() {
+        for (int i = 0; i < 10; i++) {
+            cut.pause();
+        }
+
+        verify(request, times(10)).pause();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <jetty94.wiremock.version>9.4.44.v20210927</jetty94.wiremock.version>
-        <gravitee-connector-http.version>2.0.5</gravitee-connector-http.version>
+        <gravitee-connector-http.version>2.0.7</gravitee-connector-http.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-137

## Description

Jupiter engine still rely on the V3 http connector thanks to an adapter. That adapter was not handling well pause and resume and the body was fully consumed and kept in memory before being sent to the backend. This was working for tiny body but could cause OOM with large bodies.

## Additional context
To test it, with jupiter engine enabled:

- Declare an api with an endpoint accepting posting large request bodies.
- Generate a 500MB file using the following command: `head -c 524288000 /dev/urandom > payload.txt`
- Try to post the file to your api:  
  - It should not work well before this fix.
  - It should work with the the fix.

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-137-jupiter-backpressure-on-post/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-yolhtvzkaw.chromatic.com)
<!-- Storybook placeholder end -->
