### PR TITLE
chore: host.docker.internal is not resolved under linux.

### DIFF
--- a/gravitee-apim-perf/grafana/docker-compose.yml
+++ b/gravitee-apim-perf/grafana/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - "9090:9090/tcp"
     volumes:
       - ${PWD}/config/prometheus.yml:/etc/prometheus/prometheus.yml
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   promscale:
     image: timescale/promscale:latest


### PR DESCRIPTION
We have to bind it the docker gateway IP

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-eaojadsuyn.chromatic.com)
<!-- Storybook placeholder end -->
