### PR TITLE
fix(rest-api): increase BooleanQuery maxClauseCount when is necessary

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/AbstractDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/AbstractDocumentSearcher.java
@@ -45,6 +45,12 @@ public abstract class AbstractDocumentSearcher implements DocumentSearcher {
     protected static final String FIELD_TYPE = "type";
     protected static final String FIELD_API_TYPE_VALUE = "api";
 
+    protected static void increaseMaxClauseCountIfNecessary(int size) {
+        if (size > BooleanQuery.getMaxClauseCount()) {
+            BooleanQuery.setMaxClauseCount(size);
+        }
+    }
+
     protected Analyzer analyzer = new CustomWhitespaceAnalyzer();
 
     @Autowired
@@ -120,9 +126,8 @@ public abstract class AbstractDocumentSearcher implements DocumentSearcher {
             Object values = filters.get(FIELD_API_TYPE_VALUE);
             if (Collection.class.isAssignableFrom(values.getClass())) {
                 Collection valuesAsCollection = (Collection) values;
-                if (valuesAsCollection.size() > BooleanQuery.getMaxClauseCount()) {
-                    BooleanQuery.setMaxClauseCount(valuesAsCollection.size());
-                }
+                increaseMaxClauseCountIfNecessary(valuesAsCollection.size());
+
                 BooleanQuery.Builder filterApisQuery = new BooleanQuery.Builder();
                 ((Collection<?>) values).forEach(
                         value -> filterApisQuery.add(new TermQuery(new Term(apiReferenceField, (String) value)), BooleanClause.Occur.SHOULD)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcher.java
@@ -127,6 +127,7 @@ public class ApiDocumentSearcher extends AbstractDocumentSearcher {
 
     private Optional<BooleanQuery> buildIdsQuery(io.gravitee.rest.api.service.search.query.Query query) {
         if (!isBlank(query.getQuery()) && query.getIds() != null && !query.getIds().isEmpty()) {
+            increaseMaxClauseCountIfNecessary(query.getIds().size());
             BooleanQuery.Builder mainQuery = new BooleanQuery.Builder();
             query.getIds().forEach(id -> mainQuery.add(new TermQuery(new Term(FIELD_ID, (String) id)), BooleanClause.Occur.SHOULD));
             return Optional.of(mainQuery.build());


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8568

## Description

Increase BooleanQuery maxClauseCount when is necessary

✏️ Bug fix for Decathlon 


## Additional context
Not sure if a test is necessary but I should be able to do a tu if you want. 

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8568-3-18-x-fix-maxclausecount/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kicohosouw.chromatic.com)
<!-- Storybook placeholder end -->
