### PR TITLE
fix: resolve deployment of an api with group as primary owner

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PermissionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PermissionServiceImpl.java
@@ -108,13 +108,16 @@ public class PermissionServiceImpl extends AbstractService implements Permission
     }
 
     private static boolean isOrganizationAdmin() {
-        return SecurityContextHolder
-            .getContext()
-            .getAuthentication()
-            .getAuthorities()
-            .stream()
-            .map(GrantedAuthority::getAuthority)
-            .anyMatch(ORGANIZATION_ADMIN::equals);
+        return (
+            SecurityContextHolder.getContext().getAuthentication() != null &&
+            SecurityContextHolder
+                .getContext()
+                .getAuthentication()
+                .getAuthorities()
+                .stream()
+                .map(GrantedAuthority::getAuthority)
+                .anyMatch(ORGANIZATION_ADMIN::equals)
+        );
     }
 
     private boolean hasApiManagementRole(final ExecutionContext executionContext, UserEntity user) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PermissionServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PermissionServiceTest.java
@@ -15,13 +15,11 @@
  */
 package io.gravitee.rest.api.service.impl;
 
-import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.when;
 
-import io.gravitee.rest.api.idp.api.authentication.UserDetails;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.permissions.*;
 import io.gravitee.rest.api.service.MembershipService;
@@ -232,6 +230,32 @@ public class PermissionServiceTest {
         setSecurityContext(true);
         assertTrue(permissionService.hasManagementRights(GraviteeContext.getExecutionContext(), USER_NAME));
         assertTrue(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.API_MEMBER,
+                "reference-id",
+                RolePermissionAction.UPDATE
+            )
+        );
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    public void shouldNotByPassChecksWithoutAuthentication() {
+        final SecurityContext securityContext = mock(SecurityContext.class);
+        SecurityContextHolder.setContext(securityContext);
+
+        reset(userService);
+        reset(membershipService);
+
+        UserEntity user = new UserEntity();
+        user.setId(USER_NAME);
+        user.setRoles(Collections.emptySet());
+
+        doReturn(user).when(userService).findByIdWithRoles(GraviteeContext.getExecutionContext(), USER_NAME);
+        doReturn(null).when(membershipService).getUserMemberPermissions(any(), any(), any(), any());
+        assertFalse(permissionService.hasManagementRights(GraviteeContext.getExecutionContext(), USER_NAME));
+        assertFalse(
             permissionService.hasPermission(
                 GraviteeContext.getExecutionContext(),
                 RolePermission.API_MEMBER,


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8464
https://gravitee.atlassian.net/browse/APIM-84

## Description

A small description of what you did in that PR.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8484-fix-npe-permissions/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-affbndmdsw.chromatic.com)
<!-- Storybook placeholder end -->
