### PR TITLE
[console] Apm 606 dynamic created page

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4-confirmation.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4-confirmation.component.html
@@ -15,13 +15,13 @@
     limitations under the License.
 
 -->
-<mat-card>
+<mat-card *ngIf="api">
   <div class="api-creation-confirmation__content">
     <div class="api-creation-confirmation__content__header">
       <div class="api-creation-confirmation__content__header__icon">
         <mat-icon svgIcon="gio:check"></mat-icon>
       </div>
-      <h2 *ngIf="api">{{ api.name }} has been created</h2>
+      <h2>{{ api.name }} has been {{ api.lifecycleState === 'PUBLISHED' ? 'deployed' : 'created' }}</h2>
       <button mat-flat-button color="primary" (click)="navigate('management.apis.detail.portal.general')">
         Open my API in API Management
       </button>

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4-confirmation.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4-confirmation.component.html
@@ -21,7 +21,7 @@
       <div class="api-creation-confirmation__content__header__icon">
         <mat-icon svgIcon="gio:check"></mat-icon>
       </div>
-      <h2>My new API has been created</h2>
+      <h2 *ngIf="api">{{ api.name }} has been created</h2>
       <button mat-flat-button color="primary" (click)="navigate('management.apis.detail.portal.general')">
         Open my API in API Management
       </button>

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4-confirmation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4-confirmation.component.spec.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { InteractivityChecker } from '@angular/cdk/a11y';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { MatCardHarness } from '@angular/material/card/testing';
+
+import { ApiCreationV4ConfirmationComponent } from './api-creation-v4-confirmation.component';
+import { ApiCreationV4Module } from './api-creation-v4.module';
+
+import { fakeApiEntity } from '../../../../entities/api-v4';
+import { GioPermissionModule } from '../../../../shared/components/gio-permission/gio-permission.module';
+import { CONSTANTS_TESTING, GioHttpTestingModule } from '../../../../shared/testing';
+import { UIRouterState, UIRouterStateParams } from '../../../../ajs-upgraded-providers';
+
+describe('ApiCreationV4ConfirmationComponent', () => {
+  const API_ID = 'api-id';
+
+  const fakeAjsState = {
+    go: jest.fn(),
+  };
+
+  let fixture: ComponentFixture<ApiCreationV4ConfirmationComponent>;
+  let rootLoader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+
+  const init = async () => {
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, GioPermissionModule, GioHttpTestingModule, ApiCreationV4Module, MatIconTestingModule],
+      providers: [
+        { provide: UIRouterState, useValue: fakeAjsState },
+        { provide: UIRouterStateParams, useValue: { apiId: API_ID } },
+      ],
+    })
+      .overrideProvider(InteractivityChecker, {
+        useValue: {
+          isFocusable: () => true, // This traps focus checks and so avoid warnings when dealing with
+        },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(ApiCreationV4ConfirmationComponent);
+    rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+
+    fixture.detectChanges();
+  };
+
+  beforeEach(async () => await init());
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  describe('API created', () => {
+    it('should display API name', async () => {
+      const createdApi = fakeApiEntity({ id: API_ID, name: 'my brand new API' });
+
+      httpTestingController
+        .expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/v4/apis/${createdApi.id}`, method: 'GET' })
+        .flush(createdApi);
+
+      const mainCard = await rootLoader.getHarness(MatCardHarness);
+      const innerText = await mainCard.getText();
+      expect(innerText.startsWith('my brand new API' + ' has been created')).toBeTruthy();
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4-confirmation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4-confirmation.component.spec.ts
@@ -71,8 +71,8 @@ describe('ApiCreationV4ConfirmationComponent', () => {
   });
 
   describe('API created', () => {
-    it('should display API name', async () => {
-      const createdApi = fakeApiEntity({ id: API_ID, name: 'my brand new API' });
+    it('should display API name and created', async () => {
+      const createdApi = fakeApiEntity({ id: API_ID, name: 'my brand new API', lifecycleState: 'CREATED' });
 
       httpTestingController
         .expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/v4/apis/${createdApi.id}`, method: 'GET' })
@@ -81,6 +81,20 @@ describe('ApiCreationV4ConfirmationComponent', () => {
       const mainCard = await rootLoader.getHarness(MatCardHarness);
       const innerText = await mainCard.getText();
       expect(innerText.startsWith('my brand new API' + ' has been created')).toBeTruthy();
+    });
+  });
+
+  describe('API deployed', () => {
+    it('should display API name and deployed', async () => {
+      const createdApi = fakeApiEntity({ id: API_ID, name: 'my brand new API', lifecycleState: 'PUBLISHED' });
+
+      httpTestingController
+        .expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/v4/apis/${createdApi.id}`, method: 'GET' })
+        .flush(createdApi);
+
+      const mainCard = await rootLoader.getHarness(MatCardHarness);
+      const innerText = await mainCard.getText();
+      expect(innerText.startsWith('my brand new API' + ' has been deployed')).toBeTruthy();
     });
   });
 });

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4-confirmation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4-confirmation.component.spec.ts
@@ -25,8 +25,7 @@ import { MatCardHarness } from '@angular/material/card/testing';
 import { ApiCreationV4ConfirmationComponent } from './api-creation-v4-confirmation.component';
 import { ApiCreationV4Module } from './api-creation-v4.module';
 
-import { fakeApiEntity } from '../../../../entities/api-v4';
-import { GioPermissionModule } from '../../../../shared/components/gio-permission/gio-permission.module';
+import { ApiEntity, fakeApiEntity } from '../../../../entities/api-v4';
 import { CONSTANTS_TESTING, GioHttpTestingModule } from '../../../../shared/testing';
 import { UIRouterState, UIRouterStateParams } from '../../../../ajs-upgraded-providers';
 
@@ -43,7 +42,7 @@ describe('ApiCreationV4ConfirmationComponent', () => {
 
   const init = async () => {
     await TestBed.configureTestingModule({
-      imports: [NoopAnimationsModule, GioPermissionModule, GioHttpTestingModule, ApiCreationV4Module, MatIconTestingModule],
+      imports: [NoopAnimationsModule, GioHttpTestingModule, ApiCreationV4Module, MatIconTestingModule],
       providers: [
         { provide: UIRouterState, useValue: fakeAjsState },
         { provide: UIRouterStateParams, useValue: { apiId: API_ID } },
@@ -72,11 +71,8 @@ describe('ApiCreationV4ConfirmationComponent', () => {
 
   describe('API created', () => {
     it('should display API name and created', async () => {
-      const createdApi = fakeApiEntity({ id: API_ID, name: 'my brand new API', lifecycleState: 'CREATED' });
-
-      httpTestingController
-        .expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/v4/apis/${createdApi.id}`, method: 'GET' })
-        .flush(createdApi);
+      const api = fakeApiEntity({ id: API_ID, name: 'my brand new API', lifecycleState: 'CREATED' });
+      expectOneGet(api);
 
       const mainCard = await rootLoader.getHarness(MatCardHarness);
       const innerText = await mainCard.getText();
@@ -86,15 +82,16 @@ describe('ApiCreationV4ConfirmationComponent', () => {
 
   describe('API deployed', () => {
     it('should display API name and deployed', async () => {
-      const createdApi = fakeApiEntity({ id: API_ID, name: 'my brand new API', lifecycleState: 'PUBLISHED' });
-
-      httpTestingController
-        .expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/v4/apis/${createdApi.id}`, method: 'GET' })
-        .flush(createdApi);
+      const api = fakeApiEntity({ id: API_ID, name: 'my brand new API', lifecycleState: 'PUBLISHED' });
+      expectOneGet(api);
 
       const mainCard = await rootLoader.getHarness(MatCardHarness);
       const innerText = await mainCard.getText();
       expect(innerText.startsWith('my brand new API' + ' has been deployed')).toBeTruthy();
     });
   });
+
+  function expectOneGet(api: ApiEntity) {
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/v4/apis/${api.id}`, method: 'GET' }).flush(api);
+  }
 });

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4-confirmation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4-confirmation.component.ts
@@ -13,20 +13,40 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, Inject } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
 import { StateService } from '@uirouter/core';
+import { catchError, takeUntil, tap } from 'rxjs/operators';
+import { EMPTY, Subject } from 'rxjs';
 
-import { UIRouterState } from '../../../../ajs-upgraded-providers';
+import { UIRouterState, UIRouterStateParams } from '../../../../ajs-upgraded-providers';
+import { ApiV4Service } from '../../../../services-ngx/api-v4.service';
+import { ApiEntity } from '../../../../entities/api-v4';
 
 @Component({
   selector: 'api-creation-v4-confirmation',
   template: require('./api-creation-v4-confirmation.component.html'),
   styles: [require('./api-creation-v4-confirmation.component.scss')],
 })
-export class ApiCreationV4ConfirmationComponent {
-  constructor(@Inject(UIRouterState) readonly ajsState: StateService) {}
+export class ApiCreationV4ConfirmationComponent implements OnInit {
+  private unsubscribe$: Subject<void> = new Subject<void>();
+  public api: ApiEntity;
+  constructor(
+    @Inject(UIRouterState) readonly ajsState: StateService,
+    @Inject(UIRouterStateParams) private readonly ajsStateParams,
+    private readonly apiV4Service: ApiV4Service,
+  ) {}
 
   navigate(urlState: string) {
-    return this.ajsState.go(urlState, { apiId: this.ajsState.params.apiId }, { reload: true });
+    return this.ajsState.go(urlState, { apiId: this.ajsStateParams.apiId }, { reload: true });
+  }
+
+  ngOnInit(): void {
+    // call service to get item
+    this.apiV4Service
+      .get(this.ajsStateParams.apiId)
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((api) => {
+        this.api = api;
+      });
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4-confirmation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4-confirmation.component.ts
@@ -15,8 +15,8 @@
  */
 import { Component, Inject, OnInit } from '@angular/core';
 import { StateService } from '@uirouter/core';
-import { catchError, takeUntil, tap } from 'rxjs/operators';
-import { EMPTY, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs';
 
 import { UIRouterState, UIRouterStateParams } from '../../../../ajs-upgraded-providers';
 import { ApiV4Service } from '../../../../services-ngx/api-v4.service';
@@ -41,7 +41,6 @@ export class ApiCreationV4ConfirmationComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    // call service to get item
     this.apiV4Service
       .get(this.ajsStateParams.apiId)
       .pipe(takeUntil(this.unsubscribe$))

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.spec.ts
@@ -257,6 +257,23 @@ describe('ApiCreationV4Component', () => {
 
       expect(fakeAjsState.go).toHaveBeenCalledWith('management.apis.create-v4-confirmation', { apiId: 'api-id' });
     });
+
+    it('should go to confirmation page after clicking Deploy my API', async () => {
+      const step6Harness = await harnessLoader.getHarness(ApiCreationV4Step6Harness);
+      await step6Harness.clickDeployMyApiButton();
+
+      const req = httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/v4/apis`, method: 'POST' });
+
+      // Todo: complete with all the expected fields
+      expect(req.request.body).toEqual(
+        expect.objectContaining({
+          name: 'API name',
+        }),
+      );
+      req.flush(fakeApiEntity({ id: 'api-id' }));
+
+      expect(fakeAjsState.go).toHaveBeenCalledWith('management.apis.create-v4-confirmation', { apiId: 'api-id' });
+    });
   });
 
   function expectEntrypointsGetRequest(connectors: Partial<ConnectorListItem>[]) {

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-6/api-creation-v4-step-6.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-6/api-creation-v4-step-6.component.html
@@ -126,14 +126,14 @@
   </div>
   <div class="api-creation-v4-step-6__footer">
     <div class="api-creation-v4-step-6__footer__actions">
-      <button mat-stroked-button type="button" (click)="createApi()">
+      <button mat-stroked-button type="button" (click)="createApi(false)">
         Create my API<mat-icon
           svgIcon="gio:info"
           class="api-creation-v4-step-6__footer__button-icon"
           matTooltip="Your API can't be consumed"
         ></mat-icon>
       </button>
-      <button color="primary" mat-raised-button type="button" (click)="deployApi()">
+      <button color="primary" mat-raised-button type="button" (click)="createApi(true)">
         Deploy my API<mat-icon
           svgIcon="gio:info"
           class="api-creation-v4-step-6__footer__button-icon"

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-6/api-creation-v4-step-6.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-6/api-creation-v4-step-6.component.ts
@@ -72,9 +72,6 @@ export class ApiCreationV4Step6Component implements OnInit {
         takeUntil(this.unsubscribe$),
         tap(
           (api) => {
-            // eslint-disable-next-line
-            console.info('API created successfully', api);
-
             this.snackBarService.success('API created successfully!');
             this.ajsState.go('management.apis.create-v4-confirmation', { apiId: api.id });
           },

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-6/api-creation-v4-step-6.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-6/api-creation-v4-step-6.component.ts
@@ -15,7 +15,7 @@
  */
 
 import { Component, Inject, OnInit } from '@angular/core';
-import { catchError, takeUntil, tap } from 'rxjs/operators';
+import { takeUntil, tap } from 'rxjs/operators';
 import { EMPTY, Subject } from 'rxjs';
 import { kebabCase } from 'lodash';
 import { StateService } from '@uirouter/core';
@@ -49,10 +49,8 @@ export class ApiCreationV4Step6Component implements OnInit {
     this.currentStepPayload = this.stepService.payload;
   }
 
-  createApi(): void {
+  createApi(deploy: boolean) {
     const apiCreationPayload = this.stepService.payload;
-    // eslint-disable-next-line
-    console.info('API Creation Payload', apiCreationPayload);
 
     this.apiV4Service
       .create(
@@ -72,13 +70,13 @@ export class ApiCreationV4Step6Component implements OnInit {
         takeUntil(this.unsubscribe$),
         tap(
           (api) => {
-            this.snackBarService.success('API created successfully!');
+            this.snackBarService.success(`API ${deploy ? 'deployed' : 'created'} successfully!`);
             this.ajsState.go('management.apis.create-v4-confirmation', { apiId: api.id });
           },
-          catchError((err) => {
-            this.snackBarService.error(err.error?.message ?? 'An error occurred while created the API.');
+          (err) => {
+            this.snackBarService.error(err.error?.message ?? `An error occurred while ${deploy ? 'deploying' : 'creating'} the API.`);
             return EMPTY;
-          }),
+          },
         ),
       )
       .subscribe();

--- a/gravitee-apim-console-webui/src/services-ngx/api-v4.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v4.service.spec.ts
@@ -55,4 +55,22 @@ describe('ApiV4Service', () => {
       req.flush(fakeApiEntity());
     });
   });
+
+  describe('get', () => {
+    it('should call the API', (done) => {
+      const apiEntity = fakeApiEntity();
+
+      apiV4Service.get(apiEntity.id).subscribe((api) => {
+        expect(api.name).toEqual(apiEntity.name);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.baseURL}/v4/apis/${apiEntity.id}`,
+        method: 'GET',
+      });
+
+      req.flush(fakeApiEntity());
+    });
+  });
 });

--- a/gravitee-apim-console-webui/src/services-ngx/api-v4.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v4.service.ts
@@ -29,4 +29,8 @@ export class ApiV4Service {
   create(newApiEntity: NewApiEntity): Observable<ApiEntity> {
     return this.http.post<ApiEntity>(`${this.constants.env.baseURL}/v4/apis`, newApiEntity);
   }
+
+  get(id: string): Observable<ApiEntity> {
+    return this.http.get<ApiEntity>(`${this.constants.env.baseURL}/v4/apis/${id}`);
+  }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-606

## Description

- Call backend for newly created API
- Integrate response in html render: api name + lifecycle state
- Allow Deploy my API button in step 6 to create API as well (... Deploy is still under construction)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tjmutbbdes.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apm-606-dynamic-created-page/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
