### PR TITLE
3.15.x Revert part of href fix to ensure retrocompatibility 

### DIFF
--- a/gravitee-apim-console-webui/docker/config/templates/default.conf.tmpl
+++ b/gravitee-apim-console-webui/docker/config/templates/default.conf.tmpl
@@ -19,7 +19,7 @@ server {
     location / {
         try_files $uri $uri/ =404;
         root /usr/share/nginx/html;
-        sub_filter '<base href="/"' '<base href="{{ getenv "CONSOLE_BASE_HREF" "/" }}"';
+        sub_filter '<base href="./"' '<base href="{{ getenv "CONSOLE_BASE_HREF" "./" }}"';
         sub_filter_once on;
     }
 

--- a/gravitee-apim-console-webui/src/index.html
+++ b/gravitee-apim-console-webui/src/index.html
@@ -19,7 +19,7 @@
 <html class="bootstrap">
   <head>
     <meta charset="utf-8" />
-    <base href="/" />
+    <base href="./" />
     <title ng-bind="consoleTitle"></title>
     <meta name="description" content="" />
     <meta name="viewport" content="width=device-width" />


### PR DESCRIPTION
## Issue
https://github.com/gravitee-io/issues/issues/8518

Same as 3.18.x https://github.com/gravitee-io/gravitee-api-management/pull/2555

## Description

This commit revert part of b03a8eb705280e5f44d5a58293306d29838e79ee to ensure there is no breaking change in 3.18.x version.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ffxhwvpqyu.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/3-15-x-fix-archived-application-pb-in-log-screen/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
