### PR TITLE
fix: bump data-logging-masking policy for dev env to 2.0.3

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -642,7 +642,7 @@
 
                 <!-- Enterprise plugins -->
                 <gravitee-policy-assign-metrics.version>2.0.1</gravitee-policy-assign-metrics.version>
-                <gravitee-policy-data-logging-masking.version>2.0.1</gravitee-policy-data-logging-masking.version>
+                <gravitee-policy-data-logging-masking.version>2.0.3</gravitee-policy-data-logging-masking.version>
 
                 <!-- Management API Only -->
                 <!-- Gateway Only -->


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8842
https://gravitee.atlassian.net/browse/APIM-623

## Description

Bump data-logging-masking policy for dev env to 2.0.3
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vwwcnhotwd.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8842-content-type-with-charset/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
