### PR TITLE
[api] Refactor countPublishedByUserGroupedByCategories

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/CategoryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/CategoryService.java
@@ -40,7 +40,6 @@ public interface CategoryService {
     List<CategoryEntity> update(ExecutionContext executionContext, List<UpdateCategoryEntity> categories);
     void delete(ExecutionContext executionContext, String categoryId);
     long getTotalApisByCategory(Set<ApiEntity> apis, CategoryEntity category);
-    long getTotalApisByCategoryId(Set<Api> apis, String categoryId);
     InlinePictureEntity getPicture(final String environmentId, String categoryId);
     InlinePictureEntity getBackground(final String environmentId, String categoryId);
     List<CategoryEntity> findByPage(String pageId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/CategoryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/CategoryServiceImpl.java
@@ -361,9 +361,4 @@ public class CategoryServiceImpl extends TransactionalService implements Categor
     public long getTotalApisByCategory(Set<ApiEntity> apis, CategoryEntity category) {
         return apis.stream().filter(api -> api.getCategories() != null && api.getCategories().contains(category.getKey())).count();
     }
-
-    @Override
-    public long getTotalApisByCategoryId(Set<Api> apis, String categoryId) {
-        return apis.stream().filter(api -> api.getCategories() != null && api.getCategories().contains(categoryId)).count();
-    }
 }


### PR DESCRIPTION
## Issue

na

## Description

Reduce api search query to two
- one to search all api ids with multiple criteria
- search api with ids found before

Then group by category and count api on each

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/refactor-categories/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ecuwifyqha.chromatic.com)
<!-- Storybook placeholder end -->
