### PR TITLE
fix: restore archived applications in log filters

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscribersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscribersResource.java
@@ -107,7 +107,6 @@ public class ApiSubscribersResource extends AbstractResource {
 
         SubscriptionQuery subscriptionQuery = new SubscriptionQuery();
         subscriptionQuery.setApi(api);
-        subscriptionQuery.setStatuses(Set.of(PENDING, ACCEPTED));
 
         Collection<SubscriptionEntity> subscriptions = subscriptionService.search(executionContext, subscriptionQuery);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiSubscribersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiSubscribersResourceTest.java
@@ -44,6 +44,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.springframework.util.CollectionUtils;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
@@ -128,5 +129,12 @@ public class ApiSubscribersResourceTest extends AbstractResourceTest {
         final Collection<ApplicationListItem> applicationsResponse = response.readEntity(new GenericType<>() {});
         assertNotNull(applicationsResponse);
         assertEquals(0, applicationsResponse.size());
+    }
+
+    @Test
+    public void shouldNotFilterOnSubscriptionStatus() {
+        envTarget(API_ID).path("subscribers").request().get();
+        verify(subscriptionService)
+            .search(eq(GraviteeContext.getExecutionContext()), argThat(query -> CollectionUtils.isEmpty(query.getStatuses())));
     }
 }


### PR DESCRIPTION
see https://github.com/gravitee-io/issues/issues/8690


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-application-logs-filter/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-msrwkhhoap.chromatic.com)
<!-- Storybook placeholder end -->
