### PR TITLE
fix v4 http proxy headers and plans

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/plan/PlanSecurity.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/plan/PlanSecurity.java
@@ -17,6 +17,8 @@ package io.gravitee.definition.model.v4.plan;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRawValue;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.databind.JsonNode;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -42,4 +44,15 @@ public class PlanSecurity {
     @Schema(implementation = Object.class)
     @JsonRawValue
     private String configuration;
+
+    @JsonSetter
+    public void setConfiguration(final JsonNode configuration) {
+        if (configuration != null) {
+            this.configuration = configuration.toString();
+        }
+    }
+
+    public void setConfiguration(final String configuration) {
+        this.configuration = configuration;
+    }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/v4/Api.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/v4/Api.java
@@ -78,6 +78,7 @@ public class Api extends ReactableApi<io.gravitee.definition.model.v4.Api> {
                     OAUTH2.name().equalsIgnoreCase(plan.getSecurity().getType()) ||
                     API_KEY.name().equalsIgnoreCase(plan.getSecurity().getType()) ||
                     "api-key".equalsIgnoreCase(plan.getSecurity().getType()) ||
+                    JWT.name().equalsIgnoreCase(plan.getSecurity().getType()) ||
                     SUBSCRIPTION.name().equalsIgnoreCase(plan.getSecurity().getType())
             )
             .map(Plan::getId)

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/v4/ApiTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/v4/ApiTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.handlers.api.v4;
+
+import static io.gravitee.repository.management.model.Plan.PlanSecurityType.API_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.gravitee.definition.model.v4.plan.Plan;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.gateway.jupiter.handlers.api.security.plan.SecurityPlan;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class ApiTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = { "API_KEY", "api-key", "JWT", "OAUTH2", "SUBSCRIPTION" })
+    void shouldReturnSubscribablePlans(String securityType) {
+        final io.gravitee.definition.model.v4.Api definition = new io.gravitee.definition.model.v4.Api();
+        final ArrayList<Plan> plans = new ArrayList<>();
+        final PlanSecurity planSecurity = new PlanSecurity();
+        final Plan plan = new Plan();
+
+        planSecurity.setType(securityType);
+        plan.setId("subscribable");
+        plan.setSecurity(planSecurity);
+        plans.add(plan);
+
+        for (int i = 0; i < 5; i++) {
+            final Plan other = new Plan();
+            final PlanSecurity otherSecurity = new PlanSecurity();
+            other.setId("not-subscribable-" + i);
+            other.setSecurity(otherSecurity);
+            plans.add(other);
+        }
+
+        definition.setPlans(plans);
+
+        final Api api = new Api(definition);
+
+        assertThat(api.getSubscribablePlans()).containsExactly("subscribable");
+    }
+}


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-353 and https://graviteecommunity.atlassian.net/browse/APIM-354

## Description

- Http endpoint headers were not propagated to the client.
- OAuth2 and JWT plans were not working for v4 api.

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-353-fix-http-proxy-headers/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bniaadwilt.chromatic.com)
<!-- Storybook placeholder end -->
