### PR TITLE
fix: use right field to configure a confirm dialog

### DIFF
--- a/gravitee-apim-console-webui/src/components/alerts/alert/alert.component.ts
+++ b/gravitee-apim-console-webui/src/components/alerts/alert/alert.component.ts
@@ -125,7 +125,7 @@ const AlertComponent: ng.IComponentOptions = {
           .show(
             $mdDialog.confirm({
               title: 'Warning',
-              content: 'Are you sure you want to remove this alert?',
+              textContent: 'Are you sure you want to remove this alert?',
               ok: 'OK',
               cancel: 'Cancel',
             }),

--- a/gravitee-apim-console-webui/src/components/notifications/notificationsettings/notificationsettings.component.ts
+++ b/gravitee-apim-console-webui/src/components/notifications/notificationsettings/notificationsettings.component.ts
@@ -113,7 +113,7 @@ const NotificationSettingsComponent: ng.IComponentOptions = {
     this.delete = () => {
       const alert = this.$mdDialog.confirm({
         title: 'Warning',
-        content: 'Are you sure you want to remove this notification?',
+        textContent: 'Are you sure you want to remove this notification?',
         ok: 'OK',
         cancel: 'Cancel',
       });

--- a/gravitee-apim-console-webui/src/management/application/details/subscribe/application-subscribe.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscribe/application-subscribe.controller.ts
@@ -146,7 +146,7 @@ class ApplicationSubscribeController {
   onUnsubscribe(api, plan) {
     const alert = this.$mdDialog.confirm({
       title: 'Close subscription?',
-      content: 'Are you sure you want to close this subscription?',
+      textContent: 'Are you sure you want to close this subscription?',
       ok: 'CLOSE',
       cancel: 'CANCEL',
     });

--- a/gravitee-apim-console-webui/src/management/configuration/theme/theme.controller.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/theme/theme.controller.ts
@@ -379,7 +379,7 @@ class ThemeController {
   restoreDefaultTheme = () => {
     const confirm = this.$mdDialog.confirm({
       title: 'Restore default theme?',
-      content: 'Are you sure you want to restore the default theme? All your changes will be deleted.',
+      textContent: 'Are you sure you want to restore the default theme? All your changes will be deleted.',
       ok: 'RESTORE',
       cancel: 'CANCEL',
     });


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-408

## Description

The content of some confirmation dialog was not displayed because the field use to set the text was not the right one.
We should use `textContent` instead of `content`
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-408-confirm-dialog-without-content/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ralfjhbagl.chromatic.com)
<!-- Storybook placeholder end -->
