### PR TITLE
UAT - show alert only if alert service is enabled

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.component.ts
@@ -311,7 +311,7 @@ export class ApiNavigationComponent implements OnInit, OnDestroy {
         baseRoute: 'management.apis.detail.analytics.pathMappings',
       });
     }
-    if (this.permissionService.hasAnyMatching(['api-alert-r'])) {
+    if (this.constants.org.settings.alert?.enabled && this.permissionService.hasAnyMatching(['api-alert-r'])) {
       analyticsGroup.items.push({
         displayName: 'Alerts',
         targetRoute: 'management.apis.detail.analytics.alerts',


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-428

## Description

Show alert only if alert service is enabled
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-428-alert-menu-item-should-not-be-displayed/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-beqmjzwkgz.chromatic.com)
<!-- Storybook placeholder end -->
