### PR TITLE
Revert part of href fix to ensure retrocompatibility 

### DIFF
--- a/gravitee-apim-console-webui/docker/config/templates/default.conf.tmpl
+++ b/gravitee-apim-console-webui/docker/config/templates/default.conf.tmpl
@@ -24,7 +24,7 @@ server {
     location / {
         try_files $uri $uri/ =404;
         root /usr/share/nginx/html;
-        sub_filter '<base href="/"' '<base href="{{ getenv "CONSOLE_BASE_HREF" "/" }}"';
+        sub_filter '<base href="./"' '<base href="{{ getenv "CONSOLE_BASE_HREF" "./" }}"';
         sub_filter_once on;
     }
 

--- a/gravitee-apim-console-webui/src/index.html
+++ b/gravitee-apim-console-webui/src/index.html
@@ -19,7 +19,7 @@
 <html class="bootstrap">
   <head>
     <meta charset="utf-8" />
-    <base href="/" />
+    <base href="./" />
     <title ng-bind="consoleTitle"></title>
     <meta name="description" content="" />
     <meta name="viewport" content="width=device-width" />


### PR DESCRIPTION
## Issue
https://github.com/gravitee-io/issues/issues/8518

## Description

This commit revert part of b03a8eb705280e5f44d5a58293306d29838e79ee to ensure there is no breaking change in 3.18.x version.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/ensure-retrocompatibility-for-href/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tfvycxbzeg.chromatic.com)
<!-- Storybook placeholder end -->
