### PR TITLE
fix: v4 platform flow timeout

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/v4/DefaultApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/v4/DefaultApiReactor.java
@@ -15,14 +15,8 @@
  */
 package io.gravitee.gateway.jupiter.handlers.api.v4;
 
-import static io.gravitee.gateway.jupiter.api.ExecutionPhase.MESSAGE_REQUEST;
-import static io.gravitee.gateway.jupiter.api.ExecutionPhase.MESSAGE_RESPONSE;
-import static io.gravitee.gateway.jupiter.api.ExecutionPhase.REQUEST;
-import static io.gravitee.gateway.jupiter.api.ExecutionPhase.RESPONSE;
-import static io.gravitee.gateway.jupiter.api.context.InternalContextAttributes.ATTR_INTERNAL_ENTRYPOINT_CONNECTOR;
-import static io.gravitee.gateway.jupiter.api.context.InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE;
-import static io.gravitee.gateway.jupiter.api.context.InternalContextAttributes.ATTR_INTERNAL_INVOKER;
-import static io.gravitee.gateway.jupiter.api.context.InternalContextAttributes.ATTR_INTERNAL_INVOKER_SKIP;
+import static io.gravitee.gateway.jupiter.api.ExecutionPhase.*;
+import static io.gravitee.gateway.jupiter.api.context.InternalContextAttributes.*;
 import static io.reactivex.rxjava3.core.Completable.defer;
 import static io.reactivex.rxjava3.core.Observable.interval;
 import static java.lang.Boolean.TRUE;
@@ -42,11 +36,7 @@ import io.gravitee.gateway.env.RequestTimeoutConfiguration;
 import io.gravitee.gateway.jupiter.api.ExecutionFailure;
 import io.gravitee.gateway.jupiter.api.ExecutionPhase;
 import io.gravitee.gateway.jupiter.api.connector.entrypoint.EntrypointConnector;
-import io.gravitee.gateway.jupiter.api.context.ContextAttributes;
-import io.gravitee.gateway.jupiter.api.context.DeploymentContext;
-import io.gravitee.gateway.jupiter.api.context.ExecutionContext;
-import io.gravitee.gateway.jupiter.api.context.GenericRequest;
-import io.gravitee.gateway.jupiter.api.context.HttpExecutionContext;
+import io.gravitee.gateway.jupiter.api.context.*;
 import io.gravitee.gateway.jupiter.api.hook.ChainHook;
 import io.gravitee.gateway.jupiter.api.hook.InvokerHook;
 import io.gravitee.gateway.jupiter.api.invoker.Invoker;
@@ -238,10 +228,12 @@ public class DefaultApiReactor extends AbstractLifecycleComponent<ReactorHandler
             .chainWithIf(executeProcessorChain(ctx, onMessageProcessors, MESSAGE_RESPONSE), isEventNative)
             .chainWithOnError(error -> processThrowable(ctx, error))
             .chainWith(upstream -> timeout(upstream, ctx))
-            // Platform post flows must always be executed.
-            .chainWith(platformFlowChain.execute(ctx, RESPONSE))
-            .chainWithIf(platformFlowChain.execute(ctx, MESSAGE_RESPONSE), isEventNative)
-            .chainWith(upstream -> timeout(upstream, ctx))
+            // Platform post flows must always be executed (whatever timeout or error).
+            .chainWith(
+                new CompletableReactorChain(platformFlowChain.execute(ctx, RESPONSE))
+                    .chainWithIf(platformFlowChain.execute(ctx, MESSAGE_RESPONSE), isEventNative)
+                    .chainWith(upstream -> timeout(upstream, ctx))
+            )
             // Handle entrypoint response.
             .chainWith(handleEntrypointResponse(ctx))
             // Catch possible unexpected errors before executing after Handle Processors
@@ -364,9 +356,10 @@ public class DefaultApiReactor extends AbstractLifecycleComponent<ReactorHandler
         );
     }
 
-    private void setApiResponseTimeMetric(ExecutionContext ctx) {
-        if (ctx.request().metrics().getApiResponseTimeMs() > Integer.MAX_VALUE) {
-            ctx.request().metrics().setApiResponseTimeMs(System.currentTimeMillis() - ctx.request().metrics().getApiResponseTimeMs());
+    private void setApiResponseTimeMetric(final ExecutionContext ctx) {
+        final Metrics metrics = ctx.request().metrics();
+        if (metrics.getApiResponseTimeMs() > Integer.MAX_VALUE) {
+            metrics.setApiResponseTimeMs(System.currentTimeMillis() - metrics.getApiResponseTimeMs());
         }
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-350

## Description

With the integration of platform flow execution on v4 api, the timeout applied for platform flow (with grace delay) wasn't working well.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-350-platform-flow-timeout/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rebedqcnho.chromatic.com)
<!-- Storybook placeholder end -->
