### PR TITLE
fix: disable checksum validation on liquibase 3.18.0 changeset

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_18_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_18_0/schema.yml
@@ -2,6 +2,7 @@ databaseChangeLog:
   - changeSet:
       id: 3.18.0
       author: GraviteeSource Team
+      validCheckSum: ANY
       changes:
         # ################
         # Alert Changes


### PR DESCRIPTION

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-3-18-0-liquibase-changeset/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
