### PR TITLE
fix: interrupt http-post when redeploying api

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/v4/AsyncApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/v4/AsyncApiReactor.java
@@ -76,6 +76,7 @@ public class AsyncApiReactor extends AbstractLifecycleComponent<ReactorHandler> 
 
     private static final Logger log = LoggerFactory.getLogger(AsyncApiReactor.class);
     private static final String ATTR_INVOKER_SKIP = "invoker.skip";
+    protected static final int STOP_UNTIL_INTERVAL_PERIOD_MS = 100;
     protected final List<ChainHook> processorChainHooks;
     private final Api api;
     private final ComponentProvider componentProvider;
@@ -368,9 +369,9 @@ public class AsyncApiReactor extends AbstractLifecycleComponent<ReactorHandler> 
     }
 
     private Completable stopUntil() {
-        return interval(100, TimeUnit.MILLISECONDS)
+        return interval(STOP_UNTIL_INTERVAL_PERIOD_MS, TimeUnit.MILLISECONDS)
             .timestamp()
-            .takeWhile(t -> pendingRequests.get() > 0 && t.time() < pendingRequestsTimeout)
+            .takeWhile(t -> pendingRequests.get() > 0 && (t.value() + 1) * STOP_UNTIL_INTERVAL_PERIOD_MS < pendingRequestsTimeout)
             .ignoreElements()
             .onErrorComplete()
             .doFinally(this::stopNow);

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/test/java/io/gravitee/plugin/entrypoint/http/post/DummyMessageRequest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/test/java/io/gravitee/plugin/entrypoint/http/post/DummyMessageRequest.java
@@ -34,11 +34,16 @@ import javax.net.ssl.SSLSession;
 
 public class DummyMessageRequest implements Request {
 
+    private HttpVersion httpVersion = HttpVersion.HTTP_1_1;
     Flowable<Message> flowableMessages;
     HttpMethod method;
     Maybe<Buffer> body;
 
     HttpHeaders headers;
+
+    public void setHttpVersion(HttpVersion httpVersion) {
+        this.httpVersion = httpVersion;
+    }
 
     @Override
     public Flowable<Message> messages() {
@@ -165,7 +170,7 @@ public class DummyMessageRequest implements Request {
 
     @Override
     public HttpVersion version() {
-        return null;
+        return httpVersion;
     }
 
     @Override


### PR DESCRIPTION
When redeploying an api being used, the gateway must close the connection with an appropriate message indicating to the consuming application it must reconnect in order to consume the freshly deployed api.

The behavior for http-post differ from the behavior for websocket or sse where the connection is immediately closed.
For http-post, a pending request timeout is applied prior to close the connection (`api.pending_requests_timeout`, default 10s). It makes sense since http-post is most likely to be a short time request. During that time, any new request will end to the newly deployed version of the api while the pending requests are finishing properly.
When the timeout is exhausted, the connection is closed.

For http-post, it can be quite complex to test, here is an explanation on how to test it using curl.

Make a `POST` request with curl that will post data by reading the standard input

```bash
curl -D- -XPOST -H "Transfer-Encoding: chunked" http://localhost:8082/http-post -T -
```

Copy/paste the following content:

```
gяανιтєє яσ¢кѕ
9r4v!733 r0(k5
ĞŔÁVĨŤĔĔ ŔŐČĶŚ
ġrävïtëë röċks
gŕávítéé ŕőćkś
GЯΛVIƬΣΣ ЯӨᄃKƧ
g尺ﾑ√ﾉｲ乇乇 尺ocズ丂
ⓖⓡⓐⓥⓘⓣⓔⓔ ⓡⓞ©ⓚⓢ
```

And then press **control+d** to inform curl that there is nothing more to post.

The message should have been properly sent and the following response appears:

```
HTTP/1.1 202 Accepted
X-Gravitee-Transaction-Id: a1cea97e-4f76-4219-8ea9-7e4f76721977
X-Gravitee-Request-Id: a1cea97e-4f76-4219-8ea9-7e4f76721977
transfer-encoding: chunked
```

Now do the same but **DON'T** press control+d this time. This will simply initiate a `POST` request and start sending data without ending (chunked transfer).
In the same time, redeploy the http-post api and wait for 10s. This will simulate an http-post that takes more than the pending request timeout.
You should see the following response from the server after 10s (you may certainly need to press enter multiple times to refresh the screen and see the below response):

```
HTTP/1.1 503 Service Unavailable
X-Gravitee-Transaction-Id: 6f873e35-cd5d-4a02-873e-35cd5dfa0294
X-Gravitee-Request-Id: 6f873e35-cd5d-4a02-873e-35cd5dfa0294
Connection: close
transfer-encoding: chunked
Content-Type: application/json

{
  "message" : "Stopping, please reconnect",
  "http_status_code" : 503
}
```

Finally, do the same test but press control+d just after you redeployed the http-post api. The idea is to finish to post the request within the 10s window.
The http-post request should receive a 202 Accepted response meaning that the gateway didn't close the connection immediately to let a chance to the request to finish properly.

Note: here we tested with http1.1 but the same should work with http2 (which requires to enable https and alpn).
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-http-post-interrupt-on-redeploy/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-haspqlkhzm.chromatic.com)
<!-- Storybook placeholder end -->
