### PR TITLE
fix: npe on message condition

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/jupiter/http/vertx/VertxHttpServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/jupiter/http/vertx/VertxHttpServerRequest.java
@@ -137,12 +137,12 @@ public class VertxHttpServerRequest extends AbstractVertxServerRequest {
 
     @Override
     public void setMessagesInterceptor(Function<FlowableTransformer<Message, Message>, FlowableTransformer<Message, Message>> interceptor) {
-        messageFlow.setOnMessagesInterceptor(interceptor);
+        getMessageFlow().setOnMessagesInterceptor(interceptor);
     }
 
     @Override
     public void unsetMessagesInterceptor() {
-        messageFlow.unsetOnMessagesInterceptor();
+        getMessageFlow().unsetOnMessagesInterceptor();
     }
 
     private MessageFlow getMessageFlow() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/jupiter/http/vertx/VertxHttpServerResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/jupiter/http/vertx/VertxHttpServerResponse.java
@@ -128,12 +128,12 @@ public class VertxHttpServerResponse extends AbstractVertxServerResponse {
 
     @Override
     public void setMessagesInterceptor(Function<FlowableTransformer<Message, Message>, FlowableTransformer<Message, Message>> interceptor) {
-        messageFlow.setOnMessagesInterceptor(interceptor);
+        getMessageFlow().setOnMessagesInterceptor(interceptor);
     }
 
     @Override
     public void unsetMessagesInterceptor() {
-        messageFlow.unsetOnMessagesInterceptor();
+        getMessageFlow().unsetOnMessagesInterceptor();
     }
 
     private MessageFlow getMessageFlow() {


### PR DESCRIPTION
## Description

Putting a condition on a message inside the publish flow on an SSE entrypoint caused an NPE during qa tests.

```json
....
"flows": [
        {
            "name": "",
            "enabled": true,
            "selectors": [],
            "request": [],
            "response": [],
            "subscribe": [],
            "publish": [
                {
                    "name": "JSON to XML",
                    "description": "Json to xml",
                    "enabled": true,
                    "messageCondition": "{#message.content == '{}'}",
                    "policy": "json-xml",
                    "configuration": {
                        "rootElement": "root",
                        "scope": "REQUEST"
                    }
                }
            ],
            "tags": []
        }
    ]
```