### PR TITLE
fix(test-sdk): downgrade jetty server for wiremock

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/pom.xml
@@ -35,6 +35,7 @@
         <gravitee-connector-http.version>2.0.5</gravitee-connector-http.version>
         <junit-jupiter.version>5.8.2</junit-jupiter.version>
         <reactiverse-junit5-rx-java2-web-client.version>0.3.0</reactiverse-junit5-rx-java2-web-client.version>
+        <jetty94.wiremock.version>9.4.44.v20210927</jetty94.wiremock.version>
     </properties>
 
     <dependencyManagement>
@@ -53,6 +54,57 @@
                 <version>${junit-jupiter.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <!-- Need to downgrade jetty to a compatible version with wiremock (jetty is only use for tests purpose) -->
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-server</artifactId>
+                <version>${jetty94.wiremock.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-http</artifactId>
+                <version>${jetty94.wiremock.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-util</artifactId>
+                <version>${jetty94.wiremock.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-io</artifactId>
+                <version>${jetty94.wiremock.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-servlet</artifactId>
+                <version>${jetty94.wiremock.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-servlets</artifactId>
+                <version>${jetty94.wiremock.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-continuation</artifactId>
+                <version>${jetty94.wiremock.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-security</artifactId>
+                <version>${jetty94.wiremock.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-webapp</artifactId>
+                <version>${jetty94.wiremock.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-xml</artifactId>
+                <version>${jetty94.wiremock.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION

Try to fix this: https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/12283/workflows/1fc79d25-9c3a-4b16-831e-b2cb5270f152/jobs/171183/tests#failed-test-0
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-sdk-alpn-jetty/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-iwvlqehacr.chromatic.com)
<!-- Storybook placeholder end -->
