### PR TITLE
fix: remove Highchart export module

### DIFF
--- a/gravitee-apim-console-webui/src/management/management.module.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/management.module.ajs.ts
@@ -474,7 +474,6 @@ require('angular-loading-bar');
 // Highcharts
 const Highcharts = require('highcharts');
 window.Highcharts = Highcharts;
-require('highcharts/modules/exporting')(Highcharts);
 require('highcharts/highcharts-more')(Highcharts);
 require('highcharts/modules/solid-gauge')(Highcharts);
 require('highcharts/modules/no-data-to-display')(Highcharts);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-406

## Description

It is not a required module for us, and created some UI bugs (like overlapping).
Now, no user menu will be displayed on highchart graph
![image](https://user-images.githubusercontent.com/13161768/208478733-94003585-fff6-4e6f-a41c-87e4fef8ebdb.png)


### Before
![image](https://user-images.githubusercontent.com/13161768/208478326-6bc0de7e-3196-44bb-878b-70cea63fbf53.png)
![image](https://user-images.githubusercontent.com/13161768/208478444-191a69c6-68d4-455f-a2f1-bcfba738aa70.png)


### After
![image](https://user-images.githubusercontent.com/13161768/208478234-a2c7b0e5-cfdf-4f42-b228-f56e1616ed94.png)
![image](https://user-images.githubusercontent.com/13161768/208478491-f6d987ed-a278-44f5-b437-97b5444f4651.png)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-406-fix-highcharts-module/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rjnglkeunj.chromatic.com)
<!-- Storybook placeholder end -->
