### PR TITLE
Use `key` attribute instead of `id` in the `categories` of an API

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImpl.java
@@ -86,7 +86,8 @@ public class ApiSearchServiceImpl extends AbstractService implements ApiSearchSe
     public GenericApiEntity findGenericById(final ExecutionContext executionContext, final String apiId) {
         final Api api = this.findApiById(executionContext, apiId, false);
         PrimaryOwnerEntity primaryOwner = primaryOwnerService.getPrimaryOwner(executionContext, api.getId());
-        return genericApiMapper.toGenericApi(api, primaryOwner);
+        final List<CategoryEntity> categories = categoryService.findAll(executionContext.getEnvironmentId());
+        return genericApiMapper.toGenericApi(executionContext, api, primaryOwner, categories);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImplTest.java
@@ -38,6 +38,7 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.flow.FlowReferenceType;
+import io.gravitee.rest.api.model.CategoryEntity;
 import io.gravitee.rest.api.model.MembershipEntity;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.UserEntity;
@@ -119,7 +120,7 @@ public class ApiSearchServiceImplTest {
     private WorkflowService workflowService;
 
     @Spy
-    private CategoryMapper categoryMapper = new CategoryMapper(mock(CategoryService.class));
+    private CategoryMapper categoryMapper = new CategoryMapper(categoryService);
 
     @InjectMocks
     private ApiConverter apiConverter = Mockito.spy(new ApiConverter());
@@ -296,16 +297,24 @@ public class ApiSearchServiceImplTest {
         api.setId(API_ID);
         api.setEnvironmentId("DEFAULT");
         api.setDefinitionVersion(DefinitionVersion.V2);
+        api.setCategories(Set.of("cat1", "cat2"));
 
         when(apiRepository.findById(API_ID)).thenReturn(Optional.of(api));
         UserEntity userEntity = new UserEntity();
         userEntity.setId("user");
         when(primaryOwnerService.getPrimaryOwner(any(), eq(API_ID))).thenReturn(new PrimaryOwnerEntity(userEntity));
-
+        CategoryEntity category1 = new CategoryEntity();
+        category1.setId("cat1");
+        category1.setKey("category1");
+        CategoryEntity category2 = new CategoryEntity();
+        category2.setId("cat2");
+        category2.setKey("category2");
+        when(categoryService.findAll("DEFAULT")).thenReturn(List.of(category1, category2));
         final GenericApiEntity indexableApi = apiSearchService.findGenericById(GraviteeContext.getExecutionContext(), API_ID);
 
         assertThat(indexableApi).isNotNull();
         assertThat(indexableApi).isInstanceOf(io.gravitee.rest.api.model.api.ApiEntity.class);
+        assertThat(indexableApi.getCategories()).isEqualTo(Set.of("category1", "category2"));
     }
 
     @Test(expected = ApiNotFoundException.class)


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8628
https://gravitee.atlassian.net/browse/APIM-366

Current behavior on the portal 🙈 
![image](https://user-images.githubusercontent.com/4112568/207871402-aeea26c8-75a9-458e-98db-97f98f3e1f32.png)



## Description

Use key attribute instead of id in the categories of an API.

It restores the pre-3.19 behavior and is also consistent with the data returned by `ApiSearchService#findAllGenericByEnvironment`



<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8628-fix-categories/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-adwhseffnl.chromatic.com)
<!-- Storybook placeholder end -->
