### PR TITLE
feat: implement background mechanism to check kafka connectivity

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/pom.xml
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/pom.xml
@@ -128,6 +128,12 @@
             <artifactId>vertx-junit5</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-core</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/configuration/KafkaDefaultConfiguration.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/configuration/KafkaDefaultConfiguration.java
@@ -13,15 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.plugin.endpoint.kafka.strategy;
+package io.gravitee.plugin.endpoint.kafka.configuration;
 
-import io.gravitee.gateway.jupiter.api.qos.QosOptions;
-import io.gravitee.plugin.endpoint.kafka.factory.KafkaReceiverFactory;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface QosStrategyFactory {
-    <K, V> QosStrategy<K, V> createQosStrategy(final KafkaReceiverFactory kafkaReceiverFactory, final QosOptions qosOptions);
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class KafkaDefaultConfiguration {
+
+    public static final int RECONNECT_ATTEMPT = 10;
+    public static final int RECONNECT_BACKOFF_MS = 1000;
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/error/AbstractKafkaErrorTransformer.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/error/AbstractKafkaErrorTransformer.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.endpoint.kafka.error;
+
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import reactor.core.publisher.Sinks;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class AbstractKafkaErrorTransformer {
+
+    protected static <T> void mayThrowConnectionClosedException(
+        final Sinks.Many<T> kafkaErrorSink,
+        final Map<MetricName, ? extends Metric> metrics
+    ) {
+        metrics
+            .values()
+            .stream()
+            .filter(metric -> metric.metricName().name().equals("connection-close-total") && metric.metricValue() != null)
+            .map(metric -> Double.parseDouble(metric.metricValue().toString()))
+            .filter(connectionCloseTotal -> connectionCloseTotal > 0)
+            .findFirst()
+            .ifPresent(
+                metric -> {
+                    kafkaErrorSink.tryEmitError(new KafkaConnectionClosedException());
+                    throw new KafkaConnectionClosedException();
+                }
+            );
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/error/KafkaConnectionClosedException.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/error/KafkaConnectionClosedException.java
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.plugin.endpoint.kafka.strategy;
-
-import io.gravitee.gateway.jupiter.api.qos.QosOptions;
-import io.gravitee.plugin.endpoint.kafka.factory.KafkaReceiverFactory;
+package io.gravitee.plugin.endpoint.kafka.error;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface QosStrategyFactory {
-    <K, V> QosStrategy<K, V> createQosStrategy(final KafkaReceiverFactory kafkaReceiverFactory, final QosOptions qosOptions);
+public class KafkaConnectionClosedException extends RuntimeException {
+
+    public KafkaConnectionClosedException() {
+        super();
+    }
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/error/KafkaReceiverErrorTransformer.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/error/KafkaReceiverErrorTransformer.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.endpoint.kafka.error;
+
+import static io.gravitee.plugin.endpoint.kafka.configuration.KafkaDefaultConfiguration.RECONNECT_ATTEMPT;
+import static io.gravitee.plugin.endpoint.kafka.configuration.KafkaDefaultConfiguration.RECONNECT_BACKOFF_MS;
+
+import io.gravitee.plugin.endpoint.kafka.strategy.QosStrategy;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.retry.Retry;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class KafkaReceiverErrorTransformer extends AbstractKafkaErrorTransformer {
+
+    private static final int KAFKA_CONNECTION_CHECK_INTERVAL = RECONNECT_ATTEMPT * RECONNECT_BACKOFF_MS;
+
+    public static <K, V> Function<Flux<ConsumerRecord<K, V>>, Publisher<ConsumerRecord<K, V>>> transform(
+        final QosStrategy<K, V> qosStrategy
+    ) {
+        return consumerRecordFlux -> {
+            AtomicReference<Consumer<K, V>> consumerRef = new AtomicReference<>();
+            Sinks.Many<ConsumerRecord<K, V>> kafkaErrorSink = Sinks.many().unicast().onBackpressureError();
+            return consumerRecordFlux
+                .zipWith(storeConsumerReference(qosStrategy, consumerRef), (c, o) -> c)
+                .mergeWith(kafkaErrorSink.asFlux())
+                .doOnSubscribe(subscription -> handleKafkaDisconnection(consumerRef, kafkaErrorSink));
+        };
+    }
+
+    private static <K, V> Flux<Boolean> storeConsumerReference(
+        final QosStrategy<K, V> qosStrategy,
+        final AtomicReference<Consumer<K, V>> consumerRef
+    ) {
+        return Flux
+            .defer(
+                () ->
+                    qosStrategy
+                        .kafkaReceiver()
+                        .doOnConsumer(
+                            consumer -> {
+                                consumerRef.set(consumer);
+                                return true;
+                            }
+                        )
+            )
+            .cache()
+            .repeat();
+    }
+
+    private static <K, V> void handleKafkaDisconnection(
+        final AtomicReference<Consumer<K, V>> consumerRef,
+        final Sinks.Many<ConsumerRecord<K, V>> kafkaErrorSink
+    ) {
+        Flux
+            .interval(Duration.ofMillis(KAFKA_CONNECTION_CHECK_INTERVAL))
+            .publishOn(Schedulers.boundedElastic())
+            .doOnNext(
+                interval -> {
+                    Consumer<K, V> consumer = consumerRef.get();
+                    if (consumer != null) {
+                        mayThrowConnectionClosedException(kafkaErrorSink, consumer.metrics());
+                    }
+                }
+            )
+            .retryWhen(Retry.indefinitely().filter(throwable -> !(throwable instanceof KafkaConnectionClosedException)))
+            .subscribe(
+                interval -> log.debug("Kafka endpoint connection validated."),
+                throwable -> log.warn("Kafka endpoint connector disconnected.")
+            );
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/error/KafkaSenderErrorTransformer.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/error/KafkaSenderErrorTransformer.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.endpoint.kafka.error;
+
+import static io.gravitee.plugin.endpoint.kafka.configuration.KafkaDefaultConfiguration.RECONNECT_ATTEMPT;
+import static io.gravitee.plugin.endpoint.kafka.configuration.KafkaDefaultConfiguration.RECONNECT_BACKOFF_MS;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
+import reactor.core.scheduler.Schedulers;
+import reactor.kafka.sender.KafkaSender;
+import reactor.kafka.sender.SenderResult;
+import reactor.util.retry.Retry;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Slf4j
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class KafkaSenderErrorTransformer extends AbstractKafkaErrorTransformer {
+
+    private static final int KAFKA_CONNECTION_CHECK_INTERVAL = RECONNECT_ATTEMPT * RECONNECT_BACKOFF_MS;
+
+    public static <K, V, T> Function<Flux<SenderResult<T>>, Publisher<SenderResult<T>>> transform(final KafkaSender<K, V> kafkaSender) {
+        return consumerRecordFlux -> {
+            AtomicReference<Producer<K, V>> producerRef = new AtomicReference<>();
+            Sinks.Many<SenderResult<T>> kafkaErrorSink = Sinks.many().unicast().onBackpressureError();
+            return consumerRecordFlux
+                .zipWith(storeProduceReference(kafkaSender, producerRef), (r, o) -> r)
+                .mergeWith(kafkaErrorSink.asFlux())
+                .doOnSubscribe(subscription -> handleKafkaDisconnection(producerRef, kafkaErrorSink))
+                .doOnError(throwable -> kafkaSender.close());
+        };
+    }
+
+    private static <K, V> Flux<Boolean> storeProduceReference(
+        final KafkaSender<K, V> kafkaSender,
+        final AtomicReference<Producer<K, V>> producerRef
+    ) {
+        return Flux
+            .defer(
+                () ->
+                    kafkaSender.doOnProducer(
+                        producer -> {
+                            producerRef.set(producer);
+                            return true;
+                        }
+                    )
+            )
+            .cache()
+            .repeat();
+    }
+
+    private static <V, K, T> void handleKafkaDisconnection(
+        final AtomicReference<Producer<K, V>> producerRef,
+        final Sinks.Many<SenderResult<T>> kafkaErrorSink
+    ) {
+        Flux
+            .interval(Duration.ofMillis(KAFKA_CONNECTION_CHECK_INTERVAL))
+            .publishOn(Schedulers.boundedElastic())
+            .doOnNext(
+                interval -> {
+                    Producer<K, V> producer = producerRef.get();
+                    if (producer != null) {
+                        mayThrowConnectionClosedException(kafkaErrorSink, producer.metrics());
+                    }
+                }
+            )
+            .retryWhen(Retry.indefinitely().filter(throwable -> !(throwable instanceof KafkaConnectionClosedException)))
+            .subscribe(
+                interval -> log.debug("Kafka endpoint connection validated."),
+                throwable -> log.warn("Kafka endpoint connector disconnected.")
+            );
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/strategy/DefaultQosStrategyFactory.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/strategy/DefaultQosStrategyFactory.java
@@ -26,7 +26,7 @@ import io.gravitee.plugin.endpoint.kafka.strategy.impl.NoneStrategy;
  */
 public class DefaultQosStrategyFactory implements QosStrategyFactory {
 
-    public QosStrategy createQosStrategy(final KafkaReceiverFactory kafkaReceiverFactory, final QosOptions qosOptions) {
+    public <K, V> QosStrategy<K, V> createQosStrategy(final KafkaReceiverFactory kafkaReceiverFactory, final QosOptions qosOptions) {
         if (qosOptions != null && qosOptions.getQos() != null) {
             switch (qosOptions.getQos()) {
                 case NONE:

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/strategy/QosStrategy.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/strategy/QosStrategy.java
@@ -20,24 +20,27 @@ import io.gravitee.plugin.endpoint.kafka.configuration.KafkaEndpointConnectorCon
 import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import reactor.core.publisher.Flux;
+import reactor.kafka.receiver.KafkaReceiver;
 import reactor.kafka.receiver.ReceiverOptions;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface QosStrategy {
+public interface QosStrategy<K, V> {
     Runnable doNothing = () -> {};
 
     default void addCustomConfig(final Map<String, Object> config) {}
 
-    Flux<ConsumerRecord<String, byte[]>> receive(
+    KafkaReceiver<K, V> kafkaReceiver();
+
+    Flux<ConsumerRecord<K, V>> receive(
         final ExecutionContext executionContext,
         final KafkaEndpointConnectorConfiguration configuration,
-        final ReceiverOptions<String, byte[]> receiverOptions
+        final ReceiverOptions<K, V> receiverOptions
     );
 
-    Runnable buildAckRunnable(final ConsumerRecord<String, byte[]> consumerRecord);
+    Runnable buildAckRunnable(final ConsumerRecord<K, V> consumerRecord);
 
-    String generateId(final ConsumerRecord<String, byte[]> consumerRecord);
+    String generateId(final ConsumerRecord<K, V> consumerRecord);
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/strategy/impl/AbstractQosStrategy.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/strategy/impl/AbstractQosStrategy.java
@@ -15,23 +15,31 @@
  */
 package io.gravitee.plugin.endpoint.kafka.strategy.impl;
 
+import io.gravitee.plugin.endpoint.kafka.factory.CustomConsumerFactory;
 import io.gravitee.plugin.endpoint.kafka.factory.KafkaReceiverFactory;
 import io.gravitee.plugin.endpoint.kafka.strategy.QosStrategy;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
 import reactor.kafka.receiver.KafkaReceiver;
 import reactor.kafka.receiver.ReceiverOptions;
+import reactor.kafka.receiver.internals.DefaultKafkaReceiver;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
-public abstract class AbstractQosStrategy implements QosStrategy {
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Accessors(fluent = true)
+public abstract class AbstractQosStrategy<K, V> implements QosStrategy<K, V> {
 
     private final KafkaReceiverFactory kafkaReceiverFactory;
+    private DefaultKafkaReceiver<K, V> kafkaReceiver;
 
-    protected <K, V> KafkaReceiver<K, V> createReceiver(final ReceiverOptions<K, V> receiverOptions) {
-        return kafkaReceiverFactory.createReceiver(receiverOptions);
+    protected KafkaReceiver<K, V> initReceiver(final ReceiverOptions<K, V> options) {
+        kafkaReceiver = new DefaultKafkaReceiver<>(CustomConsumerFactory.INSTANCE, options);
+        return kafkaReceiver;
     }
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/strategy/impl/BalancedStrategy.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/strategy/impl/BalancedStrategy.java
@@ -26,28 +26,28 @@ import reactor.kafka.receiver.ReceiverOptions;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class BalancedStrategy extends AbstractQosStrategy {
+public class BalancedStrategy<K, V> extends AbstractQosStrategy<K, V> {
 
     public BalancedStrategy(final KafkaReceiverFactory kafkaReceiverFactory) {
         super(kafkaReceiverFactory);
     }
 
     @Override
-    public Flux<ConsumerRecord<String, byte[]>> receive(
+    public Flux<ConsumerRecord<K, V>> receive(
         final ExecutionContext executionContext,
         final KafkaEndpointConnectorConfiguration configuration,
-        final ReceiverOptions<String, byte[]> receiverOptions
+        final ReceiverOptions<K, V> receiverOptions
     ) {
-        return createReceiver(receiverOptions).receiveAutoAck().concatMap(c -> c);
+        return initReceiver(receiverOptions).receiveAutoAck().concatMap(c -> c);
     }
 
     @Override
-    public Runnable buildAckRunnable(final ConsumerRecord<String, byte[]> consumerRecord) {
+    public Runnable buildAckRunnable(final ConsumerRecord<K, V> consumerRecord) {
         return doNothing;
     }
 
     @Override
-    public String generateId(final ConsumerRecord<String, byte[]> consumerRecord) {
+    public String generateId(final ConsumerRecord<K, V> consumerRecord) {
         return null;
     }
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/strategy/impl/NoneStrategy.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/strategy/impl/NoneStrategy.java
@@ -29,7 +29,7 @@ import reactor.kafka.receiver.ReceiverOptions;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class NoneStrategy extends AbstractQosStrategy {
+public class NoneStrategy<K, V> extends AbstractQosStrategy<K, V> {
 
     public NoneStrategy(final KafkaReceiverFactory kafkaReceiverFactory) {
         super(kafkaReceiverFactory);
@@ -41,22 +41,22 @@ public class NoneStrategy extends AbstractQosStrategy {
     }
 
     @Override
-    public Flux<ConsumerRecord<String, byte[]>> receive(
+    public Flux<ConsumerRecord<K, V>> receive(
         final ExecutionContext executionContext,
         final KafkaEndpointConnectorConfiguration configuration,
-        final ReceiverOptions<String, byte[]> receiverOptions
+        final ReceiverOptions<K, V> receiverOptions
     ) {
-        ReceiverOptions<String, byte[]> noCommitReceiverOptions = receiverOptions.commitInterval(Duration.ZERO).commitBatchSize(0);
-        return createReceiver(noCommitReceiverOptions).receive().map(receiverRecord -> receiverRecord);
+        ReceiverOptions<K, V> noCommitReceiverOptions = receiverOptions.commitInterval(Duration.ZERO).commitBatchSize(0);
+        return initReceiver(noCommitReceiverOptions).receive().map(receiverRecord -> receiverRecord);
     }
 
     @Override
-    public Runnable buildAckRunnable(final ConsumerRecord<String, byte[]> consumerRecord) {
+    public Runnable buildAckRunnable(final ConsumerRecord<K, V> consumerRecord) {
         return doNothing;
     }
 
     @Override
-    public String generateId(final ConsumerRecord<String, byte[]> consumerRecord) {
+    public String generateId(final ConsumerRecord<K, V> consumerRecord) {
         return null;
     }
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/test/java/io/gravitee/plugin/endpoint/kafka/KafkaEndpointConnectorFactoryTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/test/java/io/gravitee/plugin/endpoint/kafka/KafkaEndpointConnectorFactoryTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class KafkaEndpointConnectorFactoryTest {
+class KafkaEndpointConnectorFactoryTest {
 
     private KafkaEndpointConnectorFactory kafkaEndpointConnectorFactory;
 


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-196

## Description

Properly handle error to return a more understandable error to client.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-196-kafka-errors/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lxlzmglwjk.chromatic.com)
<!-- Storybook placeholder end -->
