### PR TITLE
fix: issue when one kafka sub connections got closed

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/KafkaEndpointConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/KafkaEndpointConnector.java
@@ -290,10 +290,6 @@ public class KafkaEndpointConnector extends EndpointAsyncConnector {
         }
     }
 
-    private Flowable<Message> getMessageFlowable(final ExecutionContext ctx, final Throwable throwable) {
-        return interruptMessagesWith(ctx, throwable.getCause());
-    }
-
     /**
      * This method could be overridden to add custom configuration for consumer client
      * @param config

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/error/KafkaReceiverErrorTransformer.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/error/KafkaReceiverErrorTransformer.java
@@ -51,7 +51,9 @@ public class KafkaReceiverErrorTransformer extends AbstractKafkaErrorTransformer
             Sinks.Many<ConsumerRecord<K, V>> kafkaErrorSink = Sinks.many().unicast().onBackpressureError();
             return consumerRecordFlux
                 .zipWith(storeConsumerReference(qosStrategy, consumerRef), (c, o) -> c)
-                .mergeWith(kafkaErrorSink.asFlux())
+                .materialize()
+                .mergeWith(kafkaErrorSink.asFlux().materialize())
+                .<ConsumerRecord<K, V>>dematerialize()
                 .doOnSubscribe(subscription -> handleKafkaDisconnection(consumerRef, kafkaErrorSink));
         };
     }


### PR DESCRIPTION
## Description

Check if there is any remaining active connection before throwing close exception.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-kafka-subscribe-disconnection/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-efkhwmsjup.chromatic.com)
<!-- Storybook placeholder end -->
