### PR TITLE
fix: improve api search in platform analytics logs dashboard 

### DIFF
--- a/gravitee-apim-console-webui/src/management/management.route.ts
+++ b/gravitee-apim-console-webui/src/management/management.route.ts
@@ -237,7 +237,7 @@ function managementRouterConfig($stateProvider) {
         },
       },
       resolve: {
-        apis: ($stateParams: StateParams, ApiService: ApiService) => ApiService.list(),
+        apis: ($stateParams: StateParams, ApiService: ApiService) => ApiService.findAllNames(),
         applications: ($stateParams: StateParams, ApplicationService: ApplicationService) => ApplicationService.list(['owner', 'picture']),
       },
     })

--- a/gravitee-apim-console-webui/src/services/api.service.ts
+++ b/gravitee-apim-console-webui/src/services/api.service.ts
@@ -144,6 +144,15 @@ export class ApiService {
     return this.$http.get(url, opts);
   }
 
+  findAllNames(order?: string, opts?: any): IHttpPromise<any> {
+    opts = opts || {};
+    opts.params = {
+      order,
+    };
+
+    return this.$http.get(`${this.Constants.env.baseURL}/apis/names`, opts);
+  }
+
   searchApis(query?: string, page?: any, order?: string, opts?: any): IHttpPromise<any> {
     let url = `${this.Constants.env.baseURL}/apis/_search/`;
 

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiRepository.java
@@ -18,7 +18,6 @@ package io.gravitee.repository.management.api;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.search.*;
-import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.model.Api;
 import java.util.List;
 import java.util.Optional;
@@ -48,6 +47,8 @@ public interface ApiRepository extends CrudRepository<Api, String> {
     Page<String> searchIds(List<ApiCriteria> apiCriteria, Pageable pageable, Sortable sortable);
 
     Set<String> listCategories(ApiCriteria apiCriteria) throws TechnicalException;
+
+    List<Api> findAllNames(ApiCriteria apiCriteria, Sortable sortable) throws TechnicalException;
 
     Optional<Api> findByEnvironmentIdAndCrossId(String environmentId, String crossId) throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-gateway-bridge-http/gravitee-apim-repository-gateway-bridge-http-client/src/main/java/io/gravitee/repository/bridge/client/management/HttpApiRepository.java
@@ -94,6 +94,11 @@ public class HttpApiRepository extends AbstractRepository implements ApiReposito
     }
 
     @Override
+    public List<Api> findAllNames(ApiCriteria apiCriteria, Sortable sortable) {
+        throw new IllegalStateException();
+    }
+
+    @Override
     public Set<String> listCategories(ApiCriteria apiCriteria) throws TechnicalException {
         throw new IllegalStateException();
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
@@ -25,10 +25,7 @@ import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.search.*;
 import io.gravitee.repository.management.api.search.builder.PageableBuilder;
-import io.gravitee.repository.management.model.Api;
-import io.gravitee.repository.management.model.ApiLifecycleState;
-import io.gravitee.repository.management.model.LifecycleState;
-import io.gravitee.repository.management.model.Visibility;
+import io.gravitee.repository.management.model.*;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Types;
@@ -270,6 +267,16 @@ public class JdbcApiRepository extends JdbcAbstractPageableRepository<Api> imple
             LOGGER.error("Failed to list categories api:", ex);
             throw new TechnicalException("Failed to list categories", ex);
         }
+    }
+
+    @Override
+    public List<Api> findAllNames(ApiCriteria apiCriteria, Sortable sortable) throws TechnicalException {
+        final StringBuilder sbQuery = new StringBuilder("select a.id, a.name from ").append(this.tableName).append(" a ");
+        if (null != apiCriteria) {
+            sbQuery.append("where ").append(convert(apiCriteria)).append(" ");
+        }
+        applySortable(sortable, sbQuery);
+        return jdbcTemplate.query(sbQuery.toString(), ps -> fillPreparedStatement(apiCriteria, ps, 1), getOrm().getRowMapper());
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiRepository.java
@@ -135,6 +135,11 @@ public class MongoApiRepository implements ApiRepository {
     }
 
     @Override
+    public List<Api> findAllNames(ApiCriteria apiCriteria, Sortable sortable) throws TechnicalException {
+        return mapper.collection2list(internalApiRepo.findAllNames(apiCriteria, sortable), ApiMongo.class, Api.class);
+    }
+
+    @Override
     public Optional<Api> findByEnvironmentIdAndCrossId(String environmentId, String crossId) throws TechnicalException {
         return internalApiRepo.findByEnvironmentIdAndCrossId(environmentId, crossId).map(this::mapApi);
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryCustom.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryCustom.java
@@ -41,5 +41,7 @@ public interface ApiMongoRepositoryCustom {
      */
     Page<String> searchIds(List<ApiCriteria> apiCriteria, Pageable pageable, Sortable sortable);
 
+    List<ApiMongo> findAllNames(ApiCriteria apiCriteria, Sortable sortable);
+
     Set<String> listCategories(ApiCriteria apiCriteria);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryImpl.java
@@ -86,7 +86,7 @@ public class ApiMongoRepositoryImpl implements ApiMongoRepositoryCustom {
         if (sortable == null) {
             sort = Sort.by(ASC, "name");
         } else {
-            Sort.Direction sortOrder = sortable.order().equals(Order.ASC) ? ASC : Sort.Direction.DESC;
+            Sort.Direction sortOrder = Order.ASC.equals(sortable.order()) ? ASC : Sort.Direction.DESC;
             sort = Sort.by(sortOrder, FieldUtils.toCamelCase(sortable.field()));
         }
 
@@ -99,6 +99,27 @@ public class ApiMongoRepositoryImpl implements ApiMongoRepositoryCustom {
         List<String> apisIds = mongoTemplate.find(query, ApiMongo.class).stream().map(ApiMongo::getId).collect(Collectors.toList());
 
         return new Page<>(apisIds, pageable.pageNumber(), apisIds.size(), total);
+    }
+
+    @Override
+    public List<ApiMongo> findAllNames(ApiCriteria apiCriteria, Sortable sortable) {
+        final Query query = new Query();
+        query.fields().include("_id", "name");
+
+        if (apiCriteria != null) {
+            fillQuery(query, List.of(apiCriteria));
+        }
+
+        Sort sort;
+        if (sortable == null) {
+            sort = Sort.by(ASC, "name");
+        } else {
+            Sort.Direction sortOrder = sortable.order().equals(Order.ASC) ? ASC : Sort.Direction.DESC;
+            sort = Sort.by(sortOrder, FieldUtils.toCamelCase(sortable.field()));
+        }
+
+        query.with(sort);
+        return mongoTemplate.find(query, ApiMongo.class);
     }
 
     private Query buildQuery(ApiFieldFilter apiFieldFilter, List<ApiCriteria> orApiCriteria) {

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/ApiRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/ApiRepositoryTest.java
@@ -23,24 +23,17 @@ import static io.gravitee.repository.utils.DateUtils.parse;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toSet;
 import static org.junit.Assert.*;
 
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.config.AbstractRepositoryTest;
 import io.gravitee.repository.exceptions.TechnicalException;
-import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldFilter;
 import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.api.search.builder.SortableBuilder;
-import io.gravitee.repository.management.model.Api;
-import io.gravitee.repository.management.model.ApiLifecycleState;
-import io.gravitee.repository.management.model.LifecycleState;
-import io.gravitee.repository.management.model.Visibility;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
+import io.gravitee.repository.management.model.*;
 import java.util.*;
 import org.junit.Test;
 
@@ -470,5 +463,71 @@ public class ApiRepositoryTest extends AbstractRepositoryTest {
         assertNotNull(apis);
         assertFalse(apis.isEmpty());
         assertEquals(9, apis.size());
+    }
+
+    @Test
+    public void shouldSearchAllApiNames() throws TechnicalException {
+        List<Api> apiNames = apiRepository.findAllNames(null, null);
+
+        assertNotNull(apiNames);
+        assertFalse(apiNames.isEmpty());
+        assertEquals(9, apiNames.size());
+        assertTrue(
+            apiNames
+                .stream()
+                .map(Api::getName)
+                .collect(toList())
+                .containsAll(
+                    asList(
+                        "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012",
+                        "api-to-delete name",
+                        "api-to-findById name",
+                        "api-to-update name",
+                        "api-with-categories name",
+                        "duplicated-crossId-api name",
+                        "duplicated-crossId-api name",
+                        "duplicated-crossId-api name",
+                        "grouped-api name"
+                    )
+                )
+        );
+    }
+
+    @Test
+    public void shouldSearchAllApiNamesByNameDesc() throws TechnicalException {
+        List<Api> apiNames = apiRepository.findAllNames(null, new SortableBuilder().field("name").order(Order.DESC).build());
+
+        assertNotNull(apiNames);
+        assertFalse(apiNames.isEmpty());
+        assertEquals(9, apiNames.size());
+        assertTrue(
+            apiNames
+                .stream()
+                .map(Api::getName)
+                .collect(toList())
+                .containsAll(
+                    asList(
+                        "grouped-api name",
+                        "duplicated-crossId-api name",
+                        "duplicated-crossId-api name",
+                        "duplicated-crossId-api name",
+                        "api-with-categories name",
+                        "api-to-update name",
+                        "api-to-findById name",
+                        "api-to-delete name",
+                        "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012"
+                    )
+                )
+        );
+    }
+
+    @Test
+    public void shouldSearchAllPublicApiNames() throws TechnicalException {
+        List<Api> apiNames = apiRepository.findAllNames(new ApiCriteria.Builder().visibility(PUBLIC).build(), null);
+
+        assertNotNull(apiNames);
+        assertFalse(apiNames.isEmpty());
+        assertEquals(2, apiNames.size());
+        assertTrue(apiNames.stream().map(Api::getName).collect(toList()).containsAll(asList("grouped-api name", "api-to-findById name")));
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/ApiRepositoryMock.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/config/mock/ApiRepositoryMock.java
@@ -255,5 +255,55 @@ public class ApiRepositoryMock extends AbstractRepositoryMock<ApiRepository> {
                     mock(Api.class)
                 )
             );
+
+        Api longNameApi = new Api();
+        longNameApi.setName(
+            "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012"
+        );
+        Api toDeleteApi = new Api();
+        toDeleteApi.setName("api-to-delete name");
+        Api toFindBydIdApi = new Api();
+        toFindBydIdApi.setName("api-to-findById name");
+        Api toUpdatedApi = new Api();
+        toUpdatedApi.setName("api-to-update name");
+        Api withCategoriesApi = new Api();
+        withCategoriesApi.setName("api-with-categories name");
+        Api duplicatedNameApi = new Api();
+        duplicatedNameApi.setName("duplicated-crossId-api name");
+        Api withGroupApi = new Api();
+        withGroupApi.setName("grouped-api name");
+
+        when(apiRepository.findAllNames(isNull(), isNull()))
+            .thenReturn(
+                List.of(
+                    longNameApi,
+                    toDeleteApi,
+                    toFindBydIdApi,
+                    toUpdatedApi,
+                    withCategoriesApi,
+                    duplicatedNameApi,
+                    duplicatedNameApi,
+                    duplicatedNameApi,
+                    withGroupApi
+                )
+            );
+
+        when(apiRepository.findAllNames(isNull(), eq(new SortableBuilder().field("name").order(Order.DESC).build())))
+            .thenReturn(
+                List.of(
+                    withGroupApi,
+                    duplicatedNameApi,
+                    duplicatedNameApi,
+                    duplicatedNameApi,
+                    withCategoriesApi,
+                    toUpdatedApi,
+                    toFindBydIdApi,
+                    toDeleteApi,
+                    longNameApi
+                )
+            );
+
+        when(apiRepository.findAllNames(eq(new ApiCriteria.Builder().visibility(PUBLIC).build()), isNull()))
+            .thenReturn(List.of(withGroupApi, toFindBydIdApi));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiName.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiName.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.api;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@EqualsAndHashCode
+public class ApiName {
+
+    @Schema(description = "Api's uuid.", example = "00f8c9e7-78fc-4907-b8c9-e778fc790750")
+    private String id;
+
+    @Schema(description = "Api's name. Duplicate names can exists.", example = "My Api")
+    private String name;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiRepositoryProxy.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/proxy/ApiRepositoryProxy.java
@@ -88,6 +88,11 @@ public class ApiRepositoryProxy extends AbstractProxy<ApiRepository> implements 
     }
 
     @Override
+    public List<Api> findAllNames(ApiCriteria apiCriteria, Sortable sortable) throws TechnicalException {
+        return target.findAllNames(apiCriteria, sortable);
+    }
+
+    @Override
     public Optional<Api> findByEnvironmentIdAndCrossId(String environmentId, String crossId) throws TechnicalException {
         return target.findByEnvironmentIdAndCrossId(environmentId, crossId);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
@@ -170,6 +170,14 @@ public interface ApiService {
     Collection<String> searchIds(ExecutionContext executionContext, String query, Map<String, Object> filters, Sortable sortable)
         throws TechnicalException;
 
+    List<ApiName> findAllNames(
+        ExecutionContext executionContext,
+        String user,
+        ApiQuery apiQuery,
+        Sortable sortable,
+        boolean isSimpleUserAuthenticated
+    ) throws TechnicalException;
+
     Page<ApiEntity> search(
         ExecutionContext executionContext,
         String query,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -101,14 +101,7 @@ import io.gravitee.rest.api.model.WorkflowReferenceType;
 import io.gravitee.rest.api.model.WorkflowState;
 import io.gravitee.rest.api.model.alert.AlertReferenceType;
 import io.gravitee.rest.api.model.alert.AlertTriggerEntity;
-import io.gravitee.rest.api.model.api.ApiDeploymentEntity;
-import io.gravitee.rest.api.model.api.ApiEntity;
-import io.gravitee.rest.api.model.api.ApiEntrypointEntity;
-import io.gravitee.rest.api.model.api.ApiQuery;
-import io.gravitee.rest.api.model.api.NewApiEntity;
-import io.gravitee.rest.api.model.api.RollbackApiEntity;
-import io.gravitee.rest.api.model.api.SwaggerApiEntity;
-import io.gravitee.rest.api.model.api.UpdateApiEntity;
+import io.gravitee.rest.api.model.api.*;
 import io.gravitee.rest.api.model.api.header.ApiHeaderEntity;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.model.common.Pageable;
@@ -2824,6 +2817,25 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     @Override
     public Collection<String> searchIds(ExecutionContext executionContext, String query, Map<String, Object> filters, Sortable sortable) {
         return this.searchInDefinition(executionContext, query, filters, sortable).getDocuments();
+    }
+
+    @Override
+    public List<ApiName> findAllNames(
+        ExecutionContext executionContext,
+        String user,
+        ApiQuery query,
+        Sortable sortable,
+        boolean isSimpleUserAuthenticated
+    ) throws TechnicalException {
+        ApiCriteria.Builder apiCriteria = queryToCriteria(executionContext, query);
+
+        if (isSimpleUserAuthenticated) {
+            apiCriteria.ids(findIdsByUser(executionContext, user, query, sortable, false));
+        }
+        return this.apiRepository.findAllNames(apiCriteria.build(), convert(sortable))
+            .stream()
+            .map(api -> new ApiName(api.getId(), api.getName()))
+            .collect(toList());
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_FindAllNamesTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_FindAllNamesTest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.api.search.builder.SortableBuilder;
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.rest.api.model.api.ApiName;
+import io.gravitee.rest.api.model.common.Sortable;
+import io.gravitee.rest.api.model.common.SortableImpl;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ApiService_FindAllNamesTest {
+
+    private static final String API_1 = "api-1";
+    private static final String API_2 = "api-2";
+    private static final String API_NAME = "an api";
+    private static final String API_NAME_2 = "another api";
+    private static final String USER = "a user";
+    private static final String ENVIRONMENT_ID = "DEFAULT";
+    private static final ApiCriteria.Builder apiCriteriaBuilder = new ApiCriteria.Builder().environmentId(ENVIRONMENT_ID);
+    private static final String USER_ROLE_ID = "role-1";
+
+    @InjectMocks
+    private ApiServiceImpl apiService;
+
+    @Mock
+    private ApiRepository apiRepository;
+
+    @Test
+    public void findAllNamesShouldReturnAllNames() throws TechnicalException {
+        Api api = new Api();
+        api.setId(API_1);
+        api.setName(API_NAME);
+
+        ArgumentCaptor<ApiCriteria> criteriaArgumentCaptor = ArgumentCaptor.forClass(ApiCriteria.class);
+        when(apiRepository.findAllNames(criteriaArgumentCaptor.capture(), any())).thenReturn(List.of(api));
+
+        List<ApiName> result = apiService.findAllNames(GraviteeContext.getExecutionContext(), USER, null, null, false);
+
+        assertThat(result).hasSize(1).extracting(ApiName::getName, ApiName::getId).containsExactly(tuple(API_NAME, API_1));
+        verify(apiRepository).findAllNames(any(ApiCriteria.class), isNull());
+        assertThat(criteriaArgumentCaptor.getValue()).usingRecursiveComparison().isEqualTo(apiCriteriaBuilder.build());
+    }
+
+    @Test
+    public void findAllNamesShouldReturnAllNamesSorted() throws TechnicalException {
+        Api api = new Api();
+        api.setId(API_1);
+        api.setName(API_NAME);
+
+        ArgumentCaptor<ApiCriteria> criteriaArgumentCaptor = ArgumentCaptor.forClass(ApiCriteria.class);
+        when(apiRepository.findAllNames(criteriaArgumentCaptor.capture(), any())).thenReturn(List.of(api));
+        Sortable sort = new SortableImpl("name", false);
+        List<ApiName> result = apiService.findAllNames(GraviteeContext.getExecutionContext(), USER, null, sort, false);
+
+        assertThat(result).hasSize(1).extracting(ApiName::getName, ApiName::getId).containsExactly(tuple(API_NAME, API_1));
+        assertThat(criteriaArgumentCaptor.getValue()).usingRecursiveComparison().isEqualTo(apiCriteriaBuilder.build());
+
+        io.gravitee.repository.management.api.search.Sortable expectedSort = new SortableBuilder().field("name").setAsc(false).build();
+        verify(apiRepository).findAllNames(any(ApiCriteria.class), eq(expectedSort));
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-564

## Description

In this pull request we introduce a new endpoint dedicated to the load of all api names for the analytics. Today users with a lot of apis have timeouts when they try to access this page.
For example with **2000** apis the time to load the api names is **greater than 10s** with the classic search. With the `/apis/name` endpoint the time is **around 300ms**

To test this improvement you'll need to create a lot of data in your db and elastic. After that you'll be able to acess to the platform analytics dashboard and click on <kbd>view logs</kbd>. 


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-improve-search/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-arfxhpnqrq.chromatic.com)
<!-- Storybook placeholder end -->
