### PR TITLE
fix: API key synchronization gives precedence to active keys

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/definition/ApiKey.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/definition/ApiKey.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.gateway.handlers.api.definition;
 
+import static io.gravitee.repository.management.model.Subscription.Status.ACCEPTED;
+
 import io.gravitee.repository.management.model.Subscription;
 
 /**
@@ -50,7 +52,7 @@ public class ApiKey extends io.gravitee.repository.management.model.ApiKey {
         return subscription;
     }
 
-    public Subscription.Status getSubscriptionStatus() {
-        return subscriptionStatus;
+    public boolean isActive() {
+        return !isRevoked() && !isPaused() && subscriptionStatus == ACCEPTED;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/ApiKeysCache.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/ApiKeysCache.java
@@ -59,7 +59,7 @@ public class ApiKeysCache {
      * @return cached value
      */
     public Optional<ApiKey> save(ApiKey apiKey) {
-        if (apiKey.isRevoked() || apiKey.isPaused() || apiKey.getSubscriptionStatus() != ACCEPTED) {
+        if (!apiKey.isActive()) {
             return saveInactive(apiKey);
         }
         return saveActive(apiKey);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/task/ApiKeyRefresher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/cache/task/ApiKeyRefresher.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.services.sync.cache.task;
 
 import static java.util.Collections.emptyList;
+import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.*;
 
 import io.gravitee.gateway.handlers.api.definition.ApiKey;
@@ -53,7 +54,7 @@ public abstract class ApiKeyRefresher implements Callable<Result<Boolean>> {
         logger.debug("Refresh api-keys");
 
         try {
-            findApiKeys(criteria).forEach(cache::save);
+            findApiKeys(criteria).stream().sorted(comparing(ApiKey::isActive)).forEach(cache::save);
             return Result.success(true);
         } catch (Exception ex) {
             return Result.failure(ex);


### PR DESCRIPTION
Sometimes, an API key synchronization occurs at the same time for an active API key, and an inactive API key, both having the same cache-key. For example, if a subscription using a shared API key is closed, then immediately recreated.

This fix ensures that inactive API keys are synchronized first, And so, they don't disable any active API key that has just been added in cache.

## Issue

https://gravitee.atlassian.net/browse/APIM-209
https://github.com/gravitee-io/issues/issues/8600

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim209-fixapikeysync/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xsetvlfpid.chromatic.com)
<!-- Storybook placeholder end -->
