### PR TITLE
test: reduce e2e tests bridge gateway synchronization delay

### DIFF
--- a/gravitee-apim-e2e/docker/common/docker-compose-bridge.yml
+++ b/gravitee-apim-e2e/docker/common/docker-compose-bridge.yml
@@ -70,7 +70,7 @@ services:
     environment:
       - gravitee_reporters_elasticsearch_endpoints_0=http://elasticsearch:9200
       - gravitee_api_jupiterMode_enabled=${JUPITER_MODE_ENABLED:-false}
-      - gravitee_services_sync_delay=2000
+      - gravitee_services_sync_delay=500
       - "JAVA_OPTS=${JAVA_OPTS} ${JACOCO_OPTS}"
       - gravitee_services_bridge_http_enabled=true
       - gravitee_services_bridge_http_port=18092


### PR DESCRIPTION
High delay leads to flaky e2e tests, cause test ends before subscription is synchronized by the gateway.
This PR reduces the delay to 500, same configuration as regular gateway in docker-compose-apis.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-izjfjxjojo.chromatic.com)
<!-- Storybook placeholder end -->
