### PR TITLE
fix: prevent NPE when evaluating EL null api properties

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/el/ApiVariables.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/el/ApiVariables.java
@@ -47,7 +47,7 @@ class ApiVariables {
     }
 
     public Map<String, String> getProperties() {
-        if (apiProperties == null) {
+        if (apiProperties == null && api.getDefinition().getProperties() != null) {
             this.apiProperties =
                 api
                     .getDefinition()

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/context/ApiTemplateVariableProviderTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/context/ApiTemplateVariableProviderTest.java
@@ -15,12 +15,16 @@
  */
 package io.gravitee.gateway.handlers.api.context;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.gravitee.definition.model.v4.Api;
 import io.gravitee.el.TemplateEngine;
+import io.gravitee.el.exceptions.ExpressionEvaluationException;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+import org.springframework.expression.spel.SpelEvaluationException;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class ApiTemplateVariableProviderTest {
@@ -58,6 +62,50 @@ class ApiTemplateVariableProviderTest {
         engine.eval("{#properties[prop2]}", String.class).test().assertValue("value2");
         engine.eval("{#api.properties[prop1]}", String.class).test().assertValue("value1");
         engine.eval("{#api.properties[prop2]}", String.class).test().assertValue("value2");
+    }
+
+    @Test
+    void should_return_no_value_when_evaluate_unknown_api_properties_in_EL() {
+        var apiDefinition = Api.builder().properties(Map.of("prop1", "value1", "prop2", "value2")).buildv2();
+
+        TemplateEngine engine = buildTemplateEngine(apiDefinition);
+        engine.eval("{#properties[unknown]}", String.class).test().assertNoValues();
+        engine.eval("{#api.properties[unknown]}", String.class).test().assertNoValues();
+    }
+
+    @Test
+    void should_throw_when_evaluate_null_api_properties_in_EL() {
+        var apiDefinition = Api.builder().buildv2();
+
+        TemplateEngine engine = buildTemplateEngine(apiDefinition);
+        engine
+            .eval("{#properties[prop2]}", String.class)
+            .test()
+            .assertError(
+                e -> {
+                    assertThat(e)
+                        .isInstanceOf(ExpressionEvaluationException.class)
+                        .hasCauseInstanceOf(SpelEvaluationException.class)
+                        .hasStackTraceContaining("EL1007E: Property or field 'prop2' cannot be found on null");
+
+                    return true;
+                }
+            );
+        engine
+            .eval("{#api.properties[prop1]}", String.class)
+            .test()
+            .assertError(
+                e -> {
+                    assertThat(e)
+                        .isInstanceOf(ExpressionEvaluationException.class)
+                        .hasCauseInstanceOf(SpelEvaluationException.class)
+                        .hasStackTraceContaining(
+                            "EL1021E: A problem occurred whilst attempting to access the property 'properties': 'Unable to access property 'properties' through getter method"
+                        );
+
+                    return true;
+                }
+            );
     }
 
     private static TemplateEngine buildTemplateEngine(io.gravitee.definition.model.Api apiDefinition) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-465

## Description

In the v4 engine, we were not checking for null properties before creating the map. Therefore, an NPE was thrown. Hopefully, it was caught by the EL engine.
I would prefer avoiding throwing NPE, so this commit checks for null before creating the map.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim465-api-properties-in-el-handle-null/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-guhuauonty.chromatic.com)
<!-- Storybook placeholder end -->
