### PR TITLE
Use correct permissions in the menu of the organization settings screen 

### DIFF
--- a/gravitee-apim-console-webui/src/organization/configuration/organization-settings.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/organization-settings.html
@@ -79,7 +79,10 @@
         </li>
       </ul>
 
-      <div class="aui-nav-heading" ng-if="$ctrl.settingsMenu.notificationTemplates.perm">
+      <div
+        class="aui-nav-heading"
+        ng-if="$ctrl.settingsMenu.tags.perm || $ctrl.settingsMenu.tenants.perm || $ctrl.settingsMenu.policies.perm"
+      >
         <strong>Gateway</strong>
       </div>
       <ul class="aui-nav">


### PR DESCRIPTION
## Issue

NA

## Description

In the organization settings screen, the `Gateway` menu was conditionally displayed based on `notificationTemplates` permission instead of `tags`, `tenants` or `policies` ones
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zduduchnja.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/fix-org-settings-menu-permission/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
