### PR TITLE
Handle flow step order in database - 3.18

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/FlowConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/converter/FlowConverter.java
@@ -31,9 +31,12 @@ import io.gravitee.repository.management.model.flow.FlowStep;
 import io.gravitee.rest.api.service.common.UuidString;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 
 /**
@@ -78,8 +81,8 @@ public class FlowConverter {
         flow.setOrder(order);
         flow.setReferenceType(referenceType);
         flow.setReferenceId(referenceId);
-        flow.setPost(flowDefinition.getPost().stream().map(this::toRepositoryStep).collect(Collectors.toList()));
-        flow.setPre(flowDefinition.getPre().stream().map(this::toRepositoryStep).collect(Collectors.toList()));
+        flow.setPost(toRepositoryFlowSteps(flowDefinition.getPost()));
+        flow.setPre(toRepositoryFlowSteps(flowDefinition.getPre()));
         flow.setPath(flowDefinition.getPath());
         flow.setOperator(FlowOperator.valueOf(flowDefinition.getOperator().name()));
         flow.setName(flowDefinition.getName());
@@ -92,6 +95,18 @@ public class FlowConverter {
                 : Collections.emptyList()
         );
         return flow;
+    }
+
+    @NotNull
+    private List<FlowStep> toRepositoryFlowSteps(List<Step> steps) {
+        if (steps == null) {
+            return Collections.emptyList();
+        }
+
+        return IntStream
+            .range(0, steps.size())
+            .mapToObj(index -> this.toRepositoryStep(steps.get(index), index))
+            .collect(Collectors.toList());
     }
 
     private FlowConsumer toRepositoryConsumer(Consumer consumer) {
@@ -108,7 +123,8 @@ public class FlowConverter {
         return consumer;
     }
 
-    private FlowStep toRepositoryStep(Step step) {
+    @NotNull
+    private FlowStep toRepositoryStep(Step step, int order) {
         FlowStep flowStep = new FlowStep();
         flowStep.setPolicy(step.getPolicy());
         flowStep.setName(step.getName());
@@ -116,6 +132,7 @@ public class FlowConverter {
         flowStep.setConfiguration(step.getConfiguration());
         flowStep.setDescription(step.getDescription());
         flowStep.setCondition(step.getCondition());
+        flowStep.setOrder(order);
         return flowStep;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/converter/FlowConverterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/converter/FlowConverterTest.java
@@ -63,6 +63,20 @@ public class FlowConverterTest {
     }
 
     @Test
+    public void toModelShouldKeepTheStepOrder() {
+        Flow flowDefinition = new Flow();
+        flowDefinition.setPre(pre());
+
+        var model = converter.toRepository(flowDefinition, FlowReferenceType.ORGANIZATION, "DEFAULT", 0);
+
+        assertEquals(2, model.getPre().size());
+        assertEquals("IPFiltering", model.getPre().get(0).getName());
+        assertEquals(0, model.getPre().get(0).getOrder());
+        assertEquals("HTTP Callout", model.getPre().get(1).getName());
+        assertEquals(1, model.getPre().get(1).getOrder());
+    }
+
+    @Test
     public void toDefinitionShouldSetPathOperatorFromPathAndOperatorValues() {
         final PathOperator expectedOperator = pathOperator();
 
@@ -97,7 +111,13 @@ public class FlowConverterTest {
         step.setName("IPFiltering");
         step.setPolicy("ip-filtering");
         step.setConfiguration("{\"whitelistIps\":[\"0.0.0.0/0\"]}");
-        return List.of(step);
+
+        Step step2 = new Step();
+        step2.setEnabled(true);
+        step2.setName("HTTP Callout");
+        step2.setPolicy("http-callout");
+        step2.setConfiguration("{\"url\":\"http://localhost\"}");
+        return List.of(step, step2);
     }
 
     private static List<Step> post() {
@@ -147,5 +167,40 @@ public class FlowConverterTest {
 
         Step step = converter.toDefinitionStep(flowStep);
         assertEquals("{\"key\":\"</value\\nvalue>\"}", step.getConfiguration());
+    }
+
+    @Test
+    public void toDefinitionShouldKeepTheStepOrder() {
+        final PathOperator expectedOperator = pathOperator();
+
+        var flow = new io.gravitee.repository.management.model.flow.Flow();
+        flow.setPath("/");
+        flow.setOperator(FlowOperator.STARTS_WITH);
+        flow.setConsumers(List.of());
+        flow.setPre(definitionPre());
+
+        Flow flowDefinition = converter.toDefinition(flow);
+
+        assertEquals(2, flowDefinition.getPre().size());
+        assertEquals("IPFiltering", flowDefinition.getPre().get(0).getName());
+        assertEquals("HTTP Callout", flowDefinition.getPre().get(1).getName());
+    }
+
+    private static List<FlowStep> definitionPre() {
+        FlowStep flowStep = new FlowStep();
+        flowStep.setEnabled(true);
+        flowStep.setName("IPFiltering");
+        flowStep.setPolicy("ip-filtering");
+        flowStep.setConfiguration("{\"whitelistIps\":[\"0.0.0.0/0\"]}");
+        flowStep.setOrder(0);
+
+        FlowStep flowStep2 = new FlowStep();
+        flowStep2.setEnabled(true);
+        flowStep2.setName("HTTP Callout");
+        flowStep2.setPolicy("http-callout");
+        flowStep2.setConfiguration("{\"url\":\"http://localhost\"}");
+        flowStep2.setOrder(1);
+
+        return List.of(flowStep, flowStep2);
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-533
https://github.com/gravitee-io/issues/issues/8805

## Description

Since 3.18.15, Primary Keys have been added to multiple existing tables.
In the `flow_steps` table, we used 3 fields for the PK : flow_id, phase and order.

However, the order field was never filled and so it led to SQL error "duplicate key".

This PR allows to handle flow steps order in database.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hnfkwboqkz.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/handle-flow-step-order-in-database-3-18/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->

[APIM-533]: https://gravitee.atlassian.net/browse/APIM-533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ