### PR TITLE
fix(liquibase): bump liquibase version to latest

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
@@ -33,7 +33,7 @@
     <properties>
         <!-- Dependencies version -->
         <HikariCP.version>5.0.0</HikariCP.version>
-        <liquibase.version>3.10.3</liquibase.version>
+        <liquibase.version>4.17.0</liquibase.version>
         <liquibase-slf4j.version>4.0.0</liquibase-slf4j.version>
         <mariaDB.version>2.5.3</mariaDB.version>
         <mssql-jdbc.version>9.4.1.jre8</mssql-jdbc.version>

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/common/AbstractJdbcRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/common/AbstractJdbcRepositoryConfiguration.java
@@ -209,7 +209,6 @@ public abstract class AbstractJdbcRepositoryConfiguration implements Application
                 new ClassLoaderResourceAccessor(this.getClass().getClassLoader()),
                 new JdbcConnection(conn)
             );
-            liquibase.setIgnoreClasspathPrefix(true);
             liquibase.update((Contexts) null);
         } catch (Exception ex) {
             throw new DatabaseInitializationException("Failed to set up database", ex);

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_19_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_19_0/schema.yml
@@ -2,6 +2,7 @@ databaseChangeLog:
   - changeSet:
       id: 3.19.0
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         # ################
         # Apis v4 Changes
@@ -61,13 +62,11 @@ databaseChangeLog:
               - column:
                   name: definition_version
                   type: nvarchar(64)
-                  beforeColumn: definition
                   constraints:
                     nullable: true
               - column:
                   name: type
                   type: nvarchar(64)
-                  afterColumn: definition
                   constraints:
                     nullable: true
         # ################

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
@@ -179,7 +179,6 @@ public class JdbcTestRepositoryInitializer implements TestRepositoryInitializer 
                 new ClassLoaderResourceAccessor(this.getClass().getClassLoader()),
                 new JdbcConnection(conn)
             );
-            liquibase.setIgnoreClasspathPrefix(true);
             liquibase.update((Contexts) null);
         } catch (final Exception ex) {
             LOGGER.error("Failed to set up database: ", ex);


### PR DESCRIPTION
## Issue

N/A

## Description

- bump liquibase to have the most up to date version and fix this issue https://github.com/liquibase/liquibase/issues/1639
- must adapt 3.19.0 changeset and skip checksum validation
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/bump-liquibase/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cvjhwoonml.chromatic.com)
<!-- Storybook placeholder end -->
