### PR TITLE
refactor: load apis pages to avoid timeout in platform analytics

### DIFF
--- a/gravitee-apim-console-webui/src/management/management.route.ts
+++ b/gravitee-apim-console-webui/src/management/management.route.ts
@@ -237,7 +237,7 @@ function managementRouterConfig($stateProvider) {
         },
       },
       resolve: {
-        apis: ($stateParams: StateParams, ApiService: ApiService) => ApiService.list(),
+        apis: ($stateParams: StateParams, ApiService: ApiService) => ApiService.list(null, false, 1, null, null, null, 100),
         applications: ($stateParams: StateParams, ApplicationService: ApplicationService) => ApplicationService.list(['owner', 'picture']),
       },
     })

--- a/gravitee-apim-console-webui/src/management/platform/logs/platform-logs.controller.ts
+++ b/gravitee-apim-console-webui/src/management/platform/logs/platform-logs.controller.ts
@@ -17,6 +17,7 @@ import { StateService } from '@uirouter/core';
 import { IScope } from 'angular';
 import * as _ from 'lodash';
 
+import { ApiService } from '../../../services/api.service';
 import AnalyticsService, { LogsQuery } from '../../../services/analytics.service';
 
 class PlatformLogsController {
@@ -30,7 +31,13 @@ class PlatformLogsController {
   private applications;
   private init: boolean;
 
-  constructor(private AnalyticsService: AnalyticsService, private Constants, private $state: StateService, private $scope: IScope) {
+  constructor(
+    private ApiService: ApiService,
+    private AnalyticsService: AnalyticsService,
+    private Constants,
+    private $state: StateService,
+    private $scope: IScope,
+  ) {
     'ngInject';
 
     this.onPaginate = this.onPaginate.bind(this);
@@ -53,9 +60,24 @@ class PlatformLogsController {
     });
 
     this.metadata = {
-      apis: this.apis.data,
+      apis: this.apis.data.data,
       applications: this.applications.data,
     };
+
+    this.loadApis();
+  }
+
+  loadApis() {
+    const promises = [];
+    for (let i = 2; i <= this.apis.data.page.total_pages; i++) {
+      promises.push(this.ApiService.list(null, false, i, null, null, null, 100));
+    }
+
+    Promise.all(promises).then((results) => {
+      results.forEach((result) => {
+        this.metadata.apis = this.metadata.apis.concat(result.data.data);
+      });
+    });
   }
 
   timeframeChange(timeframe) {

--- a/gravitee-apim-console-webui/src/services/api.service.ts
+++ b/gravitee-apim-console-webui/src/services/api.service.ts
@@ -124,7 +124,7 @@ export class ApiService {
     return this.Constants.env.settings.analytics.clientTimeout as number;
   }
 
-  list(category?: string, portal?: boolean, page?: any, order?: string, opts?: any, ids?: string[]): IHttpPromise<any> {
+  list(category?: string, portal?: boolean, page?: any, order?: string, opts?: any, ids?: string[], size?: number): IHttpPromise<any> {
     let url = `${this.Constants.env.baseURL}/apis/`;
 
     // Fallback to paginated list if a page parameter is provided.
@@ -137,6 +137,7 @@ export class ApiService {
       category: category,
       portal: portal,
       page: page,
+      size: size,
       order: order,
       ids: ids,
     };


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-564
https://github.com/gravitee-io/issues/issues/8822

## Description

Here we load api names using multiple call. 

We tried to use the `md-select` with a  search header like it's done in the applications but it does not really works. There is still problems when we try to unselect data in the list or the selected list.

I think that the best way to fix it today is to keep using a simple select and think about another implementation or to migrate the page.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-improve-front-apis-search/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ziwlomrkzo.chromatic.com)
<!-- Storybook placeholder end -->
