### PR TITLE
feat: add support for condition at message level

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/MessageConditionSupplier.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/MessageConditionSupplier.java
@@ -13,20 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.gateway.jupiter.core.context;
-
-import io.gravitee.gateway.api.http.HttpHeaders;
-import io.gravitee.gateway.jupiter.api.context.Response;
+package io.gravitee.definition.model;
 
 /**
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * Interface allowing to indicate that the entity can supply a message condition.
+ *
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface MutableResponse extends Response, OnMessagesInterceptor {
+@FunctionalInterface
+public interface MessageConditionSupplier {
     /**
-     * Allows to replace the response headers.
-     *
-     * @param headers the new response headers.
+     * Returns the message condition or <code>null</code> if there is no message condition defined.
+     * @return the message condition or <code>null</code>.
      */
-    void setHeaders(final HttpHeaders headers);
+    String getMessageCondition();
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/flow/step/Step.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/flow/step/Step.java
@@ -57,6 +57,8 @@ public class Step implements Serializable {
 
     private String condition;
 
+    private String messageCondition;
+
     @JsonSetter
     public void setConfiguration(final JsonNode configuration) {
         if (configuration != null) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-buffer/src/main/java/io/gravitee/gateway/buffer/netty/BufferImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-buffer/src/main/java/io/gravitee/gateway/buffer/netty/BufferImpl.java
@@ -72,8 +72,8 @@ public class BufferImpl implements Buffer {
     }
 
     @Override
-    public Buffer appendString(String str, String enc) {
-        return append(str, Charset.forName(Objects.requireNonNull(enc)));
+    public Buffer appendString(String str, String charset) {
+        return append(str, Charset.forName(Objects.requireNonNull(charset)));
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/condition/ExpressionLanguageMessageConditionFilter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/condition/ExpressionLanguageMessageConditionFilter.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.core.condition;
+
+import io.gravitee.definition.model.MessageConditionSupplier;
+import io.gravitee.el.TemplateEngine;
+import io.gravitee.el.exceptions.ExpressionEvaluationException;
+import io.gravitee.el.spel.function.xml.DocumentBuilderFactoryUtils;
+import io.gravitee.gateway.jupiter.api.context.MessageExecutionContext;
+import io.gravitee.gateway.jupiter.api.message.Message;
+import io.reactivex.Maybe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link ConditionFilter} base on an EL expression.
+ *
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ExpressionLanguageMessageConditionFilter<T extends MessageConditionSupplier> implements MessageConditionFilter<T> {
+
+    private static final Logger log = LoggerFactory.getLogger(DocumentBuilderFactoryUtils.class);
+
+    @Override
+    public Maybe<T> filter(MessageExecutionContext ctx, T elt, Message message) {
+        final String condition = elt.getMessageCondition();
+
+        if (condition == null || condition.isEmpty()) {
+            return Maybe.just(elt);
+        }
+
+        return ctx
+            .getTemplateEngine(message)
+            .eval(condition, Boolean.class)
+            .filter(Boolean::booleanValue)
+            .map(aBoolean -> elt)
+            .onErrorComplete(ExpressionEvaluationException.class::isInstance)
+            .doOnError(throwable -> log.warn("Error parsing condition {}", condition, throwable));
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/condition/MessageConditionFilter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/condition/MessageConditionFilter.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.core.condition;
+
+import io.gravitee.definition.model.MessageConditionSupplier;
+import io.gravitee.gateway.jupiter.api.context.MessageExecutionContext;
+import io.gravitee.gateway.jupiter.api.message.Message;
+import io.reactivex.Maybe;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface MessageConditionFilter<T extends MessageConditionSupplier> {
+    /**
+     * Filters the given element by applying a message condition on it.
+     *
+     * @param ctx the current request context.
+     * @param elt the elt to apply the filter on.
+     *
+     * @return a {@link Maybe} containing the filtered element or empty if the element didn't pass the filter step.
+     */
+    Maybe<T> filter(MessageExecutionContext ctx, T elt, Message message);
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/context/MutableRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/context/MutableRequest.java
@@ -16,12 +16,16 @@
 package io.gravitee.gateway.jupiter.core.context;
 
 import io.gravitee.gateway.jupiter.api.context.Request;
+import io.gravitee.gateway.jupiter.api.message.Message;
+import io.reactivex.Completable;
+import io.reactivex.FlowableTransformer;
+import java.util.function.Function;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface MutableRequest extends Request {
+public interface MutableRequest extends Request, OnMessagesInterceptor {
     /**
      * Allow setting context path.
      *

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/context/OnMessagesInterceptor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/context/OnMessagesInterceptor.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.core.context;
+
+import io.gravitee.gateway.jupiter.api.message.Message;
+import io.reactivex.FlowableTransformer;
+import java.util.function.Function;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface OnMessagesInterceptor {
+    /**
+     * Set an interceptor allowing to capture any call to {@link MutableRequest#onMessages(FlowableTransformer)} or {@link MutableResponse#onMessages(FlowableTransformer)}.
+     * The captured {@link FlowableTransformer} will then be provided to the specified function which will be able to provide its own {@link FlowableTransformer}.
+     * <p/>
+     * This can be particularly useful to avoid, replace or compose the transformation set by a policy on the incoming messages.
+     * <p/>
+     * Ex: calculate the message content size before and after a policy is applied on a message.
+     * <p/>
+     * <pre>
+     *      request.setOnMessagesInterceptor(onMessages ->
+     *             messages -> {
+     *                 final AtomicLong initialTotalSize = new AtomicLong(0);
+     *                 final AtomicLong finalTotalSize = new AtomicLong(0);
+     *                 return messages
+     *                     .doOnNext(message -> initialTotalSize.addAndGet(message.content().length()))
+     *                     .compose(onMessages)
+     *                     .doOnNext(message -> finalTotalSize.addAndGet(message.content().length()));
+     *             }
+     *         );
+     * </pre>
+     *
+     * @param interceptor the function taking the {@link FlowableTransformer} provided by the call to {@link MutableRequest#onMessages(FlowableTransformer)} or {@link MutableResponse#onMessages(FlowableTransformer)} and returns another {@link FlowableTransformer} as a replacement.
+     */
+    void setMessagesInterceptor(Function<FlowableTransformer<Message, Message>, FlowableTransformer<Message, Message>> interceptor);
+
+    /**
+     * Unset the <code>onMessages</code> interceptor.
+     * Removing the interceptor has only effect on future calls to {@link MutableRequest#onMessages(FlowableTransformer)} or {@link MutableResponse#onMessages(FlowableTransformer)}.
+     *
+     * <b>WARN: </b> it is the responsibility of the caller to make sure the interceptor is set and unset at the right time to avoid any undesired side effects.
+     */
+    void unsetMessagesInterceptor();
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/jupiter/core/condition/CompositeConditionFilterTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/jupiter/core/condition/CompositeConditionFilterTest.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.jupiter.core.condition;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.definition.model.ConditionSupplier;
 import io.gravitee.gateway.jupiter.api.context.HttpExecutionContext;
 import io.reactivex.Maybe;
 import io.reactivex.observers.TestObserver;
@@ -36,42 +37,42 @@ class CompositeConditionFilterTest {
     protected static final String MOCK_EXCEPTION = "Mock exception";
 
     @Mock
-    private ConditionFilter<Object> evaluator1;
+    private ConditionFilter<ConditionSupplier> evaluator1;
 
     @Mock
-    private ConditionFilter<Object> evaluator2;
+    private ConditionFilter<ConditionSupplier> evaluator2;
 
     @Mock
-    private ConditionFilter<Object> evaluator3;
+    private ConditionFilter<ConditionSupplier> evaluator3;
 
     @Mock
     private HttpExecutionContext ctx;
 
     @Mock
-    private Object conditionSupplier;
+    private ConditionSupplier conditionSupplier;
 
     @Test
     void shouldNotFilterWhenAllEvaluatorsReturnTheValue() {
-        final CompositeConditionFilter<Object> cut = new CompositeConditionFilter<>(evaluator1, evaluator2, evaluator3);
+        final CompositeConditionFilter<ConditionSupplier> cut = new CompositeConditionFilter<>(evaluator1, evaluator2, evaluator3);
 
         mockFilter(evaluator1);
         mockFilter(evaluator2);
         mockFilter(evaluator3);
 
-        final TestObserver<Object> obs = cut.filter(ctx, conditionSupplier).test();
+        final TestObserver<ConditionSupplier> obs = cut.filter(ctx, conditionSupplier).test();
 
         obs.assertResult(conditionSupplier);
     }
 
     @Test
     void shouldFilterWhenOneEvaluatorReturnsEmpty() {
-        final CompositeConditionFilter<Object> cut = new CompositeConditionFilter<>(evaluator1, evaluator2, evaluator3);
+        final CompositeConditionFilter<ConditionSupplier> cut = new CompositeConditionFilter<>(evaluator1, evaluator2, evaluator3);
 
         mockFilter(evaluator1);
         mockFilter(evaluator2);
         mockFilterEmpty(evaluator3);
 
-        final TestObserver<Object> obs = cut.filter(ctx, conditionSupplier).test();
+        final TestObserver<ConditionSupplier> obs = cut.filter(ctx, conditionSupplier).test();
 
         obs.assertResult();
         obs.assertNoValues();
@@ -79,24 +80,24 @@ class CompositeConditionFilterTest {
 
     @Test
     void shouldErrorWhenOneEvaluatorReturnsError() {
-        final CompositeConditionFilter<Object> cut = new CompositeConditionFilter<>(evaluator1, evaluator2, evaluator3);
+        final CompositeConditionFilter<ConditionSupplier> cut = new CompositeConditionFilter<>(evaluator1, evaluator2, evaluator3);
 
         mockFilter(evaluator1);
         mockFilter(evaluator2);
         mockFilterError(evaluator3);
 
-        final TestObserver<Object> obs = cut.filter(ctx, conditionSupplier).test();
+        final TestObserver<ConditionSupplier> obs = cut.filter(ctx, conditionSupplier).test();
 
         obs.assertErrorMessage(MOCK_EXCEPTION);
     }
 
     @Test
     void shouldNotContinueWhenReturnsEmpty() {
-        final CompositeConditionFilter<Object> cut = new CompositeConditionFilter<>(evaluator1, evaluator2, evaluator3);
+        final CompositeConditionFilter<ConditionSupplier> cut = new CompositeConditionFilter<>(evaluator1, evaluator2, evaluator3);
 
         mockFilterEmpty(evaluator1);
 
-        final TestObserver<Object> obs = cut.filter(ctx, conditionSupplier).test();
+        final TestObserver<ConditionSupplier> obs = cut.filter(ctx, conditionSupplier).test();
 
         obs.assertResult();
         obs.assertNoValues();
@@ -105,15 +106,15 @@ class CompositeConditionFilterTest {
         verifyNoInteractions(evaluator3);
     }
 
-    private void mockFilter(ConditionFilter<Object> filter) {
+    private void mockFilter(ConditionFilter<ConditionSupplier> filter) {
         when(filter.filter(ctx, conditionSupplier)).thenAnswer(i -> Maybe.just(i.getArgument(1)));
     }
 
-    private void mockFilterEmpty(ConditionFilter<Object> filter) {
+    private void mockFilterEmpty(ConditionFilter<ConditionSupplier> filter) {
         when(filter.filter(ctx, conditionSupplier)).thenAnswer(i -> Maybe.empty());
     }
 
-    private void mockFilterError(ConditionFilter<Object> filter) {
+    private void mockFilterError(ConditionFilter<ConditionSupplier> filter) {
         when(filter.filter(ctx, conditionSupplier)).thenAnswer(i -> Maybe.error(new RuntimeException(MOCK_EXCEPTION)));
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/jupiter/core/condition/ExpressionLanguageMessageConditionFilterTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/jupiter/core/condition/ExpressionLanguageMessageConditionFilterTest.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.core.condition;
+
+import static io.gravitee.gateway.jupiter.core.condition.CompositeConditionFilterTest.MOCK_EXCEPTION;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.definition.model.MessageConditionSupplier;
+import io.gravitee.el.TemplateEngine;
+import io.gravitee.el.exceptions.ExpressionEvaluationException;
+import io.gravitee.gateway.jupiter.api.context.MessageExecutionContext;
+import io.gravitee.gateway.jupiter.api.message.DefaultMessage;
+import io.gravitee.gateway.jupiter.api.message.Message;
+import io.reactivex.Maybe;
+import io.reactivex.observers.TestObserver;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class ExpressionLanguageMessageConditionFilterTest {
+
+    private static final String EXPRESSION = "test";
+    private static final Message MESSAGE = new DefaultMessage("test");
+
+    final ExpressionLanguageMessageConditionFilter<MessageConditionSupplier> cut = new ExpressionLanguageMessageConditionFilter<>();
+
+    @Mock
+    private MessageExecutionContext ctx;
+
+    @Mock
+    private TemplateEngine templateEngine;
+
+    @Test
+    void shouldNotFilterWhenConditionEvaluatedToTrue() {
+        final MessageConditionSupplier conditionSupplier = () -> EXPRESSION;
+        when(ctx.getTemplateEngine(MESSAGE)).thenReturn(templateEngine);
+        when(templateEngine.eval(EXPRESSION, Boolean.class)).thenReturn(Maybe.just(true));
+
+        final TestObserver<MessageConditionSupplier> obs = cut.filter(ctx, conditionSupplier, MESSAGE).test();
+
+        obs.assertResult(conditionSupplier);
+    }
+
+    @Test
+    void shouldNotFilterWhenEmptyCondition() {
+        final MessageConditionSupplier conditionSupplier = () -> "";
+
+        final TestObserver<MessageConditionSupplier> obs = cut.filter(ctx, conditionSupplier, MESSAGE).test();
+
+        obs.assertResult(conditionSupplier);
+    }
+
+    @Test
+    void shouldNotFilterWhenNullCondition() {
+        final MessageConditionSupplier conditionSupplier = () -> null;
+        final TestObserver<MessageConditionSupplier> obs = cut.filter(ctx, conditionSupplier, MESSAGE).test();
+
+        obs.assertResult(conditionSupplier);
+    }
+
+    @Test
+    void shouldFilterWhenConditionEvaluatedToFalse() {
+        final MessageConditionSupplier conditionSupplier = () -> EXPRESSION;
+        when(ctx.getTemplateEngine(MESSAGE)).thenReturn(templateEngine);
+        when(templateEngine.eval(EXPRESSION, Boolean.class)).thenReturn(Maybe.just(false));
+
+        final TestObserver<MessageConditionSupplier> obs = cut.filter(ctx, conditionSupplier, MESSAGE).test();
+
+        obs.assertResult();
+        obs.assertNoValues();
+    }
+
+    @Test
+    void shouldFilterWhenExpressionEvaluationException() {
+        final MessageConditionSupplier conditionSupplier = () -> EXPRESSION;
+        when(ctx.getTemplateEngine(MESSAGE)).thenReturn(templateEngine);
+        when(templateEngine.eval(EXPRESSION, Boolean.class)).thenReturn(Maybe.error(new ExpressionEvaluationException(EXPRESSION)));
+
+        cut.filter(ctx, conditionSupplier, MESSAGE).test().assertResult();
+    }
+
+    @Test
+    void shouldThrowErrorWhenErrorOccured() {
+        final MessageConditionSupplier conditionSupplier = () -> EXPRESSION;
+        when(ctx.getTemplateEngine(MESSAGE)).thenReturn(templateEngine);
+        when(templateEngine.eval(EXPRESSION, Boolean.class)).thenReturn(Maybe.error(new RuntimeException(MOCK_EXCEPTION)));
+
+        cut.filter(ctx, conditionSupplier, MESSAGE).test().assertFailure(RuntimeException.class);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
@@ -32,6 +32,7 @@ import io.gravitee.gateway.handlers.api.services.ApiKeyService;
 import io.gravitee.gateway.handlers.api.services.SubscriptionService;
 import io.gravitee.gateway.jupiter.core.condition.CompositeConditionFilter;
 import io.gravitee.gateway.jupiter.core.condition.ExpressionLanguageConditionFilter;
+import io.gravitee.gateway.jupiter.core.condition.ExpressionLanguageMessageConditionFilter;
 import io.gravitee.gateway.jupiter.flow.condition.evaluation.HttpMethodConditionFilter;
 import io.gravitee.gateway.jupiter.flow.condition.evaluation.PathBasedConditionFilter;
 import io.gravitee.gateway.jupiter.handlers.api.processor.ApiProcessorChainFactory;
@@ -119,7 +120,11 @@ public class ApiHandlerConfiguration {
 
     @Bean
     public PolicyFactory policyFactory(final PolicyPluginFactory policyPluginFactory) {
-        return new DefaultPolicyFactory(policyPluginFactory, new ExpressionLanguageConditionFilter<>());
+        return new DefaultPolicyFactory(
+            policyPluginFactory,
+            new ExpressionLanguageConditionFilter<>(),
+            new ExpressionLanguageMessageConditionFilter<>()
+        );
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/jupiter/http/vertx/MessageFlow.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/jupiter/http/vertx/MessageFlow.java
@@ -16,15 +16,17 @@
 package io.gravitee.gateway.jupiter.http.vertx;
 
 import io.gravitee.gateway.jupiter.api.message.Message;
-import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.FlowableTransformer;
+import java.util.function.Function;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
 public class MessageFlow {
+
+    private Function<FlowableTransformer<Message, Message>, FlowableTransformer<Message, Message>> onMessagesInterceptor;
 
     protected Flowable<Message> messages = Flowable.empty();
 
@@ -37,6 +39,20 @@ public class MessageFlow {
     }
 
     public void onMessages(final FlowableTransformer<Message, Message> onMessages) {
-        this.messages = this.messages.compose(onMessages);
+        if (onMessagesInterceptor != null) {
+            this.messages = this.messages.compose(onMessagesInterceptor.apply(onMessages));
+        } else {
+            this.messages = this.messages.compose(onMessages);
+        }
+    }
+
+    public void setOnMessagesInterceptor(
+        Function<FlowableTransformer<Message, Message>, FlowableTransformer<Message, Message>> interceptor
+    ) {
+        this.onMessagesInterceptor = interceptor;
+    }
+
+    public void unsetOnMessagesInterceptor() {
+        this.onMessagesInterceptor = null;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/jupiter/http/vertx/VertxHttpServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/jupiter/http/vertx/VertxHttpServerRequest.java
@@ -23,6 +23,7 @@ import io.gravitee.gateway.jupiter.api.ws.WebSocket;
 import io.gravitee.gateway.jupiter.http.vertx.ws.VertxWebSocket;
 import io.reactivex.*;
 import io.vertx.reactivex.core.http.HttpServerRequest;
+import java.util.function.Function;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -32,8 +33,8 @@ public class VertxHttpServerRequest extends AbstractVertxServerRequest {
 
     private final BufferFlow bufferFlow;
     private MessageFlow messageFlow;
-    protected Boolean isWebSocket = null;
-    protected WebSocket webSocket;
+    private Boolean isWebSocket = null;
+    private WebSocket webSocket;
 
     public VertxHttpServerRequest(final HttpServerRequest nativeRequest, IdGenerator idGenerator) {
         super(nativeRequest, idGenerator);
@@ -132,6 +133,16 @@ public class VertxHttpServerRequest extends AbstractVertxServerRequest {
     @Override
     public Completable onMessages(final FlowableTransformer<Message, Message> onMessages) {
         return Completable.fromRunnable(() -> getMessageFlow().onMessages(onMessages));
+    }
+
+    @Override
+    public void setMessagesInterceptor(Function<FlowableTransformer<Message, Message>, FlowableTransformer<Message, Message>> interceptor) {
+        messageFlow.setOnMessagesInterceptor(interceptor);
+    }
+
+    @Override
+    public void unsetMessagesInterceptor() {
+        messageFlow.unsetOnMessagesInterceptor();
     }
 
     private MessageFlow getMessageFlow() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/jupiter/http/vertx/VertxHttpServerResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/jupiter/http/vertx/VertxHttpServerResponse.java
@@ -17,14 +17,9 @@ package io.gravitee.gateway.jupiter.http.vertx;
 
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.jupiter.api.message.Message;
-import io.gravitee.gateway.jupiter.api.ws.WebSocket;
-import io.reactivex.Completable;
-import io.reactivex.Flowable;
-import io.reactivex.FlowableTransformer;
-import io.reactivex.Maybe;
-import io.reactivex.MaybeTransformer;
-import io.reactivex.Single;
+import io.reactivex.*;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import org.reactivestreams.Subscription;
 
 /**
@@ -129,6 +124,16 @@ public class VertxHttpServerResponse extends AbstractVertxServerResponse {
     @Override
     public Completable onMessages(final FlowableTransformer<Message, Message> onMessages) {
         return Completable.fromRunnable(() -> getMessageFlow().onMessages(onMessages));
+    }
+
+    @Override
+    public void setMessagesInterceptor(Function<FlowableTransformer<Message, Message>, FlowableTransformer<Message, Message>> interceptor) {
+        messageFlow.setOnMessagesInterceptor(interceptor);
+    }
+
+    @Override
+    public void unsetMessagesInterceptor() {
+        messageFlow.unsetOnMessagesInterceptor();
     }
 
     private MessageFlow getMessageFlow() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/jupiter/http/vertx/MessageFlowTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/jupiter/http/vertx/MessageFlowTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.http.vertx;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.jupiter.api.message.DefaultMessage;
+import io.gravitee.gateway.jupiter.api.message.Message;
+import io.reactivex.Flowable;
+import io.reactivex.FlowableTransformer;
+import io.reactivex.subscribers.TestSubscriber;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class MessageFlowTest {
+
+    @Test
+    void shouldApplyMessageInterceptor() {
+        final MessageFlow cut = new MessageFlow();
+        final Function<FlowableTransformer<Message, Message>, FlowableTransformer<Message, Message>> interceptor = onMessages ->
+            upstream -> upstream.doOnNext(message -> message.attribute("intercepted", true)).compose(onMessages);
+
+        cut.messages(Flowable.just(new DefaultMessage("test")));
+        cut.setOnMessagesInterceptor(interceptor);
+
+        cut.onMessages(upstream -> upstream.map(message -> message.content(Buffer.buffer("Transformed test"))));
+
+        final TestSubscriber<Message> obs = cut.messages().test();
+
+        obs.assertComplete();
+        obs.assertValue(message -> message.<Boolean>attribute("intercepted") && message.content().toString().equals("Transformed test"));
+    }
+
+    @Test
+    void shouldApplyOnMessagesWhenNoInterceptor() {
+        final MessageFlow cut = new MessageFlow();
+
+        cut.messages(Flowable.just(new DefaultMessage("test")));
+        cut.onMessages(upstream -> upstream.map(message -> message.content(Buffer.buffer("Transformed test"))));
+
+        final TestSubscriber<Message> obs = cut.messages().test();
+
+        obs.assertComplete();
+        obs.assertValue(message -> message.content().toString().equals("Transformed test"));
+    }
+
+    @Test
+    void shouldUnsetOnMessagesInterceptor() {
+        final MessageFlow cut = new MessageFlow();
+        final Function<FlowableTransformer<Message, Message>, FlowableTransformer<Message, Message>> interceptor = onMessages ->
+            upstream -> upstream.doOnNext(message -> message.attribute("intercepted", true)).compose(onMessages);
+
+        cut.messages(Flowable.just(new DefaultMessage("test")));
+        cut.setOnMessagesInterceptor(interceptor);
+        cut.unsetOnMessagesInterceptor();
+        cut.onMessages(upstream -> upstream.map(message -> message.content(Buffer.buffer("Transformed test"))));
+
+        final TestSubscriber<Message> obs = cut.messages().test();
+
+        obs.assertComplete();
+        obs.assertValue(message -> message.attribute("intercepted") == null && message.content().toString().equals("Transformed test"));
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/jupiter/http/vertx/VertxHttpServerRequestTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/jupiter/http/vertx/VertxHttpServerRequestTest.java
@@ -20,9 +20,11 @@ import static org.mockito.Mockito.*;
 
 import io.gravitee.common.http.IdGenerator;
 import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.jupiter.api.message.Message;
 import io.gravitee.gateway.jupiter.api.ws.WebSocket;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
+import io.reactivex.FlowableTransformer;
 import io.reactivex.Maybe;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.subscribers.TestSubscriber;
@@ -31,6 +33,7 @@ import io.vertx.core.http.HttpVersion;
 import io.vertx.reactivex.core.http.HttpHeaders;
 import io.vertx.reactivex.core.http.HttpServerRequest;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -445,6 +448,26 @@ class VertxHttpServerRequestTest {
     void shouldResume() {
         cut.resume();
         verify(httpServerRequest).resume();
+    }
+
+    @Test
+    void shouldSetOnMessagesInterceptor() {
+        final MessageFlow messageFlow = mock(MessageFlow.class);
+        ReflectionTestUtils.setField(cut, "messageFlow", messageFlow);
+        final Function<FlowableTransformer<Message, Message>, FlowableTransformer<Message, Message>> interceptor = mock(Function.class);
+        cut.setMessagesInterceptor(interceptor);
+
+        verify(messageFlow).setOnMessagesInterceptor(interceptor);
+    }
+
+    @Test
+    void shouldUnsetOnMessagesInterceptor() {
+        final MessageFlow messageFlow = mock(MessageFlow.class);
+        ReflectionTestUtils.setField(cut, "messageFlow", messageFlow);
+
+        cut.unsetMessagesInterceptor();
+
+        verify(messageFlow).unsetOnMessagesInterceptor();
     }
 
     private void mockWithEmpty() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/jupiter/http/vertx/VertxHttpServerResponseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/jupiter/http/vertx/VertxHttpServerResponseTest.java
@@ -16,23 +16,23 @@
 package io.gravitee.gateway.jupiter.http.vertx;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import io.gravitee.gateway.api.buffer.Buffer;
+import io.gravitee.gateway.jupiter.api.message.Message;
 import io.gravitee.reporter.api.http.Metrics;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
+import io.reactivex.FlowableTransformer;
 import io.reactivex.Maybe;
 import io.reactivex.observers.TestObserver;
 import io.reactivex.subscribers.TestSubscriber;
 import io.vertx.reactivex.core.http.HttpHeaders;
 import io.vertx.reactivex.core.http.HttpServerRequest;
 import io.vertx.reactivex.core.http.HttpServerResponse;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -377,6 +377,26 @@ class VertxHttpServerResponseTest {
         obs.assertComplete();
         verify(httpServerResponse, times(0)).rxSend(any(Flowable.class));
         verify(httpServerResponse, times(0)).rxEnd();
+    }
+
+    @Test
+    void shouldSetOnMessagesInterceptor() {
+        final MessageFlow messageFlow = mock(MessageFlow.class);
+        ReflectionTestUtils.setField(cut, "messageFlow", messageFlow);
+        final Function<FlowableTransformer<Message, Message>, FlowableTransformer<Message, Message>> interceptor = mock(Function.class);
+        cut.setMessagesInterceptor(interceptor);
+
+        verify(messageFlow).setOnMessagesInterceptor(interceptor);
+    }
+
+    @Test
+    void shouldUnsetOnMessagesInterceptor() {
+        final MessageFlow messageFlow = mock(MessageFlow.class);
+        ReflectionTestUtils.setField(cut, "messageFlow", messageFlow);
+
+        cut.unsetMessagesInterceptor();
+
+        verify(messageFlow).unsetOnMessagesInterceptor();
     }
 
     private void mockWithEmpty() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/jupiter/policy/ConditionalPolicy.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/jupiter/policy/ConditionalPolicy.java
@@ -16,33 +16,57 @@
 package io.gravitee.gateway.jupiter.policy;
 
 import io.gravitee.definition.model.ConditionSupplier;
+import io.gravitee.definition.model.MessageConditionSupplier;
 import io.gravitee.gateway.jupiter.api.context.GenericExecutionContext;
 import io.gravitee.gateway.jupiter.api.context.HttpExecutionContext;
 import io.gravitee.gateway.jupiter.api.context.MessageExecutionContext;
 import io.gravitee.gateway.jupiter.api.message.Message;
 import io.gravitee.gateway.jupiter.api.policy.Policy;
 import io.gravitee.gateway.jupiter.core.condition.ConditionFilter;
+import io.gravitee.gateway.jupiter.core.condition.MessageConditionFilter;
+import io.gravitee.gateway.jupiter.core.context.MutableExecutionContext;
+import io.gravitee.gateway.jupiter.core.context.MutableRequest;
+import io.gravitee.gateway.jupiter.core.context.MutableResponse;
+import io.gravitee.gateway.jupiter.core.context.OnMessagesInterceptor;
 import io.reactivex.Completable;
-import io.reactivex.Flowable;
-import io.reactivex.Maybe;
+import io.reactivex.FlowableTransformer;
+import io.reactivex.Single;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class ConditionalPolicy implements Policy, ConditionSupplier {
+public class ConditionalPolicy implements Policy, ConditionSupplier, MessageConditionSupplier {
 
     public static final Logger LOGGER = LoggerFactory.getLogger(ConditionalPolicy.class);
+    protected static final String ATTR_SKIP_MESSAGE_POLICY = "skipMessagePolicy";
 
     protected final Policy policy;
     protected final String condition;
+    protected final String messageCondition;
     private final ConditionFilter<ConditionalPolicy> conditionFilter;
+    private final MessageConditionFilter<ConditionalPolicy> messageConditionFilter;
 
-    public ConditionalPolicy(Policy policy, String condition, ConditionFilter<ConditionalPolicy> conditionFilter) {
+    private final boolean conditionDefined;
+    private final boolean messageConditionDefined;
+
+    public ConditionalPolicy(
+        Policy policy,
+        String condition,
+        String messageCondition,
+        ConditionFilter<ConditionalPolicy> conditionFilter,
+        MessageConditionFilter<ConditionalPolicy> messageConditionFilter
+    ) {
         this.policy = policy;
         this.condition = condition;
+        this.messageCondition = messageCondition;
         this.conditionFilter = conditionFilter;
+        this.messageConditionFilter = messageConditionFilter;
+
+        this.conditionDefined = condition != null && !condition.isBlank();
+        this.messageConditionDefined = messageCondition != null && !messageCondition.isBlank();
     }
 
     @Override
@@ -62,12 +86,16 @@ public class ConditionalPolicy implements Policy, ConditionSupplier {
 
     @Override
     public Completable onMessageRequest(final MessageExecutionContext ctx) {
-        return onCondition(ctx, policy.onMessageRequest(ctx));
+        final MutableRequest request = ((MutableExecutionContext) ctx).request();
+
+        return onCondition(ctx, onMessagesCondition(ctx, request, policy.onMessageRequest(ctx)));
     }
 
     @Override
     public Completable onMessageResponse(final MessageExecutionContext ctx) {
-        return onCondition(ctx, policy.onMessageResponse(ctx));
+        final MutableResponse response = ((MutableExecutionContext) ctx).response();
+
+        return onCondition(ctx, onMessagesCondition(ctx, response, policy.onMessageResponse(ctx)));
     }
 
     @Override
@@ -75,15 +103,57 @@ public class ConditionalPolicy implements Policy, ConditionSupplier {
         return condition;
     }
 
+    @Override
+    public String getMessageCondition() {
+        return messageCondition;
+    }
+
     private Completable onCondition(GenericExecutionContext ctx, Completable toExecute) {
+        if (!conditionDefined) {
+            return toExecute;
+        }
+
         return conditionFilter.filter(ctx, this).flatMapCompletable(conditionalPolicy -> toExecute);
     }
 
-    private Maybe<Message> onCondition(GenericExecutionContext ctx, Maybe<Message> toExecute) {
-        return conditionFilter.filter(ctx, this).flatMap(conditionalPolicy -> toExecute);
+    private Completable onMessagesCondition(MessageExecutionContext ctx, OnMessagesInterceptor interceptor, Completable toExecute) {
+        if (!messageConditionDefined) {
+            return toExecute;
+        }
+
+        return toExecute
+            .doFinally(interceptor::unsetMessagesInterceptor)
+            .doOnSubscribe(disposable -> interceptor.setMessagesInterceptor(onMessages -> messagesInterceptor(ctx, onMessages)));
     }
 
-    private Flowable<Message> onCondition(GenericExecutionContext ctx, Flowable<Message> toExecute) {
-        return conditionFilter.filter(ctx, this).flatMapPublisher(conditionalPolicy -> toExecute);
+    private Single<Message> onMessageCondition(MessageExecutionContext ctx, Message message) {
+        return messageConditionFilter
+            .filter(ctx, this, message)
+            .isEmpty()
+            .map(
+                skipMessagePolicy -> {
+                    message.attribute(ATTR_SKIP_MESSAGE_POLICY, skipMessagePolicy);
+                    return message;
+                }
+            );
+    }
+
+    private FlowableTransformer<Message, Message> messagesInterceptor(
+        MessageExecutionContext ctx,
+        FlowableTransformer<Message, Message> onMessages
+    ) {
+        return upstream ->
+            upstream
+                .flatMapSingle(message -> onMessageCondition(ctx, message))
+                .groupBy(message -> message.attribute(ATTR_SKIP_MESSAGE_POLICY))
+                .flatMap(
+                    messages -> {
+                        final boolean skipPolicy = Boolean.TRUE.equals(messages.getKey());
+                        if (skipPolicy) {
+                            return messages;
+                        }
+                        return messages.compose(onMessages);
+                    }
+                );
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/jupiter/policy/DefaultPolicyFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/jupiter/policy/DefaultPolicyFactory.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.jupiter.policy;
 import io.gravitee.gateway.jupiter.api.ExecutionPhase;
 import io.gravitee.gateway.jupiter.api.policy.Policy;
 import io.gravitee.gateway.jupiter.core.condition.ExpressionLanguageConditionFilter;
+import io.gravitee.gateway.jupiter.core.condition.ExpressionLanguageMessageConditionFilter;
 import io.gravitee.gateway.jupiter.policy.adapter.policy.PolicyAdapter;
 import io.gravitee.gateway.policy.PolicyManifest;
 import io.gravitee.gateway.policy.PolicyMetadata;
@@ -38,13 +39,16 @@ public class DefaultPolicyFactory implements PolicyFactory {
     private final PolicyPluginFactory policyPluginFactory;
     private final io.gravitee.gateway.policy.PolicyFactory v3PolicyFactory;
     private final ExpressionLanguageConditionFilter<ConditionalPolicy> filter;
+    private final ExpressionLanguageMessageConditionFilter<ConditionalPolicy> messageFilter;
 
     public DefaultPolicyFactory(
         final PolicyPluginFactory policyPluginFactory,
-        final ExpressionLanguageConditionFilter<ConditionalPolicy> filter
+        final ExpressionLanguageConditionFilter<ConditionalPolicy> filter,
+        final ExpressionLanguageMessageConditionFilter<ConditionalPolicy> messageFilter
     ) {
         this.policyPluginFactory = policyPluginFactory;
         this.filter = filter;
+        this.messageFilter = messageFilter;
         // V3 policy factory doesn't need condition evaluator anymore as condition is directly handled by jupiter.
         this.v3PolicyFactory = new io.gravitee.gateway.policy.impl.PolicyFactoryImpl(policyPluginFactory);
     }
@@ -57,7 +61,13 @@ public class DefaultPolicyFactory implements PolicyFactory {
         final PolicyMetadata policyMetadata
     ) {
         return policies.computeIfAbsent(
-            generateKey(executionPhase, policyManifest, policyConfiguration, policyMetadata.getCondition()),
+            generateKey(
+                executionPhase,
+                policyManifest,
+                policyConfiguration,
+                policyMetadata.getCondition(),
+                policyMetadata.getMessageCondition()
+            ),
             k -> createPolicy(executionPhase, policyManifest, policyConfiguration, policyMetadata)
         );
     }
@@ -91,8 +101,11 @@ public class DefaultPolicyFactory implements PolicyFactory {
 
         if (policy != null) {
             final String condition = policyMetadata.getCondition();
-            if (condition != null && !condition.isBlank()) {
-                policy = new ConditionalPolicy(policy, condition, filter);
+            final String messageCondition = policyMetadata.getMessageCondition();
+
+            // Avoid creating a conditional policy if no condition or message condition is defined.
+            if (isNotBlank(condition) || isNotBlank(messageCondition)) {
+                policy = new ConditionalPolicy(policy, condition, messageCondition, filter, messageFilter);
             }
         }
 
@@ -108,7 +121,8 @@ public class DefaultPolicyFactory implements PolicyFactory {
         final ExecutionPhase executionPhase,
         final PolicyManifest policyManifest,
         final PolicyConfiguration policyConfiguration,
-        final String condition
+        final String condition,
+        final String messageCondition
     ) {
         return (
             Objects.hashCode(executionPhase) +
@@ -117,7 +131,13 @@ public class DefaultPolicyFactory implements PolicyFactory {
             "-" +
             Objects.hashCode(policyConfiguration) +
             "-" +
-            Objects.hashCode(condition)
+            Objects.hashCode(condition) +
+            "-" +
+            Objects.hashCode(messageCondition)
         );
+    }
+
+    private boolean isNotBlank(String s) {
+        return s != null && !s.isBlank();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/jupiter/v4/policy/DefaultPolicyChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/jupiter/v4/policy/DefaultPolicyChainFactory.java
@@ -98,7 +98,12 @@ public class DefaultPolicyChainFactory implements PolicyChainFactory {
     }
 
     private PolicyMetadata buildPolicyMetadata(Step step) {
-        final PolicyMetadata policyMetadata = new PolicyMetadata(step.getPolicy(), step.getConfiguration(), step.getCondition());
+        final PolicyMetadata policyMetadata = new PolicyMetadata(
+            step.getPolicy(),
+            step.getConfiguration(),
+            step.getCondition(),
+            step.getMessageCondition()
+        );
         policyMetadata.metadata().put(PolicyMetadata.MetadataKeys.EXECUTION_MODE, ExecutionMode.JUPITER);
 
         return policyMetadata;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/PolicyMetadata.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/policy/PolicyMetadata.java
@@ -32,19 +32,22 @@ public class PolicyMetadata {
     private final String name;
     private final String configuration;
     private final String condition;
+    private final String messageCondition;
     private final Map<MetadataKeys, Object> metadata;
 
     public PolicyMetadata(String name, String configuration) {
-        this.name = name;
-        this.configuration = configuration;
-        this.condition = null;
-        this.metadata = new EnumMap<>(MetadataKeys.class);
+        this(name, configuration, null);
     }
 
     public PolicyMetadata(String name, String configuration, String condition) {
+        this(name, configuration, condition, null);
+    }
+
+    public PolicyMetadata(String name, String configuration, String condition, String messageCondition) {
         this.name = name;
         this.configuration = configuration;
         this.condition = condition;
+        this.messageCondition = messageCondition;
         this.metadata = new EnumMap<>(MetadataKeys.class);
     }
 
@@ -58,6 +61,10 @@ public class PolicyMetadata {
 
     public String getCondition() {
         return condition;
+    }
+
+    public String getMessageCondition() {
+        return messageCondition;
     }
 
     public Map<MetadataKeys, Object> metadata() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/jupiter/policy/ConditionalPolicyTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/jupiter/policy/ConditionalPolicyTest.java
@@ -1,0 +1,338 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.policy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.gateway.jupiter.api.context.ExecutionContext;
+import io.gravitee.gateway.jupiter.api.context.Request;
+import io.gravitee.gateway.jupiter.api.context.Response;
+import io.gravitee.gateway.jupiter.api.message.DefaultMessage;
+import io.gravitee.gateway.jupiter.api.message.Message;
+import io.gravitee.gateway.jupiter.api.policy.Policy;
+import io.gravitee.gateway.jupiter.core.condition.ConditionFilter;
+import io.gravitee.gateway.jupiter.core.condition.MessageConditionFilter;
+import io.gravitee.gateway.jupiter.core.context.MutableExecutionContext;
+import io.gravitee.gateway.jupiter.core.context.MutableRequest;
+import io.gravitee.gateway.jupiter.core.context.MutableResponse;
+import io.reactivex.*;
+import io.reactivex.subscribers.TestSubscriber;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class ConditionalPolicyTest {
+
+    protected static final String CONDITION = "{#context.attributes != null}";
+    protected static final String MESSAGE_CONDITION = "{#message.content != null}";
+    protected static final String MESSAGE_CONTENT = "test";
+    protected static final String TRANSFORMED_MESSAGE_CONTENT = "Transformed test";
+    protected static final Flowable<Message> MESSAGES = Flowable.just(new DefaultMessage(MESSAGE_CONTENT));
+    protected static final FlowableTransformer<Message, Message> ON_MESSAGES = upstream ->
+        upstream.map(message -> new DefaultMessage(TRANSFORMED_MESSAGE_CONTENT));
+    protected static final String POLICY_ID = "policyId";
+
+    @Mock
+    private Policy policy;
+
+    @Mock
+    private ConditionFilter<ConditionalPolicy> conditionFilter;
+
+    @Mock
+    private MessageConditionFilter<ConditionalPolicy> messageConditionFilter;
+
+    @Mock(extraInterfaces = MutableExecutionContext.class)
+    private ExecutionContext ctx;
+
+    @Mock(extraInterfaces = MutableRequest.class)
+    private Request request;
+
+    @Mock(extraInterfaces = MutableResponse.class)
+    private Response response;
+
+    @Spy
+    private Completable spyCompletable = Completable.complete();
+
+    @BeforeEach
+    void init() {
+        lenient().when(policy.onRequest(ctx)).thenReturn(spyCompletable);
+        lenient().when(policy.onMessageRequest(ctx)).thenReturn(spyCompletable);
+        lenient().when(policy.onResponse(ctx)).thenReturn(spyCompletable);
+        lenient().when(policy.onMessageResponse(ctx)).thenReturn(spyCompletable);
+
+        lenient().when(ctx.request()).thenReturn(request);
+        lenient().when(ctx.response()).thenReturn(response);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldNotExecuteConditionOnRequestWhenNoCondition(String condition) {
+        final ConditionalPolicy cut = new ConditionalPolicy(policy, condition, null, conditionFilter, messageConditionFilter);
+
+        cut.onRequest(ctx).test().assertComplete();
+
+        verify(policy).onRequest(ctx);
+        verify(spyCompletable).subscribe(any(CompletableObserver.class));
+        verifyNoMoreInteractions(policy);
+        verifyNoInteractions(conditionFilter);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldNotExecuteConditionOnResponseWhenNoCondition(String condition) {
+        final ConditionalPolicy cut = new ConditionalPolicy(policy, condition, null, conditionFilter, messageConditionFilter);
+
+        cut.onResponse(ctx).test().assertComplete();
+
+        verify(policy).onResponse(ctx);
+        verify(spyCompletable).subscribe(any(CompletableObserver.class));
+        verifyNoMoreInteractions(policy);
+        verifyNoInteractions(conditionFilter);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldExecuteConditionOnMessageRequestWhenNoCondition(String condition) {
+        final ConditionalPolicy cut = new ConditionalPolicy(policy, condition, null, conditionFilter, messageConditionFilter);
+
+        cut.onMessageRequest(ctx).test().assertComplete();
+
+        verify(policy).onMessageRequest(ctx);
+        verify(spyCompletable).subscribe(any(CompletableObserver.class));
+        verifyNoMoreInteractions(policy);
+        verifyNoInteractions(conditionFilter);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldExecuteConditionOnMessageResponseWhenNoCondition(String condition) {
+        final ConditionalPolicy cut = new ConditionalPolicy(policy, condition, null, conditionFilter, messageConditionFilter);
+
+        cut.onMessageResponse(ctx).test().assertComplete();
+
+        verify(policy).onMessageResponse(ctx);
+        verify(spyCompletable).subscribe(any(CompletableObserver.class));
+        verifyNoMoreInteractions(policy);
+        verifyNoInteractions(conditionFilter);
+    }
+
+    @Test
+    void shouldExecuteConditionAndPolicyOnRequest() {
+        final ConditionalPolicy cut = new ConditionalPolicy(policy, CONDITION, null, conditionFilter, messageConditionFilter);
+
+        when(conditionFilter.filter(ctx, cut)).thenReturn(Maybe.just(cut));
+
+        cut.onRequest(ctx).test().assertComplete();
+
+        verify(policy).onRequest(ctx);
+        verify(spyCompletable).subscribe(any(CompletableObserver.class));
+        verifyNoMoreInteractions(policy);
+    }
+
+    @Test
+    void shouldNotExecutePolicyOnRequestWhenConditionIsNotMet() {
+        final ConditionalPolicy cut = new ConditionalPolicy(policy, CONDITION, null, conditionFilter, messageConditionFilter);
+
+        when(conditionFilter.filter(ctx, cut)).thenReturn(Maybe.empty());
+
+        cut.onRequest(ctx).test().assertComplete();
+
+        verify(policy).onRequest(ctx);
+        verify(spyCompletable, never()).subscribe(any(CompletableObserver.class));
+        verifyNoMoreInteractions(policy);
+    }
+
+    @Test
+    void shouldExecuteConditionAndPolicyOnResponse() {
+        final ConditionalPolicy cut = new ConditionalPolicy(policy, CONDITION, null, conditionFilter, messageConditionFilter);
+
+        when(conditionFilter.filter(ctx, cut)).thenReturn(Maybe.just(cut));
+
+        cut.onResponse(ctx).test().assertComplete();
+
+        verify(policy).onResponse(ctx);
+        verify(spyCompletable).subscribe(any(CompletableObserver.class));
+        verifyNoMoreInteractions(policy);
+    }
+
+    @Test
+    void shouldNotExecutePolicyOnResponseWhenConditionIsNotMet() {
+        final ConditionalPolicy cut = new ConditionalPolicy(policy, CONDITION, null, conditionFilter, messageConditionFilter);
+
+        when(conditionFilter.filter(ctx, cut)).thenReturn(Maybe.empty());
+
+        cut.onResponse(ctx).test().assertComplete();
+
+        verify(policy).onResponse(ctx);
+        verify(spyCompletable, never()).subscribe(any(CompletableObserver.class));
+        verifyNoMoreInteractions(policy);
+    }
+
+    @Test
+    void shouldExecuteMessageConditionOnMessageRequest() {
+        final Flowable<Message> messages = Flowable.just(new DefaultMessage(MESSAGE_CONTENT));
+        final FlowableTransformer<Message, Message> onMessages = upstream ->
+            upstream.map(message -> new DefaultMessage(TRANSFORMED_MESSAGE_CONTENT));
+        final ConditionalPolicy cut = new ConditionalPolicy(policy, null, MESSAGE_CONDITION, conditionFilter, messageConditionFilter);
+        final ArgumentCaptor<Function<FlowableTransformer<Message, Message>, FlowableTransformer<Message, Message>>> onMessagesInterceptor = ArgumentCaptor.forClass(
+            Function.class
+        );
+
+        doNothing().when(((MutableRequest) request)).setMessagesInterceptor(onMessagesInterceptor.capture());
+        when(messageConditionFilter.filter(eq(ctx), eq(cut), any(Message.class))).thenReturn(Maybe.just(cut));
+
+        cut.onMessageRequest(ctx).test().assertComplete();
+
+        verify(policy).onMessageRequest(ctx);
+        verify(spyCompletable).subscribe(any(CompletableObserver.class));
+        verifyNoMoreInteractions(policy);
+
+        final TestSubscriber<Message> obs = messages.compose(onMessagesInterceptor.getValue().apply(onMessages)).test();
+        obs.assertComplete();
+
+        // Message content has changed because the condition was evaluated to true.
+        obs.assertValue(message -> message.content().toString().equals(TRANSFORMED_MESSAGE_CONTENT));
+    }
+
+    @Test
+    void shouldNotExecutePolicyOnMessageRequestWhenConditionIsNotMet() {
+        final ConditionalPolicy cut = new ConditionalPolicy(policy, null, MESSAGE_CONDITION, conditionFilter, messageConditionFilter);
+        final ArgumentCaptor<Function<FlowableTransformer<Message, Message>, FlowableTransformer<Message, Message>>> onMessagesInterceptor = ArgumentCaptor.forClass(
+            Function.class
+        );
+
+        doNothing().when(((MutableRequest) request)).setMessagesInterceptor(onMessagesInterceptor.capture());
+        when(messageConditionFilter.filter(eq(ctx), eq(cut), any(Message.class))).thenReturn(Maybe.empty());
+
+        cut.onMessageRequest(ctx).test().assertComplete();
+
+        verify(policy).onMessageRequest(ctx);
+        verify(spyCompletable).subscribe(any(CompletableObserver.class));
+        verifyNoMoreInteractions(policy);
+
+        final TestSubscriber<Message> obs = MESSAGES.compose(onMessagesInterceptor.getValue().apply(ON_MESSAGES)).test();
+        obs.assertComplete();
+
+        // Message content hasn't changed because the condition was evaluated to false.
+        obs.assertValue(message -> message.content().toString().equals(MESSAGE_CONTENT));
+    }
+
+    @Test
+    void shouldExecutePolicyOnMessageRequestWithoutInterceptorWhenNoMessageCondition() {
+        final ConditionalPolicy cut = new ConditionalPolicy(policy, null, null, conditionFilter, messageConditionFilter);
+
+        cut.onMessageRequest(ctx).test().assertComplete();
+
+        verify(policy).onMessageRequest(ctx);
+        verify(spyCompletable).subscribe(any(CompletableObserver.class));
+        verifyNoMoreInteractions(policy);
+    }
+
+    @Test
+    void shouldExecuteMessageConditionOnMessageResponse() {
+        final Flowable<Message> messages = Flowable.just(new DefaultMessage(MESSAGE_CONTENT));
+        final FlowableTransformer<Message, Message> onMessages = upstream ->
+            upstream.map(message -> new DefaultMessage(TRANSFORMED_MESSAGE_CONTENT));
+        final ConditionalPolicy cut = new ConditionalPolicy(policy, null, MESSAGE_CONDITION, conditionFilter, messageConditionFilter);
+        final ArgumentCaptor<Function<FlowableTransformer<Message, Message>, FlowableTransformer<Message, Message>>> onMessagesInterceptor = ArgumentCaptor.forClass(
+            Function.class
+        );
+
+        doNothing().when(((MutableResponse) response)).setMessagesInterceptor(onMessagesInterceptor.capture());
+        when(messageConditionFilter.filter(eq(ctx), eq(cut), any(Message.class))).thenReturn(Maybe.just(cut));
+
+        cut.onMessageResponse(ctx).test().assertComplete();
+
+        verify(policy).onMessageResponse(ctx);
+        verify(spyCompletable).subscribe(any(CompletableObserver.class));
+        verifyNoMoreInteractions(policy);
+
+        final TestSubscriber<Message> obs = messages.compose(onMessagesInterceptor.getValue().apply(onMessages)).test();
+        obs.assertComplete();
+
+        // Message content has changed because the condition was evaluated to true.
+        obs.assertValue(message -> message.content().toString().equals(TRANSFORMED_MESSAGE_CONTENT));
+    }
+
+    @Test
+    void shouldNotExecutePolicyOnMessageResponseWhenConditionIsNotMet() {
+        final ConditionalPolicy cut = new ConditionalPolicy(policy, null, MESSAGE_CONDITION, conditionFilter, messageConditionFilter);
+        final ArgumentCaptor<Function<FlowableTransformer<Message, Message>, FlowableTransformer<Message, Message>>> onMessagesInterceptor = ArgumentCaptor.forClass(
+            Function.class
+        );
+
+        doNothing().when(((MutableResponse) response)).setMessagesInterceptor(onMessagesInterceptor.capture());
+        when(messageConditionFilter.filter(eq(ctx), eq(cut), any(Message.class))).thenReturn(Maybe.empty());
+
+        cut.onMessageResponse(ctx).test().assertComplete();
+
+        verify(policy).onMessageResponse(ctx);
+        verify(spyCompletable).subscribe(any(CompletableObserver.class));
+        verifyNoMoreInteractions(policy);
+
+        final TestSubscriber<Message> obs = MESSAGES.compose(onMessagesInterceptor.getValue().apply(ON_MESSAGES)).test();
+        obs.assertComplete();
+
+        // Message content hasn't changed because the condition was evaluated to false.
+        obs.assertValue(message -> message.content().toString().equals(MESSAGE_CONTENT));
+    }
+
+    @Test
+    void shouldExecutePolicyOnMessageResponseWithoutInterceptorWhenNoMessageCondition() {
+        final ConditionalPolicy cut = new ConditionalPolicy(policy, null, null, conditionFilter, messageConditionFilter);
+
+        cut.onMessageResponse(ctx).test().assertComplete();
+
+        verify(policy).onMessageResponse(ctx);
+        verify(spyCompletable).subscribe(any(CompletableObserver.class));
+        verifyNoMoreInteractions(policy);
+    }
+
+    @Test
+    void shouldGetOriginalPolicyId() {
+        final ConditionalPolicy cut = new ConditionalPolicy(policy, null, null, conditionFilter, messageConditionFilter);
+
+        when(policy.id()).thenReturn(POLICY_ID);
+        assertEquals(POLICY_ID, cut.id());
+    }
+
+    @Test
+    void shouldGetCondition() {
+        final ConditionalPolicy cut = new ConditionalPolicy(policy, CONDITION, MESSAGE_CONDITION, conditionFilter, messageConditionFilter);
+
+        assertEquals(CONDITION, cut.getCondition());
+    }
+
+    @Test
+    void shouldGetMessageCondition() {
+        final ConditionalPolicy cut = new ConditionalPolicy(policy, CONDITION, MESSAGE_CONDITION, conditionFilter, messageConditionFilter);
+
+        assertEquals(MESSAGE_CONDITION, cut.getMessageCondition());
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/context/SubscriptionRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/context/SubscriptionRequest.java
@@ -28,6 +28,7 @@ import io.gravitee.gateway.jupiter.core.context.MutableRequest;
 import io.gravitee.reporter.api.http.Metrics;
 import io.reactivex.*;
 import java.util.Collections;
+import java.util.function.Function;
 import javax.net.ssl.SSLSession;
 
 /**
@@ -254,5 +255,15 @@ public class SubscriptionRequest implements MutableRequest {
     public Completable onMessages(FlowableTransformer<Message, Message> onMessages) {
         // No transformation on messages can be performed on a subscription request.
         return Completable.complete();
+    }
+
+    @Override
+    public void setMessagesInterceptor(Function<FlowableTransformer<Message, Message>, FlowableTransformer<Message, Message>> interceptor) {
+        // No message so no interceptor.
+    }
+
+    @Override
+    public void unsetMessagesInterceptor() {
+        // No message so no interceptor.
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/context/SubscriptionResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/context/SubscriptionResponse.java
@@ -23,6 +23,7 @@ import io.gravitee.gateway.jupiter.api.message.Message;
 import io.gravitee.gateway.jupiter.core.context.MutableResponse;
 import io.gravitee.gateway.jupiter.http.vertx.MessageFlow;
 import io.reactivex.*;
+import java.util.function.Function;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -144,5 +145,15 @@ public class SubscriptionResponse implements MutableResponse {
     @Override
     public Completable end() {
         return Completable.defer(() -> chunks.ignoreElements().andThen(Completable.fromRunnable(() -> ended = true)));
+    }
+
+    @Override
+    public void setMessagesInterceptor(Function<FlowableTransformer<Message, Message>, FlowableTransformer<Message, Message>> interceptor) {
+        this.messageFlow.setOnMessagesInterceptor(interceptor);
+    }
+
+    @Override
+    public void unsetMessagesInterceptor() {
+        this.messageFlow.unsetOnMessagesInterceptor();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/DebugConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/DebugConfiguration.java
@@ -34,9 +34,11 @@ import io.gravitee.gateway.flow.FlowPolicyResolverFactory;
 import io.gravitee.gateway.flow.FlowResolver;
 import io.gravitee.gateway.flow.policy.PolicyChainFactory;
 import io.gravitee.gateway.handlers.api.definition.Api;
+import io.gravitee.gateway.jupiter.core.condition.ExpressionLanguageMessageConditionFilter;
 import io.gravitee.gateway.jupiter.debug.DebugReactorEventListener;
 import io.gravitee.gateway.jupiter.debug.policy.DebugPolicyChainFactory;
 import io.gravitee.gateway.jupiter.debug.policy.condition.DebugExpressionLanguageConditionFilter;
+import io.gravitee.gateway.jupiter.debug.policy.condition.DebugExpressionLanguageMessageConditionFilter;
 import io.gravitee.gateway.jupiter.debug.reactor.DebugHttpRequestDispatcher;
 import io.gravitee.gateway.jupiter.debug.reactor.processor.DebugPlatformProcessorChainFactory;
 import io.gravitee.gateway.jupiter.handlers.api.flow.resolver.FlowResolverFactory;
@@ -255,7 +257,11 @@ public class DebugConfiguration {
 
     @Bean
     public PolicyFactory debugPolicyFactory(final PolicyPluginFactory policyPluginFactory) {
-        return new DefaultPolicyFactory(policyPluginFactory, new DebugExpressionLanguageConditionFilter());
+        return new DefaultPolicyFactory(
+            policyPluginFactory,
+            new DebugExpressionLanguageConditionFilter(),
+            new DebugExpressionLanguageMessageConditionFilter()
+        );
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/jupiter/debug/policy/condition/DebugExpressionLanguageMessageConditionFilter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/jupiter/debug/policy/condition/DebugExpressionLanguageMessageConditionFilter.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.debug.policy.condition;
+
+import io.gravitee.gateway.jupiter.api.context.MessageExecutionContext;
+import io.gravitee.gateway.jupiter.api.message.Message;
+import io.gravitee.gateway.jupiter.core.condition.ExpressionLanguageMessageConditionFilter;
+import io.gravitee.gateway.jupiter.debug.reactor.context.DebugExecutionContext;
+import io.gravitee.gateway.jupiter.policy.ConditionalPolicy;
+import io.reactivex.Maybe;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class DebugExpressionLanguageMessageConditionFilter extends ExpressionLanguageMessageConditionFilter<ConditionalPolicy> {
+
+    @Override
+    public Maybe<ConditionalPolicy> filter(final MessageExecutionContext ctx, final ConditionalPolicy elt, Message message) {
+        return super
+            .filter(ctx, elt, message)
+            .doOnEvent(
+                (conditionalPolicy, throwable) -> {
+                    if (ctx instanceof DebugExecutionContext && throwable == null) {
+                        DebugExecutionContext debugCtx = (DebugExecutionContext) ctx;
+                        boolean isConditionTruthy = conditionalPolicy != null;
+                        debugCtx.getCurrentDebugStep().onConditionFilter(elt.getCondition(), isConditionTruthy);
+                    }
+                }
+            );
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/flow/FlowStep.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/flow/FlowStep.java
@@ -64,4 +64,9 @@ public class FlowStep {
      * Condition attached to the FlowStep
      */
     private String condition;
+
+    /**
+     * Message condition attached to the FlowStep
+     */
+    private String messageCondition;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcFlowRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcFlowRepository.java
@@ -85,6 +85,7 @@ public class JdbcFlowRepository extends JdbcAbstractCrudRepository<Flow, String>
                 .addColumn("configuration", Types.NVARCHAR, String.class)
                 .addColumn("order", Types.INTEGER, int.class)
                 .addColumn("condition", Types.NVARCHAR, String.class)
+                .addColumn("message_condition", Types.NVARCHAR, String.class)
                 .build();
     }
 
@@ -460,7 +461,7 @@ public class JdbcFlowRepository extends JdbcAbstractCrudRepository<Flow, String>
                 escapeReservedWord("order") +
                 ", " +
                 escapeReservedWord("condition") +
-                ", phase ) values ( ?, ?, ?, ?, ? , ?, ?, ?, ?)",
+                ", phase, message_condition ) values ( ?, ?, ?, ?, ? , ?, ?, ?, ?, ?)",
                 new BatchPreparedStatementSetter() {
                     @Override
                     public void setValues(PreparedStatement ps, int i) throws SQLException {
@@ -474,6 +475,7 @@ public class JdbcFlowRepository extends JdbcAbstractCrudRepository<Flow, String>
                         ps.setInt(7, flowStep.getOrder());
                         ps.setString(8, flowStep.getCondition());
                         ps.setString(9, phase.name());
+                        ps.setString(10, flowStep.getMessageCondition());
                     }
 
                     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_20_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_20_0/schema.yml
@@ -15,3 +15,15 @@ databaseChangeLog:
             constraintName: pk_${gravitee_prefix}flow_selector_channel_entrypoints
             columnNames: flow_id, channel_entrypoint
             tableName: ${gravitee_prefix}flow_selector_channel_entrypoints
+        - addColumn:
+            tableName: ${gravitee_prefix}flow_steps
+            columns:
+              - column:
+                  name: message_condition
+                  type: nvarchar(256)
+                  constraints:
+                    nullable: true
+        - modifyDataType:
+            tableName: ${gravitee_prefix}flow_steps
+            columnName: condition
+            newDataType: nvarchar(256)

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/FlowV4RepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/FlowV4RepositoryTest.java
@@ -64,6 +64,13 @@ public class FlowV4RepositoryTest extends AbstractManagementRepositoryTest {
 
         assertEquals(2, flow.getRequest().size());
         assertEquals(3, flow.getResponse().size());
+        assertEquals(1, flow.getPublish().size());
+        assertEquals(1, flow.getSubscribe().size());
+
+        assertEquals("{#request.headers != null}", flow.getPublish().get(0).getCondition());
+        assertEquals("{#message.content != null}", flow.getPublish().get(0).getMessageCondition());
+        assertEquals("{#response.headers != null}", flow.getSubscribe().get(0).getCondition());
+        assertEquals("{#message.headers != null}", flow.getSubscribe().get(0).getMessageCondition());
 
         assertEquals(3, flow.getSelectors().size());
         flow
@@ -110,15 +117,30 @@ public class FlowV4RepositoryTest extends AbstractManagementRepositoryTest {
         flow.setSelectors(List.of(flowHttpSelector, flowConditionSelector));
 
         FlowStep postStep = new FlowStep();
-        postStep.setName("post-step");
+        postStep.setName("response-step");
         postStep.setPolicy("policy");
         flow.setResponse(List.of(postStep));
-        FlowStep preStep = new FlowStep();
-        preStep.setName("pre-step");
-        preStep.setPolicy("policy");
-        preStep.setCondition("pre-condition");
-        preStep.setOrder(1);
-        flow.setRequest(List.of(preStep));
+        FlowStep requestStep = new FlowStep();
+        requestStep.setName("request-step");
+        requestStep.setPolicy("policy");
+        requestStep.setCondition("request-condition");
+        requestStep.setOrder(1);
+        flow.setRequest(List.of(requestStep));
+
+        FlowStep publishStep = new FlowStep();
+        publishStep.setName("publish-step");
+        publishStep.setPolicy("policy");
+        publishStep.setCondition("publish-condition");
+        publishStep.setOrder(1);
+        flow.setPublish(List.of(publishStep));
+
+        FlowStep subscribeStep = new FlowStep();
+        subscribeStep.setName("subscribe-step");
+        subscribeStep.setPolicy("policy");
+        subscribeStep.setCondition("subscribe-condition");
+        subscribeStep.setOrder(1);
+        flow.setSubscribe(List.of(subscribeStep));
+
         flow.setReferenceId("my-orga");
         flow.setReferenceType(FlowReferenceType.ORGANIZATION);
         flow.setUpdatedAt(new Date(1470157767000L));
@@ -139,15 +161,19 @@ public class FlowV4RepositoryTest extends AbstractManagementRepositoryTest {
                 )
         );
 
-        assertEquals(flowCreated.getCreatedAt(), flow.getCreatedAt());
-        assertEquals(flowCreated.isEnabled(), flow.isEnabled());
-        assertEquals(flowCreated.getReferenceId(), flow.getReferenceId());
-        assertEquals(flowCreated.getUpdatedAt(), flow.getUpdatedAt());
-        assertEquals(flowCreated.getTags().size(), flow.getTags().size());
-        assertEquals(flowCreated.getTags(), flow.getTags());
-        assertEquals(flowCreated.getOrder(), flow.getOrder());
-        assertEquals(flowCreated.getRequest().get(0).getOrder(), flow.getRequest().get(0).getOrder());
-        assertEquals(flowCreated.getRequest().get(0).getCondition(), flow.getRequest().get(0).getCondition());
+        assertEquals(flow.getCreatedAt(), flowCreated.getCreatedAt());
+        assertEquals(flow.isEnabled(), flowCreated.isEnabled());
+        assertEquals(flow.getReferenceId(), flowCreated.getReferenceId());
+        assertEquals(flow.getUpdatedAt(), flowCreated.getUpdatedAt());
+        assertEquals(flow.getTags().size(), flowCreated.getTags().size());
+        assertEquals(flow.getTags(), flowCreated.getTags());
+        assertEquals(flow.getOrder(), flowCreated.getOrder());
+        assertEquals(flow.getRequest().get(0).getOrder(), flowCreated.getRequest().get(0).getOrder());
+        assertEquals(flow.getRequest().get(0).getCondition(), flowCreated.getRequest().get(0).getCondition());
+        assertEquals(flow.getPublish().get(0).getCondition(), flowCreated.getPublish().get(0).getCondition());
+        assertEquals(flow.getPublish().get(0).getCondition(), flowCreated.getPublish().get(0).getCondition());
+        assertEquals(flow.getSubscribe().get(0).getCondition(), flowCreated.getSubscribe().get(0).getCondition());
+        assertEquals(flow.getSubscribe().get(0).getCondition(), flowCreated.getSubscribe().get(0).getCondition());
     }
 
     @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/flow-v4-tests/flows.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/flow-v4-tests/flows.json
@@ -80,6 +80,30 @@
         "enabled": true,
         "order": 3
       }
+    ],
+    "publish": [
+      {
+        "name": "JSON to XML",
+        "description": "Json to xml",
+        "enabled": true,
+        "condition": "{#request.headers != null}",
+        "messageCondition": "{#message.content != null}",
+        "policy": "json-xml",
+        "configuration": "{\n          \"rootElement\": \"root\",\n          \"scope\": \"REQUEST\"\n        }",
+        "order": 1
+      }
+    ],
+    "subscribe": [
+      {
+        "name": "JSON to XML",
+        "description": "Json to xml",
+        "enabled": true,
+        "condition": "{#response.headers != null}",
+        "messageCondition": "{#message.headers != null}",
+        "policy": "json-xml",
+        "configuration": "{\n          \"rootElement\": \"root\",\n          \"scope\": \"RESPONSE\"\n        }",
+        "order": 1
+      }
     ]
   },
   {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/v4/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/v4/api/ApiResource.java
@@ -138,10 +138,7 @@ public class ApiResource extends AbstractResource {
     @ApiResponse(
         responseCode = "200",
         description = "API successfully updated",
-        content = @Content(
-            mediaType = MediaType.APPLICATION_JSON,
-            schema = @Schema(implementation = io.gravitee.rest.api.model.api.ApiEntity.class)
-        )
+        content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ApiEntity.class))
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
     @Permissions(
@@ -212,10 +209,7 @@ public class ApiResource extends AbstractResource {
     @ApiResponse(
         responseCode = "200",
         description = "API successfully deployed",
-        content = @Content(
-            mediaType = MediaType.APPLICATION_JSON,
-            schema = @Schema(implementation = io.gravitee.rest.api.model.api.ApiEntity.class)
-        )
+        content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ApiEntity.class))
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
     @Permissions({ @Permission(value = RolePermission.API_DEFINITION, acls = RolePermissionAction.UPDATE) })

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -10,7 +10,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0
-  version: "3.19.0-alpha.2-SNAPSHOT"
+  version: "3.20.0-SNAPSHOT"
 servers:
   - url: http://localhost:8083/portal/environments/{envId}
     description: The portal API for a given environment

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/FlowMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/FlowMapper.java
@@ -105,6 +105,7 @@ public class FlowMapper {
         repositoryStep.setConfiguration(definitionStep.getConfiguration());
         repositoryStep.setDescription(definitionStep.getDescription());
         repositoryStep.setCondition(definitionStep.getCondition());
+        repositoryStep.setMessageCondition(definitionStep.getMessageCondition());
         return repositoryStep;
     }
 
@@ -116,6 +117,7 @@ public class FlowMapper {
         definitionStep.setConfiguration(repositoryStep.getConfiguration());
         definitionStep.setDescription(repositoryStep.getDescription());
         definitionStep.setCondition(repositoryStep.getCondition());
+        definitionStep.setMessageCondition(repositoryStep.getMessageCondition());
         return definitionStep;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/FlowMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/FlowMapperTest.java
@@ -37,6 +37,8 @@ import org.junit.Test;
  */
 public class FlowMapperTest {
 
+    protected static final String POLICY_CONDITION = "Policy condition";
+    protected static final String MESSAGE_LEVEL_CONDITION = "Message level condition";
     private final FlowMapper flowMapper = new FlowMapper();
 
     private static List<Selector> selectors() {
@@ -55,6 +57,8 @@ public class FlowMapperTest {
         step.setEnabled(true);
         step.setName("IPFiltering");
         step.setPolicy("ip-filtering");
+        step.setCondition(POLICY_CONDITION);
+        step.setMessageCondition(MESSAGE_LEVEL_CONDITION);
         step.setConfiguration("{\"whitelistIps\":[\"0.0.0.0/0\"]}");
         return List.of(step);
     }
@@ -64,6 +68,8 @@ public class FlowMapperTest {
         step.setEnabled(true);
         step.setName("Transform Headers");
         step.setPolicy("transform-headers");
+        step.setCondition(POLICY_CONDITION);
+        step.setMessageCondition(MESSAGE_LEVEL_CONDITION);
         step.setConfiguration("{\"scope\":\"RESPONSE\",\"addHeaders\":[{\"name\":\"x-platform\",\"value\":\"true\"}]}");
         return List.of(step);
     }
@@ -92,6 +98,11 @@ public class FlowMapperTest {
         assertFalse(model.getTags().isEmpty());
         assertEquals(FlowReferenceType.ORGANIZATION, model.getReferenceType());
         assertEquals("DEFAULT", model.getReferenceId());
+
+        assertEquals(POLICY_CONDITION, model.getPublish().get(0).getCondition());
+        assertEquals(MESSAGE_LEVEL_CONDITION, model.getPublish().get(0).getMessageCondition());
+        assertEquals(POLICY_CONDITION, model.getSubscribe().get(0).getCondition());
+        assertEquals(MESSAGE_LEVEL_CONDITION, model.getSubscribe().get(0).getMessageCondition());
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -58,9 +58,9 @@
         <gravitee-cockpit-api.version>1.12.0</gravitee-cockpit-api.version>
         <gravitee-common.version>1.28.0</gravitee-common.version>
         <gravitee-connector-api.version>1.1.4</gravitee-connector-api.version>
-        <gravitee-expression-language.version>1.11.2</gravitee-expression-language.version>
+        <gravitee-expression-language.version>1.11.3</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>1.48.0-alpha.2</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.48.0-alpha.3</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>1.25.0</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-173

## Description

This PR is about adding the support for executing a condition at message level.

## Additional context

To test it, you can update an existing async api to add a policy on the publish or subscribe section. That policy can contain either a `condition` that will be applied once during the MESSAGE_REQUEST phase or a `messageCondition` that will be applied on each message. Example of policy with message condition:

```json
"publish": [
                 {
                    "name": "JSON to XML",
                    "description": "Json to xml",
                    "enabled": true,
                    "messageCondition": "{#message.content == '{}'}",
                    "policy": "json-xml",
                    "configuration": {
                        "rootElement": "root",
                        "scope": "REQUEST"
                    }
                }
        
            ]
```

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-173-condition-message-level/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uadcslxteh.chromatic.com)
<!-- Storybook placeholder end -->
