### PR TITLE
Add primary keys on all tables as MySQL clusters require it

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_15_20/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_15_20/schema.yml
@@ -1,0 +1,65 @@
+databaseChangeLog:
+  - changeSet:
+      id: 3.15.20
+      author: GraviteeSource Team
+      changes:
+        - addPrimaryKey:
+            constraintName: pk_${gravitee_prefix}alert_event_rules
+            columnNames: alert_id, alert_event
+            tableName: ${gravitee_prefix}alert_event_rules
+        - addPrimaryKey:
+            constraintName: pk_${gravitee_prefix}api_groups
+            columnNames: api_id, group_id
+            tableName: ${gravitee_prefix}api_groups
+        - addPrimaryKey:
+            constraintName: pk_${gravitee_prefix}application_groups
+            columnNames: application_id, group_id
+            tableName: ${gravitee_prefix}application_groups
+        - addPrimaryKey:
+            constraintName: pk_${gravitee_prefix}client_registration_provider_scopes
+            columnNames: client_registration_provider_id, scope
+            tableName: ${gravitee_prefix}client_registration_provider_scopes
+        - addPrimaryKey:
+            constraintName: pk_${gravitee_prefix}custom_user_fields_values
+            columnNames: key, reference_id, reference_type
+            tableName: ${gravitee_prefix}custom_user_fields_values
+        - addPrimaryKey:
+            constraintName: pk_${gravitee_prefix}databasechangelog
+            columnNames: ID
+            tableName: ${gravitee_prefix}databasechangelog
+        - addPrimaryKey:
+            constraintName: pk_${gravitee_prefix}event_environments
+            columnNames: event_id, environment_id
+            tableName: ${gravitee_prefix}event_environments
+        - addPrimaryKey:
+            constraintName: pk_${gravitee_prefix}flow_steps
+            columnNames: flow_id, order, phase
+            tableName: ${gravitee_prefix}flow_steps
+        - addPrimaryKey:
+            constraintName: pk_${gravitee_prefix}group_event_rules
+            columnNames: group_id, group_event
+            tableName: ${gravitee_prefix}group_event_rules
+        - addPrimaryKey:
+            constraintName: pk_${gravitee_prefix}installation
+            columnNames: id
+            tableName: ${gravitee_prefix}installation
+        - addPrimaryKey:
+            constraintName: pk_${gravitee_prefix}installation_informations
+            columnNames: installation_id, information_key
+            tableName: ${gravitee_prefix}installation_informations
+        - addPrimaryKey:
+            constraintName: pk_${gravitee_prefix}node_monitoring
+            columnNames: id
+            tableName: ${gravitee_prefix}node_monitoring
+        - addPrimaryKey:
+            constraintName: pk_${gravitee_prefix}notification_templates
+            columnNames: id
+            tableName: ${gravitee_prefix}notification_templates
+        - addPrimaryKey:
+            constraintName: pk_${gravitee_prefix}promotions
+            columnNames: id
+            tableName: ${gravitee_prefix}promotions
+        - addPrimaryKey:
+            constraintName: pk_${gravitee_prefix}tag_groups
+            columnNames: tag_id, group_id
+            tableName: ${gravitee_prefix}tag_groups

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -121,3 +121,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v3_15_3/schema.yml
   - include:
       - file: liquibase/changelogs/v3_15_14/schema.yml
+  - include:
+      - file: liquibase/changelogs/v3_15_20/schema.yml


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/6323

## Description

Add primary keys on all tables as MySQL clusters require it.
For details see https://dev.mysql.com/blog-archive/enforce-primary-key-constraints-on-replication/

To list all tables without PK you can run the following query: 
```sql
select tab.table_schema as database_name,
       tab.table_name
from information_schema.tables tab
         left join information_schema.table_constraints tco
                   on tab.table_schema = tco.table_schema
                       and tab.table_name = tco.table_name
                       and tco.constraint_type = 'PRIMARY KEY'
where tco.constraint_type is null
  and tab.table_schema not in ('mysql', 'information_schema',
                               'performance_schema', 'sys')
  and tab.table_type = 'BASE TABLE'
  and tab.table_schema = 'gravitee' -- <-- database name
order by tab.table_schema,
         tab.table_name;
```

Due to technical improvements related to repository tests done since the 3.15.x branch we decided to add a test to ensure every table has a primary key on the 3.20.x + branches, see https://github.com/gravitee-io/gravitee-api-management/pull/2848

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-akihbalzyk.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/add-primary-keys/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
