### PR TITLE
fix(test): webhook entrypoint integration test is requesting a wiremock which is never responding

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -606,7 +606,7 @@ jobs:
             - run:
                   name: Run tests
                   command: |
-                      mvn -U --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dplugin-modules -Dskip.validation=true -T 2C
+                      mvn -U --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dorg.slf4j.simpleLogger.showThreadName=true -Dplugin-modules -Dskip.validation=true -T 2C
             - run:
                   name: Save test results
                   command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -606,7 +606,7 @@ jobs:
             - run:
                   name: Run tests
                   command: |
-                      mvn -U --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dorg.slf4j.simpleLogger.showThreadName=true -Dplugin-modules -Dskip.validation=true -T 2C
+                      mvn -U --fail-fast -s .gravitee.settings.xml test --no-transfer-progress -Dplugin-modules -Dskip.validation=true
             - run:
                   name: Save test results
                   command: |

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/DefaultSubscriptionDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/DefaultSubscriptionDispatcher.java
@@ -85,7 +85,19 @@ public class DefaultSubscriptionDispatcher extends AbstractService<SubscriptionD
                             // Maintain state depending on subscription status
                             // + timer on end (dispose on timer)
                             // subscribe
-                            Disposable subscribe = reactorHandler.handle(context).subscribe();
+                            Disposable subscribe = reactorHandler
+                                .handle(context)
+                                .subscribe(
+                                    () -> {},
+                                    throwable -> {
+                                        LOGGER.error(
+                                            "Error occurs on subscription id[{}] api[{}]",
+                                            subscription.getId(),
+                                            subscription.getApi(),
+                                            throwable
+                                        );
+                                    }
+                                );
                             actives.put(subscription.getId(), subscribe);
                         }
                     } catch (Exception ex) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/DefaultSubscriptionDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/DefaultSubscriptionDispatcher.java
@@ -56,6 +56,7 @@ public class DefaultSubscriptionDispatcher extends AbstractService<SubscriptionD
 
     @Override
     public void dispatch(Subscription subscription) {
+        LOGGER.debug("Dispatching subscription id[{}] and api[{}]", subscription.getId(), subscription.getApi());
         if ("ACCEPTED".equalsIgnoreCase(subscription.getStatus())) {
             if (!actives.containsKey(subscription.getId())) {
                 Acceptor<SubscriptionAcceptor> acceptor = subscriptionAcceptorResolver.resolve(subscription);
@@ -115,6 +116,7 @@ public class DefaultSubscriptionDispatcher extends AbstractService<SubscriptionD
                 }
             );
         }
+        LOGGER.debug("Subscription id[{}] api[{}] properly dispatched", subscription.getId(), subscription.getApi());
     }
 
     private void disposeAll() {

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/test/java/io/gravitee/plugin/entrypoint/webhook/WebhookEntrypointMockEndpointIntegrationTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/test/java/io/gravitee/plugin/entrypoint/webhook/WebhookEntrypointMockEndpointIntegrationTest.java
@@ -77,7 +77,7 @@ class WebhookEntrypointMockEndpointIntegrationTest extends AbstractGatewayTest {
         interval(50, MILLISECONDS)
             .takeWhile(i -> wiremock.countRequestsMatching(anyRequestedFor(urlPathEqualTo(callbackPath)).build()).getCount() < 7)
             .test()
-            .awaitDone(1, SECONDS)
+            .awaitDone(10, SECONDS)
             .assertComplete();
 
         // verify requests received by wiremock
@@ -105,7 +105,7 @@ class WebhookEntrypointMockEndpointIntegrationTest extends AbstractGatewayTest {
         interval(50, MILLISECONDS)
             .takeWhile(i -> wiremock.countRequestsMatching(anyRequestedFor(urlPathEqualTo(callbackPath)).build()).getCount() < 7)
             .test()
-            .awaitDone(1, SECONDS)
+            .awaitDone(10, SECONDS)
             .assertComplete();
 
         // verify requests received by wiremock

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/test/java/io/gravitee/plugin/entrypoint/webhook/WebhookEntrypointMockEndpointIntegrationTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/test/java/io/gravitee/plugin/entrypoint/webhook/WebhookEntrypointMockEndpointIntegrationTest.java
@@ -82,6 +82,10 @@ class WebhookEntrypointMockEndpointIntegrationTest extends AbstractGatewayTest {
 
         // verify requests received by wiremock
         wiremock.verify(7, postRequestedFor(urlPathEqualTo(WEBHOOK_URL_PATH)).withRequestBody(equalTo("Mock data")));
+
+        // close the subscription to avoid maintaining it between test methods
+        subscription.setStatus("CLOSED");
+        getBean(SubscriptionDispatcher.class).dispatch(subscription);
     }
 
     @Test
@@ -111,6 +115,10 @@ class WebhookEntrypointMockEndpointIntegrationTest extends AbstractGatewayTest {
                 .withHeader("Header1", equalTo("my-header-1-value"))
                 .withHeader("Header2", equalTo("my-header-2-value"))
         );
+
+        // close the subscription to avoid maintaining it between test methods
+        subscription.setStatus("CLOSED");
+        getBean(SubscriptionDispatcher.class).dispatch(subscription);
     }
 
     private Subscription buildTestSubscription(WebhookEntrypointConnectorSubscriptionConfiguration configuration)

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/test/java/io/gravitee/plugin/entrypoint/webhook/WebhookEntrypointMockEndpointIntegrationTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/test/java/io/gravitee/plugin/entrypoint/webhook/WebhookEntrypointMockEndpointIntegrationTest.java
@@ -42,7 +42,6 @@ import org.junit.jupiter.api.Test;
  * @author GraviteeSource Team
  */
 @GatewayTest
-@DeployApi({ "/apis/webhook-entrypoint.json" })
 class WebhookEntrypointMockEndpointIntegrationTest extends AbstractGatewayTest {
 
     private static final String API_ID = "my-api";
@@ -63,6 +62,7 @@ class WebhookEntrypointMockEndpointIntegrationTest extends AbstractGatewayTest {
 
     @Test
     @DisplayName("Should send messages from mock endpoint to webhook entrypoint callback URL")
+    @DeployApi({ "/apis/webhook-entrypoint.json" })
     void shouldSendMessagesFromMockEndpointToWebhookEntrypoint() throws JsonProcessingException {
         WebhookEntrypointConnectorSubscriptionConfiguration configuration = new WebhookEntrypointConnectorSubscriptionConfiguration();
         final String callbackPath = WEBHOOK_URL_PATH + "/without-header";
@@ -90,6 +90,7 @@ class WebhookEntrypointMockEndpointIntegrationTest extends AbstractGatewayTest {
 
     @Test
     @DisplayName("Should send messages from mock endpoint to webhook entrypoint callback URL, with additional headers")
+    @DeployApi({ "/apis/webhook-entrypoint-2.json" })
     void shouldSendMessagesFromMockEndpointToWebhookEntrypointWithHeaders() throws JsonProcessingException {
         WebhookEntrypointConnectorSubscriptionConfiguration configuration = new WebhookEntrypointConnectorSubscriptionConfiguration();
         final String callbackPath = WEBHOOK_URL_PATH + "/with-headers";
@@ -98,6 +99,7 @@ class WebhookEntrypointMockEndpointIntegrationTest extends AbstractGatewayTest {
         wiremock.stubFor(post(callbackPath).willReturn(ok()));
 
         Subscription subscription = buildTestSubscription(configuration);
+        subscription.setApi(API_ID + "-2");
 
         getBean(SubscriptionDispatcher.class).dispatch(subscription);
 

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/test/java/io/gravitee/plugin/entrypoint/webhook/WebhookEntrypointMockEndpointIntegrationTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/test/java/io/gravitee/plugin/entrypoint/webhook/WebhookEntrypointMockEndpointIntegrationTest.java
@@ -67,6 +67,7 @@ class WebhookEntrypointMockEndpointIntegrationTest extends AbstractGatewayTest {
     void shouldSendMessagesFromMockEndpointToWebhookEntrypoint() throws JsonProcessingException {
         WebhookEntrypointConnectorSubscriptionConfiguration configuration = new WebhookEntrypointConnectorSubscriptionConfiguration();
         configuration.setCallbackUrl(String.format("http://localhost:%s%s", wiremock.port(), WEBHOOK_URL_PATH));
+        wiremock.stubFor(post(WEBHOOK_URL_PATH).willReturn(ok()));
 
         Subscription subscription = buildTestSubscription(configuration);
 
@@ -89,6 +90,7 @@ class WebhookEntrypointMockEndpointIntegrationTest extends AbstractGatewayTest {
         WebhookEntrypointConnectorSubscriptionConfiguration configuration = new WebhookEntrypointConnectorSubscriptionConfiguration();
         configuration.setCallbackUrl(String.format("http://localhost:%s%s", wiremock.port(), WEBHOOK_URL_PATH));
         configuration.setHeaders(List.of(new HttpHeader("Header1", "my-header-1-value"), new HttpHeader("Header2", "my-header-2-value")));
+        wiremock.stubFor(post(WEBHOOK_URL_PATH).willReturn(ok()));
 
         Subscription subscription = buildTestSubscription(configuration);
 

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/test/resources/apis/webhook-entrypoint-2.json
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/test/resources/apis/webhook-entrypoint-2.json
@@ -1,0 +1,43 @@
+{
+  "id": "my-api-2",
+  "name": "my-api-2",
+  "apiVersion": "1.0",
+  "definitionVersion": "4.0.0",
+  "type": "async",
+  "description": "API v4 using webhook entrypoint",
+  "listeners": [
+    {
+      "type": "subscription",
+      "paths": [
+        {
+          "path": "/test-2"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "webhook"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default",
+      "type": "mock",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "mock",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "messageInterval": 5,
+            "messageContent": "Mock data",
+            "messageCount": 7
+          }
+        }
+      ]
+    }
+  ],
+  "flows": []
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/test/resources/logback-test.xml
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/test/resources/logback-test.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2015-2016, The Gravitee team (http://www.gravitee.io)
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{5} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.gravitee" level="DEBUG" additivity="false">
+        <appender-ref ref="STDOUT" />
+    </logger>
+
+    <!-- Strictly speaking, the level attribute is not necessary since -->
+    <!-- the level of the root level is set to DEBUG by default.       -->
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
## Description

We have a flaky test in Webhook entrypoint integration test
https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/12283/workflows/1fc79d25-9c3a-4b16-831e-b2cb5270f152/jobs/171183/parallel-runs/0/steps/0-106

This PR aims to confirm the theory in which the cause is the fact we never configure wiremock with a valid stub for valid request. meaning the request never ends properly.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-webhook-integration-test/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xtfuyjxurg.chromatic.com)
<!-- Storybook placeholder end -->
