### PR TITLE
fix(console): remove second scroll in gw instance details page

### DIFF
--- a/gravitee-apim-console-webui/src/management/instances/instance-details/instance-details-environment/instance-details-environment.component.scss
+++ b/gravitee-apim-console-webui/src/management/instances/instance-details/instance-details-environment/instance-details-environment.component.scss
@@ -9,8 +9,6 @@
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  overflow-y: auto;
-  height: 80vh;
 
   &__cards {
     display: flex;


### PR DESCRIPTION
## Issue

https://graviteecommunity.atlassian.net/browse/APIM-XXX

## Description

We not keep the top bar lock on the top like in other page. only one scroll

Before : 
![image](https://user-images.githubusercontent.com/4974420/210612391-b476249f-51d5-4b2a-a117-0604ccf954a0.png)

After : 
![image](https://user-images.githubusercontent.com/4974420/210612456-f225055b-3bc8-4e3e-bf84-829630242ab4.png)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/3-20-x-fix-gw-ui-double-scrollbar/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
