### PR TITLE
[3.18.x] chore: bump cockpit plugin version to 2.6.0

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -98,7 +98,7 @@
         <gravitee-resource-oauth2-provider-generic.version>2.0.0</gravitee-resource-oauth2-provider-generic.version>
         <gravitee-service-discovery-consul.version>1.3.0</gravitee-service-discovery-consul.version>
         <!-- Management API Only -->
-        <gravitee-cockpit-connectors-ws.version>2.5.5</gravitee-cockpit-connectors-ws.version>
+        <gravitee-cockpit-connectors-ws.version>2.6.0</gravitee-cockpit-connectors-ws.version>
         <gravitee-fetcher-bitbucket.version>1.7.0</gravitee-fetcher-bitbucket.version>
         <gravitee-fetcher-git.version>1.8.1</gravitee-fetcher-git.version>
         <gravitee-fetcher-github.version>1.6.0</gravitee-fetcher-github.version>


### PR DESCRIPTION
## Issue

https://graviteedevops.atlassian.net/browse/COC-117

## Description

Handle a graceful shutdown
Gravitee platform does not allow catching the shutdown of the node to stop plugins. That's why we are using a Shutdown Hook to stop the connectors
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/coc117-3-18/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
