### PR TITLE
fix: allow to optionally propagate accept-encoding

### DIFF
--- a/gravitee-apim-cypress/cypress/model/apis.ts
+++ b/gravitee-apim-cypress/cypress/model/apis.ts
@@ -284,15 +284,16 @@ export enum TrustStoreType {
 }
 
 export interface HttpClientOptions {
+  clearTextUpgrade: boolean;
   idleTimeout: number;
   connectTimeout: number;
   keepAlive: boolean;
   readTimeout: number;
   pipelining: boolean;
   maxConcurrentConnections: number;
+  propagateClientAcceptEncoding: boolean;
   useCompression: boolean;
   followRedirects: boolean;
-  clearTextUpgrade: boolean;
   version: HttpVersion;
 }
 

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/HttpClientOptionsDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/HttpClientOptionsDeserializer.java
@@ -54,6 +54,12 @@ public class HttpClientOptionsDeserializer extends AbstractStdScalarDeserializer
 
         httpClientOptions.setUseCompression(node.path("useCompression").asBoolean(HttpClientOptions.DEFAULT_USE_COMPRESSION));
 
+        if (node.get("propagateClientAcceptEncoding") != null) {
+            httpClientOptions.setPropagateClientAcceptEncoding(
+                node.path("propagateClientAcceptEncoding").asBoolean(HttpClientOptions.DEFAULT_PROPAGATE_CLIENT_ACCEPT_ENCODING)
+            );
+        }
+
         httpClientOptions.setFollowRedirects(node.path("followRedirects").asBoolean(HttpClientOptions.DEFAULT_FOLLOW_REDIRECTS));
 
         if (node.get("clearTextUpgrade") != null) {

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/ser/HttpClientOptionsSerializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/ser/HttpClientOptionsSerializer.java
@@ -42,6 +42,9 @@ public class HttpClientOptionsSerializer extends StdScalarSerializer<HttpClientO
         jgen.writeBooleanField("pipelining", httpClientOptions.isPipelining());
         jgen.writeNumberField("maxConcurrentConnections", httpClientOptions.getMaxConcurrentConnections());
         jgen.writeBooleanField("useCompression", httpClientOptions.isUseCompression());
+        if (!httpClientOptions.isUseCompression()) {
+            jgen.writeBooleanField("propagateClientAcceptEncoding", httpClientOptions.isPropagateClientAcceptEncoding());
+        }
         jgen.writeBooleanField("followRedirects", httpClientOptions.isFollowRedirects());
 
         // For backward compatibility

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
@@ -631,4 +631,14 @@ public class ApiDeserializerTest extends AbstractTest {
     public void definition_v1_withFlow() throws Exception {
         load("/io/gravitee/definition/jackson/api-v1-withflow.json", Api.class);
     }
+
+    @Test
+    public void definition_withclientoptions_propagateClientAcceptEncoding() throws Exception {
+        Api api = load("/io/gravitee/definition/jackson/api-withclientoptions-propagateClientAcceptEncoding.json", Api.class);
+
+        Endpoint endpoint = api.getProxy().getGroups().iterator().next().getEndpoints().iterator().next();
+        JsonNode endpointConfiguration = objectMapper().readTree(endpoint.getConfiguration());
+        assertTrue(endpointConfiguration.has("http"));
+        assertEquals(endpointConfiguration.get("http").toString(), "{\"useCompression\":false,\"propagateClientAcceptEncoding\":true}");
+    }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiSerializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiSerializerTest.java
@@ -492,6 +492,21 @@ public class ApiSerializerTest extends AbstractTest {
     }
 
     @Test
+    public void definition_withclientoptions_propagateClientAcceptEncoding() throws Exception {
+        Api api = load("/io/gravitee/definition/jackson/api-withclientoptions-propagateClientAcceptEncoding.json", Api.class);
+        String expectedDefinition = "/io/gravitee/definition/jackson/api-withclientoptions-propagateClientAcceptEncoding-expected.json";
+
+        String generatedJsonDefinition = objectMapper().writeValueAsString(api);
+        String expectedGeneratedJsonDefinition = IOUtils.toString(read(expectedDefinition));
+
+        Assert.assertNotNull(generatedJsonDefinition);
+        Assert.assertEquals(
+            objectMapper().readTree(expectedGeneratedJsonDefinition.getBytes()),
+            objectMapper().readTree(generatedJsonDefinition.getBytes())
+        );
+    }
+
+    @Test
     public void definition_withHeaders() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-headers.json", Api.class);
         String expectedDefinition = "/io/gravitee/definition/jackson/api-headers-expected.json";

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-withclientoptions-propagateClientAcceptEncoding-expected.json
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-withclientoptions-propagateClientAcceptEncoding-expected.json
@@ -1,0 +1,51 @@
+{
+  "id": "my-api",
+  "name": "my-team-api",
+  "version": "undefined",
+  "gravitee": "1.0.0",
+  "flow_mode": "DEFAULT",
+  "proxy": {
+    "virtual_hosts": [
+      {
+        "path": "/team"
+      }
+    ],
+    "strip_context_path": false,
+    "preserve_host": false,
+    "groups": [
+      {
+        "name": "default-group",
+        "endpoints": [
+          {
+            "name": "default",
+            "target": "http://localhost:8083/myapi",
+            "http": {
+              "useCompression": false,
+              "propagateClientAcceptEncoding": true
+            },
+            "weight": 1,
+            "backup": false,
+            "type": "http"
+          }
+        ],
+        "load_balancing": {
+          "type": "ROUND_ROBIN"
+        },
+        "http": {
+          "connectTimeout": 5000,
+          "idleTimeout": 60000,
+          "keepAlive": true,
+          "readTimeout": 10000,
+          "pipelining": false,
+          "maxConcurrentConnections": 100,
+          "useCompression": true,
+          "followRedirects": false
+        }
+      }
+    ]
+  },
+  "paths": {
+    "/*": []
+  },
+  "properties": []
+}

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-withclientoptions-propagateClientAcceptEncoding.json
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-withclientoptions-propagateClientAcceptEncoding.json
@@ -1,0 +1,24 @@
+{
+  "id": "my-api",
+  "name": "my-team-api",
+
+  "proxy": {
+    "context_path": "/team",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8083/myapi",
+        "http": {
+          "useCompression": false,
+          "propagateClientAcceptEncoding": true
+        }
+      }
+    ],
+    "strip_context_path": false
+  },
+
+  "paths": {
+    "/*": [
+    ]
+  }
+}

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/HttpClientOptions.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/HttpClientOptions.java
@@ -31,6 +31,7 @@ public class HttpClientOptions implements Serializable {
     public static boolean DEFAULT_KEEP_ALIVE = true;
     public static boolean DEFAULT_PIPELINING = false;
     public static boolean DEFAULT_USE_COMPRESSION = true;
+    public static boolean DEFAULT_PROPAGATE_CLIENT_ACCEPT_ENCODING = false;
     public static boolean DEFAULT_FOLLOW_REDIRECTS = false;
     public static boolean DEFAULT_CLEAR_TEXT_UPGRADE = true;
     public static ProtocolVersion DEFAULT_PROTOCOL_VERSION = ProtocolVersion.HTTP_1_1;
@@ -55,6 +56,9 @@ public class HttpClientOptions implements Serializable {
 
     @JsonProperty("useCompression")
     private boolean useCompression = DEFAULT_USE_COMPRESSION;
+
+    @JsonProperty("propagateClientAcceptEncoding")
+    private boolean propagateClientAcceptEncoding = DEFAULT_PROPAGATE_CLIENT_ACCEPT_ENCODING;
 
     @JsonProperty("followRedirects")
     private boolean followRedirects = DEFAULT_FOLLOW_REDIRECTS;
@@ -119,6 +123,14 @@ public class HttpClientOptions implements Serializable {
 
     public void setUseCompression(boolean useCompression) {
         this.useCompression = useCompression;
+    }
+
+    public boolean isPropagateClientAcceptEncoding() {
+        return propagateClientAcceptEncoding;
+    }
+
+    public void setPropagateClientAcceptEncoding(boolean propagateClientAcceptEncoding) {
+        this.propagateClientAcceptEncoding = propagateClientAcceptEncoding;
     }
 
     public boolean isFollowRedirects() {

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -46,7 +46,7 @@
     <properties>
         <!-- Versions of the plugins for the full distribution -->
         <!-- Management API & Gateway -->
-        <gravitee-connector-http.version>1.1.11</gravitee-connector-http.version>
+        <gravitee-connector-http.version>1.1.12</gravitee-connector-http.version>
         <gravitee-policy-apikey.version>2.4.0</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>1.5.0</gravitee-policy-assign-attributes.version>
         <gravitee-policy-assign-content.version>1.7.0</gravitee-policy-assign-content.version>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-endpoint-discovery/src/test/java/io/gravitee/gateway/services/endpoint/discovery/verticle/EndpointDiscoveryVerticleTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-endpoint-discovery/src/test/java/io/gravitee/gateway/services/endpoint/discovery/verticle/EndpointDiscoveryVerticleTest.java
@@ -229,6 +229,7 @@ public class EndpointDiscoveryVerticleTest {
             "\"pipelining\":false," +
             "\"maxConcurrentConnections\":100," +
             "\"useCompression\":true," +
+            "\"propagateClientAcceptEncoding\":false," +
             "\"followRedirects\":false," +
             "\"clearTextUpgrade\":true," +
             "\"version\":\"HTTP_1_1\"" +

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <jetty94.wiremock.version>9.4.44.v20210927</jetty94.wiremock.version>
-        <gravitee-connector-http.version>1.1.11</gravitee-connector-http.version>
+        <gravitee-connector-http.version>1.1.12</gravitee-connector-http.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7935

**Description**

See https://github.com/gravitee-io/gravitee-connector-http/pull/43 for details

** Additional information **

The option "Propagate client Accept-Header header" is accessible only if "Enabled compression" is disabled

![image](https://user-images.githubusercontent.com/5955401/196753616-7d7b33ea-a2cb-483c-964f-128955a813ce.png)


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jjjeyxvfhf.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/7935-optionnally-propagate-accept-encoding/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
