### PR TITLE
fix: host header propagation for http1.1 and http2

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/jupiter/http/vertx/AbstractVertxServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/jupiter/http/vertx/AbstractVertxServerRequest.java
@@ -38,6 +38,7 @@ abstract class AbstractVertxServerRequest implements MutableRequest {
     protected final long timestamp;
     protected final Metrics metrics;
     protected final HttpServerRequest nativeRequest;
+    private final String originalHost;
     protected String contextPath;
     protected String pathInfo;
     protected String id;
@@ -50,6 +51,7 @@ abstract class AbstractVertxServerRequest implements MutableRequest {
 
     AbstractVertxServerRequest(HttpServerRequest nativeRequest, IdGenerator idGenerator) {
         this.nativeRequest = nativeRequest;
+        this.originalHost = this.nativeRequest.host();
         this.timestamp = System.currentTimeMillis();
         this.id = idGenerator.randomString();
         this.headers = new VertxHttpHeaders(nativeRequest.headers().getDelegate());
@@ -213,6 +215,11 @@ abstract class AbstractVertxServerRequest implements MutableRequest {
     @Override
     public String host() {
         return this.nativeRequest.host();
+    }
+
+    @Override
+    public String originalHost() {
+        return this.originalHost;
     }
 
     /**

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/jupiter/http/vertx/VertxHttpServerRequestTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/jupiter/http/vertx/VertxHttpServerRequestTest.java
@@ -439,6 +439,15 @@ class VertxHttpServerRequestTest {
     }
 
     @Test
+    void shouldReturnOriginalHost() {
+        when(httpServerRequest.host()).thenReturn("original.host", "changed.host");
+        cut = new VertxHttpServerRequest(httpServerRequest, idGenerator);
+
+        assertEquals("original.host", cut.originalHost());
+        assertEquals("changed.host", cut.host());
+    }
+
+    @Test
     void shouldPause() {
         cut.pause();
         verify(httpServerRequest).pause();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/context/SubscriptionRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/context/SubscriptionRequest.java
@@ -108,6 +108,11 @@ public class SubscriptionRequest implements MutableRequest {
     }
 
     @Override
+    public String originalHost() {
+        return DEFAULT_LOCALHOST;
+    }
+
+    @Override
     public String path() {
         return "";
     }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/resources/logback-test.xml
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/resources/logback-test.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2015-2016, The Gravitee team (http://www.gravitee.io)
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{5} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.gravitee" level="DEBUG" additivity="false">
+        <appender-ref ref="STDOUT" />
+    </logger>
+
+    <!-- Strictly speaking, the level attribute is not necessary since -->
+    <!-- the level of the root level is set to DEBUG by default.       -->
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/test/java/io/gravitee/plugin/entrypoint/http/post/DummyMessageRequest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/test/java/io/gravitee/plugin/entrypoint/http/post/DummyMessageRequest.java
@@ -139,6 +139,11 @@ public class DummyMessageRequest implements Request {
     }
 
     @Override
+    public String originalHost() {
+        return null;
+    }
+
+    @Override
     public String path() {
         return null;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <gravitee-connector-api.version>1.1.4</gravitee-connector-api.version>
         <gravitee-expression-language.version>2.0.0-alpha.2</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>2.0.0-alpha.5</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>2.0.0-alpha.6</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>2.0.0-alpha.3</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-349

## Description

The new http-proxy connector wasn't handling host header as it should.
The host header coming from the client request is not propagated. The host header is only propagated if changed during the request flow (thanks to a policy).
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-349-http-host-propagation/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bbluwmrqdc.chromatic.com)
<!-- Storybook placeholder end -->
