### PR TITLE
UAT - v3 planEntity should use v3 enum for type 

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionResourceTest.java
@@ -141,7 +141,7 @@ public class ApiSubscriptionResourceTest extends AbstractResourceTest {
 
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
         JsonNode responseBody = response.readEntity(JsonNode.class);
-        assertEquals("oauth2", responseBody.get("plan").get("security").asText());
+        assertEquals(PlanSecurityType.OAUTH2.name(), responseBody.get("plan").get("security").asText());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionResourceTest.java
@@ -88,7 +88,7 @@ public class ApplicationSubscriptionResourceTest extends AbstractResourceTest {
 
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
         JsonNode responseBody = response.readEntity(JsonNode.class);
-        assertEquals("oauth2", responseBody.get("plan").get("security").asText());
+        assertEquals(PlanSecurityType.OAUTH2.name(), responseBody.get("plan").get("security").asText());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionsResourceTest.java
@@ -101,7 +101,7 @@ public class ApplicationSubscriptionsResourceTest extends AbstractResourceTest {
         );
 
         JsonNode responseBody = response.readEntity(JsonNode.class);
-        assertEquals("oauth2", responseBody.get("plan").get("security").asText());
+        assertEquals(PlanSecurityType.OAUTH2.name(), responseBody.get("plan").get("security").asText());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/PlanEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/PlanEntity.java
@@ -345,7 +345,7 @@ public class PlanEntity implements GenericPlanEntity {
     public PlanSecurity getPlanSecurity() {
         PlanSecurity planSecurity = new PlanSecurity();
         if (security != null) {
-            planSecurity.setType(io.gravitee.rest.api.model.v4.plan.PlanSecurityType.valueOfLabel(security.name()).getLabel());
+            planSecurity.setType(PlanSecurityType.valueOf(security.name()).name());
         }
         planSecurity.setConfiguration(securityDefinition);
         return planSecurity;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-389

## Description

V3 planEntity should use v3 enum for type
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-389-no-apikey-displayed/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
