### PR TITLE
Revert "chore: Added ExitOnOutOfMemoryError JVM option as default into gravitee startup scripts"

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/bin/gravitee
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/bin/gravitee
@@ -89,9 +89,6 @@ JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
 # space for a full heap dump.
 #JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=$GRAVITEE_HOME/logs/heapdump.hprof"
 
-# JVM exits on the first occurrence of an out-of-memory error.
-JAVA_OPTS="$JAVA_OPTS -XX:+ExitOnOutOfMemoryError"
-
 # Disables explicit GC
 JAVA_OPTS="$JAVA_OPTS -XX:+DisableExplicitGC"
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/bin/gravitee
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/bin/gravitee
@@ -88,9 +88,6 @@ JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError"
 # space for a full heap dump.
 #JAVA_OPTS="$JAVA_OPTS -XX:HeapDumpPath=$GRAVITEE_HOME/logs/heapdump.hprof"
 
-# JVM exits on the first occurrence of an out-of-memory error.
-JAVA_OPTS="$JAVA_OPTS -XX:+ExitOnOutOfMemoryError"
-
 # Disables explicit GC
 JAVA_OPTS="$JAVA_OPTS -XX:+DisableExplicitGC"
 


### PR DESCRIPTION
## Issue

N/A

## Description
This reverts commit 231a527b70ebe6057aa761eaa44a84c34b81fbd5 and 37a73581c7fbb359513629b973dc290893b4d6e6.

Like @brasseld and @leleueri said [here](https://github.com/gravitee-io/gravitee-access-management/pull/2387#pullrequestreview-1248036400) and [here](https://github.com/gravitee-io/gravitee-api-management/pull/2915#issuecomment-1381817927), we should think of a better way to handle this.
If APIM simply stops on OOM exception, we will have no possibility to get a heap dump for analysis.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/revert-exit-on-oom-jvm-option/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pwiudbgwas.chromatic.com)
<!-- Storybook placeholder end -->
