### PR TITLE
Fix API synchronizer to undeploy API with wrong tags

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/ActionOnApi.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/ActionOnApi.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.manager;
+
+/**
+ * This enum is used by {@link ApiManager} in the requiredActionFor method
+ * and can be used for instance in APISynchronizer to determine what to do with API being synchronized
+ *
+ * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public enum ActionOnApi {
+    DEPLOY,
+    UNDEPLOY,
+    NONE,
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/ApiManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/ApiManager.java
@@ -28,7 +28,7 @@ import java.util.Collection;
  * @author GraviteeSource Team
  */
 public interface ApiManager {
-    boolean requireDeployment(ReactableApi reactableApi);
+    ActionOnApi requiredActionFor(ReactableApi reactableApi);
 
     /**
      * Register an API definition. It is a "create or update" operation, if the api was previously existing, the


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-445

## Description

Fix API synchronizer to undeploy API with wrong tags
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-445-fix-api-synchronization/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zviugjscor.chromatic.com)
<!-- Storybook placeholder end -->
