### PR TITLE
fix(jdbc): handle query with page number higher than max page with data

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/pom.xml
@@ -121,6 +121,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- MySQL -->
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAbstractPageableRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAbstractPageableRepository.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.repository.jdbc.management;
 
+import static java.util.Collections.emptyList;
+
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.Pageable;
 import java.util.List;
@@ -33,22 +35,26 @@ abstract class JdbcAbstractPageableRepository<T> extends JdbcAbstractRepository<
         super(prefix, tableName);
     }
 
-    <U> Page<U> getResultAsPage(final Pageable page, final List<U> items) {
-        if (page != null) {
-            LOGGER.debug("Getting results as page {} for {}", page, items);
-            int start = page.from();
-            if ((start == 0) && (page.pageNumber() > 0)) {
-                start = page.pageNumber() * page.pageSize();
-            }
-            int rows = page.pageSize();
-            if ((rows == 0) && (page.to() > 0)) {
-                rows = page.to() - start;
-            }
-            if (start + rows > items.size()) {
-                rows = items.size() - start;
-            }
-            return new Page<>(items.subList(start, start + rows), start / page.pageSize(), rows, items.size());
+    static <U> Page<U> getResultAsPage(final Pageable page, final List<U> items) {
+        if (page == null) {
+            return new Page<>(items, 0, items.size(), items.size());
         }
-        return new Page<>(items, 0, items.size(), items.size());
+
+        LOGGER.debug("Getting results as page {} for {}", page, items);
+        int start = page.from();
+
+        // If the page is out of bounds, return an empty list
+        if (start > items.size()) {
+            return new Page<>(emptyList(), page.pageNumber(), 0, items.size());
+        }
+
+        if ((start == 0) && (page.pageNumber() > 0)) {
+            start = page.pageNumber() * page.pageSize();
+        }
+        int rows = page.pageSize();
+        if (start + rows > items.size()) {
+            rows = items.size() - start;
+        }
+        return new Page<>(items.subList(start, start + rows), start / page.pageSize(), rows, items.size());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/management/JdbcAbstractPageableRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/management/JdbcAbstractPageableRepositoryTest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.management;
+
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.repository.management.api.search.Pageable;
+import io.gravitee.repository.management.api.search.builder.PageableBuilder;
+import java.util.List;
+import org.junit.Test;
+
+public class JdbcAbstractPageableRepositoryTest {
+
+    private static final List<String> aListOfString = List.of("one", "two", "three", "four", "five");
+
+    @Test
+    public void getResultAsPageReturnsPagesWithData() {
+        Pageable pageable = new PageableBuilder().pageNumber(0).pageSize(2).build();
+        Page<String> page = JdbcAbstractPageableRepository.getResultAsPage(pageable, aListOfString);
+
+        assertEquals(5, page.getTotalElements());
+        assertEquals(0, page.getPageNumber());
+        assertEquals(2, page.getPageElements());
+        assertEquals(List.of("one", "two"), page.getContent());
+
+        pageable = new PageableBuilder().pageNumber(1).pageSize(2).build();
+        page = JdbcAbstractPageableRepository.getResultAsPage(pageable, aListOfString);
+
+        assertEquals(5, page.getTotalElements());
+        assertEquals(1, page.getPageNumber());
+        assertEquals(2, page.getPageElements());
+        assertEquals(List.of("three", "four"), page.getContent());
+
+        pageable = new PageableBuilder().pageNumber(2).pageSize(2).build();
+        page = JdbcAbstractPageableRepository.getResultAsPage(pageable, aListOfString);
+
+        assertEquals(5, page.getTotalElements());
+        assertEquals(2, page.getPageNumber());
+        assertEquals(1, page.getPageElements());
+        assertEquals(List.of("five"), page.getContent());
+    }
+
+    @Test
+    public void getResultAsPageReturnsEmptyPageForPageableWithoutData() {
+        Pageable pageable = new PageableBuilder().pageNumber(1).pageSize(10).build();
+        Page<String> page = JdbcAbstractPageableRepository.getResultAsPage(pageable, aListOfString);
+
+        assertEquals(5, page.getTotalElements());
+        assertEquals(1, page.getPageNumber());
+        assertEquals(0, page.getPageElements());
+        assertEquals(emptyList(), page.getContent());
+    }
+
+    @Test
+    public void getResultAsPageWithoutPageableReturnsEverything() {
+        Page<String> page = JdbcAbstractPageableRepository.getResultAsPage(null, aListOfString);
+
+        assertEquals(5, page.getTotalElements());
+        assertEquals(0, page.getPageNumber());
+        assertEquals(5, page.getPageElements());
+        assertEquals(List.of("one", "two", "three", "four", "five"), page.getContent());
+    }
+
+    @Test
+    public void getResultAsPageComputeStartIndexBasedOnPageable() {
+        Pageable pageable = mock(Pageable.class);
+        when(pageable.pageNumber()).thenReturn(2);
+        when(pageable.pageSize()).thenReturn(2);
+        when(pageable.from()).thenReturn(0);
+        when(pageable.to()).thenReturn(15);
+
+        Page<String> page = JdbcAbstractPageableRepository.getResultAsPage(pageable, aListOfString);
+
+        assertEquals(5, page.getTotalElements());
+        assertEquals(2, page.getPageNumber());
+        assertEquals(1, page.getPageElements());
+        assertEquals(List.of("five"), page.getContent());
+    }
+}


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8773
https://gravitee.atlassian.net/browse/APIM-510

## Description

When querying data it now returns an empty page if the pageable point to a page higher than the last page containing data. Previously it was throwing an error.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-510-fix-jdbc-pagination/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jokykherid.chromatic.com)
<!-- Storybook placeholder end -->


[APIM-510]: https://gravitee.atlassian.net/browse/APIM-510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ