### PR TITLE
fix: fix application search by ID without environment criteria

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -159,13 +159,15 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
                 return Collections.emptySet();
             }
 
-            ApplicationCriteria criteria = new ApplicationCriteria.Builder()
+            ApplicationCriteria.Builder criteriaBuilder = new ApplicationCriteria.Builder()
                 .ids(applicationIds.toArray(new String[0]))
-                .environmentIds(executionContext.getEnvironmentId())
-                .status(ApplicationStatus.ACTIVE)
-                .build();
+                .status(ApplicationStatus.ACTIVE);
 
-            Page<Application> applications = applicationRepository.search(criteria, null);
+            if (executionContext.hasEnvironmentId()) {
+                criteriaBuilder.environmentIds(executionContext.getEnvironmentId());
+            }
+
+            Page<Application> applications = applicationRepository.search(criteriaBuilder.build(), null);
 
             if (applications.getContent().isEmpty()) {
                 return emptySet();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_FindByIdsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_FindByIdsTest.java
@@ -38,7 +38,6 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.configuration.application.ClientRegistrationService;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
-import io.gravitee.rest.api.service.impl.ApplicationServiceImpl;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.junit.After;
@@ -121,6 +120,22 @@ public class ApplicationService_FindByIdsTest {
             .ids(Sets.newHashSet(APPLICATION_IDS))
             .status(ApplicationStatus.ACTIVE)
             .environmentIds(executionContext.getEnvironmentId())
+            .build();
+        doReturn(new Page(Arrays.asList(app1, app2), 1, 2, 2)).when(applicationRepository).search(criteria, null);
+        doReturn(2).when(primaryOwners).size();
+
+        final Set<ApplicationListItem> applications = applicationService.findByIds(executionContext, APPLICATION_IDS);
+
+        assertNotNull(applications);
+        assertEquals(APPLICATION_IDS, applications.stream().map(ApplicationListItem::getId).collect(Collectors.toList()));
+    }
+
+    @Test
+    public void shouldFindByIdsWithNoEnvironmentCriteria() throws TechnicalException {
+        ExecutionContext executionContext = new ExecutionContext("DEFAULT", null);
+        ApplicationCriteria criteria = new ApplicationCriteria.Builder()
+            .ids(Sets.newHashSet(APPLICATION_IDS))
+            .status(ApplicationStatus.ACTIVE)
             .build();
         doReturn(new Page(Arrays.asList(app1, app2), 1, 2, 2)).when(applicationRepository).search(criteria, null);
         doReturn(2).when(primaryOwners).size();


### PR DESCRIPTION
fix: fix application search by ID without environment criteria

ApplicationAlertServiceImpl.updateAlertsRecipients searches applications by ID, But there is no environment in executionContext, cause it's build from an event containing only the organizationID. So it leads to an EnvironmentNotFoundException.

This fixes handles properly application search when there is no environmentId in ExecutionContext.
