### PR TITLE
feat: support user defined endpoint on v4 definition

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -764,7 +764,7 @@
                 <gravitee-policy-data-logging-masking.version>2.0.1</gravitee-policy-data-logging-masking.version>
                 <gravitee-policy-interrupt.version>1.1.0</gravitee-policy-interrupt.version>
                 <gravitee-entrypoint-sse-advanced.version>2.0.0-alpha.5</gravitee-entrypoint-sse-advanced.version>
-                <gravitee-entrypoint-webhook-advanced.version>1.0.0-SNAPSHOT</gravitee-entrypoint-webhook-advanced.version>
+                <gravitee-entrypoint-webhook-advanced.version>1.0.0-alpha.1</gravitee-entrypoint-webhook-advanced.version>
                 <gravitee-endpoint-kafka-advanced.version>1.0.0-alpha.8</gravitee-endpoint-kafka-advanced.version>
                 <gravitee-endpoint-mqtt5-advanced.version>1.0.0-alpha.4</gravitee-endpoint-mqtt5-advanced.version>
 
@@ -788,13 +788,13 @@
                     <type>zip</type>
                     <scope>runtime</scope>
                 </dependency>
-<!--                <dependency>-->
-<!--                    <groupId>com.graviteesource.entrypoint</groupId>-->
-<!--                    <artifactId>gravitee-entrypoint-webhook-advanced</artifactId>-->
-<!--                    <version>${gravitee-entrypoint-webhook-advanced.version}</version>-->
-<!--                    <scope>runtime</scope>-->
-<!--                    <type>zip</type>-->
-<!--                </dependency>-->
+                <dependency>
+                    <groupId>com.graviteesource.entrypoint</groupId>
+                    <artifactId>gravitee-entrypoint-webhook-advanced</artifactId>
+                    <version>${gravitee-entrypoint-webhook-advanced.version}</version>
+                    <scope>runtime</scope>
+                    <type>zip</type>
+                </dependency>
                 <!-- Endpoints -->
                 <dependency>
                     <groupId>com.graviteesource.endpoint</groupId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/v4/endpoint/EndpointCriteria.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/v4/endpoint/EndpointCriteria.java
@@ -18,25 +18,30 @@ package io.gravitee.gateway.jupiter.core.v4.endpoint;
 import io.gravitee.gateway.jupiter.api.ApiType;
 import io.gravitee.gateway.jupiter.api.ConnectorMode;
 import java.util.Set;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Getter
+@Setter
 public class EndpointCriteria {
 
     public static final EndpointCriteria ENDPOINT_UP = new EndpointCriteria();
 
-    /* Name could be either:
+    /*
+     * Name could be either:
      * <ul>
      *     <li>the name of an endpoint</li>
      *     <li>the name of an endpoint group</li>
      * </ul>
      */
-    private final String name;
-    private final ApiType apiType;
-    private final Set<ConnectorMode> modes;
-    private final ManagedEndpoint.Status endpointStatus;
+    private String name;
+    private ApiType apiType;
+    private Set<ConnectorMode> modes;
+    private ManagedEndpoint.Status endpointStatus;
 
     public EndpointCriteria() {
         this(null, null);
@@ -75,21 +80,5 @@ public class EndpointCriteria {
         }
 
         return apiType == null || apiType.equals(managedEndpoint.getConnector().supportedApi());
-    }
-
-    public ApiType getApiType() {
-        return apiType;
-    }
-
-    public Set<ConnectorMode> getModes() {
-        return modes;
-    }
-
-    public ManagedEndpoint.Status getEndpointStatus() {
-        return endpointStatus;
-    }
-
-    public String getName() {
-        return name;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/v4/DefaultApiReactorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/v4/DefaultApiReactorFactory.java
@@ -187,7 +187,7 @@ public class DefaultApiReactorFactory implements ReactorFactory<Api> {
                 deploymentContext.componentProvider(componentProvider);
                 deploymentContext.templateVariableProviders(commonTemplateVariableProviders(api));
 
-                final EndpointManager endpointManager = new DefaultEndpointManager(
+                final DefaultEndpointManager endpointManager = new DefaultEndpointManager(
                     api.getDefinition(),
                     endpointConnectorPluginManager,
                     deploymentContext
@@ -204,11 +204,14 @@ public class DefaultApiReactorFactory implements ReactorFactory<Api> {
                 final DefaultDlqServiceFactory dlqServiceFactory = new DefaultDlqServiceFactory(api.getDefinition(), endpointManager);
                 customComponentProvider.add(DlqServiceFactory.class, dlqServiceFactory);
 
+                final List<TemplateVariableProvider> ctxTemplateVariableProviders = ctxTemplateVariableProviders(api);
+                ctxTemplateVariableProviders.add(endpointManager);
+
                 return new DefaultApiReactor(
                     api,
                     deploymentContext,
                     componentProvider,
-                    ctxTemplateVariableProviders(api),
+                    ctxTemplateVariableProviders,
                     policyManager,
                     entrypointConnectorPluginManager,
                     endpointConnectorPluginManager,
@@ -295,6 +298,7 @@ public class DefaultApiReactorFactory implements ReactorFactory<Api> {
         if (api.getDefinition().getType() == ApiType.SYNC) {
             requestTemplateVariableProviders.add(new ContentTemplateVariableProvider());
         }
+
         return requestTemplateVariableProviders;
     }
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/README.adoc
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/README.adoc
@@ -135,6 +135,31 @@ Here are the attributes for configuring the keystore options (client certificate
 
 |===
 
+=== User Defined Endpoint
+
+The `http-proxy` endpoint connector support User Defined Endpoint. User Defined Endpoint relies on the use of the context attribute `gravitee.attribute.request.endpoint` offering the capability to dynamically select a particular endpoint (by name), modify its path and query parameters or completely override the endpoint url.
+
+The `gravitee.attribute.request.endpoint` attribute can be set using the *Assign Attribute policy*, or you can use *Dynamic Routing Policy* to apply more complex routing rules.
+
+This attribute is structured like following: `<endpoint>:<url>` or just `<url>`, where:
+
+* `<endpoint>` is either the name of an endpoint or a group of endpoints.
+* `<url>` is an absolute or relative url. Absolute url replaces the endpoint's target whereas relative url is appended to the endpoint's target.
+
+Given this format, it is possible to specify:
+
+* An *endpoint group name* followed by an optional path, ex: `my-group:/foo/bar` or just `my-group:`. The group with the same name is selected and the next endpoint is retrieved (with the load balancing strategy). The path is appended to the endpoint target.
+* An *endpoint name* followed by an optional path, ex: `my-endpoint:/foo/bar` or just `my-endpoint`. The endpoint having the exact same name is selected and the path is appended to the endpoint url.
+* A *complete url*, ex: `https://somewhere.com/foo/bar`. The next endpoint of the default group is selected (with load balanced strategy applied). The endpoint is only selected to use the underlying http client with the same options (timeout, ssl, …) and the complete url replaces the endpoint target. Note that a complete url prefixed with an endpoint or group name can be used to force usage of its associated http client and inherit from the same options (ssl, pool, ...), ex: `my-endpoint:https://somewhere.com/foo/bar`.
+* A *relative url*, ex: `/foo/bar`. The next endpoint is retrieved from the default group (with load balancing strategy). The path is appended to the endpoint target.
+* Some *query parameters*, ex: `?foo=bar`. The next endpoint is retrieved from the default group (with load balancing strategy). The query params are appended to the endpoint target and current request parameters.
+
+Note that, when having only 1 group with 1 endpoint named `default`, the following values for the `gravitee.attribute.request.endpoint` attribute are equivalent:
+
+* `default:`
+* (_empty_)
+* `{#endpoints['default']}`
+
 === Examples
 
 Bellow you will find a full `http-proxy` endpoint configuration example:

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/VertxHttpClientHelper.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/VertxHttpClientHelper.java
@@ -22,6 +22,7 @@ import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointCon
 import io.vertx.core.http.RequestOptions;
 import io.vertx.rxjava3.core.Vertx;
 import io.vertx.rxjava3.core.http.HttpClient;
+import java.net.URL;
 import java.util.StringJoiner;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -60,6 +61,15 @@ public class VertxHttpClientHelper {
     }
 
     public static RequestOptions configureAbsoluteUri(RequestOptions requestOptions, String uri, MultiValueMap<String, String> parameters) {
+        final URL target = VertxHttpClient.buildUrl(buildFinalUri(uri, parameters));
+
+        return requestOptions
+            .setURI(target.getQuery() == null ? target.getPath() : target.getPath() + URI_QUERY_DELIMITER_CHAR + target.getQuery())
+            .setPort(VertxHttpClient.getPort(target, VertxHttpClient.isSecureProtocol(target.getProtocol())))
+            .setHost(target.getHost());
+    }
+
+    public static RequestOptions configureRelativeUri(RequestOptions requestOptions, String uri, MultiValueMap<String, String> parameters) {
         return requestOptions.setURI(buildFinalUri(uri, parameters));
     }
 

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/client/VertxHttpClientHelperTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/client/VertxHttpClientHelperTest.java
@@ -15,21 +15,27 @@
  */
 package io.gravitee.plugin.endpoint.http.proxy.client;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+import io.gravitee.common.util.LinkedMultiValueMap;
 import io.gravitee.definition.model.v4.http.HttpClientOptions;
 import io.gravitee.definition.model.v4.http.HttpProxyOptions;
 import io.gravitee.definition.model.v4.ssl.SslOptions;
 import io.gravitee.gateway.jupiter.http.vertx.client.VertxHttpClient;
 import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorConfiguration;
+import io.vertx.core.http.RequestOptions;
 import io.vertx.rxjava3.core.Vertx;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
@@ -42,45 +48,49 @@ class VertxHttpClientHelperTest {
     protected static final String DEFAULT_TARGET = "http://localhost:8080/team";
 
     @Mock
-    private MockedStatic<VertxHttpClient> vertxHttpClientMockedStatic;
-
-    @Mock
     private VertxHttpClient.VertxHttpClientBuilder vertxHttpClientBuilder;
-
-    @BeforeEach
-    void init() {
-        vertxHttpClientMockedStatic.when(VertxHttpClient::builder).thenReturn(vertxHttpClientBuilder);
-    }
-
-    @AfterEach
-    void teardDown() {
-        vertxHttpClientMockedStatic.close();
-    }
 
     @Test
     void shouldCallBuilderWithArguments() {
-        final HttpProxyEndpointConnectorConfiguration configuration = new HttpProxyEndpointConnectorConfiguration();
-        final Vertx vertx = mock(Vertx.class);
-        final Configuration nodeConfiguration = mock(Configuration.class);
-        final HttpClientOptions httpOptions = new HttpClientOptions();
-        final SslOptions sslOptions = new SslOptions();
-        final HttpProxyOptions proxyOptions = new HttpProxyOptions();
+        try (MockedStatic<VertxHttpClient> vertxHttpClientMockedStatic = Mockito.mockStatic(VertxHttpClient.class)) {
+            vertxHttpClientMockedStatic.when(VertxHttpClient::builder).thenReturn(vertxHttpClientBuilder);
 
-        configuration.setHttpOptions(httpOptions);
-        configuration.setSslOptions(sslOptions);
-        configuration.setProxyOptions(proxyOptions);
+            final HttpProxyEndpointConnectorConfiguration configuration = new HttpProxyEndpointConnectorConfiguration();
+            final Vertx vertx = mock(Vertx.class);
+            final Configuration nodeConfiguration = mock(Configuration.class);
+            final HttpClientOptions httpOptions = new HttpClientOptions();
+            final SslOptions sslOptions = new SslOptions();
+            final HttpProxyOptions proxyOptions = new HttpProxyOptions();
 
-        when(vertxHttpClientBuilder.vertx(vertx)).thenReturn(vertxHttpClientBuilder);
-        when(vertxHttpClientBuilder.nodeConfiguration(nodeConfiguration)).thenReturn(vertxHttpClientBuilder);
-        when(vertxHttpClientBuilder.defaultTarget(DEFAULT_TARGET)).thenReturn(vertxHttpClientBuilder);
-        when(vertxHttpClientBuilder.httpOptions(httpOptions)).thenReturn(vertxHttpClientBuilder);
-        when(vertxHttpClientBuilder.sslOptions(sslOptions)).thenReturn(vertxHttpClientBuilder);
-        when(vertxHttpClientBuilder.proxyOptions(proxyOptions)).thenReturn(vertxHttpClientBuilder);
+            configuration.setHttpOptions(httpOptions);
+            configuration.setSslOptions(sslOptions);
+            configuration.setProxyOptions(proxyOptions);
 
-        final VertxHttpClient vertxHttpClient = mock(VertxHttpClient.class);
-        when(vertxHttpClientBuilder.build()).thenReturn(vertxHttpClient);
-        VertxHttpClientHelper.buildHttpClient(vertx, nodeConfiguration, configuration, DEFAULT_TARGET);
+            when(vertxHttpClientBuilder.vertx(vertx)).thenReturn(vertxHttpClientBuilder);
+            when(vertxHttpClientBuilder.nodeConfiguration(nodeConfiguration)).thenReturn(vertxHttpClientBuilder);
+            when(vertxHttpClientBuilder.defaultTarget(DEFAULT_TARGET)).thenReturn(vertxHttpClientBuilder);
+            when(vertxHttpClientBuilder.httpOptions(httpOptions)).thenReturn(vertxHttpClientBuilder);
+            when(vertxHttpClientBuilder.sslOptions(sslOptions)).thenReturn(vertxHttpClientBuilder);
+            when(vertxHttpClientBuilder.proxyOptions(proxyOptions)).thenReturn(vertxHttpClientBuilder);
 
-        verify(vertxHttpClient).createHttpClient();
+            final VertxHttpClient vertxHttpClient = mock(VertxHttpClient.class);
+            when(vertxHttpClientBuilder.build()).thenReturn(vertxHttpClient);
+            VertxHttpClientHelper.buildHttpClient(vertx, nodeConfiguration, configuration, DEFAULT_TARGET);
+
+            verify(vertxHttpClient).createHttpClient();
+        }
+    }
+
+    @Test
+    void shouldConfigureAbsoluteUri() {
+        final RequestOptions requestOptions = new RequestOptions();
+        final LinkedMultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+
+        parameters.put("foo", List.of("bar"));
+        VertxHttpClientHelper.configureAbsoluteUri(requestOptions, "https://api.gravitee.io/echo?foo=bar1&hello=gravitee", parameters);
+
+        assertThat(requestOptions.getURI()).isEqualTo("/echo?foo=bar1&hello=gravitee&foo=bar");
+        assertThat(requestOptions.getHost()).isEqualTo("api.gravitee.io");
+        assertThat(requestOptions.getPort()).isEqualTo(443);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/exception/EndpointGroupNameAlreadyExistsException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/exception/EndpointGroupNameAlreadyExistsException.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.exception;
+
+import static java.util.Collections.singletonMap;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.service.exceptions.AbstractManagementException;
+import java.util.Map;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class EndpointGroupNameAlreadyExistsException extends AbstractManagementException {
+
+    private final String name;
+
+    public EndpointGroupNameAlreadyExistsException(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getMessage() {
+        return "The endpoint group name [" + name + "] is already used by another endpoint or endpoint group.";
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "api.endpointsGroup.name.exists";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return singletonMap("api.endpointsGroup[].name", name);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/exception/EndpointNameAlreadyExistsException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/exception/EndpointNameAlreadyExistsException.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.exception;
+
+import static java.util.Collections.singletonMap;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.service.exceptions.AbstractManagementException;
+import java.util.Map;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class EndpointNameAlreadyExistsException extends AbstractManagementException {
+
+    private final String name;
+
+    public EndpointNameAlreadyExistsException(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getMessage() {
+        return "The endpoint name [" + name + "] is already used by another endpoint or endpoint group.";
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "api.endpointsGroup.endpoint.name.exists";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return singletonMap("api.endpointsGroup[].endpoint.name", name);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImplTest.java
@@ -28,9 +28,7 @@ import io.gravitee.definition.model.v4.service.Service;
 import io.gravitee.rest.api.service.exceptions.EndpointMissingException;
 import io.gravitee.rest.api.service.exceptions.EndpointNameInvalidException;
 import io.gravitee.rest.api.service.v4.EndpointConnectorPluginService;
-import io.gravitee.rest.api.service.v4.exception.EndpointGroupTypeInvalidException;
-import io.gravitee.rest.api.service.v4.exception.EndpointGroupTypeMismatchInvalidException;
-import io.gravitee.rest.api.service.v4.exception.EndpointTypeInvalidException;
+import io.gravitee.rest.api.service.v4.exception.*;
 import io.gravitee.rest.api.service.v4.validation.EndpointGroupsValidationService;
 import java.util.List;
 import org.junit.Before;
@@ -137,6 +135,64 @@ public class EndpointGroupsValidationServiceImplTest {
     }
 
     @Test
+    public void shouldThrowValidationExceptionWithEndpointNameAlreadyExists() {
+        EndpointGroup endpointGroup = new EndpointGroup();
+        endpointGroup.setName("my name");
+        endpointGroup.setType("http");
+        Endpoint endpoint = new Endpoint();
+        endpoint.setName("my name");
+        endpoint.setType("http");
+        endpointGroup.setEndpoints(List.of(endpoint));
+
+        assertThatExceptionOfType(EndpointNameAlreadyExistsException.class)
+            .isThrownBy(() -> endpointGroupsValidationService.validateAndSanitize(List.of(endpointGroup)));
+    }
+
+    @Test
+    public void shouldThrowValidationExceptionWithEndpointNameAlreadyExistsInAnotherGroup() {
+        EndpointGroup endpointGroup = new EndpointGroup();
+        endpointGroup.setName("group1");
+        endpointGroup.setType("http");
+        Endpoint endpoint = new Endpoint();
+        endpoint.setName("my name");
+        endpoint.setType("http");
+        endpointGroup.setEndpoints(List.of(endpoint));
+
+        EndpointGroup endpointGroup2 = new EndpointGroup();
+        endpointGroup2.setName("group2");
+        endpointGroup2.setType("http");
+        Endpoint endpoint2 = new Endpoint();
+        endpoint2.setName("my name");
+        endpoint2.setType("http");
+        endpointGroup2.setEndpoints(List.of(endpoint2));
+
+        assertThatExceptionOfType(EndpointNameAlreadyExistsException.class)
+            .isThrownBy(() -> endpointGroupsValidationService.validateAndSanitize(List.of(endpointGroup, endpointGroup2)));
+    }
+
+    @Test
+    public void shouldThrowValidationExceptionWithEndpointGroupNameAlreadyExistsInAnotherGroup() {
+        EndpointGroup endpointGroup = new EndpointGroup();
+        endpointGroup.setName("group1");
+        endpointGroup.setType("http");
+        Endpoint endpoint = new Endpoint();
+        endpoint.setName("my name");
+        endpoint.setType("http");
+        endpointGroup.setEndpoints(List.of(endpoint));
+
+        EndpointGroup endpointGroup2 = new EndpointGroup();
+        endpointGroup2.setName("my name");
+        endpointGroup2.setType("http");
+        Endpoint endpoint2 = new Endpoint();
+        endpoint2.setName("endpoint2");
+        endpoint2.setType("http");
+        endpointGroup2.setEndpoints(List.of(endpoint2));
+
+        assertThatExceptionOfType(EndpointGroupNameAlreadyExistsException.class)
+            .isThrownBy(() -> endpointGroupsValidationService.validateAndSanitize(List.of(endpointGroup, endpointGroup2)));
+    }
+
+    @Test
     public void shouldThrowValidationExceptionWithWrongEndpointGroupType() {
         EndpointGroup endpointGroup = new EndpointGroup();
         endpointGroup.setName("name");
@@ -160,10 +216,10 @@ public class EndpointGroupsValidationServiceImplTest {
     @Test
     public void shouldThrowValidationExceptionWithWrongEndpointType() {
         EndpointGroup endpointGroup = new EndpointGroup();
-        endpointGroup.setName("name");
+        endpointGroup.setName("group");
         endpointGroup.setType("http");
         Endpoint endpoint = new Endpoint();
-        endpoint.setName("name");
+        endpoint.setName("endpoint");
         endpointGroup.setEndpoints(List.of(endpoint));
         assertThatExceptionOfType(EndpointTypeInvalidException.class)
             .isThrownBy(() -> endpointGroupsValidationService.validateAndSanitize(List.of(endpointGroup)));
@@ -172,10 +228,10 @@ public class EndpointGroupsValidationServiceImplTest {
     @Test
     public void shouldThrowValidationExceptionWithMismatch() {
         EndpointGroup endpointGroup = new EndpointGroup();
-        endpointGroup.setName("name");
+        endpointGroup.setName("group");
         endpointGroup.setType("http");
         Endpoint endpoint = new Endpoint();
-        endpoint.setName("name");
+        endpoint.setName("endpoint");
         endpoint.setType("wrong");
         endpointGroup.setEndpoints(List.of(endpoint));
         assertThatExceptionOfType(EndpointGroupTypeMismatchInvalidException.class)

--- a/pom.xml
+++ b/pom.xml
@@ -56,11 +56,11 @@
         <gravitee-bom.version>3.0.0</gravitee-bom.version>
         <gravitee-alert-api.version>1.9.1</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>2.0.0</gravitee-cockpit-api.version>
-        <gravitee-common.version>2.0.0</gravitee-common.version>
+        <gravitee-common.version>2.1.0-alpha.1</gravitee-common.version>
         <gravitee-connector-api.version>1.1.4</gravitee-connector-api.version>
         <gravitee-expression-language.version>2.0.1</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>2.1.0-alpha.3</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>2.1.0-alpha.4</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>2.0.1</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-455

## Description

This PR allows to support user defined endpoint on v4 sync api. User defined endpoint is a specific gravitee attribute used by some policies such as Dynamic Routing Policy. It allows to alter the endpoint's target during the request execution.

This attribute is structured like following: `<endpoint>:<url>` or just `<url>`, where:

* `<endpoint>` is either the name of an endpoint or a group of endpoints.
* `<url>` is an absolute or relative url. Absolute url replaces the endpoint's target whereas relative url is appended to the endpoint's target.



[APIM-455]: https://gravitee.atlassian.net/browse/APIM-455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-455-user-defined-endpoint/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mgueggofct.chromatic.com)
<!-- Storybook placeholder end -->
