### PR TITLE
feat: enable alert-engine by default

### DIFF
--- a/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.html
@@ -207,24 +207,6 @@
       </mat-card-content>
     </mat-card>
 
-    <mat-card class="settings-general__form__card" formGroupName="alert">
-      <h2 gioTableOfContents>Alerting</h2>
-      <mat-card-content>
-        <gio-form-slide-toggle
-          [matTooltip]="providedConfigurationMessage"
-          [matTooltipDisabled]="!isReadonlySetting('alert.enabled')"
-          appearance="fill"
-          class="settings-general__form__card__form-field"
-        >
-          <mat-icon *ngIf="isReadonlySetting('alert.enabled')" class="settings-general__form__card__form-field__icon" gioFormPrefix
-            >lock</mat-icon
-          >
-          <gio-form-label>Enable Alerting</gio-form-label>
-          <mat-slide-toggle gioFormSlideToggle formControlName="enabled" aria-label="Alerting enabled " name="alert"></mat-slide-toggle>
-        </gio-form-slide-toggle>
-      </mat-card-content>
-    </mat-card>
-
     <mat-card class="settings-general__form__card" formGroupName="cors">
       <h2 gioTableOfContents>CORS</h2>
       <mat-card-content>

--- a/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.spec.ts
@@ -273,42 +273,6 @@ describe('ConsoleSettingsComponent', () => {
     });
   });
 
-  describe('alert', () => {
-    it('should disable field when setting is readonly', async () => {
-      expectConsoleSettingsGetRequest({
-        alert: {
-          enabled: false,
-        },
-        metadata: {
-          readonly: ['alert.enabled'],
-        },
-      });
-
-      const enableAlertingSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ name: 'alert' }));
-      expect(await enableAlertingSlideToggle.isDisabled()).toEqual(true);
-    });
-
-    it('should save alert settings', async () => {
-      expectConsoleSettingsGetRequest({
-        alert: {
-          enabled: false,
-        },
-      });
-
-      const enableAlertingSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ name: 'alert' }));
-      await enableAlertingSlideToggle.check();
-
-      const saveButton = await loader.getHarness(GioSaveBarHarness);
-      await saveButton.clickSubmit();
-
-      expectConsoleSettingsSendRequest({
-        alert: {
-          enabled: true,
-        },
-      });
-    });
-  });
-
   describe('cors', () => {
     it('should disable field when setting is readonly', async () => {
       expectConsoleSettingsGetRequest({

--- a/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.ts
@@ -88,7 +88,6 @@ export class OrgSettingsGeneralComponent implements OnInit, OnDestroy {
             tasks: [toFormState(this.settings, 'scheduler.tasks')],
             notifications: [toFormState(this.settings, 'scheduler.notifications')],
           }),
-          alert: this.fb.group({ enabled: [toFormState(this.settings, 'alert.enabled')] }),
           cors: this.fb.group({
             allowOrigin: [
               toFormState(this.settings, 'cors.allowOrigin', [], 'http.api.management.cors.allow-origin'),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -172,7 +172,7 @@ public enum Key {
         new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))
     ),
 
-    ALERT_ENABLED("alert.enabled", "false", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
+    ALERT_ENABLED("alert.enabled", "true", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
 
     LOGGING_DEFAULT_MAX_DURATION("logging.default.max.duration", "0", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
     LOGGING_AUDIT_ENABLED("logging.audit.enabled", "false", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-538

## Description

Remove the toggle in organization settings to enable alert-engine.
alert-engine is activated by default for a new installation of APIM.
Flag alert.enabled can be overridden in the yaml file


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cpxtpjvyac.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/enable-ae-by-default/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
