### PR TITLE
fix: SubscriptionResponse should handle body operations

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/DefaultSubscriptionDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/DefaultSubscriptionDispatcher.java
@@ -24,7 +24,6 @@ import io.gravitee.common.service.AbstractService;
 import io.gravitee.common.utils.RxHelper;
 import io.gravitee.gateway.api.service.Subscription;
 import io.gravitee.gateway.jupiter.api.ListenerType;
-import io.gravitee.gateway.jupiter.api.context.ContextAttributes;
 import io.gravitee.gateway.jupiter.api.context.InternalContextAttributes;
 import io.gravitee.gateway.jupiter.core.context.MutableExecutionContext;
 import io.gravitee.gateway.jupiter.reactor.ApiReactor;

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mqtt5/src/main/java/io/gravitee/plugin/endpoint/mqtt5/Mqtt5EndpointConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mqtt5/src/main/java/io/gravitee/plugin/endpoint/mqtt5/Mqtt5EndpointConnector.java
@@ -63,8 +63,8 @@ public class Mqtt5EndpointConnector extends EndpointAsyncConnector {
     public static final Set<ConnectorMode> SUPPORTED_MODES = Set.of(ConnectorMode.PUBLISH, ConnectorMode.SUBSCRIBE);
     public static final Set<Qos> SUPPORTED_QOS = Set.of(Qos.NONE, Qos.AUTO);
     static final String MQTT5_CONTEXT_ATTRIBUTE = ContextAttributes.ATTR_PREFIX + "mqtt5.";
-    static final String CONTEXT_ATTRIBUTE_MQTT5_CLIENT_ID = MQTT5_CONTEXT_ATTRIBUTE + "clientId";
-    static final String CONTEXT_ATTRIBUTE_MQTT5_TOPIC = MQTT5_CONTEXT_ATTRIBUTE + "topic";
+    public static final String CONTEXT_ATTRIBUTE_MQTT5_CLIENT_ID = MQTT5_CONTEXT_ATTRIBUTE + "clientId";
+    public static final String CONTEXT_ATTRIBUTE_MQTT5_TOPIC = MQTT5_CONTEXT_ATTRIBUTE + "topic";
     static final String CONTEXT_ATTRIBUTE_MQTT5_RESPONSE_TOPIC = MQTT5_CONTEXT_ATTRIBUTE + "responseTopic";
     private static final Set<QosCapability> SUPPORTED_QOS_CAPABILITIES = Set.of(QosCapability.AUTO_ACK);
     static final String MQTT5_INTERNAL_CONTEXT_ATTRIBUTE = "mqtt5.";

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mqtt5/src/test/java/io/gravitee/plugin/endpoint/mqtt5/Mqtt5EndpointConnectorFactoryTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mqtt5/src/test/java/io/gravitee/plugin/endpoint/mqtt5/Mqtt5EndpointConnectorFactoryTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class Mqtt5EndpointConnectorFactoryTest {
+class Mqtt5EndpointConnectorFactoryTest {
 
     private Mqtt5EndpointConnectorFactory mqtt5EndpointConnectorFactory;
     private DeploymentContext deploymentContext;

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mqtt5/src/test/resources/logback-test.xml
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mqtt5/src/test/resources/logback-test.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2015-2016, The Gravitee team (http://www.gravitee.io)
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{5} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.gravitee" level="DEBUG" additivity="false">
+        <appender-ref ref="STDOUT" />
+    </logger>
+
+    <!-- Strictly speaking, the level attribute is not necessary since -->
+    <!-- the level of the root level is set to DEBUG by default.       -->
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-384

## Description

If an error occurs when connecting to the endpoint (let's say QoS incompatibility), the flow is interrupted and error is processed by the `AbstractFailureProcessor`.

This processor is adding the error message in the body of the response. Current implementation of `SubscriptionResponse` was not implementing the `body` related method, meaning the `chunks` were never set. It causes a `NullPointerException` which is now fixed

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-384-subscriptionresponse-error/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-skgxtrgnbb.chromatic.com)
<!-- Storybook placeholder end -->
