### PR TITLE
share EndpointResolver in custom provider

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandlerFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandlerFactory.java
@@ -156,12 +156,9 @@ public class ApiReactorHandlerFactory implements ReactorHandlerFactory<Api> {
                     applicationContext.getBean(ObjectMapper.class)
                 );
 
-                final Invoker invoker = invokerFactory(
-                    api,
-                    applicationContext.getBean(Vertx.class),
-                    endpointResolver(referenceRegister, groupLifecycleManager)
-                )
-                    .create();
+                EndpointResolver endpointResolver = endpointResolver(referenceRegister, groupLifecycleManager);
+                customComponentProvider.add(EndpointResolver.class, endpointResolver);
+                final Invoker invoker = invokerFactory(api, applicationContext.getBean(Vertx.class), endpointResolver).create();
 
                 if (isV3ExecutionMode(api)) {
                     // Force creation of a dedicated PolicyFactory for each api as it may involve cache we want to be released when api is undeployed.


### PR DESCRIPTION
## Issue

gravitee-io/issues#8385

## Description

Share EndpointResolver in custom provider so the policy can instanciate the EndpointResolver.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8385-fix-traffic-shadowing-policy/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bwhgpriqay.chromatic.com)
<!-- Storybook placeholder end -->
