### PR TITLE
implement a paginated Api#searchIds

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiRepository.java
@@ -35,7 +35,9 @@ import java.util.Set;
 public interface ApiRepository extends CrudRepository<Api, String> {
     Page<Api> search(ApiCriteria apiCriteria, Sortable sortable, Pageable pageable, ApiFieldExclusionFilter apiFieldExclusionFilter);
 
-    List<Api> search(ApiCriteria apiCriteria);
+    default List<Api> search(ApiCriteria apiCriteria) {
+        return search(apiCriteria, new ApiFieldExclusionFilter.Builder().build());
+    }
 
     List<Api> search(ApiCriteria apiCriteria, ApiFieldExclusionFilter apiFieldExclusionFilter);
 

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiRepository.java
@@ -33,14 +33,6 @@ import java.util.Set;
  * @author GraviteeSource Team
  */
 public interface ApiRepository extends CrudRepository<Api, String> {
-    default Page<Api> search(ApiCriteria apiCriteria, Pageable pageable) {
-        return search(apiCriteria, null, pageable, null);
-    }
-
-    default Page<Api> search(ApiCriteria apiCriteria, Sortable sortable, Pageable pageable) {
-        return search(apiCriteria, sortable, pageable, null);
-    }
-
     Page<Api> search(ApiCriteria apiCriteria, Sortable sortable, Pageable pageable, ApiFieldExclusionFilter apiFieldExclusionFilter);
 
     List<Api> search(ApiCriteria apiCriteria);

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiRepository.java
@@ -36,7 +36,7 @@ public interface ApiRepository extends CrudRepository<Api, String> {
     Page<Api> search(ApiCriteria apiCriteria, Sortable sortable, Pageable pageable, ApiFieldExclusionFilter apiFieldExclusionFilter);
 
     default List<Api> search(ApiCriteria apiCriteria) {
-        return search(apiCriteria, new ApiFieldExclusionFilter.Builder().build());
+        return search(apiCriteria, ApiFieldExclusionFilter.noExclusion());
     }
 
     List<Api> search(ApiCriteria apiCriteria, ApiFieldExclusionFilter apiFieldExclusionFilter);

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiRepository.java
@@ -43,7 +43,7 @@ public interface ApiRepository extends CrudRepository<Api, String> {
 
     Set<Api> search(ApiCriteria apiCriteria, ApiFieldInclusionFilter apiFieldInclusionFilter);
 
-    List<String> searchIds(Sortable sortable, ApiCriteria... apiCriteria);
+    List<String> searchIds(List<ApiCriteria> apiCriteria, Sortable sortable);
 
     Page<String> searchIds(List<ApiCriteria> apiCriteria, Pageable pageable, Sortable sortable);
 

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiRepository.java
@@ -55,6 +55,8 @@ public interface ApiRepository extends CrudRepository<Api, String> {
 
     List<String> searchIds(Sortable sortable, ApiCriteria... apiCriteria);
 
+    Page<String> searchIds(List<ApiCriteria> apiCriteria, Pageable pageable, Sortable sortable);
+
     Set<String> listCategories(ApiCriteria apiCriteria) throws TechnicalException;
 
     Optional<Api> findByEnvironmentIdAndCrossId(String environmentId, String crossId) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiRepository.java
@@ -43,8 +43,6 @@ public interface ApiRepository extends CrudRepository<Api, String> {
 
     Set<Api> search(ApiCriteria apiCriteria, ApiFieldInclusionFilter apiFieldInclusionFilter);
 
-    List<String> searchIds(List<ApiCriteria> apiCriteria, Sortable sortable);
-
     Page<String> searchIds(List<ApiCriteria> apiCriteria, Pageable pageable, Sortable sortable);
 
     Set<String> listCategories(ApiCriteria apiCriteria) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiRepository.java
@@ -49,10 +49,6 @@ public interface ApiRepository extends CrudRepository<Api, String> {
 
     Set<Api> search(ApiCriteria apiCriteria, ApiFieldInclusionFilter apiFieldInclusionFilter);
 
-    default List<String> searchIds(ApiCriteria... apiCriteria) {
-        return searchIds(null, apiCriteria);
-    }
-
     List<String> searchIds(Sortable sortable, ApiCriteria... apiCriteria);
 
     Page<String> searchIds(List<ApiCriteria> apiCriteria, Pageable pageable, Sortable sortable);

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/ApiFieldExclusionFilter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/ApiFieldExclusionFilter.java
@@ -23,20 +23,29 @@ import java.util.Objects;
  */
 public class ApiFieldExclusionFilter {
 
-    private final boolean definition;
-    private final boolean picture;
+    public static ApiFieldExclusionFilter noExclusion() {
+        return new ApiFieldExclusionFilter();
+    }
+
+    private final boolean definitionExcluded;
+    private final boolean pictureExcluded;
+
+    private ApiFieldExclusionFilter() {
+        this.definitionExcluded = false;
+        this.pictureExcluded = false;
+    }
 
     private ApiFieldExclusionFilter(ApiFieldExclusionFilter.Builder builder) {
-        this.definition = builder.definition;
-        this.picture = builder.picture;
+        this.definitionExcluded = builder.excludeDefinition;
+        this.pictureExcluded = builder.excludePicture;
     }
 
-    public boolean isDefinition() {
-        return definition;
+    public boolean isDefinitionExcluded() {
+        return definitionExcluded;
     }
 
-    public boolean isPicture() {
-        return picture;
+    public boolean isPictureExcluded() {
+        return pictureExcluded;
     }
 
     @Override
@@ -44,26 +53,26 @@ public class ApiFieldExclusionFilter {
         if (this == o) return true;
         if (!(o instanceof ApiFieldExclusionFilter)) return false;
         ApiFieldExclusionFilter that = (ApiFieldExclusionFilter) o;
-        return definition == that.definition && picture == that.picture;
+        return definitionExcluded == that.definitionExcluded && pictureExcluded == that.pictureExcluded;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(definition, picture);
+        return Objects.hash(definitionExcluded, pictureExcluded);
     }
 
     public static class Builder {
 
-        private boolean definition;
-        private boolean picture;
+        private boolean excludeDefinition;
+        private boolean excludePicture;
 
         public ApiFieldExclusionFilter.Builder excludeDefinition() {
-            this.definition = true;
+            this.excludeDefinition = true;
             return this;
         }
 
         public ApiFieldExclusionFilter.Builder excludePicture() {
-            this.picture = true;
+            this.excludePicture = true;
             return this;
         }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApiRepository.java
@@ -38,6 +38,11 @@ import org.springframework.stereotype.Component;
 public class HttpApiRepository extends AbstractRepository implements ApiRepository {
 
     @Override
+    public Set<Api> findAll() throws TechnicalException {
+        throw new IllegalStateException();
+    }
+
+    @Override
     public Optional<Api> findById(String apiId) throws TechnicalException {
         return blockingGet(get("/apis/" + apiId, BodyCodecs.optional(Api.class)).send()).payload();
     }
@@ -89,22 +94,17 @@ public class HttpApiRepository extends AbstractRepository implements ApiReposito
     }
 
     @Override
-    public Page<String> searchIds(List<ApiCriteria> apiCriteria, Pageable pageable, Sortable sortable) {
-        throw new IllegalStateException();
-    }
-
-    @Override
-    public List<String> searchIds(Sortable sortable, ApiCriteria... apiCriteria) {
-        throw new IllegalStateException();
-    }
-
-    @Override
-    public Set<Api> findAll() throws TechnicalException {
-        throw new IllegalStateException();
-    }
-
-    @Override
     public Set<Api> search(ApiCriteria apiCriteria, ApiFieldInclusionFilter apiFieldInclusionFilter) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public List<String> searchIds(List<ApiCriteria> apiCriteria, Sortable sortable) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Page<String> searchIds(List<ApiCriteria> apiCriteria, Pageable pageable, Sortable sortable) {
         throw new IllegalStateException();
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApiRepository.java
@@ -99,11 +99,6 @@ public class HttpApiRepository extends AbstractRepository implements ApiReposito
     }
 
     @Override
-    public List<String> searchIds(List<ApiCriteria> apiCriteria, Sortable sortable) {
-        throw new IllegalStateException();
-    }
-
-    @Override
     public Page<String> searchIds(List<ApiCriteria> apiCriteria, Pageable pageable, Sortable sortable) {
         throw new IllegalStateException();
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApiRepository.java
@@ -77,8 +77,8 @@ public class HttpApiRepository extends AbstractRepository implements ApiReposito
         try {
             return blockingGet(
                 get("/apis", BodyCodecs.list(Api.class))
-                    .addQueryParam("excludeDefinition", Boolean.toString(apiFieldExclusionFilter.isDefinition()))
-                    .addQueryParam("excludePicture", Boolean.toString(apiFieldExclusionFilter.isPicture()))
+                    .addQueryParam("excludeDefinition", Boolean.toString(apiFieldExclusionFilter.isDefinitionExcluded()))
+                    .addQueryParam("excludePicture", Boolean.toString(apiFieldExclusionFilter.isPictureExcluded()))
                     .send()
             )
                 .payload();

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApiRepository.java
@@ -89,6 +89,11 @@ public class HttpApiRepository extends AbstractRepository implements ApiReposito
     }
 
     @Override
+    public Page<String> searchIds(List<ApiCriteria> apiCriteria, Pageable pageable, Sortable sortable) {
+        throw new IllegalStateException();
+    }
+
+    @Override
     public List<String> searchIds(Sortable sortable, ApiCriteria... apiCriteria) {
         throw new IllegalStateException();
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAbstractPageableRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAbstractPageableRepository.java
@@ -33,7 +33,7 @@ abstract class JdbcAbstractPageableRepository<T> extends JdbcAbstractRepository<
         super(prefix, tableName);
     }
 
-    Page<T> getResultAsPage(final Pageable page, final List<T> items) {
+    <U> Page<U> getResultAsPage(final Pageable page, final List<U> items) {
         if (page != null) {
             LOGGER.debug("Getting results as page {} for {}", page, items);
             int start = page.from();

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
@@ -184,11 +184,6 @@ public class JdbcApiRepository extends JdbcAbstractPageableRepository<Api> imple
     }
 
     @Override
-    public List<Api> search(ApiCriteria apiCriteria) {
-        return findByCriteria(apiCriteria, null, null);
-    }
-
-    @Override
     public List<Api> search(ApiCriteria apiCriteria, ApiFieldExclusionFilter apiFieldExclusionFilter) {
         return findByCriteria(apiCriteria, null, apiFieldExclusionFilter);
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
@@ -444,10 +444,10 @@ public class JdbcApiRepository extends JdbcAbstractPageableRepository<Api> imple
             "ac.*, a.id, a.environment_id, a.name, a.description, a.version, a.deployed_at, a.created_at, a.updated_at, " +
             "a.visibility, a.lifecycle_state, a.api_lifecycle_state";
 
-        if (apiFieldExclusionFilter == null || !apiFieldExclusionFilter.isDefinition()) {
+        if (apiFieldExclusionFilter == null || !apiFieldExclusionFilter.isDefinitionExcluded()) {
             projection += ", a.definition";
         }
-        if (apiFieldExclusionFilter == null || !apiFieldExclusionFilter.isPicture()) {
+        if (apiFieldExclusionFilter == null || !apiFieldExclusionFilter.isPictureExcluded()) {
             projection += ", a.picture, a.background";
         }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiRepository.java
@@ -111,8 +111,8 @@ public class MongoApiRepository implements ApiRepository {
     }
 
     @Override
-    public List<String> searchIds(Sortable sortable, ApiCriteria... apiCriteria) {
-        return internalApiRepo.searchIds(sortable, apiCriteria);
+    public List<String> searchIds(List<ApiCriteria> apiCriteria, Sortable sortable) {
+        return internalApiRepo.searchIds(apiCriteria, sortable);
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiRepository.java
@@ -105,11 +105,6 @@ public class MongoApiRepository implements ApiRepository {
     }
 
     @Override
-    public List<String> searchIds(ApiCriteria... apiCriteria) {
-        return internalApiRepo.searchIds(null, apiCriteria);
-    }
-
-    @Override
     public List<String> searchIds(Sortable sortable, ApiCriteria... apiCriteria) {
         return internalApiRepo.searchIds(sortable, apiCriteria);
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiRepository.java
@@ -115,6 +115,11 @@ public class MongoApiRepository implements ApiRepository {
     }
 
     @Override
+    public Page<String> searchIds(List<ApiCriteria> apiCriteria, Pageable pageable, Sortable sortable) {
+        return internalApiRepo.searchIds(apiCriteria, pageable, sortable);
+    }
+
+    @Override
     public Set<String> listCategories(ApiCriteria apiCriteria) {
         return internalApiRepo.listCategories(apiCriteria);
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiRepository.java
@@ -100,13 +100,9 @@ public class MongoApiRepository implements ApiRepository {
     }
 
     @Override
-    public List<Api> search(ApiCriteria apiCriteria) {
-        return findByCriteria(apiCriteria, null);
-    }
-
-    @Override
     public List<Api> search(ApiCriteria apiCriteria, ApiFieldExclusionFilter apiFieldExclusionFilter) {
-        return findByCriteria(apiCriteria, apiFieldExclusionFilter);
+        final Page<ApiMongo> apisMongo = internalApiRepo.search(apiCriteria, null, null, apiFieldExclusionFilter);
+        return mapper.collection2list(apisMongo.getContent(), ApiMongo.class, Api.class);
     }
 
     @Override
@@ -132,11 +128,6 @@ public class MongoApiRepository implements ApiRepository {
     @Override
     public Optional<Api> findByEnvironmentIdAndCrossId(String environmentId, String crossId) throws TechnicalException {
         return internalApiRepo.findByEnvironmentIdAndCrossId(environmentId, crossId).map(this::mapApi);
-    }
-
-    private List<Api> findByCriteria(ApiCriteria apiCriteria, ApiFieldExclusionFilter apiFieldExclusionFilter) {
-        final Page<ApiMongo> apisMongo = internalApiRepo.search(apiCriteria, null, null, apiFieldExclusionFilter);
-        return mapper.collection2list(apisMongo.getContent(), ApiMongo.class, Api.class);
     }
 
     private ApiMongo mapApi(Api api) {

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiRepository.java
@@ -50,6 +50,11 @@ public class MongoApiRepository implements ApiRepository {
     private GraviteeMapper mapper;
 
     @Override
+    public Set<Api> findAll() throws TechnicalException {
+        return internalApiRepo.findAll().stream().map(this::mapApi).collect(Collectors.toSet());
+    }
+
+    @Override
     public Optional<Api> findById(String apiId) throws TechnicalException {
         ApiMongo apiMongo = internalApiRepo.findById(apiId).orElse(null);
         return Optional.ofNullable(mapApi(apiMongo));
@@ -105,6 +110,11 @@ public class MongoApiRepository implements ApiRepository {
     }
 
     @Override
+    public Set<Api> search(ApiCriteria criteria, ApiFieldInclusionFilter apiFieldInclusionFilter) {
+        return internalApiRepo.search(criteria, apiFieldInclusionFilter).stream().map(this::mapApi).collect(Collectors.toSet());
+    }
+
+    @Override
     public List<String> searchIds(Sortable sortable, ApiCriteria... apiCriteria) {
         return internalApiRepo.searchIds(sortable, apiCriteria);
     }
@@ -119,6 +129,11 @@ public class MongoApiRepository implements ApiRepository {
         return internalApiRepo.listCategories(apiCriteria);
     }
 
+    @Override
+    public Optional<Api> findByEnvironmentIdAndCrossId(String environmentId, String crossId) throws TechnicalException {
+        return internalApiRepo.findByEnvironmentIdAndCrossId(environmentId, crossId).map(this::mapApi);
+    }
+
     private List<Api> findByCriteria(ApiCriteria apiCriteria, ApiFieldExclusionFilter apiFieldExclusionFilter) {
         final Page<ApiMongo> apisMongo = internalApiRepo.search(apiCriteria, null, null, apiFieldExclusionFilter);
         return mapper.collection2list(apisMongo.getContent(), ApiMongo.class, Api.class);
@@ -130,20 +145,5 @@ public class MongoApiRepository implements ApiRepository {
 
     private Api mapApi(ApiMongo apiMongo) {
         return (apiMongo == null) ? null : mapper.map(apiMongo, Api.class);
-    }
-
-    @Override
-    public Set<Api> findAll() throws TechnicalException {
-        return internalApiRepo.findAll().stream().map(this::mapApi).collect(Collectors.toSet());
-    }
-
-    @Override
-    public Set<Api> search(ApiCriteria criteria, ApiFieldInclusionFilter apiFieldInclusionFilter) {
-        return internalApiRepo.search(criteria, apiFieldInclusionFilter).stream().map(this::mapApi).collect(Collectors.toSet());
-    }
-
-    @Override
-    public Optional<Api> findByEnvironmentIdAndCrossId(String environmentId, String crossId) throws TechnicalException {
-        return internalApiRepo.findByEnvironmentIdAndCrossId(environmentId, crossId).map(this::mapApi);
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiRepository.java
@@ -111,11 +111,6 @@ public class MongoApiRepository implements ApiRepository {
     }
 
     @Override
-    public List<String> searchIds(List<ApiCriteria> apiCriteria, Sortable sortable) {
-        return internalApiRepo.searchIds(apiCriteria, sortable);
-    }
-
-    @Override
     public Page<String> searchIds(List<ApiCriteria> apiCriteria, Pageable pageable, Sortable sortable) {
         return internalApiRepo.searchIds(apiCriteria, pageable, sortable);
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryCustom.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryCustom.java
@@ -44,7 +44,5 @@ public interface ApiMongoRepositoryCustom {
      */
     Page<String> searchIds(List<ApiCriteria> apiCriteria, Pageable pageable, Sortable sortable);
 
-    List<String> searchIds(List<ApiCriteria> apiCriteria, Sortable sortable);
-
     Set<String> listCategories(ApiCriteria apiCriteria);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryCustom.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryCustom.java
@@ -44,7 +44,7 @@ public interface ApiMongoRepositoryCustom {
      */
     Page<String> searchIds(List<ApiCriteria> apiCriteria, Pageable pageable, Sortable sortable);
 
-    List<String> searchIds(Sortable sortable, ApiCriteria... apiCriteria);
+    List<String> searchIds(List<ApiCriteria> apiCriteria, Sortable sortable);
 
     Set<String> listCategories(ApiCriteria apiCriteria);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryCustom.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryCustom.java
@@ -34,6 +34,16 @@ public interface ApiMongoRepositoryCustom {
 
     List<ApiMongo> search(ApiCriteria criteria, ApiFieldInclusionFilter apiFieldInclusionFilter);
 
+    /**
+     * Find ids of APIs matching the given criteria.
+     *
+     * @param apiCriteria the search criteria
+     * @param pageable    the pagination criteria
+     * @param sortable    the sort criteria
+     * @return the list of matching APIs' ids
+     */
+    Page<String> searchIds(List<ApiCriteria> apiCriteria, Pageable pageable, Sortable sortable);
+
     List<String> searchIds(Sortable sortable, ApiCriteria... apiCriteria);
 
     Set<String> listCategories(ApiCriteria apiCriteria);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryImpl.java
@@ -137,10 +137,10 @@ public class ApiMongoRepositoryImpl implements ApiMongoRepositoryCustom {
         final Query query = new Query();
 
         if (apiFieldExclusionFilter != null) {
-            if (apiFieldExclusionFilter.isDefinition()) {
+            if (apiFieldExclusionFilter.isDefinitionExcluded()) {
                 query.fields().exclude("definition");
             }
-            if (apiFieldExclusionFilter.isPicture()) {
+            if (apiFieldExclusionFilter.isPictureExcluded()) {
                 query.fields().exclude("picture");
                 query.fields().exclude("background");
             }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryImpl.java
@@ -86,27 +86,6 @@ public class ApiMongoRepositoryImpl implements ApiMongoRepositoryCustom {
     }
 
     @Override
-    public List<String> searchIds(List<ApiCriteria> apiCriteria, Sortable sortable) {
-        ApiFieldInclusionFilter apiFieldInclusionFilter = new ApiFieldInclusionFilter.Builder().build();
-        final Query query = buildQuery(apiFieldInclusionFilter, apiCriteria);
-
-        if (sortable != null) {
-            query.with(
-                Sort.by(
-                    sortable.order().equals(Order.ASC) ? Sort.Direction.ASC : Sort.Direction.DESC,
-                    FieldUtils.toCamelCase(sortable.field())
-                )
-            );
-        } else {
-            query.with(Sort.by(ASC, "name"));
-        }
-
-        List<ApiMongo> apis = mongoTemplate.find(query, ApiMongo.class);
-
-        return apis.parallelStream().map(ApiMongo::getId).collect(Collectors.toList());
-    }
-
-    @Override
     public Page<String> searchIds(List<ApiCriteria> apiCriteria, Pageable pageable, Sortable sortable) {
         Objects.requireNonNull(pageable, "Pageable must not be null");
 

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/ApiRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/ApiRepositoryTest.java
@@ -357,29 +357,6 @@ public class ApiRepositoryTest extends AbstractRepositoryTest {
     }
 
     @Test
-    public void searchByPageable() {
-        Page<Api> apiPage = apiRepository.search(
-            new ApiCriteria.Builder().version("1").build(),
-            new PageableBuilder().pageNumber(0).pageSize(2).build()
-        );
-
-        assertEquals(4, apiPage.getTotalElements());
-        assertEquals(2, apiPage.getPageElements());
-        Iterator<Api> apiIterator = apiPage.getContent().iterator();
-        assertEquals("api-to-delete", apiIterator.next().getId());
-        assertEquals("api-to-findById", apiIterator.next().getId());
-
-        apiPage =
-            apiRepository.search(new ApiCriteria.Builder().version("1").build(), new PageableBuilder().pageNumber(1).pageSize(2).build());
-
-        assertEquals(4, apiPage.getTotalElements());
-        assertEquals(2, apiPage.getPageElements());
-        apiIterator = apiPage.getContent().iterator();
-        assertEquals("api-to-update", apiIterator.next().getId());
-        assertEquals("grouped-api", apiIterator.next().getId());
-    }
-
-    @Test
     public void shouldFindByLifecycleStates() {
         final List<Api> apis = apiRepository.search(new ApiCriteria.Builder().lifecycleStates(singletonList(PUBLISHED)).build());
         assertNotNull(apis);

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/ApiRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/ApiRepositoryTest.java
@@ -220,19 +220,6 @@ public class ApiRepositoryTest extends AbstractRepositoryTest {
         assertTrue(apis.stream().map(Api::getId).collect(toList()).containsAll(asList("api-to-delete", "api-to-update", "big-name")));
     }
 
-    @Test
-    public void shouldFindIdsWithMultipleApiCriteria() {
-        List<String> apis = apiRepository.searchIds(
-            new ApiCriteria.Builder().ids("api-to-delete", "api-to-update", "unknown").build(),
-            new ApiCriteria.Builder().environments(Arrays.asList("DEV", "DEVS")).build(),
-            new ApiCriteria.Builder().groups("api-group", "unknown").build()
-        );
-        assertNotNull(apis);
-        assertFalse(apis.isEmpty());
-        assertEquals(4, apis.size());
-        assertTrue(apis.containsAll(asList("api-to-delete", "api-to-update", "big-name", "grouped-api")));
-    }
-
     @Test(expected = IllegalStateException.class)
     public void shouldNotUpdateUnknownApi() throws TechnicalException {
         Api unknownApi = new Api();

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/ApiRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/ApiRepositoryTest.java
@@ -31,7 +31,9 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiFieldInclusionFilter;
 import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldExclusionFilter;
+import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.repository.management.api.search.builder.PageableBuilder;
+import io.gravitee.repository.management.api.search.builder.SortableBuilder;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.ApiLifecycleState;
 import io.gravitee.repository.management.model.LifecycleState;
@@ -479,5 +481,43 @@ public class ApiRepositoryTest extends AbstractRepositoryTest {
     @Test(expected = Exception.class)
     public void shouldFindMultipleByEnvironmentIdAndCrossId_throwsException() throws TechnicalException {
         apiRepository.findByEnvironmentIdAndCrossId("ENV6", "duplicated-crossId");
+    }
+
+    @Test
+    public void searchIdsWithPageable() {
+        Page<String> apiIds = apiRepository.searchIds(
+            List.of(new ApiCriteria.Builder().version("1").build()),
+            new PageableBuilder().pageNumber(0).pageSize(2).build(),
+            null
+        );
+
+        assertEquals(4, apiIds.getTotalElements());
+        assertEquals(2, apiIds.getPageElements());
+
+        assertEquals("api-to-delete", apiIds.getContent().get(0));
+        assertEquals("api-to-findById", apiIds.getContent().get(1));
+
+        apiIds =
+            apiRepository.searchIds(
+                List.of(new ApiCriteria.Builder().version("1").build()),
+                new PageableBuilder().pageNumber(1).pageSize(2).build(),
+                null
+            );
+
+        assertEquals(4, apiIds.getTotalElements());
+        assertEquals(2, apiIds.getPageElements());
+
+        assertEquals("api-to-update", apiIds.getContent().get(0));
+        assertEquals("grouped-api", apiIds.getContent().get(1));
+
+        apiIds =
+            apiRepository.searchIds(
+                List.of(new ApiCriteria.Builder().version("1").build()),
+                new PageableBuilder().pageNumber(0).pageSize(4).build(),
+                new SortableBuilder().field("updated_at").order(Order.DESC).build()
+            );
+
+        assertEquals("api-to-update", apiIds.getContent().get(0));
+        assertEquals("api-to-delete", apiIds.getContent().get(1));
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/ApiRepositoryMock.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/ApiRepositoryMock.java
@@ -25,18 +25,21 @@ import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiFieldInclusionFilter;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldExclusionFilter;
+import io.gravitee.repository.management.api.search.Order;
+import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.builder.PageableBuilder;
+import io.gravitee.repository.management.api.search.builder.SortableBuilder;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.ApiLifecycleState;
 import io.gravitee.repository.management.model.LifecycleState;
@@ -146,15 +149,6 @@ public class ApiRepositoryMock extends AbstractRepositoryMock<ApiRepository> {
         when(apiRepository.search(new ApiCriteria.Builder().environments(asList("DEV", "DEVS")).build()))
             .thenReturn(asList(apiToUpdate, apiToDelete, apiBigName));
 
-        when(
-            apiRepository.searchIds(
-                eq(new ApiCriteria.Builder().ids("api-to-delete", "api-to-update", "unknown").build()),
-                eq(new ApiCriteria.Builder().environments(asList("DEV", "DEVS")).build()),
-                eq(new ApiCriteria.Builder().groups(asList("api-group", "unknown")).build())
-            )
-        )
-            .thenReturn(asList("api-to-delete", "api-to-update", "big-name", "grouped-api"));
-
         when(apiRepository.update(argThat(o -> o == null || o.getId().equals("unknown")))).thenThrow(new IllegalStateException());
 
         when(apiRepository.search(new ApiCriteria.Builder().name("api-to-findById name").build())).thenReturn(singletonList(apiToFindById));
@@ -227,5 +221,30 @@ public class ApiRepositoryMock extends AbstractRepositoryMock<ApiRepository> {
         when(apiRepository.findByEnvironmentIdAndCrossId("ENV6", "searched-crossId2")).thenReturn(Optional.of(apiToFindByCrossId));
 
         when(apiRepository.findByEnvironmentIdAndCrossId("ENV6", "duplicated-crossId")).thenThrow(new TechnicalException("test exception"));
+
+        when(
+            apiRepository.searchIds(
+                List.of(new ApiCriteria.Builder().version("1").build()),
+                new PageableBuilder().pageNumber(0).pageSize(2).build(),
+                null
+            )
+        )
+            .thenReturn(new Page<>(List.of("api-to-delete", "api-to-findById"), 0, 2, 4));
+        when(
+            apiRepository.searchIds(
+                List.of(new ApiCriteria.Builder().version("1").build()),
+                new PageableBuilder().pageNumber(1).pageSize(2).build(),
+                null
+            )
+        )
+            .thenReturn(new Page<>(List.of("api-to-update", "grouped-api"), 0, 2, 4));
+        when(
+            apiRepository.searchIds(
+                List.of(new ApiCriteria.Builder().version("1").build()),
+                new PageableBuilder().pageNumber(0).pageSize(4).build(),
+                new SortableBuilder().field("updated_at").order(Order.DESC).build()
+            )
+        )
+            .thenReturn(new Page<>(List.of("api-to-update", "api-to-delete"), 0, 2, 4));
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/ApiRepositoryMock.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/ApiRepositoryMock.java
@@ -171,12 +171,6 @@ public class ApiRepositoryMock extends AbstractRepositoryMock<ApiRepository> {
         when(apiRepository.search(new ApiCriteria.Builder().visibility(PUBLIC).build())).thenReturn(asList(apiToFindById, groupedApi));
         when(apiRepository.search(new ApiCriteria.Builder().environmentId("DEFAULT").build()))
             .thenReturn(asList(apiToFindById, groupedApi));
-        when(apiRepository.search(new ApiCriteria.Builder().version("1").build(), new PageableBuilder().pageNumber(0).pageSize(2).build()))
-            .thenReturn(new io.gravitee.common.data.domain.Page<>(asList(apiToDelete, apiToFindById), 0, 2, 4));
-        when(apiRepository.search(new ApiCriteria.Builder().version("1").build(), new PageableBuilder().pageNumber(1).pageSize(2).build()))
-            .thenReturn(new io.gravitee.common.data.domain.Page<>(asList(apiToUpdate, groupedApi), 1, 2, 4));
-        when(apiRepository.search(new ApiCriteria.Builder().version("1").build(), new PageableBuilder().build()))
-            .thenReturn(new io.gravitee.common.data.domain.Page<>(asList(apiToDelete, apiToFindById, apiToUpdate, groupedApi), 0, 4, 4));
 
         when(apiRepository.search(new ApiCriteria.Builder().lifecycleStates(singletonList(PUBLISHED)).build()))
             .thenReturn(asList(apiToUpdate, groupedApi, apiToUpdate));

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/api-tests/apis.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/api-tests/apis.json
@@ -7,7 +7,7 @@
     "definition" : "{\"id\" : \"product\",\"name\" : \"Product\",\"version\" : \"1\",\"proxy\" : {  \"context_path\" : \"/product\",  \"endpoint\" : \"http://toto.com\",  \"endpoints\" : [ {    \"target\" : \"http://toto.com\",    \"weight\" : 1,    \"name\" : \"endpointName\"  } ],  \"strip_context_path\" : false,  \"http\" : {    \"configuration\" : {      \"connectTimeout\" : 5000,      \"idleTimeout\" : 60000,      \"keepAlive\" : true,      \"dumpRequest\" : false    }  }},\"paths\" : {  \"/\" : [ {    \"methods\" : [ ],    \"api-key\" : {}  } ]},\"tags\" : [ ]\n}",
     "visibility" : "PRIVATE",
     "createdAt": 1439022010883,
-    "updatedAt": 1439022010883,
+    "updatedAt": 1439022010893,
     "lifecycleState": "STOPPED",
     "apiLifecycleState": "UNPUBLISHED",
     "disableMembershipNotifications": true
@@ -20,7 +20,7 @@
     "definition" : "{\"id\" : \"product\",\"name\" : \"Product\",\"version\" : \"1\",\"proxy\" : {  \"context_path\" : \"/product\",  \"endpoint\" : \"http://toto.com\",  \"endpoints\" : [ {    \"target\" : \"http://toto.com\",    \"weight\" : 1,    \"name\" : \"endpointName\"  } ],  \"strip_context_path\" : false,  \"http\" : {    \"configuration\" : {      \"connectTimeout\" : 5000,      \"idleTimeout\" : 60000,      \"keepAlive\" : true,      \"dumpRequest\" : false    }  }},\"paths\" : {  \"/\" : [ {    \"methods\" : [ ],    \"api-key\" : {}  } ]},\"tags\" : [ ]\n}",
     "visibility" : "PRIVATE",
     "createdAt": 1439022010883,
-    "updatedAt": 1439022010883,
+    "updatedAt": 1439022010983,
     "lifecycleState": "STOPPED",
     "apiLifecycleState": "PUBLISHED",
     "disableMembershipNotifications": true

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentAnalyticsResource.java
@@ -37,6 +37,9 @@ import io.gravitee.rest.api.model.analytics.query.StatsQuery;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.api.ApiQuery;
 import io.gravitee.rest.api.model.application.ApplicationQuery;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.model.common.SortableImpl;
 import io.gravitee.rest.api.service.AnalyticsService;
 import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.ApplicationService;
@@ -145,7 +148,9 @@ public class EnvironmentAnalyticsResource extends AbstractResource {
         switch (analyticsParam.getField()) {
             case API_FIELD:
                 if (isAdmin()) {
-                    return buildCountStat(apiService.searchIds(executionContext, new ApiQuery()).size());
+                    return buildCountStat(
+                        apiService.searchIds(executionContext, new ApiQuery(), new PageableImpl(0, 1), null).getTotalElements()
+                    );
                 } else {
                     return buildCountStat(apiService.findIdsByUser(executionContext, getAuthenticatedUser(), new ApiQuery(), false).size());
                 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiResourceNotAdminTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiResourceNotAdminTest.java
@@ -173,7 +173,7 @@ public class ApiResourceNotAdminTest extends AbstractResourceTest {
     @Test
     public void shouldNotAccessToApiState_BecauseNotAMember() {
         when(apiService.searchIds(eq(GraviteeContext.getExecutionContext()), any(ApiQuery.class), any(PageableImpl.class), isNull()))
-                .thenReturn(new Page<>(emptyList(), 0, 0, 0));
+            .thenReturn(new Page<>(emptyList(), 0, 0, 0));
 
         final Response response = envTarget(API + "/state").request().get();
         assertEquals(FORBIDDEN_403, response.getStatus());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiResourceNotAdminTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiResourceNotAdminTest.java
@@ -17,18 +17,22 @@ package io.gravitee.rest.api.management.rest.resource;
 
 import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
 import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
+import io.gravitee.common.data.domain.Page;
 import io.gravitee.definition.model.Proxy;
 import io.gravitee.definition.model.VirtualHost;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.model.api.ApiQuery;
 import io.gravitee.rest.api.model.api.UpdateApiEntity;
+import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.Collections;
@@ -168,6 +172,9 @@ public class ApiResourceNotAdminTest extends AbstractResourceTest {
 
     @Test
     public void shouldNotAccessToApiState_BecauseNotAMember() {
+        when(apiService.searchIds(eq(GraviteeContext.getExecutionContext()), any(ApiQuery.class), any(PageableImpl.class), isNull()))
+                .thenReturn(new Page<>(emptyList(), 0, 0, 0));
+
         final Response response = envTarget(API + "/state").request().get();
         assertEquals(FORBIDDEN_403, response.getStatus());
     }
@@ -225,8 +232,8 @@ public class ApiResourceNotAdminTest extends AbstractResourceTest {
             .thenReturn(Sets.newSet(membershipEntity));
 
         when(roleService.findById(eq(roleId))).thenReturn(role);
-        when(apiService.searchIds(eq(GraviteeContext.getExecutionContext()), anyString(), any(), any()))
-            .thenReturn(Collections.singletonList(mockApi.getId()));
+        when(apiService.searchIds(eq(GraviteeContext.getExecutionContext()), any(ApiQuery.class), any(PageableImpl.class), isNull()))
+            .thenReturn(new Page<>(Collections.singletonList(mockApi.getId()), 0, 1, 1));
 
         final Response response = envTarget(API + "/state").request().get();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiResourceNotAdminTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiResourceNotAdminTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.*;
 
 import io.gravitee.definition.model.Proxy;
 import io.gravitee.definition.model.VirtualHost;
+import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.api.UpdateApiEntity;
@@ -194,7 +195,7 @@ public class ApiResourceNotAdminTest extends AbstractResourceTest {
     }
 
     @Test
-    public void shouldAccessToApiState_BecauseGroupMember_onApi() {
+    public void shouldAccessToApiState_BecauseGroupMember_onApi() throws TechnicalException {
         final String groupId = "group_id";
         final String roleId = "role_id";
         MembershipEntity membershipEntity = mock(MembershipEntity.class);
@@ -224,7 +225,8 @@ public class ApiResourceNotAdminTest extends AbstractResourceTest {
             .thenReturn(Sets.newSet(membershipEntity));
 
         when(roleService.findById(eq(roleId))).thenReturn(role);
-        when(apiService.searchIds(eq(GraviteeContext.getExecutionContext()), any())).thenReturn(Collections.singletonList(mockApi.getId()));
+        when(apiService.searchIds(eq(GraviteeContext.getExecutionContext()), anyString(), any(), any()))
+            .thenReturn(Collections.singletonList(mockApi.getId()));
 
         final Response response = envTarget(API + "/state").request().get();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiRepositoryProxy.java
@@ -78,8 +78,8 @@ public class ApiRepositoryProxy extends AbstractProxy<ApiRepository> implements 
     }
 
     @Override
-    public List<String> searchIds(Sortable sortable, ApiCriteria... apiCriteria) {
-        return target.searchIds(sortable, apiCriteria);
+    public List<String> searchIds(List<ApiCriteria> apiCriteria, Sortable sortable) {
+        return target.searchIds(apiCriteria, sortable);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiRepositoryProxy.java
@@ -93,6 +93,11 @@ public class ApiRepositoryProxy extends AbstractProxy<ApiRepository> implements 
     }
 
     @Override
+    public Page<String> searchIds(List<ApiCriteria> apiCriteria, Pageable pageable, Sortable sortable) {
+        return target.searchIds(apiCriteria, pageable, sortable);
+    }
+
+    @Override
     public Set<Api> findAll() throws TechnicalException {
         return target.findAll();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiRepositoryProxy.java
@@ -78,11 +78,6 @@ public class ApiRepositoryProxy extends AbstractProxy<ApiRepository> implements 
     }
 
     @Override
-    public List<String> searchIds(List<ApiCriteria> apiCriteria, Sortable sortable) {
-        return target.searchIds(apiCriteria, sortable);
-    }
-
-    @Override
     public Page<String> searchIds(List<ApiCriteria> apiCriteria, Pageable pageable, Sortable sortable) {
         return target.searchIds(apiCriteria, pageable, sortable);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiRepositoryProxy.java
@@ -68,11 +68,6 @@ public class ApiRepositoryProxy extends AbstractProxy<ApiRepository> implements 
     }
 
     @Override
-    public Page<Api> search(ApiCriteria apiCriteria, Pageable pageable) {
-        return target.search(apiCriteria, pageable);
-    }
-
-    @Override
     public List<Api> search(ApiCriteria apiCriteria) {
         return target.search(apiCriteria);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiRepositoryProxy.java
@@ -83,11 +83,6 @@ public class ApiRepositoryProxy extends AbstractProxy<ApiRepository> implements 
     }
 
     @Override
-    public List<String> searchIds(ApiCriteria... apiCriteria) {
-        return target.searchIds(apiCriteria);
-    }
-
-    @Override
     public List<String> searchIds(Sortable sortable, ApiCriteria... apiCriteria) {
         return target.searchIds(sortable, apiCriteria);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
@@ -18,7 +18,6 @@ package io.gravitee.rest.api.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.definition.model.DefinitionVersion;
-import io.gravitee.definition.model.Plan;
 import io.gravitee.definition.model.Rule;
 import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.repository.exceptions.TechnicalException;
@@ -167,11 +166,6 @@ public interface ApiService {
     Collection<ApiEntity> search(ExecutionContext executionContext, ApiQuery query);
 
     Page<String> searchIds(ExecutionContext executionContext, ApiQuery query, Pageable pageable, Sortable sortable);
-
-    default Collection<String> searchIds(ExecutionContext executionContext, String query, Map<String, Object> filters)
-        throws TechnicalException {
-        return searchIds(executionContext, query, filters, null);
-    }
 
     Collection<String> searchIds(ExecutionContext executionContext, String query, Map<String, Object> filters, Sortable sortable)
         throws TechnicalException;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
@@ -166,8 +166,6 @@ public interface ApiService {
 
     Collection<ApiEntity> search(ExecutionContext executionContext, ApiQuery query);
 
-    Collection<String> searchIds(ExecutionContext executionContext, ApiQuery query);
-
     Page<String> searchIds(ExecutionContext executionContext, ApiQuery query, Pageable pageable, Sortable sortable);
 
     default Collection<String> searchIds(ExecutionContext executionContext, String query, Map<String, Object> filters)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
@@ -168,6 +168,8 @@ public interface ApiService {
 
     Collection<String> searchIds(ExecutionContext executionContext, ApiQuery query);
 
+    Page<String> searchIds(ExecutionContext executionContext, ApiQuery query, Pageable pageable, Sortable sortable);
+
     default Collection<String> searchIds(ExecutionContext executionContext, String query, Map<String, Object> filters)
         throws TechnicalException {
         return searchIds(executionContext, query, filters, null);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -1184,8 +1184,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             return Set.of();
         }
         // Just one call to apiRepository to preserve sort
-        ApiCriteria[] apiCriteria = apiCriteriaList.toArray(new ApiCriteria[apiCriteriaList.size()]);
-        List<String> apiIds = apiRepository.searchIds(convert(sortable), apiCriteria);
+        List<String> apiIds = apiRepository.searchIds(apiCriteriaList, convert(sortable));
         return new LinkedHashSet<>(apiIds);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -2733,6 +2733,18 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     }
 
     @Override
+    public Page<String> searchIds(ExecutionContext executionContext, ApiQuery query, Pageable pageable, Sortable sortable) {
+        try {
+            LOGGER.debug("Search API ids by {}", query);
+            ApiCriteria apiCriteria = queryToCriteria(executionContext, query).build();
+            return apiRepository.searchIds(List.of(apiCriteria), convert(pageable), convert(sortable));
+        } catch (Exception ex) {
+            final String errorMessage = "An error occurs while trying to search for API ids: " + query;
+            throw new TechnicalManagementException(errorMessage, ex);
+        }
+    }
+
+    @Override
     public Page<ApiEntity> search(
         ExecutionContext executionContext,
         String query,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -56,6 +56,7 @@ import io.gravitee.repository.management.api.ApiQualityRuleRepository;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldExclusionFilter;
+import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.ApiLifecycleState;
 import io.gravitee.repository.management.model.Audit;
@@ -1184,7 +1185,9 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             return Set.of();
         }
         // Just one call to apiRepository to preserve sort
-        List<String> apiIds = apiRepository.searchIds(apiCriteriaList, convert(sortable));
+        // FIXME: Remove this hardcoded page size, it should be handled properly in the service
+        Pageable pageable = new PageableImpl(0, Integer.MAX_VALUE);
+        List<String> apiIds = apiRepository.searchIds(apiCriteriaList, convert(pageable), convert(sortable)).getContent();
         return new LinkedHashSet<>(apiIds);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -2711,28 +2711,6 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     }
 
     @Override
-    public Collection<String> searchIds(ExecutionContext executionContext, ApiQuery query) {
-        try {
-            LOGGER.debug("Search API ids by {}", query);
-            Optional<Collection<String>> optionalTargetIds = this.searchInDefinition(executionContext, query);
-
-            if (optionalTargetIds.isPresent()) {
-                Collection<String> targetIds = optionalTargetIds.get();
-                if (targetIds.isEmpty()) {
-                    return Collections.emptySet();
-                }
-                query.setIds(targetIds);
-            }
-
-            return apiRepository.searchIds(null, queryToCriteria(executionContext, query).build());
-        } catch (Exception ex) {
-            final String errorMessage = "An error occurs while trying to search for API ids: " + query;
-            LOGGER.error(errorMessage, ex);
-            throw new TechnicalManagementException(errorMessage, ex);
-        }
-    }
-
-    @Override
     public Page<String> searchIds(ExecutionContext executionContext, ApiQuery query, Pageable pageable, Sortable sortable) {
         try {
             LOGGER.debug("Search API ids by {}", query);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -2724,7 +2724,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 query.setIds(targetIds);
             }
 
-            return apiRepository.searchIds(queryToCriteria(executionContext, query).build());
+            return apiRepository.searchIds(null, queryToCriteria(executionContext, query).build());
         } catch (Exception ex) {
             final String errorMessage = "An error occurs while trying to search for API ids: " + query;
             LOGGER.error(errorMessage, ex);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TaskServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TaskServiceImpl.java
@@ -225,7 +225,7 @@ public class TaskServiceImpl extends AbstractService implements TaskService {
         if (!groupIds.isEmpty()) {
             ApiCriteria criteria = new ApiCriteria.Builder().groups(groupIds).build();
 
-            apiIds.addAll(apiRepository.searchIds(criteria));
+            apiIds.addAll(apiRepository.searchIds(null, criteria));
         }
 
         if (isEnvironmentAdmin()) {
@@ -237,7 +237,7 @@ public class TaskServiceImpl extends AbstractService implements TaskService {
 
             ApiCriteria criteria = new ApiCriteria.Builder().environments(environmentIds).build();
 
-            apiIds.addAll(apiRepository.searchIds(criteria));
+            apiIds.addAll(apiRepository.searchIds(null, criteria));
         }
 
         return apiIds;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/filtering/FilteringServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/filtering/FilteringServiceImpl.java
@@ -22,7 +22,6 @@ import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.model.SubscriptionStatus;
 import io.gravitee.rest.api.model.TopApiEntity;
 import io.gravitee.rest.api.model.api.ApiQuery;
-import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.common.ExecutionContext;
@@ -151,7 +150,7 @@ public class FilteringServiceImpl extends AbstractService implements FilteringSe
         Map<String, Object> filters = new HashMap<>();
         filters.put("api", apis);
 
-        return apiService.searchIds(executionContext, query, filters);
+        return apiService.searchIds(executionContext, query, filters, null);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/ApiPrimaryOwnerRemovalUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/ApiPrimaryOwnerRemovalUpgrader.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.service.impl.upgrade;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.*;
 
+import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.EnvironmentRepository;
@@ -27,7 +28,14 @@ import io.gravitee.repository.management.api.OrganizationRepository;
 import io.gravitee.repository.management.api.RoleRepository;
 import io.gravitee.repository.management.api.UserRepository;
 import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.api.search.Order;
+import io.gravitee.repository.management.api.search.Pageable;
+import io.gravitee.repository.management.api.search.Sortable;
+import io.gravitee.repository.management.api.search.builder.PageableBuilder;
+import io.gravitee.repository.management.api.search.builder.SortableBuilder;
 import io.gravitee.repository.management.model.*;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.model.common.SortableImpl;
 import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.service.Upgrader;
 import io.gravitee.rest.api.service.common.UuidString;
@@ -102,17 +110,29 @@ public class ApiPrimaryOwnerRemovalUpgrader implements Upgrader, Ordered {
     private void checkOrganization(String organizationId) throws TechnicalException {
         String apiPrimaryOwnerRoleId = findApiPrimaryOwnerRoleId(organizationId);
         List<String> environmentIds = findEnvironmentIds(organizationId);
-        List<String> apiIds = apiRepository.searchIds(null, new ApiCriteria.Builder().environments(environmentIds).build());
-        List<String> unCorruptedApiIds = findApiPrimaryOwnerReferenceIds(apiPrimaryOwnerRoleId, apiIds);
-        if (shouldFix(apiIds, unCorruptedApiIds)) {
-            ArrayList<String> corruptedApiIds = new ArrayList<>(apiIds);
-            corruptedApiIds.removeAll(unCorruptedApiIds);
+        ArrayList<String> corruptedApiIds = new ArrayList<>();
+
+        int page = 0;
+        int size = 100;
+        Pageable pageable = new PageableBuilder().pageNumber(page).pageNumber(size).build();
+        Sortable sortable = new SortableBuilder().field("updated_at").order(Order.DESC).build();
+
+        List<String> apiIds = apiRepository
+            .searchIds(List.of(new ApiCriteria.Builder().environments(environmentIds).build()), pageable, sortable)
+            .getContent();
+
+        while (!apiIds.isEmpty()) {
+            corruptedApiIds.addAll(findCorruptedApiIds(apiPrimaryOwnerRoleId, apiIds));
+            pageable = new PageableBuilder().pageNumber(page++).pageNumber(size).build();
+            apiIds =
+                apiRepository
+                    .searchIds(List.of(new ApiCriteria.Builder().environments(environmentIds).build()), pageable, sortable)
+                    .getContent();
+        }
+
+        if (!corruptedApiIds.isEmpty()) {
             warnOrFix(corruptedApiIds, apiPrimaryOwnerRoleId);
         }
-    }
-
-    private boolean shouldFix(List<String> apiIds, List<String> unCorruptedApiIds) {
-        return apiIds.size() > unCorruptedApiIds.size();
     }
 
     private void warnOrFix(List<String> apiIds, String apiPrimaryOwnerRoleId) throws TechnicalException {
@@ -174,12 +194,15 @@ public class ApiPrimaryOwnerRemovalUpgrader implements Upgrader, Ordered {
         return environmentRepository.findByOrganization(organizationId).stream().map(Environment::getId).collect(toList());
     }
 
-    private List<String> findApiPrimaryOwnerReferenceIds(String apiPrimaryOwnerRoleId, List<String> apiIds) throws TechnicalException {
-        return membershipRepository
+    private List<String> findCorruptedApiIds(String apiPrimaryOwnerRoleId, List<String> apiIds) throws TechnicalException {
+        List<String> apiIdWithPrimaryOwner = membershipRepository
             .findByReferencesAndRoleId(MembershipReferenceType.API, apiIds, apiPrimaryOwnerRoleId)
             .stream()
             .map(Membership::getReferenceId)
             .collect(toList());
+        List<String> corruptedApiIds = new ArrayList<>(apiIds);
+        corruptedApiIds.removeAll(apiIdWithPrimaryOwner);
+        return corruptedApiIds;
     }
 
     private Membership prepareMembership(String poRoleId) throws TechnicalException {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/ApiPrimaryOwnerRemovalUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/ApiPrimaryOwnerRemovalUpgrader.java
@@ -102,7 +102,7 @@ public class ApiPrimaryOwnerRemovalUpgrader implements Upgrader, Ordered {
     private void checkOrganization(String organizationId) throws TechnicalException {
         String apiPrimaryOwnerRoleId = findApiPrimaryOwnerRoleId(organizationId);
         List<String> environmentIds = findEnvironmentIds(organizationId);
-        List<String> apiIds = apiRepository.searchIds(new ApiCriteria.Builder().environments(environmentIds).build());
+        List<String> apiIds = apiRepository.searchIds(null, new ApiCriteria.Builder().environments(environmentIds).build());
         List<String> unCorruptedApiIds = findApiPrimaryOwnerReferenceIds(apiPrimaryOwnerRoleId, apiIds);
         if (shouldFix(apiIds, unCorruptedApiIds)) {
             ArrayList<String> corruptedApiIds = new ArrayList<>(apiIds);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_FindByUserTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_FindByUserTest.java
@@ -137,8 +137,7 @@ public class ApiService_FindByUserTest {
             .thenReturn(singletonList(api));
         List<ApiCriteria> apiCriteriaList = new ArrayList<>();
         apiCriteriaList.add(new ApiCriteria.Builder().environmentId("DEFAULT").ids("api-1").build());
-        ApiCriteria[] apiCriteria = apiCriteriaList.toArray(new ApiCriteria[apiCriteriaList.size()]);
-        when(apiRepository.searchIds(null, apiCriteria)).thenReturn(singletonList("api-1"));
+        when(apiRepository.searchIds(eq(apiCriteriaList), any(), any())).thenReturn(new Page<>(List.of("api-1"), 0, 1, 1));
 
         MembershipEntity membership = new MembershipEntity();
         membership.setId("id");
@@ -202,10 +201,7 @@ public class ApiService_FindByUserTest {
         api2.setId("api2");
         api2.setName("api2");
 
-        List<ApiCriteria> apiCriteriaList = new ArrayList<>();
-        apiCriteriaList.add(new ApiCriteria.Builder().environmentId("DEFAULT").ids(api1.getId(), api2.getId()).build());
-        ApiCriteria[] apiCriteria = apiCriteriaList.toArray(new ApiCriteria[apiCriteriaList.size()]);
-        when(apiRepository.searchIds(any(), any())).thenReturn(Arrays.asList(api2.getId(), api1.getId()));
+        when(apiRepository.searchIds(any(), any(), any())).thenReturn(new Page<>(List.of(api2.getId(), api1.getId()), 0, 2, 2));
 
         MembershipEntity membership1 = new MembershipEntity();
         membership1.setId("id1");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/FilteringServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/FilteringServiceTest.java
@@ -19,9 +19,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -33,7 +31,6 @@ import io.gravitee.rest.api.model.SubscriptionStatus;
 import io.gravitee.rest.api.model.TopApiEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.api.ApiLifecycleState;
-import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.common.GraviteeContext;
@@ -371,7 +368,12 @@ public class FilteringServiceTest {
             .findPublishedIdsByUser(eq(GraviteeContext.getExecutionContext()), eq("user-#1"));
         doReturn(List.of("api-#3"))
             .when(apiService)
-            .searchIds(eq(GraviteeContext.getExecutionContext()), eq(aQuery), eq(Map.of("api", Set.of("api-#1", "api-#2", "api-#3"))));
+            .searchIds(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(aQuery),
+                eq(Map.of("api", Set.of("api-#1", "api-#2", "api-#3"))),
+                isNull()
+            );
 
         Collection<String> searchItems = filteringService.searchApis(GraviteeContext.getExecutionContext(), "user-#1", aQuery);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/ApiPrimaryOwnerRemovalUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/ApiPrimaryOwnerRemovalUpgraderTest.java
@@ -96,7 +96,7 @@ public class ApiPrimaryOwnerRemovalUpgraderTest {
         when(roleRepository.findByScopeAndNameAndReferenceIdAndReferenceType(any(), any(), any(), any()))
             .thenReturn(Optional.of(apiPoRole()));
 
-        when(apiRepository.searchIds(any())).thenReturn(List.of("api-test"));
+        when(apiRepository.searchIds(isNull(), any())).thenReturn(List.of("api-test"));
 
         when(membershipRepository.findByReferencesAndRoleId(any(), any(), any())).thenReturn(Set.of());
 
@@ -118,7 +118,7 @@ public class ApiPrimaryOwnerRemovalUpgraderTest {
         when(roleRepository.findByScopeAndNameAndReferenceIdAndReferenceType(any(), any(), any(), any()))
             .thenReturn(Optional.of(apiPoRole()));
 
-        when(apiRepository.searchIds(any())).thenReturn(List.of("api-test"));
+        when(apiRepository.searchIds(isNull(), any())).thenReturn(List.of("api-test"));
 
         when(membershipRepository.findByReferencesAndRoleId(any(), any(), any())).thenReturn(Set.of());
 
@@ -147,7 +147,7 @@ public class ApiPrimaryOwnerRemovalUpgraderTest {
         when(roleRepository.findByScopeAndNameAndReferenceIdAndReferenceType(any(), any(), any(), any()))
             .thenReturn(Optional.of(apiPoRole()));
 
-        when(apiRepository.searchIds(any())).thenReturn(List.of("api-test"));
+        when(apiRepository.searchIds(isNull(), any())).thenReturn(List.of("api-test"));
 
         when(membershipRepository.findByReferencesAndRoleId(any(), any(), any())).thenReturn(Set.of());
 
@@ -174,7 +174,7 @@ public class ApiPrimaryOwnerRemovalUpgraderTest {
         when(roleRepository.findByScopeAndNameAndReferenceIdAndReferenceType(any(), any(), any(), any()))
             .thenReturn(Optional.of(apiPoRole()));
 
-        when(apiRepository.searchIds(any())).thenReturn(List.of("api-test"));
+        when(apiRepository.searchIds(isNull(), any())).thenReturn(List.of("api-test"));
 
         when(membershipRepository.findByReferencesAndRoleId(any(), any(), any())).thenReturn(Set.of(membership("api-test")));
 


### PR DESCRIPTION
## Issue

N/A

## Description

- implement a paginated Api#searchIds method
- use search apiIds with pageable
- remove "default searchIds" to have only one non pageable searchIds
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qqwnmxnwhq.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/refactor-searchids/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
