### PR TITLE
[console] Add more entrypoint info to payload

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.spec.ts
@@ -154,9 +154,9 @@ describe('ApiCreationV4Component', () => {
       const step2Harness = await harnessLoader.getHarness(ApiCreationV4Step2Harness);
 
       expectEntrypointsGetRequest([
-        fakeConnectorListItem({ id: 'sse', supportedApiType: 'async' }),
-        fakeConnectorListItem({ id: 'webhook', supportedApiType: 'async' }),
-        fakeConnectorListItem({ id: 'http', supportedApiType: 'sync' }),
+        fakeConnectorListItem({ id: 'sse', supportedApiType: 'async', name: 'SSE' }),
+        fakeConnectorListItem({ id: 'webhook', supportedApiType: 'async', name: 'Webhook' }),
+        fakeConnectorListItem({ id: 'http', supportedApiType: 'sync', name: 'HTTP' }),
       ]);
 
       expect(await step2Harness.getEntrypointsList()).toEqual(['sse', 'webhook']);
@@ -167,14 +167,17 @@ describe('ApiCreationV4Component', () => {
       const step2Harness = await harnessLoader.getHarness(ApiCreationV4Step2Harness);
 
       expectEntrypointsGetRequest([
-        fakeConnectorListItem({ id: 'sse', supportedApiType: 'async' }),
-        fakeConnectorListItem({ id: 'webhook', supportedApiType: 'async' }),
+        fakeConnectorListItem({ id: 'sse', supportedApiType: 'async', name: 'SSE' }),
+        fakeConnectorListItem({ id: 'webhook', supportedApiType: 'async', name: 'Webhook' }),
       ]);
 
       await step2Harness.fillStep(['sse', 'webhook']);
 
       await step2Harness.clickValidate();
-      expect(component.currentStep.payload.selectedEntrypoints).toEqual(['sse', 'webhook']);
+      expect(component.currentStep.payload.selectedEntrypoints).toEqual([
+        { id: 'sse', name: 'SSE' },
+        { id: 'webhook', name: 'Webhook' },
+      ]);
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/models/ApiCreationPayload.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/models/ApiCreationPayload.ts
@@ -17,5 +17,8 @@ export type ApiCreationPayload = Partial<{
   name?: string;
   version?: string;
   description?: string;
-  selectedEntrypoints?: string[];
+  selectedEntrypoints?: {
+    id: string;
+    name: string;
+  }[];
 }>;

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/services/api-creation-stepper.service.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/services/api-creation-stepper.service.spec.ts
@@ -40,7 +40,7 @@ describe('ApiCreationStepperService', () => {
       },
     ],
     {
-      selectedEntrypoints: ['initial value'],
+      selectedEntrypoints: [{ id: '1', name: 'initial value' }],
     },
   );
 
@@ -79,14 +79,14 @@ describe('ApiCreationStepperService', () => {
       name: 'Step 1',
       description: 'Step 2',
       version: 'Step 3',
-      selectedEntrypoints: ['initial value'],
+      selectedEntrypoints: [{ id: '1', name: 'initial value' }],
     });
   });
 
   it('should go to step 1 and change patch payload', () => {
     apiCreationStepperService.goToStep(0);
     apiCreationStepperService.goToNextStep((previousPayload) => {
-      previousPayload.selectedEntrypoints.push('new value');
+      previousPayload.selectedEntrypoints.push({ id: '2', name: 'new value' });
 
       return { ...previousPayload, name: 'Step 1 - edited' };
     });
@@ -101,7 +101,10 @@ describe('ApiCreationStepperService', () => {
       name: 'Step 1 - edited',
       description: 'Step 2',
       version: 'Step 3',
-      selectedEntrypoints: ['initial value', 'new value'],
+      selectedEntrypoints: [
+        { id: '1', name: 'initial value' },
+        { id: '2', name: 'new value' },
+      ],
     });
   });
 });

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-2/api-creation-v4-step-2.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-2/api-creation-v4-step-2.component.html
@@ -26,14 +26,15 @@
     <mat-selection-list formControlName="selectedEntrypoints" class="gio-selection-list" disableRipple="true">
       <mat-list-option
         *ngFor="let entrypoint of entrypoints"
-        [value]="entrypoint.id"
+        [id]="entrypoint.value.id"
+        [value]="entrypoint.value"
         checkboxPosition="before"
         #listOption
         [class.entrypoint-selected]="listOption.selected"
       >
         <gio-selection-list-option-layout>
           <gio-selection-list-option-layout-title>
-            {{ entrypoint.name }}
+            {{ entrypoint.value.name }}
             <span class="gio-badge-primary strong-badge">New</span>
             <span class="gio-badge-accent strong-badge" *ngIf="entrypoint.isEnterprise">Enterprise</span>
           </gio-selection-list-option-layout-title>

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-2/api-creation-v4-step-2.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-2/api-creation-v4-step-2.component.ts
@@ -25,8 +25,10 @@ import { EntrypointService } from '../../../../../../services-ngx/entrypoint.ser
 import { ApiCreationStepService } from '../../services/api-creation-step.service';
 
 type EntrypointVM = {
-  id: string;
-  name: string;
+  value: {
+    id: string;
+    name: string;
+  };
   description: string;
   isEnterprise: boolean;
 };
@@ -40,6 +42,7 @@ export class ApiCreationV4Step2Component implements OnInit, OnDestroy {
   private unsubscribe$: Subject<void> = new Subject<void>();
 
   public formGroup: FormGroup;
+
   public entrypoints: EntrypointVM[];
 
   constructor(
@@ -64,8 +67,10 @@ export class ApiCreationV4Step2Component implements OnInit, OnDestroy {
       )
       .subscribe((entrypointPlugins) => {
         this.entrypoints = entrypointPlugins.map((entrypoint) => ({
-          id: entrypoint.id,
-          name: entrypoint.name,
+          value: {
+            id: entrypoint.id,
+            name: entrypoint.name,
+          },
           description: entrypoint.description,
           isEnterprise: entrypoint.id.endsWith('-advanced'),
         }));
@@ -93,7 +98,7 @@ export class ApiCreationV4Step2Component implements OnInit, OnDestroy {
       .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
         width: '500px',
         data: {
-          title: entrypoint.name,
+          title: entrypoint.value.name,
           content: `${entrypoint.description} <br> 🚧 More information coming soon 🚧`,
           confirmButton: `Ok`,
         },

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-2/api-creation-v4-step-2.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-2/api-creation-v4-step-2.harness.ts
@@ -32,7 +32,7 @@ export class ApiCreationV4Step2Harness extends ComponentHarness {
     }),
   );
 
-  protected getListOptionByValue = (id: string) => this.locatorFor(MatListOptionHarness.with({ selector: `[ng-reflect-value="${id}"]` }))();
+  protected getListOptionById = (id: string) => this.locatorFor(MatListOptionHarness.with({ selector: `#${id}` }))();
 
   async clickPrevious(): Promise<void> {
     return this.getPreviousButton().then((elt) => elt.click());
@@ -47,14 +47,14 @@ export class ApiCreationV4Step2Harness extends ComponentHarness {
   }
 
   async markEntrypointSelectedById(id: string): Promise<void> {
-    const listOption = await this.getListOptionByValue(id);
+    const listOption = await this.getListOptionById(id);
     await listOption.select();
   }
 
   async getEntrypointsList(): Promise<string[]> {
     const list = await this.locatorFor(MatSelectionListHarness.with({ selector: '.gio-selection-list' }))();
 
-    const options = (await list.getItems()).map(async (option) => await (await option.host()).getAttribute('ng-reflect-value'));
+    const options = (await list.getItems()).map(async (option) => await (await option.host()).getAttribute('id'));
 
     return Promise.all(options);
   }


### PR DESCRIPTION
Preparation for including entrypoints in the summary and in the stepper...

## Issue

https://gravitee.atlassian.net/browse/APIM-570

## Description

Transform selectedEntrypoints list to contain objects
Integrate data into payload from Step 2

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-znxisyzlsu.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-570-refactor-entrypoints/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
