### PR TITLE
chore: allow building UI docker images in one command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,8 +219,6 @@ commands:
             - run:
                   name: Build UI docker image
                   command: |
-                      cp -fr docker/config .
-
                       docker buildx build --push --platform=linux/arm64,linux/amd64 -f docker/Dockerfile \
                       -t graviteeio.azurecr.io/<< parameters.docker-image-name >>:$TAG \
                       .

--- a/gravitee-apim-console-webui/docker/Dockerfile
+++ b/gravitee-apim-console-webui/docker/Dockerfile
@@ -17,7 +17,7 @@
 FROM graviteeio/nginx:1.23
 LABEL maintainer="contact@graviteesource.com"
 
-ADD config /etc/confd
+ADD ./docker/config /etc/confd
 
 COPY ./dist /usr/share/nginx/html/
 

--- a/gravitee-apim-portal-webui/docker/Dockerfile
+++ b/gravitee-apim-portal-webui/docker/Dockerfile
@@ -17,7 +17,7 @@
 FROM graviteeio/nginx:1.23
 LABEL maintainer="contact@graviteesource.com"
 
-ADD config /etc/confd
+ADD ./docker/config /etc/confd
 
 COPY ./dist /usr/share/nginx/html/
 


### PR DESCRIPTION
## Issue

N/A

## Description

With the previous Dockerfile, we needed to copy the `docker/config` folder manually to have it next to the `dist` directory. By updating the path in the Dockerfile, we can run directly the docker build command once we packaged the ui.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uxziqyeijq.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-docker-ui-build/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
