### PR TITLE
escape all special characters when looking for a user

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoUserRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoUserRepository.java
@@ -44,7 +44,7 @@ import org.springframework.stereotype.Component;
 public class MongoUserRepository implements UserRepository {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
-    private final Pattern escaper = Pattern.compile("([^a-zA-z0-9])");
+    private final Pattern escaper = Pattern.compile("([^a-zA-Z0-9])");
 
     @Autowired
     private UserMongoRepository internalUserRepo;

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/UserRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/UserRepositoryTest.java
@@ -199,7 +199,7 @@ public class UserRepositoryTest extends AbstractRepositoryTest {
 
     @Test
     public void findUserBySourceSpecialCharacters() throws Exception {
-        Optional<User> user = userRepository.findBySource("sourceSpecialChar", "sourceIdSpecialChar+test@me", "DEV");
+        Optional<User> user = userRepository.findBySource("sourceSpecialChar", "sourceIdSpecialChar+test@me [IT] & others", "DEV");
         assertTrue(user.isPresent());
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/UserRepositoryMock.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/UserRepositoryMock.java
@@ -158,7 +158,8 @@ public class UserRepositoryMock extends AbstractRepositoryMock<UserRepository> {
         when(userRepository.findBySource("gravitee", "user1", "DEV")).thenReturn(of(user1));
         when(userRepository.findBySource("gravitee", "USER1", "DEV")).thenReturn(of(user1));
         when(userRepository.findBySource("gravitee", "user", "DEV")).thenReturn(empty());
-        when(userRepository.findBySource("sourceSpecialChar", "sourceIdSpecialChar+test@me", "DEV")).thenReturn(of(userSpecialChar));
+        when(userRepository.findBySource("sourceSpecialChar", "sourceIdSpecialChar+test@me [IT] & others", "DEV"))
+            .thenReturn(of(userSpecialChar));
         when(userRepository.findById("user1")).thenReturn(of(user1));
         when(userRepository.findByIds(asList("user1", "user5"))).thenReturn(new HashSet<>(asList(user1, user5)));
 

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/user-tests/users.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/user-tests/users.json
@@ -90,7 +90,7 @@
     "id": "idSpecialChar",
     "organizationId": "DEV",
     "source": "sourceSpecialChar",
-    "sourceId": "sourceIdSpecialChar+test@me",
+    "sourceId": "sourceIdSpecialChar+test@me [IT] & others",
     "password": "passwordSpecialChar",
     "email": "emailSpecialChar",
     "status": "ACTIVE",


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8672

## Description

Escape all special characters when looking for a user
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8672-duplicate-users-if-special-characters/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
