### PR TITLE
feat: update path mapping page and make it read only for APIs created by gko

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings-add-dialog/api-path-mappings-add-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings-add-dialog/api-path-mappings-add-dialog.component.html
@@ -1,0 +1,73 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h2 mat-dialog-title class="title">Add Path Mapping</h2>
+
+<mat-dialog-content class="content">
+  <mat-tab-group dynamicHeight mat-stretch-tabs (selectedTabChange)="onSelectedTab($event)">
+    <!-- Add Path Mapping -->
+    <mat-tab [label]="tabLabels.AddPathMapping">
+      <div class="content__tab">
+        <mat-dialog-content class="content" [formGroup]="pathFormGroup">
+          <mat-form-field class="content__path__form-field" appearance="fill">
+            <mat-label>Path mapping</mat-label>
+            <input
+              type="text"
+              aria-label="Path mapping input"
+              placeholder="/products/:productId"
+              matInput
+              formControlName="path"
+              required
+            />
+            <mat-error *ngIf="pathFormGroup.controls.path.hasError('required')">Path mapping is required.</mat-error>
+            <mat-error *ngIf="pathFormGroup.controls.path.hasError('isUnique')">Path mapping already exists.</mat-error>
+            <mat-error *ngIf="pathFormGroup.controls.path.hasError('pattern')"
+              >Wrong path mapping pattern. Example: /products/:productId</mat-error
+            >
+          </mat-form-field>
+        </mat-dialog-content>
+      </div>
+    </mat-tab>
+
+    <!-- Import Swagger -->
+    <mat-tab [label]="tabLabels.SwaggerDocument">
+      <div class="content__tab">
+        <mat-dialog-content class="content" [formGroup]="pathFormGroup">
+          <mat-radio-group formControlName="path" class="radio-group" data-testid="designer-template-parameter-case">
+            <mat-radio-button *ngFor="let page of swaggerDocs" [value]="page.name">{{ page.name }}</mat-radio-button>
+          </mat-radio-group>
+          <mat-error *ngIf="!swaggerDocs.length">No swagger documentation on your API.</mat-error>
+          <mat-error *ngIf="pathFormGroup.controls.path.hasError('isUnique')">Path mapping already exists.</mat-error>
+        </mat-dialog-content>
+      </div>
+    </mat-tab>
+  </mat-tab-group>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end" class="actions">
+  <button class="confirm-dialog__cancel-button" mat-flat-button [mat-dialog-close]="false">Cancel</button>
+  <button
+    class="confirm-dialog__confirm-button"
+    color="primary"
+    mat-raised-button
+    data-testid="confirm-dialog"
+    [disabled]="pathFormGroup.controls.path.errors !== null"
+    (click)="onAddPath()"
+  >
+    Add
+  </button>
+</mat-dialog-actions>

--- a/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings-add-dialog/api-path-mappings-add-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings-add-dialog/api-path-mappings-add-dialog.component.html
@@ -22,23 +22,25 @@
     <!-- Add Path Mapping -->
     <mat-tab [label]="tabLabels.AddPathMapping">
       <div class="content__tab">
-        <mat-dialog-content class="content" [formGroup]="pathFormGroup">
-          <mat-form-field class="content__path__form-field" appearance="fill">
-            <mat-label>Path mapping</mat-label>
-            <input
-              type="text"
-              aria-label="Path mapping input"
-              placeholder="/products/:productId"
-              matInput
-              formControlName="path"
-              required
-            />
-            <mat-error *ngIf="pathFormGroup.controls.path.hasError('required')">Path mapping is required.</mat-error>
-            <mat-error *ngIf="pathFormGroup.controls.path.hasError('isUnique')">Path mapping already exists.</mat-error>
-            <mat-error *ngIf="pathFormGroup.controls.path.hasError('pattern')"
-              >Wrong path mapping pattern. Example: /products/:productId</mat-error
-            >
-          </mat-form-field>
+        <mat-dialog-content class="content">
+          <form [formGroup]="pathFormGroup">
+            <mat-form-field class="content__path__form-field" appearance="fill">
+              <mat-label>Path mapping</mat-label>
+              <input
+                type="text"
+                aria-label="Path mapping input"
+                placeholder="/products/:productId"
+                matInput
+                formControlName="path"
+                required
+              />
+              <mat-error *ngIf="pathFormGroup.controls.path.hasError('required')">Path mapping is required.</mat-error>
+              <mat-error *ngIf="pathFormGroup.controls.path.hasError('isUnique')">Path mapping already exists.</mat-error>
+              <mat-error *ngIf="pathFormGroup.controls.path.hasError('pattern')"
+                >Wrong path mapping pattern. Example: /products/:productId</mat-error
+              >
+            </mat-form-field>
+          </form>
         </mat-dialog-content>
       </div>
     </mat-tab>
@@ -46,26 +48,25 @@
     <!-- Import Swagger -->
     <mat-tab [label]="tabLabels.SwaggerDocument">
       <div class="content__tab">
-        <mat-dialog-content class="content" [formGroup]="pathFormGroup">
-          <mat-radio-group formControlName="path" class="radio-group" data-testid="designer-template-parameter-case">
-            <mat-radio-button *ngFor="let page of swaggerDocs" [value]="page.name">{{ page.name }}</mat-radio-button>
+        <mat-dialog-content class="content">
+          <mat-radio-group class="radio-group" [(ngModel)]="selectedSwaggerDoc">
+            <mat-radio-button *ngFor="let page of swaggerDocs" [value]="page.id">{{ page.name }}</mat-radio-button>
           </mat-radio-group>
-          <mat-error *ngIf="!swaggerDocs.length">No swagger documentation on your API.</mat-error>
-          <mat-error *ngIf="pathFormGroup.controls.path.hasError('isUnique')">Path mapping already exists.</mat-error>
+          <mat-error *ngIf="!swaggerDocs?.length">No swagger documentation on your API.</mat-error>
         </mat-dialog-content>
       </div>
     </mat-tab>
   </mat-tab-group>
 </mat-dialog-content>
 
-<mat-dialog-actions align="end" class="actions">
+<mat-dialog-actions class="actions">
   <button class="confirm-dialog__cancel-button" mat-flat-button [mat-dialog-close]="false">Cancel</button>
   <button
     class="confirm-dialog__confirm-button"
     color="primary"
     mat-raised-button
-    data-testid="confirm-dialog"
-    [disabled]="pathFormGroup.controls.path.errors !== null"
+    aria-label="Add path mapping"
+    [disabled]="pathFormGroup.invalid && !selectedSwaggerDoc"
     (click)="onAddPath()"
   >
     Add

--- a/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings-add-dialog/api-path-mappings-add-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings-add-dialog/api-path-mappings-add-dialog.component.scss
@@ -1,0 +1,32 @@
+.content {
+  width: 600px;
+
+  &__path__form-field {
+    width: 100%;
+  }
+
+  .mat-error {
+    padding: 8px 0;
+  }
+
+  &__tab {
+    padding-top: 16px;
+
+    .radio-group {
+      display: flex;
+      flex-direction: column;
+
+      .mat-radio-button {
+        padding: 8px;
+      }
+
+      &__button {
+        margin: 8px 0 0 0;
+      }
+    }
+  }
+}
+
+.actions {
+  justify-content: end;
+}

--- a/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings-add-dialog/api-path-mappings-add-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings-add-dialog/api-path-mappings-add-dialog.component.spec.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatInputHarness } from '@angular/material/input/testing';
+
+import { ApiPathMappingsAddDialogComponent } from './api-path-mappings-add-dialog.component';
+
+import { ApiPathMappingsModule } from '../api-path-mappings.module';
+import { fakeApi } from '../../../../../entities/api/Api.fixture';
+import { GioHttpTestingModule } from '../../../../../shared/testing';
+
+describe('ApiPathMappingsEditDialogComponent', () => {
+  const API_ID = 'apiId';
+  const api = fakeApi({ id: API_ID, path_mappings: ['/test', '/test/:id'] });
+
+  let fixture: ComponentFixture<ApiPathMappingsAddDialogComponent>;
+  let loader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, GioHttpTestingModule, ApiPathMappingsModule],
+      providers: [
+        { provide: MAT_DIALOG_DATA, useValue: { api, path: '/test' } },
+        { provide: MatDialogRef, useValue: {} },
+      ],
+    });
+
+    fixture = TestBed.createComponent(ApiPathMappingsAddDialogComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  describe('form tests', () => {
+    it('should init the form with the path value', async () => {
+      const input = await loader.getHarness(MatInputHarness.with({ selector: '[aria-label="Path mapping input"]' }));
+      expect(await input.getValue()).toStrictEqual('/test');
+    });
+
+    it('should save new path mapping', async () => {
+      await loader
+        .getHarness(MatInputHarness.with({ selector: '[aria-label="Path mapping input"]' }))
+        .then((input) => input.setValue('/test2'));
+      expect(
+        await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Save path mapping"]' })).then((btn) => btn.isDisabled()),
+      ).toStrictEqual(false);
+    });
+
+    it('should not be able to save existing path', async () => {
+      await loader
+        .getHarness(MatInputHarness.with({ selector: '[aria-label="Path mapping input"]' }))
+        .then((input) => input.setValue('/test/:id'));
+
+      expect(
+        await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Save path mapping"]' })).then((btn) => btn.isDisabled()),
+      ).toStrictEqual(true);
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings-add-dialog/api-path-mappings-add-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings-add-dialog/api-path-mappings-add-dialog.component.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, Inject } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { catchError, switchMap, takeUntil, tap } from 'rxjs/operators';
+import { EMPTY, Subject } from 'rxjs';
+import { MatTabChangeEvent } from '@angular/material/tabs';
+
+import { Api } from '../../../../../entities/api';
+import { ApiService } from '../../../../../services-ngx/api.service';
+import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
+import { isUnique } from '../../../../../shared/utils';
+import { Page } from '../../../../../entities/page';
+
+export interface ApiPathMappingsAddDialogData {
+  api: Api;
+  swaggerDocs: Page[];
+}
+
+@Component({
+  selector: 'api-path-mappings-add-dialog',
+  template: require('./api-path-mappings-add-dialog.component.html'),
+  styles: [require('./api-path-mappings-add-dialog.component.scss')],
+})
+export class ApiPathMappingsAddDialogComponent {
+  tabLabels = {
+    AddPathMapping: 'Path',
+    SwaggerDocument: 'Swagger Document',
+  };
+
+  private api: Api;
+  private unsubscribe$: Subject<boolean> = new Subject<boolean>();
+
+  public pathFormGroup: FormGroup;
+  public swaggerDocs: Page[];
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) dialogData: ApiPathMappingsAddDialogData,
+    private readonly dialogRef: MatDialogRef<ApiPathMappingsAddDialogData>,
+    private readonly apiService: ApiService,
+    private readonly snackBarService: SnackBarService,
+  ) {
+    this.api = dialogData.api;
+    this.swaggerDocs = dialogData.swaggerDocs;
+    this.pathFormGroup = this.initFormGroup();
+  }
+
+  private initFormGroup() {
+    return new FormGroup({
+      path: new FormControl('', [isUnique(this.api.path_mappings), Validators.pattern('^/[a-zA-Z0-9:/]+')]),
+    });
+  }
+
+  public ngOnDestroy(): void {
+    this.unsubscribe$.next(true);
+    this.unsubscribe$.unsubscribe();
+  }
+
+  onSelectedTab(event: MatTabChangeEvent) {
+    this.pathFormGroup = this.initFormGroup();
+    switch (event.tab.textLabel) {
+      case this.tabLabels.AddPathMapping:
+        this.pathFormGroup.addValidators(Validators.required);
+        break;
+    }
+  }
+
+  onAddPath() {
+    this.apiService
+      .get(this.api.id)
+      .pipe(
+        takeUntil(this.unsubscribe$),
+        switchMap((api) => {
+          api.path_mappings.push(this.pathFormGroup.getRawValue().path);
+          return this.apiService.update(api);
+        }),
+        catchError(() => {
+          this.snackBarService.error(`An error occurred while trying to add the path mapping ${this.pathFormGroup.getRawValue().path}.`);
+          return EMPTY;
+        }),
+        tap(() => {
+          this.snackBarService.success(`The path mapping has been successfully added!`);
+          this.dialogRef.close();
+        }),
+      )
+      .subscribe();
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings.component.html
+++ b/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings.component.html
@@ -15,7 +15,22 @@
     limitations under the License.
 
 -->
-<h2>Path Mappings</h2>
+<div class="path-mappings__header">
+  <h2>Path Mappings</h2>
+  <div>
+    <button
+      *gioPermission="{ anyOf: ['api-definition-u'] }"
+      mat-raised-button
+      type="button"
+      color="primary"
+      [disabled]="isReadOnly"
+      (click)="addPathMapping()"
+    >
+      <mat-icon svgIcon="gio:plus"></mat-icon>
+      Add New Path Mapping
+    </button>
+  </div>
+</div>
 
 <div class="path-mappings">
   <table mat-table id="pathMappingsTable" aria-label="Path mappings table" class="path-mappings__table" [dataSource]="pathMappingsDS">
@@ -37,6 +52,7 @@
             aria-label="Button to edit a path mapping"
             matTooltip="Edit path mapping"
             *gioPermission="{ anyOf: ['api-definition-u'] }"
+            [disabled]="isReadOnly"
             (click)="editPathMapping(element.path)"
           >
             <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
@@ -46,6 +62,7 @@
             mat-icon-button
             aria-label="Button to delete a path mapping"
             matTooltip="Delete path mapping"
+            [disabled]="isReadOnly"
             (click)="deletePathMapping(element.path)"
           >
             <mat-icon svgIcon="gio:trash"></mat-icon>

--- a/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings.component.scss
@@ -9,7 +9,18 @@
 .path-mappings {
   @include mat.elevation(3);
 
+  &__table__actions {
+    float: right;
+  }
+
   &__table {
     width: 100%;
+    margin: 8px 0;
+  }
+
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings.component.spec.ts
@@ -34,6 +34,7 @@ import { CONSTANTS_TESTING, GioHttpTestingModule } from '../../../../shared/test
 import { User } from '../../../../entities/user';
 import { fakeApi } from '../../../../entities/api/Api.fixture';
 import { Api } from '../../../../entities/api';
+import { Page } from '../../../../entities/page';
 
 describe('ApiPathMappingsComponent', () => {
   const API_ID = 'apiId';
@@ -82,6 +83,7 @@ describe('ApiPathMappingsComponent', () => {
       });
 
       expectApiGetRequest(api);
+      expectApiPagesGetRequest(api, []);
 
       const { headerCells, rowCells } = await computeApisTableCells();
       expect(headerCells).toEqual([
@@ -103,6 +105,7 @@ describe('ApiPathMappingsComponent', () => {
         path_mappings: [],
       });
       expectApiGetRequest(api);
+      expectApiPagesGetRequest(api, []);
 
       const { headerCells, rowCells } = await computeApisTableCells();
       expect(headerCells).toEqual([
@@ -123,6 +126,7 @@ describe('ApiPathMappingsComponent', () => {
         path_mappings: ['/test', '/test/:id'],
       });
       expectApiGetRequest(api);
+      expectApiPagesGetRequest(api, []);
 
       let { rowCells } = await computeApisTableCells();
       expect(rowCells).toEqual([
@@ -142,6 +146,7 @@ describe('ApiPathMappingsComponent', () => {
       expectApiGetRequest(api);
       expectApiPutRequest(updatedApi);
       expectApiGetRequest(updatedApi);
+      expectApiPagesGetRequest(api, []);
 
       ({ rowCells } = await computeApisTableCells());
       expect(rowCells).toEqual([['/test', '']]);
@@ -155,6 +160,7 @@ describe('ApiPathMappingsComponent', () => {
         path_mappings: ['/test', '/test/:id'],
       });
       expectApiGetRequest(api);
+      expectApiPagesGetRequest(api, []);
 
       let { rowCells } = await computeApisTableCells();
       expect(rowCells).toEqual([
@@ -172,7 +178,6 @@ describe('ApiPathMappingsComponent', () => {
       await dialog.getHarness(MatButtonHarness.with({ selector: '[aria-label="Save path mapping"]' })).then((element) => element.click());
 
       expectApiGetRequest(api);
-
       const updatedApi = { ...api, path_mappings: ['/test', '/updated/:id'] };
       expectApiPutRequest(updatedApi);
 
@@ -180,6 +185,7 @@ describe('ApiPathMappingsComponent', () => {
       expect(snackBars.length).toBe(1);
 
       expectApiGetRequest(updatedApi);
+      expectApiPagesGetRequest(api, []);
       ({ rowCells } = await computeApisTableCells());
       expect(rowCells).toEqual([
         ['/test', ''],
@@ -190,6 +196,13 @@ describe('ApiPathMappingsComponent', () => {
 
   function expectApiGetRequest(api: Api) {
     httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/apis/${api.id}`, method: 'GET' }).flush(api);
+    fixture.detectChanges();
+  }
+
+  function expectApiPagesGetRequest(api: Api, pages: Page[]) {
+    httpTestingController
+      .expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/apis/${api.id}/pages?type=SWAGGER&api=${api.id}`, method: 'GET' })
+      .flush(pages);
     fixture.detectChanges();
   }
 

--- a/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings.module.ts
@@ -16,7 +16,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { MatTableModule } from '@angular/material/table';
-import { GioIconsModule } from '@gravitee/ui-particles-angular';
+import { GioFormFilePickerModule, GioIconsModule } from '@gravitee/ui-particles-angular';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatTooltipModule } from '@angular/material/tooltip';
@@ -25,14 +25,17 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatRadioModule } from '@angular/material/radio';
 
 import { ApiPathMappingsComponent } from './api-path-mappings.component';
 import { ApiPathMappingsEditDialogComponent } from './api-path-mappings-edit-dialog/api-path-mappings-edit-dialog.component';
+import { ApiPathMappingsAddDialogComponent } from './api-path-mappings-add-dialog/api-path-mappings-add-dialog.component';
 
 import { GioPermissionModule } from '../../../../shared/components/gio-permission/gio-permission.module';
 
 @NgModule({
-  declarations: [ApiPathMappingsComponent, ApiPathMappingsEditDialogComponent],
+  declarations: [ApiPathMappingsComponent, ApiPathMappingsAddDialogComponent, ApiPathMappingsEditDialogComponent],
   exports: [ApiPathMappingsComponent],
   imports: [
     CommonModule,
@@ -49,6 +52,9 @@ import { GioPermissionModule } from '../../../../shared/components/gio-permissio
     MatSnackBarModule,
     MatTableModule,
     MatTooltipModule,
+    MatTabsModule,
+    GioFormFilePickerModule,
+    MatRadioModule,
   ],
 })
 export class ApiPathMappingsModule {}

--- a/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/pathMappings/api-path-mappings.module.ts
@@ -23,7 +23,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatRadioModule } from '@angular/material/radio';
@@ -39,8 +39,10 @@ import { GioPermissionModule } from '../../../../shared/components/gio-permissio
   exports: [ApiPathMappingsComponent],
   imports: [
     CommonModule,
+    FormsModule,
     ReactiveFormsModule,
 
+    GioFormFilePickerModule,
     GioIconsModule,
     GioPermissionModule,
 
@@ -49,12 +51,11 @@ import { GioPermissionModule } from '../../../../shared/components/gio-permissio
     MatFormFieldModule,
     MatIconModule,
     MatInputModule,
+    MatRadioModule,
     MatSnackBarModule,
     MatTableModule,
     MatTooltipModule,
     MatTabsModule,
-    GioFormFilePickerModule,
-    MatRadioModule,
   ],
 })
 export class ApiPathMappingsModule {}

--- a/gravitee-apim-console-webui/src/management/management.module.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/management.module.ajs.ts
@@ -702,7 +702,6 @@ graviteeManagementModule.controller('ApiEventsController', ApiEventsController);
 graviteeManagementModule.controller('ApiHistoryController', ApiHistoryController);
 graviteeManagementModule.controller('ApiResourcesController', ApiResourcesController);
 graviteeManagementModule.controller('ApiPathMappingsController', ApiPathMappingsController);
-graviteeManagementModule.controller('ApiPathMappingsController', ApiPathMappingsController);
 graviteeManagementModule.controller('DialogAddPathMappingController', DialogAddPathMappingController);
 graviteeManagementModule.controller('DialogImportPathMappingController', DialogImportPathMappingController);
 graviteeManagementModule.controller('DialogAddPropertyController', DialogAddPropertyController);

--- a/gravitee-apim-console-webui/src/services-ngx/api.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api.service.spec.ts
@@ -426,4 +426,37 @@ describe('ApiService', () => {
       }
     });
   });
+
+  describe('importPathMappings', () => {
+    it('should call the API', (done) => {
+      const apiId = 'api#1';
+      const pageId = 'pageId';
+      const apiVersion = 'apiVersion';
+
+      apiService.importPathMappings(apiId, pageId, apiVersion).subscribe(() => {
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.baseURL}/apis/${apiId}/import-path-mappings?page=${pageId}&definitionVersion=${apiVersion}`,
+        method: 'POST',
+      });
+      req.flush({});
+    });
+
+    it('should call the API without api version', (done) => {
+      const apiId = 'api#1';
+      const pageId = 'pageId';
+
+      apiService.importPathMappings(apiId, pageId, null).subscribe(() => {
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.baseURL}/apis/${apiId}/import-path-mappings?page=${pageId}`,
+        method: 'POST',
+      });
+      req.flush({});
+    });
+  });
 });

--- a/gravitee-apim-console-webui/src/services-ngx/api.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api.service.ts
@@ -249,4 +249,14 @@ export class ApiService {
   migrateApiToPolicyStudio(apiId: string): Observable<Api> {
     return this.http.post<Api>(`${this.constants.env.baseURL}/apis/${apiId}/_migrate`, {});
   }
+
+  importPathMappings(apiId: string, pageId: any, definitionVersion?: string): Observable<Api> {
+    let params = `?page=${pageId}`;
+
+    if (definitionVersion) {
+      params += `&definitionVersion=${definitionVersion}`;
+    }
+
+    return this.http.post<Api>(`${this.constants.env.baseURL}/apis/${apiId}/import-path-mappings${params}`, {});
+  }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-434

## Description

Migrate old path mapping to the new Angular version and make the path mappings read-only if they were created using Kubernetes operator

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zwdhxdbmzk.chromatic.com)
<!-- Storybook placeholder end -->
