### PR TITLE
chore: Added ExitOnOutOfMemoryError JVM option as default into gravitee startup scripts

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/bin/gravitee
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/bin/gravitee
@@ -89,6 +89,9 @@ JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
 # space for a full heap dump.
 #JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=$GRAVITEE_HOME/logs/heapdump.hprof"
 
+# JVM exits on the first occurrence of an out-of-memory error.
+JAVA_OPTS="$JAVA_OPTS -XX:+ExitOnOutOfMemoryError"
+
 # Disables explicit GC
 JAVA_OPTS="$JAVA_OPTS -XX:+DisableExplicitGC"
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/bin/gravitee
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/bin/gravitee
@@ -88,6 +88,9 @@ JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
 # space for a full heap dump.
 #JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=$GRAVITEE_HOME/logs/heapdump.hprof"
 
+# JVM exits on the first occurrence of an out-of-memory error.
+JAVA_OPTS="$JAVA_OPTS -XX:+ExitOnOutOfMemoryError"
+
 # Disables explicit GC
 JAVA_OPTS="$JAVA_OPTS -XX:+DisableExplicitGC"
 


### PR DESCRIPTION
## Description

In case of OOM sometimes the JVM (vertx) does not respond, while the liveness and readiness probes are working in Kubernetes. This is a problem because Kubernetes does not restart the pods in this case.

A Java option "-XX:+ExitOnOutOfMemoryError" is added by default in the gravitee startup scripts. JVM exits on the first occurrence of an out-of-memory error.
