### PR TITLE
UAT -  use same icons & tooltips for API list and detail

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation-title/api-navigation-title.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation-title/api-navigation-title.component.html
@@ -18,26 +18,32 @@
 <div class="api-navigation-title">
   <mat-icon
     *ngIf="apiState === 'STARTED'"
-    [matTooltip]="apiState"
+    matTooltip="Started"
     class="api-navigation-title__icon api-navigation-title__icon__play"
     svgIcon="gio:play-circle"
   ></mat-icon>
   <mat-icon
     *ngIf="apiState !== 'STARTED'"
-    [matTooltip]="apiState"
+    matTooltip="Stopped"
     class="api-navigation-title__icon api-navigation-title__icon__stop"
     svgIcon="gio:stop-circle"
   ></mat-icon>
-  <mat-icon *ngIf="!apiIsSync" class="api-navigation-title__icon api-navigation-title__icon__refresh" svgIcon="gio:refresh-cw"></mat-icon>
+  <mat-icon
+    *ngIf="!apiIsSync"
+    matTooltip="API out of sync"
+    class="api-navigation-title__icon api-navigation-title__icon__refresh"
+    svgIcon="gio:refresh-cw"
+  >
+  </mat-icon>
   <mat-icon
     *ngIf="apiLifecycleState === 'PUBLISHED'"
-    [matTooltip]="apiLifecycleState"
+    matTooltip="Published"
     class="api-navigation-title__icon"
     svgIcon="gio:cloud-published"
   ></mat-icon>
   <mat-icon
     *ngIf="apiLifecycleState !== 'PUBLISHED'"
-    [matTooltip]="apiLifecycleState"
+    matTooltip="Unpublished"
     class="api-navigation-title__icon"
     svgIcon="gio:cloud-unpublished"
   ></mat-icon>

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
@@ -55,17 +55,41 @@
     <ng-container matColumnDef="states">
       <th mat-header-cell *matHeaderCellDef id="states"></th>
       <td mat-cell *matCellDef="let element">
-        <mat-icon *ngIf="element.state === 'STARTED'" matTooltip="Started" class="states__api-started" size="20">play_circle</mat-icon>
-        <mat-icon *ngIf="element.state !== 'STARTED'" matTooltip="Stopped" class="states__api-not-started" size="20">stop_circle</mat-icon>
-        <mat-icon *ngIf="element.isNotSynced$ | async" matTooltip="API out of sync" class="states__api-is-not-synced" size="20"
-          >sync_problem</mat-icon
-        >
-        <mat-icon *ngIf="element.lifecycleState === 'PUBLISHED'" matTooltip="Published" class="states__api-published" size="20"
-          >cloud_done</mat-icon
-        >
-        <mat-icon *ngIf="element.lifecycleState !== 'PUBLISHED'" matTooltip="Unpublished" class="states__api-not-published" size="20"
-          >cloud_off</mat-icon
-        >
+        <mat-icon
+          *ngIf="element.state === 'STARTED'"
+          matTooltip="Started"
+          class="states__api-started"
+          size="20"
+          svgIcon="gio:play-circle"
+        ></mat-icon>
+        <mat-icon
+          *ngIf="element.state !== 'STARTED'"
+          matTooltip="Stopped"
+          class="states__api-not-started"
+          size="20"
+          svgIcon="gio:stop-circle"
+        ></mat-icon>
+        <mat-icon
+          *ngIf="element.isNotSynced$ | async"
+          matTooltip="API out of sync"
+          class="states__api-is-not-synced"
+          size="20"
+          svgIcon="gio:refresh-cw"
+        ></mat-icon>
+        <mat-icon
+          *ngIf="element.lifecycleState === 'PUBLISHED'"
+          matTooltip="Published"
+          class="states__api-published"
+          size="20"
+          svgIcon="gio:cloud-published"
+        ></mat-icon>
+        <mat-icon
+          *ngIf="element.lifecycleState !== 'PUBLISHED'"
+          matTooltip="Unpublished"
+          class="states__api-not-published"
+          size="20"
+          svgIcon="gio:cloud-unpublished"
+        ></mat-icon>
         <mat-icon
           *ngIf="element.origin === 'kubernetes'"
           matTooltip="Kubernetes Origin"


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-378

## Description

Use same icons & tooltips for API list and detail.
More detail in figma file: https://www.figma.com/file/okDdv0Rs884yxKgXQROqaG/Perseverance-design-system?node-id=6283%3A10681&t=qhlWZVhiDxIDttQc-4

![image](https://user-images.githubusercontent.com/13161768/207267945-2b7e40ad-1156-45dc-8d6b-9f05a26638f5.png)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-378-use-same-icons-for-api-list-and-detail/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nxruxsodfq.chromatic.com)
<!-- Storybook placeholder end -->
