### PR TITLE
UAT - Init endpoint variable when no other exists

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.spec.ts
@@ -301,7 +301,7 @@ describe('ApiProxyGroupEndpointEditComponent', () => {
     });
   });
 
-  describe('Create mode', () => {
+  describe('Create mode with existing endpoints', () => {
     let api: Api;
 
     beforeEach(async () => {
@@ -379,6 +379,86 @@ describe('ApiProxyGroupEndpointEditComponent', () => {
                 type: 'HTTP',
                 inherit: false,
               },
+              {
+                name: 'endpoint#3',
+                target: 'https//dummy.com',
+                tenants: null,
+                weight: 42,
+                backup: false,
+                type: 'http',
+                inherit: true,
+                healthcheck: {
+                  enabled: false,
+                },
+              },
+            ],
+          },
+        ],
+      });
+    });
+  });
+
+  describe('Create mode without existing endpoints', () => {
+    let api: Api;
+
+    beforeEach(async () => {
+      TestBed.overrideProvider(UIRouterStateParams, { useValue: { apiId: API_ID, groupName: DEFAULT_GROUP_NAME, endpointName: null } });
+      TestBed.compileComponents();
+      fixture = TestBed.createComponent(ApiProxyGroupEndpointEditComponent);
+      loader = TestbedHarnessEnvironment.loader(fixture);
+      httpTestingController = TestBed.inject(HttpTestingController);
+      fixture.detectChanges();
+
+      api = fakeApi({
+        id: API_ID,
+        proxy: {
+          groups: [
+            {
+              name: 'default-group',
+              endpoints: [],
+            },
+          ],
+        },
+      });
+
+      expectApiGetRequest(api);
+      expectConnectorRequest();
+      expectTenantsRequest();
+    });
+
+    it('should create new endpoint', async () => {
+      await loader
+        .getHarness(MatInputHarness.with({ selector: '[aria-label="Endpoint name input"]' }))
+        .then((input) => input.setValue('endpoint#3'));
+
+      const saveBar = await loader.getHarness(GioSaveBarHarness);
+      expect(await saveBar.isSubmitButtonInvalid()).toBeTruthy();
+
+      await loader
+        .getHarness(MatSelectHarness.with({ selector: '[aria-label="Endpoint type"]' }))
+        .then((select) => select.clickOptions({ text: 'http' }));
+
+      expect(await saveBar.isSubmitButtonInvalid()).toBeTruthy();
+
+      await loader
+        .getHarness(MatInputHarness.with({ selector: '[aria-label="Endpoint weight input"]' }))
+        .then((input) => input.setValue('42'));
+
+      expect(await saveBar.isSubmitButtonInvalid()).toBeTruthy();
+
+      await loader
+        .getHarness(MatInputHarness.with({ selector: '[aria-label="Endpoint target input"]' }))
+        .then((input) => input.setValue('https//dummy.com'));
+      expect(await saveBar.isSubmitButtonInvalid()).toBeFalsy();
+      await saveBar.clickSubmit();
+
+      expectApiGetRequest(api);
+      const req = httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/apis/${api.id}`, method: 'PUT' });
+      expect(req.request.body.proxy).toStrictEqual({
+        groups: [
+          {
+            name: 'default-group',
+            endpoints: [
               {
                 name: 'endpoint#3',
                 target: 'https//dummy.com',

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.ts
@@ -170,6 +170,8 @@ export class ApiProxyGroupEndpointEditComponent implements OnInit, OnDestroy {
       this.endpoint = {
         ...group.endpoints.find((endpoint) => endpoint.name === this.ajsStateParams.endpointName),
       };
+    } else {
+      this.endpoint = {};
     }
 
     this.generalForm = this.formBuilder.group({
@@ -181,10 +183,7 @@ export class ApiProxyGroupEndpointEditComponent implements OnInit, OnDestroy {
         [
           Validators.required,
           Validators.pattern(/^[^:]*$/),
-          isUniq(
-            group.endpoints.reduce((acc, endpoint) => [...acc, endpoint.name], []),
-            this.endpoint?.name,
-          ),
+          isUniq(group.endpoints?.reduce((acc, endpoint) => [...acc, endpoint.name], []) ?? [], this.endpoint?.name),
         ],
       ],
       type: [{ value: this.endpoint?.type ?? 'http', disabled: this.isReadOnly }, [Validators.required]],


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-407

## Description

Init endpoint variable when no other exists
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-407-new-endpoint-on-new-endpointgroup/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uffqgkwizv.chromatic.com)
<!-- Storybook placeholder end -->
