### PR TITLE
UAT - Init endpoint list in creation mode

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.spec.ts
@@ -415,7 +415,6 @@ describe('ApiProxyGroupEndpointEditComponent', () => {
           groups: [
             {
               name: 'default-group',
-              endpoints: [],
             },
           ],
         },

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.ts
@@ -111,6 +111,11 @@ export class ApiProxyGroupEndpointEditComponent implements OnInit, OnDestroy {
             endpointIndex = api.proxy.groups[groupIndex].endpoints.findIndex(
               (endpoint) => endpoint.name === this.ajsStateParams.endpointName,
             );
+          } else {
+            if (!api.proxy.groups[groupIndex].endpoints) {
+              api.proxy.groups[groupIndex].endpoints = [];
+            }
+            endpointIndex = api.proxy.groups[groupIndex].endpoints.length;
           }
 
           const updatedEndpoint = toProxyGroupEndpoint(


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-407

## Description

Init endpoint list in creation mode
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-407-new-endpoint-on-new-endpointgroup/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nejwsngolc.chromatic.com)
<!-- Storybook placeholder end -->
