### PR TITLE
fix: raise primary owner removal upgrader order

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/ApiPrimaryOwnerRemovalUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/ApiPrimaryOwnerRemovalUpgrader.java
@@ -155,7 +155,7 @@ public class ApiPrimaryOwnerRemovalUpgrader implements Upgrader, Ordered {
 
     @Override
     public int getOrder() {
-        return 100;
+        return 200;
     }
 
     private String findApiPrimaryOwnerRoleId(String organizationId) throws TechnicalException {


### PR DESCRIPTION
this upgrader must run after the default system role upgrader to avoid failures causing the process to be skipped.

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-api-primary-owner-removal-upgrader/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jftjejqqfg.chromatic.com)
<!-- Storybook placeholder end -->
