### PR TITLE
fix: properly clean previous deployed acceptors

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/ReactorHandlerRegistryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/ReactorHandlerRegistryTest.java
@@ -615,6 +615,20 @@ public class ReactorHandlerRegistryTest {
         Assert.assertEquals("api1", subscriptionAcceptorsIterator.next().apiId());
     }
 
+    @Test
+    public void shouldHaveNoEntrypoints_removeSameReactableWithHttpAndSubscriptionAcceptors() {
+        DummyReactable reactable = createReactable("reactable1");
+        ReactorHandler handler = createReactorHandler(new DefaultHttpAcceptor("/products/v1"), new DefaultSubscriptionAcceptor("api1"));
+        when(reactorHandlerFactoryManager.create(reactable)).thenReturn(List.of(handler));
+        reactorHandlerRegistry.create(reactable);
+
+        DummyReactable updateReactable = createReactable("reactable1");
+        reactorHandlerRegistry.remove(updateReactable);
+
+        Assert.assertEquals(0, reactorHandlerRegistry.getAcceptors(HttpAcceptor.class).size());
+        Assert.assertEquals(0, reactorHandlerRegistry.getAcceptors(SubscriptionAcceptor.class).size());
+    }
+
     private void assertEntryPoint(String host, String path, HttpAcceptor httpAcceptor) {
         Assert.assertEquals(host, httpAcceptor.host());
         Assert.assertEquals(path, httpAcceptor.path());


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-382

## Description

A small description of what you did in that PR.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-382-cherry-pick/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bucrhpoytq.chromatic.com)
<!-- Storybook placeholder end -->
