### PR TITLE
chore: rollback global version changed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     </issueManagement>
     <properties>
         <!-- Version properties -->
-        <revision>3.20.4</revision>
+        <revision>3.20.0</revision>
         <sha1/>
         <changelist>-SNAPSHOT</changelist>
 


### PR DESCRIPTION
## Description

During the last release of 3.19 we merged all changes in master and didn't noticed that the version has been updated during the merge. The goal of this pr is to come back to 3.20.0-SNAPSHOT version.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/chore-rollback-version/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qvmeclgfzh.chromatic.com)
<!-- Storybook placeholder end -->
