### PR TITLE
ci: fix generated version [skip CI]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1256,7 +1256,7 @@ jobs:
                       git tag ${GRAVITEEIO_VERSION_WITH_QUALIFIER}
 
                       # If we are on master branch, we need to create the support branch
-                      if [ "${CIRCLE_BRANCH}" == "master" ]; then
+                      if [ "${CIRCLE_BRANCH}" = "master" ]; then
                         export MAINTENANCE_GIT_BRANCH="${GRAVITEEIO_VERSION_MAJOR}.${GRAVITEEIO_VERSION_MINOR}.x"
 
                         git checkout -b ${MAINTENANCE_GIT_BRANCH}
@@ -1273,10 +1273,10 @@ jobs:
                         git checkout ${CIRCLE_BRANCH}
                       fi
 
-                      if [ "${CIRCLE_BRANCH}" == "master" ]; then
+                      if [ "${CIRCLE_BRANCH}" = "master" ]; then
                         sed -i "s#<revision>.*</revision>#<revision>${GRAVITEEIO_VERSION_MAJOR}.$((${GRAVITEEIO_VERSION_MINOR}+1)).0</revision>#" pom.xml
                         sed -i "s#<changelist>.*</changelist>#<changelist>-SNAPSHOT</changelist>#" pom.xml
-                      elif [ "${GRAVITEEIO_QUALIFIER}" == ""]; then
+                      elif [ "${GRAVITEEIO_QUALIFIER}" = "" ]; then
                         sed -i "s#<revision>.*</revision>#<revision>${GRAVITEEIO_VERSION_MAJOR}.${GRAVITEEIO_VERSION_MINOR}.$((${GRAVITEEIO_VERSION_PATCH}+1))</revision>#" pom.xml
                         sed -i "s#<changelist>.*</changelist>#<changelist>-SNAPSHOT</changelist>#" pom.xml
                       else
@@ -1341,7 +1341,7 @@ jobs:
                         DOCKER_BUILD_PORTAL_UI_TAG+="      -t graviteeio/apim-portal-ui:${GRAVITEEIO_VERSION_MAJOR}.${GRAVITEEIO_VERSION_MINOR}      -t graviteeio/apim-portal-ui:${GRAVITEEIO_VERSION_MAJOR}.${GRAVITEEIO_VERSION_MINOR}-ee      -t graviteeio/apim-portal-ui:${GRAVITEEIO_VERSION}-ee"
 
                         #  create x, x-ee and latest tags only if it's the latest version and there is no qualifier
-                        if [ "<< parameters.docker_tag_as_latest >>" == "true" ]; then
+                        if [ "<< parameters.docker_tag_as_latest >>" = "true" ]; then
                           DOCKER_BUILD_GATEWAY_TAG+="        -t graviteeio/apim-gateway:${GRAVITEEIO_VERSION_MAJOR}           -t graviteeio/apim-gateway:${GRAVITEEIO_VERSION_MAJOR}-ee           -t graviteeio/apim-gateway:latest"
                           DOCKER_BUILD_MANAGEMENT_API_TAG+=" -t graviteeio/apim-management-api:${GRAVITEEIO_VERSION_MAJOR}    -t graviteeio/apim-management-api:${GRAVITEEIO_VERSION_MAJOR}-ee    -t graviteeio/apim-management-api:latest"
                           DOCKER_BUILD_MANAGEMENT_UI_TAG+="  -t graviteeio/apim-management-ui:${GRAVITEEIO_VERSION_MAJOR}     -t graviteeio/apim-management-ui:${GRAVITEEIO_VERSION_MAJOR}-ee     -t graviteeio/apim-management-ui:latest"
@@ -1360,7 +1360,7 @@ jobs:
                       docker login --username="${DOCKERHUB_BOT_USER_NAME}" -p="${DOCKERHUB_BOT_USER_TOKEN}"
 
                       # Push all tags if not dry-run mode
-                      if [ "<< parameters.dry_run >>" == "false" ]; then                    
+                      if [ "<< parameters.dry_run >>" = "false" ]; then                    
                         docker push --all-tags graviteeio/apim-management-api
                         docker push --all-tags graviteeio/apim-gateway
                         docker push --all-tags graviteeio/apim-management-ui
@@ -1689,7 +1689,7 @@ jobs:
                       cd ${GIT_GRAVITEE_PACKAGES_REPO}/apim/3.x
                       ./build.sh -v << parameters.graviteeio_version >>
 
-                      if [ "<< parameters.dry_run >>" == "false" ]; then
+                      if [ "<< parameters.dry_run >>" = "false" ]; then
                           docker run --rm -v "${GIT_GRAVITEE_PACKAGES_REPO}/apim/3.x:/packages" -e PACKAGECLOUD_TOKEN=${GIO_PACKAGECLOUD_TOKEN} digitalocean/packagecloud push --yes --skip-errors --verbose graviteeio/rpms/el/7 /packages/*.rpm
                       else
                           echo "This is just a DRY RUN, no RPMs will be published"

--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
     </issueManagement>
     <properties>
         <!-- Version properties -->
-        <revision>3.19.0</revision>
-        <sha1>-.1</sha1>
+        <revision>3.19.1</revision>
+        <sha1></sha1>
         <changelist>-SNAPSHOT</changelist>
 
         <!-- Vert.X version is mandatory for vertx-grpc-protoc-plugin in gravitee-apim-gateway-standalone-container -->


### PR DESCRIPTION
## Issue

N/A

## Description

During the last 3.19.0 release, the next version was wrongly generated.
This PR fixes the version and the way this version is determined