### PR TITLE
fix: use api properties in el

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/Api.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/Api.java
@@ -117,4 +117,8 @@ public class Api implements Serializable {
             this.plans = null;
         }
     }
+
+    public static ApiBuilder builder() {
+        return new ApiBuilder();
+    }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ApiBuilder.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ApiBuilder.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.model.v4;
+
+import io.gravitee.definition.model.Properties;
+import io.gravitee.definition.model.v4.property.Property;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class ApiBuilder {
+
+    private final Api api;
+
+    public ApiBuilder() {
+        this.api = new Api();
+    }
+
+    public ApiBuilder id(String id) {
+        api.setId(id);
+        return this;
+    }
+
+    public ApiBuilder name(String name) {
+        api.setName(name);
+        return this;
+    }
+
+    public ApiBuilder apiVersion(String apiVersion) {
+        api.setApiVersion(apiVersion);
+        return this;
+    }
+
+    public ApiBuilder properties(Map<String, String> properties) {
+        api.setProperties(
+            properties.entrySet().stream().map(p -> new Property(p.getKey(), p.getValue(), false, false)).collect(Collectors.toList())
+        );
+        return this;
+    }
+
+    public Api build() {
+        return api;
+    }
+
+    public io.gravitee.definition.model.Api buildv2() {
+        var apiv2 = new io.gravitee.definition.model.Api();
+        apiv2.setId(api.getId());
+        apiv2.setName(api.getName());
+        apiv2.setVersion(api.getApiVersion());
+
+        if (api.getProperties() != null) {
+            var props = new Properties();
+            props.setProperties(
+                api
+                    .getProperties()
+                    .stream()
+                    .map(p -> new io.gravitee.definition.model.Property(p.getKey(), p.getValue(), p.isEncrypted()))
+                    .collect(Collectors.toList())
+            );
+            apiv2.setProperties(props);
+        }
+        return apiv2;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/context/ApiProperties.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/context/ApiProperties.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.handlers.api.context;
 
 import io.gravitee.gateway.handlers.api.definition.Api;
+import java.util.Map;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -41,7 +42,7 @@ class ApiProperties {
         return this.api.getApiVersion();
     }
 
-    public io.gravitee.definition.model.Properties getProperties() {
-        return this.api.getDefinition().getProperties();
+    public Map<String, String> getProperties() {
+        return this.api.getDefinition().getProperties().getValues();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/el/ApiVariables.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/el/ApiVariables.java
@@ -15,9 +15,10 @@
  */
 package io.gravitee.gateway.jupiter.handlers.api.el;
 
-import io.gravitee.definition.model.v4.property.Property;
+import io.gravitee.common.util.TemplatedValueHashMap;
 import io.gravitee.gateway.jupiter.handlers.api.v4.Api;
-import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
@@ -26,6 +27,8 @@ import java.util.List;
 class ApiVariables {
 
     private final Api api;
+
+    private Map<String, String> apiProperties;
 
     ApiVariables(final Api api) {
         this.api = api;
@@ -43,7 +46,25 @@ class ApiVariables {
         return this.api.getApiVersion();
     }
 
-    public List<Property> getProperties() {
-        return this.api.getDefinition().getProperties();
+    public Map<String, String> getProperties() {
+        if (apiProperties == null) {
+            this.apiProperties =
+                api
+                    .getDefinition()
+                    .getProperties()
+                    .stream()
+                    .collect(
+                        Collectors.toMap(
+                            io.gravitee.definition.model.v4.property.Property::getKey,
+                            io.gravitee.definition.model.v4.property.Property::getValue,
+                            (v1, v2) -> {
+                                throw new RuntimeException(String.format("Duplicate key for values %s and %s", v1, v2));
+                            },
+                            TemplatedValueHashMap::new
+                        )
+                    );
+        }
+
+        return this.apiProperties;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/context/ApiTemplateVariableProviderTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/context/ApiTemplateVariableProviderTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.context;
+
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.el.TemplateEngine;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ApiTemplateVariableProviderTest {
+
+    @Test
+    void should_provide_api_id_in_EL() {
+        var apiDefinition = Api.builder().id("api#id").buildv2();
+
+        TemplateEngine engine = buildTemplateEngine(apiDefinition);
+        engine.eval("{#api.id}", String.class).test().assertValue("api#id");
+    }
+
+    @Test
+    void should_provide_api_name_in_EL() {
+        var apiDefinition = Api.builder().name("api#name").buildv2();
+
+        TemplateEngine engine = buildTemplateEngine(apiDefinition);
+        engine.eval("{#api.name}", String.class).test().assertValue("api#name");
+    }
+
+    @Test
+    void should_provide_api_version_in_EL() {
+        var apiDefinition = Api.builder().apiVersion("api#version").buildv2();
+
+        TemplateEngine engine = buildTemplateEngine(apiDefinition);
+        engine.eval("{#api.version}", String.class).test().assertValue("api#version");
+    }
+
+    @Test
+    void should_provide_api_properties_in_EL() {
+        var apiDefinition = Api.builder().properties(Map.of("prop1", "value1", "prop2", "value2")).buildv2();
+
+        TemplateEngine engine = buildTemplateEngine(apiDefinition);
+        engine.eval("{#properties[prop1]}", String.class).test().assertValue("value1");
+        engine.eval("{#properties[prop2]}", String.class).test().assertValue("value2");
+        engine.eval("{#api.properties[prop1]}", String.class).test().assertValue("value1");
+        engine.eval("{#api.properties[prop2]}", String.class).test().assertValue("value2");
+    }
+
+    private static TemplateEngine buildTemplateEngine(io.gravitee.definition.model.Api apiDefinition) {
+        var engine = TemplateEngine.templateEngine();
+        var apiContextProvider = new ApiTemplateVariableProvider(new io.gravitee.gateway.handlers.api.definition.Api(apiDefinition));
+        apiContextProvider.provide(engine.getTemplateContext());
+        return engine;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/el/ApiTemplateVariableProviderTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/el/ApiTemplateVariableProviderTest.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.handlers.api.el;
+
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.el.TemplateEngine;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ApiTemplateVariableProviderTest {
+
+    @Test
+    void should_provide_api_id_in_EL() {
+        var apiDefinition = Api.builder().id("api#id").build();
+
+        TemplateEngine engine = buildTemplateEngine(apiDefinition);
+        engine.eval("{#api.id}", String.class).test().assertValue("api#id");
+    }
+
+    @Test
+    void should_provide_api_name_in_EL() {
+        var apiDefinition = Api.builder().name("api#name").build();
+
+        TemplateEngine engine = buildTemplateEngine(apiDefinition);
+        engine.eval("{#api.name}", String.class).test().assertValue("api#name");
+    }
+
+    @Test
+    void should_provide_api_version_in_EL() {
+        var apiDefinition = Api.builder().apiVersion("api#version").build();
+
+        TemplateEngine engine = buildTemplateEngine(apiDefinition);
+        engine.eval("{#api.version}", String.class).test().assertValue("api#version");
+    }
+
+    @Test
+    void should_provide_api_properties_in_EL() {
+        var apiDefinition = Api.builder().properties(Map.of("prop1", "value1", "prop2", "value2")).build();
+
+        TemplateEngine engine = buildTemplateEngine(apiDefinition);
+        engine.eval("{#api.properties[prop1]}", String.class).test().assertValue("value1");
+        engine.eval("{#api.properties[prop2]}", String.class).test().assertValue("value2");
+    }
+
+    private static TemplateEngine buildTemplateEngine(Api apiDefinition) {
+        var engine = TemplateEngine.templateEngine();
+        var apiContextProvider = new ApiTemplateVariableProvider(new io.gravitee.gateway.jupiter.handlers.api.v4.Api(apiDefinition));
+        apiContextProvider.provide(engine.getTemplateContext());
+        return engine;
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-465

## Description

Ensure to have a map for api properties in the template context.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim465-api-properties-in-el/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wvvhchyqdo.chromatic.com)
<!-- Storybook placeholder end -->
