### PR TITLE
fix: use headers list in webhook entrypoint plugin configuration

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/main/java/io/gravitee/plugin/entrypoint/webhook/WebhookEntrypointConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/main/java/io/gravitee/plugin/entrypoint/webhook/WebhookEntrypointConnector.java
@@ -161,9 +161,9 @@ public class WebhookEntrypointConnector extends EntrypointAsyncConnector {
                         subscriptionConfiguration
                             .getHeaders()
                             .forEach(
-                                (key, value) -> {
-                                    if (!request.headers().contains(key)) {
-                                        request.putHeader(key, value);
+                                header -> {
+                                    if (!request.headers().contains(header.getName())) {
+                                        request.putHeader(header.getName(), header.getValue());
                                     }
                                 }
                             );

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/main/java/io/gravitee/plugin/entrypoint/webhook/configuration/HttpHeader.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/main/java/io/gravitee/plugin/entrypoint/webhook/configuration/HttpHeader.java
@@ -15,35 +15,21 @@
  */
 package io.gravitee.plugin.entrypoint.webhook.configuration;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import io.gravitee.gateway.jupiter.api.connector.entrypoint.async.EntrypointConnectorSubscriptionConfiguration;
-import io.gravitee.plugin.entrypoint.webhook.WebhookEntrypointConnector;
-import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.ToString;
 
 /**
  * @author GraviteeSource Team
  */
 @Getter
 @Setter
-@ToString
-public class WebhookEntrypointConnectorSubscriptionConfiguration implements EntrypointConnectorSubscriptionConfiguration {
+@NoArgsConstructor
+@AllArgsConstructor
+public class HttpHeader {
 
-    @JsonProperty
-    @Override
-    public String entrypointId() {
-        return WebhookEntrypointConnector.ENTRYPOINT_ID;
-    }
+    private String name;
 
-    /**
-     * The callback URL called by the entrypoint on a message.
-     */
-    private String callbackUrl;
-
-    /**
-     * The list of headers to add to the request to the callback URL.
-     */
-    private List<HttpHeader> headers;
+    private String value;
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/test/java/io/gravitee/plugin/entrypoint/webhook/WebhookEntrypointMockEndpointIntegrationTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/test/java/io/gravitee/plugin/entrypoint/webhook/WebhookEntrypointMockEndpointIntegrationTest.java
@@ -30,7 +30,9 @@ import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
 import io.gravitee.gateway.api.service.Subscription;
 import io.gravitee.gateway.jupiter.reactor.v4.subscription.SubscriptionDispatcher;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.webhook.configuration.HttpHeader;
 import io.gravitee.plugin.entrypoint.webhook.configuration.WebhookEntrypointConnectorSubscriptionConfiguration;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.UUID;
@@ -86,7 +88,7 @@ class WebhookEntrypointMockEndpointIntegrationTest extends AbstractGatewayTest {
     void shouldSendMessagesFromMockEndpointToWebhookEntrypointWithHeaders() throws JsonProcessingException {
         WebhookEntrypointConnectorSubscriptionConfiguration configuration = new WebhookEntrypointConnectorSubscriptionConfiguration();
         configuration.setCallbackUrl(String.format("http://localhost:%s%s", wiremock.port(), WEBHOOK_URL_PATH));
-        configuration.setHeaders(Map.of("Header1", "my-header-1-value", "Header2", "my-header-2-value"));
+        configuration.setHeaders(List.of(new HttpHeader("Header1", "my-header-1-value"), new HttpHeader("Header2", "my-header-2-value")));
 
         Subscription subscription = buildTestSubscription(configuration);
 


### PR DESCRIPTION
https://graviteecommunity.atlassian.net/browse/APIM-184
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/api-65-headerslist/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uqayksevtf.chromatic.com)
<!-- Storybook placeholder end -->
