### PR TITLE
fix(console): avoid horizontal scroll on logs page

### DIFF
--- a/gravitee-apim-console-webui/src/management/_forms.scss
+++ b/gravitee-apim-console-webui/src/management/_forms.scss
@@ -87,7 +87,8 @@
   }
 }
 .gv-forms.gv-forms-fluid {
-  max-width: 100%;
+  max-width: 0;
+  min-width: 100%;
 }
 
 .custom-user-fields-values {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-487

## Description

avoid horizontal scroll on logs page

## Additional context

<img width="1244" alt="image" src="https://user-images.githubusercontent.com/4974420/209165067-89581dc1-ed76-4e9c-a092-f813c27581f3.png">


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/3-2-x-fix-logs-style/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nvtajznvaf.chromatic.com)
<!-- Storybook placeholder end -->
