### PR TITLE
refactor: rename Organization Settings into Organization

### DIFF
--- a/docker/quick-setup/tags-internal-external/README.md
+++ b/docker/quick-setup/tags-internal-external/README.md
@@ -11,7 +11,7 @@ Here is a docker-compose to run APIM with two gateways:
 ## How to use ?
 
 In the Console UI:
-- Go to `Organization settings / Gateway / Sharding tags`
+- Go to `Organization / Gateway / Sharding tags`
 - Create two tags: `internal` and `external` 
 - Create your APIs and select configure them with tags (`YourAPI / Proxy / Deployments`)
 

--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
@@ -128,7 +128,7 @@ export class GioSideNavComponent implements OnInit {
         icon: 'gio:building',
         targetRoute: 'organization',
         baseRoute: 'organization',
-        displayName: 'Organization settings',
+        displayName: 'Organization',
         permissions: ['organization-settings-r'],
       },
     ]);

--- a/gravitee-apim-console-webui/src/management/configuration/configuration.route.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/configuration.route.ts
@@ -690,7 +690,7 @@ function configurationRouterConfig($stateProvider: StateProvider) {
       url: '/tags',
       component: 'moved',
       resolve: {
-        destinationName: () => 'Organization settings > Tags',
+        destinationName: () => 'Organization > Tags',
         permissions: () => ['organization-tag-r'],
         goTo: () => 'organization.settings.ng-tags',
         destinationIcon: () => 'settings_applications',
@@ -709,7 +709,7 @@ function configurationRouterConfig($stateProvider: StateProvider) {
       url: '/tenants',
       component: 'moved',
       resolve: {
-        destinationName: () => 'Organization settings > Tenants',
+        destinationName: () => 'Organization > Tenants',
         permissions: () => ['organization-tenant-r'],
         goTo: () => 'organization.settings.ng-tenants',
         destinationIcon: () => 'settings_applications',


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-468

## Description

Rename `Organization settings` into `Organization`
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-468-rename-organization-settings-menu/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vcfrpmkuld.chromatic.com)
<!-- Storybook placeholder end -->
