### PR TITLE
perf(mongodb): optimize database access when searching APIs

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiRepository.java
@@ -17,14 +17,13 @@ package io.gravitee.repository.management.api;
 
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
-import io.gravitee.repository.management.api.search.ApiCriteria;
-import io.gravitee.repository.management.api.search.ApiFieldFilter;
-import io.gravitee.repository.management.api.search.Pageable;
-import io.gravitee.repository.management.api.search.Sortable;
+import io.gravitee.repository.management.api.search.*;
+import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.model.Api;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -33,9 +32,18 @@ import java.util.Set;
  * @author GraviteeSource Team
  */
 public interface ApiRepository extends CrudRepository<Api, String> {
+    /* Default batch size for streamed search. Indeed, the streamed search calls the paginated search*/
+    int DEFAULT_STREAM_BATCH_SIZE = 100;
+
     Page<Api> search(ApiCriteria apiCriteria, Sortable sortable, Pageable pageable, ApiFieldFilter apiFieldFilter);
 
     List<Api> search(ApiCriteria apiCriteria, ApiFieldFilter apiFieldFilter);
+
+    default Stream<Api> search(ApiCriteria apiCriteria, Sortable sortable, ApiFieldFilter apiFieldFilter) {
+        return search(apiCriteria, sortable, apiFieldFilter, DEFAULT_STREAM_BATCH_SIZE);
+    }
+
+    Stream<Api> search(ApiCriteria apiCriteria, Sortable sortable, ApiFieldFilter apiFieldFilter, int batchSize);
 
     Page<String> searchIds(List<ApiCriteria> apiCriteria, Pageable pageable, Sortable sortable);
 

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApiRepository.java
@@ -27,6 +27,7 @@ import io.gravitee.repository.management.model.Api;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.springframework.stereotype.Component;
 
 /**
@@ -80,6 +81,11 @@ public class HttpApiRepository extends AbstractRepository implements ApiReposito
             // Ensure that an exception is thrown and managed by the caller
             throw new IllegalStateException(te);
         }
+    }
+
+    @Override
+    public Stream<Api> search(ApiCriteria apiCriteria, Sortable sortable, ApiFieldFilter apiFieldFilter, int batchSize) {
+        throw new IllegalStateException();
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
@@ -24,6 +24,7 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.search.*;
+import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.ApiLifecycleState;
 import io.gravitee.repository.management.model.LifecycleState;
@@ -33,6 +34,7 @@ import java.sql.ResultSet;
 import java.sql.Types;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -180,6 +182,12 @@ public class JdbcApiRepository extends JdbcAbstractPageableRepository<Api> imple
     @Override
     public List<Api> search(ApiCriteria apiCriteria, ApiFieldFilter apiFieldFilter) {
         return findByCriteria(apiCriteria, null, apiFieldFilter);
+    }
+
+    @Override
+    public Stream<Api> search(ApiCriteria apiCriteria, Sortable sortable, ApiFieldFilter apiFieldFilter, int batchSize) {
+        // As in JDBC, we do not paginate, we can not use the batch size
+        return findByCriteria(apiCriteria, sortable, apiFieldFilter).stream();
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/ApiRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/ApiRepositoryTest.java
@@ -23,11 +23,13 @@ import static io.gravitee.repository.utils.DateUtils.parse;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 import static org.junit.Assert.*;
 
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.config.AbstractRepositoryTest;
 import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldFilter;
 import io.gravitee.repository.management.api.search.Order;
@@ -37,6 +39,8 @@ import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.ApiLifecycleState;
 import io.gravitee.repository.management.model.LifecycleState;
 import io.gravitee.repository.management.model.Visibility;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.util.*;
 import org.junit.Test;
 
@@ -457,5 +461,14 @@ public class ApiRepositoryTest extends AbstractRepositoryTest {
 
         assertEquals("api-to-update", apiIds.getContent().get(0));
         assertEquals("api-to-delete", apiIds.getContent().get(1));
+    }
+
+    @Test
+    public void shouldStreamSearch() throws NoSuchFieldException, IllegalAccessException {
+        List<Api> apis = apiRepository.search(null, null, ApiFieldFilter.allFields(), 2).collect(toList());
+
+        assertNotNull(apis);
+        assertFalse(apis.isEmpty());
+        assertEquals(9, apis.size());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/ApiRepositoryMock.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/ApiRepositoryMock.java
@@ -44,6 +44,7 @@ import io.gravitee.repository.management.model.LifecycleState;
 import io.gravitee.repository.management.model.Visibility;
 import java.util.*;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.mockito.Mockito;
 import org.mockito.internal.util.collections.Sets;
 
@@ -239,5 +240,20 @@ public class ApiRepositoryMock extends AbstractRepositoryMock<ApiRepository> {
             )
         )
             .thenReturn(new Page<>(List.of("api-to-update", "api-to-delete"), 0, 2, 4));
+
+        when(apiRepository.search(null, null, ApiFieldFilter.allFields(), 2))
+            .thenReturn(
+                Stream.of(
+                    mock(Api.class),
+                    mock(Api.class),
+                    mock(Api.class),
+                    mock(Api.class),
+                    mock(Api.class),
+                    mock(Api.class),
+                    mock(Api.class),
+                    mock(Api.class),
+                    mock(Api.class)
+                )
+            );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiRepositoryProxy.java
@@ -26,6 +26,7 @@ import io.gravitee.repository.management.model.Api;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.springframework.stereotype.Component;
 
 /**
@@ -64,6 +65,11 @@ public class ApiRepositoryProxy extends AbstractProxy<ApiRepository> implements 
     @Override
     public List<Api> search(ApiCriteria apiCriteria, ApiFieldFilter apiFieldFilter) {
         return target.search(apiCriteria, apiFieldFilter);
+    }
+
+    @Override
+    public Stream<Api> search(ApiCriteria apiCriteria, Sortable sortable, ApiFieldFilter apiFieldFilter, int batchSize) {
+        return target.search(apiCriteria, sortable, apiFieldFilter, batchSize);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/VirtualHostServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/VirtualHostServiceTest.java
@@ -20,12 +20,16 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.common.data.domain.Page;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.definition.model.VirtualHost;
 import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldFilter;
+import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.VirtualHostService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
@@ -35,6 +39,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -77,7 +82,14 @@ public class VirtualHostServiceTest {
 
     @Test
     public void shouldSucceed_create_noApi() {
-        when(apiRepository.search(null, ApiFieldFilter.allFields())).thenReturn(Collections.emptyList());
+        when(
+            apiRepository.search(
+                new ApiCriteria.Builder().environmentId(GraviteeContext.getCurrentEnvironment()).build(),
+                null,
+                new ApiFieldFilter.Builder().excludePicture().build()
+            )
+        )
+            .thenReturn(Stream.empty());
 
         virtualHostService.sanitizeAndValidate(
             GraviteeContext.getExecutionContext(),
@@ -88,8 +100,14 @@ public class VirtualHostServiceTest {
     @Test
     public void shouldSucceed_create_noMatchingPath() {
         Api api1 = createMock("mock1", "/existing");
-        when(apiRepository.search(null, ApiFieldFilter.allFields())).thenReturn(Collections.singletonList(api1));
-
+        when(
+            apiRepository.search(
+                new ApiCriteria.Builder().environmentId(GraviteeContext.getCurrentEnvironment()).build(),
+                null,
+                new ApiFieldFilter.Builder().excludePicture().build()
+            )
+        )
+            .thenReturn(Stream.of(api1));
         virtualHostService.sanitizeAndValidate(
             GraviteeContext.getExecutionContext(),
             Collections.singletonList(new VirtualHost("/context"))
@@ -99,7 +117,14 @@ public class VirtualHostServiceTest {
     @Test(expected = ApiContextPathAlreadyExistsException.class)
     public void shouldFail_create_existingPath() {
         Api api1 = createMock("mock1", "/context");
-        when(apiRepository.search(null, ApiFieldFilter.allFields())).thenReturn(Collections.singletonList(api1));
+        when(
+            apiRepository.search(
+                new ApiCriteria.Builder().environmentId(GraviteeContext.getCurrentEnvironment()).build(),
+                null,
+                new ApiFieldFilter.Builder().excludePicture().build()
+            )
+        )
+            .thenReturn(Stream.of(api1));
 
         virtualHostService.sanitizeAndValidate(
             GraviteeContext.getExecutionContext(),
@@ -110,8 +135,14 @@ public class VirtualHostServiceTest {
     @Test
     public void shouldFail_create_sameBasePath() {
         Api api1 = createMock("mock1", "/context2");
-        when(apiRepository.search(null, ApiFieldFilter.allFields())).thenReturn(Collections.singletonList(api1));
-
+        when(
+            apiRepository.search(
+                new ApiCriteria.Builder().environmentId(GraviteeContext.getCurrentEnvironment()).build(),
+                null,
+                new ApiFieldFilter.Builder().excludePicture().build()
+            )
+        )
+            .thenReturn(Stream.of(api1));
         virtualHostService.sanitizeAndValidate(
             GraviteeContext.getExecutionContext(),
             Collections.singletonList(new VirtualHost("/context"))
@@ -121,7 +152,6 @@ public class VirtualHostServiceTest {
     @Test
     public void shouldFail_create_sameBasePath2() {
         Api api1 = createMock("mock1", "/context");
-        when(apiRepository.search(null, ApiFieldFilter.allFields())).thenReturn(Collections.singletonList(api1));
 
         virtualHostService.sanitizeAndValidate(
             GraviteeContext.getExecutionContext(),
@@ -132,7 +162,14 @@ public class VirtualHostServiceTest {
     @Test(expected = ApiContextPathAlreadyExistsException.class)
     public void shouldFail_create_existingPath_trailingSlash() {
         Api api1 = createMock("mock1", "/context");
-        when(apiRepository.search(null, ApiFieldFilter.allFields())).thenReturn(Collections.singletonList(api1));
+        when(
+            apiRepository.search(
+                new ApiCriteria.Builder().environmentId(GraviteeContext.getCurrentEnvironment()).build(),
+                null,
+                new ApiFieldFilter.Builder().excludePicture().build()
+            )
+        )
+            .thenReturn(Stream.of(api1));
 
         virtualHostService.sanitizeAndValidate(
             GraviteeContext.getExecutionContext(),
@@ -143,7 +180,14 @@ public class VirtualHostServiceTest {
     @Test(expected = ApiContextPathAlreadyExistsException.class)
     public void shouldFail_create_existingPath_trailingSlash2() {
         Api api1 = createMock("mock1", "/context/");
-        when(apiRepository.search(null, ApiFieldFilter.allFields())).thenReturn(Collections.singletonList(api1));
+        when(
+            apiRepository.search(
+                new ApiCriteria.Builder().environmentId(GraviteeContext.getCurrentEnvironment()).build(),
+                null,
+                new ApiFieldFilter.Builder().excludePicture().build()
+            )
+        )
+            .thenReturn(Stream.of(api1));
 
         virtualHostService.sanitizeAndValidate(
             GraviteeContext.getExecutionContext(),
@@ -154,7 +198,14 @@ public class VirtualHostServiceTest {
     @Test(expected = ApiContextPathAlreadyExistsException.class)
     public void shouldFail_create_existingSubPath() {
         Api api1 = createMock("mock1", "/context/subpath");
-        when(apiRepository.search(null, ApiFieldFilter.allFields())).thenReturn(Collections.singletonList(api1));
+        when(
+            apiRepository.search(
+                new ApiCriteria.Builder().environmentId(GraviteeContext.getCurrentEnvironment()).build(),
+                null,
+                new ApiFieldFilter.Builder().excludePicture().build()
+            )
+        )
+            .thenReturn(Stream.of(api1));
 
         virtualHostService.sanitizeAndValidate(
             GraviteeContext.getExecutionContext(),
@@ -165,7 +216,14 @@ public class VirtualHostServiceTest {
     @Test
     public void shouldSucceed_create_virtualHostWithSamePath() {
         Api api1 = createMock("mock1", "/context", "api.gravitee.io");
-        when(apiRepository.search(null, ApiFieldFilter.allFields())).thenReturn(Collections.singletonList(api1));
+        when(
+            apiRepository.search(
+                new ApiCriteria.Builder().environmentId(GraviteeContext.getCurrentEnvironment()).build(),
+                null,
+                new ApiFieldFilter.Builder().excludePicture().build()
+            )
+        )
+            .thenReturn(Stream.of(api1));
 
         virtualHostService.sanitizeAndValidate(
             GraviteeContext.getExecutionContext(),
@@ -176,7 +234,14 @@ public class VirtualHostServiceTest {
     @Test(expected = ApiContextPathAlreadyExistsException.class)
     public void shouldSucceed_create_sameVirtualHostAndSamePath() {
         Api api1 = createMock("mock1", "/context", "api.gravitee.io");
-        when(apiRepository.search(null, ApiFieldFilter.allFields())).thenReturn(Collections.singletonList(api1));
+        when(
+            apiRepository.search(
+                new ApiCriteria.Builder().environmentId(GraviteeContext.getCurrentEnvironment()).build(),
+                null,
+                new ApiFieldFilter.Builder().excludePicture().build()
+            )
+        )
+            .thenReturn(Stream.of(api1));
 
         virtualHostService.sanitizeAndValidate(
             GraviteeContext.getExecutionContext(),
@@ -187,7 +252,14 @@ public class VirtualHostServiceTest {
     @Test(expected = ApiContextPathAlreadyExistsException.class)
     public void shouldSucceed_create_sameVirtualHostAndSameSubPath() {
         Api api1 = createMock("mock1", "/context", "api.gravitee.io");
-        when(apiRepository.search(null, ApiFieldFilter.allFields())).thenReturn(Collections.singletonList(api1));
+        when(
+            apiRepository.search(
+                new ApiCriteria.Builder().environmentId(GraviteeContext.getCurrentEnvironment()).build(),
+                null,
+                new ApiFieldFilter.Builder().excludePicture().build()
+            )
+        )
+            .thenReturn(Stream.of(api1));
 
         virtualHostService.sanitizeAndValidate(
             GraviteeContext.getExecutionContext(),
@@ -277,7 +349,6 @@ public class VirtualHostServiceTest {
     private Api createMock(String api, String path, String host) {
         Api api1 = mock(Api.class);
         when(api1.getId()).thenReturn(api);
-        when(api1.getEnvironmentId()).thenReturn("DEFAULT");
         if (host == null) {
             when(api1.getDefinition())
                 .thenReturn("{\"id\": \"" + api + "\",\"name\": \"API 1\",\"proxy\": {\"context_path\": \"" + path + "\"}}");


### PR DESCRIPTION
## Issue

N/A

## Description

Introducing a search method that returns a Stream of API, to be used in VirtualHost service checker.
When creating an API, we have to check that the contextPath / virtual hosts are not already existing. For that we have to load every API, to fetch their definition and compare the endpoints.

With this new search methods, the database no longer load all APIs, but use a paginated search. 
And if the contextPath / virtual hosts already exists, the process stops and does load more APIs.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-osntxwdwvl.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/3-18-x-search-stream/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
