### PR TITLE
UAT - highlight the user avatar only and not the background

### DIFF
--- a/gravitee-apim-console-webui/src/components/gio-user-menu/gio-user-menu.component.scss
+++ b/gravitee-apim-console-webui/src/components/gio-user-menu/gio-user-menu.component.scss
@@ -44,6 +44,10 @@
     }
   }
 
+  &__button-avatar {
+    border-radius: 50%;
+  }
+
   &__avatar {
     display: inline-block;
   }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-433

## Description

highlight the user avatar only and not the background

## Additional context

Before
https://user-images.githubusercontent.com/13161768/207277662-82049bb7-b3aa-489b-acc6-89cbee2c2596.mov

After
https://user-images.githubusercontent.com/13161768/207277738-27e5063b-687b-4141-a0d3-c93dbaea1c08.mov

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-433-remove-square-background-hover-on-user-picture/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bnwosraxty.chromatic.com)
<!-- Storybook placeholder end -->
