### PR TITLE
fix: import kubernetes managed api with state

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/UpdateApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/UpdateApiEntity.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.gravitee.common.component.Lifecycle;
 import io.gravitee.definition.model.*;
 import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.definition.model.plugins.resources.Resource;
@@ -151,6 +152,9 @@ public class UpdateApiEntity {
     @JsonProperty("background_url")
     @Schema(description = "the API background URL")
     private String backgroundUrl;
+
+    @Schema(hidden = true, description = "The API's lifecycle state has been added for the kubernetes operator only.")
+    private Lifecycle.State state;
 
     @JsonIgnore
     public void setProperties(PropertiesEntity properties) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -568,7 +568,9 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
             if (DefinitionContext.isKubernetes(repoApi.getOrigin())) {
                 // Be sure that api is always marked as STARTED when managed by k8s.
-                repoApi.setLifecycleState(LifecycleState.STARTED);
+                repoApi.setLifecycleState(
+                    api.getState() == null ? LifecycleState.STARTED : LifecycleState.valueOf(api.getState().toString())
+                );
 
                 // Set the api lifecycle state if defined or set it to CREATED by default.
                 repoApi.setApiLifecycleState(
@@ -1201,7 +1203,11 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
             if (DefinitionContext.isKubernetes(api.getOrigin())) {
                 // Be sure that api is started when managed by k8s.
-                api.setLifecycleState(LifecycleState.STARTED);
+                api.setLifecycleState(
+                    updateApiEntity.getState() == null
+                        ? LifecycleState.STARTED
+                        : LifecycleState.valueOf(updateApiEntity.getState().toString())
+                );
                 if (updateApiEntity.getLifecycleState() != null) {
                     api.setApiLifecycleState(ApiLifecycleState.valueOf(updateApiEntity.getLifecycleState().name()));
                 }


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-205

## Description

Today when an API is imported using the kubernetes operator, it's started by default. When I play with my API state ( stop it, start it, stop it... ) I have to call multiple endpoints to be able to deploy it on the gateway and have my management api up to date. The gool of this fix is to reduce the number of http request and be able to manage the api state directly in the import only for kubernetes operator apis
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-205-import-kub-api-with-state/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ircplfqmpu.chromatic.com)
<!-- Storybook placeholder end -->
