### PR TITLE
get artifactory credentials from keeper

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -637,10 +637,18 @@ jobs:
         executor:
             name: node-lts
             class: small
+        environment:
+            ARTIFACTORY_URL: "https://odbxikk7vo-artifactory.services.clever-cloud.com"
         steps:
             - attach_workspace:
                   at: .
             - get-apim-version
+            - keeper/env-export:
+                  secret-url: keeper://R7NuqoW0KD-8l-kjx0-PgQ/field/login
+                  var-name: ARTIFACTORY_USER
+            - keeper/env-export:
+                  secret-url: keeper://R7NuqoW0KD-8l-kjx0-PgQ/field/password
+                  var-name: ARTIFACTORY_API_KEY
             - artifactory-orb/install
             - artifactory-orb/configure
             - run:


### PR DESCRIPTION
## Issue

N/A

## Description

When publishing UIs dists to artifactory,  get credentials from keeper
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jcvcrwiihn.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/get-artifactory-credentials-from-keeper-3.18.x/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
