### PR TITLE
API key synchronization gives precedence to active keys

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/ApiKeyService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/ApiKeyService.java
@@ -38,7 +38,7 @@ public class ApiKeyService implements io.gravitee.gateway.api.service.ApiKeyServ
     @Override
     public void save(ApiKey apiKey) {
         String cacheKey = buildCacheKey(apiKey);
-        if (apiKey.isRevoked() || apiKey.isPaused()) {
+        if (!apiKey.isActive()) {
             LOGGER.debug(
                 "Remove an api-key from cache [id: {}] [plan: {}] [app: {}]",
                 apiKey.getId(),

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/service/ApiKeyServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/service/ApiKeyServiceTest.java
@@ -28,7 +28,7 @@ public class ApiKeyServiceTest {
 
     @Test
     public void should_add_and_get_active_apiKey_in_cache() {
-        ApiKey apiKey = buildApiKey("my-api", "my-key");
+        ApiKey apiKey = buildApiKey("my-api", "my-key", true);
 
         apiKeyService.save(apiKey);
 
@@ -42,12 +42,12 @@ public class ApiKeyServiceTest {
     }
 
     @Test
-    public void should_remove_expired_apiKey_from_cache() {
-        ApiKey apiKey = buildApiKey("my-api", "my-key");
+    public void should_remove_inactive_apiKey_from_cache() {
+        ApiKey apiKey = buildApiKey("my-api", "my-key", true);
 
         apiKeyService.save(apiKey);
 
-        apiKey.setRevoked(true);
+        apiKey.setActive(false);
 
         apiKeyService.save(apiKey);
 
@@ -55,24 +55,11 @@ public class ApiKeyServiceTest {
         assertFalse(apiKeyService.getByApiAndKey("my-api", "my-key").isPresent());
     }
 
-    @Test
-    public void should_remove_paused_apiKey_from_cache() {
-        ApiKey apiKey = buildApiKey("my-api", "my-key");
-
-        apiKeyService.save(apiKey);
-
-        apiKey.setPaused(true);
-
-        apiKeyService.save(apiKey);
-
-        // paused API key has been removed from cache
-        assertFalse(apiKeyService.getByApiAndKey("my-api", "my-key").isPresent());
-    }
-
-    private ApiKey buildApiKey(String api, String key) {
+    private ApiKey buildApiKey(String api, String key, boolean active) {
         ApiKey apiKey = new ApiKey();
         apiKey.setApi(api);
         apiKey.setKey(key);
+        apiKey.setActive(active);
         return apiKey;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -10,7 +10,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0
-  version: "3.19.5-SNAPSHOT"
+  version: "3.19.7-SNAPSHOT"
 servers:
   - url: http://localhost:8083/portal/environments/{envId}
     description: The portal API for a given environment

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <gravitee-connector-api.version>1.1.4</gravitee-connector-api.version>
         <gravitee-expression-language.version>1.11.3</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>1.44.1</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.44.2</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>1.25.0</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8846

## Description

Re implementation of what have been done in this PR: https://github.com/gravitee-io/gravitee-api-management/pull/2905

## Additional context

Depends on https://github.com/gravitee-io/gravitee-gateway-api/pull/178
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-llanbyidsj.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8846-api-subscription-not-working-after-closing-and-re-creat/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
