### PR TITLE
fix: merge dematerialized flux to get a completed merge flux

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/test/java/io/gravitee/plugin/endpoint/kafka/KafkaEndpointConnectorTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/test/java/io/gravitee/plugin/endpoint/kafka/KafkaEndpointConnectorTest.java
@@ -164,7 +164,6 @@ class KafkaEndpointConnectorTest {
         TestSubscriber<Message> messageTestSubscriber = Flowable
             .just(DefaultMessage.builder().headers(HttpHeaders.create().add("key", "value")).content(Buffer.buffer("message")).build())
             .compose(messagesTransformerCaptor.getValue())
-            .take(1)
             .test();
         messageTestSubscriber.await(10, TimeUnit.SECONDS);
         messageTestSubscriber.assertComplete();
@@ -308,7 +307,6 @@ class KafkaEndpointConnectorTest {
         TestSubscriber<Message> messageTestSubscriber = Flowable
             .just(DefaultMessage.builder().headers(HttpHeaders.create().add("key", "value")).content(Buffer.buffer("message")).build())
             .compose(messagesTransformerCaptor.getValue())
-            .take(1)
             .test();
 
         messageTestSubscriber.await(15, TimeUnit.SECONDS);


### PR DESCRIPTION

## Description

Quick fix about kafka error management to complete publish flux when it completes.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-kafka-publish/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ilpksggeot.chromatic.com)
<!-- Storybook placeholder end -->
