### PR TITLE
fix: check subscriptions ids before evict

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -10,7 +10,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0
-  version: "3.19.0-alpha.2-SNAPSHOT"
+  version: "3.19.4-SNAPSHOT"
 servers:
   - url: http://localhost:8083/portal/environments/{envId}
     description: The portal API for a given environment


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-284

## Description

Today users can create and close subscriptions related to an API, client id and plan.
Those 3 ids are combined to create  a key and cache the subscription internally. This cache is refreshed every 5s with a refresher. However in the search query the subscriptions are ordered by created_date descending. It means that the following scenario is possible:

Using For the same API, client id and plan

→ Subscription 1 is created and Accepted at time T

→ Subscription 1 is closed at T + x

→ Subscription 2 is created and accepted at T + y


It means that the search query will return subscription 2 and then subscription 1. 
Nevertheless here is what should happens at refresher level:

→ Loop 1 at T should add subscription 1 in cache as it’s accepted using key api_id.client_id.plan_id
→ Loop 2 at T + z should:

update the cache using the same key api_id.client_id.plan_id with the subscription 2

Evict subscription 2 from the cache because Subscription 1 is closed and have the same non    unique cache key

## Additional context

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-subscription-cache/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jjiegwlkrn.chromatic.com)
<!-- Storybook placeholder end -->
