### PR TITLE
chore: add deprecated comments on repository apikey deprecated attributes

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/ApiKey.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/ApiKey.java
@@ -53,19 +53,28 @@ public class ApiKey implements Serializable {
     /**
      * The subscription for which the Api Key is generated
      *
+     * @deprecated
+     * Starting from 3.17 this field is kept for backward compatibility only and subscriptions should be used instead
      */
+    @Deprecated(since = "3.17.0", forRemoval = true)
     private String subscription;
 
     /**
      * The subscribed plan
      *
+     * @deprecated
+     * Starting from 3.17 this field is kept for backward compatibility and plans should be accessed through subscriptions instead
      */
+    @Deprecated(since = "3.17.0", forRemoval = true)
     private String plan;
 
     /**
      * The api on which this api key is used
      *
+     * @deprecated
+     * Starting from 3.17 this field is kept for backward compatibility and apis should be accessed through subscriptions instead
      */
+    @Deprecated(since = "3.17.0", forRemoval = true)
     private String api;
 
     /**

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ApiKeyMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ApiKeyMongo.java
@@ -56,19 +56,28 @@ public class ApiKeyMongo {
     /**
      * The subscription for which the Api Key is generated
      *
+     * @deprecated
+     * Starting from 3.17 this field is kept for backward compatibility only and subscriptions should be used instead
      */
+    @Deprecated(since = "3.17.0", forRemoval = true)
     private String subscription;
 
     /**
      * The subscribed plan
      *
+     * @deprecated
+     * Starting from 3.17 this field is kept for backward compatibility and plans should be accessed through subscriptions instead
      */
+    @Deprecated(since = "3.17.0", forRemoval = true)
     private String plan;
 
     /**
      * The api on which this api key is used
      *
+     * @deprecated
+     * Starting from 3.17 this field is kept for backward compatibility and apis should be accessed through subscriptions instead
      */
+    @Deprecated(since = "3.17.0", forRemoval = true)
     private String api;
 
     /**


### PR DESCRIPTION
chore: add deprecated comments on repository apikey deprecated attributes

Deprecated comments were already present on getter/setters, but not on attributes. So that may be confusing when reading the code, seeing those non-deprecated attributes.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/chore-deprecatedattributes/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ugmywqbgsv.chromatic.com)
<!-- Storybook placeholder end -->
