### PR TITLE
fix:instance monitoring

### DIFF
--- a/gravitee-apim-console-webui/src/management/instances/details/instance-details-monitoring/instance-details-monitoring.component.html
+++ b/gravitee-apim-console-webui/src/management/instances/details/instance-details-monitoring/instance-details-monitoring.component.html
@@ -22,25 +22,25 @@
   <div class="gio-instance-details-monitoring__main-indicators">
     <mat-card class="gio-instance-details-monitoring__main-indicators__card">
       <div class="gio-instance-details-monitoring__main-indicators__card__percentage">
-        <gio-circular-percentage [score]="this.monitoringData?.process.cpu_percent / 100" reverseColor="true"></gio-circular-percentage>
+        <gio-circular-percentage [score]="monitoringData?.process?.cpu_percent / 100" reverseColor="true"></gio-circular-percentage>
       </div>
       <h4>CPU</h4>
     </mat-card>
     <mat-card class="gio-instance-details-monitoring__main-indicators__card">
       <div class="gio-instance-details-monitoring__main-indicators__card__percentage">
-        <gio-circular-percentage [score]="this.monitoringData?.jvm.heap_used_percent / 100" reverseColor="true"></gio-circular-percentage>
+        <gio-circular-percentage [score]="monitoringData?.jvm?.heap_used_percent / 100" reverseColor="true"></gio-circular-percentage>
       </div>
       <h4>Heap</h4>
     </mat-card>
     <mat-card class="gio-instance-details-monitoring__main-indicators__card">
       <div class="gravitee-monitoring-indicator-value gio-instance-details-monitoring__main-indicators__card__value">
-        {{ monitoringData.gc.old_collection_count }}
+        {{ monitoringData?.gc?.old_collection_count }}
       </div>
       <h4>GC collections</h4>
     </mat-card>
     <mat-card class="gio-instance-details-monitoring__main-indicators__card">
       <div class="gravitee-monitoring-indicator-value gio-instance-details-monitoring__main-indicators__card__value">
-        {{ monitoringData.process.open_file_descriptors }}
+        {{ monitoringData?.process?.open_file_descriptors }}
       </div>
       <h4>File Descriptors</h4>
     </mat-card>
@@ -54,108 +54,112 @@
       </h2>
       <dl class="gio-description-list">
         <dt>Date</dt>
-        <dd>{{ monitoringData.jvm.timestamp | date: 'medium' }}</dd>
+        <dd>{{ monitoringData?.jvm?.timestamp | date: 'medium' }}</dd>
         <dt>Uptime</dt>
-        <dd>{{ humanizeDuration(monitoringData.jvm.uptime_in_millis) }}</dd>
+        <dd>{{ humanizeDuration(monitoringData?.jvm?.uptime_in_millis) }}</dd>
         <dt>Heap used</dt>
-        <dd>{{ humanizeSize(monitoringData.jvm.heap_used_in_bytes) }}</dd>
+        <dd>{{ humanizeSize(monitoringData?.jvm?.heap_used_in_bytes) }}</dd>
         <dt>Percent of heap used</dt>
-        <dd>{{ monitoringData.jvm.heap_used_percent + '%' }}</dd>
+        <dd>{{ monitoringData?.jvm?.heap_used_percent + '%' }}</dd>
         <dt>Heap committed</dt>
-        <dd>{{ humanizeSize(monitoringData.jvm.heap_committed_in_bytes) }}</dd>
+        <dd>{{ humanizeSize(monitoringData?.jvm?.heap_committed_in_bytes) }}</dd>
         <dt>Heap max</dt>
-        <dd>{{ humanizeSize(monitoringData.jvm.heap_max_in_bytes) }}</dd>
+        <dd>{{ humanizeSize(monitoringData?.jvm?.heap_max_in_bytes) }}</dd>
         <dt>Non heap used</dt>
-        <dd>{{ humanizeSize(monitoringData.jvm.non_heap_used_in_bytes) }}</dd>
+        <dd>{{ humanizeSize(monitoringData?.jvm?.non_heap_used_in_bytes) }}</dd>
         <dt>Non heap committed</dt>
-        <dd>{{ humanizeSize(monitoringData.jvm.non_heap_committed_in_bytes) }}</dd>
+        <dd>{{ humanizeSize(monitoringData?.jvm?.non_heap_committed_in_bytes) }}</dd>
       </dl>
       <div class="gio-instance-details-monitoring__jvm__pool">
         <mat-card>
           <dl class="gio-description-list">
             <dt>Young pool used</dt>
-            <dd>{{ humanizeSize(monitoringData.jvm.young_pool_used_in_bytes) }}</dd>
+            <dd>{{ humanizeSize(monitoringData?.jvm?.young_pool_used_in_bytes) }}</dd>
             <dt>Young pool max</dt>
-            <dd>{{ humanizeSize(monitoringData.jvm.young_pool_max_in_bytes) }}</dd>
+            <dd>{{ humanizeSize(monitoringData?.jvm?.young_pool_max_in_bytes) }}</dd>
           </dl>
           <div class="gio-instance-details-monitoring__jvm__pool__progress-bar">
-            <strong>{{ ratioLabel(monitoringData.jvm.young_pool_used_in_bytes, monitoringData.jvm.young_pool_max_in_bytes) }}</strong>
+            <strong>{{ ratioLabel(monitoringData?.jvm?.young_pool_used_in_bytes, monitoringData?.jvm?.young_pool_max_in_bytes) }}</strong>
             <mat-progress-bar
               mode="determinate"
-              [value]="ratio(monitoringData.jvm.young_pool_used_in_bytes, monitoringData.jvm.young_pool_max_in_bytes)"
+              [value]="ratio(monitoringData?.jvm?.young_pool_used_in_bytes, monitoringData?.jvm?.young_pool_max_in_bytes)"
             ></mat-progress-bar>
           </div>
           <dl class="gio-description-list">
             <dt>Young pool peak used</dt>
-            <dd>{{ humanizeSize(monitoringData.jvm.young_pool_peak_used_in_bytes) }}</dd>
+            <dd>{{ humanizeSize(monitoringData?.jvm?.young_pool_peak_used_in_bytes) }}</dd>
             <dt>Young pool peak max</dt>
-            <dd>{{ humanizeSize(monitoringData.jvm.young_pool_peak_max_in_bytes) }}</dd>
+            <dd>{{ humanizeSize(monitoringData?.jvm?.young_pool_peak_max_in_bytes) }}</dd>
           </dl>
           <div class="gio-instance-details-monitoring__jvm__pool__progress-bar">
             <strong>{{
-              ratioLabel(monitoringData.jvm.young_pool_peak_used_in_bytes, monitoringData.jvm.young_pool_peak_max_in_bytes)
+              ratioLabel(monitoringData?.jvm?.young_pool_peak_used_in_bytes, monitoringData?.jvm?.young_pool_peak_max_in_bytes)
             }}</strong>
             <mat-progress-bar
               mode="determinate"
-              [value]="ratio(monitoringData.jvm.young_pool_peak_used_in_bytes, monitoringData.jvm.young_pool_peak_max_in_bytes)"
+              [value]="ratio(monitoringData?.jvm?.young_pool_peak_used_in_bytes, monitoringData?.jvm?.young_pool_peak_max_in_bytes)"
             ></mat-progress-bar>
           </div>
         </mat-card>
         <mat-card>
           <dl class="gio-description-list">
             <dt>Survivor pool used</dt>
-            <dd>{{ humanizeSize(monitoringData.jvm.survivor_pool_used_in_bytes) }}</dd>
+            <dd>{{ humanizeSize(monitoringData?.jvm?.survivor_pool_used_in_bytes) }}</dd>
             <dt>Survivor pool max</dt>
-            <dd>{{ humanizeSize(monitoringData.jvm.survivor_pool_max_in_bytes) }}</dd>
+            <dd>{{ humanizeSize(monitoringData?.jvm?.survivor_pool_max_in_bytes) }}</dd>
           </dl>
           <div class="gio-instance-details-monitoring__jvm__pool__progress-bar">
-            <strong>{{ ratioLabel(monitoringData.jvm.survivor_pool_used_in_bytes, monitoringData.jvm.survivor_pool_max_in_bytes) }}</strong>
+            <strong>{{
+              ratioLabel(monitoringData?.jvm?.survivor_pool_used_in_bytes, monitoringData?.jvm?.survivor_pool_max_in_bytes)
+            }}</strong>
             <mat-progress-bar
               mode="determinate"
-              [value]="ratio(monitoringData.jvm.survivor_pool_used_in_bytes, monitoringData.jvm.survivor_pool_max_in_bytes)"
+              [value]="ratio(monitoringData?.jvm?.survivor_pool_used_in_bytes, monitoringData?.jvm?.survivor_pool_max_in_bytes)"
             ></mat-progress-bar>
           </div>
           <dl class="gio-description-list">
             <dt>Survivor pool peak used</dt>
-            <dd>{{ humanizeSize(monitoringData.jvm.survivor_pool_peak_used_in_bytes) }}</dd>
+            <dd>{{ humanizeSize(monitoringData?.jvm?.survivor_pool_peak_used_in_bytes) }}</dd>
             <dt>Survivor pool peak max</dt>
-            <dd>{{ humanizeSize(monitoringData.jvm.survivor_pool_peak_max_in_bytes) }}</dd>
+            <dd>{{ humanizeSize(monitoringData?.jvm?.survivor_pool_peak_max_in_bytes) }}</dd>
           </dl>
           <div class="gio-instance-details-monitoring__jvm__pool__progress-bar">
             <strong>{{
-              ratioLabel(monitoringData.jvm.survivor_pool_peak_used_in_bytes, monitoringData.jvm.survivor_pool_peak_max_in_bytes)
+              ratioLabel(monitoringData?.jvm?.survivor_pool_peak_used_in_bytes, monitoringData?.jvm?.survivor_pool_peak_max_in_bytes)
             }}</strong>
             <mat-progress-bar
               mode="determinate"
-              [value]="ratio(monitoringData.jvm.survivor_pool_peak_used_in_bytes, monitoringData.jvm.survivor_pool_peak_max_in_bytes)"
+              [value]="ratio(monitoringData?.jvm?.survivor_pool_peak_used_in_bytes, monitoringData?.jvm?.survivor_pool_peak_max_in_bytes)"
             ></mat-progress-bar>
           </div>
         </mat-card>
         <mat-card>
           <dl class="gio-description-list">
             <dt>Old pool used</dt>
-            <dd>{{ humanizeSize(monitoringData.jvm.old_pool_used_in_bytes) }}</dd>
+            <dd>{{ humanizeSize(monitoringData?.jvm?.old_pool_used_in_bytes) }}</dd>
             <dt>Old pool max</dt>
-            <dd>{{ humanizeSize(monitoringData.jvm.old_pool_max_in_bytes) }}</dd>
+            <dd>{{ humanizeSize(monitoringData?.jvm?.old_pool_max_in_bytes) }}</dd>
           </dl>
           <div class="gio-instance-details-monitoring__jvm__pool__progress-bar">
-            <strong>{{ ratioLabel(monitoringData.jvm.old_pool_used_in_bytes, monitoringData.jvm.old_pool_max_in_bytes) }}</strong>
+            <strong>{{ ratioLabel(monitoringData?.jvm?.old_pool_used_in_bytes, monitoringData?.jvm?.old_pool_max_in_bytes) }}</strong>
             <mat-progress-bar
               mode="determinate"
-              [value]="ratio(monitoringData.jvm.old_pool_used_in_bytes, monitoringData.jvm.old_pool_max_in_bytes)"
+              [value]="ratio(monitoringData?.jvm?.old_pool_used_in_bytes, monitoringData?.jvm?.old_pool_max_in_bytes)"
             ></mat-progress-bar>
           </div>
           <dl class="gio-description-list">
             <dt>Old pool peak used</dt>
-            <dd>{{ humanizeSize(monitoringData.jvm.old_pool_peak_used_in_bytes) }}</dd>
+            <dd>{{ humanizeSize(monitoringData?.jvm?.old_pool_peak_used_in_bytes) }}</dd>
             <dt>Old pool peak max</dt>
-            <dd>{{ humanizeSize(monitoringData.jvm.old_pool_peak_max_in_bytes) }}</dd>
+            <dd>{{ humanizeSize(monitoringData?.jvm?.old_pool_peak_max_in_bytes) }}</dd>
           </dl>
           <div class="gio-instance-details-monitoring__jvm__pool__progress-bar">
-            <strong>{{ ratioLabel(monitoringData.jvm.old_pool_peak_used_in_bytes, monitoringData.jvm.old_pool_peak_max_in_bytes) }}</strong>
+            <strong>{{
+              ratioLabel(monitoringData?.jvm?.old_pool_peak_used_in_bytes, monitoringData?.jvm?.old_pool_peak_max_in_bytes)
+            }}</strong>
             <mat-progress-bar
               mode="determinate"
-              [value]="ratio(monitoringData.jvm.old_pool_peak_used_in_bytes, monitoringData.jvm.old_pool_peak_max_in_bytes)"
+              [value]="ratio(monitoringData?.jvm?.old_pool_peak_used_in_bytes, monitoringData?.jvm?.old_pool_peak_max_in_bytes)"
             ></mat-progress-bar>
           </div>
         </mat-card>
@@ -171,10 +175,12 @@
       </h2>
       <dl class="gio-description-list">
         <dt>Percent of use</dt>
-        <dd>{{ monitoringData.cpu.percent_use + '%' }}</dd>
+        <dd>{{ monitoringData?.cpu?.percent_use + '%' }}</dd>
         <dt>Load average</dt>
         <dd>
-          <div *ngFor="let loadAverage of monitoringData.cpu.load_average | keyvalue">[{{ loadAverage.key }}] {{ loadAverage.value }}</div>
+          <div *ngFor="let loadAverage of monitoringData?.cpu?.load_average | keyvalue: originalOrder">
+            [{{ loadAverage.key }}] {{ loadAverage.value }}
+          </div>
         </dd>
       </dl>
     </mat-card>
@@ -185,9 +191,9 @@
       </h2>
       <dl class="gio-description-list">
         <dt>Open file descriptors</dt>
-        <dd>{{ monitoringData.process.open_file_descriptors }}</dd>
+        <dd>{{ monitoringData?.process?.open_file_descriptors }}</dd>
         <dt>Max file descriptors</dt>
-        <dd>{{ monitoringData.process.max_file_descriptors }}</dd>
+        <dd>{{ monitoringData?.process?.max_file_descriptors }}</dd>
       </dl>
     </mat-card>
     <mat-card flex="50" data-testid="instance-monitoring_thread-box">
@@ -197,9 +203,9 @@
       </h2>
       <dl class="gio-description-list">
         <dt>Count</dt>
-        <dd>{{ monitoringData.thread.count }}</dd>
+        <dd>{{ monitoringData?.thread?.count }}</dd>
         <dt>Peak count</dt>
-        <dd>{{ monitoringData.thread.peak_count }}</dd>
+        <dd>{{ monitoringData?.thread?.peak_count }}</dd>
       </dl>
     </mat-card>
     <mat-card flex="50" data-testid="instance-monitoring_gc-box">
@@ -209,13 +215,13 @@
       </h2>
       <dl class="gio-description-list">
         <dt>Young collection count</dt>
-        <dd>{{ monitoringData.gc.young_collection_count }}</dd>
+        <dd>{{ monitoringData?.gc?.young_collection_count }}</dd>
         <dt>Young collection time</dt>
-        <dd>{{ monitoringData.gc.young_collection_time_in_millis + ' ms' }}</dd>
+        <dd>{{ monitoringData?.gc?.young_collection_time_in_millis + ' ms' }}</dd>
         <dt>Old collection count</dt>
-        <dd>{{ monitoringData.gc.old_collection_count }}</dd>
+        <dd>{{ monitoringData?.gc?.old_collection_count }}</dd>
         <dt>Old collection time</dt>
-        <dd>{{ monitoringData.gc.old_collection_time_in_millis + ' ms' }}</dd>
+        <dd>{{ monitoringData?.gc?.old_collection_time_in_millis + ' ms' }}</dd>
       </dl>
     </mat-card>
   </div>

--- a/gravitee-apim-console-webui/src/management/instances/details/instance-details-monitoring/instance-details-monitoring.component.ts
+++ b/gravitee-apim-console-webui/src/management/instances/details/instance-details-monitoring/instance-details-monitoring.component.ts
@@ -69,6 +69,11 @@ export class InstanceDetailsMonitoringComponent implements OnInit, OnDestroy {
     }
   }
 
+  // Preserve original property order for the 'keyvalue' pipe
+  originalOrder(): number {
+    return 0;
+  }
+
   humanizeDuration(timeInMillis) {
     return duration(-timeInMillis).humanize(true);
   }


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-286

## Description

- keep load-average order when displaying
- check nullity before displaying data
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-instance-environment/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bfcbeaiepa.chromatic.com)
<!-- Storybook placeholder end -->
