### PR TITLE
fix: disable DOCTYPE usage for wsdl imports [ 3.18.x ]

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/main/java/io/gravitee/rest/api/spec/converter/wsdl/WSDLToOpenAPIConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/main/java/io/gravitee/rest/api/spec/converter/wsdl/WSDLToOpenAPIConverter.java
@@ -23,6 +23,7 @@ import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.spec.converter.OpenAPIConverter;
 import io.gravitee.rest.api.spec.converter.wsdl.exception.WsdlDescriptorException;
+import io.gravitee.rest.api.spec.converter.wsdl.reader.GraviteeWSDLReaderImpl;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.info.Info;
@@ -35,7 +36,6 @@ import java.io.InputStream;
 import java.util.*;
 import java.util.Map.Entry;
 import javax.wsdl.*;
-import javax.wsdl.extensions.ElementExtensible;
 import javax.wsdl.extensions.schema.Schema;
 import javax.xml.namespace.QName;
 import org.slf4j.Logger;
@@ -82,12 +82,10 @@ public class WSDLToOpenAPIConverter implements OpenAPIConverter {
 
     private Definition loadWSDL(InputStream stream) {
         try {
-            WSDLReaderImpl reader = new WSDLReaderImpl();
+            WSDLReaderImpl reader = new GraviteeWSDLReaderImpl();
             reader.setFeature("javax.wsdl.importDocuments", true);
             return reader.readWSDL(null, new InputSource(stream));
         } catch (WSDLException e) {
-            LOGGER.info("Unable to read WSDL", e);
-            e.printStackTrace();
             throw new WsdlDescriptorException("Unable to read WSDL");
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/main/java/io/gravitee/rest/api/spec/converter/wsdl/reader/GraviteeWSDLReaderImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/main/java/io/gravitee/rest/api/spec/converter/wsdl/reader/GraviteeWSDLReaderImpl.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.spec.converter.wsdl.reader;
+
+import com.ibm.wsdl.xml.WSDLReaderImpl;
+import java.io.IOException;
+import javax.wsdl.Definition;
+import javax.wsdl.WSDLException;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+/**
+ * @author GraviteeSource Team
+ *
+ * see: <a href="https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html">XML External Entity Prevention Cheat Sheet</a>
+ */
+public class GraviteeWSDLReaderImpl extends WSDLReaderImpl {
+
+    private static final Logger logger = LoggerFactory.getLogger(GraviteeWSDLReaderImpl.class);
+
+    @Override
+    public Definition readWSDL(String documentBaseURI, InputSource inputSource) throws WSDLException {
+        String location = inputSource.getSystemId() != null ? inputSource.getSystemId() : "- WSDL Document -";
+        return this.readWSDL(documentBaseURI, getDocument(inputSource, location));
+    }
+
+    private static Document getDocument(InputSource inputSource, String desc) throws WSDLException {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        String FEATURE = null;
+        try {
+            // This is the PRIMARY defense. If DTDs (doctypes) are disallowed, almost all
+            // XML entity attacks are prevented
+            // Xerces 2 only - http://xerces.apache.org/xerces2-j/features.html#disallow-doctype-decl
+            FEATURE = "http://apache.org/xml/features/disallow-doctype-decl";
+            dbf.setFeature(FEATURE, true);
+
+            // If you can't completely disable DTDs, then at least do the following:
+            // Xerces 1 - http://xerces.apache.org/xerces-j/features.html#external-general-entities
+            // Xerces 2 - http://xerces.apache.org/xerces2-j/features.html#external-general-entities
+            // JDK7+ - http://xml.org/sax/features/external-general-entities
+            //This feature has to be used together with the following one, otherwise it will not protect you from XXE for sure
+            FEATURE = "http://xml.org/sax/features/external-general-entities";
+            dbf.setFeature(FEATURE, false);
+
+            // Xerces 1 - http://xerces.apache.org/xerces-j/features.html#external-parameter-entities
+            // Xerces 2 - http://xerces.apache.org/xerces2-j/features.html#external-parameter-entities
+            // JDK7+ - http://xml.org/sax/features/external-parameter-entities
+            //This feature has to be used together with the previous one, otherwise it will not protect you from XXE for sure
+            FEATURE = "http://xml.org/sax/features/external-parameter-entities";
+            dbf.setFeature(FEATURE, false);
+
+            // Disable external DTDs as well
+            FEATURE = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
+            dbf.setFeature(FEATURE, false);
+
+            // and these as well, per Timothy Morgan's 2014 paper: "XML Schema, DTD, and Entity Attacks"
+            dbf.setXIncludeAware(false);
+            dbf.setExpandEntityReferences(false);
+        } catch (ParserConfigurationException e) {
+            // This should catch a failed setFeature feature
+            logger.info(
+                "ParserConfigurationException was thrown. The feature '" + FEATURE + "' is probably not supported by your XML processor."
+            );
+        }
+
+        dbf.setNamespaceAware(true);
+        dbf.setValidating(false);
+
+        // Load XML file or stream using a XXE agnostic configured parser...
+        try {
+            DocumentBuilder safebuilder = dbf.newDocumentBuilder();
+            return safebuilder.parse(inputSource);
+        } catch (ParserConfigurationException e) {
+            throw new WSDLException("PARSER_ERROR", "Problem parsing '" + desc + "'.", e);
+        } catch (IOException e) {
+            throw new WSDLException("IO_ERROR", "Problem parsing '" + desc + "'.", e);
+        } catch (SAXException e) {
+            throw new WSDLException("SAX_ERROR", "Problem parsing '" + desc + "'.", e);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/test/java/io/gravitee/rest/api/spec/converter/wsdl/WSDLToOpenAPIConverterExceptionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/test/java/io/gravitee/rest/api/spec/converter/wsdl/WSDLToOpenAPIConverterExceptionTest.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.spec.converter.wsdl;
+
+import io.gravitee.rest.api.spec.converter.wsdl.exception.WsdlDescriptorException;
+import org.junit.Test;
+
+public class WSDLToOpenAPIConverterExceptionTest {
+
+    private WSDLToOpenAPIConverter converter = new WSDLToOpenAPIConverter();
+
+    @Test(expected = WsdlDescriptorException.class)
+    public void convertWsdlWithException() {
+        converter.toOpenAPI(this.getClass().getResourceAsStream("/root_pwd.wsdl"));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/test/resources/root_pwd.wsdl
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/test/resources/root_pwd.wsdl
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!DOCTYPE root [<!ENTITY test SYSTEM 'file:///etc/passwd'>]>
+<definitions name="StockQuote"
+             targetNamespace="http://example.com/stockquote/service"
+             xmlns:tns="http://example.com/stockquote/service"
+             xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+             xmlns:defs="http://example.com/stockquote/definitions"
+             xmlns="http://schemas.xmlsoap.org/wsdl/">
+    <binding name="StockQuoteSoapBinding" type="defs:StockQuotePortType">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <operation name="GetLastTradePrice">
+            <soap:operation soapAction="http://example.com/GetLastTradePrice"/>
+            <input>
+                <soap:body use="literal"/>
+            </input>
+            <output>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+    </binding>
+    <service name="StockQuoteService">
+        <port name="StockQuotePort" binding="tns:StockQuoteBinding">
+            <soap:address location="http://example.com/stockquote"/>
+        </port>
+    </service>
+    <documentation>&test;</documentation>
+</definitions>


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-XXX

## Description

While using wsdl imports it's possible to use the DOCTYPE attribute to access data from the server. The goal of this PR is to disable this feature.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-wsdl-318x/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ffimqzflgd.chromatic.com)
<!-- Storybook placeholder end -->
