### PR TITLE
Change Upgrader order at startup

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/ApiPrimaryOwnerRemovalUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/ApiPrimaryOwnerRemovalUpgrader.java
@@ -155,7 +155,7 @@ public class ApiPrimaryOwnerRemovalUpgrader implements Upgrader, Ordered {
 
     @Override
     public int getOrder() {
-        return 100;
+        return 140;
     }
 
     private String findApiPrimaryOwnerRoleId(String organizationId) throws TechnicalException {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DefaultOrganizationAdminRoleUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DefaultOrganizationAdminRoleUpgrader.java
@@ -49,6 +49,6 @@ public class DefaultOrganizationAdminRoleUpgrader extends OrganizationUpgrader {
 
     @Override
     public int getOrder() {
-        return 160;
+        return 130;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DefaultRolesUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DefaultRolesUpgrader.java
@@ -78,6 +78,6 @@ public class DefaultRolesUpgrader extends OneShotUpgrader {
 
     @Override
     public int getOrder() {
-        return 150;
+        return 120;
     }
 }


### PR DESCRIPTION
Issue

N/A

## Description

ApiPrimaryOwnerRemovalUpgrader introduced in 3.18.10 can generate an error on an empty database at startup because it tries to get the primary owner role from the db. But this role is created by another Upgrader after this one.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/upgrader-startup-order/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qfaerchzil.chromatic.com)
<!-- Storybook placeholder end -->
