### PR TITLE
feat: consumer can update the configuration of his subscription

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/task/IncrementalSubscriptionRefresher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/task/IncrementalSubscriptionRefresher.java
@@ -15,8 +15,10 @@
  */
 package io.gravitee.gateway.services.sync.cache.task;
 
+import static io.gravitee.repository.management.model.Subscription.Status.ACCEPTED;
 import static io.gravitee.repository.management.model.Subscription.Status.CLOSED;
 import static io.gravitee.repository.management.model.Subscription.Status.PAUSED;
+import static io.gravitee.repository.management.model.Subscription.Status.PENDING;
 
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
 import io.gravitee.repository.management.model.Subscription;
@@ -37,7 +39,7 @@ public class IncrementalSubscriptionRefresher extends SubscriptionRefresher {
 
     private final long lastRefreshAt, nextLastRefreshAt;
 
-    private static final List<Subscription.Status> REFRESH_STATUS = Arrays.asList(Subscription.Status.ACCEPTED, CLOSED, PAUSED);
+    private static final List<Subscription.Status> REFRESH_STATUS = Arrays.asList(ACCEPTED, CLOSED, PAUSED, PENDING);
 
     public IncrementalSubscriptionRefresher(final long lastRefreshAt, final long nextLastRefreshAt, final List<String> plans) {
         this.lastRefreshAt = lastRefreshAt;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/UpdateSubscriptionConfigurationEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/UpdateSubscriptionConfigurationEntity.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model;
+
+import com.fasterxml.jackson.annotation.JsonRawValue;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Map;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author GraviteeSource Team
+ */
+@NoArgsConstructor
+@Getter
+public class UpdateSubscriptionConfigurationEntity {
+
+    private String filter;
+
+    @JsonRawValue
+    private String configuration;
+
+    private Map<String, String> metadata;
+
+    public void setFilter(String filter) {
+        this.filter = filter;
+    }
+
+    public void setConfiguration(String configuration) {
+        this.configuration = configuration;
+    }
+
+    @JsonSetter
+    public void setConfiguration(final JsonNode configuration) {
+        if (configuration != null) {
+            this.configuration = configuration.toString();
+        }
+    }
+
+    public void setMetadata(Map<String, String> metadata) {
+        this.metadata = metadata;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/SubscriptionService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/SubscriptionService.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.service;
 
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.Order;
+import io.gravitee.repository.management.model.Subscription;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.pagedresult.Metadata;
@@ -51,9 +52,11 @@ public interface SubscriptionService {
 
     SubscriptionEntity update(ExecutionContext executionContext, UpdateSubscriptionEntity subscription);
 
-    SubscriptionEntity updateDaysToExpirationOnLastNotification(String subscriptionId, Integer value);
-
     SubscriptionEntity update(ExecutionContext executionContext, UpdateSubscriptionEntity subscription, String clientId);
+
+    SubscriptionEntity update(ExecutionContext executionContext, UpdateSubscriptionEntity updateSubscription, Subscription.Status status);
+
+    SubscriptionEntity updateDaysToExpirationOnLastNotification(String subscriptionId, Integer value);
 
     SubscriptionEntity process(ExecutionContext executionContext, ProcessSubscriptionEntity processSubscription, String userId);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
@@ -527,7 +527,25 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
 
     @Override
     public SubscriptionEntity update(final ExecutionContext executionContext, UpdateSubscriptionEntity updateSubscription) {
-        return update(executionContext, updateSubscription, null);
+        return update(executionContext, updateSubscription, null, null);
+    }
+
+    @Override
+    public SubscriptionEntity update(
+        final ExecutionContext executionContext,
+        UpdateSubscriptionEntity updateSubscription,
+        String clientId
+    ) {
+        return update(executionContext, updateSubscription, clientId, null);
+    }
+
+    @Override
+    public SubscriptionEntity update(
+        final ExecutionContext executionContext,
+        UpdateSubscriptionEntity updateSubscription,
+        Subscription.Status status
+    ) {
+        return update(executionContext, updateSubscription, null, status);
     }
 
     @Override
@@ -560,11 +578,11 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
         }
     }
 
-    @Override
-    public SubscriptionEntity update(
+    private SubscriptionEntity update(
         final ExecutionContext executionContext,
         UpdateSubscriptionEntity updateSubscription,
-        String clientId
+        String clientId,
+        Subscription.Status status
     ) {
         try {
             logger.debug("Update subscription {}", updateSubscription.getId());
@@ -589,6 +607,9 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                 subscription.setDaysToExpirationOnLastNotification(null);
                 if (clientId != null) {
                     subscription.setClientId(clientId);
+                }
+                if (status != null) {
+                    subscription.setStatus(status);
                 }
 
                 subscription = subscriptionRepository.update(subscription);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionServiceTest.java
@@ -810,6 +810,44 @@ public class SubscriptionServiceTest {
         verify(subscriptionValidationService, times(1)).validateAndSanitize(updatedSubscription);
     }
 
+    @Test
+    public void shouldUpdateSubscriptionWithClientId() throws Exception {
+        UpdateSubscriptionEntity updatedSubscription = new UpdateSubscriptionEntity();
+        updatedSubscription.setId(SUBSCRIPTION_ID);
+
+        Subscription subscription = buildTestSubscription(ACCEPTED);
+
+        // Stub
+        when(subscriptionRepository.findById(SUBSCRIPTION_ID)).thenReturn(Optional.of(subscription));
+        when(subscriptionRepository.update(any())).thenAnswer(returnsFirstArg());
+        when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN_ID)).thenReturn(planEntity);
+
+        // Run
+        subscriptionService.update(GraviteeContext.getExecutionContext(), updatedSubscription, "my-client-id");
+
+        // Verify
+        verify(subscriptionRepository, times(1)).update(argThat(s -> "my-client-id".equals(s.getClientId())));
+    }
+
+    @Test
+    public void shouldUpdateSubscriptionWithStatus() throws Exception {
+        UpdateSubscriptionEntity updatedSubscription = new UpdateSubscriptionEntity();
+        updatedSubscription.setId(SUBSCRIPTION_ID);
+
+        Subscription subscription = buildTestSubscription(ACCEPTED);
+
+        // Stub
+        when(subscriptionRepository.findById(SUBSCRIPTION_ID)).thenReturn(Optional.of(subscription));
+        when(subscriptionRepository.update(any())).thenAnswer(returnsFirstArg());
+        when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN_ID)).thenReturn(planEntity);
+
+        // Run
+        subscriptionService.update(GraviteeContext.getExecutionContext(), updatedSubscription, PENDING);
+
+        // Verify
+        verify(subscriptionRepository, times(1)).update(argThat(s -> s.getStatus() == PENDING));
+    }
+
     @Test(expected = SubscriptionNotFoundException.class)
     public void shouldNotCloseSubscriptionBecauseDoesNoExist() throws Exception {
         // Stub
@@ -1513,7 +1551,7 @@ public class SubscriptionServiceTest {
     }
 
     @Test
-    public void update_should_update_subscription_with_endingDate_and_set_apiKey_expiration_if_not_shared_apikey() throws Exception {
+    public void shouldUpdateSubscriptionWithEndingDateAndSetApiKeyExpirationIfNotSharedApikey() throws Exception {
         UpdateSubscriptionEntity updatedSubscription = new UpdateSubscriptionEntity();
         updatedSubscription.setId(SUBSCRIPTION_ID);
         updatedSubscription.setEndingAt(new Date());
@@ -1557,7 +1595,7 @@ public class SubscriptionServiceTest {
     }
 
     @Test
-    public void update_should_update_subscription_with_endingDate_and_dont_set_apiKey_expiration_if_shared_apikey() throws Exception {
+    public void shouldUpdateSubscriptionWithEndingDateAndDontSetApiKeyExpirationIfSharedApikey() throws Exception {
         UpdateSubscriptionEntity updatedSubscription = new UpdateSubscriptionEntity();
         updatedSubscription.setId(SUBSCRIPTION_ID);
         updatedSubscription.setEndingAt(new Date());


### PR DESCRIPTION
feat: consumer can update the configuration of his subscription

If the plan requires manual validation,
Status of the subscription will be set to PENDING, as API publisher will have to approve it.

## Issue

https://graviteecommunity.atlassian.net/browse/APIM-216
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-216-consumerupdatespublisherapproves/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nkvwzhgmiv.chromatic.com)
<!-- Storybook placeholder end -->
