### PR TITLE
fix: API deserialization set plan.api from api.id if not in definition

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/ApiDeserializer.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/main/java/io/gravitee/definition/jackson/datatype/api/deser/ApiDeserializer.java
@@ -192,6 +192,9 @@ public class ApiDeserializer extends StdScalarDeserializer<Api> {
                             try {
                                 Plan plan = jsonNode.traverse(jp.getCodec()).readValueAs(Plan.class);
                                 plan.getFlows().forEach(flow -> flow.setStage(FlowStage.PLAN));
+                                if (plan.getApi() == null) {
+                                    plan.setApi(api.getId());
+                                }
                                 plans.add(plan);
                             } catch (IOException e) {
                                 logger.error("Plan {} can not be de-serialized", jsonNode.asText());

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiDeserializerTest.java
@@ -15,26 +15,43 @@
  */
 package io.gravitee.definition.jackson.api;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import io.gravitee.common.http.HttpHeader;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.definition.jackson.AbstractTest;
-import io.gravitee.definition.model.*;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.Cors;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.Endpoint;
+import io.gravitee.definition.model.EndpointGroup;
+import io.gravitee.definition.model.ExecutionMode;
+import io.gravitee.definition.model.Failover;
+import io.gravitee.definition.model.FlowMode;
+import io.gravitee.definition.model.LoadBalancerType;
+import io.gravitee.definition.model.Logging;
+import io.gravitee.definition.model.LoggingContent;
+import io.gravitee.definition.model.LoggingMode;
+import io.gravitee.definition.model.LoggingScope;
+import io.gravitee.definition.model.Plan;
+import io.gravitee.definition.model.Policy;
 import io.gravitee.definition.model.Properties;
+import io.gravitee.definition.model.ResponseTemplate;
+import io.gravitee.definition.model.Rule;
+import io.gravitee.definition.model.VirtualHost;
 import io.gravitee.definition.model.flow.Consumer;
 import io.gravitee.definition.model.flow.ConsumerType;
 import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.definition.model.flow.FlowStage;
 import io.gravitee.definition.model.flow.Step;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -480,16 +497,6 @@ public class ApiDeserializerTest extends AbstractTest {
         Assert.assertNotNull(group);
     }
 
-    private void checkHeader(List<HttpHeader> headers, String headerName, String headerValue) {
-        Assert.assertNotNull(headers);
-        List<HttpHeader> expectedHeaders = headers
-            .stream()
-            .filter(httpHeader -> headerName.equals(httpHeader.getName()))
-            .collect(Collectors.toList());
-        assertEquals(expectedHeaders.size(), 1);
-        assertEquals(headerValue, expectedHeaders.get(0).getValue());
-    }
-
     @Test
     public void definition_withResponseTemplates() throws Exception {
         Api api = load("/io/gravitee/definition/jackson/api-response-templates.json", Api.class);
@@ -665,5 +672,13 @@ public class ApiDeserializerTest extends AbstractTest {
         JsonNode endpointConfiguration = objectMapper().readTree(endpoint.getConfiguration());
         assertTrue(endpointConfiguration.has("http"));
         assertEquals(endpointConfiguration.get("http").toString(), "{\"useCompression\":false,\"propagateClientAcceptEncoding\":true}");
+    }
+
+    @Test
+    public void shouldSetPlanApiFromApiId() throws Exception {
+        Api api = load("/io/gravitee/definition/jackson/api-plan-without-apiId.json", Api.class);
+
+        assertEquals(1, api.getPlans().size());
+        assertEquals("my-api-id", api.getPlans().get(0).getApi());
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-plan-without-apiId.json
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/resources/io/gravitee/definition/jackson/api-plan-without-apiId.json
@@ -1,0 +1,22 @@
+{
+  "id": "my-api-id",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/my-api",
+    "endpoint": "http://localhost:1234",
+    "strip_context_path": false
+  },
+  "flows": [],
+  "plans": [
+    {
+      "id": "plan-1",
+      "name": "Plan 1",
+      "status": "PUBLISHED",
+      "security": "OAUTH2",
+      "securityDefinition": "",
+      "tags": [],
+      "flows": []
+    }
+  ]
+}


### PR DESCRIPTION
In 3.15, plan.api are not set in API definitions.
So, when a user migrates from 3.15 version, plans in API deployment events are deserialized with api = null.

That make fail the API key authentication process (ApiKeyPlanBasedAuthenticationHandler::preCheckSubscription uses plan.getApi()). User has to start/stop his API in order to make it work again.

This commit fixes API deserialization, setting plan.api from api.id if it's not set in definition.

## Issue

https://github.com/gravitee-io/issues/issues/8762


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-plansapideserialization-on318/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xjqmwiyzgd.chromatic.com)
<!-- Storybook placeholder end -->
