### PR TITLE
feat: add resource to set api definition context

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiDefinitionContextResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiDefinitionContextResource.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource;
+
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.rest.security.Permission;
+import io.gravitee.rest.api.management.rest.security.Permissions;
+import io.gravitee.rest.api.model.api.DefinitionContextEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.ApiDefinitionContextService;
+import io.swagger.v3.oas.annotations.Hidden;
+import javax.inject.Inject;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class ApiDefinitionContextResource {
+
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("api")
+    private String apiId;
+
+    private final ApiDefinitionContextService definitionContextService;
+
+    @Inject
+    public ApiDefinitionContextResource(ApiDefinitionContextService definitionContextService) {
+        this.definitionContextService = definitionContextService;
+    }
+
+    @PUT
+    @Hidden
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.API_DEFINITION, acls = RolePermissionAction.UPDATE) })
+    public Response updateDefinitionContext(@Valid @NotNull DefinitionContextEntity definitionContext) {
+        definitionContextService.setDefinitionContext(apiId, definitionContext);
+        return Response.ok().build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
@@ -985,6 +985,11 @@ public class ApiResource extends AbstractResource {
         return resourceContext.getResource(ApiDefinitionResource.class);
     }
 
+    @Path("definition-context")
+    public ApiDefinitionContextResource getApiDefinitionContextResource() {
+        return resourceContext.getResource(ApiDefinitionContextResource.class);
+    }
+
     private void setSynchronizationState(final ExecutionContext executionContext, ApiStateEntity apiStateEntity) {
         apiStateEntity.setIsSynchronized(apiService.isSynchronized(executionContext, apiStateEntity.getApiId()));
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/AbstractResourceTest.java
@@ -27,51 +27,7 @@ import io.gravitee.rest.api.management.rest.JerseySpringTest;
 import io.gravitee.rest.api.security.authentication.AuthenticationProvider;
 import io.gravitee.rest.api.security.cookies.CookieGenerator;
 import io.gravitee.rest.api.security.utils.AuthoritiesProvider;
-import io.gravitee.rest.api.service.AccessControlService;
-import io.gravitee.rest.api.service.AlertAnalyticsService;
-import io.gravitee.rest.api.service.AlertService;
-import io.gravitee.rest.api.service.AnalyticsService;
-import io.gravitee.rest.api.service.ApiDuplicatorService;
-import io.gravitee.rest.api.service.ApiExportService;
-import io.gravitee.rest.api.service.ApiKeyService;
-import io.gravitee.rest.api.service.ApiMetadataService;
-import io.gravitee.rest.api.service.ApiService;
-import io.gravitee.rest.api.service.ApplicationMetadataService;
-import io.gravitee.rest.api.service.ApplicationService;
-import io.gravitee.rest.api.service.AuditService;
-import io.gravitee.rest.api.service.CategoryService;
-import io.gravitee.rest.api.service.ConfigService;
-import io.gravitee.rest.api.service.CustomUserFieldService;
-import io.gravitee.rest.api.service.DebugApiService;
-import io.gravitee.rest.api.service.EnvironmentService;
-import io.gravitee.rest.api.service.FetcherService;
-import io.gravitee.rest.api.service.GroupService;
-import io.gravitee.rest.api.service.InstallationService;
-import io.gravitee.rest.api.service.JsonPatchService;
-import io.gravitee.rest.api.service.MediaService;
-import io.gravitee.rest.api.service.MembershipService;
-import io.gravitee.rest.api.service.MessageService;
-import io.gravitee.rest.api.service.NotifierService;
-import io.gravitee.rest.api.service.OrganizationService;
-import io.gravitee.rest.api.service.PageService;
-import io.gravitee.rest.api.service.ParameterService;
-import io.gravitee.rest.api.service.PermissionService;
-import io.gravitee.rest.api.service.PlanService;
-import io.gravitee.rest.api.service.PolicyService;
-import io.gravitee.rest.api.service.QualityMetricsService;
-import io.gravitee.rest.api.service.RatingService;
-import io.gravitee.rest.api.service.RoleService;
-import io.gravitee.rest.api.service.SocialIdentityProviderService;
-import io.gravitee.rest.api.service.SubscriptionService;
-import io.gravitee.rest.api.service.SwaggerService;
-import io.gravitee.rest.api.service.TagService;
-import io.gravitee.rest.api.service.TaskService;
-import io.gravitee.rest.api.service.TicketService;
-import io.gravitee.rest.api.service.TokenService;
-import io.gravitee.rest.api.service.TopApiService;
-import io.gravitee.rest.api.service.UserService;
-import io.gravitee.rest.api.service.VirtualHostService;
-import io.gravitee.rest.api.service.WorkflowService;
+import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.configuration.application.ApplicationTypeService;
 import io.gravitee.rest.api.service.configuration.application.ClientRegistrationService;
 import io.gravitee.rest.api.service.configuration.dictionary.DictionaryService;
@@ -318,6 +274,9 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
 
     @Autowired
     protected MediaService mediaService;
+
+    @Autowired
+    protected ApiDefinitionContextService definitionContextService;
 
     @Before
     public void setUp() throws Exception {
@@ -686,6 +645,11 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
         @Bean
         public EndpointConnectorPluginService endpointConnectorPluginService() {
             return mock(EndpointConnectorPluginService.class);
+        }
+
+        @Bean
+        public ApiDefinitionContextService definitionContextService() {
+            return mock(ApiDefinitionContextService.class);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiDefinitionContextResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiDefinitionContextResourceTest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource;
+
+import static io.gravitee.definition.model.DefinitionContext.*;
+import static javax.ws.rs.client.Entity.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.model.api.DefinitionContextEntity;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import javax.ws.rs.core.Response;
+import org.junit.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class ApiDefinitionContextResourceTest extends AbstractResourceTest {
+
+    private static final String API_ID = "d635e8d0-8b19-40f6-8cc3-e53633109e08";
+    private static final String DEFINITION_CONTEXT_PATH = "definition-context";
+
+    @Override
+    protected String contextPath() {
+        return "apis/";
+    }
+
+    @Test
+    public void shouldReturn500IfTechnicalException() {
+        doThrow(new TechnicalManagementException()).when(definitionContextService).setDefinitionContext(eq(API_ID), any());
+
+        Response response = envTarget(API_ID).path(DEFINITION_CONTEXT_PATH).request().put(json(newKubernetesContext()));
+
+        assertEquals(HttpStatusCode.INTERNAL_SERVER_ERROR_500, response.getStatus());
+    }
+
+    @Test
+    public void shouldReturn403IfNotGranted() {
+        when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(false);
+        Response response = envTarget(API_ID).path(DEFINITION_CONTEXT_PATH).request().put(json(newKubernetesContext()));
+        assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
+    }
+
+    @Test
+    public void shouldReturn200AndSetDefinitionContext() {
+        Response response = envTarget(API_ID).path(DEFINITION_CONTEXT_PATH).request().put(json(newKubernetesContext()));
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        verify(definitionContextService, times(1))
+            .setDefinitionContext(
+                eq(API_ID),
+                argThat(
+                    context -> {
+                        assertThat(context).usingRecursiveComparison().isEqualTo(newKubernetesContext());
+                        return true;
+                    }
+                )
+            );
+    }
+
+    @Test
+    public void shouldReturn400WithNullOrigin() {
+        DefinitionContextEntity definitionContextEntity = new DefinitionContextEntity(null, MODE_FULLY_MANAGED);
+        Response response = envTarget(API_ID).path(DEFINITION_CONTEXT_PATH).request().put(json(definitionContextEntity));
+        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+    }
+
+    @Test
+    public void shouldReturn400WithUnknownOrigin() {
+        DefinitionContextEntity definitionContextEntity = new DefinitionContextEntity("unknown", MODE_FULLY_MANAGED);
+        Response response = envTarget(API_ID).path(DEFINITION_CONTEXT_PATH).request().put(json(definitionContextEntity));
+        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+    }
+
+    @Test
+    public void shouldReturn400WithNullMode() {
+        DefinitionContextEntity definitionContextEntity = new DefinitionContextEntity(ORIGIN_KUBERNETES, null);
+        Response response = envTarget(API_ID).path(DEFINITION_CONTEXT_PATH).request().put(json(definitionContextEntity));
+        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+    }
+
+    @Test
+    public void shouldReturn400WithUnknownMode() {
+        DefinitionContextEntity definitionContextEntity = new DefinitionContextEntity(ORIGIN_KUBERNETES, "unknown");
+        Response response = envTarget(API_ID).path(DEFINITION_CONTEXT_PATH).request().put(json(definitionContextEntity));
+        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+    }
+
+    private static DefinitionContextEntity newKubernetesContext() {
+        return new DefinitionContextEntity(ORIGIN_KUBERNETES, MODE_FULLY_MANAGED);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/DefinitionContextEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/DefinitionContextEntity.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.api;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import lombok.*;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DefinitionContextEntity {
+
+    @NotNull
+    @Pattern(regexp = "(kubernetes|management)")
+    private String origin;
+
+    @NotNull
+    @Pattern(regexp = "(fully_managed|api_definition_only)")
+    private String mode;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiDefinitionContextService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiDefinitionContextService.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service;
+
+import io.gravitee.rest.api.model.api.DefinitionContextEntity;
+
+public interface ApiDefinitionContextService {
+    void setDefinitionContext(String apiId, DefinitionContextEntity definitionContext);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDefinitionContextServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDefinitionContextServiceImpl.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.rest.api.model.api.DefinitionContextEntity;
+import io.gravitee.rest.api.service.ApiDefinitionContextService;
+import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Component
+public class ApiDefinitionContextServiceImpl implements ApiDefinitionContextService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ApiDefinitionContextServiceImpl.class);
+
+    private final ApiRepository apiRepository;
+
+    @Autowired
+    public ApiDefinitionContextServiceImpl(@Lazy ApiRepository apiRepository) {
+        this.apiRepository = apiRepository;
+    }
+
+    @Override
+    public void setDefinitionContext(String apiId, DefinitionContextEntity definitionContext) {
+        try {
+            Api api = apiRepository.findById(apiId).orElseThrow(() -> new ApiNotFoundException(apiId));
+            api.setOrigin(definitionContext.getOrigin());
+            api.setMode(definitionContext.getMode());
+            apiRepository.update(api);
+        } catch (TechnicalException e) {
+            LOG.error("An error has occurred while trying to set definition context on API " + apiId, e);
+            throw new TechnicalManagementException(e);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDefinitionContextServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDefinitionContextServiceTest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static io.gravitee.definition.model.DefinitionContext.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.rest.api.model.api.DefinitionContextEntity;
+import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.util.Optional;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ApiDefinitionContextServiceTest {
+
+    private static final String API_ID = "f866a23f-966d-41be-8b79-41126721ab8b";
+
+    @Mock
+    private ApiRepository apiRepository;
+
+    @InjectMocks
+    private ApiDefinitionContextServiceImpl definitionContextService;
+
+    @Test
+    public void shouldSetDefinitionContext() throws TechnicalException {
+        Api apiWithNullContext = newApi();
+        DefinitionContextEntity kubernetesContext = newKubernetesContext();
+
+        when(apiRepository.findById(API_ID)).thenReturn(Optional.of(apiWithNullContext));
+
+        definitionContextService.setDefinitionContext(API_ID, kubernetesContext);
+
+        verify(apiRepository, times(1))
+            .update(
+                argThat(
+                    api -> {
+                        assertThat(api.getOrigin()).isEqualTo(ORIGIN_KUBERNETES);
+                        assertThat(api.getMode()).isEqualTo(MODE_FULLY_MANAGED);
+                        return true;
+                    }
+                )
+            );
+    }
+
+    @Test(expected = ApiNotFoundException.class)
+    public void shouldThrowApiNotFoundException() throws TechnicalException {
+        when(apiRepository.findById(API_ID)).thenReturn(Optional.empty());
+        definitionContextService.setDefinitionContext(API_ID, newKubernetesContext());
+    }
+
+    @Test(expected = TechnicalManagementException.class)
+    public void shouldThrowTechnicalManagementException() throws TechnicalException {
+        when(apiRepository.findById(API_ID)).thenThrow(TechnicalException.class);
+        definitionContextService.setDefinitionContext(API_ID, newKubernetesContext());
+    }
+
+    private static Api newApi() {
+        Api api = new Api();
+        api.setId(API_ID);
+        return api;
+    }
+
+    private static DefinitionContextEntity newKubernetesContext() {
+        return new DefinitionContextEntity(ORIGIN_KUBERNETES, MODE_FULLY_MANAGED);
+    }
+}


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/APIM-15
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/feat-set-definition-context/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xemtaflzvz.chromatic.com)
<!-- Storybook placeholder end -->
