### PR TITLE
feat: manage errors for subscription api

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/command/SubscriptionFailureCommand.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/command/SubscriptionFailureCommand.java
@@ -13,42 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.model.command;
+package io.gravitee.definition.model.command;
 
-import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
- * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class CommandQuery {
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Data
+public class SubscriptionFailureCommand {
 
-    private String to;
-    private List<CommandTags> tags;
-
-    private String notAckBy;
-
-    public String getTo() {
-        return to;
-    }
-
-    public void setTo(String to) {
-        this.to = to;
-    }
-
-    public List<CommandTags> getTags() {
-        return tags;
-    }
-
-    public void setTags(List<CommandTags> tags) {
-        this.tags = tags;
-    }
-
-    public String getNotAckBy() {
-        return notAckBy;
-    }
-
-    public void setNotAckBy(String notAckBy) {
-        this.notAckBy = notAckBy;
-    }
+    private String subscriptionId;
+    private String failureCause;
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/context/interruption/InterruptionFailureException.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/context/interruption/InterruptionFailureException.java
@@ -34,4 +34,9 @@ public class InterruptionFailureException extends RuntimeException {
     public ExecutionFailure getExecutionFailure() {
         return executionFailure;
     }
+
+    @Override
+    public String getMessage() {
+        return executionFailure.message();
+    }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.handlers.api.spring;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.common.util.DataEncryptor;
 import io.gravitee.gateway.core.classloader.DefaultClassLoader;
 import io.gravitee.gateway.core.component.ComponentProvider;
@@ -56,11 +57,13 @@ import io.gravitee.node.api.Node;
 import io.gravitee.node.api.cache.CacheManager;
 import io.gravitee.plugin.endpoint.EndpointConnectorPluginManager;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPluginManager;
+import io.gravitee.repository.management.api.CommandRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.core.env.Environment;
 
 /**
@@ -200,9 +203,12 @@ public class ApiHandlerConfiguration {
     public SubscriptionService subscriptionService(
         CacheManager cacheManager,
         ApiKeyService apiKeyService,
-        SubscriptionDispatcher subscriptionDispatcher
+        SubscriptionDispatcher subscriptionDispatcher,
+        @Lazy CommandRepository commandRepository,
+        Node node,
+        ObjectMapper objectMapper
     ) {
-        return new SubscriptionService(cacheManager, apiKeyService, subscriptionDispatcher);
+        return new SubscriptionService(cacheManager, apiKeyService, subscriptionDispatcher, commandRepository, node, objectMapper);
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/services/SubscriptionServiceTest.java
@@ -19,13 +19,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.definition.model.command.SubscriptionFailureCommand;
 import io.gravitee.gateway.api.service.ApiKey;
 import io.gravitee.gateway.api.service.Subscription;
-import io.gravitee.gateway.handlers.api.services.ApiKeyService;
-import io.gravitee.gateway.handlers.api.services.SubscriptionService;
 import io.gravitee.gateway.jupiter.api.policy.SecurityToken;
 import io.gravitee.gateway.jupiter.reactor.v4.subscription.SubscriptionDispatcher;
 import io.gravitee.node.api.Node;
@@ -36,18 +35,25 @@ import io.gravitee.repository.management.api.CommandRepository;
 import io.gravitee.repository.management.model.Command;
 import io.gravitee.repository.management.model.MessageRecipient;
 import io.reactivex.rxjava3.core.Completable;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
+import java.util.function.BiConsumer;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class SubscriptionServiceTest {
+class SubscriptionServiceTest {
 
     private static final String PLAN_ID = "my-test-plan-id";
     private static final String API_ID = "my-test-api-id";
@@ -55,6 +61,42 @@ public class SubscriptionServiceTest {
     private static final String SUB_ID_2 = "my-test-subscription-id-2";
     private static final String API_KEY = "my-test-api-key";
     private static final String CLIENT_ID = "my-test-client-id";
+
+    private static final BiConsumer<SubscriptionService, Subscription> SAVE_ONLY_STRATEGY = SubscriptionService::save;
+
+    private static final BiConsumer<SubscriptionService, Subscription> SAVE_THEN_DISPATCH_STRATEGY = (service, subscription) -> {
+        service.save(subscription);
+        service.dispatchFor(List.of(API_ID));
+    };
+
+    private static final BiConsumer<SubscriptionService, Subscription> SAVE_OR_DISPATCH_STRATEGY = SubscriptionService::saveOrDispatch;
+
+    /**
+     * Regarding subscription of type {@link Subscription.Type#SUBSCRIPTION}, they can be dispatch with two different strategies:
+     * - {@link this#SAVE_THEN_DISPATCH_STRATEGY} Subscriptions can be saved in a cache, then deployed when belonging apis are deployed
+     * - {@link this#SAVE_OR_DISPATCH_STRATEGY} Subscriptions are directly dispatched.
+     * @return a stream of dispatching strategies
+     */
+    private static Stream<Arguments> provideDispatchingStrategies() {
+        return Stream.of(
+            Arguments.of(SAVE_THEN_DISPATCH_STRATEGY, "Save subscription first, then dispatch it for the related api"),
+            Arguments.of(SAVE_OR_DISPATCH_STRATEGY, "Dispatch a subscription directly")
+        );
+    }
+
+    /**
+     * Regarding subscription of type {@link Subscription.Type#STANDARD}, they can be saved with two different strategies.
+     * Both strategies do the same thing, they cache the subscription. This stream allows to test two different entry points for the same result.
+     * - {@link this#SAVE_ONLY_STRATEGY}
+     * - {@link this#SAVE_OR_DISPATCH_STRATEGY}
+     * @return a stream of dispatching strategies
+     */
+    private static Stream<Arguments> provideStandardSubscriptionSavingStrategies() {
+        return Stream.of(
+            Arguments.of(SAVE_ONLY_STRATEGY, "Save subscription first, then dispatch it for the related api"),
+            Arguments.of(SAVE_OR_DISPATCH_STRATEGY, "Dispatch a subscription directly")
+        );
+    }
 
     @Mock
     private ApiKeyService apiKeyService;
@@ -68,6 +110,7 @@ public class SubscriptionServiceTest {
     @Mock
     private Node node;
 
+    @Spy
     private final ObjectMapper objectMapper = new GraviteeMapper();
 
     private SubscriptionService subscriptionService;
@@ -85,11 +128,16 @@ public class SubscriptionServiceTest {
             );
     }
 
-    @Test
-    void should_add_and_getById_accepted_subscription_in_cache() {
+    @ParameterizedTest(name = "[{index}] - {1}.")
+    @MethodSource("provideStandardSubscriptionSavingStrategies")
+    @DisplayName("Should add and get by Id accepted subscription in cache")
+    void should_add_and_getById_accepted_subscription_in_cache(
+        BiConsumer<SubscriptionService, Subscription> savingStrategy,
+        String testName
+    ) {
         Subscription subscription = buildAcceptedSubscription(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
 
-        subscriptionService.save(subscription);
+        savingStrategy.accept(subscriptionService, subscription);
 
         // should find subscription in cache with relevant id
         Optional<Subscription> foundSubscription = subscriptionService.getById(SUB_ID);
@@ -101,11 +149,16 @@ public class SubscriptionServiceTest {
         assertFalse(subscriptionService.getById("sub3").isPresent());
     }
 
-    @Test
-    void should_add_and_getByApiAndClientId_accepted_subscription_in_cache() {
+    @ParameterizedTest(name = "[{index}] - {1}.")
+    @MethodSource("provideStandardSubscriptionSavingStrategies")
+    @DisplayName("Should add and get by id and client id accepted subscription in cache")
+    void should_add_and_getByApiAndClientId_accepted_subscription_in_cache(
+        BiConsumer<SubscriptionService, Subscription> savingStrategy,
+        String testName
+    ) {
         Subscription subscription = buildAcceptedSubscription(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
 
-        subscriptionService.save(subscription);
+        savingStrategy.accept(subscriptionService, subscription);
 
         // should find subscription in cache with relevant id
         Optional<Subscription> foundSubscription = subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID);
@@ -117,10 +170,12 @@ public class SubscriptionServiceTest {
         assertFalse(subscriptionService.getByApiAndClientIdAndPlan(API_ID, "another-client-id", PLAN_ID).isPresent());
     }
 
-    @Test
-    void should_add_and_getBySecurityToken_with_clientId() {
+    @ParameterizedTest(name = "[{index}] - {1}.")
+    @MethodSource("provideStandardSubscriptionSavingStrategies")
+    @DisplayName("Should add and get by security token with client id")
+    void should_add_and_getBySecurityToken_with_clientId(BiConsumer<SubscriptionService, Subscription> savingStrategy, String testName) {
         Subscription subscription = buildAcceptedSubscription(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
-        subscriptionService.save(subscription);
+        savingStrategy.accept(subscriptionService, subscription);
 
         // should find subscription in cache with relevant security token
         SecurityToken securityToken = SecurityToken.forClientId(CLIENT_ID);
@@ -133,10 +188,12 @@ public class SubscriptionServiceTest {
         assertFalse(subscriptionService.getByApiAndSecurityToken(API_ID, securityToken, PLAN_ID).isPresent());
     }
 
-    @Test
-    void should_add_and_getBySecurityToken_with_apiKey() {
+    @ParameterizedTest(name = "[{index}] - {1}.")
+    @MethodSource("provideStandardSubscriptionSavingStrategies")
+    @DisplayName("Should add and get by security token with api key")
+    void should_add_and_getBySecurityToken_with_apiKey(BiConsumer<SubscriptionService, Subscription> savingStrategy, String testName) {
         Subscription subscription = buildAcceptedSubscription(SUB_ID, API_ID, null, PLAN_ID);
-        subscriptionService.save(subscription);
+        savingStrategy.accept(subscriptionService, subscription);
 
         // mock apiKeyService : it finds related Apikey, linked to subscription
         ApiKey apiKey = new ApiKey();
@@ -154,29 +211,33 @@ public class SubscriptionServiceTest {
         assertFalse(subscriptionService.getByApiAndSecurityToken(API_ID, securityToken, PLAN_ID).isPresent());
     }
 
-    @Test
-    void should_remove_rejected_subscription_from_cache() {
+    @ParameterizedTest(name = "[{index}] - {1}.")
+    @MethodSource("provideStandardSubscriptionSavingStrategies")
+    @DisplayName("Should remove rejected subscription from cache")
+    void should_remove_rejected_subscription_from_cache(BiConsumer<SubscriptionService, Subscription> savingStrategy, String testName) {
         Subscription subscription = buildAcceptedSubscription(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
 
-        subscriptionService.save(subscription);
+        savingStrategy.accept(subscriptionService, subscription);
 
         subscription.setStatus("REJECTED");
 
-        subscriptionService.save(subscription);
+        savingStrategy.accept(subscriptionService, subscription);
 
         // rejected subscription has been removed from cache
         assertFalse(subscriptionService.getById(SUB_ID).isPresent());
     }
 
-    @Test
-    void should_update_subscription_clientId_in_cache() {
+    @ParameterizedTest(name = "[{index}] - {1}.")
+    @MethodSource("provideStandardSubscriptionSavingStrategies")
+    @DisplayName("Should update subscription client id in cache")
+    void should_update_subscription_clientId_in_cache(BiConsumer<SubscriptionService, Subscription> savingStrategy, String testName) {
         Subscription oldSubscription = buildAcceptedSubscription(SUB_ID, API_ID, "old-client-id", PLAN_ID);
 
-        subscriptionService.save(oldSubscription);
+        savingStrategy.accept(subscriptionService, oldSubscription);
 
         Subscription newSubscription = buildAcceptedSubscription(SUB_ID, API_ID, "new-client-id", PLAN_ID);
 
-        subscriptionService.save(newSubscription);
+        savingStrategy.accept(subscriptionService, newSubscription);
 
         // should find subscription in cache with its new client id
         Optional<Subscription> foundSubscription = subscriptionService.getByApiAndClientIdAndPlan(API_ID, "new-client-id", PLAN_ID);
@@ -187,14 +248,14 @@ public class SubscriptionServiceTest {
         assertFalse(subscriptionService.getByApiAndClientIdAndPlan(API_ID, "old-client-id", PLAN_ID).isPresent());
     }
 
-    @Test
-    void should_dispatch_subscription_to_dispatcher() {
-        Subscription subscription = mock(Subscription.class);
-        lenient().when(subscription.getId()).thenReturn("sub-id");
-        when(subscription.getType()).thenReturn(Subscription.Type.SUBSCRIPTION);
+    @ParameterizedTest(name = "[{index}] - {1}.")
+    @MethodSource("provideDispatchingStrategies")
+    @DisplayName("Should dispatch subscription to dispatcher")
+    void should_dispatch_subscription_to_dispatcher(BiConsumer<SubscriptionService, Subscription> dispatchingStrategy, String testName) {
+        Subscription subscription = fakeSubscription("sub-id", API_ID);
         when(subscriptionDispatcher.dispatch(subscription)).thenReturn(Completable.complete());
 
-        subscriptionService.save(subscription);
+        dispatchingStrategy.accept(subscriptionService, subscription);
 
         verify(subscriptionDispatcher).dispatch(subscription);
 
@@ -202,15 +263,15 @@ public class SubscriptionServiceTest {
         assertTrue(optSubscription.isEmpty());
     }
 
-    @Test
+    @ParameterizedTest(name = "[{index}] - {1}.")
+    @MethodSource("provideDispatchingStrategies")
     @DisplayName("Should create a command when an error occurs during dispatching of subscription")
-    void should_send_command_when_dispatching_failure() throws TechnicalException, InterruptedException {
-        Subscription subscription = mock(Subscription.class);
-        lenient().when(subscription.getId()).thenReturn("sub-id");
-        when(subscription.getType()).thenReturn(Subscription.Type.SUBSCRIPTION);
+    void should_send_command_when_dispatching_failure(BiConsumer<SubscriptionService, Subscription> dispatchingStrategy, String testName)
+        throws TechnicalException, InterruptedException {
+        Subscription subscription = fakeSubscription("sub-id", API_ID);
 
         final CountDownLatch latch = new CountDownLatch(1);
-        // When create(Command) is called, then the method is down, so we can count down the latch
+        // When create(Command) is called, then the method is over, so we can count down the latch
         doAnswer(
                 invocation -> {
                     latch.countDown();
@@ -223,7 +284,60 @@ public class SubscriptionServiceTest {
         when(subscriptionDispatcher.dispatch(subscription)).thenReturn(Completable.error(new RuntimeException("Error! 💥")));
         when(node.id()).thenReturn("node-id");
 
-        subscriptionService.save(subscription);
+        dispatchingStrategy.accept(subscriptionService, subscription);
+
+        latch.await();
+        verify(subscriptionDispatcher).dispatch(subscription);
+
+        final ArgumentCaptor<Command> commandArgumentCaptor = ArgumentCaptor.forClass(Command.class);
+        verify(commandRepository).create(commandArgumentCaptor.capture());
+
+        final Command savedCommand = commandArgumentCaptor.getValue();
+        assertThat(savedCommand)
+            .satisfies(
+                c -> {
+                    assertThat(c.getTags()).hasSize(1).allMatch(t -> t.equals(CommandTags.SUBSCRIPTION_FAILURE.name()));
+                    assertThat(c.getCreatedAt()).isEqualTo(c.getUpdatedAt());
+                    assertThat(c.getFrom()).isEqualTo("node-id");
+                    assertThat(c.getTo()).isEqualTo(MessageRecipient.MANAGEMENT_APIS.name());
+                    final SubscriptionFailureCommand subscriptionCommand = objectMapper.readValue(
+                        c.getContent(),
+                        SubscriptionFailureCommand.class
+                    );
+                    assertThat(subscriptionCommand.getSubscriptionId()).isEqualTo("sub-id");
+                    assertThat(subscriptionCommand.getFailureCause()).isEqualTo("Error! 💥");
+                }
+            );
+
+        Optional<Subscription> optSubscription = subscriptionService.getById("sub-id");
+        assertTrue(optSubscription.isEmpty());
+    }
+
+    @ParameterizedTest(name = "[{index}] - {1}.")
+    @MethodSource("provideDispatchingStrategies")
+    @DisplayName("Should create a command when an error occurs during dispatching of subscription")
+    void should_send_command_when_dispatching_failure_json_object_fallback(
+        BiConsumer<SubscriptionService, Subscription> dispatchingStrategy,
+        String testName
+    ) throws TechnicalException, InterruptedException, JsonProcessingException {
+        Subscription subscription = fakeSubscription("sub-id", API_ID);
+
+        final CountDownLatch latch = new CountDownLatch(1);
+        // When create(Command) is called, then the method is over, so we can count down the latch
+        doAnswer(
+                invocation -> {
+                    latch.countDown();
+                    return null;
+                }
+            )
+            .when(commandRepository)
+            .create(any());
+
+        when(subscriptionDispatcher.dispatch(subscription)).thenReturn(Completable.error(new RuntimeException("Error! 💥")));
+        when(node.id()).thenReturn("node-id");
+        when(objectMapper.writeValueAsString(any(SubscriptionFailureCommand.class))).thenThrow(JsonProcessingException.class);
+
+        dispatchingStrategy.accept(subscriptionService, subscription);
 
         latch.await();
         verify(subscriptionDispatcher).dispatch(subscription);
@@ -253,28 +367,67 @@ public class SubscriptionServiceTest {
     }
 
     @Test
-    void should_evict_subscriptions_when_ids_match() {
+    @DisplayName("Should save then dispatch multiple subscriptions linked to different apis to dispatcher")
+    void should_save_then_dispatch_multiple_subscription_to_dispatcher() {
+        Subscription subscription1Api1 = fakeSubscription("sub-1", "api-1");
+        Subscription subscription2Api1 = fakeSubscription("sub-2", "api-1");
+        Subscription subscription1Api2 = fakeSubscription("sub-1", "api-2");
+        Subscription subscription2Api2 = fakeSubscription("sub-2", "api-2");
+        Subscription subscription1Api3 = fakeSubscription("sub-1", "api-3");
+        when(subscriptionDispatcher.dispatch(any(Subscription.class))).thenReturn(Completable.complete());
+
+        // All subscriptions are saved as it would be done in FullSubscriptionRefresher
+        subscriptionService.save(subscription1Api1);
+        subscriptionService.save(subscription2Api1);
+        subscriptionService.save(subscription1Api2);
+        subscriptionService.save(subscription2Api2);
+        subscriptionService.save(subscription1Api3);
+
+        // Then, when related apis are deployed, we dispatch subscriptions for those apis
+        subscriptionService.dispatchFor(List.of("api-1", "api-2", "api-3"));
+
+        ArgumentCaptor<Subscription> subscriptionCaptor = ArgumentCaptor.forClass(Subscription.class);
+        verify(subscriptionDispatcher, times(5)).dispatch(subscriptionCaptor.capture());
+
+        final List<Subscription> dispatchedSubscriptions = subscriptionCaptor.getAllValues();
+        assertThat(dispatchedSubscriptions)
+            .hasSize(5)
+            .containsExactly(subscription1Api1, subscription2Api1, subscription1Api2, subscription2Api2, subscription1Api3);
+    }
+
+    @ParameterizedTest(name = "[{index}] - {1}.")
+    @MethodSource("provideStandardSubscriptionSavingStrategies")
+    @DisplayName("Should evict subscription when ids match")
+    void should_evict_subscriptions_when_ids_match(BiConsumer<SubscriptionService, Subscription> savingStrategy, String testName) {
         Subscription subscription = buildAcceptedSubscription(SUB_ID, API_ID, CLIENT_ID, PLAN_ID);
         Subscription subscription2 = buildAcceptedSubscription(SUB_ID_2, API_ID, CLIENT_ID, PLAN_ID);
 
-        subscriptionService.save(subscription);
+        savingStrategy.accept(subscriptionService, subscription);
 
         Optional<Subscription> foundSubscription = subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID);
         assertTrue(foundSubscription.isPresent());
         assertEquals(subscription.getId(), foundSubscription.get().getId());
 
-        subscriptionService.save(subscription2);
+        savingStrategy.accept(subscriptionService, subscription2);
 
         foundSubscription = subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID);
         assertTrue(foundSubscription.isPresent());
         assertEquals(subscription2.getId(), foundSubscription.get().getId());
 
         subscription.setStatus("CLOSED");
-        subscriptionService.save(subscription);
+        savingStrategy.accept(subscriptionService, subscription);
 
         foundSubscription = subscriptionService.getByApiAndClientIdAndPlan(API_ID, CLIENT_ID, PLAN_ID);
         assertTrue(foundSubscription.isPresent());
         assertEquals(subscription2.getId(), foundSubscription.get().getId());
+    }
+
+    private static Subscription fakeSubscription(String id, String apiId) {
+        Subscription subscription = new Subscription();
+        subscription.setId(id);
+        subscription.setType(Subscription.Type.SUBSCRIPTION);
+        subscription.setApi(apiId);
+        return subscription;
     }
 
     private Subscription buildAcceptedSubscription(String id, String api, String clientId, String plan) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/DefaultSubscriptionDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/DefaultSubscriptionDispatcher.java
@@ -337,14 +337,11 @@ public class DefaultSubscriptionDispatcher extends AbstractService<SubscriptionD
             upstream.andThen(
                 Completable.defer(
                     () -> {
-                        if (context.response().status() / 100 == 4 || context.response().status() / 100 == 5) {
+                        if (context.response().isStatus4xx() || context.response().isStatus5xx()) {
                             return context
                                 .response()
                                 .body()
-                                .flatMapCompletable(
-                                    buffer ->
-                                        Completable.error(new SubscriptionConnectionException(subscription.getId(), buffer.toString()))
-                                );
+                                .flatMapCompletable(buffer -> Completable.error(new SubscriptionConnectionException(buffer.toString())));
                         }
                         return Completable.complete();
                     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/SubscriptionDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/SubscriptionDispatcher.java
@@ -17,11 +17,19 @@ package io.gravitee.gateway.jupiter.reactor.v4.subscription;
 
 import io.gravitee.common.component.LifecycleComponent;
 import io.gravitee.gateway.api.service.Subscription;
+import io.reactivex.rxjava3.core.Completable;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface SubscriptionDispatcher extends LifecycleComponent<SubscriptionDispatcher> {
-    void dispatch(Subscription subscription);
+    /**
+     * Dispatches the subscription {@link io.gravitee.gateway.reactor.handler.ReactorHandler}.
+     *
+     * @param subscription the subscription .
+     *
+     * @return a {@link Completable} that completes when the subscription has been fully dispatched.
+     */
+    Completable dispatch(Subscription subscription);
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/exceptions/SubscriptionConnectionException.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/exceptions/SubscriptionConnectionException.java
@@ -17,20 +17,14 @@ package io.gravitee.gateway.jupiter.reactor.v4.subscription.exceptions;
 
 public class SubscriptionConnectionException extends Exception {
 
-    private final String subscriptionId;
     private final String errorMessage;
 
-    public SubscriptionConnectionException(String subscriptionId, String errorMessage) {
-        this.subscriptionId = subscriptionId;
+    public SubscriptionConnectionException(String errorMessage) {
         this.errorMessage = errorMessage;
     }
 
     @Override
     public String getMessage() {
-        return String.format(
-            "An error occurs while connecting to backend for subscription [%s] with error: %s",
-            subscriptionId,
-            errorMessage
-        );
+        return String.format("Connection error: %s", errorMessage);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/exceptions/SubscriptionConnectionException.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/exceptions/SubscriptionConnectionException.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.reactor.v4.subscription.exceptions;
+
+public class SubscriptionConnectionException extends Exception {
+
+    private final String subscriptionId;
+    private final String errorMessage;
+
+    public SubscriptionConnectionException(String subscriptionId, String errorMessage) {
+        this.subscriptionId = subscriptionId;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public String getMessage() {
+        return String.format(
+            "An error occurs while connecting to backend for subscription [%s] with error: %s",
+            subscriptionId,
+            errorMessage
+        );
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/exceptions/SubscriptionExpiredException.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/exceptions/SubscriptionExpiredException.java
@@ -13,17 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.model;
+package io.gravitee.gateway.jupiter.reactor.v4.subscription.exceptions;
 
-import io.swagger.v3.oas.annotations.media.Schema;
+import io.gravitee.gateway.api.service.Subscription;
 
-/**
- * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
- * @author GraviteeSource Team
- */
-@Schema(enumAsRef = true)
-public enum SubscriptionConsumerStatus {
-    STARTED,
-    STOPPED,
-    FAILURE,
+public class SubscriptionExpiredException extends Exception {
+
+    public SubscriptionExpiredException(Subscription subscription) {
+        super(
+            String.format(
+                "Subscription [%S] disabled because it has expired at [%tF %tH:%tM]",
+                subscription.getId(),
+                subscription.getEndingAt(),
+                subscription.getEndingAt(),
+                subscription.getEndingAt()
+            )
+        );
+    }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/exceptions/SubscriptionNotDispatchedException.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/exceptions/SubscriptionNotDispatchedException.java
@@ -13,42 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.model.command;
-
-import java.util.List;
+package io.gravitee.gateway.jupiter.reactor.v4.subscription.exceptions;
 
 /**
- * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class CommandQuery {
+public class SubscriptionNotDispatchedException extends RuntimeException {
 
-    private String to;
-    private List<CommandTags> tags;
+    private final String message;
 
-    private String notAckBy;
-
-    public String getTo() {
-        return to;
+    public SubscriptionNotDispatchedException(Throwable cause) {
+        this.initCause(cause);
+        this.message = this.getCause().getMessage();
     }
 
-    public void setTo(String to) {
-        this.to = to;
+    public SubscriptionNotDispatchedException(String message) {
+        this.message = message;
     }
 
-    public List<CommandTags> getTags() {
-        return tags;
-    }
-
-    public void setTags(List<CommandTags> tags) {
-        this.tags = tags;
-    }
-
-    public String getNotAckBy() {
-        return notAckBy;
-    }
-
-    public void setNotAckBy(String notAckBy) {
-        this.notAckBy = notAckBy;
+    @Override
+    public String getMessage() {
+        return message;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/DefaultSubscriptionDispatcherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/DefaultSubscriptionDispatcherTest.java
@@ -223,7 +223,13 @@ class DefaultSubscriptionDispatcherTest {
             when(subscription.getConsumerStatus()).thenReturn(Subscription.ConsumerStatus.STARTED);
             when(subscription.getConfiguration()).thenReturn("{\"entrypointId\": \"webhook\"}");
             when(context.response()).thenReturn(response);
-            when(response.status()).thenReturn(responseStatus);
+            if (responseStatus == 400) {
+                when(response.isStatus4xx()).thenReturn(true);
+            }
+            if (responseStatus == 500) {
+                when(response.isStatus4xx()).thenReturn(false);
+                when(response.isStatus5xx()).thenReturn(true);
+            }
             when(response.body()).thenReturn(Maybe.just(Buffer.buffer("Error message")));
 
             final TestScheduler testScheduler = new TestScheduler();
@@ -247,12 +253,7 @@ class DefaultSubscriptionDispatcherTest {
 
             obs.assertError(
                 t -> {
-                    assertThat(t)
-                        .isInstanceOf(SubscriptionConnectionException.class)
-                        .hasMessageStartingWith(
-                            String.format("An error occurs while connecting to backend for subscription [%s]", subscription.getId())
-                        )
-                        .hasMessageEndingWith("with error: Error message");
+                    assertThat(t).isInstanceOf(SubscriptionConnectionException.class).hasMessage("Connection error: Error message");
                     return true;
                 }
             );
@@ -279,7 +280,8 @@ class DefaultSubscriptionDispatcherTest {
         when(subscription.getConsumerStatus()).thenReturn(Subscription.ConsumerStatus.STARTED);
         when(subscription.getConfiguration()).thenReturn("{\"entrypointId\": \"webhook\"}");
         when(context.response()).thenReturn(response);
-        when(response.status()).thenReturn(200);
+        when(response.isStatus4xx()).thenReturn(false);
+        when(response.isStatus5xx()).thenReturn(false);
 
         dispatcher.dispatch(subscription).test().assertComplete();
 
@@ -314,7 +316,8 @@ class DefaultSubscriptionDispatcherTest {
         when(subscription.getConsumerStatus()).thenReturn(Subscription.ConsumerStatus.STARTED);
         when(subscription.getConfiguration()).thenReturn("{\"entrypointId\": \"webhook\"}");
         when(context.response()).thenReturn(response);
-        when(response.status()).thenReturn(200);
+        when(response.isStatus4xx()).thenReturn(false);
+        when(response.isStatus5xx()).thenReturn(false);
 
         dispatcher.dispatch(subscription).test().assertComplete();
 
@@ -350,7 +353,8 @@ class DefaultSubscriptionDispatcherTest {
         when(subscription.getConsumerStatus()).thenReturn(Subscription.ConsumerStatus.STARTED);
         when(subscription.getConfiguration()).thenReturn("{\"entrypointId\": \"webhook\"}");
         when(context.response()).thenReturn(response);
-        when(response.status()).thenReturn(200);
+        when(response.isStatus4xx()).thenReturn(false);
+        when(response.isStatus5xx()).thenReturn(false);
 
         // mock Tracer component in context, and his frame
         Tracer tracer = mock(Tracer.class);
@@ -418,7 +422,8 @@ class DefaultSubscriptionDispatcherTest {
         when(resolver.resolve(any())).thenReturn(acceptor);
         when(reactor.handle(context)).thenReturn(Completable.complete());
         when(context.response()).thenReturn(response);
-        when(response.status()).thenReturn(200);
+        when(response.isStatus4xx()).thenReturn(false);
+        when(response.isStatus5xx()).thenReturn(false);
 
         Subscription originSubscription = new Subscription();
         originSubscription.setId(SUBSCRIPTION_ID);
@@ -465,7 +470,8 @@ class DefaultSubscriptionDispatcherTest {
         when(resolver.resolve(any())).thenReturn(acceptor);
         when(reactor.handle(context)).thenReturn(Completable.complete());
         when(context.response()).thenReturn(response);
-        when(response.status()).thenReturn(200);
+        when(response.isStatus4xx()).thenReturn(false);
+        when(response.isStatus5xx()).thenReturn(false);
 
         Subscription originSubscription = new Subscription();
         originSubscription.setId(SUBSCRIPTION_ID);
@@ -650,7 +656,8 @@ class DefaultSubscriptionDispatcherTest {
         when(subscription.getStartingAt()).thenReturn(addMillisecondsToCurrentDate(5000));
         when(subscription.getConfiguration()).thenReturn("{\"entrypointId\": \"webhook\"}");
         when(context.response()).thenReturn(response);
-        when(response.status()).thenReturn(200);
+        when(response.isStatus4xx()).thenReturn(false);
+        when(response.isStatus5xx()).thenReturn(false);
 
         final TestScheduler testScheduler = new TestScheduler();
         RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
@@ -684,7 +691,8 @@ class DefaultSubscriptionDispatcherTest {
         when(subscription.getStatus()).thenReturn("ACCEPTED");
         when(subscription.getConfiguration()).thenReturn("{\"entrypointId\": \"webhook\"}");
         when(context.response()).thenReturn(response);
-        when(response.status()).thenReturn(200);
+        when(response.isStatus4xx()).thenReturn(false);
+        when(response.isStatus5xx()).thenReturn(false);
 
         // Dispatch accepted subscription
         dispatcher.dispatch(subscription).test().await().assertComplete();
@@ -739,7 +747,8 @@ class DefaultSubscriptionDispatcherTest {
         when(subscription.getConsumerStatus()).thenReturn(Subscription.ConsumerStatus.STARTED);
         when(subscription.getConfiguration()).thenReturn("{\"entrypointId\": \"webhook\"}");
         when(context.response()).thenReturn(response);
-        when(response.status()).thenReturn(200);
+        when(response.isStatus4xx()).thenReturn(false);
+        when(response.isStatus5xx()).thenReturn(false);
 
         // Dispatch accepted subscription
         dispatcher.dispatch(subscription).test().assertComplete();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/exceptions/SubscriptionNotDispatchedExceptionTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/jupiter/reactor/v4/subscription/exceptions/SubscriptionNotDispatchedExceptionTest.java
@@ -13,17 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.model;
+package io.gravitee.gateway.jupiter.reactor.v4.subscription.exceptions;
 
-import io.swagger.v3.oas.annotations.media.Schema;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Schema(enumAsRef = true)
-public enum SubscriptionConsumerStatus {
-    STARTED,
-    STOPPED,
-    FAILURE,
+class SubscriptionNotDispatchedExceptionTest {
+
+    @Test
+    void shouldGetMessageFromCause() {
+        final SubscriptionNotDispatchedException exception = new SubscriptionNotDispatchedException(new RuntimeException("Error! 💥"));
+        assertThat(exception).hasMessage("Error! 💥");
+    }
+
+    @Test
+    void shouldGetMessage() {
+        final SubscriptionNotDispatchedException exception = new SubscriptionNotDispatchedException("Error! 💥");
+        assertThat(exception).hasMessage("Error! 💥");
+    }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/task/FullSubscriptionRefresher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/task/FullSubscriptionRefresher.java
@@ -35,4 +35,9 @@ public class FullSubscriptionRefresher extends SubscriptionRefresher {
     public Result<Boolean> call() {
         return doRefresh(new SubscriptionCriteria.Builder().status(Subscription.Status.ACCEPTED).plans(plans).build(), true);
     }
+
+    @Override
+    protected void handleSubscription(io.gravitee.gateway.api.service.Subscription subscription) {
+        subscriptionService.save(subscription);
+    }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/task/IncrementalSubscriptionRefresher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/task/IncrementalSubscriptionRefresher.java
@@ -58,4 +58,9 @@ public class IncrementalSubscriptionRefresher extends SubscriptionRefresher {
                 .build()
         );
     }
+
+    @Override
+    protected void handleSubscription(io.gravitee.gateway.api.service.Subscription subscription) {
+        subscriptionService.saveOrDispatch(subscription);
+    }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/task/SubscriptionRefresher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/task/SubscriptionRefresher.java
@@ -19,7 +19,6 @@ import io.gravitee.gateway.api.service.Subscription;
 import io.gravitee.gateway.api.service.SubscriptionService;
 import io.gravitee.repository.management.api.SubscriptionRepository;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
-import java.util.Date;
 import java.util.concurrent.Callable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,7 +33,7 @@ public abstract class SubscriptionRefresher implements Callable<Result<Boolean>>
 
     private SubscriptionRepository subscriptionRepository;
 
-    private SubscriptionService subscriptionService;
+    protected SubscriptionService subscriptionService;
 
     protected Result<Boolean> doRefresh(SubscriptionCriteria criteria) {
         return doRefresh(criteria, false);
@@ -54,12 +53,14 @@ public abstract class SubscriptionRefresher implements Callable<Result<Boolean>>
                         return s;
                     }
                 )
-                .forEach(subscriptionService::save);
+                .forEach(this::handleSubscription);
             return Result.success(true);
         } catch (Exception ex) {
             return Result.failure(ex);
         }
     }
+
+    protected abstract void handleSubscription(Subscription subscription);
 
     public void setSubscriptionRepository(SubscriptionRepository subscriptionRepository) {
         this.subscriptionRepository = subscriptionRepository;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/ApiSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/ApiSynchronizerTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.gateway.api.service.SubscriptionService;
 import io.gravitee.gateway.handlers.api.definition.Api;
 import io.gravitee.gateway.handlers.api.manager.ActionOnApi;
 import io.gravitee.gateway.handlers.api.manager.ApiManager;
@@ -108,6 +109,9 @@ public class ApiSynchronizerTest extends TestCase {
     @Mock
     private ObjectMapper objectMapper;
 
+    @Mock
+    private SubscriptionService subscriptionService;
+
     @Before
     public void setUp() {
         apiSynchronizer.setExecutor(Executors.newFixedThreadPool(1));
@@ -160,6 +164,7 @@ public class ApiSynchronizerTest extends TestCase {
         verify(planRepository, never()).findByApis(anyList());
         verify(apiKeysCacheService).register(singletonList(new Api(mockApi)));
         verify(subscriptionsCacheService).register(singletonList(new Api(mockApi)));
+        verify(subscriptionService).dispatchFor(singletonList(mockApi.getId()));
     }
 
     @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/CommandTags.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/CommandTags.java
@@ -13,17 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.model;
-
-import io.swagger.v3.oas.annotations.media.Schema;
+package io.gravitee.repository.management;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Schema(enumAsRef = true)
-public enum SubscriptionConsumerStatus {
-    STARTED,
-    STOPPED,
-    FAILURE,
+public enum CommandTags {
+    DATA_TO_INDEX,
+    SUBSCRIPTION_FAILURE,
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Subscription.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Subscription.java
@@ -114,6 +114,8 @@ public class Subscription implements Serializable {
     private Map<String, String> metadata;
     private Type type = Type.STANDARD;
 
+    private String failureCause;
+
     public Subscription() {}
 
     public Subscription(Subscription cloned) {
@@ -351,6 +353,14 @@ public class Subscription implements Serializable {
         this.type = type;
     }
 
+    public String getFailureCause() {
+        return failureCause;
+    }
+
+    public void setFailureCause(String failureCause) {
+        this.failureCause = failureCause;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -402,6 +412,10 @@ public class Subscription implements Serializable {
          * Subscription has been paused
          */
         STOPPED,
+        /**
+         * Subscription has encountered a failure
+         */
+        FAILURE,
     }
 
     public enum Type {

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcSubscriptionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcSubscriptionRepository.java
@@ -99,6 +99,7 @@ public class JdbcSubscriptionRepository extends JdbcAbstractCrudRepository<Subsc
             .addColumn("status", Types.NVARCHAR, Subscription.Status.class)
             .addColumn("consumer_status", Types.NVARCHAR, Subscription.ConsumerStatus.class)
             .addColumn("consumer_paused_at", Types.TIMESTAMP, Date.class)
+            .addColumn("failure_cause", Types.NVARCHAR, String.class)
             .addColumn("paused_at", Types.TIMESTAMP, Date.class)
             .addColumn("general_conditions_content_page_id", Types.NVARCHAR, String.class)
             .addColumn("general_conditions_content_revision", Types.INTEGER, Integer.class)

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_20_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_20_0/schema.yml
@@ -52,3 +52,8 @@ databaseChangeLog:
                   type: timestamp(6)
                   constraints:
                     nullable: true
+              - column:
+                  name: failure_cause
+                  type: nvarchar(256)
+                  constraints:
+                    nullable: true

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/SubscriptionMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/SubscriptionMongo.java
@@ -116,6 +116,8 @@ public class SubscriptionMongo extends Auditable {
 
     private Map<String, String> metadata;
 
+    private String failureCause;
+
     /**
      * STANDARD, SUBSCRIPTION
      */
@@ -311,6 +313,14 @@ public class SubscriptionMongo extends Auditable {
 
     public void setType(String type) {
         this.type = type;
+    }
+
+    public String getFailureCause() {
+        return failureCause;
+    }
+
+    public void setFailureCause(String failureCause) {
+        this.failureCause = failureCause;
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/Subscription.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/Subscription.java
@@ -17,7 +17,6 @@ package io.gravitee.rest.api.management.rest.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.rest.api.model.ApiKeyMode;
-import io.gravitee.rest.api.model.PlanSecurityType;
 import io.gravitee.rest.api.model.SubscriptionConsumerStatus;
 import io.gravitee.rest.api.model.SubscriptionStatus;
 import java.util.Date;
@@ -79,13 +78,16 @@ public class Subscription {
     @JsonProperty("paused_at")
     private Date pausedAt;
 
-    @JsonProperty("consumer_paused_at")
+    @JsonProperty("consumerPausedAt")
     private Date consumerPausedAt;
 
     @JsonProperty("client_id")
     private String clientId;
 
     private Map<String, String> metadata;
+
+    @JsonProperty("failureCause")
+    private String failureCause;
 
     public String getId() {
         return id;
@@ -245,6 +247,14 @@ public class Subscription {
 
     public void setConsumerPausedAt(Date consumerPausedAt) {
         this.consumerPausedAt = consumerPausedAt;
+    }
+
+    public String getFailureCause() {
+        return failureCause;
+    }
+
+    public void setFailureCause(String failureCause) {
+        this.failureCause = failureCause;
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/SubscriptionEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/SubscriptionEntity.java
@@ -95,6 +95,8 @@ public class SubscriptionEntity {
 
     private Map<String, String> metadata;
 
+    private String failureCause;
+
     public String getId() {
         return id;
     }
@@ -285,6 +287,14 @@ public class SubscriptionEntity {
 
     public void setMetadata(Map<String, String> metadata) {
         this.metadata = metadata;
+    }
+
+    public void setFailureCause(String failureCause) {
+        this.failureCause = failureCause;
+    }
+
+    public String getFailureCause() {
+        return failureCause;
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/command/CommandTags.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/command/CommandTags.java
@@ -15,14 +15,31 @@
  */
 package io.gravitee.rest.api.model.command;
 
+import static io.gravitee.rest.api.model.command.CommandTags.CommandCastMode.MULTICAST;
+import static io.gravitee.rest.api.model.command.CommandTags.CommandCastMode.UNICAST;
+
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.RequiredArgsConstructor;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
 
+@RequiredArgsConstructor
 @Schema(enumAsRef = true)
 public enum CommandTags {
-    DATA_TO_INDEX,
+    DATA_TO_INDEX(MULTICAST),
+    SUBSCRIPTION_FAILURE(UNICAST);
+
+    private final CommandCastMode castMode;
+
+    public boolean isUnicast() {
+        return this.castMode == UNICAST;
+    }
+
+    enum CommandCastMode {
+        UNICAST,
+        MULTICAST,
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -3399,6 +3399,7 @@ components:
         enum:
           - STARTED
           - STOPPED
+          - FAILURE
 
     #Users filtering
     usersQueryParam:
@@ -4297,12 +4298,16 @@ components:
           description: Consumer status of the subscription.
           type: string
           enum:
-            - ACTIVE
-            - PAUSED
+            - STARTED
+            - STOPPED
+            - FAILURE
         consumerPausedAt:
           description: Paused date and time of the subscription for the customer.
           type: string
           format: date-time
+        failureCause:
+          description: The cause of the failure
+          type: string
         ###################
         # may be included #
         ###################

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ScheduledCommandService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ScheduledCommandService.java
@@ -13,21 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.gateway.jupiter.reactor.v4.subscription;
+package io.gravitee.rest.api.service;
 
-import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.common.component.LifecycleComponent;
 
-public class SubscriptionExpiredException extends Exception {
-
-    public SubscriptionExpiredException(Subscription subscription) {
-        super(
-            String.format(
-                "Subscription [%S] disabled because it has expired at [%tF %tH:%tM]",
-                subscription.getId(),
-                subscription.getEndingAt(),
-                subscription.getEndingAt(),
-                subscription.getEndingAt()
-            )
-        );
-    }
-}
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface ScheduledCommandService<T> extends LifecycleComponent<T> {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/SubscriptionCommandListener.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/SubscriptionCommandListener.java
@@ -15,22 +15,12 @@
  */
 package io.gravitee.rest.api.service;
 
+import io.gravitee.common.event.EventListener;
 import io.gravitee.rest.api.model.command.CommandEntity;
-import io.gravitee.rest.api.model.command.CommandQuery;
-import io.gravitee.rest.api.model.command.NewCommandEntity;
-import io.gravitee.rest.api.service.common.ExecutionContext;
-import java.util.List;
+import io.gravitee.rest.api.service.event.CommandEvent;
 
 /**
- * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface CommandService {
-    void send(ExecutionContext executionContext, NewCommandEntity message);
-
-    List<CommandEntity> search(CommandQuery query);
-
-    List<CommandEntity> search(ExecutionContext executionContext, CommandQuery query);
-    void ack(String messageId);
-    void delete(String commandId);
-}
+public interface SubscriptionCommandListener extends EventListener<CommandEvent, CommandEntity> {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/SubscriptionService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/SubscriptionService.java
@@ -72,6 +72,7 @@ public interface SubscriptionService {
     SubscriptionEntity restore(ExecutionContext executionContext, String subscription);
 
     SubscriptionEntity close(ExecutionContext executionContext, String subscription);
+    SubscriptionEntity fail(String subscriptionId, String failureCause);
 
     void delete(ExecutionContext executionContext, String subscription);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/CommandConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/CommandConverter.java
@@ -56,7 +56,7 @@ public class CommandConverter {
         commandEntity.setTo(command.getTo());
         commandEntity.setContent(command.getContent());
         commandEntity.setTags(toCommandTags(command.getTags()));
-        commandEntity.setExpired(command.getExpiredAt().before(new Date()));
+        commandEntity.setExpired(command.getExpiredAt() != null && command.getExpiredAt().before(new Date()));
         commandEntity.setProcessedInCurrentNode(isProcessedInCurrentNode(command));
         return commandEntity;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/event/CommandEvent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/event/CommandEvent.java
@@ -13,17 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.model;
-
-import io.swagger.v3.oas.annotations.media.Schema;
+package io.gravitee.rest.api.service.event;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Schema(enumAsRef = true)
-public enum SubscriptionConsumerStatus {
-    STARTED,
-    STOPPED,
-    FAILURE,
+public enum CommandEvent {
+    TO_PROCESS,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/SubscriptionFailureException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/SubscriptionFailureException.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.exceptions;
+
+import static java.util.Collections.singletonMap;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.repository.management.model.Subscription;
+import java.util.Map;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class SubscriptionFailureException extends AbstractManagementException {
+
+    private final Subscription subscription;
+
+    public SubscriptionFailureException(Subscription subscription) {
+        this.subscription = subscription;
+    }
+
+    @Override
+    public String getMessage() {
+        return ("Subscription [" + subscription.getId() + "] is in failure state: " + subscription.getFailureCause());
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "subscription.failure";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return singletonMap("subscription", subscription.getId());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ScheduledCommandsRefresherServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ScheduledCommandsRefresherServiceImpl.java
@@ -36,9 +36,9 @@ import org.springframework.stereotype.Component;
  * @author GraviteeSource Team
  */
 @Component
-public class ScheduledCommandServiceImpl
-    extends AbstractService<ScheduledCommandServiceImpl>
-    implements ScheduledCommandService<ScheduledCommandServiceImpl>, Runnable {
+public class ScheduledCommandsRefresherServiceImpl
+    extends AbstractService<ScheduledCommandsRefresherServiceImpl>
+    implements ScheduledCommandService<ScheduledCommandsRefresherServiceImpl>, Runnable {
 
     private final CommandService commandService;
 
@@ -48,7 +48,7 @@ public class ScheduledCommandServiceImpl
     private final String cronTrigger;
     private final EventManager eventManager;
 
-    public ScheduledCommandServiceImpl(
+    public ScheduledCommandsRefresherServiceImpl(
         CommandService commandService,
         Node node,
         @Qualifier("commandTaskScheduler") TaskScheduler scheduler,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionCommandListenerImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionCommandListenerImpl.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.common.event.Event;
+import io.gravitee.common.event.EventManager;
+import io.gravitee.definition.model.command.SubscriptionFailureCommand;
+import io.gravitee.rest.api.model.command.CommandEntity;
+import io.gravitee.rest.api.model.command.CommandTags;
+import io.gravitee.rest.api.service.SubscriptionCommandListener;
+import io.gravitee.rest.api.service.SubscriptionService;
+import io.gravitee.rest.api.service.event.CommandEvent;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Component
+public class SubscriptionCommandListenerImpl implements SubscriptionCommandListener {
+
+    public static final Logger LOGGER = LoggerFactory.getLogger(SubscriptionCommandListenerImpl.class);
+
+    private final SubscriptionService subscriptionService;
+
+    private final ObjectMapper objectMapper;
+
+    public SubscriptionCommandListenerImpl(EventManager eventManager, SubscriptionService subscriptionService, ObjectMapper objectMapper) {
+        this.subscriptionService = subscriptionService;
+        this.objectMapper = objectMapper;
+        eventManager.subscribeForEvents(this, CommandEvent.class);
+    }
+
+    @Override
+    public void onEvent(Event<CommandEvent, CommandEntity> event) {
+        if (
+            CommandEvent.TO_PROCESS.equals(event.type()) &&
+            event.content() != null &&
+            event.content().getTags().contains(CommandTags.SUBSCRIPTION_FAILURE)
+        ) {
+            LOGGER.debug("Command event: {}", event.content().getContent());
+            getSubscriptionCommand(event)
+                .ifPresent(command -> subscriptionService.fail(command.getSubscriptionId(), command.getFailureCause()));
+        }
+    }
+
+    private Optional<SubscriptionFailureCommand> getSubscriptionCommand(Event<CommandEvent, CommandEntity> event) {
+        try {
+            if (event.content().getContent() == null) {
+                return Optional.empty();
+            }
+            return Optional.of(objectMapper.readValue(event.content().getContent(), SubscriptionFailureCommand.class));
+        } catch (JsonProcessingException e) {
+            LOGGER.error("Error processing SubscriptionCommand", e);
+            return Optional.empty();
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionFailureCommandListenerImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionFailureCommandListenerImpl.java
@@ -35,15 +35,19 @@ import org.springframework.stereotype.Component;
  * @author GraviteeSource Team
  */
 @Component
-public class SubscriptionCommandListenerImpl implements SubscriptionCommandListener {
+public class SubscriptionFailureCommandListenerImpl implements SubscriptionCommandListener {
 
-    public static final Logger LOGGER = LoggerFactory.getLogger(SubscriptionCommandListenerImpl.class);
+    public static final Logger LOGGER = LoggerFactory.getLogger(SubscriptionFailureCommandListenerImpl.class);
 
     private final SubscriptionService subscriptionService;
 
     private final ObjectMapper objectMapper;
 
-    public SubscriptionCommandListenerImpl(EventManager eventManager, SubscriptionService subscriptionService, ObjectMapper objectMapper) {
+    public SubscriptionFailureCommandListenerImpl(
+        EventManager eventManager,
+        SubscriptionService subscriptionService,
+        ObjectMapper objectMapper
+    ) {
         this.subscriptionService = subscriptionService;
         this.objectMapper = objectMapper;
         eventManager.subscribeForEvents(this, CommandEvent.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
@@ -566,7 +566,12 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
             subscription.setConfiguration(subscriptionConfigEntity.getConfiguration());
             subscription.setUpdatedAt(new Date());
             subscription.setStatus(newSubscriptionStatus);
-            subscription.setConsumerStatus(previousSubscription.getConsumerStatus());
+            // Recover from failure or keep previous consumer status
+            subscription.setConsumerStatus(
+                previousSubscription.getConsumerStatus().equals(Subscription.ConsumerStatus.FAILURE)
+                    ? Subscription.ConsumerStatus.STARTED
+                    : previousSubscription.getConsumerStatus()
+            );
             subscription.setFailureCause(null);
 
             subscription = subscriptionRepository.update(subscription);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/spring/CommandConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/spring/CommandConfiguration.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.services.subscriptionpreexpirationnotif.spring;
+package io.gravitee.rest.api.service.spring;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -21,14 +21,18 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
 @Configuration
-public class SubscriptionPreExpirationNotificationConfiguration {
+public class CommandConfiguration {
 
     @Bean
-    @Qualifier("subscriptionPreExpirationTaskScheduler")
-    public TaskScheduler taskScheduler() {
+    @Qualifier("commandTaskScheduler")
+    public TaskScheduler commandTaskScheduler() {
         ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
-        scheduler.setThreadNamePrefix("subscription-pre-expiration-notification-");
+        scheduler.setThreadNamePrefix("commands-refresher-");
         return scheduler;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/spring/CommandRefresherConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/spring/CommandRefresherConfiguration.java
@@ -26,10 +26,10 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
  * @author GraviteeSource Team
  */
 @Configuration
-public class CommandConfiguration {
+public class CommandRefresherConfiguration {
 
     @Bean
-    @Qualifier("commandTaskScheduler")
+    @Qualifier("commandRefresherTaskScheduler")
     public TaskScheduler commandTaskScheduler() {
         ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
         scheduler.setThreadNamePrefix("commands-refresher-");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/converter/CommandConverterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/converter/CommandConverterTest.java
@@ -93,6 +93,15 @@ public class CommandConverterTest {
     }
 
     @Test
+    public void commandEntityShouldNotBeExpiredWhenNoExpiredAt() {
+        final Command command = command(null);
+
+        CommandEntity commandEntity = converter.toCommandEntity(command);
+
+        assertFalse(commandEntity.isExpired());
+    }
+
+    @Test
     public void commandEntityShouldBeExpired() {
         final Command command = command(Instant.now().minus(5, ChronoUnit.SECONDS));
 
@@ -211,7 +220,7 @@ public class CommandConverterTest {
         command.setTo("MANAGEMENT_APIS");
         command.setContent("{}");
         command.setTags(tags);
-        command.setExpiredAt(Date.from(expireAt));
+        command.setExpiredAt(expireAt == null ? null : Date.from(expireAt));
         command.setAcknowledgments(acknowledgments);
         return command;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/CommandServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/CommandServiceTest.java
@@ -93,6 +93,14 @@ public class CommandServiceTest {
     }
 
     @Test
+    public void shouldSearchWithoutOrganizationAndWithoutEnvironmentWithEmptyQuery() {
+        commandService.search(new CommandQuery());
+
+        verify(commandRepository, times(1))
+            .search(argThat(criteria -> criteria.getOrganizationId() == null && criteria.getEnvironmentId() == null));
+    }
+
+    @Test
     public void shouldNotSearchByEnvironmentWithOrganizationContext() {
         final Organization organization = new Organization();
         organization.setId("GRAVITEE");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ScheduledCommandServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ScheduledCommandServiceImplTest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.event.EventManager;
+import io.gravitee.node.api.Node;
+import io.gravitee.repository.management.model.MessageRecipient;
+import io.gravitee.rest.api.model.command.CommandEntity;
+import io.gravitee.rest.api.model.command.CommandTags;
+import io.gravitee.rest.api.service.CommandService;
+import io.gravitee.rest.api.service.event.CommandEvent;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.scheduling.TaskScheduler;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ScheduledCommandServiceImplTest {
+
+    @Mock
+    private CommandService commandService;
+
+    @Mock
+    private Node node;
+
+    @Mock
+    private EventManager eventManager;
+
+    @Mock
+    private TaskScheduler taskScheduler;
+
+    private ScheduledCommandServiceImpl cut;
+
+    @Before
+    public void setUp() {
+        cut = new ScheduledCommandServiceImpl(commandService, node, taskScheduler, "0/5 * * * * *", eventManager);
+        when(node.id()).thenReturn("node-id");
+    }
+
+    @Test
+    public void shouldNotFindCommand() {
+        when(
+            commandService.search(
+                ArgumentMatchers.argThat(
+                    query -> query.getTo().equals(MessageRecipient.MANAGEMENT_APIS.name()) && query.getNotAckBy().equals("node-id")
+                )
+            )
+        )
+            .thenReturn(List.of());
+        cut.run();
+
+        verify(commandService, never()).delete(any());
+        verify(commandService, never()).ack(any());
+        verify(eventManager, never()).publishEvent(any(), any());
+    }
+
+    @Test
+    public void shouldSyncCommandAndPublishEventAccordingly() {
+        final CommandEntity dataCommand1 = buildCommand("data-1", null);
+        final CommandEntity dataCommand2 = buildCommand("data-2", List.of(CommandTags.DATA_TO_INDEX));
+        // this case has no real business sense but is here to test the code
+        final CommandEntity dataCommand3 = buildCommand(
+            "data-subscription-3",
+            List.of(CommandTags.DATA_TO_INDEX, CommandTags.SUBSCRIPTION_FAILURE)
+        );
+        final CommandEntity subscriptionCommand1 = buildCommand("subscription-1", List.of(CommandTags.SUBSCRIPTION_FAILURE));
+        final CommandEntity subscriptionCommand2 = buildCommand("subscription-2", List.of(CommandTags.SUBSCRIPTION_FAILURE));
+
+        when(
+            commandService.search(
+                ArgumentMatchers.argThat(
+                    query -> query.getTo().equals(MessageRecipient.MANAGEMENT_APIS.name()) && query.getNotAckBy().equals("node-id")
+                )
+            )
+        )
+            .thenReturn(List.of(dataCommand1, dataCommand2, dataCommand3, subscriptionCommand1, subscriptionCommand2));
+        cut.run();
+
+        ArgumentCaptor<String> deleteCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> ackCaptor = ArgumentCaptor.forClass(String.class);
+
+        verify(commandService, times(2)).delete(deleteCaptor.capture());
+        verify(commandService, times(3)).ack(ackCaptor.capture());
+
+        assertThat(ackCaptor.getAllValues()).containsExactly("data-1", "data-2", "data-subscription-3");
+        assertThat(deleteCaptor.getAllValues()).containsExactly("subscription-1", "subscription-2");
+
+        ArgumentCaptor<CommandEntity> argumentCaptor = ArgumentCaptor.forClass(CommandEntity.class);
+        verify(eventManager, times(5)).publishEvent(eq(CommandEvent.TO_PROCESS), argumentCaptor.capture());
+        assertThat(argumentCaptor.getAllValues())
+            .extracting(CommandEntity::getId)
+            .containsExactly("data-1", "data-2", "data-subscription-3", "subscription-1", "subscription-2");
+    }
+
+    private static CommandEntity buildCommand(String id, List<CommandTags> tags) {
+        CommandEntity commandEntity = new CommandEntity();
+        commandEntity.setId(id);
+        commandEntity.setTags(tags);
+        return commandEntity;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ScheduledCommandsRefresherServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ScheduledCommandsRefresherServiceImplTest.java
@@ -31,7 +31,6 @@ import io.gravitee.rest.api.model.command.CommandTags;
 import io.gravitee.rest.api.service.CommandService;
 import io.gravitee.rest.api.service.event.CommandEvent;
 import java.util.List;
-import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -46,7 +45,7 @@ import org.springframework.scheduling.TaskScheduler;
  * @author GraviteeSource Team
  */
 @RunWith(MockitoJUnitRunner.class)
-public class ScheduledCommandServiceImplTest {
+public class ScheduledCommandsRefresherServiceImplTest {
 
     @Mock
     private CommandService commandService;
@@ -60,11 +59,11 @@ public class ScheduledCommandServiceImplTest {
     @Mock
     private TaskScheduler taskScheduler;
 
-    private ScheduledCommandServiceImpl cut;
+    private ScheduledCommandsRefresherServiceImpl cut;
 
     @Before
     public void setUp() {
-        cut = new ScheduledCommandServiceImpl(commandService, node, taskScheduler, "0/5 * * * * *", eventManager);
+        cut = new ScheduledCommandsRefresherServiceImpl(commandService, node, taskScheduler, "0/5 * * * * *", eventManager);
         when(node.id()).thenReturn("node-id");
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionCommandListenerImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionCommandListenerImplTest.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.common.event.EventManager;
+import io.gravitee.common.event.impl.SimpleEvent;
+import io.gravitee.definition.jackson.datatype.GraviteeMapper;
+import io.gravitee.rest.api.model.command.CommandEntity;
+import io.gravitee.rest.api.model.command.CommandTags;
+import io.gravitee.rest.api.service.SubscriptionService;
+import io.gravitee.rest.api.service.event.CommandEvent;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SubscriptionCommandListenerImplTest {
+
+    public static final String VALID_COMMAND_CONTENT =
+        "{\n" + "  \"subscriptionId\": \"subscription-id\",\n" + "  \"failureCause\": \"failure-cause\"\n" + "}";
+
+    public static final String INVALID_COMMAND_CONTENT =
+        "{\n" + "  \"subscriptionId\": \"subscription-id\",\n" + "  \"failureCause\": \"failu";
+
+    @Mock
+    private SubscriptionService subscriptionService;
+
+    @Mock
+    private EventManager eventManager;
+
+    private ObjectMapper objectMapper = new GraviteeMapper();
+
+    private SubscriptionCommandListenerImpl cut;
+
+    @Before
+    public void setUp() {
+        cut = new SubscriptionCommandListenerImpl(eventManager, subscriptionService, objectMapper);
+    }
+
+    @Test
+    public void shouldDoNothingWhenEventHasNoContent() {
+        cut.onEvent(new SimpleEvent<>(CommandEvent.TO_PROCESS, null));
+
+        verify(subscriptionService, never()).fail(any(), any());
+    }
+
+    @Test
+    public void shouldDoNothingWhenCommandIsNotSubscriptionFailure() {
+        cut.onEvent(new SimpleEvent<>(CommandEvent.TO_PROCESS, buildCommand(List.of(CommandTags.DATA_TO_INDEX), VALID_COMMAND_CONTENT)));
+
+        verify(subscriptionService, never()).fail(any(), any());
+    }
+
+    @Test
+    public void shouldDoNothingWhenCommandHasNoContent() {
+        cut.onEvent(new SimpleEvent<>(CommandEvent.TO_PROCESS, buildCommand(List.of(CommandTags.SUBSCRIPTION_FAILURE), null)));
+
+        verify(subscriptionService, never()).fail(any(), any());
+    }
+
+    @Test
+    public void shouldDoNothingWhenCommandHasInvalidContent() {
+        cut.onEvent(
+            new SimpleEvent<>(CommandEvent.TO_PROCESS, buildCommand(List.of(CommandTags.SUBSCRIPTION_FAILURE), INVALID_COMMAND_CONTENT))
+        );
+
+        verify(subscriptionService, never()).fail(any(), any());
+    }
+
+    @Test
+    public void shouldCallSubscriptionServiceFailWhenEventIsGood() {
+        cut.onEvent(
+            new SimpleEvent<>(CommandEvent.TO_PROCESS, buildCommand(List.of(CommandTags.SUBSCRIPTION_FAILURE), VALID_COMMAND_CONTENT))
+        );
+
+        verify(subscriptionService).fail("subscription-id", "failure-cause");
+    }
+
+    private static CommandEntity buildCommand(List<CommandTags> tags, String content) {
+        CommandEntity commandEntity = new CommandEntity();
+        commandEntity.setId("command-id");
+        commandEntity.setTags(tags);
+        commandEntity.setContent(content);
+        return commandEntity;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionFailureCommandListenerImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionFailureCommandListenerImplTest.java
@@ -32,7 +32,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 /**
@@ -40,7 +39,7 @@ import org.mockito.junit.MockitoJUnitRunner;
  * @author GraviteeSource Team
  */
 @RunWith(MockitoJUnitRunner.class)
-public class SubscriptionCommandListenerImplTest {
+public class SubscriptionFailureCommandListenerImplTest {
 
     public static final String VALID_COMMAND_CONTENT =
         "{\n" + "  \"subscriptionId\": \"subscription-id\",\n" + "  \"failureCause\": \"failure-cause\"\n" + "}";
@@ -56,11 +55,11 @@ public class SubscriptionCommandListenerImplTest {
 
     private ObjectMapper objectMapper = new GraviteeMapper();
 
-    private SubscriptionCommandListenerImpl cut;
+    private SubscriptionFailureCommandListenerImpl cut;
 
     @Before
     public void setUp() {
-        cut = new SubscriptionCommandListenerImpl(eventManager, subscriptionService, objectMapper);
+        cut = new SubscriptionFailureCommandListenerImpl(eventManager, subscriptionService, objectMapper);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-auto-fetch/src/main/java/io/gravitee/rest/api/services/fetcher/ScheduledAutoFetchService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-auto-fetch/src/main/java/io/gravitee/rest/api/services/fetcher/ScheduledAutoFetchService.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.support.CronTrigger;
 
@@ -36,6 +37,7 @@ public class ScheduledAutoFetchService extends AbstractService implements Runnab
     private static final Logger LOGGER = LoggerFactory.getLogger(ScheduledAutoFetchService.class);
 
     @Autowired
+    @Qualifier("autoFetchTaskScheduler")
     private TaskScheduler scheduler;
 
     @Autowired

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-auto-fetch/src/main/java/io/gravitee/rest/api/services/fetcher/spring/AutoFetchConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-auto-fetch/src/main/java/io/gravitee/rest/api/services/fetcher/spring/AutoFetchConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.services.fetcher.spring;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -35,6 +36,7 @@ public class AutoFetchConfiguration {
     private boolean enabled;
 
     @Bean
+    @Qualifier("autoFetchTaskScheduler")
     public TaskScheduler taskScheduler() {
         ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
         scheduler.setThreadNamePrefix("auto-fetch-");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-search-indexer/src/main/java/io/gravitee/rest/api/services/search/ScheduledSearchIndexerService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-search-indexer/src/main/java/io/gravitee/rest/api/services/search/ScheduledSearchIndexerService.java
@@ -37,6 +37,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.scheduling.TaskScheduler;
@@ -54,6 +55,7 @@ public class ScheduledSearchIndexerService extends AbstractService implements Ru
     private final Logger logger = LoggerFactory.getLogger(ScheduledSearchIndexerService.class);
 
     @Autowired
+    @Qualifier("searchIndexerTaskScheduler")
     private TaskScheduler scheduler;
 
     @Value("${services.search_indexer.cron:*/5 * * * * *}")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-search-indexer/src/main/java/io/gravitee/rest/api/services/search/spring/SearchIndexerConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-search-indexer/src/main/java/io/gravitee/rest/api/services/search/spring/SearchIndexerConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.services.search.spring;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.TaskScheduler;
@@ -28,6 +29,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 public class SearchIndexerConfiguration {
 
     @Bean
+    @Qualifier("searchIndexerTaskScheduler")
     public TaskScheduler taskScheduler() {
         ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
         scheduler.setThreadNamePrefix("searchindexer-");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-subscription-pre-expiration-notif/src/main/java/io/gravitee/rest/api/services/subscriptionpreexpirationnotif/ScheduledSubscriptionPreExpirationNotificationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-subscription-pre-expiration-notif/src/main/java/io/gravitee/rest/api/services/subscriptionpreexpirationnotif/ScheduledSubscriptionPreExpirationNotificationService.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.support.CronTrigger;
@@ -72,6 +73,7 @@ public class ScheduledSubscriptionPreExpirationNotificationService extends Abstr
     private UserService userService;
 
     @Autowired
+    @Qualifier("subscriptionPreExpirationTaskScheduler")
     private TaskScheduler scheduler;
 
     @Value("#{'${services.subscription.pre-expiration-notification-schedule:90,45,30}'.split(',')}")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-subscriptions/src/main/java/io/gravitee/rest/api/services/subscriptions/ScheduledSubscriptionsService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-subscriptions/src/main/java/io/gravitee/rest/api/services/subscriptions/ScheduledSubscriptionsService.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.support.CronTrigger;
@@ -43,6 +44,7 @@ public class ScheduledSubscriptionsService extends AbstractService implements Ru
     private final Logger logger = LoggerFactory.getLogger(ScheduledSubscriptionsService.class);
 
     @Autowired
+    @Qualifier("subscriptionsTaskScheduler")
     private TaskScheduler scheduler;
 
     @Value("${services.subscriptions.cron:0 1 * * * *}")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-subscriptions/src/main/java/io/gravitee/rest/api/services/subscriptions/spring/SubscriptionsConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-subscriptions/src/main/java/io/gravitee/rest/api/services/subscriptions/spring/SubscriptionsConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.services.subscriptions.spring;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.TaskScheduler;
@@ -28,6 +29,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 public class SubscriptionsConfiguration {
 
     @Bean
+    @Qualifier("subscriptionsTaskScheduler")
     public TaskScheduler taskScheduler() {
         ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
         scheduler.setThreadNamePrefix("refresher-");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-sync/src/main/java/io/gravitee/rest/api/services/sync/ScheduledSyncService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-sync/src/main/java/io/gravitee/rest/api/services/sync/ScheduledSyncService.java
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.support.CronTrigger;
@@ -37,6 +38,7 @@ public class ScheduledSyncService extends AbstractService implements Runnable {
     private final Logger logger = LoggerFactory.getLogger(ScheduledSyncService.class);
 
     @Autowired
+    @Qualifier("syncTaskScheduler")
     private TaskScheduler scheduler;
 
     @Value("${services.sync.cron:*/5 * * * * *}")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-sync/src/main/java/io/gravitee/rest/api/services/sync/spring/SyncConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-sync/src/main/java/io/gravitee/rest/api/services/sync/spring/SyncConfiguration.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.services.sync.spring;
 import io.gravitee.rest.api.services.sync.ApiManager;
 import io.gravitee.rest.api.services.sync.DictionaryManager;
 import io.gravitee.rest.api.services.sync.SyncManager;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.TaskScheduler;
@@ -46,6 +47,7 @@ public class SyncConfiguration {
     }
 
     @Bean
+    @Qualifier("syncTaskScheduler")
     public TaskScheduler taskScheduler() {
         ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
         scheduler.setThreadNamePrefix("sync-");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/node/GraviteeApisNode.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/node/GraviteeApisNode.java
@@ -21,6 +21,8 @@ import io.gravitee.node.container.AbstractNode;
 import io.gravitee.plugin.alert.AlertEventProducerManager;
 import io.gravitee.plugin.alert.AlertTriggerProviderManager;
 import io.gravitee.rest.api.service.InitializerService;
+import io.gravitee.rest.api.service.ScheduledCommandService;
+import io.gravitee.rest.api.service.impl.ScheduledCommandServiceImpl;
 import io.gravitee.rest.api.standalone.jetty.JettyEmbeddedContainer;
 import java.util.List;
 import java.util.Map;
@@ -64,6 +66,7 @@ public class GraviteeApisNode extends AbstractNode {
         components.add(JettyEmbeddedContainer.class);
         components.add(AlertTriggerProviderManager.class);
         components.add(AlertEventProducerManager.class);
+        components.add(ScheduledCommandService.class);
         return components;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/node/GraviteeApisNode.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/node/GraviteeApisNode.java
@@ -22,7 +22,6 @@ import io.gravitee.plugin.alert.AlertEventProducerManager;
 import io.gravitee.plugin.alert.AlertTriggerProviderManager;
 import io.gravitee.rest.api.service.InitializerService;
 import io.gravitee.rest.api.service.ScheduledCommandService;
-import io.gravitee.rest.api.service.impl.ScheduledCommandServiceImpl;
 import io.gravitee.rest.api.standalone.jetty.JettyEmbeddedContainer;
 import java.util.List;
 import java.util.Map;

--- a/pom.xml
+++ b/pom.xml
@@ -56,11 +56,11 @@
         <gravitee-bom.version>3.0.0</gravitee-bom.version>
         <gravitee-alert-api.version>1.9.1</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>2.0.0</gravitee-cockpit-api.version>
-        <gravitee-common.version>2.1.0-alpha.1</gravitee-common.version>
+        <gravitee-common.version>2.1.0-apim-373-subscription-error-management-SNAPSHOT</gravitee-common.version>
         <gravitee-connector-api.version>1.1.4</gravitee-connector-api.version>
         <gravitee-expression-language.version>2.0.1</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>2.1.0-alpha.4</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>2.1.0-apim-373-subscription-error-management-SNAPSHOT</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>2.0.1</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-373

## Description

### Gateway

Improve the gateway part (SubscriptionDispatcher) to send commands to the database when a subscription fails.
- A failure can be an error during the dispatch, a message processing exception, etc.
- Some errors should not be retried, so we improved the behavior to be able to choose which throwables should be retried or not.

#### Subscriptions synchronisation process

Before this PR, subscriptions where fetched before the deployment of apis in `ApiSynchronizer`. 
For `STANDARD` subscriptions, it was useful to have all the subscriptions loaded when deploying the API, making it usable immediately.
For `SUBSCRIPTION` subscriptions, it causes a problem: subscriptions were dispatched before the API was deploying, making the subscription inactive. **It's the case when starting the gateway with existing APIs and subscriptions.**

The second commit of this PR aims to modify the dispatching cinematic depending on the sync phase:
- `FullSubscriptionRefresher` is called when we need to deploy an API. IN this case
  1. Cache the subscriptions
  2. Deploy the API
  3. Dispatch the subscriptions of type `SUBSCRIPTION` for this API
- `IncrementalSubscriptionRefresher` aims to detect the update of a subscription. In this case, we can dispatch the subscription directly 

### Rest-API

Add a new `SUBSCRIPTION_FAILURE` tag to commands to be able to process subscription that should be failed due to an error in its deployment (gateway side).
- Add a notion of `CommandCastMode` to know if a command should be acknowledged by the node (`MULTICAST`) of just removed directly in the database (`UNICAST`). `UNICAST` prevents other nodes to process the command by removing it directly from the database.
- Update the subscription in database with a `FAILURE` status and a `failureCause`.


[APIM-373]: https://gravitee.atlassian.net/browse/APIM-373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-373-subscription-error-management/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wedrebeibz.chromatic.com)
<!-- Storybook placeholder end -->
