### PR TITLE
fix: set counter to 0 when weight distribution is reset

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/v4/endpoint/loadbalancer/WeightedRoundRobinLoadBalancer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/v4/endpoint/loadbalancer/WeightedRoundRobinLoadBalancer.java
@@ -58,11 +58,13 @@ public class WeightedRoundRobinLoadBalancer extends WeightedLoadBalancer {
 
         WeightDistributions.WeightDistribution foundWeightDistribution = null;
         while (foundWeightDistribution == null) {
-            currentWeightDistributions.tryResetRemaining();
+            if (currentWeightDistributions.tryResetRemaining()) {
+                counter.set(0);
+            }
             int position = counter.getAndIncrement();
             if (position >= currentWeightDistributions.getDistributions().size()) {
                 counter.set(0);
-                position = 0;
+                position = counter.getAndIncrement();
             }
             WeightDistributions.WeightDistribution weightDistribution = currentWeightDistributions.getDistributions().get(position);
             if (weightDistribution.getRemaining() > 0) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-618

## Description

Reset counter to 0 when the distributions has been reset.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bnmjkcjjmr.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-618-fix-weighted-round-robin-lb/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
