### PR TITLE
Set status reason based on status code when using response template 

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/error/templates/ResponseTemplateBasedFailureProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/error/templates/ResponseTemplateBasedFailureProcessor.java
@@ -24,6 +24,7 @@ import io.gravitee.gateway.api.el.EvaluableRequest;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.processor.ProcessorFailure;
 import io.gravitee.gateway.handlers.api.processor.error.SimpleFailureProcessor;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import java.util.List;
 import java.util.Map;
 
@@ -111,6 +112,7 @@ public class ResponseTemplateBasedFailureProcessor extends SimpleFailureProcesso
 
     private void handleTemplate(final ExecutionContext context, final ResponseTemplate template, final ProcessorFailure failure) {
         context.response().status(template.getStatusCode());
+        context.response().reason(HttpResponseStatus.valueOf(template.getStatusCode()).reasonPhrase());
         context.response().headers().set(HttpHeaderNames.CONNECTION, HttpHeadersValues.CONNECTION_CLOSE);
 
         if (template.getBody() != null && !template.getBody().isEmpty()) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/processor/error/template/ResponseTemplateBasedFailureProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/processor/error/template/ResponseTemplateBasedFailureProcessor.java
@@ -25,6 +25,7 @@ import io.gravitee.gateway.jupiter.api.ExecutionFailure;
 import io.gravitee.gateway.jupiter.api.context.RequestExecutionContext;
 import io.gravitee.gateway.jupiter.api.el.EvaluableRequest;
 import io.gravitee.gateway.jupiter.handlers.api.processor.error.AbstractFailureProcessor;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import io.reactivex.Completable;
 import java.util.List;
 import java.util.Map;
@@ -127,6 +128,7 @@ public class ResponseTemplateBasedFailureProcessor extends AbstractFailureProces
         final ExecutionFailure executionFailure
     ) {
         context.response().status(template.getStatusCode());
+        context.response().reason(HttpResponseStatus.valueOf(template.getStatusCode()).reasonPhrase());
         context.response().headers().set(HttpHeaderNames.CONNECTION, HttpHeadersValues.CONNECTION_CLOSE);
 
         if (template.getBody() != null && !template.getBody().isEmpty()) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/error/templates/ResponseTemplateBasedFailureProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/error/templates/ResponseTemplateBasedFailureProcessorTest.java
@@ -15,7 +15,9 @@
  */
 package io.gravitee.gateway.handlers.api.processor.error.templates;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.http.MediaType;
@@ -26,7 +28,6 @@ import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.api.handler.Handler;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
-import io.gravitee.gateway.api.processor.ProcessorFailure;
 import io.gravitee.reporter.api.http.Metrics;
 import java.util.Collections;
 import java.util.HashMap;
@@ -120,6 +121,7 @@ public class ResponseTemplateBasedFailureProcessorTest {
         processor.handle(context);
 
         verify(response, times(1)).status(HttpStatusCode.BAD_REQUEST_400);
+        verify(response, times(1)).reason("Bad Request");
     }
 
     @Test
@@ -146,6 +148,7 @@ public class ResponseTemplateBasedFailureProcessorTest {
         processor.handle(context);
 
         verify(response, times(1)).status(HttpStatusCode.BAD_REQUEST_400);
+        verify(response, times(1)).reason("Bad Request");
     }
 
     @Test
@@ -204,6 +207,7 @@ public class ResponseTemplateBasedFailureProcessorTest {
         processor.handle(context);
 
         verify(response, times(1)).status(HttpStatusCode.BAD_GATEWAY_502);
+        verify(response, times(1)).reason("Bad Gateway");
     }
 
     @Test
@@ -231,6 +235,7 @@ public class ResponseTemplateBasedFailureProcessorTest {
         processor.handle(context);
 
         verify(response, times(1)).status(HttpStatusCode.BAD_REQUEST_400);
+        verify(response, times(1)).reason("Bad Request");
     }
 
     @Test
@@ -260,5 +265,6 @@ public class ResponseTemplateBasedFailureProcessorTest {
         processor.handle(context);
 
         verify(response, times(1)).status(HttpStatusCode.BAD_REQUEST_400);
+        verify(response, times(1)).reason("Bad Request");
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/processor/error/template/ResponseTemplateBasedFailureProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/processor/error/template/ResponseTemplateBasedFailureProcessorTest.java
@@ -65,6 +65,7 @@ public class ResponseTemplateBasedFailureProcessorTest extends AbstractProcessor
         templateBasedFailureProcessor.execute(ctx).test().assertResult();
 
         verify(mockResponse, times(1)).status(HttpStatusCode.INTERNAL_SERVER_ERROR_500);
+        verify(mockResponse, times(1)).reason("Internal Server Error");
     }
 
     @Test
@@ -86,6 +87,7 @@ public class ResponseTemplateBasedFailureProcessorTest extends AbstractProcessor
         templateBasedFailureProcessor.execute(ctx).test().assertResult();
 
         verify(mockResponse, times(1)).status(HttpStatusCode.BAD_REQUEST_400);
+        verify(mockResponse, times(1)).reason("Bad Request");
     }
 
     @Test
@@ -108,6 +110,7 @@ public class ResponseTemplateBasedFailureProcessorTest extends AbstractProcessor
         templateBasedFailureProcessor.execute(ctx).test().assertResult();
 
         verify(mockResponse, times(1)).status(HttpStatusCode.BAD_REQUEST_400);
+        verify(mockResponse, times(1)).reason("Bad Request");
     }
 
     @Test
@@ -131,6 +134,7 @@ public class ResponseTemplateBasedFailureProcessorTest extends AbstractProcessor
         templateBasedFailureProcessor.execute(ctx).test().assertResult();
 
         verify(mockResponse, times(1)).status(HttpStatusCode.INTERNAL_SERVER_ERROR_500);
+        verify(mockResponse, times(1)).reason("Internal Server Error");
     }
 
     @Test
@@ -158,6 +162,7 @@ public class ResponseTemplateBasedFailureProcessorTest extends AbstractProcessor
         templateBasedFailureProcessor.execute(ctx).test().assertResult();
 
         verify(mockResponse, times(1)).status(HttpStatusCode.BAD_GATEWAY_502);
+        verify(mockResponse, times(1)).reason("Bad Gateway");
     }
 
     @Test
@@ -181,6 +186,7 @@ public class ResponseTemplateBasedFailureProcessorTest extends AbstractProcessor
         templateBasedFailureProcessor.execute(ctx).test().assertResult();
 
         verify(mockResponse, times(1)).status(HttpStatusCode.BAD_REQUEST_400);
+        verify(mockResponse, times(1)).reason("Bad Request");
     }
 
     @Test
@@ -204,5 +210,6 @@ public class ResponseTemplateBasedFailureProcessorTest extends AbstractProcessor
         templateBasedFailureProcessor.execute(ctx).test().assertResult();
 
         verify(mockResponse, times(1)).status(HttpStatusCode.BAD_REQUEST_400);
+        verify(mockResponse, times(1)).reason("Bad Request");
     }
 }


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-237

## Description

Set status reason based on status code when using response template 
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-237-fix-status-reason-response-template/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jkblrryllz.chromatic.com)
<!-- Storybook placeholder end -->
