### PR TITLE
feat: set the Content-Length header

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/context/AbstractRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/context/AbstractRequest.java
@@ -255,6 +255,12 @@ public abstract class AbstractRequest implements MutableRequest {
     }
 
     @Override
+    public void contentLength(long contentLength) {
+        headers.set(io.vertx.core.http.HttpHeaders.CONTENT_LENGTH, Long.toString(contentLength));
+        headers.remove(io.vertx.core.http.HttpHeaders.TRANSFER_ENCODING);
+    }
+
+    @Override
     public void messages(final Flowable<Message> messages) {
         lazyMessageFlow().messages(messages);
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/context/AbstractResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/context/AbstractResponse.java
@@ -129,6 +129,12 @@ public abstract class AbstractResponse implements MutableResponse {
     }
 
     @Override
+    public void contentLength(long contentLength) {
+        headers.set(io.vertx.core.http.HttpHeaders.CONTENT_LENGTH, Long.toString(contentLength));
+        headers.remove(io.vertx.core.http.HttpHeaders.TRANSFER_ENCODING);
+    }
+
+    @Override
     public void messages(final Flowable<Message> messages) {
         lazyMessageFlow().messages(messages);
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/jupiter/http/vertx/AbstractVertxServerResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/jupiter/http/vertx/AbstractVertxServerResponse.java
@@ -17,10 +17,9 @@ package io.gravitee.gateway.jupiter.http.vertx;
 
 import io.gravitee.common.http.HttpHeadersValues;
 import io.gravitee.common.http.HttpVersion;
-import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.http.vertx.VertxHttpHeaders;
 import io.gravitee.gateway.jupiter.core.context.AbstractResponse;
-import io.gravitee.gateway.jupiter.core.context.MutableResponse;
+import io.vertx.core.http.HttpHeaders;
 import io.vertx.rxjava3.core.http.HttpServerResponse;
 
 /**
@@ -77,21 +76,27 @@ abstract class AbstractVertxServerResponse extends AbstractResponse {
     }
 
     protected void prepareHeaders() {
-        if (!nativeResponse.headWritten() && HttpVersion.HTTP_2 == serverRequest.version()) {
-            if (
-                headers.contains(io.vertx.core.http.HttpHeaders.CONNECTION) &&
-                headers.getAll(io.vertx.core.http.HttpHeaders.CONNECTION).contains(HttpHeadersValues.CONNECTION_GO_AWAY)
-            ) {
-                // 'Connection: goAway' is a special header indicating the native connection should be shutdown because of the node itself will shutdown.
-                serverRequest.nativeRequest.connection().shutdown();
+        if (!nativeResponse.headWritten()) {
+            if (HttpVersion.HTTP_2 == serverRequest.version()) {
+                if (
+                    headers.contains(io.vertx.core.http.HttpHeaders.CONNECTION) &&
+                    headers.getAll(io.vertx.core.http.HttpHeaders.CONNECTION).contains(HttpHeadersValues.CONNECTION_GO_AWAY)
+                ) {
+                    // 'Connection: goAway' is a special header indicating the native connection should be shutdown because of the node itself will shutdown.
+                    serverRequest.nativeRequest.connection().shutdown();
+                }
+
+                // As per https://tools.ietf.org/html/rfc7540#section-8.1.2.2
+                // connection-specific header fields must be removed from response headers
+                headers
+                    .remove(io.vertx.core.http.HttpHeaders.CONNECTION)
+                    .remove(io.vertx.core.http.HttpHeaders.KEEP_ALIVE)
+                    .remove(io.vertx.core.http.HttpHeaders.TRANSFER_ENCODING);
             }
 
-            // As per https://tools.ietf.org/html/rfc7540#section-8.1.2.2
-            // connection-specific header fields must be removed from response headers
-            headers
-                .remove(io.vertx.core.http.HttpHeaders.CONNECTION)
-                .remove(io.vertx.core.http.HttpHeaders.KEEP_ALIVE)
-                .remove(io.vertx.core.http.HttpHeaders.TRANSFER_ENCODING);
+            if (headers.contains(HttpHeaders.CONTENT_LENGTH)) {
+                headers.remove(HttpHeaders.TRANSFER_ENCODING);
+            }
         }
     }
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/test/java/io/gravitee/plugin/entrypoint/http/post/DummyMessageRequest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/test/java/io/gravitee/plugin/entrypoint/http/post/DummyMessageRequest.java
@@ -216,4 +216,7 @@ public class DummyMessageRequest implements Request {
     public Completable onMessages(FlowableTransformer<Message, Message> onMessages) {
         return Completable.complete();
     }
+
+    @Override
+    public void contentLength(long l) {}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <gravitee-connector-api.version>1.1.4</gravitee-connector-api.version>
         <gravitee-expression-language.version>2.0.0-alpha.2</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>2.1.0-alpha.1</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>2.1.0-alpha.3</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>2.0.0-alpha.3</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-442

## Description

Implement `contentLength` method of `HttpResponse` that sets `Content-Length` header.
It also removes any `Transfert-Encoding` header otherwise `Content-Length` will be ignored.
See https://greenbytes.de/tech/webdav/rfc2616.html#rfc.section.4.4

Also, before sending the response, we clean the headers by removing any `Transfert-Encoding` header if the `Content-Length` is present. It means that someone manually added the `Content-Length` header, and therefore, the chunk is not relevant anymore


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim442-set-content-length/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ykezwczlzb.chromatic.com)
<!-- Storybook placeholder end -->
