### PR TITLE
tests: fix DebugApiService tests

### DIFF
--- a/gravitee-apim-console-webui/jest.setup.js
+++ b/gravitee-apim-console-webui/jest.setup.js
@@ -44,7 +44,13 @@ export function setupAngularJsTesting() {
     angular.mock.module('gravitee-management');
     // `downgradeInjectable` Does not seem to work with the current test configuration. Waiting for the angular migration to have a less hybrid config than now.
     angular.module('gravitee-management').factory('ngGioPendoService', [() => ({})]);
-    angular.module('gravitee-management').factory('ngIfMatchEtagInterceptor', [() => ({})]);
+    angular.module('gravitee-management').factory('ngIfMatchEtagInterceptor', [
+      () => ({
+        getLastEtag(key) {
+          return '';
+        },
+      }),
+    ]);
 
     angular.module('gravitee-management').constant('Constants', {
       org: {

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
@@ -104,7 +104,8 @@ describe('ApisListComponent', () => {
           visibility: 'Visibility',
         },
       ]);
-      expect(rowCells).toEqual([['', '🪐 Planets', 'play_circlecloud_done', '/planets', '', 'admin', 'Policy studio', 'public', 'edit']]);
+      expect(rowCells).toEqual([['', '🪐 Planets', '', '/planets', '', 'admin', 'Policy studio', 'public', 'edit']]);
+      expect(await loader.getHarness(MatIconHarness.with({ selector: '.states__api-started' }))).toBeTruthy();
     }));
 
     it('should display one row with kubernetes icon', fakeAsync(async () => {
@@ -230,10 +231,9 @@ describe('ApisListComponent', () => {
           visibility: 'Visibility',
         },
       ]);
-      expect(rowCells).toEqual([
-        ['', '🪐 Planets', 'play_circlecloud_done', '/planets', '', '100%', 'admin', 'Policy studio', 'public', 'edit'],
-      ]);
+      expect(rowCells).toEqual([['', '🪐 Planets', '', '/planets', '', '100%', 'admin', 'Policy studio', 'public', 'edit']]);
       expect(fixture.debugElement.query(By.css('.quality-score__good'))).toBeTruthy();
+      expect(await loader.getHarness(MatIconHarness.with({ selector: '.states__api-started' }))).toBeTruthy();
     }));
 
     it('should display bad quality score', fakeAsync(async () => {


### PR DESCRIPTION
## Issue

N/A

## Description

Fix 2 unit tests:
 - debug-api.service => init ngIfMatchInterceptor with a fake `getLastEtag` method
 - api-list.component => the way icons are displayed has changed and the is no longer some text in the html table. We now check the existence of the right MatIcon.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-console-tests-part-2/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-njkzxvmjdd.chromatic.com)
<!-- Storybook placeholder end -->
