### PR TITLE
feat: improve image upload errors displayed the user

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
@@ -277,7 +277,7 @@ public class ApiResource extends AbstractResource {
             ImageUtils.verify(apiToUpdate.getPicture());
             ImageUtils.verify(apiToUpdate.getBackground());
         } catch (InvalidImageException e) {
-            throw new BadRequestException("Invalid image format");
+            throw new BadRequestException("Invalid image format : " + e.getMessage());
         }
 
         final ApiEntity currentApi = (ApiEntity) responseApi.getEntity();


### PR DESCRIPTION
feat: improve image upload errors displayed the user

Add cause of the invalid image format in the message, as the user can understand the cause of the error. InvalidImageException's messages are user-friendly enough to be displayed in the UI.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/feat-improveimageerrorsmessage/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vtfukpbbhe.chromatic.com)
<!-- Storybook placeholder end -->
