### PR TITLE
fix-missing-qos-requirement-websocket

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-websocket/src/main/java/io/gravitee/plugin/entrypoint/websocket/WebSocketEntrypointConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-websocket/src/main/java/io/gravitee/plugin/entrypoint/websocket/WebSocketEntrypointConnector.java
@@ -63,6 +63,7 @@ public class WebSocketEntrypointConnector extends EntrypointAsyncConnector {
         if (qos == Qos.AUTO) {
             qosRequirementBuilder.capabilities(Set.of(QosCapability.AUTO_ACK)).build();
         }
+        qosRequirement = qosRequirementBuilder.build();
     }
 
     @Override

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-websocket/src/test/java/io/gravitee/plugin/entrypoint/websocket/WebSocketEntrypointConnectorTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-websocket/src/test/java/io/gravitee/plugin/entrypoint/websocket/WebSocketEntrypointConnectorTest.java
@@ -30,6 +30,8 @@ import io.gravitee.gateway.jupiter.api.context.Response;
 import io.gravitee.gateway.jupiter.api.message.DefaultMessage;
 import io.gravitee.gateway.jupiter.api.message.Message;
 import io.gravitee.gateway.jupiter.api.qos.Qos;
+import io.gravitee.gateway.jupiter.api.qos.QosCapability;
+import io.gravitee.gateway.jupiter.api.qos.QosRequirement;
 import io.gravitee.gateway.jupiter.api.ws.WebSocket;
 import io.gravitee.plugin.entrypoint.websocket.configuration.WebSocketEntrypointConnectorConfiguration;
 import io.reactivex.rxjava3.core.Completable;
@@ -102,6 +104,21 @@ class WebSocketEntrypointConnectorTest {
     @Test
     void shouldSupportPublishAndSubscribeModes() {
         assertThat(cut.supportedModes()).containsOnly(ConnectorMode.PUBLISH, ConnectorMode.SUBSCRIBE);
+    }
+
+    @Test
+    void shouldReturnQosRequirement() {
+        QosRequirement qosRequirement = cut.qosRequirement();
+        assertThat(qosRequirement.getQos()).isEqualTo(Qos.NONE);
+        assertThat(qosRequirement.getCapabilities()).isEmpty();
+    }
+
+    @Test
+    void shouldReturnQosRequirementWithCapabilities() {
+        WebSocketEntrypointConnector cut = new WebSocketEntrypointConnector(Qos.AUTO, configuration);
+        QosRequirement qosRequirement = cut.qosRequirement();
+        assertThat(qosRequirement.getQos()).isEqualTo(Qos.AUTO);
+        assertThat(qosRequirement.getCapabilities()).containsOnly(QosCapability.AUTO_ACK);
     }
 
     @Test


### PR DESCRIPTION
## Description

Fix an issue with websocket to support new qos implementation

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-missing-qos-requirement-websocket/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jasarcmula.chromatic.com)
<!-- Storybook placeholder end -->
