### PR TITLE
fix(cockpit): make hello command reply update only organization

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/OrganizationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/OrganizationResource.java
@@ -132,7 +132,7 @@ public class OrganizationResource extends AbstractResource {
     @ApiResponse(responseCode = "204", description = "Organization successfully updated")
     @ApiResponse(responseCode = "500", description = "Internal server error")
     public Response update(UpdateOrganizationEntity organizationEntity) {
-        OrganizationEntity updatedOrganization = organizationService.update(
+        OrganizationEntity updatedOrganization = organizationService.updateOrganizationAndFlows(
             GraviteeContext.getExecutionContext(),
             GraviteeContext.getCurrentOrganization(),
             organizationEntity

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/OrganizationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/OrganizationService.java
@@ -33,7 +33,11 @@ public interface OrganizationService {
 
     OrganizationEntity updateOrganization(ExecutionContext executionContext, UpdateOrganizationEntity organizationEntity);
 
-    OrganizationEntity update(ExecutionContext executionContext, String organizationId, UpdateOrganizationEntity organizationEntity);
+    OrganizationEntity updateOrganizationAndFlows(
+        ExecutionContext executionContext,
+        String organizationId,
+        UpdateOrganizationEntity organizationEntity
+    );
 
     void delete(String organizationId);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/OrganizationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/OrganizationService.java
@@ -31,6 +31,8 @@ public interface OrganizationService {
 
     OrganizationEntity createOrUpdate(ExecutionContext executionContext, UpdateOrganizationEntity organizationEntity);
 
+    OrganizationEntity updateOrganization(ExecutionContext executionContext, UpdateOrganizationEntity organizationEntity);
+
     OrganizationEntity update(ExecutionContext executionContext, String organizationId, UpdateOrganizationEntity organizationEntity);
 
     void delete(String organizationId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/producer/HelloCommandProducer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/producer/HelloCommandProducer.java
@@ -128,6 +128,6 @@ public class HelloCommandProducer implements CommandProducer<HelloCommand, Hello
         UpdateOrganizationEntity updateOrganization = new UpdateOrganizationEntity(defaultOrganization);
         updateOrganization.setCockpitId(defaultOrganizationCockpitId);
 
-        organizationService.createOrUpdate(GraviteeContext.getExecutionContext(), updateOrganization);
+        organizationService.updateOrganization(GraviteeContext.getExecutionContext(), updateOrganization);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/OrganizationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/OrganizationServiceImpl.java
@@ -88,6 +88,28 @@ public class OrganizationServiceImpl extends TransactionalService implements Org
     }
 
     @Override
+    public OrganizationEntity updateOrganization(ExecutionContext executionContext, final UpdateOrganizationEntity organizationEntity) {
+        try {
+            Optional<Organization> organizationOptional = organizationRepository.findById(executionContext.getOrganizationId());
+            if (organizationOptional.isPresent()) {
+                Organization organization = convert(organizationEntity);
+                organization.setId(organizationOptional.get().getId());
+                OrganizationEntity updatedOrganization = convert(organizationRepository.update(organization));
+                createPublishOrganizationEvent(executionContext, updatedOrganization);
+                return updatedOrganization;
+            } else {
+                throw new OrganizationNotFoundException(executionContext.getOrganizationId());
+            }
+        } catch (TechnicalException ex) {
+            LOGGER.error("An error occurs while trying to update organization {}", organizationEntity.getName(), ex);
+            throw new TechnicalManagementException(
+                "An error occurs while trying to update organization " + organizationEntity.getName(),
+                ex
+            );
+        }
+    }
+
+    @Override
     public OrganizationEntity createOrUpdate(ExecutionContext executionContext, final UpdateOrganizationEntity organizationEntity) {
         try {
             String organizationId = executionContext.getOrganizationId();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/OrganizationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/OrganizationServiceImpl.java
@@ -114,7 +114,7 @@ public class OrganizationServiceImpl extends TransactionalService implements Org
         try {
             String organizationId = executionContext.getOrganizationId();
             try {
-                return this.update(executionContext, organizationId, organizationEntity);
+                return this.updateOrganizationAndFlows(executionContext, organizationId, organizationEntity);
             } catch (OrganizationNotFoundException e) {
                 Organization organization = convert(organizationEntity);
                 organization.setId(organizationId);
@@ -138,7 +138,7 @@ public class OrganizationServiceImpl extends TransactionalService implements Org
     }
 
     @Override
-    public OrganizationEntity update(
+    public OrganizationEntity updateOrganizationAndFlows(
         ExecutionContext executionContext,
         String organizationId,
         final UpdateOrganizationEntity organizationEntity

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/CockpitIdUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/CockpitIdUpgrader.java
@@ -51,7 +51,7 @@ public class CockpitIdUpgrader implements Upgrader, Ordered {
                 org -> {
                     UpdateOrganizationEntity newOrganization = new UpdateOrganizationEntity(org);
                     newOrganization.setCockpitId(org.getId());
-                    organizationService.update(executionContext, org.getId(), newOrganization);
+                    organizationService.updateOrganization(executionContext, newOrganization);
                 }
             );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/producer/HelloCommandProducerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/producer/HelloCommandProducerTest.java
@@ -170,7 +170,7 @@ public class HelloCommandProducerTest {
         cut.handleReply(helloReply);
 
         verify(organizationService)
-            .createOrUpdate(
+            .updateOrganization(
                 argThat(executionContext -> executionContext.getOrganizationId().equals(defaultOrgId)),
                 argThat(
                     org ->

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/OrganizationService_UpdateOrganizationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/OrganizationService_UpdateOrganizationTest.java
@@ -1,0 +1,190 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.OrganizationRepository;
+import io.gravitee.repository.management.model.Organization;
+import io.gravitee.repository.management.model.flow.FlowReferenceType;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.model.OrganizationEntity;
+import io.gravitee.rest.api.model.UpdateOrganizationEntity;
+import io.gravitee.rest.api.service.EnvironmentService;
+import io.gravitee.rest.api.service.EventService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.configuration.flow.FlowService;
+import io.gravitee.rest.api.service.exceptions.OrganizationNotFoundException;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import javassist.tools.rmi.ObjectNotFoundException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
+ * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class OrganizationService_UpdateOrganizationTest {
+
+    private static final String ORG_ID = "orgid";
+    private static final String NAME = "name";
+    private static final String DESCRIPTION = "description";
+    private static final String COCKPIT_ID = "cockpitId";
+    private static final String RANDOM_COCKPIT_ID = "randomCockpitId";
+    private static final String FLOW_MODE = "DEFAULT";
+    private static final List<String> HRIDS = Collections.singletonList("hrid");
+    private static final List<String> DOMAINS = Collections.singletonList("domainRestrictions");
+
+    @InjectMocks
+    private OrganizationServiceImpl organizationService = new OrganizationServiceImpl();
+
+    @Mock
+    private OrganizationRepository mockOrganizationRepository;
+
+    @Mock
+    private EventService eventService;
+
+    @Mock
+    private ObjectMapper mapper;
+
+    @Mock
+    private FlowService mockFlowService;
+
+    @Mock
+    private EnvironmentService environmentService;
+
+    @Before
+    public void setup() {
+        GraviteeContext.setCurrentOrganization("orgid");
+    }
+
+    @After
+    public void tearDown() {
+        GraviteeContext.cleanContext();
+    }
+
+    @Test
+    public void shouldThrowOrganizationNotFoundException() throws TechnicalException {
+        UpdateOrganizationEntity updateOrganizationEntity = new UpdateOrganizationEntity();
+        updateOrganizationEntity.setCockpitId(COCKPIT_ID);
+
+        when(mockOrganizationRepository.findById(any())).thenReturn(Optional.empty());
+
+        assertThrows(
+            OrganizationNotFoundException.class,
+            () -> organizationService.updateOrganization(GraviteeContext.getExecutionContext(), updateOrganizationEntity)
+        );
+    }
+
+    @Test
+    public void shouldThrowTechnicalException() throws TechnicalException {
+        UpdateOrganizationEntity updateOrganizationEntity = new UpdateOrganizationEntity();
+        updateOrganizationEntity.setName(NAME);
+        updateOrganizationEntity.setDescription(DESCRIPTION);
+        updateOrganizationEntity.setHrids(HRIDS);
+        updateOrganizationEntity.setDomainRestrictions(DOMAINS);
+        updateOrganizationEntity.setCockpitId(COCKPIT_ID);
+
+        Organization organization = new Organization();
+        organization.setId(ORG_ID);
+        organization.setCockpitId(RANDOM_COCKPIT_ID);
+        organization.setFlowMode(FLOW_MODE);
+        organization.setHrids(HRIDS);
+        organization.setDomainRestrictions(DOMAINS);
+        organization.setName(NAME);
+        organization.setDescription(DESCRIPTION);
+
+        when(mockOrganizationRepository.findById(any())).thenReturn(Optional.of(organization));
+        when(mockOrganizationRepository.update(any())).thenThrow(new TechnicalException("Technical error"));
+
+        assertThrows(
+            TechnicalManagementException.class,
+            () -> organizationService.updateOrganization(GraviteeContext.getExecutionContext(), updateOrganizationEntity)
+        );
+    }
+
+    @Test
+    public void shouldUpdateTechincalException() throws TechnicalException {
+        UpdateOrganizationEntity updateOrganizationEntity = new UpdateOrganizationEntity();
+        updateOrganizationEntity.setName(NAME);
+        updateOrganizationEntity.setDescription(DESCRIPTION);
+        updateOrganizationEntity.setHrids(HRIDS);
+        updateOrganizationEntity.setDomainRestrictions(DOMAINS);
+        updateOrganizationEntity.setCockpitId(COCKPIT_ID);
+
+        Organization organization = new Organization();
+        organization.setId(ORG_ID);
+        organization.setCockpitId(RANDOM_COCKPIT_ID);
+        organization.setFlowMode(FLOW_MODE);
+        organization.setHrids(HRIDS);
+        organization.setDomainRestrictions(DOMAINS);
+        organization.setName(NAME);
+        organization.setDescription(DESCRIPTION);
+        when(mockOrganizationRepository.findById(any())).thenReturn(Optional.of(organization));
+
+        Organization expectedOrganization = new Organization();
+        expectedOrganization.setId(ORG_ID);
+        expectedOrganization.setCockpitId(COCKPIT_ID);
+        expectedOrganization.setFlowMode(FLOW_MODE);
+        expectedOrganization.setHrids(HRIDS);
+        expectedOrganization.setDomainRestrictions(DOMAINS);
+        expectedOrganization.setName(NAME);
+        expectedOrganization.setDescription(DESCRIPTION);
+
+        when(mockFlowService.findByReference(FlowReferenceType.ORGANIZATION, ORG_ID)).thenReturn(Collections.emptyList());
+
+        EnvironmentEntity env1 = new EnvironmentEntity();
+        env1.setId("env_1");
+        when(environmentService.findByOrganization(ORG_ID)).thenReturn(Collections.singletonList(env1));
+
+        when(mockOrganizationRepository.update(any())).thenReturn(expectedOrganization);
+
+        OrganizationEntity result = organizationService.updateOrganization(GraviteeContext.getExecutionContext(), updateOrganizationEntity);
+
+        assertNotNull(result);
+        assertEquals(ORG_ID, result.getId());
+        assertEquals(COCKPIT_ID, result.getCockpitId());
+        verify(mockOrganizationRepository)
+            .update(
+                argThat(
+                    o -> {
+                        assertEquals(COCKPIT_ID, o.getCockpitId());
+                        assertEquals(FLOW_MODE, o.getFlowMode());
+                        assertEquals(HRIDS, o.getHrids());
+                        assertEquals(DOMAINS, o.getDomainRestrictions());
+                        assertEquals(NAME, o.getName());
+                        assertEquals(DESCRIPTION, o.getDescription());
+                        return true;
+                    }
+                )
+            );
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-583

## Description

An Hello command is send by APIM And answered by Cockpit. During the reply process APIM tries to update the organisation with the cockpit default organisation id. The problem is that today the create or update method is used to do it. This method effectively updates the organisation but it updates the platform flows too.

For example, when you run the Gravitee stack, in a Kubernetes context, you can have 3 APIM API and 2 Cockpit API, so multiple Hello Commands are send simultaneously. In the create or update method all the flows are get, then delete and finally recreated for each hello command. 

Here we simplify the update to avoid this problem.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-fix-cockpit-hello-command/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nzznjkykux.chromatic.com)
<!-- Storybook placeholder end -->
