### PR TITLE
test: enable failover and trigger it

### DIFF
--- a/gravitee-apim-e2e/.env
+++ b/gravitee-apim-e2e/.env
@@ -3,6 +3,7 @@ MANAGEMENT_BASE_URL=http://localhost:8083/management
 PORTAL_BASE_URL=http://localhost:8083/portal/environments
 GATEWAY_BASE_URL=http://localhost:8082
 WIREMOCK_BASE_URL=http://localhost:8080 # If the gateway is run in docker change the variable to `WIREMOCK_BASE_URL=http://wiremock:8080`
+WIREMOCK_BASE_URL_FOR_JEST=http://wiremock:8080 # If Jest is run in local environment change the variable to `WIREMOCK_BASE_URL=http://localhost:8080`
 
 # usernames and passwords
 ADMIN_USERNAME=admin

--- a/gravitee-apim-e2e/api-test/resources/wiremock/mappings/delayed.json
+++ b/gravitee-apim-e2e/api-test/resources/wiremock/mappings/delayed.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPattern": "/delayed"
+  },
+  "response": {
+    "status": 503,
+    "fixedDelayMilliseconds": 4000,
+    "headers": {
+      "X-Wiremock": "true"
+    }
+  }
+}

--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/failover/enable-failover-and-trigger-it.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/failover/enable-failover-and-trigger-it.spec.ts
@@ -13,8 +13,184 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { describe } from '@jest/globals';
+import { APIsApi } from '@gravitee/management-webclient-sdk/src/lib/apis/APIsApi';
+import { forManagementAsApiUser } from '@gravitee/utils/configuration';
+import { afterAll, beforeAll, describe, expect, test } from '@jest/globals';
+import { succeed } from '@lib/jest-utils';
+import { ApisFaker } from '@gravitee/fixtures/management/ApisFaker';
+import { ApiEntity } from '@gravitee/management-webclient-sdk/src/lib/models/ApiEntity';
+import { PlansFaker } from '@gravitee/fixtures/management/PlansFaker';
+import { LifecycleAction } from '@gravitee/management-webclient-sdk/src/lib/models/LifecycleAction';
+import { PlanStatus } from '@gravitee/management-webclient-sdk/src/lib/models/PlanStatus';
+import { fetchGatewayServiceUnavailable, fetchGatewaySuccess } from '@gravitee/utils/gateway';
+import { teardownApisAndApplications } from '@gravitee/utils/management';
+import { verifyWiremockRequest } from '@gravitee/utils/wiremock';
+import fetchApi from 'node-fetch';
+
+const orgId = 'DEFAULT';
+const envId = 'DEFAULT';
+const apisResourceAsPublisher = new APIsApi(forManagementAsApiUser());
 
 describe('Enable failover and trigger it', () => {
-  test.skip('To complete', async () => {});
+  const brokenEndpoint = {
+    inherit: true,
+    name: 'Broken endpoint',
+    target: `${process.env.WIREMOCK_BASE_URL}/delayed`,
+    weight: 1,
+    backup: false,
+    type: 'http',
+  };
+
+  const workingEndpoint = {
+    inherit: true,
+    name: 'Working endpoint',
+    target: `${process.env.WIREMOCK_BASE_URL}/hello?name=endpoint`,
+    weight: 1,
+    backup: false,
+    type: 'http',
+  };
+
+  describe('No failover, 1 broken endpoint and 1 working endpoint', () => {
+    let createdApi1: ApiEntity;
+
+    beforeAll(async () => {
+      // create an API with a published free plan and 2 endpoints in one endpoint group (lb: round-robin)
+      createdApi1 = await succeed(
+        apisResourceAsPublisher.importApiDefinitionRaw({
+          envId,
+          orgId,
+          body: ApisFaker.apiImport({
+            plans: [PlansFaker.plan({ status: PlanStatus.PUBLISHED })],
+            proxy: ApisFaker.proxy({
+              groups: [
+                {
+                  name: 'default-group',
+                  endpoints: [brokenEndpoint, workingEndpoint],
+                },
+              ],
+            }),
+          }),
+        }),
+      );
+
+      // start API
+      await apisResourceAsPublisher.doApiLifecycleAction({
+        envId,
+        orgId,
+        api: createdApi1.id,
+        action: LifecycleAction.START,
+      });
+    });
+
+    test('Should fail to connect with the first endpoint', async () => {
+      await fetchGatewayServiceUnavailable({
+        contextPath: createdApi1.context_path,
+        async expectedResponseValidator(response) {
+          return response.headers.has('X-Wiremock');
+        },
+      });
+    });
+
+    afterAll(async () => {
+      await teardownApisAndApplications(orgId, envId, [createdApi1.id]);
+    });
+  });
+
+  describe('With failover, 2 broken endpoints and 1 working endpoint', () => {
+    let createdApi2: ApiEntity;
+
+    beforeAll(async () => {
+      // create an API with a published free plan and 3 endpoints in one endpoint group (lb: round-robin) and failover
+      createdApi2 = await succeed(
+        apisResourceAsPublisher.importApiDefinitionRaw({
+          envId,
+          orgId,
+          body: ApisFaker.apiImport({
+            plans: [PlansFaker.plan({ status: PlanStatus.PUBLISHED })],
+            proxy: ApisFaker.proxy({
+              failover: { maxAttempts: 5, retryTimeout: 2000 },
+              groups: [
+                {
+                  name: 'default-group',
+                  endpoints: [brokenEndpoint, { ...brokenEndpoint, name: 'Broken endpoint2' }, workingEndpoint],
+                },
+              ],
+            }),
+          }),
+        }),
+      );
+
+      // start it
+      await apisResourceAsPublisher.doApiLifecycleAction({
+        envId,
+        orgId,
+        api: createdApi2.id,
+        action: LifecycleAction.START,
+      });
+    });
+
+    test('Should succeed to reach the working endpoint after failover happened', async () => {
+      await fetchGatewaySuccess({ contextPath: createdApi2.context_path });
+      const { count: before } = await verifyWiremockRequest('/delayed', 'GET').then((res) => res.json());
+      const response = await fetchApi(`${process.env.GATEWAY_BASE_URL}${createdApi2.context_path}`).then((res) => res.json());
+      const { count: after } = await verifyWiremockRequest('/delayed', 'GET').then((res) => res.json());
+      expect(after - before).toEqual(2);
+      expect(response.message).toEqual('Hello, Endpoint!');
+    });
+
+    afterAll(async () => {
+      await teardownApisAndApplications(orgId, envId, [createdApi2.id]);
+    });
+  });
+
+  describe('With failover, 2 broken endpoints', () => {
+    let createdApi3: ApiEntity;
+
+    beforeAll(async () => {
+      // create an API with a published free plan and 3 endpoints in one endpoint group (lb: round-robin) and failover
+      createdApi3 = await succeed(
+        apisResourceAsPublisher.importApiDefinitionRaw({
+          envId,
+          orgId,
+          body: ApisFaker.apiImport({
+            plans: [PlansFaker.plan({ status: PlanStatus.PUBLISHED })],
+            proxy: ApisFaker.proxy({
+              failover: { maxAttempts: 1, retryTimeout: 2000 },
+              groups: [
+                {
+                  name: 'default-group',
+                  http: {
+                    connectTimeout: 1500,
+                    readTimeout: 3000,
+                  },
+                  endpoints: [brokenEndpoint, { ...brokenEndpoint, name: 'Broken endpoint2' }, workingEndpoint],
+                },
+              ],
+            }),
+          }),
+        }),
+      );
+
+      // start API
+      await apisResourceAsPublisher.doApiLifecycleAction({
+        envId,
+        orgId,
+        api: createdApi3.id,
+        action: LifecycleAction.START,
+      });
+    });
+
+    test('Should fail after trying to reach bad endpoints <MAX ATTEMPT> times', async () => {
+      await fetchGatewaySuccess({ contextPath: createdApi3.context_path, maxRetries: 20 });
+      const { count: before } = await verifyWiremockRequest('/delayed', 'GET').then((res) => res.json());
+      const response = await fetchApi(`${process.env.GATEWAY_BASE_URL}${createdApi3.context_path}`);
+      const { count: after } = await verifyWiremockRequest('/delayed', 'GET').then((res) => res.json());
+      expect(after - before).toEqual(2);
+      expect(response.status).toEqual(502);
+    }, 35000);
+
+    afterAll(async () => {
+      await teardownApisAndApplications(orgId, envId, [createdApi3.id]);
+    });
+  });
 });

--- a/gravitee-apim-e2e/docker/api-tests/docker-compose-api-tests.yml
+++ b/gravitee-apim-e2e/docker/api-tests/docker-compose-api-tests.yml
@@ -29,6 +29,7 @@ services:
       - GATEWAY_BASE_URL=http://gateway:8082
       - WIREMOCK_BASE_URL=http://wiremock:8080
       - JUPITER_MODE_ENABLED=${JUPITER_MODE_ENABLED:-false}
+      - WIREMOCK_BASE_URL_FOR_JEST=http://wiremock:8080
     depends_on:
       management_api:
         condition: service_healthy

--- a/gravitee-apim-e2e/lib/utils/gateway.ts
+++ b/gravitee-apim-e2e/lib/utils/gateway.ts
@@ -48,6 +48,10 @@ export async function fetchGatewayBadRequest(request?: Partial<GatewayRequest>, 
   return _fetchGatewayWithRetries({ expectedStatusCode: 400, ...request }, logger);
 }
 
+export async function fetchGatewayServiceUnavailable(request?: Partial<GatewayRequest>, logger: Logger = console) {
+  return _fetchGatewayWithRetries({ expectedStatusCode: 503, ...request }, logger);
+}
+
 async function _fetchGatewayWithRetries(attributes: Partial<GatewayRequest>, logger: Logger): Promise<Response> {
   const request = <GatewayRequest>{
     expectedStatusCode: 200,

--- a/gravitee-apim-e2e/lib/utils/wiremock.ts
+++ b/gravitee-apim-e2e/lib/utils/wiremock.ts
@@ -28,3 +28,10 @@ export async function setWiremockState(scenarioName: string, state: string) {
     throw new Error(`Unable to put scenario ${scenarioName} in state ${state} (HTTP ${status})`);
   }
 }
+
+export async function verifyWiremockRequest(url: string, method: string) {
+  return fetchApi(`${process.env.WIREMOCK_BASE_URL_FOR_JEST}/__admin/requests/count`, {
+    method: 'POST',
+    body: JSON.stringify({ method, url }),
+  });
+}


### PR DESCRIPTION
## Description
This adds 3 tests to verify that the failover functionality is working properly.

1st test: checks behaviour without failover
2nd test: makes sure that failover works and can eventually reach a working endpoint  
3rd test: makes sure that it only tries <MAX_ATTEMPTS> times to look for a working endpoint and returns failure if it doesn't



APIM-164

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/test-apim-164-enable-failover-and-trigger-it-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bogfvewjrq.chromatic.com)
<!-- Storybook placeholder end -->
