### PR TITLE
UAT - Share the api etag value across angularJS and angular.

### DIFF
--- a/gravitee-apim-console-webui/jest.setup.js
+++ b/gravitee-apim-console-webui/jest.setup.js
@@ -44,6 +44,7 @@ export function setupAngularJsTesting() {
     angular.mock.module('gravitee-management');
     // `downgradeInjectable` Does not seem to work with the current test configuration. Waiting for the angular migration to have a less hybrid config than now.
     angular.module('gravitee-management').factory('ngGioPendoService', [() => ({})]);
+    angular.module('gravitee-management').factory('ngIfMatchEtagInterceptor', [() => ({})]);
 
     angular.module('gravitee-management').constant('Constants', {
       org: {

--- a/gravitee-apim-console-webui/src/management/api/analytics/logs/logging-configuration.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/logs/logging-configuration.controller.ts
@@ -19,11 +19,11 @@ import { ConfigureLoggingDialogController } from './configure-logging.dialog';
 
 import { ApiService } from '../../../../services/api.service';
 import NotificationService from '../../../../services/notification.service';
-
 import '@gravitee/ui-components/wc/gv-switch';
 import '@gravitee/ui-components/wc/gv-expression-language';
 import '@gravitee/ui-components/wc/gv-option';
 import '@gravitee/ui-components/wc/gv-button';
+import { IfMatchEtagInterceptor } from '../../../../shared/interceptors/if-match-etag.interceptor';
 
 class ApiLoggingConfigurationController {
   private initialApi: any;
@@ -42,6 +42,7 @@ class ApiLoggingConfigurationController {
     private $scope,
     private Constants,
     private spelGrammar: any,
+    private readonly ngIfMatchEtagInterceptor: IfMatchEtagInterceptor,
   ) {
     'ngInject';
 
@@ -153,7 +154,7 @@ class ApiLoggingConfigurationController {
     this.ApiService.update(this.api).then((updatedApi) => {
       this.NotificationService.show('Logging configuration has been updated');
       this.api = updatedApi.data;
-      this.api.etag = updatedApi.headers('etag');
+      this.ngIfMatchEtagInterceptor.updateLastEtag('api', updatedApi.headers('etag'));
       this.initialApi = _.cloneDeep(updatedApi.data);
       this.$scope.formLogging.$setPristine();
       this.$rootScope.$broadcast('apiChangeSuccess', { api: this.api });

--- a/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/pathMappings.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/pathMappings.controller.ts
@@ -22,6 +22,7 @@ import DialogImportPathMappingController from './modal/import-pathMapping.dialog
 import { ApiService } from '../../../../services/api.service';
 import { DocumentationQuery, DocumentationService } from '../../../../services/documentation.service';
 import NotificationService from '../../../../services/notification.service';
+import { IfMatchEtagInterceptor } from '../../../../shared/interceptors/if-match-etag.interceptor';
 
 class ApiPathMappingsController {
   private api: any;
@@ -38,6 +39,7 @@ class ApiPathMappingsController {
     private $rootScope,
     DocumentationService: DocumentationService,
     private $state,
+    private readonly ngIfMatchEtagInterceptor: IfMatchEtagInterceptor,
   ) {
     'ngInject';
     this.api = this.$scope.$parent.apiCtrl.api;
@@ -138,7 +140,7 @@ class ApiPathMappingsController {
   private onSave(updatedApi) {
     this.api = updatedApi.data;
     this.api.path_mappings = _.sortBy(this.api.path_mappings);
-    this.api.etag = updatedApi.headers('etag');
+    this.ngIfMatchEtagInterceptor.updateLastEtag('api', updatedApi.headers('etag'));
     this.$rootScope.$broadcast('apiChangeSuccess', { api: this.api });
     this.NotificationService.show("API '" + this.$scope.$parent.apiCtrl.api.name + "' saved");
   }

--- a/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ts
@@ -422,7 +422,6 @@ class ApiHistoryController {
     delete payload.background_url;
     delete payload.categories;
     delete payload.groups;
-    delete payload.etag;
     delete payload.context_path;
     delete payload.disable_membership_notifications;
     delete payload.labels;

--- a/gravitee-apim-console-webui/src/management/api/creation/steps/api-creation.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/steps/api-creation.controller.ts
@@ -22,6 +22,7 @@ import NotificationService from '../../../../services/notification.service';
 import UserService from '../../../../services/user.service';
 import NewApiImportController, { getDefinitionVersionDescription, getDefinitionVersionTitle } from '../newApiImport.controller';
 import { PlanSecurityType } from '../../../../entities/plan/plan';
+import { IfMatchEtagInterceptor } from '../../../../shared/interceptors/if-match-etag.interceptor';
 
 interface Page {
   fileName: string;
@@ -100,6 +101,7 @@ class ApiCreationController {
     private $state: StateService,
     private Constants: any,
     private $rootScope,
+    private readonly ngIfMatchEtagInterceptor: IfMatchEtagInterceptor,
   ) {
     'ngInject';
     this.api = {
@@ -277,7 +279,7 @@ class ApiCreationController {
         if (readyForReview) {
           this.ApiService.askForReview(api.data).then((response) => {
             api.data.workflow_state = 'IN_REVIEW';
-            api.data.etag = response.headers('etag');
+            this.ngIfMatchEtagInterceptor.updateLastEtag('api', response.headers('etag'));
             this.api = api.data;
             this.$rootScope.$broadcast('apiChangeSuccess', { api: api.data });
           });

--- a/gravitee-apim-console-webui/src/management/api/design/properties/properties.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/design/properties/properties.controller.ts
@@ -19,6 +19,7 @@ import * as _ from 'lodash';
 
 import { ApiService } from '../../../../services/api.service';
 import NotificationService from '../../../../services/notification.service';
+import { IfMatchEtagInterceptor } from '../../../../shared/interceptors/if-match-etag.interceptor';
 
 interface IApiPropertiesScope extends ng.IScope {
   formDynamicProperties: any;
@@ -48,6 +49,7 @@ class ApiPropertiesController {
     private NotificationService: NotificationService,
     private $scope: IApiPropertiesScope,
     private $rootScope,
+    private readonly ngIfMatchEtagInterceptor: IfMatchEtagInterceptor,
   ) {
     'ngInject';
     this.dynamicPropertyProviders = [
@@ -156,7 +158,7 @@ class ApiPropertiesController {
     this.api.services['dynamic-property'] = this.dynamicPropertyService;
     return this.ApiService.update(this.api).then((updatedApi) => {
       this.api = updatedApi.data;
-      this.api.etag = updatedApi.headers('etag');
+      this.ngIfMatchEtagInterceptor.updateLastEtag('api', updatedApi.headers('etag'));
       this.$rootScope.$broadcast('apiChangeSuccess', { api: this.api });
       this.NotificationService.show("API '" + (this.$scope as any).$parent.apiCtrl.api.name + "' saved");
     });

--- a/gravitee-apim-console-webui/src/management/management.module.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/management.module.ajs.ts
@@ -535,6 +535,7 @@ import { ApiProxyHealthCheckComponent } from './api/proxy/health-check/api-proxy
 import { ApiPortalPlanListComponent } from './api/portal/plans/api-portal-plan-list/api-portal-plan-list.component';
 import { ApiPortalPlanEditComponent } from './api/portal/plans/plan/edit/api-portal-plan-edit.component';
 import { TaskService } from '../services-ngx/task.service';
+import { IfMatchEtagInterceptor } from '../shared/interceptors/if-match-etag.interceptor';
 
 (<any>window).moment = moment;
 require('angular-moment-picker');
@@ -1088,6 +1089,8 @@ graviteeManagementModule.controller('QuickTimeRangeController', QuickTimeRangeCo
 
 // Promotions
 graviteeManagementModule.service('promotionService', PromotionService);
+
+graviteeManagementModule.factory('ngIfMatchEtagInterceptor', downgradeInjectable(IfMatchEtagInterceptor));
 
 graviteeManagementModule.filter('humanDateFilter', () => {
   return function (input) {

--- a/gravitee-apim-console-webui/src/services-ngx/debug-api.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/debug-api.service.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable, Inject } from '@angular/core';
 import { Observable } from 'rxjs';
 
@@ -49,37 +49,33 @@ export class DebugApiService {
       });
     }
 
-    return this.http.post<Event>(
-      `${this.constants.env.baseURL}/apis/${api.id}/_debug`,
-      {
-        version: api.version,
-        description: api.description,
-        proxy: api.proxy,
-        paths: api.paths,
-        flows: api.flows,
-        plans: api.plans,
-        visibility: api.visibility,
-        name: api.name,
-        services: api.services,
-        properties: api.properties,
-        tags: api.tags,
-        picture: api.picture,
-        picture_url: api.picture_url,
-        background: api.background,
-        background_url: api.background_url,
-        resources: api.resources,
-        categories: api.categories,
-        groups: api.groups,
-        labels: api.labels,
-        path_mappings: api.path_mappings,
-        response_templates: api.response_templates,
-        lifecycle_state: api.lifecycle_state,
-        disable_membership_notifications: api.disable_membership_notifications,
-        flow_mode: api.flow_mode,
-        gravitee: api.gravitee,
-        request,
-      },
-      { headers: new HttpHeaders({ ...(api.etag ? { 'If-Match': api.etag } : {}) }) },
-    );
+    return this.http.post<Event>(`${this.constants.env.baseURL}/apis/${api.id}/_debug`, {
+      version: api.version,
+      description: api.description,
+      proxy: api.proxy,
+      paths: api.paths,
+      flows: api.flows,
+      plans: api.plans,
+      visibility: api.visibility,
+      name: api.name,
+      services: api.services,
+      properties: api.properties,
+      tags: api.tags,
+      picture: api.picture,
+      picture_url: api.picture_url,
+      background: api.background,
+      background_url: api.background_url,
+      resources: api.resources,
+      categories: api.categories,
+      groups: api.groups,
+      labels: api.labels,
+      path_mappings: api.path_mappings,
+      response_templates: api.response_templates,
+      lifecycle_state: api.lifecycle_state,
+      disable_membership_notifications: api.disable_membership_notifications,
+      flow_mode: api.flow_mode,
+      gravitee: api.gravitee,
+      request,
+    });
   }
 }

--- a/gravitee-apim-console-webui/src/services/api.service.ts
+++ b/gravitee-apim-console-webui/src/services/api.service.ts
@@ -20,6 +20,7 @@ import { ApplicationExcludeFilter } from './application.service';
 
 import { Constants } from '../entities/Constants';
 import { PagedResult } from '../entities/pagedResult';
+import { IfMatchEtagInterceptor } from '../shared/interceptors/if-match-etag.interceptor';
 
 export class LogsQuery {
   from: number;
@@ -38,7 +39,12 @@ interface IMembership {
 }
 
 export class ApiService {
-  constructor(private readonly $http: IHttpService, private readonly $rootScope: IRootScopeService, private readonly Constants: Constants) {
+  constructor(
+    private readonly $http: IHttpService,
+    private readonly $rootScope: IRootScopeService,
+    private readonly Constants: Constants,
+    private readonly ngIfMatchEtagInterceptor: IfMatchEtagInterceptor,
+  ) {
     'ngInject';
   }
 
@@ -170,12 +176,20 @@ export class ApiService {
     return this.$http.get(`${this.Constants.env.baseURL}/apis/` + '?group=' + group);
   }
 
-  start(api: { id: string; etag: string }): IHttpPromise<any> {
-    return this.$http.post(`${this.Constants.env.baseURL}/apis/` + api.id + '?action=START', {}, { headers: { 'If-Match': api.etag } });
+  start(api: { id: string }): IHttpPromise<any> {
+    return this.$http.post(
+      `${this.Constants.env.baseURL}/apis/` + api.id + '?action=START',
+      {},
+      { headers: { 'If-Match': this.ngIfMatchEtagInterceptor.getLastEtag('api') } },
+    );
   }
 
-  stop(api: { id: string; etag: string }): IHttpPromise<any> {
-    return this.$http.post(`${this.Constants.env.baseURL}/apis/` + api.id + '?action=STOP', {}, { headers: { 'If-Match': api.etag } });
+  stop(api: { id: string }): IHttpPromise<any> {
+    return this.$http.post(
+      `${this.Constants.env.baseURL}/apis/` + api.id + '?action=STOP',
+      {},
+      { headers: { 'If-Match': this.ngIfMatchEtagInterceptor.getLastEtag('api') } },
+    );
   }
 
   reload(name: string): IHttpPromise<any> {
@@ -218,7 +232,7 @@ export class ApiService {
         gravitee: api.gravitee,
         execution_mode: api.execution_mode,
       },
-      { headers: { 'If-Match': api.etag } },
+      { headers: { 'If-Match': this.ngIfMatchEtagInterceptor.getLastEtag('api') } },
     );
   }
 
@@ -724,27 +738,27 @@ export class ApiService {
     return endpointsName.filter((endpointName) => name === endpointName).length > 1;
   }
 
-  askForReview(api: { id: string; etag: any }, message?: any): IHttpPromise<any> {
+  askForReview(api: { id: string }, message?: any): IHttpPromise<any> {
     return this.$http.post(
       `${this.Constants.env.baseURL}/apis/${api.id}/reviews?action=ASK`,
       { message },
-      { headers: { 'If-Match': api.etag } },
+      { headers: { 'If-Match': this.ngIfMatchEtagInterceptor.getLastEtag('api') } },
     );
   }
 
-  acceptReview(api: { id: string; etag: any }, message: any): IHttpPromise<any> {
+  acceptReview(api: { id: string }, message: any): IHttpPromise<any> {
     return this.$http.post(
       `${this.Constants.env.baseURL}/apis/${api.id}/reviews?action=ACCEPT`,
       { message },
-      { headers: { 'If-Match': api.etag } },
+      { headers: { 'If-Match': this.ngIfMatchEtagInterceptor.getLastEtag('api') } },
     );
   }
 
-  rejectReview(api: { id: string; etag: any }, message: any): IHttpPromise<any> {
+  rejectReview(api: { id: string }, message: any): IHttpPromise<any> {
     return this.$http.post(
       `${this.Constants.env.baseURL}/apis/${api.id}/reviews?action=REJECT`,
       { message: message },
-      { headers: { 'If-Match': api.etag } },
+      { headers: { 'If-Match': this.ngIfMatchEtagInterceptor.getLastEtag('api') } },
     );
   }
 

--- a/gravitee-apim-console-webui/src/services/debugApi.service.ts
+++ b/gravitee-apim-console-webui/src/services/debugApi.service.ts
@@ -17,9 +17,14 @@ import { IHttpService, IPromise } from 'angular';
 
 import { Constants } from '../entities/Constants';
 import { Event } from '../entities/event/event';
+import { IfMatchEtagInterceptor } from '../shared/interceptors/if-match-etag.interceptor';
 
 export class DebugApiService {
-  constructor(private readonly $http: IHttpService, private readonly Constants: Constants) {
+  constructor(
+    private readonly $http: IHttpService,
+    private readonly Constants: Constants,
+    private readonly ngIfMatchEtagInterceptor: IfMatchEtagInterceptor,
+  ) {
     'ngInject';
   }
 
@@ -73,7 +78,7 @@ export class DebugApiService {
           gravitee: api.gravitee,
           request,
         },
-        { headers: { 'If-Match': api.etag } },
+        { headers: { 'If-Match': this.ngIfMatchEtagInterceptor.getLastEtag('api') } },
       )
       .then((value) => value.data);
   }

--- a/gravitee-apim-console-webui/src/shared/interceptors/http-interceptors.ts
+++ b/gravitee-apim-console-webui/src/shared/interceptors/http-interceptors.ts
@@ -25,5 +25,5 @@ export const httpInterceptorProviders = [
   { provide: HTTP_INTERCEPTORS, useClass: CsrfInterceptor, multi: true },
   { provide: HTTP_INTERCEPTORS, useClass: AccessControlAllowCredentialsInterceptor, multi: true },
   { provide: HTTP_INTERCEPTORS, useClass: ReplaceEnvInterceptor, multi: true },
-  { provide: HTTP_INTERCEPTORS, useClass: IfMatchEtagInterceptor, multi: true },
+  { provide: HTTP_INTERCEPTORS, useExisting: IfMatchEtagInterceptor, multi: true },
 ];


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-394

## Description

Share the api etag value across angularJS and angular.
This value is used to ensure a PUT or a POST is made on the most recent data of the API.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-394-api-etag-desync-between-angularjs-and-angular/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rqxvudreje.chromatic.com)
<!-- Storybook placeholder end -->
