### PR TITLE
fix: ignore message level policy for v2 platform flows

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/jupiter/policy/DefaultPolicyChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/jupiter/policy/DefaultPolicyChainFactory.java
@@ -15,8 +15,7 @@
  */
 package io.gravitee.gateway.jupiter.policy;
 
-import static io.gravitee.gateway.jupiter.api.ExecutionPhase.MESSAGE_REQUEST;
-import static io.gravitee.gateway.jupiter.api.ExecutionPhase.REQUEST;
+import static io.gravitee.gateway.jupiter.api.ExecutionPhase.*;
 
 import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.definition.model.flow.Flow;
@@ -109,11 +108,11 @@ public class DefaultPolicyChainFactory implements PolicyChainFactory {
     }
 
     private List<Step> getSteps(Flow flow, ExecutionPhase phase) {
-        final List<Step> steps;
+        List<Step> steps = null;
 
-        if (phase == REQUEST || phase == MESSAGE_REQUEST) {
+        if (phase == REQUEST) {
             steps = flow.getPre();
-        } else {
+        } else if (phase == RESPONSE) {
             steps = flow.getPost();
         }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/jupiter/policy/DefaultPolicyChainFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/jupiter/policy/DefaultPolicyChainFactoryTest.java
@@ -235,4 +235,14 @@ class DefaultPolicyChainFactoryTest {
 
         verifyNoMoreInteractions(policyManager);
     }
+
+    @Test
+    public void shouldNoCreateAnyPolicyWhenUnsupportedPhase() {
+        final Flow flow = mock(Flow.class);
+
+        final PolicyChain policyChain = cut.create("fowchain-test", flow, ExecutionPhase.MESSAGE_REQUEST);
+        assertNotNull(policyChain);
+
+        verifyNoInteractions(policyManager);
+    }
 }


### PR DESCRIPTION
Deploying a v4 api with policies on platform flow returns error 500.

Note: platform flow are currently defined using v2 definition which doesn't support message level policies.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-ignore-message-level-policy-for-v2-platform-flow/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-grwuhkelpl.chromatic.com)
<!-- Storybook placeholder end -->
