### PR TITLE
Console - add ApiCreationStep state to save valid state 

### DIFF
--- a/gravitee-apim-console-webui/package.json
+++ b/gravitee-apim-console-webui/package.json
@@ -157,7 +157,7 @@
     "lint": "npm run lint:eslint && npm run prettier",
     "lint:eslint": "eslint --ext .json,.ts ./src",
     "lint:eslint:fix": "eslint --ext .json,.ts ./src --fix",
-    "lint:fix": "npm run lint:eslint:fix && npm run prettier:fix && npm run lint:license:fix",
+    "lint:fix": "npm run lint:eslint:fix && npm run lint:license:fix && npm run prettier:fix",
     "lint:license": "license-check-and-add check -f license-check-config.json",
     "lint:license:fix": "license-check-and-add add -f license-check-config.json -r",
     "postinstall": "ngcc",

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.module.ts
@@ -34,6 +34,7 @@ import { ApiCreationV4Step6Component } from './steps/step-6/api-creation-v4-step
 import { ApiCreationV4ConfirmationComponent } from './api-creation-v4-confirmation.component';
 import { ApiCreationV4Step21Component } from './steps/step-2-1/api-creation-v4-step-2-1.component';
 import { ApiCreationStepperMenuModule } from './components/api-creation-stepper-menu/api-creation-stepper-menu.module';
+import { Step1MenuItemComponent } from './steps/step-1-menu-item/step-1-menu-item.component';
 
 import { GioSelectionListOptionModule } from '../../../../shared/components/gio-selection-list-option/gio-selection-list-option.module';
 @NgModule({
@@ -60,6 +61,7 @@ import { GioSelectionListOptionModule } from '../../../../shared/components/gio-
     ApiCreationV4Component,
     ApiCreationV4StepWipComponent,
     ApiCreationV4Step1Component,
+    Step1MenuItemComponent,
     ApiCreationV4Step2Component,
     ApiCreationV4Step21Component,
     ApiCreationV4Step6Component,

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/api-creation-stepper-menu.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/api-creation-stepper-menu.component.html
@@ -23,7 +23,7 @@
 
   <div class="steps">
     <stepper-menu-step
-      *ngFor="let step of lastStepOfEachLabel"
+      *ngFor="let step of menuSteps"
       [stepNumber]="step.labelNumber"
       [step]="step"
       [activeStep]="currentStep.labelNumber === step.labelNumber"

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/api-creation-stepper-menu.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/api-creation-stepper-menu.component.html
@@ -23,7 +23,7 @@
 
   <div class="steps">
     <stepper-menu-step
-      *ngFor="let step of lastStepPerLabelNumber"
+      *ngFor="let step of lastStepOfEachLabel"
       [stepNumber]="step.labelNumber"
       [step]="step"
       [activeStep]="currentStep.labelNumber === step.labelNumber"

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/api-creation-stepper-menu.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/api-creation-stepper-menu.component.html
@@ -25,7 +25,8 @@
     <stepper-menu-step
       *ngFor="let step of lastStepPerLabelNumber"
       [stepNumber]="step.labelNumber"
-      [currentStep]="currentStep.labelNumber"
+      [step]="step"
+      [activeStep]="currentStep.labelNumber === step.labelNumber"
       >{{ step.label }}</stepper-menu-step
     >
   </div>

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/api-creation-stepper-menu.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/api-creation-stepper-menu.component.spec.ts
@@ -17,28 +17,33 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Component } from '@angular/core';
 import { HarnessLoader } from '@angular/cdk/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
 
 import { ApiCreationStepperMenuModule } from './api-creation-stepper-menu.module';
 import { StepperMenuStepHarness } from './stepper-menu-step/stepper-menu-step.harness';
+import { MenuStepItem } from './api-creation-stepper-menu.component';
+import { TestStepMenuItemComponent } from './test-step-meinu-item.component';
 
 import { ApiCreationStep } from '../../services/api-creation-stepper.service';
 
 @Component({
-  template: `<api-creation-stepper-menu [steps]="steps" [currentStep]="currentStep"></api-creation-stepper-menu>`,
+  template: `<api-creation-stepper-menu [menuSteps]="menuSteps" [currentStep]="currentStep"></api-creation-stepper-menu>`,
 })
 class TestHostComponent {
-  public steps: ApiCreationStep[] = [];
+  public menuSteps: MenuStepItem[] = [];
   public currentStep: ApiCreationStep = undefined;
 }
 
-const FAKE_STEPS: ApiCreationStep[] = [
+const FAKE_STEPS: MenuStepItem[] = [
   {
     id: 'step-1',
     component: undefined,
+    menuItemComponent: TestStepMenuItemComponent,
     label: 'Step 1',
     labelNumber: 1,
     state: 'valid',
     patchPayload: () => ({}),
+    payload: { name: 'test' },
   },
   {
     id: 'step-2',
@@ -47,6 +52,7 @@ const FAKE_STEPS: ApiCreationStep[] = [
     labelNumber: 2,
     state: 'initial',
     patchPayload: () => ({}),
+    payload: {},
   },
   {
     id: 'step-3',
@@ -55,6 +61,7 @@ const FAKE_STEPS: ApiCreationStep[] = [
     labelNumber: 3,
     state: 'initial',
     patchPayload: () => ({}),
+    payload: {},
   },
 ];
 
@@ -63,16 +70,16 @@ describe('ApiCreationStepperMenuComponent', () => {
   let component: TestHostComponent;
   let harnessLoader: HarnessLoader;
 
-  const initConfigureTestingModule = async (steps: ApiCreationStep[], currentStep: ApiCreationStep) => {
+  const initConfigureTestingModule = async (steps: MenuStepItem[], currentStep: ApiCreationStep) => {
     await TestBed.configureTestingModule({
-      declarations: [TestHostComponent],
-      imports: [ApiCreationStepperMenuModule],
+      declarations: [TestHostComponent, TestStepMenuItemComponent],
+      imports: [ApiCreationStepperMenuModule, MatIconTestingModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestHostComponent);
     harnessLoader = await TestbedHarnessEnvironment.loader(fixture);
     component = fixture.componentInstance;
-    component.steps = steps;
+    component.menuSteps = steps;
     component.currentStep = currentStep;
     fixture.detectChanges();
   };
@@ -105,5 +112,12 @@ describe('ApiCreationStepperMenuComponent', () => {
     const menuSteps = await harnessLoader.getAllHarnesses(StepperMenuStepHarness);
 
     expect(await menuSteps[2].hasStepIcon()).toEqual(false);
+  });
+
+  it('should show content', async () => {
+    await initConfigureTestingModule(FAKE_STEPS, FAKE_STEPS[1]);
+    const menuSteps = await harnessLoader.getAllHarnesses(StepperMenuStepHarness);
+
+    expect(await menuSteps[0].getStepContent()).toContain('test');
   });
 });

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/api-creation-stepper-menu.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/api-creation-stepper-menu.component.spec.ts
@@ -33,6 +33,7 @@ class TestHostComponent {
 
 const FAKE_STEPS: ApiCreationStep[] = [
   {
+    id: 'step-1',
     component: undefined,
     label: 'Step 1',
     labelNumber: 1,
@@ -40,6 +41,7 @@ const FAKE_STEPS: ApiCreationStep[] = [
     patchPayload: () => ({}),
   },
   {
+    id: 'step-2',
     component: undefined,
     label: 'Step 2',
     labelNumber: 2,
@@ -47,6 +49,7 @@ const FAKE_STEPS: ApiCreationStep[] = [
     patchPayload: () => ({}),
   },
   {
+    id: 'step-3',
     component: undefined,
     label: 'Step 3',
     labelNumber: 3,

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/api-creation-stepper-menu.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/api-creation-stepper-menu.component.spec.ts
@@ -17,7 +17,6 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { Component } from '@angular/core';
 import { HarnessLoader } from '@angular/cdk/testing';
-import { MatIconTestingModule } from '@angular/material/icon/testing';
 
 import { ApiCreationStepperMenuModule } from './api-creation-stepper-menu.module';
 import { StepperMenuStepHarness } from './stepper-menu-step/stepper-menu-step.harness';
@@ -37,18 +36,21 @@ const FAKE_STEPS: ApiCreationStep[] = [
     component: undefined,
     label: 'Step 1',
     labelNumber: 1,
+    state: 'valid',
     patchPayload: () => ({}),
   },
   {
     component: undefined,
     label: 'Step 2',
     labelNumber: 2,
+    state: 'initial',
     patchPayload: () => ({}),
   },
   {
     component: undefined,
     label: 'Step 3',
     labelNumber: 3,
+    state: 'initial',
     patchPayload: () => ({}),
   },
 ];
@@ -61,7 +63,7 @@ describe('ApiCreationStepperMenuComponent', () => {
   const initConfigureTestingModule = async (steps: ApiCreationStep[], currentStep: ApiCreationStep) => {
     await TestBed.configureTestingModule({
       declarations: [TestHostComponent],
-      imports: [ApiCreationStepperMenuModule, MatIconTestingModule],
+      imports: [ApiCreationStepperMenuModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestHostComponent);

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/api-creation-stepper-menu.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/api-creation-stepper-menu.component.ts
@@ -13,31 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, Input, OnChanges } from '@angular/core';
-import { groupBy } from 'lodash';
+import { Component, InjectionToken, Input } from '@angular/core';
 
+import { ApiCreationPayload } from '../../models/ApiCreationPayload';
 import { ApiCreationStep } from '../../services/api-creation-stepper.service';
+
+export const MENU_ITEM_PAYLOAD = new InjectionToken('MENU_ITEM_PAYLOAD');
+
+export interface MenuStepItem extends ApiCreationStep {
+  payload: ApiCreationPayload;
+}
 
 @Component({
   selector: 'api-creation-stepper-menu',
   template: require('./api-creation-stepper-menu.component.html'),
   styles: [require('./api-creation-stepper-menu.component.scss')],
 })
-export class ApiCreationStepperMenuComponent implements OnChanges {
+export class ApiCreationStepperMenuComponent {
   @Input()
-  public steps: ApiCreationStep[];
+  public menuSteps: MenuStepItem[];
 
   @Input()
   public currentStep: ApiCreationStep;
-
-  public lastStepOfEachLabel: ApiCreationStep[] = [];
-
-  ngOnChanges() {
-    if (!this.steps || !this.currentStep) {
-      return;
-    }
-
-    // Get the last step of each label. To have last payload of each label.
-    this.lastStepOfEachLabel = Object.entries(groupBy(this.steps, 'label')).map(([_, steps]) => steps[steps.length - 1]);
-  }
 }

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/api-creation-stepper-menu.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/api-creation-stepper-menu.component.ts
@@ -30,13 +30,14 @@ export class ApiCreationStepperMenuComponent implements OnChanges {
   @Input()
   public currentStep: ApiCreationStep;
 
-  public lastStepPerLabelNumber: ApiCreationStep[] = [];
+  public lastStepOfEachLabel: ApiCreationStep[] = [];
 
   ngOnChanges() {
     if (!this.steps || !this.currentStep) {
       return;
     }
 
-    this.lastStepPerLabelNumber = Object.entries(groupBy(this.steps, 'labelNumber')).map(([_, steps]) => steps[steps.length - 1]);
+    // Get the last step of each label. To have last payload of each label.
+    this.lastStepOfEachLabel = Object.entries(groupBy(this.steps, 'label')).map(([_, steps]) => steps[steps.length - 1]);
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/api-creation-stepper-menu.stories.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/api-creation-stepper-menu.stories.ts
@@ -21,6 +21,30 @@ import { ApiCreationStepperMenuModule } from './api-creation-stepper-menu.module
 
 import { ApiCreationStep } from '../../services/api-creation-stepper.service';
 
+const FAKE_STEPS: ApiCreationStep[] = [
+  {
+    component: undefined,
+    label: 'Step 1',
+    labelNumber: 1,
+    state: 'valid',
+    patchPayload: () => ({}),
+  },
+  {
+    component: undefined,
+    label: 'Step 2',
+    labelNumber: 2,
+    state: 'initial',
+    patchPayload: () => ({}),
+  },
+  {
+    component: undefined,
+    label: 'Step 3',
+    labelNumber: 3,
+    state: 'initial',
+    patchPayload: () => ({}),
+  },
+];
+
 export default {
   title: 'Shared / API creation stepper',
   component: ApiCreationStepperMenuComponent,
@@ -37,35 +61,8 @@ export default {
       </div>
     `,
     props: {
-      currentStep: {
-        component: undefined,
-        label: 'Step 2',
-        labelNumber: 2,
-        patchPayload: () => ({}),
-      } as ApiCreationStep,
-      steps: [
-        {
-          component: undefined,
-          label: 'Step 1',
-          labelNumber: 1,
-          type: 'primary',
-          patchPayload: () => ({}),
-        },
-        {
-          component: undefined,
-          label: 'Step 2',
-          labelNumber: 2,
-          type: 'primary',
-          patchPayload: () => ({}),
-        },
-        {
-          component: undefined,
-          label: 'Step 3',
-          labelNumber: 3,
-          type: 'primary',
-          patchPayload: () => ({}),
-        },
-      ],
+      currentStep: FAKE_STEPS[1],
+      steps: FAKE_STEPS,
     },
   }),
 } as Meta;

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/api-creation-stepper-menu.stories.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/api-creation-stepper-menu.stories.ts
@@ -16,19 +16,20 @@
 import { Meta, moduleMetadata } from '@storybook/angular';
 import { Story } from '@storybook/angular/dist/ts3.9/client/preview/types-7-0';
 
-import { ApiCreationStepperMenuComponent } from './api-creation-stepper-menu.component';
+import { ApiCreationStepperMenuComponent, MenuStepItem } from './api-creation-stepper-menu.component';
 import { ApiCreationStepperMenuModule } from './api-creation-stepper-menu.module';
+import { TestStepMenuItemComponent } from './test-step-meinu-item.component';
 
-import { ApiCreationStep } from '../../services/api-creation-stepper.service';
-
-const FAKE_STEPS: ApiCreationStep[] = [
+const FAKE_STEPS: MenuStepItem[] = [
   {
     id: 'step-1',
     component: undefined,
+    menuItemComponent: TestStepMenuItemComponent,
     label: 'Step 1',
     labelNumber: 1,
     state: 'valid',
     patchPayload: () => ({}),
+    payload: { name: 'test' },
   },
   {
     id: 'step-2',
@@ -37,6 +38,7 @@ const FAKE_STEPS: ApiCreationStep[] = [
     labelNumber: 2,
     state: 'initial',
     patchPayload: () => ({}),
+    payload: {},
   },
   {
     id: 'step-3',
@@ -45,6 +47,7 @@ const FAKE_STEPS: ApiCreationStep[] = [
     labelNumber: 3,
     state: 'initial',
     patchPayload: () => ({}),
+    payload: {},
   },
 ];
 
@@ -53,6 +56,7 @@ export default {
   component: ApiCreationStepperMenuComponent,
   decorators: [
     moduleMetadata({
+      declarations: [TestStepMenuItemComponent],
       imports: [ApiCreationStepperMenuModule],
     }),
   ],
@@ -60,7 +64,7 @@ export default {
   render: () => ({
     template: `
       <div style="width: 300px">
-        <api-creation-stepper-menu [steps]="steps" [currentStep]="currentStep"></api-creation-stepper-menu>
+        <api-creation-stepper-menu [menuSteps]="steps" [currentStep]="currentStep"></api-creation-stepper-menu>
       </div>
     `,
     props: {

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/api-creation-stepper-menu.stories.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/api-creation-stepper-menu.stories.ts
@@ -23,6 +23,7 @@ import { ApiCreationStep } from '../../services/api-creation-stepper.service';
 
 const FAKE_STEPS: ApiCreationStep[] = [
   {
+    id: 'step-1',
     component: undefined,
     label: 'Step 1',
     labelNumber: 1,
@@ -30,6 +31,7 @@ const FAKE_STEPS: ApiCreationStep[] = [
     patchPayload: () => ({}),
   },
   {
+    id: 'step-2',
     component: undefined,
     label: 'Step 2',
     labelNumber: 2,
@@ -37,6 +39,7 @@ const FAKE_STEPS: ApiCreationStep[] = [
     patchPayload: () => ({}),
   },
   {
+    id: 'step-3',
     component: undefined,
     label: 'Step 3',
     labelNumber: 3,

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/stepper-menu-step/stepper-menu-step.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/stepper-menu-step/stepper-menu-step.component.html
@@ -32,3 +32,7 @@
     <mat-icon *ngIf="stepStatus === 'ACTIVE'" class="stepper-menu-step__icon-current" svgIcon="gio:edit-pencil"></mat-icon>
   </div>
 </div>
+
+<div class="stepper-menu-step__content" *ngIf="step.menuItemComponent && step.state == 'valid'">
+  <ng-container *ngComponentOutlet="step.menuItemComponent; injector: menuItemComponentInjector"></ng-container>
+</div>

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/stepper-menu-step/stepper-menu-step.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/stepper-menu-step/stepper-menu-step.component.ts
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, Input, OnChanges } from '@angular/core';
+import { Component, Injector, Input, OnChanges } from '@angular/core';
 
-import { ApiCreationStep } from '../../../services/api-creation-stepper.service';
+import { MenuStepItem, MENU_ITEM_PAYLOAD } from '../api-creation-stepper-menu.component';
 
 @Component({
   selector: 'stepper-menu-step',
@@ -28,7 +28,7 @@ export class StepperMenuStepComponent implements OnChanges {
 
   // Step item (primary or secondary)
   @Input()
-  public step: ApiCreationStep;
+  public step: MenuStepItem;
 
   // Set to true if the step is the current edited step
   @Input()
@@ -36,13 +36,22 @@ export class StepperMenuStepComponent implements OnChanges {
 
   public stepStatus: 'INACTIVE' | 'ACTIVE' | 'FILLED';
 
+  public menuItemComponentInjector: Injector;
+
   private getStepStatus() {
     if (this.activeStep) return 'ACTIVE';
     if (this.step.state === 'valid') return 'FILLED';
     return 'INACTIVE';
   }
 
+  constructor(private readonly injector: Injector) {}
+
   ngOnChanges(): void {
     this.stepStatus = this.getStepStatus();
+
+    this.menuItemComponentInjector = Injector.create({
+      providers: [{ provide: MENU_ITEM_PAYLOAD, useValue: this.step.payload }],
+      parent: this.injector,
+    });
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/stepper-menu-step/stepper-menu-step.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/stepper-menu-step/stepper-menu-step.component.ts
@@ -15,6 +15,8 @@
  */
 import { Component, Input, OnChanges } from '@angular/core';
 
+import { ApiCreationStep } from '../../../services/api-creation-stepper.service';
+
 @Component({
   selector: 'stepper-menu-step',
   template: require('./stepper-menu-step.component.html'),
@@ -24,14 +26,19 @@ export class StepperMenuStepComponent implements OnChanges {
   @Input()
   public stepNumber: number;
 
+  // Step item (primary or secondary)
   @Input()
-  public currentStep: number;
+  public step: ApiCreationStep;
+
+  // Set to true if the step is the current edited step
+  @Input()
+  public activeStep: boolean;
 
   public stepStatus: 'INACTIVE' | 'ACTIVE' | 'FILLED';
 
   private getStepStatus() {
-    if (this.stepNumber === Math.floor(this.currentStep)) return 'ACTIVE';
-    if (this.stepNumber < this.currentStep) return 'FILLED';
+    if (this.activeStep) return 'ACTIVE';
+    if (this.step.state === 'valid') return 'FILLED';
     return 'INACTIVE';
   }
 

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/stepper-menu-step/stepper-menu-step.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/stepper-menu-step/stepper-menu-step.harness.ts
@@ -37,4 +37,8 @@ export class StepperMenuStepHarness extends ComponentHarness {
       return icon.getName();
     });
   }
+
+  async getStepContent(): Promise<string> {
+    return this.locatorFor('.stepper-menu-step__content')().then((elt) => elt.text());
+  }
 }

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/test-step-meinu-item.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/components/api-creation-stepper-menu/test-step-meinu-item.component.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, Inject } from '@angular/core';
+
+import { MENU_ITEM_PAYLOAD } from './api-creation-stepper-menu.component';
+
+import { ApiCreationPayload } from '../../models/ApiCreationPayload';
+
+@Component({
+  selector: 'test-step-menu-item',
+  template: `{{ menuItemPayload | json }}`,
+})
+export class TestStepMenuItemComponent {
+  constructor(@Inject(MENU_ITEM_PAYLOAD) public readonly menuItemPayload: ApiCreationPayload) {}
+}

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/services/api-creation-step.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/services/api-creation-step.service.ts
@@ -15,7 +15,7 @@
  */
 import { Injectable } from '@angular/core';
 
-import { ApiCreationStep, ApiCreationStepperService, NewApiCreationStep } from './api-creation-stepper.service';
+import { ApiCreationStep, ApiCreationStepperService, NewSecondaryApiCreationStep } from './api-creation-stepper.service';
 
 import { ApiCreationPayload } from '../models/ApiCreationPayload';
 
@@ -42,7 +42,7 @@ export class ApiCreationStepService {
     this.stepper.goToStepLabel(stepLabel);
   }
 
-  public addSecondaryStep(step: Omit<NewApiCreationStep, 'label'>): void {
+  public addSecondaryStep(step: NewSecondaryApiCreationStep): void {
     this.stepper.addSecondaryStep(step);
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/services/api-creation-step.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/services/api-creation-step.service.ts
@@ -30,8 +30,8 @@ export class ApiCreationStepService {
     return this.stepper.compileStepPayload(this.step);
   }
 
-  public goToNextStep(patchPayload: ApiCreationStep['patchPayload']): void {
-    this.stepper.goToNextStep(patchPayload);
+  public validStepAndGoNext(patchPayload: ApiCreationStep['patchPayload']): void {
+    this.stepper.validStepAndGoNext(patchPayload);
   }
 
   public goToPreviousStep(): void {

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/services/api-creation-step.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/services/api-creation-step.service.ts
@@ -42,7 +42,7 @@ export class ApiCreationStepService {
     this.stepper.goToStepLabel(stepLabel);
   }
 
-  public addSecondaryStep(step: NewApiCreationStep): void {
+  public addSecondaryStep(step: Omit<NewApiCreationStep, 'label'>): void {
     this.stepper.addSecondaryStep(step);
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/services/api-creation-stepper.service.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/services/api-creation-stepper.service.spec.ts
@@ -53,7 +53,7 @@ describe('ApiCreationStepperService', () => {
   });
 
   it('should save and go to next step(2)', () => {
-    apiCreationStepperService.goToNextStep((previousPayload) => ({ ...previousPayload, name: 'Step 1' }));
+    apiCreationStepperService.validStepAndGoNext((previousPayload) => ({ ...previousPayload, name: 'Step 1' }));
 
     expect(currentStep.label).toEqual('Step 2');
   });
@@ -66,19 +66,19 @@ describe('ApiCreationStepperService', () => {
   });
 
   it('should save and go to next step(2.1)', () => {
-    apiCreationStepperService.goToNextStep((previousPayload) => ({ ...previousPayload, name: `${previousPayload.name} > Step 2` }));
+    apiCreationStepperService.validStepAndGoNext((previousPayload) => ({ ...previousPayload, name: `${previousPayload.name} > Step 2` }));
 
     expect(currentStep.label).toEqual('Step 2.1');
   });
 
   it('should save and go to next step(3)', () => {
-    apiCreationStepperService.goToNextStep((previousPayload) => ({ ...previousPayload, name: `${previousPayload.name} > Step 2.1` }));
+    apiCreationStepperService.validStepAndGoNext((previousPayload) => ({ ...previousPayload, name: `${previousPayload.name} > Step 2.1` }));
 
     expect(currentStep.label).toEqual('Step 3');
   });
 
   it('should save and go to next step(4)', () => {
-    apiCreationStepperService.goToNextStep((previousPayload) => ({ ...previousPayload, name: `${previousPayload.name} > Step 3` }));
+    apiCreationStepperService.validStepAndGoNext((previousPayload) => ({ ...previousPayload, name: `${previousPayload.name} > Step 3` }));
 
     expect(currentStep.label).toEqual('Step 4');
   });
@@ -92,7 +92,7 @@ describe('ApiCreationStepperService', () => {
 
   it('should go to step 1 and change patch payload', () => {
     apiCreationStepperService.goToStepLabel('Step 1');
-    apiCreationStepperService.goToNextStep((previousPayload) => {
+    apiCreationStepperService.validStepAndGoNext((previousPayload) => {
       previousPayload.selectedEntrypoints.push({ id: '2', name: 'new value' });
 
       return { ...previousPayload, name: 'Step 1 - edited' };

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/services/api-creation-stepper.service.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/services/api-creation-stepper.service.spec.ts
@@ -49,37 +49,41 @@ describe('ApiCreationStepperService', () => {
   it('should got to fist step', () => {
     apiCreationStepperService.goToStepLabel('Step 1');
 
+    expect(currentStep.id).toEqual('step-1-1');
     expect(currentStep.label).toEqual('Step 1');
   });
 
-  it('should save and go to next step(2)', () => {
+  it('should save and go to next step(2-1)', () => {
     apiCreationStepperService.validStepAndGoNext((previousPayload) => ({ ...previousPayload, name: 'Step 1' }));
 
+    expect(currentStep.id).toEqual('step-2-1');
     expect(currentStep.label).toEqual('Step 2');
   });
 
   it('should add secondary step ', () => {
     apiCreationStepperService.addSecondaryStep({
-      label: 'Step 2.1',
       component: undefined,
     });
   });
 
-  it('should save and go to next step(2.1)', () => {
+  it('should save and go to next step(2-2)', () => {
     apiCreationStepperService.validStepAndGoNext((previousPayload) => ({ ...previousPayload, name: `${previousPayload.name} > Step 2` }));
 
-    expect(currentStep.label).toEqual('Step 2.1');
+    expect(currentStep.id).toEqual('step-2-2');
+    expect(currentStep.label).toEqual('Step 2');
   });
 
   it('should save and go to next step(3)', () => {
     apiCreationStepperService.validStepAndGoNext((previousPayload) => ({ ...previousPayload, name: `${previousPayload.name} > Step 2.1` }));
 
+    expect(currentStep.id).toEqual('step-3-1');
     expect(currentStep.label).toEqual('Step 3');
   });
 
   it('should save and go to next step(4)', () => {
     apiCreationStepperService.validStepAndGoNext((previousPayload) => ({ ...previousPayload, name: `${previousPayload.name} > Step 3` }));
 
+    expect(currentStep.id).toEqual('step-4-1');
     expect(currentStep.label).toEqual('Step 4');
   });
 

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/services/api-creation-stepper.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/services/api-creation-stepper.service.ts
@@ -22,7 +22,10 @@ import { ApiCreationPayload } from '../models/ApiCreationPayload';
 export interface NewApiCreationStep {
   label: string;
   component: Type<unknown>;
+  menuItemComponent?: Type<unknown>;
 }
+
+export type NewSecondaryApiCreationStep = Omit<NewApiCreationStep, 'label' | 'menuItemComponent'>;
 
 export interface ApiCreationStep extends NewApiCreationStep {
   id: string;
@@ -83,7 +86,7 @@ export class ApiCreationStepperService {
   /**
    * Add a secondary step after the current step.
    */
-  public addSecondaryStep(step: Omit<NewApiCreationStep, 'label'>) {
+  public addSecondaryStep(step: NewSecondaryApiCreationStep) {
     const currentStep = this.steps[this.currentStepIndex];
     this.steps.splice(this.currentStepIndex + 1, 0, {
       ...step,
@@ -105,6 +108,7 @@ export class ApiCreationStepperService {
 
     // Give current payload to next step
     this.goToStepIndex(this.currentStepIndex + 1);
+    this.steps$.next(this.steps);
   }
 
   public goToPreviousStep() {

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/services/api-creation-stepper.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/services/api-creation-stepper.service.ts
@@ -25,6 +25,7 @@ export interface NewApiCreationStep {
 }
 
 export interface ApiCreationStep extends NewApiCreationStep {
+  id: string;
   /* Main label number. Start to 1 */
   labelNumber: number;
   state: 'initial' | 'valid' | 'invalid';
@@ -56,6 +57,7 @@ export class ApiCreationStepperService {
     this.initialPayload = initialPayload ?? {};
     this.steps = creationStepPayload.map((stepPayload, index) => ({
       ...stepPayload,
+      id: `step-${index + 1}-1`,
       labelNumber: index + 1,
       state: 'initial',
       patchPayload: (p) => p,
@@ -81,13 +83,15 @@ export class ApiCreationStepperService {
   /**
    * Add a secondary step after the current step.
    */
-  public addSecondaryStep(step: NewApiCreationStep) {
+  public addSecondaryStep(step: Omit<NewApiCreationStep, 'label'>) {
     const currentStep = this.steps[this.currentStepIndex];
     this.steps.splice(this.currentStepIndex + 1, 0, {
       ...step,
+      id: `step-${currentStep.labelNumber}-${this.steps.filter((s) => s.label === currentStep.label).length + 1}`,
       state: 'initial',
       patchPayload: (p) => p,
       labelNumber: currentStep.labelNumber,
+      label: currentStep.label,
     });
     this.steps$.next(this.steps);
   }

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/services/api-creation-stepper.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/services/api-creation-stepper.service.ts
@@ -27,6 +27,7 @@ export interface NewApiCreationStep {
 export interface ApiCreationStep extends NewApiCreationStep {
   /* Main label number. Start to 1 */
   labelNumber: number;
+  state: 'initial' | 'valid' | 'invalid';
   patchPayload: (lastPayload: ApiCreationPayload) => ApiCreationPayload;
 }
 
@@ -56,6 +57,7 @@ export class ApiCreationStepperService {
     this.steps = creationStepPayload.map((stepPayload, index) => ({
       ...stepPayload,
       labelNumber: index + 1,
+      state: 'initial',
       patchPayload: (p) => p,
     }));
     this.steps$.next(this.steps);
@@ -83,15 +85,19 @@ export class ApiCreationStepperService {
     const currentStep = this.steps[this.currentStepIndex];
     this.steps.splice(this.currentStepIndex + 1, 0, {
       ...step,
+      state: 'initial',
       patchPayload: (p) => p,
       labelNumber: currentStep.labelNumber,
     });
     this.steps$.next(this.steps);
   }
 
-  public goToNextStep(patchPayload: ApiCreationStep['patchPayload']) {
+  public validStepAndGoNext(patchPayload: ApiCreationStep['patchPayload']) {
+    const currentStep = this.steps[this.currentStepIndex];
+
     // Save payload to current step & Force new object mutation for updated payload
-    this.steps[this.currentStepIndex].patchPayload = (lastPayload) => patchPayload(cloneDeep(lastPayload));
+    currentStep.patchPayload = (lastPayload) => patchPayload(cloneDeep(lastPayload));
+    currentStep.state = 'valid';
 
     // Give current payload to next step
     this.goToStepIndex(this.currentStepIndex + 1);

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-1-menu-item/step-1-menu-item.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-1-menu-item/step-1-menu-item.component.html
@@ -15,9 +15,13 @@
     limitations under the License.
 
 -->
-<div class="api-creation-v4__container">
-  <api-creation-stepper-menu [menuSteps]="menuSteps$ | async" [currentStep]="currentStep"></api-creation-stepper-menu>
-  <div class="api-creation-v4__current-step">
-    <ng-container *ngComponentOutlet="currentStep.component; injector: currentStep.injector"></ng-container>
-  </div>
-</div>
+<ng-container *ngIf="menuItem">
+  <dl>
+    <dt>API name</dt>
+    <dd class="mat-body-2">{{ menuItem.name }}</dd>
+  </dl>
+  <dl>
+    <dt>API version</dt>
+    <dd class="mat-body-2">{{ menuItem.version }}</dd>
+  </dl>
+</ng-container>

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-1-menu-item/step-1-menu-item.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-1-menu-item/step-1-menu-item.component.scss
@@ -1,0 +1,9 @@
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+.step-1-menu-item {
+  .remove-me {
+    // Remove me
+    display: none;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-1-menu-item/step-1-menu-item.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-1-menu-item/step-1-menu-item.component.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, Inject, OnInit } from '@angular/core';
+
+import { ApiCreationPayload } from '../../models/ApiCreationPayload';
+import { MENU_ITEM_PAYLOAD } from '../../components/api-creation-stepper-menu/api-creation-stepper-menu.component';
+
+interface MenuItemVM {
+  name: string;
+  version: string;
+}
+
+@Component({
+  selector: 'step-1-menu-item',
+  template: require('./step-1-menu-item.component.html'),
+  styles: [require('./step-1-menu-item.component.scss')],
+})
+export class Step1MenuItemComponent implements OnInit {
+  public menuItem: MenuItemVM;
+
+  constructor(@Inject(MENU_ITEM_PAYLOAD) private readonly menuItemPayload: ApiCreationPayload) {}
+
+  ngOnInit(): void {
+    this.menuItem = {
+      name: this.menuItemPayload.name,
+      version: this.menuItemPayload.version,
+    };
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-1/api-creation-v4-step-1.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-1/api-creation-v4-step-1.component.ts
@@ -78,7 +78,7 @@ export class ApiCreationV4Step1Component implements OnInit {
 
   save() {
     const formValue = this.form.getRawValue();
-    this.stepService.goToNextStep((previousPayload) => ({
+    this.stepService.validStepAndGoNext((previousPayload) => ({
       ...previousPayload,
       name: formValue.name,
       description: formValue.description,

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-2-1/api-creation-v4-step-2-1.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-2-1/api-creation-v4-step-2-1.component.ts
@@ -43,7 +43,7 @@ export class ApiCreationV4Step21Component implements OnInit, OnDestroy {
     this.formGroup = this.formBuilder.group({});
 
     // TODO: remove me when the step is implemented and tested
-    this.stepService.goToNextStep((previousPayload) => ({ ...previousPayload }));
+    this.stepService.validStepAndGoNext((previousPayload) => ({ ...previousPayload }));
   }
 
   ngOnDestroy() {
@@ -52,7 +52,7 @@ export class ApiCreationV4Step21Component implements OnInit, OnDestroy {
   }
 
   save(): void {
-    this.stepService.goToNextStep((previousPayload) => ({ ...previousPayload }));
+    this.stepService.validStepAndGoNext((previousPayload) => ({ ...previousPayload }));
   }
 
   goBack(): void {

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-2/api-creation-v4-step-2.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-2/api-creation-v4-step-2.component.ts
@@ -94,7 +94,7 @@ export class ApiCreationV4Step2Component implements OnInit, OnDestroy {
       component: ApiCreationV4Step21Component,
     });
 
-    this.stepService.goToNextStep((previousPayload) => ({
+    this.stepService.validStepAndGoNext((previousPayload) => ({
       ...previousPayload,
       selectedEntrypoints,
     }));

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-2/api-creation-v4-step-2.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-2/api-creation-v4-step-2.component.ts
@@ -90,7 +90,6 @@ export class ApiCreationV4Step2Component implements OnInit, OnDestroy {
     const selectedEntrypoints = this.entrypoints.map(({ id, name }) => ({ id, name })).filter((e) => selectedEntrypointsIds.includes(e.id));
 
     this.stepService.addSecondaryStep({
-      label: 'Entrypoints/Configuration',
       component: ApiCreationV4Step21Component,
     });
 

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-wip/api-creation-v4-step-wip.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-wip/api-creation-v4-step-wip.component.ts
@@ -40,6 +40,6 @@ export class ApiCreationV4StepWipComponent implements OnInit {
   }
 
   save() {
-    this.stepService.goToNextStep((previousPayload) => previousPayload);
+    this.stepService.validStepAndGoNext((previousPayload) => previousPayload);
   }
 }


### PR DESCRIPTION
Note: invalid state will be completed when we manage the dependency between states

## Issue

https://gravitee.atlassian.net/browse/APIM-611

## Description

- Improve stepper secondary step
- Add example to have menu preview for step


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tixugzzynb.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-450-init-step/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
