### PR TITLE
Apim 615 context path component

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/api-proxy-entrypoints.component.spec.ts
@@ -38,6 +38,7 @@ import { AjsRootScope, CurrentUserService, UIRouterStateParams } from '../../../
 import { User } from '../../../../entities/user';
 import { Environment } from '../../../../entities/environment/environment';
 import { fakeEnvironment } from '../../../../entities/environment/environment.fixture';
+import { PortalSettings } from '../../../../entities/portal/portalSettings';
 
 describe('ApiProxyEntrypointsComponent', () => {
   let fixture: ComponentFixture<ApiProxyEntrypointsComponent>;
@@ -86,6 +87,7 @@ describe('ApiProxyEntrypointsComponent', () => {
     it('should update context-path', async () => {
       const api = fakeApi({ id: API_ID, proxy: { virtual_hosts: [{ path: '/path' }] } });
       expectApiGetRequest(api);
+      expectApiGetPortalSettings();
 
       const saveBar = await loader.getHarness(GioSaveBarHarness);
       expect(await saveBar.isVisible()).toBe(false);
@@ -109,6 +111,7 @@ describe('ApiProxyEntrypointsComponent', () => {
     it('should disable field when origin is kubernetes', async () => {
       const api = fakeApi({ id: API_ID, proxy: { virtual_hosts: [{ path: '/path' }] }, definition_context: { origin: 'kubernetes' } });
       expectApiGetRequest(api);
+      expectApiGetPortalSettings();
 
       const saveBar = await loader.getHarness(GioSaveBarHarness);
       expect(await saveBar.isVisible()).toBe(false);
@@ -314,6 +317,7 @@ describe('ApiProxyEntrypointsComponent', () => {
 
       // Expect fetch api get and update proxy
       expectApiGetRequest(api);
+      expectApiGetPortalSettings();
       const req = httpTestingController.expectOne({ method: 'PUT', url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}` });
       expect(req.request.body.proxy.virtual_hosts).toEqual([{ path: '/path-foo' }]);
     });
@@ -385,6 +389,16 @@ describe('ApiProxyEntrypointsComponent', () => {
       ]);
     });
   });
+
+  function expectApiGetPortalSettings() {
+    const settings: PortalSettings = {
+      portal: {
+        entrypoint: 'entrypoint',
+      },
+    };
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/settings`, method: 'GET' }).flush(settings);
+    fixture.detectChanges();
+  }
 
   function expectApiGetRequest(api: Api) {
     httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/apis/${api.id}`, method: 'GET' }).flush(api);

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/context-path/api-proxy-entrypoints-context-path.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/context-path/api-proxy-entrypoints-context-path.component.html
@@ -17,8 +17,13 @@
 -->
 <form *ngIf="entrypointsForm" [formGroup]="entrypointsForm" autocomplete="off" gioFormFocusInvalid>
   <mat-card *ngIf="!virtualHostModeEnabled" class="form-card">
-    <mat-form-field class="form-card__context-path-field">
-      <mat-label>Gateway context-path</mat-label>
+    <div><strong>Context path</strong></div>
+    <div>
+      The URL location of your API. So if your URL is <strong>[{{ contextPathPrefix }}/myAPI]</strong>, then <strong>[/myAPI]</strong> is
+      the context path.
+    </div>
+    <mat-form-field appearance="outline" class="form-card__context-path-field">
+      <span matPrefix>{{ contextPathPrefix }}</span>
       <input matInput formControlName="contextPath" required />
       <mat-hint
         >Path where API is exposed, must start with a '/' and must contain any letter, capitalize letter, number, dash or

--- a/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/context-path/api-proxy-entrypoints-context-path.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/proxy/entrypoints/context-path/api-proxy-entrypoints-context-path.component.scss
@@ -1,4 +1,8 @@
 .form-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
   &__context-path-field {
     width: 100%;
     padding-bottom: 32px;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-615

## Description

Adapt existing component for context path to match new design

![screenshot-localhost_3000-2023 01 24-17_47_11](https://user-images.githubusercontent.com/1655950/214355430-cf979386-dd1b-4bf6-8af9-723184e4adc7.png)


## Additional context

Need this PR to be merged before
https://github.com/gravitee-io/gravitee-ui-particles/pull/191

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-obodjbxrcc.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-615-context-path-component/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
