### PR TITLE
chore: bump git fetcher plugin version to 1.8.1

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -70,7 +70,7 @@
         <gravitee-policy-latency.version>1.4.0</gravitee-policy-latency.version>
         <gravitee-policy-metrics-reporter.version>2.0.0</gravitee-policy-metrics-reporter.version>
         <gravitee-policy-mock.version>1.13.0</gravitee-policy-mock.version>
-	<gravitee-policy-oauth2.version>1.23.0</gravitee-policy-oauth2.version>
+	    <gravitee-policy-oauth2.version>1.23.0</gravitee-policy-oauth2.version>
         <gravitee-policy-openid-connect-userinfo.version>1.5.2</gravitee-policy-openid-connect-userinfo.version>
         <gravitee-policy-override-http-method.version>1.3.0</gravitee-policy-override-http-method.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->
@@ -100,7 +100,7 @@
         <!-- Management API Only -->
         <gravitee-cockpit-connectors-ws.version>2.4.9</gravitee-cockpit-connectors-ws.version>
         <gravitee-fetcher-bitbucket.version>1.7.0</gravitee-fetcher-bitbucket.version>
-        <gravitee-fetcher-git.version>1.8.0</gravitee-fetcher-git.version>
+        <gravitee-fetcher-git.version>1.8.1</gravitee-fetcher-git.version>
         <gravitee-fetcher-github.version>1.6.0</gravitee-fetcher-github.version>
         <gravitee-fetcher-gitlab.version>1.11.0</gravitee-fetcher-gitlab.version>
         <gravitee-fetcher-http.version>1.12.0</gravitee-fetcher-http.version>


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-244

## Description

Update git fetcher plugin to 1.8.1
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/chore-244-bump-git-fetcher-plugin-2/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
