### PR TITLE
fix: subscribers

### DIFF
--- a/gravitee-apim-e2e/api-test/src/apis/api-subscribers.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/api-subscribers.spec.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { APIsApi } from '@management-apis/APIsApi';
+import {
+  forManagementAsAdminUser,
+  forManagementAsApiUser,
+  forManagementAsAppUser,
+  forPortalAsAdminUser,
+  forPortalAsAppUser,
+} from '@client-conf/*';
+import { afterAll, beforeAll, describe, expect } from '@jest/globals';
+import { ApisFaker } from '@management-fakers/ApisFaker';
+import { ApiEntity } from '@management-models/ApiEntity';
+import { ApiLifecycleState } from '@management-models/ApiLifecycleState';
+import { APIPlansApi } from '@management-apis/APIPlansApi';
+import { ApplicationApi as PortalApplicationApi } from '@portal-apis/ApplicationApi';
+import { ApplicationsApi } from '@management-apis/ApplicationsApi';
+import { ApplicationsFaker } from '@management-fakers/ApplicationsFaker';
+import fetchApi from 'node-fetch';
+import { PlansFaker } from '@management-fakers/PlansFaker';
+import { PlanValidationType } from '@management-models/PlanValidationType';
+import { PlanEntity } from '@management-models/PlanEntity';
+import { Api } from '@portal-models/Api';
+import { ApplicationEntity } from '@management-models/ApplicationEntity';
+import { PlanSecurityType } from '@management-models/PlanSecurityType';
+import { ApiApi } from '@portal-apis/ApiApi';
+import { Visibility } from '@management-models/Visibility';
+import { succeed } from '@lib/jest-utils';
+import { GetSubscriptionByIdIncludeEnum, SubscriptionApi } from '@portal-apis/SubscriptionApi';
+import faker from '@faker-js/faker';
+import { Subscription } from '@portal-models/Subscription';
+import { APISubscriptionsApi } from '@management-apis/APISubscriptionsApi';
+import { UpdateApiEntityFromJSON } from '@management-models/UpdateApiEntity';
+
+const orgId = 'DEFAULT';
+const envId = 'DEFAULT';
+
+// Portal resources
+const portalApisAsAdminUser = new ApiApi(forPortalAsAdminUser());
+
+// Management resources
+const apisAsAdmin = new APIsApi(forManagementAsAdminUser());
+const managementApiSubscriptionsAsAdminUser = new APISubscriptionsApi(forManagementAsAdminUser());
+
+let createdApi: ApiEntity;
+
+describe('Api subscribers tests', () => {
+  beforeAll(async () => {
+    // create an api
+    createdApi = await apisAsAdmin.createApi({
+      orgId,
+      envId,
+      newApiEntity: ApisFaker.newApi(),
+    });
+
+    // publish an api
+    await apisAsAdmin.updateApi({
+      api: createdApi.id,
+      updateApiEntity: UpdateApiEntityFromJSON({
+        ...createdApi,
+        lifecycle_state: ApiLifecycleState.PUBLISHED,
+        visibility: Visibility.PUBLIC,
+      }),
+      orgId,
+      envId,
+    });
+  });
+
+  describe('GET subscribers', () => {
+    test('should not get any subscriber from portal resource', async () => {
+      const apiSubscribers = await succeed(
+        portalApisAsAdminUser.getSubscriberApplicationsByApiIdRaw({
+          apiId: createdApi.id,
+        }),
+      );
+
+      expect(apiSubscribers).toBeTruthy();
+      expect(apiSubscribers.data).toHaveLength(0);
+    });
+
+    test('should not get any subscriber from management resource', async () => {
+      const apiSubscribers = await succeed(
+        managementApiSubscriptionsAsAdminUser.getApiSubscribersRaw({
+          api: createdApi.id,
+          envId,
+          orgId,
+        }),
+      );
+
+      expect(apiSubscribers).toBeTruthy();
+      expect(apiSubscribers).toHaveLength(0);
+    });
+  });
+});

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscribersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscribersResource.java
@@ -113,6 +113,10 @@ public class ApiSubscribersResource extends AbstractResource {
 
         Set<String> applicationIds = subscriptions.stream().map(SubscriptionEntity::getApplication).collect(Collectors.toSet());
 
+        if (applicationIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
         ApplicationQuery applicationQuery = new ApplicationQuery();
         if (exclude != null && !exclude.isEmpty()) {
             applicationQuery.setExcludeFilters(exclude);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiSubscribersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiSubscribersResource.java
@@ -97,6 +97,10 @@ public class ApiSubscribersResource extends AbstractResource {
 
             Set<String> applicationIds = subscriptions.stream().map(SubscriptionEntity::getApplication).collect(Collectors.toSet());
 
+            if (applicationIds.isEmpty()) {
+                return createListResponse(executionContext, Collections.emptyList(), paginationParam);
+            }
+
             ApplicationQuery applicationQuery = new ApplicationQuery();
             applicationQuery.setIds(applicationIds);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -11,7 +11,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0
-  version: "3.18.10-SNAPSHOT"
+  version: "3.18.13-SNAPSHOT"
 servers:
   - url: http://localhost:8083/portal/environments/{envId}
     description: The portal API for a given environment


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-273

## Description

Today when you create an API without subscriptions, if you try to GET the subscribers all applications are returned. The expected behaviour is that it should return an empty array.


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-subscribers/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zdbgidekzl.chromatic.com)
<!-- Storybook placeholder end -->
