### PR TITLE
fix: check webhook entrypoint configuration header name format

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/main/resources/schemas/subscriptions/schema-form.json
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/main/resources/schemas/subscriptions/schema-form.json
@@ -18,7 +18,9 @@
         "properties": {
           "name": {
             "type": "string",
-            "title": "Name"
+            "title": "Name",
+            "minLength": 1,
+            "pattern" : "^\\S*$"
           },
           "value": {
             "type": "string",


### PR DESCRIPTION
Ensure webhook entrypoint configuration HTTP header names :
- are not empty
- doesn't contain any space character

## Issue

https://graviteecommunity.atlassian.net/browse/APIM-184
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-184-headernamenotemptynospaces/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bcfevesdge.chromatic.com)
<!-- Storybook placeholder end -->
