### PR TITLE
chore: bump git fetcher plugin version to 1.8.1 [ 3.18.x ]

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -100,7 +100,7 @@
         <!-- Management API Only -->
         <gravitee-cockpit-connectors-ws.version>2.4.9</gravitee-cockpit-connectors-ws.version>
         <gravitee-fetcher-bitbucket.version>1.7.0</gravitee-fetcher-bitbucket.version>
-        <gravitee-fetcher-git.version>1.8.0</gravitee-fetcher-git.version>
+        <gravitee-fetcher-git.version>1.8.1</gravitee-fetcher-git.version>
         <gravitee-fetcher-github.version>1.6.0</gravitee-fetcher-github.version>
         <gravitee-fetcher-gitlab.version>1.11.0</gravitee-fetcher-gitlab.version>
         <gravitee-fetcher-http.version>1.12.0</gravitee-fetcher-http.version>


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-244

## Description

Cherry pick commit from 3.19.x

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/chore-244-bump-git-fetcher-plugin-3-18-x/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
