### PR TITLE
fix: keep plan policies during migration

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PlanServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PlanServiceImpl.java
@@ -278,34 +278,34 @@ public class PlanServiceImpl extends TransactionalService implements PlanService
 
             newPlan.setCharacteristics(updatePlan.getCharacteristics());
 
-            // if order change, reorder all pages
+            PlanEntity oldPlanEntity = convert(oldPlan);
+
+            flowService.save(FlowReferenceType.PLAN, updatePlan.getId(), updatePlan.getFlows());
+            PlanEntity newPlanEntity = convert(newPlan);
+
+            if (!planSynchronizationProcessor.processCheckSynchronization(oldPlanEntity, newPlanEntity)) {
+                newPlan.setNeedRedeployAt(newPlan.getUpdatedAt());
+            }
+
+            // if order change, reorder all plans
             if (newPlan.getOrder() != updatePlan.getOrder()) {
                 newPlan.setOrder(updatePlan.getOrder());
-                reorderAndSavePlans(newPlan);
-                return null;
+                newPlan = reorderAndSavePlans(newPlan);
             } else {
-                PlanEntity oldPlanEntity = convert(oldPlan);
-
-                flowService.save(FlowReferenceType.PLAN, updatePlan.getId(), updatePlan.getFlows());
-                PlanEntity newPlanEntity = convert(newPlan);
-
-                if (!planSynchronizationProcessor.processCheckSynchronization(oldPlanEntity, newPlanEntity)) {
-                    newPlan.setNeedRedeployAt(newPlan.getUpdatedAt());
-                }
                 newPlan = planRepository.update(newPlan);
-
-                auditService.createApiAuditLog(
-                    executionContext,
-                    newPlan.getApi(),
-                    Collections.singletonMap(Audit.AuditProperties.PLAN, newPlan.getId()),
-                    PLAN_UPDATED,
-                    newPlan.getUpdatedAt(),
-                    oldPlan,
-                    newPlan
-                );
-
-                return convert(newPlan);
             }
+
+            auditService.createApiAuditLog(
+                executionContext,
+                newPlan.getApi(),
+                Collections.singletonMap(Audit.AuditProperties.PLAN, newPlan.getId()),
+                PLAN_UPDATED,
+                newPlan.getUpdatedAt(),
+                oldPlan,
+                newPlan
+            );
+
+            return convert(newPlan);
         } catch (TechnicalException ex) {
             logger.error("An error occurs while trying to update plan {}", updatePlan.getName(), ex);
             throw new TechnicalManagementException(
@@ -547,7 +547,7 @@ public class PlanServiceImpl extends TransactionalService implements PlanService
         return config;
     }
 
-    private void reorderAndSavePlans(final Plan planToReorder) throws TechnicalException {
+    private Plan reorderAndSavePlans(final Plan planToReorder) throws TechnicalException {
         final Collection<Plan> plans = planRepository.findByApi(planToReorder.getApi());
         Plan[] plansToReorder = plans
             .stream()
@@ -573,7 +573,7 @@ public class PlanServiceImpl extends TransactionalService implements PlanService
                 }
             }
             // update the modified plan
-            planRepository.update(planToReorder);
+            return planRepository.update(planToReorder);
         } catch (final TechnicalException ex) {
             logger.error("An error occurs while trying to update plan {}", planToReorder.getId(), ex);
             throw new TechnicalManagementException("An error occurs while trying to update plan " + planToReorder.getId(), ex);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/migration/APIV1toAPIV2Converter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/migration/APIV1toAPIV2Converter.java
@@ -145,6 +145,7 @@ public class APIV1toAPIV2Converter {
                     plan.setDescription(planEntity.getDescription());
                     plan.setType(planEntity.getType());
                     plan.setStatus(planEntity.getStatus());
+                    plan.setOrder(planEntity.getOrder());
                     plan.setFlows(migratePathsToFlows(planEntity.getPaths(), policies));
                     if (planEntity.getTags() != null) {
                         plan.setTags(new HashSet<>(planEntity.getTags()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_UpdateTest.java
@@ -261,6 +261,33 @@ public class PlanService_UpdateTest {
         verify(flowService, times(1)).save(FlowReferenceType.PLAN, updatePlan.getId(), updatePlan.getFlows());
     }
 
+    @Test
+    public void shouldUpdateApi_PlanOrder() throws Exception {
+        final String PAGE_ID = "PAGE_ID_TEST";
+        when(plan.getStatus()).thenReturn(PUBLISHED);
+        when(plan.getType()).thenReturn(Plan.PlanType.API);
+        when(plan.getSecurity()).thenReturn(Plan.PlanSecurityType.KEY_LESS);
+        when(plan.getApi()).thenReturn(API_ID);
+        when(plan.getOrder()).thenReturn(1);
+        when(planRepository.findById(PLAN_ID)).thenReturn(Optional.of(plan));
+        when(planRepository.update(any())).thenReturn(plan);
+        when(parameterService.findAsBoolean(eq(GraviteeContext.getExecutionContext()), any(), eq(ParameterReferenceType.ENVIRONMENT)))
+            .thenReturn(true);
+
+        mockApiDefinitionVersion(V2);
+        when(apiRepository.findById(API_ID)).thenReturn(Optional.of(api));
+
+        UpdatePlanEntity updatePlan = mock(UpdatePlanEntity.class);
+        when(updatePlan.getId()).thenReturn(PLAN_ID);
+        when(updatePlan.getName()).thenReturn("NameUpdated");
+        when(updatePlan.getFlows()).thenReturn(asList(new Flow()));
+        when(updatePlan.getOrder()).thenReturn(2);
+
+        planService.update(GraviteeContext.getExecutionContext(), updatePlan, true);
+
+        verify(flowService, times(1)).save(FlowReferenceType.PLAN, updatePlan.getId(), updatePlan.getFlows());
+    }
+
     @Test(expected = PlanInvalidException.class)
     public void shouldUpdateApi_PlanWithoutFlow() throws Exception {
         final String PAGE_ID = "PAGE_ID_TEST";


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-276
https://github.com/gravitee-io/issues/issues/8632

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/276-fix-plan-migration/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-oqlmgkdqbo.chromatic.com)
<!-- Storybook placeholder end -->
