### PR TITLE
Do not send Slack notification when release job is failing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1139,7 +1139,7 @@ jobs:
                   steps:
                       - slack/notify:
                             channel: C02NGT20S4W
-                            event: always
+                            event: pass
                             custom: |
                                 {
                                   "blocks": [
@@ -1290,7 +1290,7 @@ jobs:
                                 echo "export RELEASE_NOTES_PR_URL=$(cat /tmp/releaseNotesPrUrl.txt)" >> $BASH_ENV
                       - slack/notify:
                             channel: C02NGT20S4W
-                            event: always
+                            event: pass
                             custom: |
                                 {
                                   "blocks": [


### PR DESCRIPTION
## Issue

N/A

## Description

send Slack notification for nexus staging and changelog only if jobs is in success