### PR TITLE
fix: email notifier 1.5.0 with authMethods downgraded in 3.18.x

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -104,7 +104,7 @@
         <gravitee-fetcher-github.version>1.6.0</gravitee-fetcher-github.version>
         <gravitee-fetcher-gitlab.version>1.11.0</gravitee-fetcher-gitlab.version>
         <gravitee-fetcher-http.version>1.12.0</gravitee-fetcher-http.version>
-        <gravitee-notifier-email.version>1.4.1</gravitee-notifier-email.version>
+        <gravitee-notifier-email.version>1.5.0</gravitee-notifier-email.version>
         <gravitee-notifier-slack.version>1.3.0</gravitee-notifier-slack.version>
         <gravitee-notifier-webhook.version>1.1.0</gravitee-notifier-webhook.version>
         <!-- Gateway Only -->

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -11,7 +11,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0
-  version: "3.18.14-SNAPSHOT"
+  version: "3.18.18-SNAPSHOT"
 servers:
   - url: http://localhost:8083/portal/environments/{envId}
     description: The portal API for a given environment


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8830

## Description

This PR bumps up the email notifier to 1.5.0 as it was downgraded when merged in 3.18 from 3.15

Related PR: #2725 

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-email-notifier-downgrade/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tbdblfickx.chromatic.com)
<!-- Storybook placeholder end -->
