### PR TITLE
Display icons of APIs in API list screen

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
@@ -149,7 +149,7 @@ export class ApiListComponent implements OnInit, OnDestroy {
           tags: api.tags.join(', '),
           owner: api?.owner?.displayName,
           ownerEmail: api?.owner?.email,
-          picture: api.picture,
+          picture: api.picture_url,
           state: api.state,
           lifecycleState: api.lifecycle_state,
           workflowBadge: this.getWorkflowBadge(api),


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8809

## Description

Display icons of APIs in the API list screen

Partial backport of https://github.com/gravitee-io/gravitee-api-management/commit/14f68a8c53a47daa7e965be39aff4281ece44f6b on 3.19.x
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pjxvutouui.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8809-fix-icons/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
