### PR TITLE
Update flows condition max size to 512

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_18_18/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_18_18/schema.yml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: 3.18.18
+      author: GraviteeSource Team
+      changes:
+        # ################
+        # Flows Changes
+        # ################
+        - modifyDataType:
+            tableName: ${gravitee_prefix}flows
+            columnName: condition
+            newDataType: nvarchar(512)

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -135,3 +135,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v3_18_0/schema_flows.yml
   - include:
       - file: liquibase/changelogs/v3_18_2/schema.yml
+  - include:
+      - file: liquibase/changelogs/v3_18_18/schema.yml

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/flow/FlowServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/flow/FlowServiceImpl.java
@@ -136,7 +136,7 @@ public class FlowServiceImpl extends AbstractService implements FlowService {
     @Override
     public List<Flow> save(FlowReferenceType flowReferenceType, String referenceId, List<Flow> flows) {
         try {
-            LOGGER.debug("Save flows for reference {},{}", flowReferenceType, flowReferenceType);
+            LOGGER.debug("Save flows for reference {},{}", flowReferenceType, referenceId);
             flowRepository.deleteByReference(flowReferenceType, referenceId);
             if (flows == null) {
                 return List.of();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/PlansFlowsDefinitionUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/PlansFlowsDefinitionUpgrader.java
@@ -41,6 +41,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class PlansFlowsDefinitionUpgrader extends OneShotUpgrader {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlansFlowsDefinitionUpgrader.class);
+
     @Autowired
     private ApiRepository apiRepository;
 
@@ -77,6 +79,7 @@ public class PlansFlowsDefinitionUpgrader extends OneShotUpgrader {
     }
 
     protected void migrateApiFlows(String apiId, io.gravitee.definition.model.Api apiDefinition) throws Exception {
+        LOGGER.debug("Migrate flows for api [{}]", apiId);
         Map<String, Plan> plansById = planRepository.findByApi(apiId).stream().collect(toMap(Plan::getId, Function.identity()));
 
         flowService.save(FlowReferenceType.API, apiDefinition.getId(), apiDefinition.getFlows());


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8823
https://gravitee.atlassian.net/browse/APIM-567

## Description

Apply https://github.com/gravitee-io/gravitee-api-management/pull/2918 on 3.18.x, it will be reverted on 3.19.x as soon as this PR is merged -> https://github.com/gravitee-io/gravitee-api-management/pull/2983
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-567-update-flow-condition-max-size/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nwhidythqz.chromatic.com)
<!-- Storybook placeholder end -->
