### PR TITLE
exclude owner information when retrieving subscribers in API logs screen

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/analytics/apis.analytics.route.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/apis.analytics.route.ts
@@ -106,7 +106,8 @@ function apisAnalyticsRouterConfig($stateProvider) {
       },
       resolve: {
         plans: ($stateParams: StateParams, ApiService: ApiService) => ApiService.getApiPlans($stateParams.apiId),
-        applications: ($stateParams: StateParams, ApiService: ApiService) => ApiService.getSubscribers($stateParams.apiId),
+        applications: ($stateParams: StateParams, ApiService: ApiService) =>
+          ApiService.getSubscribers($stateParams.apiId, null, null, null, ['owner']),
         tenants: (TenantService: TenantService) => TenantService.list(),
       },
     })


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8567

## Description

When retrieving subscribers for the logs screen, we may have archived applications that were subscribers of the API in the past. And we need them to display properly the logs.
The idea here is to prevent the resource from loading the owner of an archived app, because it simply does not exist.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-archived-application-pb-in-log-screen/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ncztplfixb.chromatic.com)
<!-- Storybook placeholder end -->
