### PR TITLE
fix: handle last_heartbeat_at when converting Event to GatewayInstance

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/AbstractDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/AbstractDocumentSearcher.java
@@ -45,6 +45,12 @@ public abstract class AbstractDocumentSearcher implements DocumentSearcher {
     protected static final String FIELD_TYPE = "type";
     protected static final String FIELD_API_TYPE_VALUE = "api";
 
+    protected static void increaseMaxClauseCountIfNecessary(int size) {
+        if (size > BooleanQuery.getMaxClauseCount()) {
+            BooleanQuery.setMaxClauseCount(size);
+        }
+    }
+
     protected Analyzer analyzer = new CustomWhitespaceAnalyzer();
 
     @Autowired
@@ -120,9 +126,8 @@ public abstract class AbstractDocumentSearcher implements DocumentSearcher {
             Object values = filters.get(FIELD_API_TYPE_VALUE);
             if (Collection.class.isAssignableFrom(values.getClass())) {
                 Collection valuesAsCollection = (Collection) values;
-                if (valuesAsCollection.size() > BooleanQuery.getMaxClauseCount()) {
-                    BooleanQuery.setMaxClauseCount(valuesAsCollection.size());
-                }
+                increaseMaxClauseCountIfNecessary(valuesAsCollection.size());
+
                 BooleanQuery.Builder filterApisQuery = new BooleanQuery.Builder();
                 ((Collection<?>) values).forEach(
                         value -> filterApisQuery.add(new TermQuery(new Term(apiReferenceField, (String) value)), BooleanClause.Occur.SHOULD)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcher.java
@@ -108,6 +108,7 @@ public class ApiDocumentSearcher extends AbstractDocumentSearcher {
 
     private Optional<BooleanQuery> buildIdsQuery(io.gravitee.rest.api.service.search.query.Query query) {
         if (!isBlank(query.getQuery()) && query.getIds() != null && !query.getIds().isEmpty()) {
+            increaseMaxClauseCountIfNecessary(query.getIds().size());
             BooleanQuery.Builder mainQuery = new BooleanQuery.Builder();
             query.getIds().forEach(id -> mainQuery.add(new TermQuery(new Term(FIELD_ID, (String) id)), BooleanClause.Occur.SHOULD));
             return Optional.of(mainQuery.build());


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-174

## Description

Backport of https://github.com/gravitee-io/gravitee-api-management/commit/eb6fa78d3e4efcb309fbaa850f2f8e3371a568c3

Increase BooleanQuery maxClauseCount when is necessary
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nypovmghmv.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/apim-174-increase-max-clause-in-lucene/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
