### PR TITLE
ci: allow dot in sanitized branch name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,7 +226,7 @@ commands:
             - run:
                   name: Sanitize branch name
                   command: |
-                      export SANITIZED_BRANCH=$(echo "${CIRCLE_BRANCH}" | sed -E 's/[~^]+//g' | sed -E 's/[^a-zA-Z0-9]+/-/g' | sed -E 's/^-+|-+$//g' | tr "[:upper:]" "[:lower:]" | cut -c -60)
+                      export SANITIZED_BRANCH=$(echo "${CIRCLE_BRANCH}" | sed -E 's/[~^]+//g' | sed -E 's/[^a-zA-Z0-9\.]+/-/g' | sed -E 's/^-+|-+$//g' | tr "[:upper:]" "[:lower:]" | cut -c -60)
                       # Workaround for sharing this variable to the next steps
                       echo "export SANITIZED_BRANCH=$SANITIZED_BRANCH" >> $BASH_ENV
 parameters:


### PR DESCRIPTION
## Issue

N/A

## Description

Allow dot in sanitized branch name. Before this fix, the docker tag for the 3.18.x branch was `3-18-x-latest`. But it's a Breaking change, because before the sanitization commit, the docker tag was `3.18.x-latest`

As a consequence, the 3.18.x environment is no longer updated when a commit is merged 😱 

For the other usages of the sanitized branch name, it is for a URL , and dots are legal in URL
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nmeiqxczhm.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-branch-name-computing/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
