### PR TITLE
Update headers in API list screen 

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
@@ -110,7 +110,7 @@
 
     <!-- Display Context Path Column -->
     <ng-container matColumnDef="contextPath">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header id="contextPath">Context paths</th>
+      <th mat-header-cell *matHeaderCellDef mat-sort-header id="contextPath">Context Path</th>
       <td mat-cell *matCellDef="let element">
         <a>{{ element.contextPath }}</a>
       </td>
@@ -144,7 +144,7 @@
 
     <!-- Display Version Column -->
     <ng-container matColumnDef="definitionVersion">
-      <th mat-header-cell *matHeaderCellDef id="definitionVersion">Version</th>
+      <th mat-header-cell *matHeaderCellDef id="definitionVersion">Mode</th>
       <td mat-cell *matCellDef="let element">
         <span [matTooltip]="element.definitionVersion.label" class="gio-badge-neutral"
           ><mat-icon *ngIf="element.definitionVersion.icon" class="gio-left" [svgIcon]="element.definitionVersion.icon"></mat-icon

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
@@ -73,8 +73,8 @@ describe('ApisListComponent', () => {
       expect(headerCells).toEqual([
         {
           actions: '',
-          contextPath: 'Context paths',
-          definitionVersion: 'Version',
+          contextPath: 'Context Path',
+          definitionVersion: 'Mode',
           name: 'Name',
           owner: 'Owner',
           picture: '',
@@ -94,8 +94,8 @@ describe('ApisListComponent', () => {
       expect(headerCells).toEqual([
         {
           actions: '',
-          contextPath: 'Context paths',
-          definitionVersion: 'Version',
+          contextPath: 'Context Path',
+          definitionVersion: 'Mode',
           name: 'Name',
           owner: 'Owner',
           picture: '',
@@ -220,8 +220,8 @@ describe('ApisListComponent', () => {
       expect(headerCells).toEqual([
         {
           actions: '',
-          contextPath: 'Context paths',
-          definitionVersion: 'Version',
+          contextPath: 'Context Path',
+          definitionVersion: 'Mode',
           name: 'Name',
           owner: 'Owner',
           picture: '',


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-509
https://github.com/gravitee-io/issues/issues/8772

## Description

 - Change `Version` to `Mode`
 - Properly capitalize `Context Path` header
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wunegfthti.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-509-update-api-version-column/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
