### PR TITLE
chore: bump gravitee-common-elasticsearch to alpha version using rxJava3

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <elasticsearch.version>5.6.16</elasticsearch.version>
-        <gravitee-common-elasticsearch.version>4.0.0-bumpRxJava-SNAPSHOT</gravitee-common-elasticsearch.version>
+        <gravitee-common-elasticsearch.version>4.0.0-alpha.1</gravitee-common-elasticsearch.version>
         <lucene.version>6.6.1</lucene.version>
     </properties>
 


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/7990
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-commonelasticsearchversion/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
