### PR TITLE
fix: load bootstrap on legacy angularJS pages

### DIFF
--- a/gravitee-apim-console-webui/src/management/management.run.ts
+++ b/gravitee-apim-console-webui/src/management/management.run.ts
@@ -250,7 +250,7 @@ function runBlock(
   $transitions.onSuccess({}, function (trans) {
     const toState = trans.to();
     const useAngularMaterial = toState.data && toState.data.useAngularMaterial;
-    const mainContainer = angular.element(document.querySelector('.gv-main-container, .gravitee-no-sidenav-container'));
+    const mainContainer = angular.element(document.querySelector('.gravitee-no-sidenav-container, .gv-sub-content'));
     if (useAngularMaterial) {
       mainContainer.removeClass('bootstrap');
     } else {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-397

## Description

Fix the querySelector to apply bootstrap class.
`gv-main-container` does not exist (maybe a refactor ?) and we should use `gv-sub-content` instead
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-bootstrap-loading/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
