### PR TITLE
chore: bump git fetcher plugin version to 1.8.0 [ 3.15.x ]

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -99,7 +99,7 @@
         <!-- Management API Only -->
         <gravitee-cockpit-connectors-ws.version>2.4.9</gravitee-cockpit-connectors-ws.version>
         <gravitee-fetcher-bitbucket.version>1.7.0</gravitee-fetcher-bitbucket.version>
-        <gravitee-fetcher-git.version>1.7.0</gravitee-fetcher-git.version>
+        <gravitee-fetcher-git.version>1.8.0</gravitee-fetcher-git.version>
         <gravitee-fetcher-github.version>1.6.0</gravitee-fetcher-github.version>
         <gravitee-fetcher-gitlab.version>1.11.0</gravitee-fetcher-gitlab.version>
         <gravitee-fetcher-http.version>1.12.0</gravitee-fetcher-http.version>


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-244

## Description

Bump git fetcher version

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tbvxpnhhrq.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/chore-244-bump-git-fetcher-plugin/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
