### PR TITLE
fix: fix e2e for v4 api

### DIFF
--- a/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/plans/subscribe-to-V4-subscription-plan-with-publisher-approval.spec.ts
+++ b/gravitee-apim-e2e/api-test/use-case-test/src/management/publisher/plans/subscribe-to-V4-subscription-plan-with-publisher-approval.spec.ts
@@ -70,7 +70,7 @@ describeIfJupiter('V4 subscription plan subscription and approval workflow', () 
         ],
         endpointGroups: [
           {
-            name: 'default',
+            name: 'default-group',
             type: 'mock',
             endpoints: [
               {


### PR DESCRIPTION
Fix e2e failure due to endpoint group name that clashes with endpoint name.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-e2e-v4/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kiwcpaunei.chromatic.com)
<!-- Storybook placeholder end -->
