### PR TITLE
fix: let a consumer start or stop subscription if in failure

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/pom.xml
@@ -61,5 +61,27 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>
+
+        <!-- Tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Subscription.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Subscription.java
@@ -361,6 +361,22 @@ public class Subscription implements Serializable {
         this.failureCause = failureCause;
     }
 
+    /**
+     * Consumer can start subscription only if its consumer status is {@link this#consumerStatus} is {@link ConsumerStatus#STOPPED} or {@link ConsumerStatus#STARTED}
+     * @return true when consumer can start the subscription
+     */
+    public boolean canBeStartedByConsumer() {
+        return ConsumerStatus.STOPPED.equals(consumerStatus) || ConsumerStatus.FAILURE.equals(consumerStatus);
+    }
+
+    /**
+     * Consumer can stop subscription only if its consumer status is {@link this#consumerStatus} is {@link ConsumerStatus#STARTED} or {@link ConsumerStatus#STARTED}
+     * @return true when consumer can stop the subscription
+     */
+    public boolean canBeStoppedByConsumer() {
+        return ConsumerStatus.STARTED.equals(consumerStatus) || ConsumerStatus.FAILURE.equals(consumerStatus);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/management/model/SubscriptionTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/management/model/SubscriptionTest.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class SubscriptionTest {
+
+    private Subscription cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new Subscription();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Subscription.ConsumerStatus.class, names = { "STARTED", "FAILURE" })
+    void shouldBeStoppableByConsumer(Subscription.ConsumerStatus consumerStatus) {
+        final Subscription cut = this.cut;
+        cut.setConsumerStatus(consumerStatus);
+        assertThat(cut.canBeStoppedByConsumer()).isTrue();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Subscription.ConsumerStatus.class, names = { "STARTED", "FAILURE" }, mode = EnumSource.Mode.EXCLUDE)
+    void shouldNotBeStoppableByConsumer(Subscription.ConsumerStatus consumerStatus) {
+        final Subscription cut = this.cut;
+        cut.setConsumerStatus(consumerStatus);
+        assertThat(cut.canBeStoppedByConsumer()).isFalse();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Subscription.ConsumerStatus.class, names = { "STOPPED", "FAILURE" })
+    void shouldBeStartableByConsumer(Subscription.ConsumerStatus consumerStatus) {
+        final Subscription cut = this.cut;
+        cut.setConsumerStatus(consumerStatus);
+        assertThat(cut.canBeStartedByConsumer()).isTrue();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Subscription.ConsumerStatus.class, names = { "STOPPED", "FAILURE" }, mode = EnumSource.Mode.EXCLUDE)
+    void shouldNotBeStartableByConsumer(Subscription.ConsumerStatus consumerStatus) {
+        final Subscription cut = this.cut;
+        cut.setConsumerStatus(consumerStatus);
+        assertThat(cut.canBeStartedByConsumer()).isFalse();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
@@ -122,7 +122,6 @@ import io.gravitee.rest.api.service.v4.validation.SubscriptionValidationService;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -962,7 +961,7 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
             validateConsumerStatus(subscription, genericApiModel);
 
             // Here, do not care about the status managed by the publisher. The subscription will be active on the gateway if consumerStatus == ACTIVE and status == ACCEPTED
-            if (subscription.getConsumerStatus() == Subscription.ConsumerStatus.STARTED) {
+            if (subscription.canBeStoppedByConsumer()) {
                 Subscription previousSubscription = new Subscription(subscription);
                 final Date now = new Date();
                 subscription.setUpdatedAt(now);
@@ -1078,7 +1077,7 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
             final GenericApiModel genericApiModel = apiTemplateService.findByIdForTemplates(executionContext, apiId);
             validateConsumerStatus(subscription, genericApiModel);
 
-            if (subscription.getConsumerStatus() == Subscription.ConsumerStatus.STOPPED) {
+            if (subscription.canBeStartedByConsumer()) {
                 Subscription previousSubscription = new Subscription(subscription);
                 final Date now = new Date();
                 subscription.setUpdatedAt(now);


### PR DESCRIPTION
Issue
https://gravitee.atlassian.net/browse/APIM-586

Description
With the introduction of error management for subscriptions, a subscription can have its consumerStatus set to FAILURE if something went wrong.

The only way to restart the subscription was to update it from a consumer call.

It was due to a too strong validation on resume/pause capabilities by consumer on the api.

This PR fixes that by allowing a consumer to resume/pause its subscription even if it's in FAILURE.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-spzsomytfl.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-586-subscription-from-failure/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
