### PR TITLE
fix: fix dev portal themes management on multi-environments

### DIFF
--- a/gravitee-apim-console-webui/src/management/configuration/theme/theme.controller.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/theme/theme.controller.ts
@@ -354,7 +354,7 @@ class ThemeController {
   };
 
   loadTheme = () => {
-    return this.ThemeService.get().then((response) => {
+    return this.ThemeService.getCurrent().then((response) => {
       const theme: Theme = response.data;
       this.setTheme(theme);
     });

--- a/gravitee-apim-console-webui/src/services/theme.service.ts
+++ b/gravitee-apim-console-webui/src/services/theme.service.ts
@@ -20,8 +20,8 @@ class ThemeService {
   /* @ngInject */
   constructor(private $http, private Constants) {}
 
-  get() {
-    return this.$http.get(`${this.Constants.env.baseURL}/configuration/themes/default`);
+  getCurrent() {
+    return this.$http.get(`${this.Constants.env.baseURL}/configuration/themes/current`);
   }
 
   restoreDefaultTheme(theme: Theme) {
@@ -74,7 +74,11 @@ class ThemeService {
   }
 
   private getImageUrl(theme, image) {
-    return `${this.Constants.env.baseURL}/configuration/themes/${theme.id}/${image}?${theme.updated_at}`;
+    let imageUrl = `${this.Constants.env.baseURL}/configuration/themes/${theme.id}/${image}?${theme.updated_at}`;
+    if (imageUrl.includes('{:envId}')) {
+      imageUrl = imageUrl.replace('{:envId}', this.Constants.org.currentEnv.id);
+    }
+    return imageUrl;
   }
 }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ThemeResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ThemeResource.java
@@ -55,7 +55,7 @@ public class ThemeResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_THEME, acls = RolePermissionAction.READ) })
     public ThemeEntity getTheme() {
-        return themeService.findEnabled(GraviteeContext.getExecutionContext());
+        return themeService.findById(GraviteeContext.getExecutionContext(), themeId);
     }
 
     @PUT

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ThemesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ThemesResource.java
@@ -29,6 +29,7 @@ import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -54,6 +55,14 @@ public class ThemesResource extends AbstractResource {
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_THEME, acls = RolePermissionAction.CREATE) })
     public ThemeEntity createTheme(@Valid @NotNull final NewThemeEntity theme) {
         return themeService.create(GraviteeContext.getExecutionContext(), theme);
+    }
+
+    @Path("/current")
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_THEME, acls = RolePermissionAction.READ) })
+    public ThemeEntity getCurrentTheme() {
+        return themeService.findOrCreateDefault(GraviteeContext.getExecutionContext());
     }
 
     @Path("{themeId}")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/AbstractResourceTest.java
@@ -278,6 +278,9 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
     @Autowired
     protected ApiDefinitionContextService definitionContextService;
 
+    @Autowired
+    protected ThemeService themeService;
+
     @Before
     public void setUp() throws Exception {
         when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(true);
@@ -650,6 +653,11 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
         @Bean
         public ApiDefinitionContextService definitionContextService() {
             return mock(ApiDefinitionContextService.class);
+        }
+
+        @Bean
+        public ThemeService themeService() {
+            return mock(ThemeService.class);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ThemeResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ThemeResourceTest.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource;
+
+import static io.gravitee.common.http.HttpStatusCode.*;
+import static javax.ws.rs.client.Entity.json;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.rest.api.model.theme.ThemeDefinition;
+import io.gravitee.rest.api.model.theme.ThemeEntity;
+import io.gravitee.rest.api.model.theme.UpdateThemeEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.ThemeNotFoundException;
+import javax.ws.rs.core.Response;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class ThemeResourceTest extends AbstractResourceTest {
+
+    private static final String THEME_ID = "my-theme-id";
+
+    @Override
+    protected String contextPath() {
+        return "configuration/themes/";
+    }
+
+    @Before
+    public void init() {
+        reset(themeService);
+    }
+
+    @Test
+    public void shouldNotFindThemeById() {
+        when(themeService.findById(GraviteeContext.getExecutionContext(), THEME_ID)).thenThrow(ThemeNotFoundException.class);
+
+        final Response response = envTarget(THEME_ID).request().get();
+        assertEquals(NOT_FOUND_404, response.getStatus());
+    }
+
+    @Test
+    public void shouldFindThemeById() {
+        ThemeEntity theme = new ThemeEntity();
+        theme.setId(THEME_ID);
+
+        when(themeService.findById(GraviteeContext.getExecutionContext(), THEME_ID)).thenReturn(theme);
+
+        final Response response = envTarget(THEME_ID).request().get();
+
+        assertEquals(OK_200, response.getStatus());
+        final ThemeEntity responseTheme = response.readEntity(ThemeEntity.class);
+        assertNotNull(responseTheme);
+        assertEquals(theme, responseTheme);
+    }
+
+    @Test
+    public void shouldDeleteTheme() {
+        final Response response = envTarget(THEME_ID).request().delete();
+
+        assertEquals(NO_CONTENT_204, response.getStatus());
+        verify(themeService).delete(GraviteeContext.getExecutionContext(), THEME_ID);
+    }
+
+    @Test
+    public void shouldUpdateTheme() {
+        UpdateThemeEntity updateTheme = new UpdateThemeEntity();
+        updateTheme.setId(THEME_ID);
+        updateTheme.setName("my-theme");
+        updateTheme.setDefinition(new ThemeDefinition());
+
+        ThemeEntity theme = new ThemeEntity();
+        theme.setId(THEME_ID);
+
+        when(themeService.update(GraviteeContext.getExecutionContext(), updateTheme)).thenReturn(theme);
+
+        final Response response = envTarget(THEME_ID).request().put(json(updateTheme));
+
+        assertEquals(OK_200, response.getStatus());
+        verify(themeService).update(eq(GraviteeContext.getExecutionContext()), eq(updateTheme));
+
+        final ThemeEntity responseTheme = response.readEntity(ThemeEntity.class);
+        assertNotNull(responseTheme);
+        assertEquals(theme, responseTheme);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ThemesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ThemesResourceTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource;
+
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static javax.ws.rs.client.Entity.json;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.rest.api.model.theme.NewThemeEntity;
+import io.gravitee.rest.api.model.theme.ThemeEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import javax.ws.rs.core.Response;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class ThemesResourceTest extends AbstractResourceTest {
+
+    private static final String THEME_ID = "my-theme-id";
+
+    @Override
+    protected String contextPath() {
+        return "configuration/themes";
+    }
+
+    @Before
+    public void init() {
+        reset(themeService);
+    }
+
+    @Test
+    public void shouldCreateTheme() {
+        NewThemeEntity newTheme = new NewThemeEntity();
+        newTheme.setName("my-theme");
+
+        ThemeEntity createdTheme = new ThemeEntity();
+        createdTheme.setId(THEME_ID);
+        createdTheme.setName("my-theme");
+
+        when(themeService.create(eq(GraviteeContext.getExecutionContext()), eq(newTheme))).thenReturn(createdTheme);
+
+        final Response response = envTarget().request().post(json(newTheme));
+
+        assertEquals(OK_200, response.getStatus());
+        verify(themeService).create(eq(GraviteeContext.getExecutionContext()), eq(newTheme));
+
+        final ThemeEntity responseTheme = response.readEntity(ThemeEntity.class);
+        assertNotNull(responseTheme);
+        assertEquals(createdTheme, responseTheme);
+    }
+
+    @Test
+    public void shouldGetCurrentTheme() {
+        ThemeEntity activeTheme = new ThemeEntity();
+        activeTheme.setId(THEME_ID);
+        activeTheme.setName("my-theme");
+
+        when(themeService.findOrCreateDefault(eq(GraviteeContext.getExecutionContext()))).thenReturn(activeTheme);
+
+        final Response response = envTarget("/current").request().get();
+
+        assertEquals(OK_200, response.getStatus());
+
+        final ThemeEntity responseTheme = response.readEntity(ThemeEntity.class);
+        assertNotNull(responseTheme);
+        assertEquals(activeTheme, responseTheme);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ThemeResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ThemeResource.java
@@ -45,11 +45,8 @@ public class ThemeResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     public Response getPortalTheme() {
         ThemeEntity theme = themeService.findEnabled(GraviteeContext.getExecutionContext());
-        if (theme.getId() != null) {
-            String themeURL = PortalApiLinkHelper.themeURL(uriInfo.getBaseUriBuilder(), theme.getId());
-            return Response.ok(themeMapper.convert(theme, themeURL)).build();
-        }
-        return Response.ok().build();
+        String themeURL = PortalApiLinkHelper.themeURL(uriInfo.getBaseUriBuilder(), theme.getId());
+        return Response.ok(themeMapper.convert(theme, themeURL)).build();
     }
 
     @GET

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/AbstractResourceTest.java
@@ -259,6 +259,12 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
     @Autowired
     private AuthoritiesProvider authoritiesProvider;
 
+    @Autowired
+    protected ThemeService themeService;
+
+    @Autowired
+    protected ThemeMapper themeMapper;
+
     public AbstractResourceTest() {
         super(
             new AuthenticationProviderManager() {
@@ -347,6 +353,8 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
         reset(authenticationProvider);
         reset(environmentService);
         reset(accessControlService);
+        reset(themeService);
+        reset(themeMapper);
     }
 
     @Configuration
@@ -686,6 +694,16 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
         @Bean
         public AccessControlService accessControlService() {
             return mock(AccessControlService.class);
+        }
+
+        @Bean
+        public ThemeService themeService() {
+            return mock(ThemeService.class);
+        }
+
+        @Bean
+        public ThemeMapper themeMapper() {
+            return mock(ThemeMapper.class);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ThemeResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ThemeResourceTest.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.resource;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.rest.api.model.theme.ThemeEntity;
+import io.gravitee.rest.api.portal.rest.model.ThemeResponse;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import javax.ws.rs.core.Response;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class ThemeResourceTest extends AbstractResourceTest {
+
+    private static final String THEME_ID = "my-theme-id";
+
+    @Override
+    protected String contextPath() {
+        return "theme";
+    }
+
+    @Before
+    public void init() {
+        reset(themeService);
+    }
+
+    @Test
+    public void shouldGetPortalTheme() {
+        ThemeEntity themeEntity = new ThemeEntity();
+        themeEntity.setId(THEME_ID);
+
+        when(themeService.findEnabled(GraviteeContext.getExecutionContext())).thenReturn(themeEntity);
+        when(themeMapper.convert(any(), any())).thenCallRealMethod();
+
+        final Response response = target().request().get();
+
+        ThemeResponse resultTheme = response.readEntity(ThemeResponse.class);
+        assertNotNull(resultTheme);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ThemeService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ThemeService.java
@@ -33,6 +33,7 @@ public interface ThemeService {
     ThemeEntity update(final ExecutionContext executionContext, UpdateThemeEntity theme);
     void delete(final ExecutionContext executionContext, String themeId);
     ThemeEntity findEnabled(final ExecutionContext executionContext);
+    ThemeEntity findOrCreateDefault(ExecutionContext executionContext);
     ThemeEntity resetToDefaultTheme(final ExecutionContext executionContext, String themeId);
     PictureEntity getLogo(final ExecutionContext executionContext, String themeId);
     PictureEntity getOptionalLogo(final ExecutionContext executionContext, String themeId);


### PR DESCRIPTION
Themes ID management was messy, always using 'default' as the theme ID. That led to inconsistencies when using themes on multiple environments : one environment was overriding theme of the other, cause using the same 'default' ID.

This commit restores a proper ID management on themes :
- On theme creation, its ID is a randomly generated UUID
- API routes containing theme ID (/themes/{id}) now really uses the id in path to identify the theme

When dev portal searches the theme to use, it searches for the enabled theme on the environment if there is one, or gets the default theme values.

When console searches the theme to display on settings, it searches for the first theme on this environmenet, priority to enabled one. If there is no theme yet, a default one will be created and used.

That's retrocompatible with users having the 'default' theme in their database.

https://gravitee.atlassian.net/browse/APIM-563
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wzqdwavpjp.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim563-fixmultienvthemes/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
