### PR TITLE
Bump `gravitee-policy-cache` to 1.15.2

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -50,7 +50,7 @@
         <gravitee-policy-apikey.version>2.4.0</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>1.5.0</gravitee-policy-assign-attributes.version>
         <gravitee-policy-assign-content.version>1.7.0</gravitee-policy-assign-content.version>
-        <gravitee-policy-cache.version>1.15.1</gravitee-policy-cache.version>
+        <gravitee-policy-cache.version>1.15.2</gravitee-policy-cache.version>
         <gravitee-policy-callout-http.version>1.15.0</gravitee-policy-callout-http.version>
         <gravitee-policy-dynamic-routing.version>1.11.1</gravitee-policy-dynamic-routing.version>
         <gravitee-policy-generate-http-signature.version>1.1.0</gravitee-policy-generate-http-signature.version>


### PR DESCRIPTION

## Issue

https://graviteecommunity.atlassian.net/browse/APIM-77
https://github.com/gravitee-io/issues/issues/8366

## Description

Bump `gravitee-policy-cache` to 1.15.2
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zvznacrxrk.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/apim-77-update-policy-cache/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
