### PR TITLE
fix(gateway): make API v1 paths based with API key plan work

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/ApiSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/ApiSynchronizer.java
@@ -389,6 +389,7 @@ public class ApiSynchronizer extends AbstractSynchronizer {
         plan.setSelectionRule(repoPlan.getSelectionRule());
         plan.setTags(repoPlan.getTags());
         plan.setStatus(repoPlan.getStatus().name());
+        plan.setApi(repoPlan.getApi());
 
         if (repoPlan.getSecurity() != null) {
             plan.setSecurity(repoPlan.getSecurity().name());

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/ApiSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/ApiSynchronizerTest.java
@@ -391,13 +391,20 @@ public class ApiSynchronizerTest extends TestCase {
             .thenReturn(singletonList(mockEvent));
 
         final Plan plan = new Plan();
+        plan.setId("planId");
         plan.setApi(mockApi.getId());
+        plan.setStatus(Plan.Status.PUBLISHED);
         when(planRepository.findByApis(anyList())).thenReturn(singletonList(plan));
         mockEnvironmentAndOrganization();
 
         apiSynchronizer.synchronize(System.currentTimeMillis() - 5000, System.currentTimeMillis(), ENVIRONMENTS);
 
-        verify(apiManager).register(new Api(mockApi));
+        ArgumentCaptor<Api> apiCaptor = ArgumentCaptor.forClass(Api.class);
+        verify(apiManager).register(apiCaptor.capture());
+        Api verifyApi = apiCaptor.getValue();
+        assertEquals(API_ID, verifyApi.getId());
+        assertEquals(verifyApi.getDefinition().getPlan("planId").getApi(), mockApi.getId());
+
         verify(apiManager, never()).unregister(any(String.class));
         verify(planRepository, times(1)).findByApis(anyList());
         verify(apiKeysCacheService).register(singletonList(new Api(mockApi)));


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-178

## Description

> Jeoffrey - FYI the issue is that V1 plan doesn't map the plan api id during the sync of the api on the gateway side
Things have changed on the way the subscription are retrieved by the gateway (subscriptionService). It now uses the plan.getApi() which is null, it does not work anymore.I think a quick fix would be to add

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-178-3-19-x-fix-api-key/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uowmwuwnnb.chromatic.com)
<!-- Storybook placeholder end -->
