### PR TITLE
fix: keep overrideEntrypoint value during sanitization

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/VirtualHostService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/VirtualHostService.java
@@ -17,7 +17,7 @@ package io.gravitee.rest.api.service;
 
 import io.gravitee.definition.model.VirtualHost;
 import io.gravitee.rest.api.service.common.ExecutionContext;
-import java.util.Collection;
+import java.util.List;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -31,7 +31,7 @@ public interface VirtualHostService {
      * @param virtualHosts
      * @return sanitized virtualHosts
      */
-    default Collection<VirtualHost> sanitizeAndValidate(ExecutionContext executionContext, Collection<VirtualHost> virtualHosts) {
+    default List<VirtualHost> sanitizeAndValidate(ExecutionContext executionContext, List<VirtualHost> virtualHosts) {
         return sanitizeAndValidate(executionContext, virtualHosts, null);
     }
 
@@ -46,7 +46,7 @@ public interface VirtualHostService {
      * @param api
      * @return sanitized virtualHosts
      */
-    Collection<VirtualHost> sanitizeAndValidate(ExecutionContext executionContext, Collection<VirtualHost> virtualHosts, String api);
+    List<VirtualHost> sanitizeAndValidate(ExecutionContext executionContext, List<VirtualHost> virtualHosts, String api);
 
     /**
      * this method sanitizes the path of the virtual host.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/VirtualHostServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/VirtualHostServiceImpl.java
@@ -24,8 +24,8 @@ import io.gravitee.rest.api.service.exceptions.InvalidVirtualHostException;
 import io.gravitee.rest.api.service.v4.exception.InvalidHostException;
 import io.gravitee.rest.api.service.v4.exception.PathAlreadyExistsException;
 import io.gravitee.rest.api.service.v4.validation.PathValidationService;
-import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
@@ -43,23 +43,25 @@ public class VirtualHostServiceImpl extends TransactionalService implements Virt
     }
 
     @Override
-    public Collection<VirtualHost> sanitizeAndValidate(
-        ExecutionContext executionContext,
-        Collection<VirtualHost> virtualHosts,
-        String apiId
-    ) {
+    public List<VirtualHost> sanitizeAndValidate(ExecutionContext executionContext, List<VirtualHost> virtualHosts, String apiId) {
         // Sanitize virtual hosts
+        // Result list has same order as input list
         List<Path> paths = virtualHosts
             .stream()
             .map(virtualHost -> new Path(virtualHost.getHost(), virtualHost.getPath()))
             .collect(Collectors.toList());
 
         try {
-            return pathValidationService
-                .validateAndSanitizePaths(executionContext, apiId, paths)
-                .stream()
-                .map(path -> new VirtualHost(path.getHost(), path.getPath()))
-                .collect(Collectors.toList());
+            int index = 0;
+            List<Path> sanitizedPaths = pathValidationService.validateAndSanitizePaths(executionContext, apiId, paths);
+            for (Path path : sanitizedPaths) {
+                // sanitized list of Path has same order as input list, so we can rely on index to update the input list.
+                // The goal here is to change only the path and host of the vHost and to keep the value of overrideEntrypoint.
+                VirtualHost virtualHost = virtualHosts.get(index++);
+                virtualHost.setHost(path.getHost());
+                virtualHost.setPath(path.getPath());
+            }
+            return virtualHosts;
         } catch (PathAlreadyExistsException e) {
             throw new ApiContextPathAlreadyExistsException(e.getPathValue());
         } catch (InvalidHostException e) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/services/ApiServiceCockpitImplTest.java
@@ -17,8 +17,8 @@ package io.gravitee.rest.api.service.cockpit.services;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.anyCollection;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.never;
@@ -63,7 +63,6 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.converter.PageConverter;
 import io.gravitee.rest.api.service.exceptions.ApiContextPathAlreadyExistsException;
-import io.gravitee.rest.api.service.v4.PlanSearchService;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -891,7 +890,7 @@ public class ApiServiceCockpitImplTest {
         proxy.setVirtualHosts(List.of(virtualHost));
         api.setProxy(proxy);
 
-        when(virtualHostService.sanitizeAndValidate(any(), anyCollection(), eq(null))).thenReturn(List.of(virtualHost));
+        when(virtualHostService.sanitizeAndValidate(any(), anyList(), eq(null))).thenReturn(List.of(virtualHost));
         var message = service.checkContextPath(GraviteeContext.getExecutionContext(), api);
 
         verify(virtualHostService).sanitizeAndValidate(any(), eq(List.of(virtualHost)), eq(null));
@@ -906,7 +905,7 @@ public class ApiServiceCockpitImplTest {
         proxy.setVirtualHosts(List.of(virtualHost));
         api.setProxy(proxy);
 
-        when(virtualHostService.sanitizeAndValidate(any(), anyCollection(), eq(null)))
+        when(virtualHostService.sanitizeAndValidate(any(), anyList(), eq(null)))
             .thenThrow(new ApiContextPathAlreadyExistsException("contextPath"));
         var message = service.checkContextPath(GraviteeContext.getExecutionContext(), api);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/VirtualHostServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/VirtualHostServiceTest.java
@@ -15,8 +15,11 @@
  */
 package io.gravitee.rest.api.service.impl;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -30,19 +33,15 @@ import io.gravitee.rest.api.service.VirtualHostService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApiContextPathAlreadyExistsException;
 import io.gravitee.rest.api.service.exceptions.InvalidVirtualHostException;
-import io.gravitee.rest.api.service.exceptions.InvalidVirtualHostNullHostException;
 import io.gravitee.rest.api.service.v4.impl.validation.PathValidationServiceImpl;
 import io.gravitee.rest.api.service.v4.validation.PathValidationService;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -82,10 +81,13 @@ public class VirtualHostServiceTest {
     public void shouldSucceed_create_noApi() {
         when(apiRepository.search(null)).thenReturn(Collections.emptyList());
 
-        virtualHostService.sanitizeAndValidate(
+        List<VirtualHost> virtualHosts = virtualHostService.sanitizeAndValidate(
             GraviteeContext.getExecutionContext(),
             Collections.singletonList(new VirtualHost("/context"))
         );
+
+        assertEquals(1, virtualHosts.size());
+        assertEquals(new VirtualHost(null, "/context/", false), virtualHosts.iterator().next());
     }
 
     @Test
@@ -93,10 +95,13 @@ public class VirtualHostServiceTest {
         Api api1 = createMock("mock1", "/existing");
         when(apiRepository.search(null)).thenReturn(Collections.singletonList(api1));
 
-        virtualHostService.sanitizeAndValidate(
+        List<VirtualHost> virtualHosts = virtualHostService.sanitizeAndValidate(
             GraviteeContext.getExecutionContext(),
             Collections.singletonList(new VirtualHost("/context"))
         );
+
+        assertEquals(1, virtualHosts.size());
+        assertEquals(new VirtualHost(null, "/context/", false), virtualHosts.iterator().next());
     }
 
     @Test(expected = ApiContextPathAlreadyExistsException.class)
@@ -115,10 +120,13 @@ public class VirtualHostServiceTest {
         Api api1 = createMock("mock1", "/context2");
         when(apiRepository.search(null)).thenReturn(Collections.singletonList(api1));
 
-        virtualHostService.sanitizeAndValidate(
+        List<VirtualHost> virtualHosts = virtualHostService.sanitizeAndValidate(
             GraviteeContext.getExecutionContext(),
             Collections.singletonList(new VirtualHost("/context"))
         );
+
+        assertEquals(1, virtualHosts.size());
+        assertEquals(new VirtualHost(null, "/context/", false), virtualHosts.iterator().next());
     }
 
     @Test
@@ -126,10 +134,13 @@ public class VirtualHostServiceTest {
         Api api1 = createMock("mock1", "/context");
         when(apiRepository.search(null)).thenReturn(Collections.singletonList(api1));
 
-        virtualHostService.sanitizeAndValidate(
+        List<VirtualHost> virtualHosts = virtualHostService.sanitizeAndValidate(
             GraviteeContext.getExecutionContext(),
             Collections.singletonList(new VirtualHost("/context2"))
         );
+
+        assertEquals(1, virtualHosts.size());
+        assertEquals(new VirtualHost(null, "/context2/", false), virtualHosts.iterator().next());
     }
 
     @Test(expected = ApiContextPathAlreadyExistsException.class)
@@ -170,10 +181,13 @@ public class VirtualHostServiceTest {
         Api api1 = createMock("mock1", "/context", "api.gravitee.io");
         when(apiRepository.search(null)).thenReturn(Collections.singletonList(api1));
 
-        virtualHostService.sanitizeAndValidate(
+        List<VirtualHost> virtualHosts = virtualHostService.sanitizeAndValidate(
             GraviteeContext.getExecutionContext(),
             Collections.singletonList(new VirtualHost("/context"))
         );
+
+        assertEquals(1, virtualHosts.size());
+        assertEquals(new VirtualHost(null, "/context/", false), virtualHosts.iterator().next());
     }
 
     @Test(expected = ApiContextPathAlreadyExistsException.class)
@@ -181,10 +195,13 @@ public class VirtualHostServiceTest {
         Api api1 = createMock("mock1", "/context", "api.gravitee.io");
         when(apiRepository.search(null)).thenReturn(Collections.singletonList(api1));
 
-        virtualHostService.sanitizeAndValidate(
+        List<VirtualHost> virtualHosts = virtualHostService.sanitizeAndValidate(
             GraviteeContext.getExecutionContext(),
             Collections.singletonList(new VirtualHost("api.gravitee.io", "/context"))
         );
+
+        assertEquals(1, virtualHosts.size());
+        assertEquals(new VirtualHost("api.gravitee.io", "/context/", false), virtualHosts.iterator().next());
     }
 
     @Test(expected = ApiContextPathAlreadyExistsException.class)
@@ -206,7 +223,13 @@ public class VirtualHostServiceTest {
         environmentEntity.setDomainRestrictions(Collections.singletonList(vhost.getHost()));
         when(environmentService.findById(any())).thenReturn(environmentEntity);
 
-        virtualHostService.sanitizeAndValidate(GraviteeContext.getExecutionContext(), Collections.singletonList(vhost));
+        List<VirtualHost> virtualHosts = virtualHostService.sanitizeAndValidate(
+            GraviteeContext.getExecutionContext(),
+            Collections.singletonList(vhost)
+        );
+
+        assertEquals(1, virtualHosts.size());
+        assertEquals(new VirtualHost("valid.host.gravitee.io", "/validVhostPath/", false), virtualHosts.iterator().next());
     }
 
     @Test
@@ -219,7 +242,12 @@ public class VirtualHostServiceTest {
         environmentEntity.setDomainRestrictions(Collections.singletonList(domainConstraint));
         when(environmentService.findById(any())).thenReturn(environmentEntity);
 
-        virtualHostService.sanitizeAndValidate(GraviteeContext.getExecutionContext(), Collections.singletonList(vhost));
+        List<VirtualHost> virtualHosts = virtualHostService.sanitizeAndValidate(
+            GraviteeContext.getExecutionContext(),
+            Collections.singletonList(vhost)
+        );
+        assertEquals(1, virtualHosts.size());
+        assertEquals(new VirtualHost("level2.level1.valid.host.gravitee.io", "/validVhostPath/", false), virtualHosts.iterator().next());
     }
 
     @Test
@@ -232,7 +260,12 @@ public class VirtualHostServiceTest {
         environmentEntity.setDomainRestrictions(Arrays.asList("test.gravitee.io", "other.gravitee.io", domainConstraint));
         when(environmentService.findById(any())).thenReturn(environmentEntity);
 
-        virtualHostService.sanitizeAndValidate(GraviteeContext.getExecutionContext(), Collections.singletonList(vhost));
+        List<VirtualHost> virtualHosts = virtualHostService.sanitizeAndValidate(
+            GraviteeContext.getExecutionContext(),
+            Collections.singletonList(vhost)
+        );
+        assertEquals(1, virtualHosts.size());
+        assertEquals(new VirtualHost("level2.level1.valid.host.gravitee.io", "/validVhostPath/", false), virtualHosts.iterator().next());
     }
 
     @Test(expected = InvalidVirtualHostException.class)
@@ -252,7 +285,18 @@ public class VirtualHostServiceTest {
         final VirtualHost vhost2 = new VirtualHost(null, "/path_2");
         final VirtualHost vhost3 = new VirtualHost("host3", "/path_3");
 
-        virtualHostService.sanitizeAndValidate(GraviteeContext.getExecutionContext(), List.of(vhost1, vhost2, vhost3));
+        List<VirtualHost> virtualHosts = virtualHostService.sanitizeAndValidate(
+            GraviteeContext.getExecutionContext(),
+            List.of(vhost1, vhost2, vhost3)
+        );
+
+        assertEquals(3, virtualHosts.size());
+        assertEquals(new VirtualHost("host1", "/path_1/", false), virtualHosts.get(0));
+        assertEquals(new VirtualHost(null, "/path_2/", false), virtualHosts.get(1));
+        assertEquals(new VirtualHost("host3", "/path_3/", false), virtualHosts.get(2));
+
+        // Check that even with multiple vHost, apiRepository is called only once
+        verify(apiRepository, times(1)).search(null);
     }
 
     @Test
@@ -265,12 +309,26 @@ public class VirtualHostServiceTest {
         environmentEntity.setDomainRestrictions(Arrays.asList("test.gravitee.io", "other.gravitee.io"));
         when(environmentService.findById(any())).thenReturn(environmentEntity);
 
-        final Collection<VirtualHost> virtualHosts = virtualHostService.sanitizeAndValidate(
+        final List<VirtualHost> virtualHosts = virtualHostService.sanitizeAndValidate(
             GraviteeContext.getExecutionContext(),
             Collections.singletonList(vhost)
         );
-        Assert.assertEquals(1, virtualHosts.size());
-        Assert.assertEquals("test.gravitee.io", virtualHosts.iterator().next().getHost());
+        assertEquals(1, virtualHosts.size());
+        assertEquals(new VirtualHost("test.gravitee.io", "/validVhostPath/", false), virtualHosts.iterator().next());
+    }
+
+    @Test
+    public void shouldKeepOverrideEntrypointValue() {
+        VirtualHost vhost = getValidVirtualHost();
+        vhost.setOverrideEntrypoint(true);
+
+        List<VirtualHost> virtualHosts = virtualHostService.sanitizeAndValidate(
+            GraviteeContext.getExecutionContext(),
+            Collections.singletonList(vhost)
+        );
+
+        assertEquals(1, virtualHosts.size());
+        assertEquals(new VirtualHost("valid.host.gravitee.io", "/validVhostPath/", true), virtualHosts.iterator().next());
     }
 
     private Api createMock(String api, String path) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-483

## Description

Modify the current virtualHost list during sanitization instead of creating a new one.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jueadknhmc.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-483-fix-override-entrypoint-checkbox/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
