### PR TITLE
chore: host.docker.internal is not resolved under linux.

### DIFF
--- a/gravitee-apim-perf/grafana/docker-compose.yml
+++ b/gravitee-apim-perf/grafana/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - "9090:9090/tcp"
     volumes:
       - ${PWD}/config/prometheus.yml:/etc/prometheus/prometheus.yml
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   promscale:
     image: timescale/promscale:latest


### PR DESCRIPTION
We have to bind it the docker gateway IP

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-yqwpiayrpw.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/chore-make-grafana-compose-usable-under-linux/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
