### PR TITLE
fix(console): aligne paginator sub component in table wrapper

### DIFF
--- a/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.component.scss
+++ b/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.component.scss
@@ -74,9 +74,10 @@ $typography: map.get(gio.$mat-theme, typography);
       }
     }
 
-    // ⚠️ Material deep override
+    // ⚠️ Material override on custom override
     // Remove form field padding provided to display mat-hint and mat-error. Not used here
-    .gio-table-wrapper__header-bar__search-field {
+    // For search field and mat-paginator
+    .gio-table-wrapper__header-bar {
       .mat-form-field-wrapper {
         padding-bottom: 0;
       }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-287

## Description

Before : 
<img width="377" alt="image" src="https://user-images.githubusercontent.com/4974420/210986768-e4c17740-6486-4563-a61c-159ef5389abe.png">

After : 

![image](https://user-images.githubusercontent.com/4974420/210977423-191ed3f0-8a7d-4a2a-8e1b-e5bd22d9ca4a.png)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-table-wrapper/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ybiftrknhx.chromatic.com)
<!-- Storybook placeholder end -->
