### PR TITLE
fix: check application apiKey mode according to environment in request

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/AbstractApiKeyResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/AbstractApiKeyResource.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource;
+
+import io.gravitee.rest.api.model.ApplicationEntity;
+import io.gravitee.rest.api.service.ApplicationService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
+import io.gravitee.rest.api.service.exceptions.InvalidApplicationApiKeyModeException;
+import javax.inject.Inject;
+
+/**
+ * A resource that manages API keys.
+ *
+ * @author GraviteeSource Team
+ */
+public class AbstractApiKeyResource extends AbstractResource {
+
+    @Inject
+    private ApplicationService applicationService;
+
+    protected void checkApplicationUsesSharedApiKey(ApplicationEntity applicationEntity) {
+        checkApplicationUsesSharedApiKey(applicationEntity, true);
+    }
+
+    protected void checkApplicationDoesntUseSharedApiKey(ApplicationEntity applicationEntity) {
+        checkApplicationUsesSharedApiKey(applicationEntity, false);
+    }
+
+    protected void checkApplicationDoesntUseSharedApiKey(ExecutionContext executionContext, String applicationId) {
+        ApplicationEntity applicationEntity = applicationService.findById(executionContext, applicationId);
+        if (applicationEntity == null) {
+            throw new ApplicationNotFoundException(applicationId);
+        }
+        checkApplicationDoesntUseSharedApiKey(applicationEntity);
+    }
+
+    private void checkApplicationUsesSharedApiKey(ApplicationEntity applicationEntity, boolean usesSharedApiKey) {
+        if (applicationEntity.hasApiKeySharedMode() != usesSharedApiKey) {
+            throw new InvalidApplicationApiKeyModeException(
+                String.format(
+                    "Invalid operation for api key mode [%s] of application [%s]",
+                    applicationEntity.getApiKeyMode(),
+                    applicationEntity.getId()
+                )
+            );
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationApiKeyResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationApiKeyResource.java
@@ -39,7 +39,7 @@ import javax.ws.rs.core.Response;
  * @author GraviteeSource Team
  */
 @Tag(name = "API Keys")
-public class ApplicationApiKeyResource extends AbstractResource {
+public class ApplicationApiKeyResource extends AbstractApiKeyResource {
 
     @Inject
     private ApiKeyService apiKeyService;
@@ -68,6 +68,7 @@ public class ApplicationApiKeyResource extends AbstractResource {
             return Response.status(Response.Status.BAD_REQUEST).entity("'key' parameter does not correspond to the application").build();
         }
 
+        checkApplicationUsesSharedApiKey(apiKeyEntity.getApplication());
         apiKeyService.revoke(executionContext, apiKeyEntity, true);
         return Response.status(Response.Status.NO_CONTENT).build();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionApiKeyResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionApiKeyResource.java
@@ -38,7 +38,7 @@ import javax.ws.rs.core.Response;
  * @author GraviteeSource Team
  */
 @Tag(name = "API Keys")
-public class ApplicationSubscriptionApiKeyResource extends AbstractResource {
+public class ApplicationSubscriptionApiKeyResource extends AbstractApiKeyResource {
 
     @Inject
     private ApiKeyService apiKeyService;
@@ -66,6 +66,7 @@ public class ApplicationSubscriptionApiKeyResource extends AbstractResource {
     @Permissions({ @Permission(value = RolePermission.APPLICATION_SUBSCRIPTION, acls = RolePermissionAction.DELETE) })
     public Response revokeApiKeyForApplicationSubscription() {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        checkApplicationDoesntUseSharedApiKey(executionContext, application);
         ApiKeyEntity apiKeyEntity = apiKeyService.findById(executionContext, apikey);
         if (!apiKeyEntity.hasSubscription(subscription)) {
             return Response.status(Response.Status.BAD_REQUEST).entity("'key' parameter does not correspond to the subscription").build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationApiKeyResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationApiKeyResourceTest.java
@@ -47,10 +47,9 @@ public class ApplicationApiKeyResourceTest extends AbstractResourceTest {
 
     @Test
     public void revoke_should_return_http_400_if_application_doesnt_use_shared_api_key() {
-        mockExistingApplication(ApiKeyMode.EXCLUSIVE);
-
         ApplicationEntity applicationEntity = new ApplicationEntity();
         applicationEntity.setId(APPLICATION_ID);
+        applicationEntity.setApiKeyMode(ApiKeyMode.EXCLUSIVE);
 
         ApiKeyEntity apiKeyEntity = new ApiKeyEntity();
         apiKeyEntity.setApplication(applicationEntity);
@@ -60,15 +59,16 @@ public class ApplicationApiKeyResourceTest extends AbstractResourceTest {
 
         Response response = envTarget().request().delete();
         assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+
+        verify(apiKeyService).findById(GraviteeContext.getExecutionContext(), APIKEY_ID);
         verifyNoMoreInteractions(apiKeyService);
     }
 
     @Test
     public void revoke_should_return_http_400_if_application_doesnt_match_api_key() {
-        mockExistingApplication(ApiKeyMode.SHARED);
-
         ApplicationEntity applicationEntity = new ApplicationEntity();
         applicationEntity.setId("another-app");
+        applicationEntity.setApiKeyMode(ApiKeyMode.SHARED);
 
         ApiKeyEntity apiKeyEntity = new ApiKeyEntity();
         apiKeyEntity.setApplication(applicationEntity);
@@ -83,10 +83,9 @@ public class ApplicationApiKeyResourceTest extends AbstractResourceTest {
 
     @Test
     public void revoke_should_call_revoke_service_and_return_http_204() {
-        mockExistingApplication(ApiKeyMode.SHARED);
-
         ApplicationEntity applicationEntity = new ApplicationEntity();
         applicationEntity.setId(APPLICATION_ID);
+        applicationEntity.setApiKeyMode(ApiKeyMode.SHARED);
 
         ApiKeyEntity apiKeyEntity = new ApiKeyEntity();
         apiKeyEntity.setApplication(applicationEntity);
@@ -98,11 +97,5 @@ public class ApplicationApiKeyResourceTest extends AbstractResourceTest {
         verify(apiKeyService, times(1)).findById(GraviteeContext.getExecutionContext(), APIKEY_ID);
         verify(apiKeyService, times(1)).revoke(GraviteeContext.getExecutionContext(), apiKeyEntity, true);
         verifyNoMoreInteractions(apiKeyService);
-    }
-
-    private void mockExistingApplication(ApiKeyMode apiKeyMode) {
-        ApplicationEntity application = new ApplicationEntity();
-        application.setApiKeyMode(apiKeyMode);
-        when(applicationService.findById(GraviteeContext.getExecutionContext(), APPLICATION_ID)).thenReturn(application);
     }
 }


### PR DESCRIPTION
API key mode check needs to read application, and so, needs the relevant ExecutionContext with environment set.

Before this fix, the check was performed in parent route controller, while resource is resolved according to path. But at this step, ExecutionContext is not yet populated regarding the path variables. So, it ends always looking in DEFAULT environment, even if URL contains a custom environment.

This fixes performs the check during the controller process, when environment is properly set in ExecutionContext.

## Issue

https://github.com/gravitee-io/issues/issues/8765

