### PR TITLE
fix(postgreSQL): 3.18.0 migration script handle existing commands

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_18_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_18_0/schema.yml
@@ -23,6 +23,7 @@ databaseChangeLog:
               - column:
                   name: organization_id
                   type: nvarchar(64)
+                  defaultValue: DEFAULT
                   constraints:
                     nullable: false
               - dropNotNullConstraint:


### PR DESCRIPTION
This fix adds a default value for commands.organization_id during liquibase migration, Cause the new column is not NULLable, the migration fail if there are records in the table, and no default value.

After this default value has been set during liquibase migration, The CommandOrganizationUpgrader will run and set the proper organization to each command.

## Issue

https://github.com/gravitee-io/issues/issues/8774

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-commandsliquibase-3-18/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
