### PR TITLE
Bump `gravitee-policy-assign` to 1.5.1

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -48,7 +48,7 @@
         <!-- Management API & Gateway -->
         <gravitee-connector-http.version>1.1.12</gravitee-connector-http.version>
         <gravitee-policy-apikey.version>2.4.0</gravitee-policy-apikey.version>
-        <gravitee-policy-assign-attributes.version>1.5.0</gravitee-policy-assign-attributes.version>
+        <gravitee-policy-assign-attributes.version>1.5.1</gravitee-policy-assign-attributes.version>
         <gravitee-policy-assign-content.version>1.7.0</gravitee-policy-assign-content.version>
         <gravitee-policy-cache.version>1.15.2</gravitee-policy-cache.version>
         <gravitee-policy-callout-http.version>1.15.0</gravitee-policy-callout-http.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-537
https://github.com/gravitee-io/issues/issues/8810

## Description

Bump `gravitee-policy-assign` to 1.5.1 to fix issue related to `response` attribute not set, see: https://github.com/gravitee-io/gravitee-policy-assign-attributes/releases/tag/1.5.1
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cmvwcshcsw.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.blob.core.windows.net/apim-537-fix-el-on-response/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
