### PR TITLE
APIM-182 properly handle kafka clients creation

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/v4/invoker/EndpointInvoker.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/v4/invoker/EndpointInvoker.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.jupiter.core.v4.invoker;
 import static io.gravitee.gateway.jupiter.api.context.InternalContextAttributes.ATTR_INTERNAL_ENTRYPOINT_CONNECTOR;
 
 import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.common.service.AbstractService;
 import io.gravitee.gateway.jupiter.api.ApiType;
 import io.gravitee.gateway.jupiter.api.ExecutionFailure;
 import io.gravitee.gateway.jupiter.api.connector.endpoint.EndpointConnector;
@@ -33,7 +34,7 @@ import io.reactivex.rxjava3.core.Completable;
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class EndpointInvoker implements Invoker {
+public class EndpointInvoker extends AbstractService<EndpointInvoker> implements Invoker {
 
     public static final String NO_ENDPOINT_FOUND_KEY = "NO_ENDPOINT_FOUND";
     public static final String INCOMPATIBLE_QOS_KEY = "INCOMPATIBLE_QOS";
@@ -72,5 +73,18 @@ public class EndpointInvoker implements Invoker {
         }
 
         return endpointConnector.connect(ctx);
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        super.doStop();
+        endpointResolver.stop();
+    }
+
+    @Override
+    public EndpointInvoker preStop() throws Exception {
+        super.preStop();
+        endpointResolver.preStop();
+        return this;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/v4/AsyncReactorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/v4/AsyncReactorFactory.java
@@ -24,9 +24,6 @@ import io.gravitee.gateway.core.classloader.DefaultClassLoader;
 import io.gravitee.gateway.core.component.ComponentProvider;
 import io.gravitee.gateway.core.component.CompositeComponentProvider;
 import io.gravitee.gateway.core.component.CustomComponentProvider;
-import io.gravitee.gateway.jupiter.core.v4.endpoint.DefaultEndpointConnectorResolver;
-import io.gravitee.gateway.jupiter.core.v4.entrypoint.DefaultEntrypointConnectorResolver;
-import io.gravitee.gateway.jupiter.core.v4.invoker.EndpointInvoker;
 import io.gravitee.gateway.jupiter.handlers.api.ApiPolicyManager;
 import io.gravitee.gateway.jupiter.handlers.api.flow.FlowChainFactory;
 import io.gravitee.gateway.jupiter.handlers.api.v4.flow.resolver.FlowResolverFactory;
@@ -69,7 +66,6 @@ public class AsyncReactorFactory implements ReactorFactory<Api> {
 
     protected final ApplicationContext applicationContext;
     protected final Configuration configuration;
-    private final Node node;
     protected final PolicyFactory policyFactory;
     protected final EntrypointConnectorPluginManager entrypointConnectorPluginManager;
     protected final EndpointConnectorPluginManager endpointConnectorPluginManager;
@@ -79,6 +75,7 @@ public class AsyncReactorFactory implements ReactorFactory<Api> {
     protected final ApiMessageProcessorChainFactory apiMessageProcessorChainFactory;
     protected final io.gravitee.gateway.jupiter.handlers.api.flow.resolver.FlowResolverFactory flowResolverFactory;
     protected final FlowResolverFactory v4FlowResolverFactory;
+    private final Node node;
     private final Logger logger = LoggerFactory.getLogger(AsyncReactorFactory.class);
 
     public AsyncReactorFactory(
@@ -189,8 +186,8 @@ public class AsyncReactorFactory implements ReactorFactory<Api> {
                     api,
                     apiComponentProvider,
                     policyManager,
-                    new DefaultEntrypointConnectorResolver(api.getDefinition(), entrypointConnectorPluginManager),
-                    new EndpointInvoker(new DefaultEndpointConnectorResolver(api.getDefinition(), endpointConnectorPluginManager)),
+                    entrypointConnectorPluginManager,
+                    endpointConnectorPluginManager,
                     resourceLifecycleManager,
                     apiProcessorChainFactory,
                     apiMessageProcessorChainFactory,

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/factory/KafkaReceiverFactory.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/factory/KafkaReceiverFactory.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.endpoint.kafka.factory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import reactor.kafka.receiver.KafkaReceiver;
+import reactor.kafka.receiver.ReceiverOptions;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class KafkaReceiverFactory {
+
+    public static final KafkaReceiverFactory INSTANCE = new KafkaReceiverFactory();
+    private final Map<Integer, KafkaReceiver<?, ?>> consumers = new ConcurrentHashMap<>();
+
+    public <K, V> KafkaReceiver<K, V> createReceiver(final ReceiverOptions<K, V> receiverOptions) {
+        return (KafkaReceiver<K, V>) consumers.computeIfAbsent(
+            receiverOptions.hashCode(),
+            hashCode -> KafkaReceiver.create(CustomConsumerFactory.INSTANCE, receiverOptions)
+        );
+    }
+
+    public void clear() {
+        consumers.clear();
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/factory/KafkaSenderFactory.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/factory/KafkaSenderFactory.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.endpoint.kafka.factory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import reactor.kafka.sender.KafkaSender;
+import reactor.kafka.sender.SenderOptions;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class KafkaSenderFactory {
+
+    public static final KafkaSenderFactory INSTANCE = new KafkaSenderFactory();
+    private final Map<Integer, KafkaSender<?, ?>> senders = new ConcurrentHashMap<>();
+
+    public <K, V> KafkaSender<K, V> createSender(final SenderOptions<K, V> senderOptions) {
+        return (KafkaSender<K, V>) senders.computeIfAbsent(
+            senderOptions.hashCode(),
+            hashCode -> KafkaSender.create(CustomProducerFactory.INSTANCE, senderOptions)
+        );
+    }
+
+    public void clear() {
+        senders.forEach((integer, consumer) -> consumer.close());
+        senders.clear();
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/strategy/DefaultQosStrategyFactory.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/strategy/DefaultQosStrategyFactory.java
@@ -16,6 +16,7 @@
 package io.gravitee.plugin.endpoint.kafka.strategy;
 
 import io.gravitee.gateway.jupiter.api.qos.QosOptions;
+import io.gravitee.plugin.endpoint.kafka.factory.KafkaReceiverFactory;
 import io.gravitee.plugin.endpoint.kafka.strategy.impl.BalancedStrategy;
 import io.gravitee.plugin.endpoint.kafka.strategy.impl.NoneStrategy;
 
@@ -25,13 +26,13 @@ import io.gravitee.plugin.endpoint.kafka.strategy.impl.NoneStrategy;
  */
 public class DefaultQosStrategyFactory implements QosStrategyFactory {
 
-    public QosStrategy createQosStrategy(final QosOptions qosOptions) {
+    public QosStrategy createQosStrategy(final KafkaReceiverFactory kafkaReceiverFactory, final QosOptions qosOptions) {
         if (qosOptions != null && qosOptions.getQos() != null) {
             switch (qosOptions.getQos()) {
                 case NONE:
-                    return new NoneStrategy();
+                    return new NoneStrategy(kafkaReceiverFactory);
                 case BALANCED:
-                    return new BalancedStrategy();
+                    return new BalancedStrategy(kafkaReceiverFactory);
                 case AT_BEST:
                 case AT_MOST_ONCE:
                 case AT_LEAST_ONCE:

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/strategy/QosStrategyFactory.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/strategy/QosStrategyFactory.java
@@ -16,11 +16,12 @@
 package io.gravitee.plugin.endpoint.kafka.strategy;
 
 import io.gravitee.gateway.jupiter.api.qos.QosOptions;
+import io.gravitee.plugin.endpoint.kafka.factory.KafkaReceiverFactory;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface QosStrategyFactory {
-    QosStrategy createQosStrategy(final QosOptions qosOptions);
+    QosStrategy createQosStrategy(final KafkaReceiverFactory kafkaReceiverFactory, final QosOptions qosOptions);
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/strategy/impl/AbstractQosStrategy.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/strategy/impl/AbstractQosStrategy.java
@@ -17,6 +17,8 @@ package io.gravitee.plugin.endpoint.kafka.strategy.impl;
 
 import io.gravitee.plugin.endpoint.kafka.factory.KafkaReceiverFactory;
 import io.gravitee.plugin.endpoint.kafka.strategy.QosStrategy;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import reactor.kafka.receiver.KafkaReceiver;
 import reactor.kafka.receiver.ReceiverOptions;
 
@@ -24,9 +26,12 @@ import reactor.kafka.receiver.ReceiverOptions;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public abstract class AbstractQosStrategy implements QosStrategy {
 
+    private final KafkaReceiverFactory kafkaReceiverFactory;
+
     protected <K, V> KafkaReceiver<K, V> createReceiver(final ReceiverOptions<K, V> receiverOptions) {
-        return KafkaReceiverFactory.INSTANCE.createReceiver(receiverOptions);
+        return kafkaReceiverFactory.createReceiver(receiverOptions);
     }
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/strategy/impl/AbstractQosStrategy.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/strategy/impl/AbstractQosStrategy.java
@@ -15,12 +15,10 @@
  */
 package io.gravitee.plugin.endpoint.kafka.strategy.impl;
 
-import io.gravitee.plugin.endpoint.kafka.factory.CustomConsumerFactory;
+import io.gravitee.plugin.endpoint.kafka.factory.KafkaReceiverFactory;
 import io.gravitee.plugin.endpoint.kafka.strategy.QosStrategy;
 import reactor.kafka.receiver.KafkaReceiver;
 import reactor.kafka.receiver.ReceiverOptions;
-import reactor.kafka.receiver.internals.ConsumerFactory;
-import reactor.kafka.receiver.internals.DefaultKafkaReceiver;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -28,7 +26,7 @@ import reactor.kafka.receiver.internals.DefaultKafkaReceiver;
  */
 public abstract class AbstractQosStrategy implements QosStrategy {
 
-    protected <K, V> KafkaReceiver<K, V> createReceiver(final ReceiverOptions<K, V> options) {
-        return new DefaultKafkaReceiver<>(CustomConsumerFactory.INSTANCE, options);
+    protected <K, V> KafkaReceiver<K, V> createReceiver(final ReceiverOptions<K, V> receiverOptions) {
+        return KafkaReceiverFactory.INSTANCE.createReceiver(receiverOptions);
     }
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/strategy/impl/BalancedStrategy.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/strategy/impl/BalancedStrategy.java
@@ -17,6 +17,7 @@ package io.gravitee.plugin.endpoint.kafka.strategy.impl;
 
 import io.gravitee.gateway.jupiter.api.context.ExecutionContext;
 import io.gravitee.plugin.endpoint.kafka.configuration.KafkaEndpointConnectorConfiguration;
+import io.gravitee.plugin.endpoint.kafka.factory.KafkaReceiverFactory;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import reactor.core.publisher.Flux;
 import reactor.kafka.receiver.ReceiverOptions;
@@ -26,6 +27,10 @@ import reactor.kafka.receiver.ReceiverOptions;
  * @author GraviteeSource Team
  */
 public class BalancedStrategy extends AbstractQosStrategy {
+
+    public BalancedStrategy(final KafkaReceiverFactory kafkaReceiverFactory) {
+        super(kafkaReceiverFactory);
+    }
 
     @Override
     public Flux<ConsumerRecord<String, byte[]>> receive(

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/strategy/impl/NoneStrategy.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/strategy/impl/NoneStrategy.java
@@ -17,12 +17,12 @@ package io.gravitee.plugin.endpoint.kafka.strategy.impl;
 
 import io.gravitee.gateway.jupiter.api.context.ExecutionContext;
 import io.gravitee.plugin.endpoint.kafka.configuration.KafkaEndpointConnectorConfiguration;
+import io.gravitee.plugin.endpoint.kafka.factory.KafkaReceiverFactory;
 import java.time.Duration;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import reactor.core.publisher.Flux;
-import reactor.kafka.receiver.KafkaReceiver;
 import reactor.kafka.receiver.ReceiverOptions;
 
 /**
@@ -30,6 +30,10 @@ import reactor.kafka.receiver.ReceiverOptions;
  * @author GraviteeSource Team
  */
 public class NoneStrategy extends AbstractQosStrategy {
+
+    public NoneStrategy(final KafkaReceiverFactory kafkaReceiverFactory) {
+        super(kafkaReceiverFactory);
+    }
 
     @Override
     public void addCustomConfig(final Map<String, Object> config) {

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/test/java/io/gravitee/plugin/endpoint/kafka/factory/KafkaReceiverFactoryTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/test/java/io/gravitee/plugin/endpoint/kafka/factory/KafkaReceiverFactoryTest.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import reactor.kafka.receiver.KafkaReceiver;
 import reactor.kafka.receiver.ReceiverOptions;
@@ -31,14 +32,21 @@ import reactor.kafka.receiver.ReceiverOptions;
  */
 class KafkaReceiverFactoryTest {
 
+    private KafkaReceiverFactory kafkaReceiverFactory;
+
+    @BeforeEach
+    public void beforeEach() {
+        kafkaReceiverFactory = new KafkaReceiverFactory();
+    }
+
     @Test
     void shouldReturnSameInstanceWithSameOptions() {
         Map<String, Object> config = new HashMap<>();
         config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
         ReceiverOptions<String, byte[]> receiverOptions = ReceiverOptions.<String, byte[]>create(config).subscription(Set.of("test"));
 
-        KafkaReceiver<String, byte[]> receiver1 = KafkaReceiverFactory.INSTANCE.createReceiver(receiverOptions);
-        KafkaReceiver<String, byte[]> receiver2 = KafkaReceiverFactory.INSTANCE.createReceiver(receiverOptions);
+        KafkaReceiver<String, byte[]> receiver1 = kafkaReceiverFactory.createReceiver(receiverOptions);
+        KafkaReceiver<String, byte[]> receiver2 = kafkaReceiverFactory.createReceiver(receiverOptions);
         assertThat(receiver1).isSameAs(receiver2);
     }
 
@@ -49,8 +57,8 @@ class KafkaReceiverFactoryTest {
         ReceiverOptions<String, byte[]> receiverOptions1 = ReceiverOptions.<String, byte[]>create(config).subscription(Set.of("test"));
         ReceiverOptions<String, byte[]> receiverOptions2 = ReceiverOptions.<String, byte[]>create(config).subscription(Set.of("test2"));
 
-        KafkaReceiver<String, byte[]> receiver1 = KafkaReceiverFactory.INSTANCE.createReceiver(receiverOptions1);
-        KafkaReceiver<String, byte[]> receiver2 = KafkaReceiverFactory.INSTANCE.createReceiver(receiverOptions2);
+        KafkaReceiver<String, byte[]> receiver1 = kafkaReceiverFactory.createReceiver(receiverOptions1);
+        KafkaReceiver<String, byte[]> receiver2 = kafkaReceiverFactory.createReceiver(receiverOptions2);
         assertThat(receiver1).isNotSameAs(receiver2).isNotEqualTo(receiver2);
     }
 
@@ -60,9 +68,9 @@ class KafkaReceiverFactoryTest {
         config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
         ReceiverOptions<String, byte[]> receiverOptions = ReceiverOptions.<String, byte[]>create(config).subscription(Set.of("test"));
 
-        KafkaReceiver<String, byte[]> receiver1 = KafkaReceiverFactory.INSTANCE.createReceiver(receiverOptions);
-        KafkaReceiverFactory.INSTANCE.clear();
-        KafkaReceiver<String, byte[]> receiver2 = KafkaReceiverFactory.INSTANCE.createReceiver(receiverOptions);
+        KafkaReceiver<String, byte[]> receiver1 = kafkaReceiverFactory.createReceiver(receiverOptions);
+        kafkaReceiverFactory.clear();
+        KafkaReceiver<String, byte[]> receiver2 = kafkaReceiverFactory.createReceiver(receiverOptions);
         assertThat(receiver1).isNotSameAs(receiver2).isNotEqualTo(receiver2);
     }
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/test/java/io/gravitee/plugin/endpoint/kafka/factory/KafkaReceiverFactoryTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/test/java/io/gravitee/plugin/endpoint/kafka/factory/KafkaReceiverFactoryTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.endpoint.kafka.factory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.junit.jupiter.api.Test;
+import reactor.kafka.receiver.KafkaReceiver;
+import reactor.kafka.receiver.ReceiverOptions;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class KafkaReceiverFactoryTest {
+
+    @Test
+    void shouldReturnSameInstanceWithSameOptions() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
+        ReceiverOptions<String, byte[]> receiverOptions = ReceiverOptions.<String, byte[]>create(config).subscription(Set.of("test"));
+
+        KafkaReceiver<String, byte[]> receiver1 = KafkaReceiverFactory.INSTANCE.createReceiver(receiverOptions);
+        KafkaReceiver<String, byte[]> receiver2 = KafkaReceiverFactory.INSTANCE.createReceiver(receiverOptions);
+        assertThat(receiver1).isSameAs(receiver2);
+    }
+
+    @Test
+    void shouldReturnDifferentInstanceWithDifferentOptions() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
+        ReceiverOptions<String, byte[]> receiverOptions1 = ReceiverOptions.<String, byte[]>create(config).subscription(Set.of("test"));
+        ReceiverOptions<String, byte[]> receiverOptions2 = ReceiverOptions.<String, byte[]>create(config).subscription(Set.of("test2"));
+
+        KafkaReceiver<String, byte[]> receiver1 = KafkaReceiverFactory.INSTANCE.createReceiver(receiverOptions1);
+        KafkaReceiver<String, byte[]> receiver2 = KafkaReceiverFactory.INSTANCE.createReceiver(receiverOptions2);
+        assertThat(receiver1).isNotSameAs(receiver2).isNotEqualTo(receiver2);
+    }
+
+    @Test
+    void shouldReturnNewInstanceAfterClear() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
+        ReceiverOptions<String, byte[]> receiverOptions = ReceiverOptions.<String, byte[]>create(config).subscription(Set.of("test"));
+
+        KafkaReceiver<String, byte[]> receiver1 = KafkaReceiverFactory.INSTANCE.createReceiver(receiverOptions);
+        KafkaReceiverFactory.INSTANCE.clear();
+        KafkaReceiver<String, byte[]> receiver2 = KafkaReceiverFactory.INSTANCE.createReceiver(receiverOptions);
+        assertThat(receiver1).isNotSameAs(receiver2).isNotEqualTo(receiver2);
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/test/java/io/gravitee/plugin/endpoint/kafka/factory/KafkaSenderFactoryTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/test/java/io/gravitee/plugin/endpoint/kafka/factory/KafkaSenderFactoryTest.java
@@ -16,15 +16,12 @@
 package io.gravitee.plugin.endpoint.kafka.factory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import reactor.kafka.receiver.KafkaReceiver;
-import reactor.kafka.receiver.ReceiverOptions;
 import reactor.kafka.sender.KafkaSender;
 import reactor.kafka.sender.SenderOptions;
 
@@ -34,14 +31,21 @@ import reactor.kafka.sender.SenderOptions;
  */
 class KafkaSenderFactoryTest {
 
+    private KafkaSenderFactory kafkaSenderFactory;
+
+    @BeforeEach
+    public void beforeEach() {
+        kafkaSenderFactory = new KafkaSenderFactory();
+    }
+
     @Test
     void shouldReturnSameInstanceWithSameOptions() {
         Map<String, Object> config = new HashMap<>();
         config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
         SenderOptions<String, byte[]> senderOptions = SenderOptions.create(config);
 
-        KafkaSender<String, byte[]> sender1 = KafkaSenderFactory.INSTANCE.createSender(senderOptions);
-        KafkaSender<String, byte[]> sender2 = KafkaSenderFactory.INSTANCE.createSender(senderOptions);
+        KafkaSender<String, byte[]> sender1 = kafkaSenderFactory.createSender(senderOptions);
+        KafkaSender<String, byte[]> sender2 = kafkaSenderFactory.createSender(senderOptions);
         assertThat(sender1).isSameAs(sender2);
     }
 
@@ -52,8 +56,8 @@ class KafkaSenderFactoryTest {
         SenderOptions<String, byte[]> senderOptions1 = SenderOptions.create(config);
         SenderOptions<String, byte[]> senderOptions2 = SenderOptions.<String, byte[]>create(config).maxInFlight(152);
 
-        KafkaSender<String, byte[]> sender1 = KafkaSenderFactory.INSTANCE.createSender(senderOptions1);
-        KafkaSender<String, byte[]> sender2 = KafkaSenderFactory.INSTANCE.createSender(senderOptions2);
+        KafkaSender<String, byte[]> sender1 = kafkaSenderFactory.createSender(senderOptions1);
+        KafkaSender<String, byte[]> sender2 = kafkaSenderFactory.createSender(senderOptions2);
         assertThat(sender1).isNotSameAs(sender2).isNotEqualTo(sender2);
     }
 
@@ -63,9 +67,9 @@ class KafkaSenderFactoryTest {
         config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
         SenderOptions<String, byte[]> senderOptions = SenderOptions.create(config);
 
-        KafkaSender<String, byte[]> sender1 = KafkaSenderFactory.INSTANCE.createSender(senderOptions);
-        KafkaSenderFactory.INSTANCE.clear();
-        KafkaSender<String, byte[]> sender2 = KafkaSenderFactory.INSTANCE.createSender(senderOptions);
+        KafkaSender<String, byte[]> sender1 = kafkaSenderFactory.createSender(senderOptions);
+        kafkaSenderFactory.clear();
+        KafkaSender<String, byte[]> sender2 = kafkaSenderFactory.createSender(senderOptions);
         assertThat(sender1).isNotSameAs(sender2).isNotEqualTo(sender2);
     }
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/test/java/io/gravitee/plugin/endpoint/kafka/factory/KafkaSenderFactoryTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/test/java/io/gravitee/plugin/endpoint/kafka/factory/KafkaSenderFactoryTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.endpoint.kafka.factory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.junit.jupiter.api.Test;
+import reactor.kafka.receiver.KafkaReceiver;
+import reactor.kafka.receiver.ReceiverOptions;
+import reactor.kafka.sender.KafkaSender;
+import reactor.kafka.sender.SenderOptions;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class KafkaSenderFactoryTest {
+
+    @Test
+    void shouldReturnSameInstanceWithSameOptions() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
+        SenderOptions<String, byte[]> senderOptions = SenderOptions.create(config);
+
+        KafkaSender<String, byte[]> sender1 = KafkaSenderFactory.INSTANCE.createSender(senderOptions);
+        KafkaSender<String, byte[]> sender2 = KafkaSenderFactory.INSTANCE.createSender(senderOptions);
+        assertThat(sender1).isSameAs(sender2);
+    }
+
+    @Test
+    void shouldReturnDifferentInstanceWithDifferentOptions() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
+        SenderOptions<String, byte[]> senderOptions1 = SenderOptions.create(config);
+        SenderOptions<String, byte[]> senderOptions2 = SenderOptions.<String, byte[]>create(config).maxInFlight(152);
+
+        KafkaSender<String, byte[]> sender1 = KafkaSenderFactory.INSTANCE.createSender(senderOptions1);
+        KafkaSender<String, byte[]> sender2 = KafkaSenderFactory.INSTANCE.createSender(senderOptions2);
+        assertThat(sender1).isNotSameAs(sender2).isNotEqualTo(sender2);
+    }
+
+    @Test
+    void shouldReturnNewInstanceAfterClear() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
+        SenderOptions<String, byte[]> senderOptions = SenderOptions.create(config);
+
+        KafkaSender<String, byte[]> sender1 = KafkaSenderFactory.INSTANCE.createSender(senderOptions);
+        KafkaSenderFactory.INSTANCE.clear();
+        KafkaSender<String, byte[]> sender2 = KafkaSenderFactory.INSTANCE.createSender(senderOptions);
+        assertThat(sender1).isNotSameAs(sender2).isNotEqualTo(sender2);
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/test/java/io/gravitee/plugin/endpoint/kafka/strategy/DefaultQosStrategyFactoryTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/test/java/io/gravitee/plugin/endpoint/kafka/strategy/DefaultQosStrategyFactoryTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.gravitee.gateway.jupiter.api.qos.Qos;
 import io.gravitee.gateway.jupiter.api.qos.QosOptions;
+import io.gravitee.plugin.endpoint.kafka.factory.KafkaReceiverFactory;
 import io.gravitee.plugin.endpoint.kafka.strategy.impl.BalancedStrategy;
 import io.gravitee.plugin.endpoint.kafka.strategy.impl.NoneStrategy;
 import java.util.stream.Stream;
@@ -49,7 +50,7 @@ class DefaultQosStrategyFactoryTest {
     @ParameterizedTest
     @MethodSource("provideQosFactory")
     void shouldReturnValidStrategy(Qos qos, final Class<? extends QosStrategy> qosStrategyClass) {
-        QosStrategy qosStrategy = cut.createQosStrategy(QosOptions.builder().qos(qos).build());
+        QosStrategy qosStrategy = cut.createQosStrategy(new KafkaReceiverFactory(), QosOptions.builder().qos(qos).build());
         assertThat(qosStrategy).isInstanceOf(qosStrategyClass);
     }
 
@@ -57,6 +58,7 @@ class DefaultQosStrategyFactoryTest {
     @EnumSource(value = Qos.class, names = { "NONE", "BALANCED" }, mode = EnumSource.Mode.EXCLUDE)
     void shouldThrowExceptionOnUnsupportedQos() {
         QosOptions qosOptions = QosOptions.builder().qos(null).build();
-        assertThatThrownBy(() -> cut.createQosStrategy(qosOptions)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> cut.createQosStrategy(new KafkaReceiverFactory(), qosOptions))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 }


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-182

## Description

A local hash map is used to store consumer or producer for a specific kafka options in order to reuse then instead of creating new ones on each request.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-182-kafka-clients/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qyewdfaguk.chromatic.com)
<!-- Storybook placeholder end -->
