### PR TITLE
fix(design-studio): display available resources again

### DIFF
--- a/gravitee-apim-console-webui/package-lock.json
+++ b/gravitee-apim-console-webui/package-lock.json
@@ -11300,7 +11300,7 @@
         "@angular/core": "^12.2.0",
         "@angular/forms": "^12.2.0",
         "@angular/material": "^12.2.0",
-        "@gravitee/ui-components": "^3.28.5",
+        "@gravitee/ui-components": "^3.36.1",
         "lodash": "^4.17.21",
         "rxjs": "^6.0.0"
       }

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/resources/policy-studio-resources.component.html
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/resources/policy-studio-resources.component.html
@@ -18,7 +18,7 @@
 <gv-resources
   *ngIf="!isLoading"
   class="policy-studio-resources"
-  [attr.readonly]="isReadonly"
+  [attr.readonly]="this.isReadonly"
   (:gv-resources:change)="this.onChange($event)"
   [resources]="this.apiDefinition.resources"
   [types]="this.resourceTypes"

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/resources/policy-studio-resources.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/resources/policy-studio-resources.component.ts
@@ -53,7 +53,7 @@ export class PolicyStudioResourcesComponent implements OnInit, OnDestroy {
         takeUntil(this.unsubscribe$),
         tap(([definition, resourceTypes]) => {
           this.apiDefinition = definition;
-          this.isReadonly = definition.origin === 'kubernetes';
+          this.isReadonly = definition.origin === 'kubernetes' ? true : null;
           this.resourceTypes = resourceTypes;
         }),
       )


### PR DESCRIPTION
## Issue

N/A

## Description

An HTML boolean attribute can't be false. It simply exists or not.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-desgin-studio-resources-page/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ynmxznnkjy.chromatic.com)
<!-- Storybook placeholder end -->
