### PR TITLE
feat: get subscription schema form for entrypoint plugin

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-handler/src/main/java/io/gravitee/plugin/entrypoint/EntrypointConnectorPluginManager.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-handler/src/main/java/io/gravitee/plugin/entrypoint/EntrypointConnectorPluginManager.java
@@ -17,6 +17,7 @@ package io.gravitee.plugin.entrypoint;
 
 import io.gravitee.gateway.jupiter.api.connector.entrypoint.EntrypointConnectorFactory;
 import io.gravitee.plugin.core.api.ConfigurablePluginManager;
+import java.io.IOException;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -27,4 +28,6 @@ public interface EntrypointConnectorPluginManager extends ConfigurablePluginMana
      * @return the factory <code>Class</code> according to the given plugin id
      */
     <T extends EntrypointConnectorFactory<?>> T getFactoryById(final String entrypointPluginId);
+
+    String getSubscriptionSchema(String pluginId) throws IOException;
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-handler/src/main/java/io/gravitee/plugin/entrypoint/internal/DefaultEntrypointConnectorPluginManager.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-handler/src/main/java/io/gravitee/plugin/entrypoint/internal/DefaultEntrypointConnectorPluginManager.java
@@ -22,6 +22,7 @@ import io.gravitee.plugin.core.api.PluginClassLoader;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorClassLoaderFactory;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPluginManager;
+import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
@@ -86,5 +87,10 @@ public class DefaultEntrypointConnectorPluginManager
     @Override
     public EntrypointConnectorFactory<?> getFactoryById(final String entrypointPluginId) {
         return factories.get(entrypointPluginId);
+    }
+
+    @Override
+    public String getSubscriptionSchema(String pluginId) throws IOException {
+        return getSchema(pluginId, "subscriptions");
     }
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-handler/src/test/java/io/gravitee/plugin/entrypoint/internal/DefaultEntrypointConnectorPluginManagerTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-handler/src/test/java/io/gravitee/plugin/entrypoint/internal/DefaultEntrypointConnectorPluginManagerTest.java
@@ -16,6 +16,8 @@
 package io.gravitee.plugin.entrypoint.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.gateway.jupiter.api.connector.ConnectorFactoryHelper;
@@ -26,6 +28,7 @@ import io.gravitee.plugin.entrypoint.EntrypointConnectorPluginManager;
 import io.gravitee.plugin.entrypoint.internal.fake.FakeEntrypointConnector;
 import io.gravitee.plugin.entrypoint.internal.fake.FakeEntrypointConnectorFactory;
 import io.gravitee.plugin.entrypoint.internal.fake.FakeEntrypointConnectorPlugin;
+import java.io.IOException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,6 +37,8 @@ import org.junit.jupiter.api.Test;
  * @author GraviteeSource Team
  */
 class DefaultEntrypointConnectorPluginManagerTest {
+
+    private static final String FAKE_ENTRYPOINT = "fake-entrypoint";
 
     private EntrypointConnectorPluginManager entrypointConnectorPluginManager;
 
@@ -47,7 +52,7 @@ class DefaultEntrypointConnectorPluginManagerTest {
     }
 
     @Test
-    public void shouldRegisterNewEntrypointPluginWithoutConfiguration() {
+    void shouldRegisterNewEntrypointPluginWithoutConfiguration() {
         DefaultEntrypointConnectorPlugin entrypointPlugin = new DefaultEntrypointConnectorPlugin(
             new FakeEntrypointConnectorPlugin(),
             FakeEntrypointConnectorFactory.class,
@@ -61,7 +66,7 @@ class DefaultEntrypointConnectorPluginManagerTest {
     }
 
     @Test
-    public void shouldRegisterNewEntrypointPluginWithConfiguration() {
+    void shouldRegisterNewEntrypointPluginWithConfiguration() {
         DefaultEntrypointConnectorPlugin<FakeEntrypointConnectorFactory, EntrypointConnectorConfiguration> entrypointPlugin = new DefaultEntrypointConnectorPlugin(
             new FakeEntrypointConnectorPlugin(),
             FakeEntrypointConnectorFactory.class,
@@ -78,8 +83,22 @@ class DefaultEntrypointConnectorPluginManagerTest {
     }
 
     @Test
-    public void shouldNotRetrieveUnRegisterPlugin() {
+    void shouldNotRetrieveUnRegisterPlugin() {
         final EntrypointConnector factoryById = entrypointConnectorPluginManager.getFactoryById("fake-endpoint");
         assertThat(factoryById).isNull();
+    }
+
+    @Test
+    void shouldNotFindSubscriptionSchemaFile() throws IOException {
+        entrypointConnectorPluginManager.register(new FakeEntrypointConnectorPlugin(true));
+        final String schema = entrypointConnectorPluginManager.getSubscriptionSchema(FAKE_ENTRYPOINT);
+        assertThat(schema).isNull();
+    }
+
+    @Test
+    void shouldGetFirstSubscriptionSchemaFile() throws IOException {
+        entrypointConnectorPluginManager.register(new FakeEntrypointConnectorPlugin());
+        final String schema = entrypointConnectorPluginManager.getSubscriptionSchema(FAKE_ENTRYPOINT);
+        assertThat(schema).isEqualTo("{\n  \"schema\": \"subscription\"\n}");
     }
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-handler/src/test/java/io/gravitee/plugin/entrypoint/internal/fake/FakeEntrypointConnectorPlugin.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-handler/src/test/java/io/gravitee/plugin/entrypoint/internal/fake/FakeEntrypointConnectorPlugin.java
@@ -18,8 +18,10 @@ package io.gravitee.plugin.entrypoint.internal.fake;
 import io.gravitee.gateway.jupiter.api.connector.entrypoint.EntrypointConnectorFactory;
 import io.gravitee.plugin.core.api.PluginManifest;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -27,6 +29,19 @@ import java.nio.file.Path;
  */
 public class FakeEntrypointConnectorPlugin
     implements EntrypointConnectorPlugin<FakeEntrypointConnectorFactory, FakeEntrypointConnectorConfiguration> {
+
+    private static final String WITH_SUBSCRIPTION_FILE = "with-subscription";
+    private static final String WITHOUT_SUBSCRIPTION_FILE = "without-subscription";
+
+    private final String resourceFolder;
+
+    public FakeEntrypointConnectorPlugin(boolean withoutResource) {
+        resourceFolder = withoutResource ? WITHOUT_SUBSCRIPTION_FILE : WITH_SUBSCRIPTION_FILE;
+    }
+
+    public FakeEntrypointConnectorPlugin() {
+        resourceFolder = WITH_SUBSCRIPTION_FILE;
+    }
 
     @Override
     public String id() {
@@ -50,7 +65,11 @@ public class FakeEntrypointConnectorPlugin
 
     @Override
     public Path path() {
-        return null;
+        try {
+            return Paths.get(this.getClass().getClassLoader().getResource("files/" + resourceFolder).toURI());
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-handler/src/test/resources/files/with-subscription/docs/doc.md
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-handler/src/test/resources/files/with-subscription/docs/doc.md
@@ -1,0 +1,1 @@
+plugin documentation

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-handler/src/test/resources/files/with-subscription/schemas/schema-form.json
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-handler/src/test/resources/files/with-subscription/schemas/schema-form.json
@@ -1,0 +1,3 @@
+{
+  "schema": "configuration"
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-handler/src/test/resources/files/with-subscription/schemas/subscriptions/schema-form.json
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-handler/src/test/resources/files/with-subscription/schemas/subscriptions/schema-form.json
@@ -1,0 +1,3 @@
+{
+  "schema": "subscription"
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-handler/src/test/resources/files/without-subscription/docs/doc.md
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-handler/src/test/resources/files/without-subscription/docs/doc.md
@@ -1,0 +1,1 @@
+plugin documentation

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-handler/src/test/resources/files/without-subscription/schemas/schema-form.json
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-handler/src/test/resources/files/without-subscription/schemas/schema-form.json
@@ -1,0 +1,3 @@
+{
+  "schema": "configuration"
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/v4/entrypoint/EntrypointResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/v4/entrypoint/EntrypointResource.java
@@ -83,6 +83,7 @@ public class EntrypointResource {
     )
     @ApiResponse(responseCode = "404", description = "Entrypoint not found")
     @ApiResponse(responseCode = "500", description = "Internal server error")
+    @ApiResponse(responseCode = "204", description = "Schema not found")
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = RolePermissionAction.READ) })
     public String getEntrypointSchema(@PathParam("entrypoint") String entrypoint) {
         // Check that the entrypoint exists
@@ -105,11 +106,35 @@ public class EntrypointResource {
     )
     @ApiResponse(responseCode = "404", description = "Entrypoint not found")
     @ApiResponse(responseCode = "500", description = "Internal server error")
+    @ApiResponse(responseCode = "204", description = "Documentation not found")
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = RolePermissionAction.READ) })
     public String getEntrypointDoc(@PathParam("entrypoint") String entrypoint) {
         // Check that the entrypoint exists
         entrypointService.findById(entrypoint);
 
         return entrypointService.getDocumentation(entrypoint);
+    }
+
+    @GET
+    @Path("subscriptionSchema")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+        summary = "🧪 Get a entrypoint's subscription schema",
+        description = "⚠️ This resource is in alpha version. This implies that it is likely to be modified or even removed in future versions. ⚠️. <br><br>User must have the ENVIRONMENT_API[READ] permission to use this service"
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "Entrypoint schema",
+        content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = String.class))
+    )
+    @ApiResponse(responseCode = "404", description = "Entrypoint not found")
+    @ApiResponse(responseCode = "500", description = "Internal server error")
+    @ApiResponse(responseCode = "204", description = "Subscription schema not found")
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = RolePermissionAction.READ) })
+    public String getEntrypointSubscriptionSchema(@PathParam("entrypoint") String entrypoint) {
+        // Check that the entrypoint exists
+        entrypointService.findById(entrypoint);
+
+        return entrypointService.getSubscriptionSchema(entrypoint);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/v4/entrypoint/EntrypointsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/v4/entrypoint/EntrypointsResource.java
@@ -24,6 +24,7 @@ import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.v4.connector.ConnectorExpandPluginEntity;
 import io.gravitee.rest.api.service.v4.EntrypointConnectorPluginService;
+import io.swagger.annotations.ApiParam;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -71,8 +72,18 @@ public class EntrypointsResource extends AbstractConnectorsResource {
     )
     @ApiResponse(responseCode = "500", description = "Internal server error")
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = RolePermissionAction.READ) })
-    public Collection<ConnectorExpandPluginEntity> getEntrypoints(@QueryParam("expand") List<String> expands) {
-        return super.expand(entrypointService.findAll(), expands);
+    public Collection<ConnectorExpandPluginEntity> getEntrypoints(
+        @QueryParam("expand") @ApiParam(
+            name = "expand",
+            allowableValues = "schema, icon, subscriptionSchema",
+            allowMultiple = true
+        ) List<String> expands
+    ) {
+        final Collection<ConnectorExpandPluginEntity> connectors = super.expand(entrypointService.findAll(), expands);
+        if (expands != null && expands.contains("subscriptionSchema")) {
+            connectors.forEach(connector -> connector.setSubscriptionSchema(entrypointService.getSubscriptionSchema(connector.getId())));
+        }
+        return connectors;
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/v4/entrypoint/EntrypointResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/v4/entrypoint/EntrypointResourceTest.java
@@ -1,0 +1,194 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource.v4.entrypoint;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.ConnectorMode;
+import io.gravitee.rest.api.management.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.v4.connector.ConnectorPluginEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.PluginNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.ws.rs.core.Response;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class EntrypointResourceTest extends AbstractResourceTest {
+
+    public static final String FAKE_ENTRYPOINT = "fake-entrypoint";
+
+    @Override
+    protected String contextPath() {
+        return "v4/entrypoints/fake-entrypoint";
+    }
+
+    @Before
+    public void init() {
+        reset(entrypointConnectorPluginService);
+        GraviteeContext.cleanContext();
+    }
+
+    @Test
+    public void shouldGetEntrypointSchema() {
+        ConnectorPluginEntity connectorPlugin = new ConnectorPluginEntity();
+        connectorPlugin.setId(FAKE_ENTRYPOINT);
+        connectorPlugin.setName("Fake Entrypoint");
+        connectorPlugin.setVersion("1.0");
+        connectorPlugin.setSupportedApiType(ApiType.ASYNC);
+        connectorPlugin.setSupportedModes(Set.of(ConnectorMode.SUBSCRIBE));
+        when(entrypointConnectorPluginService.findById(FAKE_ENTRYPOINT)).thenReturn(connectorPlugin);
+        when(entrypointConnectorPluginService.getSchema(FAKE_ENTRYPOINT)).thenReturn("schemaResponse");
+
+        final Response response = envTarget().path("schema").request().get();
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        final String result = response.readEntity(String.class);
+        Assertions.assertThat(result).isEqualTo("schemaResponse");
+    }
+
+    @Test
+    public void shouldNotGetEntrypointSchemaWhenPluginNotFound() {
+        ConnectorPluginEntity connectorPlugin = new ConnectorPluginEntity();
+        connectorPlugin.setId(FAKE_ENTRYPOINT);
+        connectorPlugin.setName("Fake Entrypoint");
+        connectorPlugin.setVersion("1.0");
+        connectorPlugin.setSupportedApiType(ApiType.ASYNC);
+        connectorPlugin.setSupportedModes(Set.of(ConnectorMode.SUBSCRIBE));
+        when(entrypointConnectorPluginService.findById(FAKE_ENTRYPOINT)).thenThrow(new PluginNotFoundException(FAKE_ENTRYPOINT));
+
+        final Response response = envTarget().path("schema").request().get();
+        assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
+        final String result = response.readEntity(String.class);
+        Assertions
+            .assertThat(result)
+            .isEqualTo(
+                "{\n" +
+                "  \"message\" : \"Plugin [" +
+                FAKE_ENTRYPOINT +
+                "] can not be found.\",\n" +
+                "  \"parameters\" : {\n" +
+                "    \"plugin\" : \"fake-entrypoint\"\n" +
+                "  },\n" +
+                "  \"technicalCode\" : \"plugin.notFound\",\n" +
+                "  \"http_status\" : 404\n" +
+                "}"
+            );
+    }
+
+    @Test
+    public void shouldGetEntrypointDocumentation() {
+        ConnectorPluginEntity connectorPlugin = new ConnectorPluginEntity();
+        connectorPlugin.setId(FAKE_ENTRYPOINT);
+        connectorPlugin.setName("Fake Entrypoint");
+        connectorPlugin.setVersion("1.0");
+        connectorPlugin.setSupportedApiType(ApiType.ASYNC);
+        connectorPlugin.setSupportedModes(Set.of(ConnectorMode.SUBSCRIBE));
+        when(entrypointConnectorPluginService.findById(FAKE_ENTRYPOINT)).thenReturn(connectorPlugin);
+        when(entrypointConnectorPluginService.getDocumentation(FAKE_ENTRYPOINT)).thenReturn("documentationResponse");
+
+        final Response response = envTarget().path("documentation").request().get();
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        final String result = response.readEntity(String.class);
+        Assertions.assertThat(result).isEqualTo("documentationResponse");
+    }
+
+    @Test
+    public void shouldNotGetEntrypointDocumentationWhenPluginNotFound() {
+        ConnectorPluginEntity connectorPlugin = new ConnectorPluginEntity();
+        connectorPlugin.setId(FAKE_ENTRYPOINT);
+        connectorPlugin.setName("Fake Entrypoint");
+        connectorPlugin.setVersion("1.0");
+        connectorPlugin.setSupportedApiType(ApiType.ASYNC);
+        connectorPlugin.setSupportedModes(Set.of(ConnectorMode.SUBSCRIBE));
+        when(entrypointConnectorPluginService.findById(FAKE_ENTRYPOINT)).thenThrow(new PluginNotFoundException(FAKE_ENTRYPOINT));
+
+        final Response response = envTarget().path("documentation").request().get();
+        assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
+        final String result = response.readEntity(String.class);
+        Assertions
+            .assertThat(result)
+            .isEqualTo(
+                "{\n" +
+                "  \"message\" : \"Plugin [" +
+                FAKE_ENTRYPOINT +
+                "] can not be found.\",\n" +
+                "  \"parameters\" : {\n" +
+                "    \"plugin\" : \"fake-entrypoint\"\n" +
+                "  },\n" +
+                "  \"technicalCode\" : \"plugin.notFound\",\n" +
+                "  \"http_status\" : 404\n" +
+                "}"
+            );
+    }
+
+    @Test
+    public void shouldGetEntrypointSubscriptionSchema() {
+        ConnectorPluginEntity connectorPlugin = new ConnectorPluginEntity();
+        connectorPlugin.setId(FAKE_ENTRYPOINT);
+        connectorPlugin.setName("Fake Entrypoint");
+        connectorPlugin.setVersion("1.0");
+        connectorPlugin.setSupportedApiType(ApiType.ASYNC);
+        connectorPlugin.setSupportedModes(Set.of(ConnectorMode.SUBSCRIBE));
+        when(entrypointConnectorPluginService.findById(FAKE_ENTRYPOINT)).thenReturn(connectorPlugin);
+        when(entrypointConnectorPluginService.getSubscriptionSchema(FAKE_ENTRYPOINT)).thenReturn("subscriptionSchemaResponse");
+
+        final Response response = envTarget().path("subscriptionSchema").request().get();
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        final String result = response.readEntity(String.class);
+        Assertions.assertThat(result).isEqualTo("subscriptionSchemaResponse");
+    }
+
+    @Test
+    public void shouldNotGetEntrypointSubscriptionSchemaWhenPluginNotFound() {
+        ConnectorPluginEntity connectorPlugin = new ConnectorPluginEntity();
+        connectorPlugin.setId(FAKE_ENTRYPOINT);
+        connectorPlugin.setName("Fake Entrypoint");
+        connectorPlugin.setVersion("1.0");
+        connectorPlugin.setSupportedApiType(ApiType.ASYNC);
+        connectorPlugin.setSupportedModes(Set.of(ConnectorMode.SUBSCRIBE));
+        when(entrypointConnectorPluginService.findById(FAKE_ENTRYPOINT)).thenThrow(new PluginNotFoundException(FAKE_ENTRYPOINT));
+
+        final Response response = envTarget().path("subscriptionSchema").request().get();
+        assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
+        final String result = response.readEntity(String.class);
+        Assertions
+            .assertThat(result)
+            .isEqualTo(
+                "{\n" +
+                "  \"message\" : \"Plugin [" +
+                FAKE_ENTRYPOINT +
+                "] can not be found.\",\n" +
+                "  \"parameters\" : {\n" +
+                "    \"plugin\" : \"fake-entrypoint\"\n" +
+                "  },\n" +
+                "  \"technicalCode\" : \"plugin.notFound\",\n" +
+                "  \"http_status\" : 404\n" +
+                "}"
+            );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/v4/entrypoint/EntrypointsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/v4/entrypoint/EntrypointsResourceTest.java
@@ -101,4 +101,39 @@ public class EntrypointsResourceTest extends AbstractResourceTest {
         assertEquals("schema", pluginEntity.get("schema"));
         assertEquals("icon", pluginEntity.get("icon"));
     }
+
+    @Test
+    public void shouldReturnAllEntrypointsWithSchemaAndSubscriptionSchema() {
+        ConnectorPluginEntity connectorPlugin = new ConnectorPluginEntity();
+        connectorPlugin.setId("id");
+        connectorPlugin.setName("name");
+        connectorPlugin.setVersion("1.0");
+        connectorPlugin.setSupportedApiType(ApiType.ASYNC);
+        connectorPlugin.setSupportedModes(Set.of(ConnectorMode.SUBSCRIBE));
+        when(entrypointConnectorPluginService.findAll()).thenReturn(Set.of(connectorPlugin));
+        when(entrypointConnectorPluginService.getSchema(connectorPlugin.getId())).thenReturn("schema");
+        when(entrypointConnectorPluginService.getIcon(connectorPlugin.getId())).thenReturn("icon");
+        when(entrypointConnectorPluginService.getSubscriptionSchema(connectorPlugin.getId())).thenReturn("subscriptionSchema");
+
+        final Response response = envTarget()
+            .queryParam("expand", "schema")
+            .queryParam("expand", "subscriptionSchema")
+            .queryParam("expand", "icon")
+            .request()
+            .get();
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        final List<Map<String, String>> pluginEntities = response.readEntity(List.class);
+        assertEquals(1, pluginEntities.size());
+        Map<String, String> pluginEntity = pluginEntities.get(0);
+        assertEquals("id", pluginEntity.get("id"));
+        assertEquals("name", pluginEntity.get("name"));
+        assertEquals("1.0", pluginEntity.get("version"));
+        assertEquals(ApiType.ASYNC.getLabel(), pluginEntity.get("supportedApiType"));
+        ArrayList<String> arrayList = new ArrayList<>();
+        arrayList.add(ConnectorMode.SUBSCRIBE.getLabel());
+        assertEquals(arrayList, pluginEntity.get("supportedModes"));
+        assertEquals("schema", pluginEntity.get("schema"));
+        assertEquals("icon", pluginEntity.get("icon"));
+        assertEquals("subscriptionSchema", pluginEntity.get("subscriptionSchema"));
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/connector/ConnectorExpandPluginEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/connector/ConnectorExpandPluginEntity.java
@@ -36,4 +36,5 @@ public class ConnectorExpandPluginEntity extends ConnectorPluginEntity {
 
     private String schema;
     private String icon;
+    private String subscriptionSchema;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/EntrypointConnectorPluginService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/EntrypointConnectorPluginService.java
@@ -19,4 +19,11 @@ package io.gravitee.rest.api.service.v4;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface EntrypointConnectorPluginService extends ConnectorPluginService {}
+public interface EntrypointConnectorPluginService extends ConnectorPluginService {
+    /**
+     * Retrieve the subscription schema of the entrypoint if it exists.
+     * @param connectorId is the id of the entrypoint
+     * @return the subscription schema as a string, else {@code null}
+     */
+    String getSubscriptionSchema(String connectorId);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/EntrypointConnectorPluginServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/EntrypointConnectorPluginServiceImpl.java
@@ -20,7 +20,9 @@ import io.gravitee.plugin.core.api.ConfigurablePluginManager;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPluginManager;
 import io.gravitee.rest.api.service.JsonSchemaService;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.v4.EntrypointConnectorPluginService;
+import java.io.IOException;
 import org.springframework.stereotype.Component;
 
 /**
@@ -42,5 +44,19 @@ public class EntrypointConnectorPluginServiceImpl
     @Override
     protected ConnectorFactory<?> getConnectorFactory(final String connectorId) {
         return ((EntrypointConnectorPluginManager) pluginManager).getFactoryById(connectorId);
+    }
+
+    @Override
+    public String getSubscriptionSchema(final String connectorId) {
+        try {
+            logger.debug("Find entrypoint subscription schema by ID: {}", connectorId);
+            return ((EntrypointConnectorPluginManager) pluginManager).getSubscriptionSchema(connectorId);
+        } catch (IOException ioex) {
+            logger.error("An error occurs while trying to get entrypoint subscription schema for plugin {}", connectorId, ioex);
+            throw new TechnicalManagementException(
+                "An error occurs while trying to get entrypoint subscription schema for plugin " + connectorId,
+                ioex
+            );
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/EntrypointConnectorPluginServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/EntrypointConnectorPluginServiceImplTest.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.impl;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+import com.github.fge.jsonschema.main.JsonSchema;
+import com.google.errorprone.annotations.DoNotMock;
+import io.gravitee.plugin.core.api.ConfigurablePluginManager;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPluginManager;
+import io.gravitee.rest.api.service.JsonSchemaService;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import io.gravitee.rest.api.service.v4.EntrypointConnectorPluginService;
+import java.io.IOException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class EntrypointConnectorPluginServiceImplTest {
+
+    private static final String CONNECTOR_ID = "connector-id";
+
+    private EntrypointConnectorPluginService cut;
+
+    @Mock
+    private JsonSchemaService jsonSchemaService;
+
+    @Mock
+    private EntrypointConnectorPluginManager pluginManager;
+
+    @Before
+    public void setUp() {
+        cut = new EntrypointConnectorPluginServiceImpl(jsonSchemaService, pluginManager);
+    }
+
+    @Test
+    public void shouldGetSubscriptionSchema() throws IOException {
+        when(pluginManager.getSubscriptionSchema(CONNECTOR_ID)).thenReturn("subscriptionConfiguration");
+
+        final String result = cut.getSubscriptionSchema(CONNECTOR_ID);
+
+        assertThat(result).isEqualTo("subscriptionConfiguration");
+    }
+
+    @Test
+    public void shouldNotGetSubscriptionSchemaBecauseOfIOException() throws IOException {
+        when(pluginManager.getSubscriptionSchema(CONNECTOR_ID)).thenThrow(IOException.class);
+
+        try {
+            cut.getSubscriptionSchema(CONNECTOR_ID);
+            fail("We should not go further because call should throw a TechnicalManagementException");
+        } catch (TechnicalManagementException e) {
+            assertThat(e.getMessage())
+                .isEqualTo("An error occurs while trying to get entrypoint subscription schema for plugin " + CONNECTOR_ID);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -60,11 +60,11 @@
         <gravitee-connector-api.version>1.1.4</gravitee-connector-api.version>
         <gravitee-expression-language.version>2.0.0-alpha.2</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>2.0.0-alpha.1</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>2.0.0-alpha.2</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>2.0.0-alpha.3</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>
-        <gravitee-plugin.version>1.24.1</gravitee-plugin.version>
+        <gravitee-plugin.version>1.25.0-alpha.1</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.2.0</gravitee-platform-repository-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>1.23.1</gravitee-reporter-api.version>


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-189

## Description

Enhance Entrypoint resources to be able to get the list of entrypoints with subscription schema if needed, or directly the subscription schema for an entrypoint

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-189-entrypoint-subscription/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cteekwrwdm.chromatic.com)
<!-- Storybook placeholder end -->
