### PR TITLE
fix: add validation on webhook's callbackUrl configuration

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/main/resources/schemas/subscriptions/schema-form.json
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/main/resources/schemas/subscriptions/schema-form.json
@@ -5,7 +5,9 @@
     "callbackUrl": {
       "type": "string",
       "title": "The callback URL called by the entrypoint on a message",
-      "description": "The callback URL called by the entrypoint on a message"
+      "description": "The callback URL called by the entrypoint on a message",
+      "minLength": 1,
+      "pattern" : "^(http|https)://"
     },
     "headers": {
       "type": "array",


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-282

## Description

- callbackUrl can not be an empty string
- it should be a valid http(s) url


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-282-webhook-validate-empty-callbackurl/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nsyrkwykhr.chromatic.com)
<!-- Storybook placeholder end -->
