### PR TITLE
[CI] Send slack message when changelog PR is ready

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1743,6 +1743,9 @@ jobs:
         - keeper/env-export:
             secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
             var-name: GITHUB_TOKEN
+        - keeper/env-export:
+              secret-url: keeper://ZOz4db245GNaETVwmPBk8w/field/password
+              var-name: SLACK_ACCESS_TOKEN
         - add_ssh_keys:
             fingerprints:
               - "ac:88:23:8f:c6:0f:7d:f0:fc:df:73:20:34:56:02:6c"
@@ -1760,6 +1763,29 @@ jobs:
             name: "Open a PR to create release notes into docs repository"
             working_directory: "./release"
             command: npm run zx -- ci-steps/doc-new-release-notes.mjs --version=${VERSION}
+        - when:
+              condition:
+                  not: << pipeline.parameters.dry_run>>
+              steps:
+                  - run:
+                        name: Get RELEASE_NOTES_PR_URL
+                        command: |
+                            echo "export RELEASE_NOTES_PR_URL=$(cat /tmp/releaseNotesPrUrl.txt)" >> $BASH_ENV
+                  - slack/notify:
+                        channel: C02NGT20S4W
+                        event: always
+                        custom: |
+                            {
+                              "blocks": [
+                                {
+                                  "type": "section",
+                                  "text": {
+                                    "type": "mrkdwn",
+                                    "text": ":memo: APIM Changelog << pipeline.parameters.graviteeio_version >> can be completed <${RELEASE_NOTES_PR_URL}|here> @tech_writers_team :pray:"
+                                  }
+                                }
+                              ]
+                            }
 
 workflows:
     pull_requests:

--- a/release/ci-steps/doc-new-release-notes.mjs
+++ b/release/ci-steps/doc-new-release-notes.mjs
@@ -139,4 +139,6 @@ ${allFixCommits.stdout}
 echo(chalk.blue('# Create PR on Github Doc repository'));
 echo(prBody);
 process.env.PR_BODY = prBody;
-$`gh pr create --title "[APIM] Add changelog for new ${releasingVersion} release" --body "$PR_BODY" --base master --head ${gitBranch}`;
+
+const releaseNotesPrUrl = await $`gh pr create --title "[APIM] Add changelog for new ${releasingVersion} release" --body "$PR_BODY" --base master --head ${gitBranch}`;
+$`echo ${releaseNotesPrUrl.stdout} > /tmp/releaseNotesPrUrl.txt`;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-367

## Description

Send slack message with new PR link

## Additional context
<img width="530" alt="image" src="https://user-images.githubusercontent.com/4974420/205890295-5a4f0ad7-7a91-43bc-bf26-1d5eb7c0a47a.png">

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/ci-changelog-slack/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ybvwfqguaa.chromatic.com)
<!-- Storybook placeholder end -->
