### PR TITLE
Migrate Gateway instance monitoring screen to Angular

### DIFF
--- a/gravitee-apim-console-webui/src/entities/instance/instance.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/instance/instance.fixture.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Instance } from './instance';
+import { MonitoringData } from './monitoringData';
+import { SearchResult } from './searchResult';
+
+export function fakeInstance(attributes?: Partial<Instance>): Instance {
+  const defaultValue: Instance = {
+    event: 'a8da6459-dc59-4cdb-9a64-59dc596cdb74',
+    id: '5bc17c57-b350-460d-817c-57b350060db3',
+    hostname: 'apim-master-v3-apim3-gateway-6575b8ccf7-m4s6j',
+    ip: '10.0.2.210',
+    port: '8082',
+    version: '3.20.0-SNAPSHOT (build: 174998) revision#a67b37a366',
+    state: 'STARTED',
+    started_at: new Date(1667812198374),
+    last_heartbeat_at: new Date(1667813521610),
+    operating_system_name: 'Linux',
+  };
+
+  return {
+    ...defaultValue,
+    ...attributes,
+  };
+}
+
+export function fakeMonitoringData(attributes?: Partial<MonitoringData>): MonitoringData {
+  const defaultValue: MonitoringData = {
+    cpu: {
+      percent_use: 9,
+      load_average: {
+        '1m': 1.08,
+        '5m': 0.76,
+        '15m': 0.77,
+      },
+    },
+    process: {
+      cpu_percent: 18,
+      open_file_descriptors: 444,
+      max_file_descriptors: 1048576,
+    },
+    jvm: {
+      timestamp: new Date(1667814960307),
+      uptime_in_millis: 2814465,
+      heap_used_in_bytes: 84563320,
+      heap_used_percent: 32,
+      heap_committed_in_bytes: 259522560,
+      heap_max_in_bytes: 259522560,
+      non_heap_used_in_bytes: 173936576,
+      non_heap_committed_in_bytes: 180551680,
+      young_pool_used_in_bytes: 17375680,
+      young_pool_max_in_bytes: 71630848,
+      young_pool_peak_used_in_bytes: 71630848,
+      young_pool_peak_max_in_bytes: 71630848,
+      survivor_pool_used_in_bytes: 414248,
+      survivor_pool_max_in_bytes: 8912896,
+      survivor_pool_peak_used_in_bytes: 8912896,
+      survivor_pool_peak_max_in_bytes: 8912896,
+      old_pool_used_in_bytes: 66840632,
+      old_pool_max_in_bytes: 178978816,
+      old_pool_peak_used_in_bytes: 66840632,
+      old_pool_peak_max_in_bytes: 178978816,
+    },
+    thread: {
+      count: 119,
+      peak_count: 124,
+    },
+    gc: {
+      young_collection_count: 85,
+      young_collection_time_in_millis: 1253,
+      old_collection_count: 4,
+      old_collection_time_in_millis: 971,
+    },
+  };
+
+  return {
+    ...defaultValue,
+    ...attributes,
+  };
+}
+
+export function fakeSearchResult(attributes?: Partial<SearchResult>): SearchResult {
+  const defaultValue: SearchResult = {
+    content: [fakeInstance()],
+    pageElements: 1,
+    pageNumber: 0,
+    totalElements: 1,
+  };
+
+  return {
+    ...defaultValue,
+    ...attributes,
+  };
+}

--- a/gravitee-apim-console-webui/src/entities/instance/instance.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/instance/instance.fixture.ts
@@ -1,14 +1,14 @@
 /*
  * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *
- * Licensed under the Apache License, Version 2.0 (the License);
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an AS IS BASIS,
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
@@ -22,7 +22,7 @@ export function fakeInstance(attributes?: Partial<Instance>): Instance {
     event: 'a8da6459-dc59-4cdb-9a64-59dc596cdb74',
     id: '5bc17c57-b350-460d-817c-57b350060db3',
     hostname: 'apim-master-v3-apim3-gateway-6575b8ccf7-m4s6j',
-    ip: '10.0.2.210',
+    ip: '0.0.0.0',
     port: '8082',
     version: '3.20.0-SNAPSHOT (build: 174998) revision#a67b37a366',
     state: 'STARTED',

--- a/gravitee-apim-console-webui/src/entities/instance/instance.ts
+++ b/gravitee-apim-console-webui/src/entities/instance/instance.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export interface Instance {
+  event: string;
+  id: string;
+  hostname: string;
+  ip: string;
+  port: string;
+  version: string;
+  state: string;
+  started_at: Date;
+  last_heartbeat_at: Date;
+  operating_system_name: string;
+}

--- a/gravitee-apim-console-webui/src/entities/instance/instance.ts
+++ b/gravitee-apim-console-webui/src/entities/instance/instance.ts
@@ -1,14 +1,14 @@
 /*
  * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *
- * Licensed under the Apache License, Version 2.0 (the License);
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an AS IS BASIS,
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.

--- a/gravitee-apim-console-webui/src/entities/instance/monitoringData.ts
+++ b/gravitee-apim-console-webui/src/entities/instance/monitoringData.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export interface MonitoringData {
+  cpu: {
+    percent_use: number;
+    load_average: any;
+  };
+  process: {
+    cpu_percent: number;
+    open_file_descriptors: number;
+    max_file_descriptors: number;
+  };
+  jvm: {
+    timestamp: Date;
+    uptime_in_millis: number;
+    heap_used_in_bytes: number;
+    heap_used_percent: number;
+    heap_committed_in_bytes: number;
+    heap_max_in_bytes: number;
+    non_heap_used_in_bytes: number;
+    non_heap_committed_in_bytes: number;
+    young_pool_used_in_bytes: number;
+    young_pool_max_in_bytes: number;
+    young_pool_peak_used_in_bytes: number;
+    young_pool_peak_max_in_bytes: number;
+    survivor_pool_used_in_bytes: number;
+    survivor_pool_max_in_bytes: number;
+    survivor_pool_peak_used_in_bytes: number;
+    survivor_pool_peak_max_in_bytes: number;
+    old_pool_used_in_bytes: number;
+    old_pool_max_in_bytes: number;
+    old_pool_peak_used_in_bytes: number;
+    old_pool_peak_max_in_bytes: number;
+  };
+  thread: {
+    count: number;
+    peak_count: number;
+  };
+  gc: {
+    young_collection_count: number;
+    young_collection_time_in_millis: number;
+    old_collection_count: number;
+    old_collection_time_in_millis: number;
+  };
+}

--- a/gravitee-apim-console-webui/src/entities/instance/monitoringData.ts
+++ b/gravitee-apim-console-webui/src/entities/instance/monitoringData.ts
@@ -1,14 +1,14 @@
 /*
  * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *
- * Licensed under the Apache License, Version 2.0 (the License);
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an AS IS BASIS,
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.

--- a/gravitee-apim-console-webui/src/entities/instance/searchResult.ts
+++ b/gravitee-apim-console-webui/src/entities/instance/searchResult.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Instance } from './instance';
+
+export interface SearchResult {
+  content: Instance[];
+  pageNumber: number;
+  pageElements: number;
+  totalElements: number;
+}

--- a/gravitee-apim-console-webui/src/entities/instance/searchResult.ts
+++ b/gravitee-apim-console-webui/src/entities/instance/searchResult.ts
@@ -1,14 +1,14 @@
 /*
  * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
  *
- * Licensed under the Apache License, Version 2.0 (the License);
+ * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
  *         http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an AS IS BASIS,
+ * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.

--- a/gravitee-apim-console-webui/src/management/instances/details/instance-details-monitoring/instance-details-monitoring.component.html
+++ b/gravitee-apim-console-webui/src/management/instances/details/instance-details-monitoring/instance-details-monitoring.component.html
@@ -1,0 +1,224 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div *ngIf="!instanceStarted">
+  <h1><mat-icon svgIcon="gio:alert-circle"></mat-icon> There is no data for stopped gateway instance</h1>
+</div>
+<div *ngIf="instanceStarted" class="gio-instance-details-monitoring">
+  <div class="gio-instance-details-monitoring__main-indicators">
+    <mat-card class="gio-instance-details-monitoring__main-indicators__card">
+      <div class="gio-instance-details-monitoring__main-indicators__card__percentage">
+        <gio-circular-percentage [score]="this.monitoringData?.process.cpu_percent / 100" reverseColor="true"></gio-circular-percentage>
+      </div>
+      <h4>CPU</h4>
+    </mat-card>
+    <mat-card class="gio-instance-details-monitoring__main-indicators__card">
+      <div class="gio-instance-details-monitoring__main-indicators__card__percentage">
+        <gio-circular-percentage [score]="this.monitoringData?.jvm.heap_used_percent / 100" reverseColor="true"></gio-circular-percentage>
+      </div>
+      <h4>Heap</h4>
+    </mat-card>
+    <mat-card class="gio-instance-details-monitoring__main-indicators__card">
+      <div class="gravitee-monitoring-indicator-value gio-instance-details-monitoring__main-indicators__card__value">
+        {{ monitoringData.gc.old_collection_count }}
+      </div>
+      <h4>GC collections</h4>
+    </mat-card>
+    <mat-card class="gio-instance-details-monitoring__main-indicators__card">
+      <div class="gravitee-monitoring-indicator-value gio-instance-details-monitoring__main-indicators__card__value">
+        {{ monitoringData.process.open_file_descriptors }}
+      </div>
+      <h4>File Descriptors</h4>
+    </mat-card>
+  </div>
+
+  <div class="gio-instance-details-monitoring__jvm">
+    <mat-card data-testid="instance-monitoring_jvm-box">
+      <h2 class="gio-instance-details-monitoring__card-title">
+        <mat-icon svgIcon="gio:cpu"></mat-icon>
+        <span>JVM</span>
+      </h2>
+      <dl class="gio-description-list">
+        <dt>Date</dt>
+        <dd>{{ monitoringData.jvm.timestamp | date: 'medium' }}</dd>
+        <dt>Uptime</dt>
+        <dd>{{ humanizeDuration(monitoringData.jvm.uptime_in_millis) }}</dd>
+        <dt>Heap used</dt>
+        <dd>{{ humanizeSize(monitoringData.jvm.heap_used_in_bytes) }}</dd>
+        <dt>Percent of heap used</dt>
+        <dd>{{ monitoringData.jvm.heap_used_percent + '%' }}</dd>
+        <dt>Heap committed</dt>
+        <dd>{{ humanizeSize(monitoringData.jvm.heap_committed_in_bytes) }}</dd>
+        <dt>Heap max</dt>
+        <dd>{{ humanizeSize(monitoringData.jvm.heap_max_in_bytes) }}</dd>
+        <dt>Non heap used</dt>
+        <dd>{{ humanizeSize(monitoringData.jvm.non_heap_used_in_bytes) }}</dd>
+        <dt>Non heap committed</dt>
+        <dd>{{ humanizeSize(monitoringData.jvm.non_heap_committed_in_bytes) }}</dd>
+      </dl>
+      <div class="gio-instance-details-monitoring__jvm__pool">
+        <mat-card>
+          <dl class="gio-description-list">
+            <dt>Young pool used</dt>
+            <dd>{{ humanizeSize(monitoringData.jvm.young_pool_used_in_bytes) }}</dd>
+            <dt>Young pool max</dt>
+            <dd>{{ humanizeSize(monitoringData.jvm.young_pool_max_in_bytes) }}</dd>
+          </dl>
+          <div class="gio-instance-details-monitoring__jvm__pool__progress-bar">
+            <strong>{{ ratioLabel(monitoringData.jvm.young_pool_used_in_bytes, monitoringData.jvm.young_pool_max_in_bytes) }}</strong>
+            <mat-progress-bar
+              mode="determinate"
+              [value]="ratio(monitoringData.jvm.young_pool_used_in_bytes, monitoringData.jvm.young_pool_max_in_bytes)"
+            ></mat-progress-bar>
+          </div>
+          <dl class="gio-description-list">
+            <dt>Young pool peak used</dt>
+            <dd>{{ humanizeSize(monitoringData.jvm.young_pool_peak_used_in_bytes) }}</dd>
+            <dt>Young pool peak max</dt>
+            <dd>{{ humanizeSize(monitoringData.jvm.young_pool_peak_max_in_bytes) }}</dd>
+          </dl>
+          <div class="gio-instance-details-monitoring__jvm__pool__progress-bar">
+            <strong>{{
+              ratioLabel(monitoringData.jvm.young_pool_peak_used_in_bytes, monitoringData.jvm.young_pool_peak_max_in_bytes)
+            }}</strong>
+            <mat-progress-bar
+              mode="determinate"
+              [value]="ratio(monitoringData.jvm.young_pool_peak_used_in_bytes, monitoringData.jvm.young_pool_peak_max_in_bytes)"
+            ></mat-progress-bar>
+          </div>
+        </mat-card>
+        <mat-card>
+          <dl class="gio-description-list">
+            <dt>Survivor pool used</dt>
+            <dd>{{ humanizeSize(monitoringData.jvm.survivor_pool_used_in_bytes) }}</dd>
+            <dt>Survivor pool max</dt>
+            <dd>{{ humanizeSize(monitoringData.jvm.survivor_pool_max_in_bytes) }}</dd>
+          </dl>
+          <div class="gio-instance-details-monitoring__jvm__pool__progress-bar">
+            <strong>{{ ratioLabel(monitoringData.jvm.survivor_pool_used_in_bytes, monitoringData.jvm.survivor_pool_max_in_bytes) }}</strong>
+            <mat-progress-bar
+              mode="determinate"
+              [value]="ratio(monitoringData.jvm.survivor_pool_used_in_bytes, monitoringData.jvm.survivor_pool_max_in_bytes)"
+            ></mat-progress-bar>
+          </div>
+          <dl class="gio-description-list">
+            <dt>Survivor pool peak used</dt>
+            <dd>{{ humanizeSize(monitoringData.jvm.survivor_pool_peak_used_in_bytes) }}</dd>
+            <dt>Survivor pool peak max</dt>
+            <dd>{{ humanizeSize(monitoringData.jvm.survivor_pool_peak_max_in_bytes) }}</dd>
+          </dl>
+          <div class="gio-instance-details-monitoring__jvm__pool__progress-bar">
+            <strong>{{
+              ratioLabel(monitoringData.jvm.survivor_pool_peak_used_in_bytes, monitoringData.jvm.survivor_pool_peak_max_in_bytes)
+            }}</strong>
+            <mat-progress-bar
+              mode="determinate"
+              [value]="ratio(monitoringData.jvm.survivor_pool_peak_used_in_bytes, monitoringData.jvm.survivor_pool_peak_max_in_bytes)"
+            ></mat-progress-bar>
+          </div>
+        </mat-card>
+        <mat-card>
+          <dl class="gio-description-list">
+            <dt>Old pool used</dt>
+            <dd>{{ humanizeSize(monitoringData.jvm.old_pool_used_in_bytes) }}</dd>
+            <dt>Old pool max</dt>
+            <dd>{{ humanizeSize(monitoringData.jvm.old_pool_max_in_bytes) }}</dd>
+          </dl>
+          <div class="gio-instance-details-monitoring__jvm__pool__progress-bar">
+            <strong>{{ ratioLabel(monitoringData.jvm.old_pool_used_in_bytes, monitoringData.jvm.old_pool_max_in_bytes) }}</strong>
+            <mat-progress-bar
+              mode="determinate"
+              [value]="ratio(monitoringData.jvm.old_pool_used_in_bytes, monitoringData.jvm.old_pool_max_in_bytes)"
+            ></mat-progress-bar>
+          </div>
+          <dl class="gio-description-list">
+            <dt>Old pool peak used</dt>
+            <dd>{{ humanizeSize(monitoringData.jvm.old_pool_peak_used_in_bytes) }}</dd>
+            <dt>Old pool peak max</dt>
+            <dd>{{ humanizeSize(monitoringData.jvm.old_pool_peak_max_in_bytes) }}</dd>
+          </dl>
+          <div class="gio-instance-details-monitoring__jvm__pool__progress-bar">
+            <strong>{{ ratioLabel(monitoringData.jvm.old_pool_peak_used_in_bytes, monitoringData.jvm.old_pool_peak_max_in_bytes) }}</strong>
+            <mat-progress-bar
+              mode="determinate"
+              [value]="ratio(monitoringData.jvm.old_pool_peak_used_in_bytes, monitoringData.jvm.old_pool_peak_max_in_bytes)"
+            ></mat-progress-bar>
+          </div>
+        </mat-card>
+      </div>
+    </mat-card>
+  </div>
+
+  <div class="gio-instance-details-monitoring__indicators">
+    <mat-card flex="50" data-testid="instance-monitoring_cpu-box">
+      <h2 class="gio-instance-details-monitoring__card-title">
+        <mat-icon svgIcon="gio:cpu"></mat-icon>
+        <span>CPU</span>
+      </h2>
+      <dl class="gio-description-list">
+        <dt>Percent of use</dt>
+        <dd>{{ monitoringData.cpu.percent_use + '%' }}</dd>
+        <dt>Load average</dt>
+        <dd></dd>
+        <ng-container *ngFor="let loadAverage of monitoringData.cpu.load_average | keyvalue">
+          <dt class="gio-instance-details-monitoring__indicators__sublist">{{ loadAverage.key }}</dt>
+          <dd>{{ loadAverage.value }}</dd>
+        </ng-container>
+      </dl>
+    </mat-card>
+    <mat-card flex="50" data-testid="instance-monitoring_process-box">
+      <h2 class="gio-instance-details-monitoring__card-title">
+        <mat-icon svgIcon="gio:cpu"></mat-icon>
+        <span>Process</span>
+      </h2>
+      <dl class="gio-description-list">
+        <dt>Open file descriptors</dt>
+        <dd>{{ monitoringData.process.open_file_descriptors }}</dd>
+        <dt>Max file descriptors</dt>
+        <dd>{{ monitoringData.process.max_file_descriptors }}</dd>
+      </dl>
+    </mat-card>
+    <mat-card flex="50" data-testid="instance-monitoring_thread-box">
+      <h2 class="gio-instance-details-monitoring__card-title">
+        <mat-icon svgIcon="gio:cpu"></mat-icon>
+        <span>Thread</span>
+      </h2>
+      <dl class="gio-description-list">
+        <dt>Count</dt>
+        <dd>{{ monitoringData.thread.count }}</dd>
+        <dt>Peak count</dt>
+        <dd>{{ monitoringData.thread.peak_count }}</dd>
+      </dl>
+    </mat-card>
+    <mat-card flex="50" data-testid="instance-monitoring_gc-box">
+      <h2 class="gio-instance-details-monitoring__card-title">
+        <mat-icon svgIcon="gio:cpu"></mat-icon>
+        <span>Garbage collector</span>
+      </h2>
+      <dl class="gio-description-list">
+        <dt>Young collection count</dt>
+        <dd>{{ monitoringData.gc.young_collection_count }}</dd>
+        <dt>Young collection time</dt>
+        <dd>{{ monitoringData.gc.young_collection_time_in_millis + ' ms' }}</dd>
+        <dt>Old collection count</dt>
+        <dd>{{ monitoringData.gc.old_collection_count }}</dd>
+        <dt>Old collection time</dt>
+        <dd>{{ monitoringData.gc.old_collection_time_in_millis + ' ms' }}</dd>
+      </dl>
+    </mat-card>
+  </div>
+</div>

--- a/gravitee-apim-console-webui/src/management/instances/details/instance-details-monitoring/instance-details-monitoring.component.scss
+++ b/gravitee-apim-console-webui/src/management/instances/details/instance-details-monitoring/instance-details-monitoring.component.scss
@@ -1,0 +1,71 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+.gio-instance-details-monitoring {
+  display: grid;
+  width: 100%;
+  grid-gap: 16px;
+
+  &__main-indicators {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    grid-template-rows: auto;
+    grid-gap: 1rem;
+
+    & > .mat-card > * {
+      margin-top: auto;
+    }
+
+    & gio-circular-percentage {
+      margin: auto;
+    }
+
+    &__card {
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
+      text-align: center;
+    }
+  }
+
+  &__card-title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  &__jvm {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: auto;
+
+    &__pool {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      grid-template-rows: auto;
+      grid-gap: 16px;
+      margin: 8px;
+
+      &__progress-bar {
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-end;
+        text-align: center;
+        margin-bottom: 2em;
+      }
+    }
+  }
+
+  &__indicators {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    grid-template-rows: auto;
+    grid-gap: 16px;
+
+    &__sublist {
+      text-align: right;
+      color: mat.get-color-from-palette(gio.$mat-space-palette, default);
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/instances/details/instance-details-monitoring/instance-details-monitoring.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/instances/details/instance-details-monitoring/instance-details-monitoring.component.spec.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { InstanceDetailsMonitoringComponent } from './instance-details-monitoring.component';
+import { InstanceDetailsMonitoringModule } from './instance-details-monitoring.module';
+
+import { UIRouterStateParams } from '../../../../ajs-upgraded-providers';
+import { GioHttpTestingModule } from '../../../../shared/testing';
+
+describe('InstanceMonitoringComponent', () => {
+  let fixture: ComponentFixture<InstanceDetailsMonitoringComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, GioHttpTestingModule, InstanceDetailsMonitoringModule],
+      providers: [{ provide: UIRouterStateParams, useValue: { instanceId: 'instanceId' } }],
+    });
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(InstanceDetailsMonitoringComponent);
+    fixture.detectChanges();
+  });
+
+  describe('humanizeSize', () => {
+    it.each([
+      [Infinity, 1, '-'],
+      [42, 1, '42.0 bytes'],
+      [1050, 1, '1.0 kB'],
+      [100056, 1, '97.7 kB'],
+      [4096000000, 2, '3.81 GB'],
+      [0, 1, '0.0 bytes'],
+      [42, undefined, '42.0 bytes'],
+      [42, 0, '42 bytes'],
+    ])('should convert %p bytes with precision %p into %p', (bytes, precision, result) => {
+      expect(fixture.componentInstance.humanizeSize(bytes, precision)).toBe(result);
+    });
+  });
+
+  describe('ratio', () => {
+    it.each([
+      [42, 1, 4200],
+      [42, 0, undefined],
+      [0, 42, 0],
+      [115312310, 240, 48046796],
+      [240, 115312310, 0],
+    ])('should compute ratio of %p on %p into %p', (val1, val2, result) => {
+      expect(fixture.componentInstance.ratio(val1, val2)).toBe(result);
+    });
+  });
+
+  describe('ratioLabel', () => {
+    it.each([
+      [42, 1, '4200%'],
+      [42, 0, '-%'],
+      [0, 42, '0%'],
+      [115312310, 240, '48046796%'],
+      [240, 115312310, '0%'],
+    ])('should compute ratio label of %p on %p into %p', (val1, val2, result) => {
+      expect(fixture.componentInstance.ratioLabel(val1, val2)).toBe(result);
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/instances/details/instance-details-monitoring/instance-details-monitoring.component.ts
+++ b/gravitee-apim-console-webui/src/management/instances/details/instance-details-monitoring/instance-details-monitoring.component.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import { duration } from 'moment/moment';
+import { isNil, isNumber, round } from 'lodash';
+import { delay, mergeMap, repeat, takeUntil, tap } from 'rxjs/operators';
+import { of, Subject } from 'rxjs';
+
+import { UIRouterStateParams } from '../../../../ajs-upgraded-providers';
+import { MonitoringData } from '../../../../entities/instance/monitoringData';
+import { Instance } from '../../../../entities/instance/instance';
+import { InstanceService } from '../../../../services-ngx/instance.service';
+
+@Component({
+  selector: 'instance-monitoring',
+  template: require('./instance-details-monitoring.component.html'),
+  styles: [require('./instance-details-monitoring.component.scss')],
+})
+export class InstanceDetailsMonitoringComponent implements OnInit, OnDestroy {
+  public instance: Instance;
+  public instanceStarted: boolean;
+  public monitoringData: MonitoringData;
+
+  private monitoringPolling;
+  private unsubscribe$ = new Subject<void>();
+
+  constructor(@Inject(UIRouterStateParams) private readonly ajsStateParams, private readonly instanceService: InstanceService) {}
+
+  ngOnInit(): void {
+    this.instanceService
+      .get(this.ajsStateParams.instanceId)
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((instance) => {
+        this.instance = instance;
+        this.instanceStarted = instance.state === 'STARTED';
+
+        if (this.instanceStarted) {
+          this.monitoringPolling = of({})
+            .pipe(
+              mergeMap((_) => this.instanceService.getMonitoringData(this.ajsStateParams.instanceId, this.instance.id)),
+              tap((monitoringData) => (this.monitoringData = monitoringData)),
+              delay(5000),
+              repeat(),
+            )
+            .subscribe();
+        }
+      });
+  }
+
+  ngOnDestroy() {
+    this.unsubscribe$.next();
+    this.unsubscribe$.unsubscribe();
+    if (this.monitoringPolling) {
+      this.monitoringPolling.unsubscribe();
+    }
+  }
+
+  humanizeDuration(timeInMillis) {
+    return duration(-timeInMillis).humanize(true);
+  }
+
+  humanizeSize(bytes: number, precision?: number | undefined | null): string {
+    if (!isNumber(bytes) || !isFinite(bytes)) {
+      return '-';
+    }
+    if (isNil(precision)) {
+      precision = 1;
+    }
+    const units = ['bytes', 'kB', 'MB', 'GB', 'TB', 'PB'];
+    const mostRelevantUnitIndex = bytes === 0 ? 0 : Math.floor(Math.log(bytes) / Math.log(1024));
+    const valueInSelectedUnit = bytes / Math.pow(1024, Math.floor(mostRelevantUnitIndex));
+    return `${valueInSelectedUnit.toFixed(precision)} ${units[mostRelevantUnitIndex]}`;
+  }
+
+  ratio(value: number, value2: number): number {
+    return value2 === 0 ? undefined : round((value / value2) * 100);
+  }
+
+  ratioLabel(value: number, value2: number): string {
+    const ratio = this.ratio(value, value2);
+    return ratio !== undefined ? `${ratio}%` : '-%';
+  }
+}

--- a/gravitee-apim-console-webui/src/management/instances/details/instance-details-monitoring/instance-details-monitoring.module.ts
+++ b/gravitee-apim-console-webui/src/management/instances/details/instance-details-monitoring/instance-details-monitoring.module.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatIconModule } from '@angular/material/icon';
+import { GioIconsModule } from '@gravitee/ui-particles-angular';
+
+import { InstanceDetailsMonitoringComponent } from './instance-details-monitoring.component';
+
+import { GioCircularPercentageModule } from '../../../../shared/components/gio-circular-percentage/gio-circular-percentage.module';
+import { GioClipboardModule } from '../../../../shared/components/gio-clipboard/gio-clipboard.module';
+
+@NgModule({
+  declarations: [InstanceDetailsMonitoringComponent],
+  exports: [InstanceDetailsMonitoringComponent],
+  imports: [
+    CommonModule,
+    MatCardModule,
+    MatProgressBarModule,
+    MatIconModule,
+    GioClipboardModule,
+    GioIconsModule,
+    GioCircularPercentageModule,
+  ],
+})
+export class InstanceDetailsMonitoringModule {}

--- a/gravitee-apim-console-webui/src/management/management.module.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/management.module.ajs.ts
@@ -554,6 +554,7 @@ import { SettingsNavigationComponent } from './configuration/settings-navigation
 import { ApplicationNavigationComponent } from './application/details/application-navigation/application-navigation.component';
 import { ApiNavigationComponent } from './api/api-navigation/api-navigation.component';
 import { InstancesNavigationComponent } from './instances/details/instances-navigation/instances-navigation.component';
+import { InstanceDetailsMonitoringComponent } from './instances/details/instance-details-monitoring/instance-details-monitoring.component';
 
 (<any>window).moment = moment;
 require('angular-moment-picker');
@@ -894,6 +895,7 @@ graviteeManagementModule.component('instance', InstanceComponent);
 graviteeManagementModule.component('instanceHeader', InstanceHeaderComponent);
 graviteeManagementModule.component('instanceEnvironment', InstanceEnvironmentComponent);
 graviteeManagementModule.component('instanceMonitoring', InstanceMonitoringComponent);
+graviteeManagementModule.directive('instanceDetailsMonitoring', downgradeComponent({ component: InstanceDetailsMonitoringComponent }));
 
 graviteeManagementModule.component('apiCreation', ApiCreationComponent);
 graviteeManagementModule.controller('ApiCreationController', ApiCreationController);

--- a/gravitee-apim-console-webui/src/management/management.module.ts
+++ b/gravitee-apim-console-webui/src/management/management.module.ts
@@ -27,6 +27,7 @@ import { EnvironmentApplicationModule } from './application/environment-applicat
 import { ApisModule } from './api/apis.module';
 import { SettingsNavigationModule } from './configuration/settings-navigation/settings-navigation.module';
 import { InstancesNavigationModule } from './instances/details/instances-navigation/instances-navigation.module';
+import { InstanceDetailsMonitoringModule } from './instances/details/instance-details-monitoring/instance-details-monitoring.module';
 
 import { GioConfirmDialogModule } from '../shared/components/gio-confirm-dialog/gio-confirm-dialog.module';
 import { GioPermissionModule } from '../shared/components/gio-permission/gio-permission.module';
@@ -46,6 +47,7 @@ import { GioPermissionModule } from '../shared/components/gio-permission/gio-per
     ApisModule,
     SettingsNavigationModule,
     InstancesNavigationModule,
+    InstanceDetailsMonitoringModule,
   ],
   declarations: [],
   entryComponents: [],

--- a/gravitee-apim-console-webui/src/management/management.route.ts
+++ b/gravitee-apim-console-webui/src/management/management.route.ts
@@ -181,6 +181,16 @@ function managementRouterConfig($stateProvider) {
           InstancesService.getMonitoringData($stateParams.instanceId, instance.id).then((response) => response.data),
       },
     })
+    .state('management.instances.detail.ng-monitoring', {
+      url: '/ng-monitoring',
+      component: 'instanceDetailsMonitoring',
+      data: {
+        docs: {
+          page: 'management-gateway-monitoring',
+        },
+        useAngularMaterial: true,
+      },
+    })
     .state('management.logs', {
       url: '/logs?from&to&q&page&size',
       component: 'platformLogs',

--- a/gravitee-apim-console-webui/src/services-ngx/instance.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/instance.service.spec.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { InstanceService } from './instance.service';
+
+import { CONSTANTS_TESTING, GioHttpTestingModule } from '../shared/testing';
+import { fakeInstance, fakeMonitoringData, fakeSearchResult } from '../entities/instance/instance.fixture';
+
+describe('InstanceService', () => {
+  let httpTestingController: HttpTestingController;
+  let instanceService: InstanceService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [GioHttpTestingModule],
+    });
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+    instanceService = TestBed.inject<InstanceService>(InstanceService);
+  });
+
+  describe('get', () => {
+    it('should call the API', (done) => {
+      const instanceId = '5bc17c57-b350-460d-817c-57b350060db3';
+      const fakeInstanceObject = fakeInstance();
+
+      instanceService.get(instanceId).subscribe((instance) => {
+        expect(instance).toMatchObject(fakeInstanceObject);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/instances/${instanceId}`);
+      expect(req.request.method).toEqual('GET');
+
+      req.flush(fakeInstanceObject);
+    });
+  });
+
+  describe('getMonitoringData', () => {
+    it('should call the API', (done) => {
+      const instanceId = '5bc17c57-b350-460d-817c-57b350060db3';
+      const monitoringId = '74bf7316-6475-416f-bf73-166475816fc5';
+      const fakeMonitoringDataObject = fakeMonitoringData();
+
+      instanceService.getMonitoringData(instanceId, monitoringId).subscribe((monitoringData) => {
+        expect(monitoringData).toMatchObject(fakeMonitoringDataObject);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/instances/${instanceId}/monitoring/${monitoringId}`);
+      expect(req.request.method).toEqual('GET');
+
+      req.flush(fakeMonitoringDataObject);
+    });
+  });
+
+  describe('search', () => {
+    it('should call the API', (done) => {
+      const includeStopped = false;
+      const from = 0;
+      const to = 0;
+      const page = 0;
+      const size = 100;
+      const fakeSearchResults = [fakeSearchResult()];
+
+      instanceService.search(includeStopped, from, to, page, size).subscribe((searchResults) => {
+        expect(searchResults).toMatchObject(fakeSearchResults);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(
+        `${CONSTANTS_TESTING.env.baseURL}/instances/?includeStopped=${includeStopped}&from=${from}&to=${to}&page=${page}&size=${size}`,
+      );
+      expect(req.request.method).toEqual('GET');
+
+      req.flush(fakeSearchResults);
+    });
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+});

--- a/gravitee-apim-console-webui/src/services-ngx/instance.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/instance.service.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpClient } from '@angular/common/http';
+import { Inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { Constants } from '../entities/Constants';
+import { Instance } from '../entities/instance/instance';
+import { MonitoringData } from '../entities/instance/monitoringData';
+import { SearchResult } from '../entities/instance/searchResult';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class InstanceService {
+  constructor(private readonly http: HttpClient, @Inject('Constants') private readonly constants: Constants) {}
+
+  search(includeStopped?: boolean, from?: number, to?: number, page?: number, size?: number): Observable<SearchResult> {
+    if (includeStopped === undefined) {
+      includeStopped = false;
+    }
+
+    if (from === undefined) {
+      from = 0;
+    }
+
+    if (to === undefined) {
+      to = 0;
+    }
+
+    if (page === undefined) {
+      page = 0;
+    }
+
+    if (size === undefined) {
+      size = 100;
+    }
+
+    return this.http.get<SearchResult>(
+      `${this.constants.env.baseURL}/instances/?includeStopped=${includeStopped}&from=${from}&to=${to}&page=${page}&size=${size}`,
+    );
+  }
+
+  get(id: string): Observable<Instance> {
+    return this.http.get<Instance>(`${this.constants.env.baseURL}/instances/` + id);
+  }
+
+  getMonitoringData(id: string, gatewayId: string): Observable<MonitoringData> {
+    return this.http.get<MonitoringData>(`${this.constants.env.baseURL}/instances/` + id + '/monitoring/' + gatewayId);
+  }
+}

--- a/gravitee-apim-console-webui/src/shared/components/gio-circular-percentage/gio-circular-percentage.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-circular-percentage/gio-circular-percentage.component.ts
@@ -25,16 +25,19 @@ export class GioCircularPercentageComponent {
   @Input()
   public score = 0;
 
+  @Input()
+  public reverseColor = false;
+
   public get percentage(): number {
     return parseInt((toNumber(this.score ?? 0) * 100).toFixed(0), 10);
   }
 
   public get colorClass(): string {
     if (this.percentage < 50) {
-      return 'bad-color';
+      return this.reverseColor ? 'good-color' : 'bad-color';
     } else if (this.percentage >= 50 && this.percentage < 80) {
       return 'medium-color';
     }
-    return 'good-color';
+    return this.reverseColor ? 'bad-color' : 'good-color';
   }
 }


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-286

## Description

- create a new Angular Service to make HTTP calls to Management API for Gateway stuffs
- migrate monitoring screen

## Additional information
![image](https://user-images.githubusercontent.com/13161768/200529108-0790ecd6-5380-4f3c-ac1f-8878e9cce640.png)

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nsiohcnkwk.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/migrate-instance-monitoring/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
