### PR TITLE
Refactor `searchIds` methods in `ApiService` and `ApiRepository`

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiRepository.java
@@ -33,27 +33,17 @@ import java.util.Set;
  * @author GraviteeSource Team
  */
 public interface ApiRepository extends CrudRepository<Api, String> {
-    default Page<Api> search(ApiCriteria apiCriteria, Pageable pageable) {
-        return search(apiCriteria, null, pageable, null);
-    }
-
-    default Page<Api> search(ApiCriteria apiCriteria, Sortable sortable, Pageable pageable) {
-        return search(apiCriteria, sortable, pageable, null);
-    }
-
     Page<Api> search(ApiCriteria apiCriteria, Sortable sortable, Pageable pageable, ApiFieldExclusionFilter apiFieldExclusionFilter);
 
-    List<Api> search(ApiCriteria apiCriteria);
+    default List<Api> search(ApiCriteria apiCriteria) {
+        return search(apiCriteria, ApiFieldExclusionFilter.noExclusion());
+    }
 
     List<Api> search(ApiCriteria apiCriteria, ApiFieldExclusionFilter apiFieldExclusionFilter);
 
     Set<Api> search(ApiCriteria apiCriteria, ApiFieldInclusionFilter apiFieldInclusionFilter);
 
-    default List<String> searchIds(ApiCriteria... apiCriteria) {
-        return searchIds(null, apiCriteria);
-    }
-
-    List<String> searchIds(Sortable sortable, ApiCriteria... apiCriteria);
+    Page<String> searchIds(List<ApiCriteria> apiCriteria, Pageable pageable, Sortable sortable);
 
     Set<String> listCategories(ApiCriteria apiCriteria) throws TechnicalException;
 

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/ApiFieldExclusionFilter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/ApiFieldExclusionFilter.java
@@ -23,20 +23,29 @@ import java.util.Objects;
  */
 public class ApiFieldExclusionFilter {
 
-    private final boolean definition;
-    private final boolean picture;
+    public static ApiFieldExclusionFilter noExclusion() {
+        return new ApiFieldExclusionFilter();
+    }
+
+    private final boolean definitionExcluded;
+    private final boolean pictureExcluded;
+
+    private ApiFieldExclusionFilter() {
+        this.definitionExcluded = false;
+        this.pictureExcluded = false;
+    }
 
     private ApiFieldExclusionFilter(ApiFieldExclusionFilter.Builder builder) {
-        this.definition = builder.definition;
-        this.picture = builder.picture;
+        this.definitionExcluded = builder.excludeDefinition;
+        this.pictureExcluded = builder.excludePicture;
     }
 
-    public boolean isDefinition() {
-        return definition;
+    public boolean isDefinitionExcluded() {
+        return definitionExcluded;
     }
 
-    public boolean isPicture() {
-        return picture;
+    public boolean isPictureExcluded() {
+        return pictureExcluded;
     }
 
     @Override
@@ -44,26 +53,26 @@ public class ApiFieldExclusionFilter {
         if (this == o) return true;
         if (!(o instanceof ApiFieldExclusionFilter)) return false;
         ApiFieldExclusionFilter that = (ApiFieldExclusionFilter) o;
-        return definition == that.definition && picture == that.picture;
+        return definitionExcluded == that.definitionExcluded && pictureExcluded == that.pictureExcluded;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(definition, picture);
+        return Objects.hash(definitionExcluded, pictureExcluded);
     }
 
     public static class Builder {
 
-        private boolean definition;
-        private boolean picture;
+        private boolean excludeDefinition;
+        private boolean excludePicture;
 
         public ApiFieldExclusionFilter.Builder excludeDefinition() {
-            this.definition = true;
+            this.excludeDefinition = true;
             return this;
         }
 
         public ApiFieldExclusionFilter.Builder excludePicture() {
-            this.picture = true;
+            this.excludePicture = true;
             return this;
         }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApiRepository.java
@@ -38,6 +38,11 @@ import org.springframework.stereotype.Component;
 public class HttpApiRepository extends AbstractRepository implements ApiRepository {
 
     @Override
+    public Set<Api> findAll() throws TechnicalException {
+        throw new IllegalStateException();
+    }
+
+    @Override
     public Optional<Api> findById(String apiId) throws TechnicalException {
         return blockingGet(get("/apis/" + apiId, BodyCodecs.optional(Api.class)).send()).payload();
     }
@@ -77,8 +82,8 @@ public class HttpApiRepository extends AbstractRepository implements ApiReposito
         try {
             return blockingGet(
                 get("/apis", BodyCodecs.list(Api.class))
-                    .addQueryParam("excludeDefinition", Boolean.toString(apiFieldExclusionFilter.isDefinition()))
-                    .addQueryParam("excludePicture", Boolean.toString(apiFieldExclusionFilter.isPicture()))
+                    .addQueryParam("excludeDefinition", Boolean.toString(apiFieldExclusionFilter.isDefinitionExcluded()))
+                    .addQueryParam("excludePicture", Boolean.toString(apiFieldExclusionFilter.isPictureExcluded()))
                     .send()
             )
                 .payload();
@@ -89,17 +94,12 @@ public class HttpApiRepository extends AbstractRepository implements ApiReposito
     }
 
     @Override
-    public List<String> searchIds(Sortable sortable, ApiCriteria... apiCriteria) {
-        throw new IllegalStateException();
-    }
-
-    @Override
-    public Set<Api> findAll() throws TechnicalException {
-        throw new IllegalStateException();
-    }
-
-    @Override
     public Set<Api> search(ApiCriteria apiCriteria, ApiFieldInclusionFilter apiFieldInclusionFilter) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public Page<String> searchIds(List<ApiCriteria> apiCriteria, Pageable pageable, Sortable sortable) {
         throw new IllegalStateException();
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAbstractPageableRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAbstractPageableRepository.java
@@ -33,7 +33,7 @@ abstract class JdbcAbstractPageableRepository<T> extends JdbcAbstractRepository<
         super(prefix, tableName);
     }
 
-    Page<T> getResultAsPage(final Pageable page, final List<T> items) {
+    <U> Page<U> getResultAsPage(final Pageable page, final List<U> items) {
         if (page != null) {
             LOGGER.debug("Getting results as page {} for {}", page, items);
             int start = page.from();

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiRepository.java
@@ -50,6 +50,11 @@ public class MongoApiRepository implements ApiRepository {
     private GraviteeMapper mapper;
 
     @Override
+    public Set<Api> findAll() throws TechnicalException {
+        return internalApiRepo.findAll().stream().map(this::mapApi).collect(Collectors.toSet());
+    }
+
+    @Override
     public Optional<Api> findById(String apiId) throws TechnicalException {
         ApiMongo apiMongo = internalApiRepo.findById(apiId).orElse(null);
         return Optional.ofNullable(mapApi(apiMongo));
@@ -95,46 +100,9 @@ public class MongoApiRepository implements ApiRepository {
     }
 
     @Override
-    public List<Api> search(ApiCriteria apiCriteria) {
-        return findByCriteria(apiCriteria, null);
-    }
-
-    @Override
     public List<Api> search(ApiCriteria apiCriteria, ApiFieldExclusionFilter apiFieldExclusionFilter) {
-        return findByCriteria(apiCriteria, apiFieldExclusionFilter);
-    }
-
-    @Override
-    public List<String> searchIds(ApiCriteria... apiCriteria) {
-        return internalApiRepo.searchIds(null, apiCriteria);
-    }
-
-    @Override
-    public List<String> searchIds(Sortable sortable, ApiCriteria... apiCriteria) {
-        return internalApiRepo.searchIds(sortable, apiCriteria);
-    }
-
-    @Override
-    public Set<String> listCategories(ApiCriteria apiCriteria) {
-        return internalApiRepo.listCategories(apiCriteria);
-    }
-
-    private List<Api> findByCriteria(ApiCriteria apiCriteria, ApiFieldExclusionFilter apiFieldExclusionFilter) {
         final Page<ApiMongo> apisMongo = internalApiRepo.search(apiCriteria, null, null, apiFieldExclusionFilter);
         return mapper.collection2list(apisMongo.getContent(), ApiMongo.class, Api.class);
-    }
-
-    private ApiMongo mapApi(Api api) {
-        return (api == null) ? null : mapper.map(api, ApiMongo.class);
-    }
-
-    private Api mapApi(ApiMongo apiMongo) {
-        return (apiMongo == null) ? null : mapper.map(apiMongo, Api.class);
-    }
-
-    @Override
-    public Set<Api> findAll() throws TechnicalException {
-        return internalApiRepo.findAll().stream().map(this::mapApi).collect(Collectors.toSet());
     }
 
     @Override
@@ -143,7 +111,25 @@ public class MongoApiRepository implements ApiRepository {
     }
 
     @Override
+    public Page<String> searchIds(List<ApiCriteria> apiCriteria, Pageable pageable, Sortable sortable) {
+        return internalApiRepo.searchIds(apiCriteria, pageable, sortable);
+    }
+
+    @Override
+    public Set<String> listCategories(ApiCriteria apiCriteria) {
+        return internalApiRepo.listCategories(apiCriteria);
+    }
+
+    @Override
     public Optional<Api> findByEnvironmentIdAndCrossId(String environmentId, String crossId) throws TechnicalException {
         return internalApiRepo.findByEnvironmentIdAndCrossId(environmentId, crossId).map(this::mapApi);
+    }
+
+    private ApiMongo mapApi(Api api) {
+        return (api == null) ? null : mapper.map(api, ApiMongo.class);
+    }
+
+    private Api mapApi(ApiMongo apiMongo) {
+        return (apiMongo == null) ? null : mapper.map(apiMongo, Api.class);
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryCustom.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryCustom.java
@@ -34,7 +34,15 @@ public interface ApiMongoRepositoryCustom {
 
     List<ApiMongo> search(ApiCriteria criteria, ApiFieldInclusionFilter apiFieldInclusionFilter);
 
-    List<String> searchIds(Sortable sortable, ApiCriteria... apiCriteria);
+    /**
+     * Find ids of APIs matching the given criteria.
+     *
+     * @param apiCriteria the search criteria
+     * @param pageable    the pagination criteria
+     * @param sortable    the sort criteria
+     * @return the list of matching APIs' ids
+     */
+    Page<String> searchIds(List<ApiCriteria> apiCriteria, Pageable pageable, Sortable sortable);
 
     Set<String> listCategories(ApiCriteria apiCriteria);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/api-tests/apis.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/api-tests/apis.json
@@ -7,7 +7,7 @@
     "definition" : "{\"id\" : \"product\",\"name\" : \"Product\",\"version\" : \"1\",\"proxy\" : {  \"context_path\" : \"/product\",  \"endpoint\" : \"http://toto.com\",  \"endpoints\" : [ {    \"target\" : \"http://toto.com\",    \"weight\" : 1,    \"name\" : \"endpointName\"  } ],  \"strip_context_path\" : false,  \"http\" : {    \"configuration\" : {      \"connectTimeout\" : 5000,      \"idleTimeout\" : 60000,      \"keepAlive\" : true,      \"dumpRequest\" : false    }  }},\"paths\" : {  \"/\" : [ {    \"methods\" : [ ],    \"api-key\" : {}  } ]},\"tags\" : [ ]\n}",
     "visibility" : "PRIVATE",
     "createdAt": 1439022010883,
-    "updatedAt": 1439022010883,
+    "updatedAt": 1439022010893,
     "lifecycleState": "STOPPED",
     "apiLifecycleState": "UNPUBLISHED",
     "disableMembershipNotifications": true
@@ -20,7 +20,7 @@
     "definition" : "{\"id\" : \"product\",\"name\" : \"Product\",\"version\" : \"1\",\"proxy\" : {  \"context_path\" : \"/product\",  \"endpoint\" : \"http://toto.com\",  \"endpoints\" : [ {    \"target\" : \"http://toto.com\",    \"weight\" : 1,    \"name\" : \"endpointName\"  } ],  \"strip_context_path\" : false,  \"http\" : {    \"configuration\" : {      \"connectTimeout\" : 5000,      \"idleTimeout\" : 60000,      \"keepAlive\" : true,      \"dumpRequest\" : false    }  }},\"paths\" : {  \"/\" : [ {    \"methods\" : [ ],    \"api-key\" : {}  } ]},\"tags\" : [ ]\n}",
     "visibility" : "PRIVATE",
     "createdAt": 1439022010883,
-    "updatedAt": 1439022010883,
+    "updatedAt": 1439022010983,
     "lifecycleState": "STOPPED",
     "apiLifecycleState": "PUBLISHED",
     "disableMembershipNotifications": true

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/AbstractResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/AbstractResource.java
@@ -24,6 +24,7 @@ import io.gravitee.rest.api.model.MembershipEntity;
 import io.gravitee.rest.api.model.RoleEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.api.ApiQuery;
+import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.permissions.RoleScope;
@@ -176,28 +177,29 @@ public abstract class AbstractResource {
         if (!isAdmin()) {
             // get memberships of the current user
             List<MembershipEntity> memberships = retrieveApiMembership().collect(Collectors.toList());
+
+            // if the current user is member of the API, continue
+            Optional<MembershipEntity> directMembershipEntity = memberships
+                .stream()
+                .filter(m -> API.equals(m.getReferenceType()))
+                .findAny();
+
+            if (directMembershipEntity.isPresent()) {
+                return;
+            }
+
+            // fetch group memberships
             Set<String> groups = memberships
                 .stream()
                 .filter(m -> GROUP.equals(m.getReferenceType()))
                 .map(m -> m.getReferenceId())
                 .collect(Collectors.toSet());
-            Set<String> directMembers = memberships
-                .stream()
-                .filter(m -> API.equals(m.getReferenceType()))
-                .map(m -> m.getReferenceId())
-                .collect(Collectors.toSet());
 
-            // if the current user is member of the API, continue
-            if (directMembers.contains(api)) {
-                return;
-            }
-
-            // fetch group memberships
             final ApiQuery apiQuery = new ApiQuery();
             apiQuery.setGroups(new ArrayList<>(groups));
             apiQuery.setIds(Collections.singletonList(api));
-            final Collection<String> strings = apiService.searchIds(executionContext, apiQuery);
-            final boolean canReadAPI = strings.contains(api);
+            final Collection<String> ids = apiService.searchIds(executionContext, apiQuery, new PageableImpl(1, 1), null).getContent();
+            final boolean canReadAPI = ids != null && ids.contains(api);
             if (!canReadAPI) {
                 throw new ForbiddenAccessException();
             }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentAnalyticsResource.java
@@ -37,6 +37,9 @@ import io.gravitee.rest.api.model.analytics.query.StatsQuery;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.api.ApiQuery;
 import io.gravitee.rest.api.model.application.ApplicationQuery;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.model.common.SortableImpl;
 import io.gravitee.rest.api.service.AnalyticsService;
 import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.ApplicationService;
@@ -145,7 +148,12 @@ public class EnvironmentAnalyticsResource extends AbstractResource {
         switch (analyticsParam.getField()) {
             case API_FIELD:
                 if (isAdmin()) {
-                    return buildCountStat(apiService.searchIds(executionContext, new ApiQuery()).size());
+                    return buildCountStat(
+                        // FIXME: This should use a count method instead of a search one
+                        apiService
+                            .searchIds(executionContext, new ApiQuery(), new PageableImpl(1, Integer.MAX_VALUE), null)
+                            .getTotalElements()
+                    );
                 } else {
                     return buildCountStat(apiService.findIdsByUser(executionContext, getAuthenticatedUser(), new ApiQuery(), false).size());
                 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiRepositoryProxy.java
@@ -68,11 +68,6 @@ public class ApiRepositoryProxy extends AbstractProxy<ApiRepository> implements 
     }
 
     @Override
-    public Page<Api> search(ApiCriteria apiCriteria, Pageable pageable) {
-        return target.search(apiCriteria, pageable);
-    }
-
-    @Override
     public List<Api> search(ApiCriteria apiCriteria) {
         return target.search(apiCriteria);
     }
@@ -83,13 +78,8 @@ public class ApiRepositoryProxy extends AbstractProxy<ApiRepository> implements 
     }
 
     @Override
-    public List<String> searchIds(ApiCriteria... apiCriteria) {
-        return target.searchIds(apiCriteria);
-    }
-
-    @Override
-    public List<String> searchIds(Sortable sortable, ApiCriteria... apiCriteria) {
-        return target.searchIds(sortable, apiCriteria);
+    public Page<String> searchIds(List<ApiCriteria> apiCriteria, Pageable pageable, Sortable sortable) {
+        return target.searchIds(apiCriteria, pageable, sortable);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
@@ -18,7 +18,6 @@ package io.gravitee.rest.api.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.definition.model.DefinitionVersion;
-import io.gravitee.definition.model.Plan;
 import io.gravitee.definition.model.Rule;
 import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.repository.exceptions.TechnicalException;
@@ -166,12 +165,7 @@ public interface ApiService {
 
     Collection<ApiEntity> search(ExecutionContext executionContext, ApiQuery query);
 
-    Collection<String> searchIds(ExecutionContext executionContext, ApiQuery query);
-
-    default Collection<String> searchIds(ExecutionContext executionContext, String query, Map<String, Object> filters)
-        throws TechnicalException {
-        return searchIds(executionContext, query, filters, null);
-    }
+    Page<String> searchIds(ExecutionContext executionContext, ApiQuery query, Pageable pageable, Sortable sortable);
 
     Collection<String> searchIds(ExecutionContext executionContext, String query, Map<String, Object> filters, Sortable sortable)
         throws TechnicalException;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TaskServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TaskServiceImpl.java
@@ -31,12 +31,10 @@ import io.gravitee.repository.management.api.search.UserCriteria;
 import io.gravitee.repository.management.model.*;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.MembershipMemberType;
-import io.gravitee.rest.api.model.MembershipReferenceType;
-import io.gravitee.rest.api.model.api.ApiQuery;
 import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.model.common.SortableImpl;
 import io.gravitee.rest.api.model.pagedresult.Metadata;
 import io.gravitee.rest.api.model.permissions.RoleScope;
-import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.common.ExecutionContext;
@@ -44,8 +42,6 @@ import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.exceptions.UnauthorizedAccessException;
 import io.gravitee.rest.api.service.promotion.PromotionTasksService;
 import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -98,12 +94,13 @@ public class TaskServiceImpl extends AbstractService implements TaskService {
         }
 
         try {
+            List<MembershipAndPermissions> userMembershipsAndPermissions = getUserMembershipsAndPermissions(userId);
+
             // because Tasks only consists on subscriptions, we can optimize the search by only look for apis where
             // the user has a SUBSCRIPTION_UPDATE permission
 
             // search for PENDING subscriptions
-
-            Set<String> apiIds = getApisForAPermission(executionContext, userId, SUBSCRIPTION.getName());
+            Set<String> apiIds = getApisForAPermission(executionContext, userMembershipsAndPermissions, SUBSCRIPTION.getName());
             final List<TaskEntity> tasks;
             if (apiIds.isEmpty()) {
                 tasks = new ArrayList<>();
@@ -127,7 +124,7 @@ public class TaskServiceImpl extends AbstractService implements TaskService {
             }
 
             // search for IN_REVIEW apis
-            apiIds = getApisForAPermission(executionContext, userId, REVIEWS.getName());
+            apiIds = getApisForAPermission(executionContext, userMembershipsAndPermissions, REVIEWS.getName());
             if (!apiIds.isEmpty()) {
                 apiIds.forEach(
                     apiId -> {
@@ -143,7 +140,7 @@ public class TaskServiceImpl extends AbstractService implements TaskService {
             }
 
             // search for REQUEST_FOR_CHANGES apis
-            apiIds = getApisForAPermission(executionContext, userId, DEFINITION.getName());
+            apiIds = getApisForAPermission(executionContext, userMembershipsAndPermissions, DEFINITION.getName());
             if (!apiIds.isEmpty()) {
                 apiIds.forEach(
                     apiId -> {
@@ -168,8 +165,7 @@ public class TaskServiceImpl extends AbstractService implements TaskService {
         }
     }
 
-    private Set<String> getApisForAPermission(ExecutionContext executionContext, final String userId, final String permission)
-        throws TechnicalException {
+    private List<MembershipAndPermissions> getUserMembershipsAndPermissions(final String userId) {
         // 1. find apis and group memberships
 
         Set<MembershipEntity> memberships = membershipService.getMembershipsByMemberAndReference(
@@ -186,32 +182,40 @@ public class TaskServiceImpl extends AbstractService implements TaskService {
             )
         );
 
-        Map<String, RoleEntity> roleNameToEntity = new HashMap<>();
-        Set<String> apiIds = new HashSet<>();
-        List<String> groupIds = new ArrayList<>();
+        List<MembershipAndPermissions> userMembershipAndPermissions = new ArrayList<>();
 
         for (MembershipEntity membership : memberships) {
             // 2. get API roles in each memberships and search for roleEntity only once
-            RoleEntity roleEntity = roleNameToEntity.get(membership.getRoleId());
-            if (roleEntity == null && !roleNameToEntity.containsKey(membership.getRoleId())) {
-                RoleEntity role = roleService.findById(membership.getRoleId());
-                if (role.getScope() == RoleScope.API) {
-                    roleNameToEntity.put(role.getId(), role);
-                    roleEntity = role;
-                }
+            RoleEntity role = roleService.findById(membership.getRoleId());
+            if (role.getScope() == RoleScope.API) {
+                userMembershipAndPermissions.add(new MembershipAndPermissions(membership, role.getPermissions()));
             }
-            if (roleEntity != null) {
+        }
+
+        return userMembershipAndPermissions;
+    }
+
+    private Set<String> getApisForAPermission(
+        ExecutionContext executionContext,
+        List<MembershipAndPermissions> membershipsAndPermissions,
+        final String permission
+    ) throws TechnicalException {
+        Set<String> apiIds = new HashSet<>();
+        List<String> groupIds = new ArrayList<>();
+
+        for (MembershipAndPermissions membershipAndPermissions : membershipsAndPermissions) {
+            if (membershipAndPermissions != null) {
                 // 3. get apiId or groupId only if the role has a given permission
-                final char[] rights = roleEntity.getPermissions().get(permission);
+                final char[] rights = membershipAndPermissions.permission.get(permission);
                 if (rights != null) {
                     for (char c : rights) {
                         if (c == 'U') {
-                            switch (membership.getReferenceType()) {
+                            switch (membershipAndPermissions.membership.getReferenceType()) {
                                 case GROUP:
-                                    groupIds.add(membership.getReferenceId());
+                                    groupIds.add(membershipAndPermissions.membership.getReferenceId());
                                     break;
                                 case API:
-                                    apiIds.add(membership.getReferenceId());
+                                    apiIds.add(membershipAndPermissions.membership.getReferenceId());
                                     break;
                                 default:
                                     break;
@@ -221,13 +225,14 @@ public class TaskServiceImpl extends AbstractService implements TaskService {
                 }
             }
         }
+
+        List<ApiCriteria> apiCriteriaList = new ArrayList<>();
         // 54. add apiId that comes from group
         if (!groupIds.isEmpty()) {
             ApiCriteria criteria = new ApiCriteria.Builder().groups(groupIds).build();
 
-            apiIds.addAll(apiRepository.searchIds(criteria));
+            apiCriteriaList.add(criteria);
         }
-
         if (isEnvironmentAdmin()) {
             List<String> environmentIds = environmentService
                 .findByOrganization(executionContext.getOrganizationId())
@@ -237,8 +242,13 @@ public class TaskServiceImpl extends AbstractService implements TaskService {
 
             ApiCriteria criteria = new ApiCriteria.Builder().environments(environmentIds).build();
 
-            apiIds.addAll(apiRepository.searchIds(criteria));
+            apiCriteriaList.add(criteria);
         }
+
+        // NOTE: Explicitly set the page size to MAX
+        // If we want to improve performance, we need to change the way we retrieve tasks
+        // ex: use a dedicated repository & collection to retrieve tasks
+        apiIds.addAll(apiRepository.searchIds(apiCriteriaList, convert(new PageableImpl(1, Integer.MAX_VALUE)), null).getContent());
 
         return apiIds;
     }
@@ -343,5 +353,16 @@ public class TaskServiceImpl extends AbstractService implements TaskService {
             throw new TechnicalManagementException(error, e);
         }
         return taskEntity;
+    }
+
+    private class MembershipAndPermissions {
+
+        public MembershipEntity membership;
+        public Map<String, char[]> permission;
+
+        MembershipAndPermissions(MembershipEntity membership, Map<String, char[]> permission) {
+            this.membership = membership;
+            this.permission = permission;
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/filtering/FilteringServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/filtering/FilteringServiceImpl.java
@@ -22,7 +22,6 @@ import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.model.SubscriptionStatus;
 import io.gravitee.rest.api.model.TopApiEntity;
 import io.gravitee.rest.api.model.api.ApiQuery;
-import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.common.ExecutionContext;
@@ -151,7 +150,7 @@ public class FilteringServiceImpl extends AbstractService implements FilteringSe
         Map<String, Object> filters = new HashMap<>();
         filters.put("api", apis);
 
-        return apiService.searchIds(executionContext, query, filters);
+        return apiService.searchIds(executionContext, query, filters, null);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/ApiPrimaryOwnerRemovalUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/ApiPrimaryOwnerRemovalUpgrader.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.service.impl.upgrade;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.*;
 
+import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.EnvironmentRepository;
@@ -27,7 +28,14 @@ import io.gravitee.repository.management.api.OrganizationRepository;
 import io.gravitee.repository.management.api.RoleRepository;
 import io.gravitee.repository.management.api.UserRepository;
 import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.api.search.Order;
+import io.gravitee.repository.management.api.search.Pageable;
+import io.gravitee.repository.management.api.search.Sortable;
+import io.gravitee.repository.management.api.search.builder.PageableBuilder;
+import io.gravitee.repository.management.api.search.builder.SortableBuilder;
 import io.gravitee.repository.management.model.*;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.model.common.SortableImpl;
 import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.service.Upgrader;
 import io.gravitee.rest.api.service.common.UuidString;
@@ -102,17 +110,29 @@ public class ApiPrimaryOwnerRemovalUpgrader implements Upgrader, Ordered {
     private void checkOrganization(String organizationId) throws TechnicalException {
         String apiPrimaryOwnerRoleId = findApiPrimaryOwnerRoleId(organizationId);
         List<String> environmentIds = findEnvironmentIds(organizationId);
-        List<String> apiIds = apiRepository.searchIds(new ApiCriteria.Builder().environments(environmentIds).build());
-        List<String> unCorruptedApiIds = findApiPrimaryOwnerReferenceIds(apiPrimaryOwnerRoleId, apiIds);
-        if (shouldFix(apiIds, unCorruptedApiIds)) {
-            ArrayList<String> corruptedApiIds = new ArrayList<>(apiIds);
-            corruptedApiIds.removeAll(unCorruptedApiIds);
+        ArrayList<String> corruptedApiIds = new ArrayList<>();
+
+        int page = 0;
+        int size = 100;
+        Pageable pageable = new PageableBuilder().pageNumber(page).pageNumber(size).build();
+        Sortable sortable = new SortableBuilder().field("updated_at").order(Order.DESC).build();
+
+        List<String> apiIds = apiRepository
+            .searchIds(List.of(new ApiCriteria.Builder().environments(environmentIds).build()), pageable, sortable)
+            .getContent();
+
+        while (!apiIds.isEmpty()) {
+            corruptedApiIds.addAll(findCorruptedApiIds(apiPrimaryOwnerRoleId, apiIds));
+            pageable = new PageableBuilder().pageNumber(page++).pageNumber(size).build();
+            apiIds =
+                apiRepository
+                    .searchIds(List.of(new ApiCriteria.Builder().environments(environmentIds).build()), pageable, sortable)
+                    .getContent();
+        }
+
+        if (!corruptedApiIds.isEmpty()) {
             warnOrFix(corruptedApiIds, apiPrimaryOwnerRoleId);
         }
-    }
-
-    private boolean shouldFix(List<String> apiIds, List<String> unCorruptedApiIds) {
-        return apiIds.size() > unCorruptedApiIds.size();
     }
 
     private void warnOrFix(List<String> apiIds, String apiPrimaryOwnerRoleId) throws TechnicalException {
@@ -174,12 +194,15 @@ public class ApiPrimaryOwnerRemovalUpgrader implements Upgrader, Ordered {
         return environmentRepository.findByOrganization(organizationId).stream().map(Environment::getId).collect(toList());
     }
 
-    private List<String> findApiPrimaryOwnerReferenceIds(String apiPrimaryOwnerRoleId, List<String> apiIds) throws TechnicalException {
-        return membershipRepository
+    private List<String> findCorruptedApiIds(String apiPrimaryOwnerRoleId, List<String> apiIds) throws TechnicalException {
+        List<String> apiIdWithPrimaryOwner = membershipRepository
             .findByReferencesAndRoleId(MembershipReferenceType.API, apiIds, apiPrimaryOwnerRoleId)
             .stream()
             .map(Membership::getReferenceId)
             .collect(toList());
+        List<String> corruptedApiIds = new ArrayList<>(apiIds);
+        corruptedApiIds.removeAll(apiIdWithPrimaryOwner);
+        return corruptedApiIds;
     }
 
     private Membership prepareMembership(String poRoleId) throws TechnicalException {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_FindByUserTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_FindByUserTest.java
@@ -137,8 +137,7 @@ public class ApiService_FindByUserTest {
             .thenReturn(singletonList(api));
         List<ApiCriteria> apiCriteriaList = new ArrayList<>();
         apiCriteriaList.add(new ApiCriteria.Builder().environmentId("DEFAULT").ids("api-1").build());
-        ApiCriteria[] apiCriteria = apiCriteriaList.toArray(new ApiCriteria[apiCriteriaList.size()]);
-        when(apiRepository.searchIds(null, apiCriteria)).thenReturn(singletonList("api-1"));
+        when(apiRepository.searchIds(eq(apiCriteriaList), any(), any())).thenReturn(new Page<>(List.of("api-1"), 0, 1, 1));
 
         MembershipEntity membership = new MembershipEntity();
         membership.setId("id");
@@ -202,10 +201,7 @@ public class ApiService_FindByUserTest {
         api2.setId("api2");
         api2.setName("api2");
 
-        List<ApiCriteria> apiCriteriaList = new ArrayList<>();
-        apiCriteriaList.add(new ApiCriteria.Builder().environmentId("DEFAULT").ids(api1.getId(), api2.getId()).build());
-        ApiCriteria[] apiCriteria = apiCriteriaList.toArray(new ApiCriteria[apiCriteriaList.size()]);
-        when(apiRepository.searchIds(any(), any())).thenReturn(Arrays.asList(api2.getId(), api1.getId()));
+        when(apiRepository.searchIds(any(), any(), any())).thenReturn(new Page<>(List.of(api2.getId(), api1.getId()), 0, 2, 2));
 
         MembershipEntity membership1 = new MembershipEntity();
         membership1.setId("id1");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/FilteringServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/FilteringServiceTest.java
@@ -19,9 +19,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -33,7 +31,6 @@ import io.gravitee.rest.api.model.SubscriptionStatus;
 import io.gravitee.rest.api.model.TopApiEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.api.ApiLifecycleState;
-import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.common.GraviteeContext;
@@ -371,7 +368,12 @@ public class FilteringServiceTest {
             .findPublishedIdsByUser(eq(GraviteeContext.getExecutionContext()), eq("user-#1"));
         doReturn(List.of("api-#3"))
             .when(apiService)
-            .searchIds(eq(GraviteeContext.getExecutionContext()), eq(aQuery), eq(Map.of("api", Set.of("api-#1", "api-#2", "api-#3"))));
+            .searchIds(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(aQuery),
+                eq(Map.of("api", Set.of("api-#1", "api-#2", "api-#3"))),
+                isNull()
+            );
 
         Collection<String> searchItems = filteringService.searchApis(GraviteeContext.getExecutionContext(), "user-#1", aQuery);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/ApiPrimaryOwnerRemovalUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/ApiPrimaryOwnerRemovalUpgraderTest.java
@@ -22,9 +22,14 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
+import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.*;
+import io.gravitee.repository.management.api.search.Pageable;
+import io.gravitee.repository.management.api.search.Sortable;
+import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.model.*;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -96,7 +101,12 @@ public class ApiPrimaryOwnerRemovalUpgraderTest {
         when(roleRepository.findByScopeAndNameAndReferenceIdAndReferenceType(any(), any(), any(), any()))
             .thenReturn(Optional.of(apiPoRole()));
 
-        when(apiRepository.searchIds(any())).thenReturn(List.of("api-test"));
+        when(apiRepository.searchIds(anyList(), any(Pageable.class), any(Sortable.class)))
+            .thenReturn(
+                new Page<>(List.of("api-test"), 0, 1, 2),
+                new Page<>(List.of("api-test-2"), 1, 1, 2),
+                new Page<>(Collections.emptyList(), 2, 0, 2)
+            );
 
         when(membershipRepository.findByReferencesAndRoleId(any(), any(), any())).thenReturn(Set.of());
 
@@ -105,7 +115,8 @@ public class ApiPrimaryOwnerRemovalUpgraderTest {
         assertThat(success).isTrue();
 
         verify(appender, times(1)).doAppend(argThat(event -> Level.WARN == event.getLevel() && "api-test".equals(event.getMessage())));
-
+        verify(appender, times(1)).doAppend(argThat(event -> Level.WARN == event.getLevel() && "api-test-2".equals(event.getMessage())));
+        verify(apiRepository, times(3)).searchIds(anyList(), any(Pageable.class), any(Sortable.class));
         verify(membershipRepository, never()).create(any());
     }
 
@@ -118,7 +129,12 @@ public class ApiPrimaryOwnerRemovalUpgraderTest {
         when(roleRepository.findByScopeAndNameAndReferenceIdAndReferenceType(any(), any(), any(), any()))
             .thenReturn(Optional.of(apiPoRole()));
 
-        when(apiRepository.searchIds(any())).thenReturn(List.of("api-test"));
+        when(apiRepository.searchIds(anyList(), any(Pageable.class), any(Sortable.class)))
+            .thenReturn(
+                new Page<>(List.of("api-test"), 0, 1, 2),
+                new Page<>(List.of("api-test-2"), 1, 1, 2),
+                new Page<>(Collections.emptyList(), 2, 0, 2)
+            );
 
         when(membershipRepository.findByReferencesAndRoleId(any(), any(), any())).thenReturn(Set.of());
 
@@ -129,8 +145,9 @@ public class ApiPrimaryOwnerRemovalUpgraderTest {
         assertThat(success).isTrue();
 
         verify(appender, times(1)).doAppend(argThat(event -> Level.WARN == event.getLevel() && "api-test".equals(event.getMessage())));
+        verify(appender, times(1)).doAppend(argThat(event -> Level.WARN == event.getLevel() && "api-test-2".equals(event.getMessage())));
 
-        verify(membershipRepository, times(1))
+        verify(membershipRepository, times(2))
             .create(
                 argThat(
                     membership -> membership.getMemberType() == MembershipMemberType.USER && membership.getRoleId().equals(API_PO_ROLE_ID)
@@ -147,7 +164,8 @@ public class ApiPrimaryOwnerRemovalUpgraderTest {
         when(roleRepository.findByScopeAndNameAndReferenceIdAndReferenceType(any(), any(), any(), any()))
             .thenReturn(Optional.of(apiPoRole()));
 
-        when(apiRepository.searchIds(any())).thenReturn(List.of("api-test"));
+        when(apiRepository.searchIds(anyList(), any(Pageable.class), any(Sortable.class)))
+            .thenReturn(new Page<>(List.of("api-test"), 0, 1, 1), new Page<>(Collections.emptyList(), 1, 0, 1));
 
         when(membershipRepository.findByReferencesAndRoleId(any(), any(), any())).thenReturn(Set.of());
 
@@ -174,9 +192,15 @@ public class ApiPrimaryOwnerRemovalUpgraderTest {
         when(roleRepository.findByScopeAndNameAndReferenceIdAndReferenceType(any(), any(), any(), any()))
             .thenReturn(Optional.of(apiPoRole()));
 
-        when(apiRepository.searchIds(any())).thenReturn(List.of("api-test"));
+        when(apiRepository.searchIds(anyList(), any(Pageable.class), any(Sortable.class)))
+            .thenReturn(
+                new Page<>(List.of("api-test"), 0, 1, 2),
+                new Page<>(List.of("api-test-2"), 1, 1, 2),
+                new Page<>(Collections.emptyList(), 2, 0, 2)
+            );
 
-        when(membershipRepository.findByReferencesAndRoleId(any(), any(), any())).thenReturn(Set.of(membership("api-test")));
+        when(membershipRepository.findByReferencesAndRoleId(any(), any(), any()))
+            .thenReturn(Set.of(membership("api-test")), Set.of(membership("api-test-2")));
 
         boolean success = upgrader.upgrade();
 


### PR DESCRIPTION
## Issue

NA

## Description

This (1st) PR aims to refactor some of the code used to search API. 

So, it implements a paginated Api#searchIds method and replaces it with the non-paginated one. 
We faced 3 different use cases: 
 - The pagination parameters were there but the pagination was in memory -> no pb, we replaced the call with the new method
 - The code was intentionally listing all the Ids to apply a process on all the APIs (for instance in an Upgrader) -> we modified the code to process APIs in bulk 
 - The code contains pagination but only at the resource level -> we hardcoded a call to paginated search with `Integer.MAX_VALUE` as page size, this is temporary and we will be reworked in the next PR

Notes: commits will be squashed before merging the PR

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/refactor-searchids-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wadnwdighk.chromatic.com)
<!-- Storybook placeholder end -->
