### PR TITLE
feat: api creation confirmation page

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/apis.route.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis.route.ts
@@ -133,6 +133,16 @@ function apisRouterConfig($stateProvider: StateProvider) {
         },
       },
     })
+    .state('management.apis.create-v4-confirmation', {
+      url: '/new/create/v4/confirmation/:apiId',
+      component: 'ngApiCreationV4ConfirmationComponent',
+      data: {
+        useAngularMaterial: true,
+        perms: {
+          only: ['environment-api-c'],
+        },
+      },
+    })
     .state('management.apis.create-v4', {
       url: '/new/create/v4',
       component: 'ngApiCreationV4Component',

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4-confirmation.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4-confirmation.component.html
@@ -1,0 +1,63 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<mat-card>
+  <div class="api-creation-confirmation__content">
+    <div class="api-creation-confirmation__content__header">
+      <div class="api-creation-confirmation__content__header__icon">
+        <mat-icon svgIcon="gio:check"></mat-icon>
+      </div>
+      <h2>My new API has been created</h2>
+      <button mat-flat-button color="primary" (click)="navigate('management.apis.detail.portal.general')">
+        Open my API in API Management
+      </button>
+    </div>
+    <div class="api-creation-confirmation__content__actions">
+      <h3>Next steps</h3>
+      <div class="action">
+        <div class="action__text">
+          <h4>Policy configuration</h4>
+          <div class="action__text__subtitle">Shape traffic reaching the gateway by configuring your policies with our flow editor</div>
+        </div>
+        <button mat-stroked-button (click)="navigate('management.apis.detail.design.flowsNg.design')">Create policies</button>
+      </div>
+      <div class="action">
+        <div class="action__text">
+          <h4>Debug mode</h4>
+          <div class="action__text__subtitle">Debug your API flows during the Design phase and avoid common design errors</div>
+        </div>
+        <button mat-stroked-button (click)="navigate('management.apis.detail.design.flowsNg.debug')">Debug flows</button>
+      </div>
+      <div class="action">
+        <div class="action__text">
+          <h4>Developer Portal</h4>
+          <div class="action__text__subtitle">
+            Publish your API to the Developer Portal. From there, consumers can discover, learn about and use your API
+          </div>
+        </div>
+        <button mat-stroked-button (click)="navigate('management.apis.detail.portal.general')">Manage API visibility</button>
+      </div>
+      <div class="action">
+        <div class="action__text">
+          <h4>Documentation</h4>
+          <div class="action__text__subtitle">Find everything you need to know about how to use Gravitee</div>
+        </div>
+        <a mat-stroked-button href="https://docs.gravitee.io">Open documentation</a>
+      </div>
+    </div>
+  </div>
+</mat-card>

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4-confirmation.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4-confirmation.component.scss
@@ -1,0 +1,80 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+@use '../../../../scss/gio-layout' as gio-layout;
+
+:host {
+  @include gio-layout.gio-responsive-margin-container;
+}
+
+.api-creation-confirmation {
+  &__content {
+    padding: 32px 40px 48px;
+    display: flex;
+    flex-direction: column;
+    gap: 40px;
+
+    &__header {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 24px;
+
+      &__icon {
+        border-radius: 50%;
+        height: 56px;
+        width: 56px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: mat.get-color-from-palette(gio.$mat-accent-palette, 'lighter80');
+      }
+
+      h2 {
+        margin: 0;
+      }
+    }
+
+    &__actions {
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
+
+      h3 {
+        align-self: center;
+        margin: 0;
+      }
+
+      .action {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        padding: 16px;
+        border: 1px solid mat.get-color-from-palette(gio.$mat-dove-palette, 'darker20');
+        border-radius: 8px;
+
+        &__text {
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+
+          h4 {
+            margin: 0;
+          }
+
+          &__subtitle {
+            padding-right: 30px;
+            color: mat.get-color-from-palette(gio.$mat-space-palette, 'lighter40');
+          }
+        }
+
+        a,
+        button {
+          height: 100%;
+          align-self: center;
+          flex-shrink: 0;
+        }
+      }
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4-confirmation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4-confirmation.component.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, Inject } from '@angular/core';
+import { StateService } from '@uirouter/core';
+
+import { UIRouterState } from '../../../../ajs-upgraded-providers';
+
+@Component({
+  selector: 'api-creation-v4-confirmation',
+  template: require('./api-creation-v4-confirmation.component.html'),
+  styles: [require('./api-creation-v4-confirmation.component.scss')],
+})
+export class ApiCreationV4ConfirmationComponent {
+  constructor(@Inject(UIRouterState) readonly ajsState: StateService) {}
+
+  navigate(urlState: string) {
+    return this.ajsState.go(urlState, { apiId: this.ajsState.params.apiId }, { reload: true });
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.module.ts
@@ -32,6 +32,7 @@ import { ApiCreationStepComponent } from './components/api-creation-stepper/api-
 import { ApiCreationV4Step2Component } from './steps/step-2/api-creation-v4-step-2.component';
 import { ApiCreationV4StepWipComponent } from './steps/step-wip/api-creation-v4-step-wip.component';
 import { ApiCreationV4Step6Component } from './steps/step-6/api-creation-v4-step-6.component';
+import { ApiCreationV4ConfirmationComponent } from './api-creation-v4-confirmation.component';
 
 import { GioSelectionListOptionModule } from '../../../../shared/components/gio-selection-list-option/gio-selection-list-option.module';
 @NgModule({
@@ -60,6 +61,7 @@ import { GioSelectionListOptionModule } from '../../../../shared/components/gio-
     ApiCreationV4Step1Component,
     ApiCreationV4Step2Component,
     ApiCreationV4Step6Component,
+    ApiCreationV4ConfirmationComponent,
   ],
   exports: [ApiCreationV4Component],
 })

--- a/gravitee-apim-console-webui/src/management/management.module.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/management.module.ajs.ts
@@ -529,6 +529,7 @@ import ApiPortalController from './api/portal/general/apiPortal.controller';
 import { ApiLogsConfigurationComponent } from './api/analytics/logs/configuration/api-logs-configuration.component';
 import { ApiCreationV4Component } from './api/creation/v4/api-creation-v4.component';
 import { ApiPathMappingsComponent } from './api/analytics/pathMappings/api-path-mappings.component';
+import { ApiCreationV4ConfirmationComponent } from './api/creation/v4/api-creation-v4-confirmation.component';
 
 (<any>window).moment = moment;
 require('angular-moment-picker');
@@ -865,6 +866,10 @@ graviteeManagementModule.controller('ApiCreationController', ApiCreationControll
 graviteeManagementModule.controller('NewApiImportController', NewApiImportController);
 graviteeManagementModule.directive('ngApiCreationGetStartedComponent', downgradeComponent({ component: ApiCreationGetStartedComponent }));
 graviteeManagementModule.directive('ngApiCreationV4Component', downgradeComponent({ component: ApiCreationV4Component }));
+graviteeManagementModule.directive(
+  'ngApiCreationV4ConfirmationComponent',
+  downgradeComponent({ component: ApiCreationV4ConfirmationComponent }),
+);
 graviteeManagementModule.component('apiCreationStep1', ApiCreationStep1Component);
 graviteeManagementModule.component('apiCreationStep2', ApiCreationStep2Component);
 graviteeManagementModule.component('apiCreationStep3', ApiCreationStep3Component);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-571

## Description

Create a new component for API creation confirmation

![screenshot-localhost_3000-2023 01 18-16_19_13](https://user-images.githubusercontent.com/1655950/213210740-35ce9126-7a3d-42ba-8e1f-72dfc1b6f583.png)

## Additional context

To view page go to
http://localhost:3000/#!/environments/default/apis/new/create/v4/confirmation/<existingApiId>


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cxycmcupho.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-571-api-creation-summary-created/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
