### PR TITLE
UAT - Format the notification creation date to be readable

### DIFF
--- a/gravitee-apim-console-webui/src/components/gio-notification-menu/gio-notification-menu.component.html
+++ b/gravitee-apim-console-webui/src/components/gio-notification-menu/gio-notification-menu.component.html
@@ -50,7 +50,7 @@
           <strong>{{ userNotification.title }}</strong>
         </div>
         <div mat-line>{{ userNotification.message }}</div>
-        <div mat-line>{{ userNotification.created_at }}</div>
+        <div mat-line>{{ userNotification.created_at | date: 'medium' }}</div>
       </mat-list-item>
     </mat-list>
   </mat-card>


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-404

## Description

Format the notification creation date to be readable
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-404-notification-date-not-readable/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mvzugfkhmr.chromatic.com)
<!-- Storybook placeholder end -->
