### PR TITLE
chore: bump policy-json-xml version using rxJava3

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -63,7 +63,7 @@
         <gravitee-policy-json-threat-protection.version>1.3.3</gravitee-policy-json-threat-protection.version>
         <gravitee-policy-json-to-json.version>1.7.1</gravitee-policy-json-to-json.version>
         <gravitee-policy-json-validation.version>1.6.1</gravitee-policy-json-validation.version>
-        <gravitee-policy-json-xml.version>1.2.1</gravitee-policy-json-xml.version>
+        <gravitee-policy-json-xml.version>2.0.0-alpha.1</gravitee-policy-json-xml.version>
         <gravitee-policy-jws.version>1.3.2</gravitee-policy-jws.version>
         <gravitee-policy-jwt.version>3.0.0-alpha.1</gravitee-policy-jwt.version>
         <gravitee-policy-keyless.version>2.0.0-alpha.1</gravitee-policy-keyless.version>


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/7990
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/bumprxjavapolicy-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-allnvugqjw.chromatic.com)
<!-- Storybook placeholder end -->
