### PR TITLE
feat: handle conversion of subscription containing v4 plans

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/Subscription.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/Subscription.java
@@ -232,7 +232,7 @@ public class Subscription {
 
         private final String id;
         private final String name;
-        private PlanSecurityType security;
+        private String security;
 
         public Plan(final String id, final String name) {
             this.id = id;
@@ -247,11 +247,11 @@ public class Subscription {
             return name;
         }
 
-        public PlanSecurityType getSecurity() {
+        public String getSecurity() {
             return security;
         }
 
-        public void setSecurity(PlanSecurityType security) {
+        public void setSecurity(String security) {
             this.security = security;
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionResource.java
@@ -25,9 +25,11 @@ import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.v4.PlanSearchService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -59,7 +61,7 @@ public class ApiSubscriptionResource extends AbstractResource {
     private ApiKeyService apiKeyService;
 
     @Inject
-    private PlanService planService;
+    private PlanSearchService planSearchService;
 
     @Inject
     private ApplicationService applicationService;
@@ -253,9 +255,9 @@ public class ApiSubscriptionResource extends AbstractResource {
         );
         subscription.setClientId(subscriptionEntity.getClientId());
 
-        PlanEntity plan = planService.findById(executionContext, subscriptionEntity.getPlan());
+        GenericPlanEntity plan = planSearchService.findById(executionContext, subscriptionEntity.getPlan());
         subscription.setPlan(new Subscription.Plan(plan.getId(), plan.getName()));
-        subscription.getPlan().setSecurity(plan.getSecurity());
+        subscription.getPlan().setSecurity(plan.getPlanSecurity().getType());
 
         ApplicationEntity application = applicationService.findById(executionContext, subscriptionEntity.getApplication());
         subscription.setApplication(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionResource.java
@@ -25,9 +25,11 @@ import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.v4.PlanSearchService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -53,7 +55,7 @@ public class ApplicationSubscriptionResource extends AbstractResource {
     private SubscriptionService subscriptionService;
 
     @Inject
-    private PlanService planService;
+    private PlanSearchService planSearchService;
 
     @Inject
     private UserService userService;
@@ -129,9 +131,9 @@ public class ApplicationSubscriptionResource extends AbstractResource {
             )
         );
 
-        PlanEntity plan = planService.findById(executionContext, subscriptionEntity.getPlan());
+        GenericPlanEntity plan = planSearchService.findById(executionContext, subscriptionEntity.getPlan());
         subscription.setPlan(new Subscription.Plan(plan.getId(), plan.getName()));
-        subscription.getPlan().setSecurity(plan.getSecurity());
+        subscription.getPlan().setSecurity(plan.getPlanSecurity().getType());
 
         GenericApiEntity genericApiEntity = apiSearchService.findGenericById(executionContext, subscriptionEntity.getApi());
         subscription.setApi(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionsResource.java
@@ -33,12 +33,14 @@ import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.subscription.SubscriptionMetadataQuery;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.PlanService;
 import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.v4.PlanSearchService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.Explode;
@@ -72,6 +74,9 @@ public class ApplicationSubscriptionsResource extends AbstractResource {
 
     @Inject
     private PlanService planService;
+
+    @Inject
+    private PlanSearchService planSearchService;
 
     @Inject
     private ApiService apiService;
@@ -195,9 +200,9 @@ public class ApplicationSubscriptionsResource extends AbstractResource {
             )
         );
 
-        PlanEntity plan = planService.findById(executionContext, subscriptionEntity.getPlan());
+        GenericPlanEntity plan = planSearchService.findById(executionContext, subscriptionEntity.getPlan());
         subscription.setPlan(new Subscription.Plan(plan.getId(), plan.getName()));
-        subscription.getPlan().setSecurity(plan.getSecurity());
+        subscription.getPlan().setSecurity(plan.getPlanSecurity().getType());
 
         GenericApiEntity genericApiEntity = apiSearchService.findGenericById(executionContext, subscriptionEntity.getApi());
         subscription.setApi(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionsResource.java
@@ -73,9 +73,6 @@ public class ApplicationSubscriptionsResource extends AbstractResource {
     private SubscriptionService subscriptionService;
 
     @Inject
-    private PlanService planService;
-
-    @Inject
     private PlanSearchService planSearchService;
 
     @Inject
@@ -109,7 +106,7 @@ public class ApplicationSubscriptionsResource extends AbstractResource {
         }
 
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
-        PlanEntity planEntity = planService.findById(executionContext, plan);
+        GenericPlanEntity planEntity = planSearchService.findById(executionContext, plan);
 
         if (
             planEntity.isCommentRequired() && (newSubscriptionEntity.getRequest() == null || newSubscriptionEntity.getRequest().isEmpty())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionResourceTest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource;
+
+import static io.gravitee.common.http.HttpStatusCode.CREATED_201;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.rest.api.model.ApiKeyEntity;
+import io.gravitee.rest.api.model.ApiKeyMode;
+import io.gravitee.rest.api.model.ApplicationEntity;
+import io.gravitee.rest.api.model.NewSubscriptionEntity;
+import io.gravitee.rest.api.model.PlanEntity;
+import io.gravitee.rest.api.model.PlanSecurityType;
+import io.gravitee.rest.api.model.PrimaryOwnerEntity;
+import io.gravitee.rest.api.model.ProcessSubscriptionEntity;
+import io.gravitee.rest.api.model.SubscriptionEntity;
+import io.gravitee.rest.api.model.SubscriptionStatus;
+import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.model.pagedresult.Metadata;
+import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
+import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.util.List;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.security.core.parameters.P;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class ApplicationSubscriptionResourceTest extends AbstractResourceTest {
+
+    private SubscriptionEntity fakeSubscriptionEntity;
+    private ApplicationEntity fakeApplicationEntity;
+    private static final String APPLICATION_ID = "my-application";
+    private static final String SUBSCRIPTION_ID = "my-subscription";
+    private static final String PLAN_ID = "my-plan";
+    private static final String API_ID = "my-api";
+
+    @Override
+    protected String contextPath() {
+        return "applications/" + APPLICATION_ID + "/subscriptions/";
+    }
+
+    @Before
+    public void setUp() {
+        reset(subscriptionService, userService, applicationService, planSearchService, apiSearchServiceV4, permissionService);
+
+        fakeSubscriptionEntity = new SubscriptionEntity();
+        fakeSubscriptionEntity.setId(SUBSCRIPTION_ID);
+        fakeSubscriptionEntity.setApi(API_ID);
+        fakeSubscriptionEntity.setPlan(PLAN_ID);
+
+        fakeApplicationEntity = new ApplicationEntity();
+        fakeApplicationEntity.setId(APPLICATION_ID);
+
+        when(applicationService.findById(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(fakeApplicationEntity);
+        when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(true);
+    }
+
+    @Test
+    public void getApplicationSubscription_onPlanV3() {
+        when(subscriptionService.findById(SUBSCRIPTION_ID)).thenReturn(fakeSubscriptionEntity);
+        when(userService.findById(eq(GraviteeContext.getExecutionContext()), any(), anyBoolean())).thenReturn(mock(UserEntity.class));
+
+        ApiEntity apiV3 = new ApiEntity();
+        apiV3.setPrimaryOwner(new PrimaryOwnerEntity());
+        when(apiSearchServiceV4.findGenericById(eq(GraviteeContext.getExecutionContext()), eq(API_ID))).thenReturn(apiV3);
+
+        PlanEntity planV3 = new PlanEntity();
+        planV3.setSecurity(PlanSecurityType.OAUTH2);
+        when(planSearchService.findById(eq(GraviteeContext.getExecutionContext()), eq(PLAN_ID))).thenReturn(planV3);
+
+        Response response = envTarget(SUBSCRIPTION_ID).request().get();
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        JsonNode responseBody = response.readEntity(JsonNode.class);
+        assertEquals("oauth2", responseBody.get("plan").get("security").asText());
+    }
+
+    @Test
+    public void getApplicationSubscription_onPlanV4() {
+        when(subscriptionService.findById(SUBSCRIPTION_ID)).thenReturn(fakeSubscriptionEntity);
+        when(userService.findById(eq(GraviteeContext.getExecutionContext()), any(), anyBoolean())).thenReturn(mock(UserEntity.class));
+
+        io.gravitee.rest.api.model.v4.api.ApiEntity apiV4 = new io.gravitee.rest.api.model.v4.api.ApiEntity();
+        apiV4.setPrimaryOwner(new PrimaryOwnerEntity());
+        when(apiSearchServiceV4.findGenericById(eq(GraviteeContext.getExecutionContext()), eq(API_ID))).thenReturn(apiV4);
+
+        io.gravitee.rest.api.model.v4.plan.PlanEntity planV4 = new io.gravitee.rest.api.model.v4.plan.PlanEntity();
+        PlanSecurity planSecurity = new PlanSecurity();
+        planSecurity.setType("oauth2");
+        planV4.setSecurity(planSecurity);
+        when(planSearchService.findById(eq(GraviteeContext.getExecutionContext()), eq(PLAN_ID))).thenReturn(planV4);
+
+        Response response = envTarget(SUBSCRIPTION_ID).request().get();
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        JsonNode responseBody = response.readEntity(JsonNode.class);
+        assertEquals("oauth2", responseBody.get("plan").get("security").asText());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionsResourceTest.java
@@ -28,7 +28,13 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
-import io.gravitee.rest.api.model.*;
+import io.gravitee.rest.api.model.NewSubscriptionEntity;
+import io.gravitee.rest.api.model.PlanEntity;
+import io.gravitee.rest.api.model.PlanSecurityType;
+import io.gravitee.rest.api.model.PrimaryOwnerEntity;
+import io.gravitee.rest.api.model.SubscriptionEntity;
+import io.gravitee.rest.api.model.SubscriptionStatus;
+import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.pagedresult.Metadata;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
@@ -50,7 +56,6 @@ public class ApplicationSubscriptionsResourceTest extends AbstractResourceTest {
     private static final String SUBSCRIPTION = "my-subscription";
     private static final String APPLICATION = "my-application";
     private static final String PLAN = "my-plan";
-    private static final String NEW_APIKEY = "my-new-apikey";
 
     @Override
     protected String contextPath() {
@@ -59,14 +64,14 @@ public class ApplicationSubscriptionsResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldCreateSubscription_onV3plan() {
-        reset(apiSearchServiceV4, planService, subscriptionService, userService);
+        reset(apiSearchServiceV4, planSearchService, subscriptionService, userService);
 
         NewSubscriptionEntity newSubscriptionEntity = new NewSubscriptionEntity();
         newSubscriptionEntity.setApplication(APPLICATION);
         newSubscriptionEntity.setPlan(PLAN);
         newSubscriptionEntity.setRequest("request");
 
-        when(planService.findById(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(mock(PlanEntity.class));
+        when(planSearchService.findById(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(mock(PlanEntity.class));
 
         SubscriptionEntity createdSubscription = new SubscriptionEntity();
         createdSubscription.setPlan(PLAN);
@@ -101,14 +106,15 @@ public class ApplicationSubscriptionsResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldCreateSubscription_onV4plan() {
-        reset(apiSearchServiceV4, planService, subscriptionService, userService);
+        reset(apiSearchServiceV4, planSearchService, subscriptionService, userService);
 
         NewSubscriptionEntity newSubscriptionEntity = new NewSubscriptionEntity();
         newSubscriptionEntity.setApplication(APPLICATION);
         newSubscriptionEntity.setPlan(PLAN);
         newSubscriptionEntity.setRequest("request");
 
-        when(planService.findById(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(mock(PlanEntity.class));
+        when(planSearchService.findById(eq(GraviteeContext.getExecutionContext()), any()))
+            .thenReturn(mock(io.gravitee.rest.api.model.v4.plan.PlanEntity.class));
 
         SubscriptionEntity createdSubscription = new SubscriptionEntity();
         createdSubscription.setPlan(PLAN);
@@ -145,7 +151,7 @@ public class ApplicationSubscriptionsResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldGetSubscriptions_expandingSecurity() {
-        reset(apiSearchServiceV4, planService, subscriptionService, userService);
+        reset(apiSearchServiceV4, planSearchService, subscriptionService, userService);
 
         when(subscriptionService.search(eq(GraviteeContext.getExecutionContext()), any(), any(), eq(false), eq(true)))
             .thenReturn(new Page<>(List.of(new SubscriptionEntity()), 1, 1, 1));
@@ -165,7 +171,7 @@ public class ApplicationSubscriptionsResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldGetSubscriptions_WithDefaultStatus() {
-        reset(apiSearchServiceV4, planService, subscriptionService, userService);
+        reset(apiSearchServiceV4, planSearchService, subscriptionService, userService);
 
         when(subscriptionService.search(any(ExecutionContext.class), any(), any(), anyBoolean(), anyBoolean()))
             .thenReturn(new Page<>(List.of(new SubscriptionEntity()), 1, 1, 1));
@@ -186,7 +192,7 @@ public class ApplicationSubscriptionsResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldGetSubscriptions_WithStatusFromQueryParams() {
-        reset(apiSearchServiceV4, planService, subscriptionService, userService);
+        reset(apiSearchServiceV4, planSearchService, subscriptionService, userService);
 
         when(subscriptionService.search(any(ExecutionContext.class), any(), any(), anyBoolean(), anyBoolean()))
             .thenReturn(new Page<>(List.of(new SubscriptionEntity()), 1, 1, 1));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewSubscriptionEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewSubscriptionEntity.java
@@ -15,9 +15,10 @@
  */
 package io.gravitee.rest.api.model;
 
-import java.util.Map;
-
 import com.fasterxml.jackson.annotation.JsonRawValue;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Map;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -48,5 +49,16 @@ public class NewSubscriptionEntity {
     public NewSubscriptionEntity(String plan, String application) {
         this.application = application;
         this.plan = plan;
+    }
+
+    @JsonSetter
+    public void setConfiguration(final JsonNode configuration) {
+        if (configuration != null) {
+            this.configuration = configuration.toString();
+        }
+    }
+
+    public void setConfiguration(String configuration) {
+        this.configuration = configuration;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewSubscriptionEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewSubscriptionEntity.java
@@ -16,6 +16,8 @@
 package io.gravitee.rest.api.model;
 
 import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonRawValue;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -38,6 +40,7 @@ public class NewSubscriptionEntity {
 
     private String filter;
 
+    @JsonRawValue
     private String configuration;
 
     private Map<String, String> metadata;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/PlanEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/PlanEntity.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.definition.model.Rule;
 import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
-import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import java.util.*;
 import javax.validation.constraints.NotNull;
@@ -282,6 +281,7 @@ public class PlanEntity implements GenericPlanEntity {
         this.needRedeployAt = needRedeployAt;
     }
 
+    @Override
     public boolean isCommentRequired() {
         return commentRequired;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/plan/GenericPlanEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/plan/GenericPlanEntity.java
@@ -34,6 +34,8 @@ public interface GenericPlanEntity {
 
     List<String> getExcludedGroups();
 
+    boolean isCommentRequired();
+
     String getGeneralConditions();
 
     //Those following methods need to be prefix by `Plan` in order to avoid collision with v2 model


### PR DESCRIPTION
- conversion from model subscriptions to entities handles plan conversion in a generic way, for v3 plans, or v4 plans
- subscription configuration is properly deserialized from jsonNode

## Issue

https://graviteecommunity.atlassian.net/browse/APIM-214
https://graviteecommunity.atlassian.net/browse/APIM-215
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-214-handlev4subconversion/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vntlptytji.chromatic.com)
<!-- Storybook placeholder end -->
