### PR TITLE
Filter API registration during synchronization process

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/ApiBuilder.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/ApiBuilder.java
@@ -13,21 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.definition.model.v4;
+package io.gravitee.definition.model;
 
-import io.gravitee.definition.model.v4.property.Property;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class ApiBuilder {
 
+    private final DefinitionVersion definitionVersion;
     private String apiId;
     private String name;
     private String apiVersion;
     private Map<String, String> properties;
+    private Set<String> tags;
 
-    public static ApiBuilder anApiV4() {
-        return new ApiBuilder();
+    public ApiBuilder(DefinitionVersion definitionVersion) {
+        this.definitionVersion = definitionVersion;
+    }
+
+    public static ApiBuilder anApiV2() {
+        return new ApiBuilder(DefinitionVersion.V2);
     }
 
     public ApiBuilder id(String id) {
@@ -50,16 +56,29 @@ public class ApiBuilder {
         return this;
     }
 
+    public ApiBuilder tags(Set<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
     public Api build() {
         var api = new Api();
+        api.setDefinitionVersion(definitionVersion);
         api.setId(apiId);
         api.setName(name);
-        api.setApiVersion(apiVersion);
+        api.setVersion(apiVersion);
+        api.setTags(tags);
 
         if (properties != null) {
-            api.setProperties(
-                properties.entrySet().stream().map(p -> new Property(p.getKey(), p.getValue(), false, false)).collect(Collectors.toList())
+            var props = new Properties();
+            props.setProperties(
+                properties
+                    .entrySet()
+                    .stream()
+                    .map(p -> new io.gravitee.definition.model.Property(p.getKey(), p.getValue(), false))
+                    .collect(Collectors.toList())
             );
+            api.setProperties(props);
         }
 
         return api;

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/ApiBuilder.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/ApiBuilder.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.definition.model;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -27,6 +28,7 @@ public class ApiBuilder {
     private String apiVersion;
     private Map<String, String> properties;
     private Set<String> tags;
+    private List<Plan> plans;
 
     public ApiBuilder(DefinitionVersion definitionVersion) {
         this.definitionVersion = definitionVersion;
@@ -65,6 +67,11 @@ public class ApiBuilder {
         return this;
     }
 
+    public ApiBuilder plans(List<Plan> plans) {
+        this.plans = plans;
+        return this;
+    }
+
     public Api build() {
         var api = new Api();
         api.setDefinitionVersion(definitionVersion);
@@ -72,6 +79,10 @@ public class ApiBuilder {
         api.setName(name);
         api.setVersion(apiVersion);
         api.setTags(tags);
+
+        if (plans != null) {
+            api.setPlans(plans);
+        }
 
         if (properties != null) {
             var props = new Properties();

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/ApiBuilder.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/ApiBuilder.java
@@ -36,6 +36,10 @@ public class ApiBuilder {
         return new ApiBuilder(DefinitionVersion.V2);
     }
 
+    public static ApiBuilder anApiV1() {
+        return new ApiBuilder(DefinitionVersion.V1);
+    }
+
     public ApiBuilder id(String id) {
         this.apiId = id;
         return this;

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Plan.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Plan.java
@@ -19,11 +19,17 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.definition.model.flow.Flow;
 import java.io.Serializable;
 import java.util.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Plan implements Serializable {
 
     @JsonProperty("id")
@@ -38,6 +44,7 @@ public class Plan implements Serializable {
     @JsonProperty("securityDefinition")
     private String securityDefinition;
 
+    @Builder.Default
     @JsonProperty("paths")
     private Map<String, List<Rule>> paths = new HashMap<>();
 
@@ -47,6 +54,7 @@ public class Plan implements Serializable {
     @JsonProperty("selectionRule")
     private String selectionRule;
 
+    @Builder.Default
     @JsonProperty("flows")
     private List<Flow> flows = new ArrayList<>();
 

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ApiBuilder.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ApiBuilder.java
@@ -15,7 +15,14 @@
  */
 package io.gravitee.definition.model.v4;
 
+import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
+import io.gravitee.definition.model.v4.listener.Listener;
+import io.gravitee.definition.model.v4.listener.http.HttpListener;
+import io.gravitee.definition.model.v4.listener.http.Path;
+import io.gravitee.definition.model.v4.plan.Plan;
 import io.gravitee.definition.model.v4.property.Property;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -23,13 +30,34 @@ import java.util.stream.Collectors;
 public class ApiBuilder {
 
     private String apiId;
-    private String name;
-    private String apiVersion;
+    private String name = "an-api";
+    private String apiVersion = "1.0.0";
+
+    private List<Listener> listeners;
+    private List<EndpointGroup> endpointGroups;
+
     private Map<String, String> properties;
     private Set<String> tags;
+    private List<Plan> plans;
+
+    public ApiBuilder() {
+        this(Collections.emptyList(), Collections.emptyList());
+    }
+
+    public ApiBuilder(List<Listener> listeners, List<EndpointGroup> endpointGroups) {
+        this.listeners = listeners;
+        this.endpointGroups = endpointGroups;
+    }
 
     public static ApiBuilder anApiV4() {
-        return new ApiBuilder();
+        return aSyncApiV4();
+    }
+
+    public static ApiBuilder aSyncApiV4() {
+        var httpListener = new HttpListener();
+        httpListener.setPaths(List.of(new Path()));
+
+        return new ApiBuilder(List.of(httpListener), List.of(EndpointGroup.builder().build()));
     }
 
     public ApiBuilder id(String id) {
@@ -57,12 +85,33 @@ public class ApiBuilder {
         return this;
     }
 
+    public ApiBuilder plans(List<Plan> plans) {
+        this.plans = plans;
+        return this;
+    }
+
+    public ApiBuilder listeners(List<Listener> listeners) {
+        this.listeners = listeners;
+        return this;
+    }
+
+    public ApiBuilder endpointGroups(List<EndpointGroup> endpointGroups) {
+        this.endpointGroups = endpointGroups;
+        return this;
+    }
+
     public Api build() {
         var api = new Api();
         api.setId(apiId);
         api.setName(name);
         api.setApiVersion(apiVersion);
+        api.setListeners(listeners);
+        api.setEndpointGroups(endpointGroups);
         api.setTags(tags);
+
+        if (plans != null) {
+            api.setPlans(plans);
+        }
 
         if (properties != null) {
             api.setProperties(

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ApiBuilder.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ApiBuilder.java
@@ -17,6 +17,7 @@ package io.gravitee.definition.model.v4;
 
 import io.gravitee.definition.model.v4.property.Property;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class ApiBuilder {
@@ -25,6 +26,7 @@ public class ApiBuilder {
     private String name;
     private String apiVersion;
     private Map<String, String> properties;
+    private Set<String> tags;
 
     public static ApiBuilder anApiV4() {
         return new ApiBuilder();
@@ -50,11 +52,17 @@ public class ApiBuilder {
         return this;
     }
 
+    public ApiBuilder tags(Set<String> tags) {
+        this.tags = tags;
+        return this;
+    }
+
     public Api build() {
         var api = new Api();
         api.setId(apiId);
         api.setName(name);
         api.setApiVersion(apiVersion);
+        api.setTags(tags);
 
         if (properties != null) {
             api.setProperties(

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/endpointgroup/EndpointGroup.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/endpointgroup/EndpointGroup.java
@@ -26,15 +26,13 @@ import java.io.Serializable;
 import java.util.List;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  */
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 @Getter
 @Setter
@@ -50,6 +48,7 @@ public class EndpointGroup implements Serializable {
     @NotBlank
     private String type;
 
+    @Builder.Default
     private LoadBalancer loadBalancer = new LoadBalancer();
 
     @Schema(implementation = Object.class)

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/plan/Plan.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/plan/Plan.java
@@ -19,22 +19,19 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @Getter
 @Setter
 @ToString

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/deployer/ApiDeployer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/deployer/ApiDeployer.java
@@ -46,6 +46,8 @@ public class ApiDeployer extends AbstractApiDeployer<Api> {
     public void initialize(final Api api) {
         // Filter plans according to the sharding tags and the plan status
         io.gravitee.definition.model.Api apiDefinition = api.getDefinition();
+
+        // Keep the plan filtering for io.gravitee.gateway.services.localregistry.LocalApiDefinitionRegistry
         if (apiDefinition.getPlans() != null) {
             apiDefinition.setPlans(filterPlan(api));
         } else {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/impl/ApiManagerImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/impl/ApiManagerImpl.java
@@ -113,6 +113,7 @@ public class ApiManagerImpl implements ApiManager, InitializingBean, CacheListen
         ReactableApi<?> deployedApi = get(api.getId());
 
         // Does the API have a matching sharding tags ?
+        // Keep the check of Sharding Tags for io.gravitee.gateway.services.localregistry.LocalApiDefinitionRegistry
         if (gatewayConfiguration.hasMatchingTags(api.getTags())) {
             boolean apiToDeploy = deployedApi == null || force;
             boolean apiToUpdate = !apiToDeploy && deployedApi.getDeployedAt().before(api.getDeployedAt());

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/v4/deployer/ApiDeployer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/v4/deployer/ApiDeployer.java
@@ -43,6 +43,8 @@ public class ApiDeployer extends AbstractApiDeployer<Api> {
     @Override
     public void initialize(final Api api) {
         io.gravitee.definition.model.v4.Api apiDefinition = api.getDefinition();
+
+        // Keep the plan filtering for io.gravitee.gateway.services.localregistry.LocalApiDefinitionRegistry
         if (apiDefinition.getPlans() != null) {
             apiDefinition.setPlans(filterPlans(apiDefinition.getPlans()));
         } else {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/context/ApiTemplateVariableProviderTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/context/ApiTemplateVariableProviderTest.java
@@ -15,9 +15,9 @@
  */
 package io.gravitee.gateway.handlers.api.context;
 
+import static io.gravitee.definition.model.ApiBuilder.anApiV2;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.gravitee.definition.model.v4.Api;
 import io.gravitee.el.TemplateEngine;
 import io.gravitee.el.exceptions.ExpressionEvaluationException;
 import java.util.Map;
@@ -31,7 +31,7 @@ class ApiTemplateVariableProviderTest {
 
     @Test
     void should_provide_api_id_in_EL() {
-        var apiDefinition = Api.builder().id("api#id").buildv2();
+        var apiDefinition = anApiV2().id("api#id").build();
 
         TemplateEngine engine = buildTemplateEngine(apiDefinition);
         engine.eval("{#api.id}", String.class).test().assertValue("api#id");
@@ -39,7 +39,7 @@ class ApiTemplateVariableProviderTest {
 
     @Test
     void should_provide_api_name_in_EL() {
-        var apiDefinition = Api.builder().name("api#name").buildv2();
+        var apiDefinition = anApiV2().name("api#name").build();
 
         TemplateEngine engine = buildTemplateEngine(apiDefinition);
         engine.eval("{#api.name}", String.class).test().assertValue("api#name");
@@ -47,7 +47,7 @@ class ApiTemplateVariableProviderTest {
 
     @Test
     void should_provide_api_version_in_EL() {
-        var apiDefinition = Api.builder().apiVersion("api#version").buildv2();
+        var apiDefinition = anApiV2().apiVersion("api#version").build();
 
         TemplateEngine engine = buildTemplateEngine(apiDefinition);
         engine.eval("{#api.version}", String.class).test().assertValue("api#version");
@@ -55,7 +55,7 @@ class ApiTemplateVariableProviderTest {
 
     @Test
     void should_provide_api_properties_in_EL() {
-        var apiDefinition = Api.builder().properties(Map.of("prop1", "value1", "prop2", "value2")).buildv2();
+        var apiDefinition = anApiV2().properties(Map.of("prop1", "value1", "prop2", "value2")).build();
 
         TemplateEngine engine = buildTemplateEngine(apiDefinition);
         engine.eval("{#properties[prop1]}", String.class).test().assertValue("value1");
@@ -66,7 +66,7 @@ class ApiTemplateVariableProviderTest {
 
     @Test
     void should_return_no_value_when_evaluate_unknown_api_properties_in_EL() {
-        var apiDefinition = Api.builder().properties(Map.of("prop1", "value1", "prop2", "value2")).buildv2();
+        var apiDefinition = anApiV2().properties(Map.of("prop1", "value1", "prop2", "value2")).build();
 
         TemplateEngine engine = buildTemplateEngine(apiDefinition);
         engine.eval("{#properties[unknown]}", String.class).test().assertNoValues();
@@ -75,7 +75,7 @@ class ApiTemplateVariableProviderTest {
 
     @Test
     void should_throw_when_evaluate_null_api_properties_in_EL() {
-        var apiDefinition = Api.builder().buildv2();
+        var apiDefinition = anApiV2().build();
 
         TemplateEngine engine = buildTemplateEngine(apiDefinition);
         engine

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/el/ApiTemplateVariableProviderTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/el/ApiTemplateVariableProviderTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.jupiter.handlers.api.el;
 
+import static io.gravitee.definition.model.v4.ApiBuilder.anApiV4;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.definition.model.v4.Api;
@@ -31,7 +32,7 @@ class ApiTemplateVariableProviderTest {
 
     @Test
     void should_provide_api_id_in_EL() {
-        var apiDefinition = Api.builder().id("api#id").build();
+        var apiDefinition = anApiV4().id("api#id").build();
 
         TemplateEngine engine = buildTemplateEngine(apiDefinition);
         engine.eval("{#api.id}", String.class).test().assertValue("api#id");
@@ -39,7 +40,7 @@ class ApiTemplateVariableProviderTest {
 
     @Test
     void should_provide_api_name_in_EL() {
-        var apiDefinition = Api.builder().name("api#name").build();
+        var apiDefinition = anApiV4().name("api#name").build();
 
         TemplateEngine engine = buildTemplateEngine(apiDefinition);
         engine.eval("{#api.name}", String.class).test().assertValue("api#name");
@@ -47,7 +48,7 @@ class ApiTemplateVariableProviderTest {
 
     @Test
     void should_provide_api_version_in_EL() {
-        var apiDefinition = Api.builder().apiVersion("api#version").build();
+        var apiDefinition = anApiV4().apiVersion("api#version").build();
 
         TemplateEngine engine = buildTemplateEngine(apiDefinition);
         engine.eval("{#api.version}", String.class).test().assertValue("api#version");
@@ -55,7 +56,7 @@ class ApiTemplateVariableProviderTest {
 
     @Test
     void should_provide_api_properties_in_EL() {
-        var apiDefinition = Api.builder().properties(Map.of("prop1", "value1", "prop2", "value2")).build();
+        var apiDefinition = anApiV4().properties(Map.of("prop1", "value1", "prop2", "value2")).build();
 
         TemplateEngine engine = buildTemplateEngine(apiDefinition);
         engine.eval("{#api.properties[prop1]}", String.class).test().assertValue("value1");
@@ -64,14 +65,14 @@ class ApiTemplateVariableProviderTest {
 
     @Test
     void should_return_no_value_when_evaluate_unknown_properties() {
-        var apiDefinition = Api.builder().properties(Map.of("prop1", "value1", "prop2", "value2")).build();
+        var apiDefinition = anApiV4().properties(Map.of("prop1", "value1", "prop2", "value2")).build();
 
         buildTemplateEngine(apiDefinition).eval("{#api.properties[unknown]}", String.class).test().assertNoValues();
     }
 
     @Test
     void should_throw_when_evaluate_null_api_properties_in_EL() {
-        var noProperties = Api.builder().build();
+        var noProperties = anApiV4().build();
 
         buildTemplateEngine(noProperties)
             .eval("{#api.properties[prop1]}", String.class)

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/spring/SyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/spring/SyncConfiguration.java
@@ -125,7 +125,8 @@ public class SyncConfiguration {
         SubscriptionService subscriptionService,
         ApiManager apiManager,
         EventToReactableApiAdapter eventToReactableApiAdapter,
-        PlanFetcher planFetcher
+        PlanFetcher planFetcher,
+        GatewayConfiguration gatewayConfiguration
     ) {
         return new ApiSynchronizer(
             eventRepository,
@@ -136,7 +137,8 @@ public class SyncConfiguration {
             subscriptionService,
             apiManager,
             eventToReactableApiAdapter,
-            planFetcher
+            planFetcher,
+            gatewayConfiguration
         );
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/spring/SyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/spring/SyncConfiguration.java
@@ -127,21 +127,10 @@ public class SyncConfiguration {
 
     @Bean
     public DebugApiSynchronizer debugApiSynchronizer(
-        ObjectMapper objectMapper,
-        @Qualifier("syncExecutor") ExecutorService executor,
         @Value("${services.sync.bulk_items:100}") int bulkItems,
         EventRepository eventRepository
     ) {
-        return new DebugApiSynchronizer(
-            eventRepository,
-            objectMapper,
-            executor,
-            bulkItems,
-            eventManager,
-            pluginRegistry,
-            configuration,
-            node
-        );
+        return new DebugApiSynchronizer(eventRepository, bulkItems, eventManager, pluginRegistry, configuration, node);
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/spring/SyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/spring/SyncConfiguration.java
@@ -29,6 +29,7 @@ import io.gravitee.gateway.services.sync.cache.configuration.LocalCacheConfigura
 import io.gravitee.gateway.services.sync.healthcheck.ApiSyncProbe;
 import io.gravitee.gateway.services.sync.kubernetes.KubernetesSyncService;
 import io.gravitee.gateway.services.sync.synchronizer.*;
+import io.gravitee.gateway.services.sync.synchronizer.api.EventToReactableApiAdapter;
 import io.gravitee.kubernetes.client.KubernetesClient;
 import io.gravitee.node.api.Node;
 import io.gravitee.plugin.core.api.PluginRegistry;
@@ -97,18 +98,26 @@ public class SyncConfiguration {
     }
 
     @Bean
+    public EventToReactableApiAdapter eventToReactableApiAdapter(
+        ObjectMapper objectMapper,
+        EnvironmentRepository environmentRepository,
+        OrganizationRepository organizationRepository
+    ) {
+        return new EventToReactableApiAdapter(objectMapper, environmentRepository, organizationRepository);
+    }
+
+    @Bean
     public ApiSynchronizer apiSynchronizer(
         ObjectMapper objectMapper,
         @Qualifier("syncExecutor") ExecutorService executor,
         @Value("${services.sync.bulk_items:100}") int bulkItems,
         EventRepository eventRepository,
         PlanRepository planRepository,
-        EnvironmentRepository environmentRepository,
-        OrganizationRepository organizationRepository,
         ApiKeysCacheService apiKeysCacheService,
         SubscriptionsCacheService subscriptionsCacheService,
         SubscriptionService subscriptionService,
-        ApiManager apiManager
+        ApiManager apiManager,
+        EventToReactableApiAdapter eventToReactableApiAdapter
     ) {
         return new ApiSynchronizer(
             eventRepository,
@@ -120,8 +129,7 @@ public class SyncConfiguration {
             subscriptionsCacheService,
             subscriptionService,
             apiManager,
-            environmentRepository,
-            organizationRepository
+            eventToReactableApiAdapter
         );
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/AbstractSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/AbstractSynchronizer.java
@@ -18,7 +18,6 @@ package io.gravitee.gateway.services.sync.synchronizer;
 import static io.gravitee.gateway.services.sync.SyncManager.TIMEFRAME_AFTER_DELAY;
 import static io.gravitee.gateway.services.sync.SyncManager.TIMEFRAME_BEFORE_DELAY;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.common.service.AbstractService;
 import io.gravitee.repository.management.api.EventRepository;
 import io.gravitee.repository.management.api.search.EventCriteria;
@@ -27,10 +26,6 @@ import io.gravitee.repository.management.model.EventType;
 import io.reactivex.rxjava3.core.BackpressureStrategy;
 import io.reactivex.rxjava3.core.Flowable;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
@@ -42,16 +37,10 @@ public abstract class AbstractSynchronizer extends AbstractService<AbstractSynch
 
     protected EventRepository eventRepository;
 
-    protected ObjectMapper objectMapper;
-
-    protected ExecutorService executor;
-
     protected int bulkItems;
 
-    protected AbstractSynchronizer(EventRepository eventRepository, ObjectMapper objectMapper, ExecutorService executor, int bulkItems) {
+    protected AbstractSynchronizer(EventRepository eventRepository, int bulkItems) {
         this.eventRepository = eventRepository;
-        this.objectMapper = objectMapper;
-        this.executor = executor;
         this.bulkItems = bulkItems;
     }
 
@@ -113,9 +102,5 @@ public abstract class AbstractSynchronizer extends AbstractService<AbstractSynch
 
     public int getBulkSize() {
         return bulkItems > 0 ? bulkItems : DEFAULT_BULK_SIZE;
-    }
-
-    public void setExecutor(ExecutorService executor) {
-        this.executor = executor;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/AbstractSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/AbstractSynchronizer.java
@@ -40,18 +40,20 @@ public abstract class AbstractSynchronizer extends AbstractService<AbstractSynch
 
     public static final int DEFAULT_BULK_SIZE = 100;
 
-    @Autowired
     protected EventRepository eventRepository;
 
-    @Autowired
     protected ObjectMapper objectMapper;
 
-    @Autowired
-    @Qualifier("syncExecutor")
     protected ExecutorService executor;
 
-    @Value("${services.sync.bulk_items:100}")
     protected int bulkItems;
+
+    protected AbstractSynchronizer(EventRepository eventRepository, ObjectMapper objectMapper, ExecutorService executor, int bulkItems) {
+        this.eventRepository = eventRepository;
+        this.objectMapper = objectMapper;
+        this.executor = executor;
+        this.bulkItems = bulkItems;
+    }
 
     @Override
     protected void doStart() throws Exception {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/DebugApiSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/DebugApiSynchronizer.java
@@ -18,7 +18,6 @@ package io.gravitee.gateway.services.sync.synchronizer;
 import static io.gravitee.gateway.services.sync.SyncManager.TIMEFRAME_AFTER_DELAY;
 import static io.gravitee.gateway.services.sync.SyncManager.TIMEFRAME_BEFORE_DELAY;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.common.event.EventManager;
 import io.gravitee.gateway.reactor.ReactorEvent;
 import io.gravitee.gateway.reactor.impl.ReactableWrapper;
@@ -32,11 +31,9 @@ import io.gravitee.repository.management.model.ApiDebugStatus;
 import io.gravitee.repository.management.model.Event;
 import io.gravitee.repository.management.model.EventType;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Guillaume CUSNIEUX (guillaume.cusnieux at graviteesource.com)
@@ -51,15 +48,13 @@ public class DebugApiSynchronizer extends AbstractSynchronizer {
 
     public DebugApiSynchronizer(
         EventRepository eventRepository,
-        ObjectMapper objectMapper,
-        ExecutorService executor,
         int bulkItems,
         EventManager eventManager,
         PluginRegistry pluginRegistry,
         Configuration configuration,
         Node node
     ) {
-        super(eventRepository, objectMapper, executor, bulkItems);
+        super(eventRepository, bulkItems);
         this.eventManager = eventManager;
         this.node = node;
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/DebugApiSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/DebugApiSynchronizer.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.services.sync.synchronizer;
 import static io.gravitee.gateway.services.sync.SyncManager.TIMEFRAME_AFTER_DELAY;
 import static io.gravitee.gateway.services.sync.SyncManager.TIMEFRAME_BEFORE_DELAY;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.common.event.EventManager;
 import io.gravitee.gateway.reactor.ReactorEvent;
 import io.gravitee.gateway.reactor.impl.ReactableWrapper;
@@ -25,11 +26,13 @@ import io.gravitee.node.api.Node;
 import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.plugin.core.api.Plugin;
 import io.gravitee.plugin.core.api.PluginRegistry;
+import io.gravitee.repository.management.api.EventRepository;
 import io.gravitee.repository.management.api.search.EventCriteria;
 import io.gravitee.repository.management.model.ApiDebugStatus;
 import io.gravitee.repository.management.model.Event;
 import io.gravitee.repository.management.model.EventType;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,7 +49,17 @@ public class DebugApiSynchronizer extends AbstractSynchronizer {
     private final Node node;
     private final boolean isDebugModeAvailable;
 
-    public DebugApiSynchronizer(EventManager eventManager, PluginRegistry pluginRegistry, Configuration configuration, Node node) {
+    public DebugApiSynchronizer(
+        EventRepository eventRepository,
+        ObjectMapper objectMapper,
+        ExecutorService executor,
+        int bulkItems,
+        EventManager eventManager,
+        PluginRegistry pluginRegistry,
+        Configuration configuration,
+        Node node
+    ) {
+        super(eventRepository, objectMapper, executor, bulkItems);
         this.eventManager = eventManager;
         this.node = node;
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/DictionarySynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/DictionarySynchronizer.java
@@ -27,13 +27,10 @@ import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.schedulers.Schedulers;
-import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
@@ -47,6 +44,8 @@ public class DictionarySynchronizer extends AbstractSynchronizer {
 
     private final ObjectMapper objectMapper;
 
+    private final ExecutorService executor;
+
     public DictionarySynchronizer(
         EventRepository eventRepository,
         ObjectMapper objectMapper,
@@ -54,9 +53,10 @@ public class DictionarySynchronizer extends AbstractSynchronizer {
         int bulkItems,
         DictionaryManager dictionaryManager
     ) {
-        super(eventRepository, objectMapper, executor, bulkItems);
-        this.dictionaryManager = dictionaryManager;
+        super(eventRepository, bulkItems);
         this.objectMapper = objectMapper;
+        this.executor = executor;
+        this.dictionaryManager = dictionaryManager;
     }
 
     public void synchronize(Long lastRefreshAt, Long nextLastRefreshAt, List<String> environments) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/DictionarySynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/DictionarySynchronizer.java
@@ -20,6 +20,7 @@ import static io.gravitee.repository.management.model.Event.EventProperties.DICT
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.gateway.dictionary.DictionaryManager;
+import io.gravitee.repository.management.api.EventRepository;
 import io.gravitee.repository.management.model.Event;
 import io.gravitee.repository.management.model.EventType;
 import io.reactivex.rxjava3.annotations.NonNull;
@@ -28,6 +29,7 @@ import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,11 +43,21 @@ public class DictionarySynchronizer extends AbstractSynchronizer {
 
     private final Logger logger = LoggerFactory.getLogger(DictionarySynchronizer.class);
 
-    @Autowired
-    private DictionaryManager dictionaryManager;
+    private final DictionaryManager dictionaryManager;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
+
+    public DictionarySynchronizer(
+        EventRepository eventRepository,
+        ObjectMapper objectMapper,
+        ExecutorService executor,
+        int bulkItems,
+        DictionaryManager dictionaryManager
+    ) {
+        super(eventRepository, objectMapper, executor, bulkItems);
+        this.dictionaryManager = dictionaryManager;
+        this.objectMapper = objectMapper;
+    }
 
     public void synchronize(Long lastRefreshAt, Long nextLastRefreshAt, List<String> environments) {
         final long start = System.currentTimeMillis();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/OrganizationSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/OrganizationSynchronizer.java
@@ -34,13 +34,11 @@ import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
@@ -56,6 +54,8 @@ public class OrganizationSynchronizer extends AbstractSynchronizer {
 
     private final ObjectMapper objectMapper;
 
+    private final ExecutorService executor;
+
     public OrganizationSynchronizer(
         EventRepository eventRepository,
         ObjectMapper objectMapper,
@@ -64,17 +64,17 @@ public class OrganizationSynchronizer extends AbstractSynchronizer {
         OrganizationManager organizationManager,
         GatewayConfiguration gatewayConfiguration
     ) {
-        super(eventRepository, objectMapper, executor, bulkItems);
+        super(eventRepository, bulkItems);
+        this.objectMapper = objectMapper;
+        this.executor = executor;
         this.organizationManager = organizationManager;
         this.gatewayConfiguration = gatewayConfiguration;
-        this.objectMapper = objectMapper;
     }
 
     public void synchronize(Long lastRefreshAt, Long nextLastRefreshAt, List<String> environments) {
         final long start = System.currentTimeMillis();
         final Long count;
 
-        Map<String, Event> organizationEvents;
         if (lastRefreshAt == -1) {
             count = initialSynchronizeOrganizations(nextLastRefreshAt, environments);
         } else {
@@ -143,7 +143,7 @@ public class OrganizationSynchronizer extends AbstractSynchronizer {
                                             Set<String> flowTags = consumers
                                                 .stream()
                                                 .filter((consumer -> consumer.getConsumerType().equals(ConsumerType.TAG)))
-                                                .map(consumer -> consumer.getConsumerId())
+                                                .map(Consumer::getConsumerId)
                                                 .collect(Collectors.toSet());
                                             return gatewayConfiguration.hasMatchingTags(flowTags);
                                         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/OrganizationSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/OrganizationSynchronizer.java
@@ -25,6 +25,7 @@ import io.gravitee.definition.model.flow.ConsumerType;
 import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.platform.manager.OrganizationManager;
+import io.gravitee.repository.management.api.EventRepository;
 import io.gravitee.repository.management.model.Event;
 import io.gravitee.repository.management.model.EventType;
 import io.reactivex.rxjava3.annotations.NonNull;
@@ -35,6 +36,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,14 +50,25 @@ public class OrganizationSynchronizer extends AbstractSynchronizer {
 
     private final Logger logger = LoggerFactory.getLogger(OrganizationSynchronizer.class);
 
-    @Autowired
-    private OrganizationManager organizationManager;
+    private final OrganizationManager organizationManager;
 
-    @Autowired
-    private GatewayConfiguration gatewayConfiguration;
+    private final GatewayConfiguration gatewayConfiguration;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
+
+    public OrganizationSynchronizer(
+        EventRepository eventRepository,
+        ObjectMapper objectMapper,
+        ExecutorService executor,
+        int bulkItems,
+        OrganizationManager organizationManager,
+        GatewayConfiguration gatewayConfiguration
+    ) {
+        super(eventRepository, objectMapper, executor, bulkItems);
+        this.organizationManager = organizationManager;
+        this.gatewayConfiguration = gatewayConfiguration;
+        this.objectMapper = objectMapper;
+    }
 
     public void synchronize(Long lastRefreshAt, Long nextLastRefreshAt, List<String> environments) {
         final long start = System.currentTimeMillis();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/api/EventToReactableApiAdapter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/api/EventToReactableApiAdapter.java
@@ -105,20 +105,24 @@ public class EventToReactableApiAdapter {
                     environmentId,
                     envId -> {
                         try {
-                            final Environment environment = environmentRepository.findById(envId).get();
+                            var environment = environmentRepository.findById(envId);
 
-                            organizationMap.computeIfAbsent(
-                                environment.getOrganizationId(),
-                                orgId -> {
-                                    try {
-                                        return organizationRepository.findById(orgId).get();
-                                    } catch (Exception e) {
-                                        return null;
+                            if (environment.isPresent()) {
+                                organizationMap.computeIfAbsent(
+                                    environment.get().getOrganizationId(),
+                                    orgId -> {
+                                        try {
+                                            return organizationRepository.findById(orgId).orElse(null);
+                                        } catch (Exception e) {
+                                            return null;
+                                        }
                                     }
-                                }
-                            );
+                                );
 
-                            return environment;
+                                return environment.get();
+                            }
+
+                            return null;
                         } catch (Exception e) {
                             logger.warn("An error occurred fetching the environment {} and its organization.", envId, e);
                             return null;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/api/EventToReactableApiAdapter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/api/EventToReactableApiAdapter.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.synchronizer.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.repository.management.api.EnvironmentRepository;
+import io.gravitee.repository.management.api.OrganizationRepository;
+import io.gravitee.repository.management.model.Environment;
+import io.gravitee.repository.management.model.Event;
+import io.gravitee.repository.management.model.LifecycleState;
+import io.reactivex.rxjava3.core.Maybe;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class EventToReactableApiAdapter {
+
+    private static final Logger logger = LoggerFactory.getLogger(EventToReactableApiAdapter.class);
+
+    private final ObjectMapper objectMapper;
+    private final EnvironmentRepository environmentRepository;
+    private final OrganizationRepository organizationRepository;
+
+    private final Map<String, Environment> environmentMap = new ConcurrentHashMap<>();
+    private final Map<String, io.gravitee.repository.management.model.Organization> organizationMap = new ConcurrentHashMap<>();
+
+    public EventToReactableApiAdapter(
+        ObjectMapper objectMapper,
+        EnvironmentRepository environmentRepository,
+        OrganizationRepository organizationRepository
+    ) {
+        this.objectMapper = objectMapper;
+        this.environmentRepository = environmentRepository;
+        this.organizationRepository = organizationRepository;
+    }
+
+    public Maybe<ReactableApi<?>> toReactableApi(Event apiEvent) {
+        return toApiDefinition(apiEvent);
+    }
+
+    private Maybe<ReactableApi<?>> toApiDefinition(Event apiEvent) {
+        try {
+            // Read API definition from event
+            io.gravitee.repository.management.model.Api eventPayload = objectMapper.readValue(
+                apiEvent.getPayload(),
+                io.gravitee.repository.management.model.Api.class
+            );
+
+            ReactableApi<?> api;
+
+            // Check the version of the API definition to read the right model entity
+            if (eventPayload.getDefinitionVersion() == null || !eventPayload.getDefinitionVersion().equals(DefinitionVersion.V4)) {
+                io.gravitee.definition.model.Api eventApiDefinition = objectMapper.readValue(
+                    eventPayload.getDefinition(),
+                    io.gravitee.definition.model.Api.class
+                );
+
+                // Update definition with required information for deployment phase
+                api = new io.gravitee.gateway.handlers.api.definition.Api(eventApiDefinition);
+            } else {
+                io.gravitee.definition.model.v4.Api eventApiDefinition = objectMapper.readValue(
+                    eventPayload.getDefinition(),
+                    io.gravitee.definition.model.v4.Api.class
+                );
+
+                // Update definition with required information for deployment phase
+                api = new io.gravitee.gateway.jupiter.handlers.api.v4.Api(eventApiDefinition);
+            }
+
+            api.setEnabled(eventPayload.getLifecycleState() == LifecycleState.STARTED);
+            api.setDeployedAt(apiEvent.getCreatedAt());
+
+            enhanceWithOrgAndEnv(eventPayload.getEnvironmentId(), api);
+
+            return Maybe.just(api);
+        } catch (Exception e) {
+            // Log the error and ignore this event.
+            logger.error("Unable to extract api definition from event [{}].", apiEvent.getId(), e);
+            return Maybe.empty();
+        }
+    }
+
+    private void enhanceWithOrgAndEnv(String environmentId, ReactableApi<?> definition) {
+        Environment apiEnv = null;
+
+        if (environmentId != null) {
+            apiEnv =
+                environmentMap.computeIfAbsent(
+                    environmentId,
+                    envId -> {
+                        try {
+                            final Environment environment = environmentRepository.findById(envId).get();
+
+                            organizationMap.computeIfAbsent(
+                                environment.getOrganizationId(),
+                                orgId -> {
+                                    try {
+                                        return organizationRepository.findById(orgId).get();
+                                    } catch (Exception e) {
+                                        return null;
+                                    }
+                                }
+                            );
+
+                            return environment;
+                        } catch (Exception e) {
+                            logger.warn("An error occurred fetching the environment {} and its organization.", envId, e);
+                            return null;
+                        }
+                    }
+                );
+        }
+
+        if (apiEnv != null) {
+            definition.setEnvironmentId(apiEnv.getId());
+            definition.setEnvironmentHrid(apiEnv.getHrids() != null ? apiEnv.getHrids().stream().findFirst().orElse(null) : null);
+
+            final io.gravitee.repository.management.model.Organization apiOrg = organizationMap.get(apiEnv.getOrganizationId());
+
+            if (apiOrg != null) {
+                definition.setOrganizationId(apiOrg.getId());
+                definition.setOrganizationHrid(apiOrg.getHrids() != null ? apiOrg.getHrids().stream().findFirst().orElse(null) : null);
+            }
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/api/PlanFetcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/api/PlanFetcher.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.synchronizer.api;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.Rule;
+import io.gravitee.gateway.handlers.api.definition.Api;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.PlanRepository;
+import io.gravitee.repository.management.model.Plan;
+import io.reactivex.rxjava3.annotations.NonNull;
+import io.reactivex.rxjava3.core.Flowable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PlanFetcher {
+
+    private final Logger logger = LoggerFactory.getLogger(PlanFetcher.class);
+    private final ObjectMapper objectMapper;
+    private final PlanRepository planRepository;
+
+    public PlanFetcher(ObjectMapper objectMapper, PlanRepository planRepository) {
+        this.objectMapper = objectMapper;
+        this.planRepository = planRepository;
+    }
+
+    /**
+     * Allows to start fetching plans in a bulk fashion way.
+     * @param upstream the api upstream which will be chunked into packs in order to fetch plan v1.
+     * @param bulkSize the bulk size to chunk api upstream.
+     * @return he same flow of apis.
+     */
+    @NonNull
+    public Flowable<ReactableApi<?>> fetchApiPlans(Flowable<ReactableApi<?>> upstream, int bulkSize) {
+        return upstream
+            .groupBy(ReactableApi::getDefinitionVersion)
+            .flatMap(apisByDefinitionVersion -> {
+                if (apisByDefinitionVersion.getKey() == DefinitionVersion.V1) {
+                    return apisByDefinitionVersion.buffer(bulkSize).flatMap(this::fetchV1ApiPlans);
+                } else {
+                    return apisByDefinitionVersion;
+                }
+            });
+    }
+
+    private Flowable<ReactableApi<?>> fetchV1ApiPlans(List<ReactableApi<?>> apiDefinitions) {
+        final Map<String, Api> apisById = apiDefinitions
+            .stream()
+            .map(reactableApi -> (io.gravitee.gateway.handlers.api.definition.Api) reactableApi)
+            .collect(Collectors.toMap(io.gravitee.gateway.handlers.api.definition.Api::getId, api -> api));
+
+        // Get the api id to load plan only for V1 api definition.
+        final List<String> apiV1Ids = new ArrayList<>(apisById.keySet());
+
+        try {
+            final Map<String, List<Plan>> plansByApi = planRepository
+                .findByApis(apiV1Ids)
+                .stream()
+                .collect(Collectors.groupingBy(Plan::getApi));
+
+            plansByApi.forEach((key, value) -> {
+                final io.gravitee.gateway.handlers.api.definition.Api api = apisById.get(key);
+
+                if (api.getDefinitionVersion() == DefinitionVersion.V1) {
+                    // Deploy only published plan
+                    api
+                        .getDefinition()
+                        .setPlans(
+                            value
+                                .stream()
+                                .filter(plan ->
+                                    Plan.Status.PUBLISHED.equals(plan.getStatus()) || Plan.Status.DEPRECATED.equals(plan.getStatus())
+                                )
+                                .map(this::convert)
+                                .collect(Collectors.toList())
+                        );
+                }
+            });
+        } catch (TechnicalException te) {
+            logger.error("Unexpected error while loading plans of APIs: [{}]", apiV1Ids, te);
+        }
+
+        return Flowable.fromIterable(apiDefinitions);
+    }
+
+    private io.gravitee.definition.model.Plan convert(Plan repoPlan) {
+        io.gravitee.definition.model.Plan plan = new io.gravitee.definition.model.Plan();
+
+        plan.setId(repoPlan.getId());
+        plan.setName(repoPlan.getName());
+        plan.setSecurityDefinition(repoPlan.getSecurityDefinition());
+        plan.setSelectionRule(repoPlan.getSelectionRule());
+        plan.setTags(repoPlan.getTags());
+        plan.setStatus(repoPlan.getStatus().name());
+        plan.setApi(repoPlan.getApi());
+
+        if (repoPlan.getSecurity() != null) {
+            plan.setSecurity(repoPlan.getSecurity().name());
+        } else {
+            // TODO: must be handle by a migration script
+            plan.setSecurity("api_key");
+        }
+
+        try {
+            if (repoPlan.getDefinition() != null && !repoPlan.getDefinition().trim().isEmpty()) {
+                HashMap<String, List<Rule>> paths = objectMapper.readValue(repoPlan.getDefinition(), new TypeReference<>() {});
+
+                plan.setPaths(paths);
+            }
+        } catch (IOException ioe) {
+            logger.error("Unexpected error while converting plan: {}", plan, ioe);
+        }
+
+        return plan;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/api/PlanFetcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/api/PlanFetcher.java
@@ -56,13 +56,15 @@ public class PlanFetcher {
     public Flowable<ReactableApi<?>> fetchApiPlans(Flowable<ReactableApi<?>> upstream, int bulkSize) {
         return upstream
             .groupBy(ReactableApi::getDefinitionVersion)
-            .flatMap(apisByDefinitionVersion -> {
-                if (apisByDefinitionVersion.getKey() == DefinitionVersion.V1) {
-                    return apisByDefinitionVersion.buffer(bulkSize).flatMap(this::fetchV1ApiPlans);
-                } else {
-                    return apisByDefinitionVersion;
+            .flatMap(
+                apisByDefinitionVersion -> {
+                    if (apisByDefinitionVersion.getKey() == DefinitionVersion.V1) {
+                        return apisByDefinitionVersion.buffer(bulkSize).flatMap(this::fetchV1ApiPlans);
+                    } else {
+                        return apisByDefinitionVersion;
+                    }
                 }
-            });
+            );
     }
 
     private Flowable<ReactableApi<?>> fetchV1ApiPlans(List<ReactableApi<?>> apiDefinitions) {
@@ -80,24 +82,28 @@ public class PlanFetcher {
                 .stream()
                 .collect(Collectors.groupingBy(Plan::getApi));
 
-            plansByApi.forEach((key, value) -> {
-                final io.gravitee.gateway.handlers.api.definition.Api api = apisById.get(key);
+            plansByApi.forEach(
+                (key, value) -> {
+                    final io.gravitee.gateway.handlers.api.definition.Api api = apisById.get(key);
 
-                if (api.getDefinitionVersion() == DefinitionVersion.V1) {
-                    // Deploy only published plan
-                    api
-                        .getDefinition()
-                        .setPlans(
-                            value
-                                .stream()
-                                .filter(plan ->
-                                    Plan.Status.PUBLISHED.equals(plan.getStatus()) || Plan.Status.DEPRECATED.equals(plan.getStatus())
-                                )
-                                .map(this::convert)
-                                .collect(Collectors.toList())
-                        );
+                    if (api.getDefinitionVersion() == DefinitionVersion.V1) {
+                        // Deploy only published plan
+                        api
+                            .getDefinition()
+                            .setPlans(
+                                value
+                                    .stream()
+                                    .filter(
+                                        plan ->
+                                            Plan.Status.PUBLISHED.equals(plan.getStatus()) ||
+                                            Plan.Status.DEPRECATED.equals(plan.getStatus())
+                                    )
+                                    .map(this::convert)
+                                    .collect(Collectors.toList())
+                            );
+                    }
                 }
-            });
+            );
         } catch (TechnicalException te) {
             logger.error("Unexpected error while loading plans of APIs: [{}]", apiV1Ids, te);
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/builder/RepositoryApiBuilder.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/builder/RepositoryApiBuilder.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.services.sync.builder;
 
+import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.LifecycleState;
 import java.util.Date;
@@ -36,6 +37,11 @@ public class RepositoryApiBuilder {
     public RepositoryApiBuilder updatedAt(Date updatedAt) {
         this.api.setUpdatedAt(updatedAt);
         this.api.setDeployedAt(updatedAt);
+        return this;
+    }
+
+    public RepositoryApiBuilder definitionVersion(DefinitionVersion definitionVersion) {
+        this.api.setDefinitionVersion(definitionVersion);
         return this;
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/ApiSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/ApiSynchronizerTest.java
@@ -15,13 +15,14 @@
  */
 package io.gravitee.gateway.services.sync.synchronizer;
 
+import static io.gravitee.definition.model.ApiBuilder.anApiV1;
+import static io.gravitee.definition.model.ApiBuilder.anApiV2;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.gateway.api.service.SubscriptionService;
 import io.gravitee.gateway.handlers.api.definition.Api;
 import io.gravitee.gateway.handlers.api.manager.ActionOnApi;
@@ -83,7 +84,6 @@ public class ApiSynchronizerTest {
     @Mock
     private SubscriptionsCacheService subscriptionsCacheService;
 
-    @Mock
     private ObjectMapper objectMapper;
 
     @Mock
@@ -91,6 +91,8 @@ public class ApiSynchronizerTest {
 
     @BeforeEach
     void setUp() {
+        objectMapper = new ObjectMapper();
+
         apiSynchronizer =
             new ApiSynchronizer(
                 eventRepository,
@@ -110,16 +112,9 @@ public class ApiSynchronizerTest {
 
     @Test
     void initialSynchronize() throws Exception {
-        io.gravitee.repository.management.model.Api api = new RepositoryApiBuilder()
-            .id(API_ID)
-            .updatedAt(new Date())
-            .definition("test")
-            .environment(ENVIRONMENT_ID)
-            .build();
+        var apiDefinition = anApiV2().id(API_ID).build();
 
-        final io.gravitee.definition.model.Api mockApi = mockApi(api);
-
-        final Event mockEvent = mockEvent(api, EventType.PUBLISH_API);
+        final Event mockEvent = anEvent(apiDefinition, EventType.PUBLISH_API);
         when(
             eventRepository.searchLatest(
                 argThat(
@@ -156,22 +151,16 @@ public class ApiSynchronizerTest {
 
         verify(apiManager, never()).unregister(any(String.class));
         verify(planRepository, never()).findByApis(anyList());
-        verify(apiKeysCacheService).register(singletonList(new Api(mockApi)));
-        verify(subscriptionsCacheService).register(singletonList(new Api(mockApi)));
-        verify(subscriptionService).dispatchFor(singletonList(mockApi.getId()));
+        verify(apiKeysCacheService).register(singletonList(new Api(apiDefinition)));
+        verify(subscriptionsCacheService).register(singletonList(new Api(apiDefinition)));
+        verify(subscriptionService).dispatchFor(singletonList(apiDefinition.getId()));
     }
 
     @Test
     void initialSynchronizeWithNoEnvironment() throws Exception {
-        io.gravitee.repository.management.model.Api api = new RepositoryApiBuilder()
-            .id(API_ID)
-            .updatedAt(new Date())
-            .definition("test")
-            .build();
+        var apiDefinition = anApiV2().id(API_ID).build();
 
-        final io.gravitee.definition.model.Api mockApi = mockApi(api);
-
-        final Event mockEvent = mockEvent(api, EventType.PUBLISH_API);
+        final Event mockEvent = anEvent(apiDefinition, EventType.PUBLISH_API);
         when(
             eventRepository.searchLatest(
                 argThat(
@@ -210,30 +199,23 @@ public class ApiSynchronizerTest {
             .register(
                 argThat(
                     (ArgumentMatcher<List<ReactableApi<?>>>) reactableApis ->
-                        reactableApis.size() == 1 && reactableApis.get(0).equals(new Api(mockApi))
+                        reactableApis.size() == 1 && reactableApis.get(0).equals(new Api(apiDefinition))
                 )
             );
         verify(subscriptionsCacheService)
             .register(
                 argThat(
                     (ArgumentMatcher<List<ReactableApi<?>>>) reactableApis ->
-                        reactableApis.size() == 1 && reactableApis.get(0).equals(new Api(mockApi))
+                        reactableApis.size() == 1 && reactableApis.get(0).equals(new Api(apiDefinition))
                 )
             );
     }
 
     @Test
     void initialSynchronize_withEnvironmentAndOrganization_withoutHrId_shouldSetHrIdToNull() throws Exception {
-        io.gravitee.repository.management.model.Api api = new RepositoryApiBuilder()
-            .id(API_ID)
-            .updatedAt(new Date())
-            .definition("test")
-            .environment(ENVIRONMENT_ID)
-            .build();
+        var apiDefinition = anApiV2().id(API_ID).build();
 
-        mockApi(api);
-
-        final Event mockEvent = mockEvent(api, EventType.PUBLISH_API);
+        final Event mockEvent = anEvent(apiDefinition, EventType.PUBLISH_API);
         when(
             eventRepository.searchLatest(
                 argThat(
@@ -271,16 +253,9 @@ public class ApiSynchronizerTest {
 
     @Test
     void initialSynchronizeWithNoOrganization() throws Exception {
-        io.gravitee.repository.management.model.Api api = new RepositoryApiBuilder()
-            .id(API_ID)
-            .updatedAt(new Date())
-            .definition("test")
-            .environment(ENVIRONMENT_ID)
-            .build();
+        var apiDefinition = anApiV2().id(API_ID).build();
 
-        final io.gravitee.definition.model.Api mockApi = mockApi(api);
-
-        final Event mockEvent = mockEvent(api, EventType.PUBLISH_API);
+        final Event mockEvent = anEvent(apiDefinition, EventType.PUBLISH_API);
         when(
             eventRepository.searchLatest(
                 argThat(
@@ -322,22 +297,15 @@ public class ApiSynchronizerTest {
 
         verify(apiManager, never()).unregister(any(String.class));
         verify(planRepository, never()).findByApis(anyList());
-        verify(apiKeysCacheService).register(singletonList(new Api(mockApi)));
-        verify(subscriptionsCacheService).register(singletonList(new Api(mockApi)));
+        verify(apiKeysCacheService).register(singletonList(new Api(apiDefinition)));
+        verify(subscriptionsCacheService).register(singletonList(new Api(apiDefinition)));
     }
 
     @Test
     void publishWithDefinitionV2() throws Exception {
-        io.gravitee.repository.management.model.Api api = new RepositoryApiBuilder()
-            .id(API_ID)
-            .updatedAt(new Date())
-            .definition("test")
-            .environment(ENVIRONMENT_ID)
-            .build();
+        var apiDefinition = anApiV2().id(API_ID).build();
 
-        final io.gravitee.definition.model.Api mockApi = mockApi(api);
-
-        final Event mockEvent = mockEvent(api, EventType.PUBLISH_API);
+        final Event mockEvent = anEvent(apiDefinition, EventType.PUBLISH_API);
         when(
             eventRepository.searchLatest(
                 argThat(
@@ -359,26 +327,18 @@ public class ApiSynchronizerTest {
 
         apiSynchronizer.synchronize(System.currentTimeMillis() - 5000, System.currentTimeMillis(), ENVIRONMENTS);
 
-        verify(apiManager).register(new Api(mockApi));
+        verify(apiManager).register(new Api(apiDefinition));
         verify(apiManager, never()).unregister(any(String.class));
         verify(planRepository, never()).findByApis(anyList());
-        verify(apiKeysCacheService).register(singletonList(new Api(mockApi)));
-        verify(subscriptionsCacheService).register(singletonList(new Api(mockApi)));
+        verify(apiKeysCacheService).register(singletonList(new Api(apiDefinition)));
+        verify(subscriptionsCacheService).register(singletonList(new Api(apiDefinition)));
     }
 
     @Test
     void publishWithDefinitionV1() throws Exception {
-        io.gravitee.repository.management.model.Api api = new RepositoryApiBuilder()
-            .id(API_ID)
-            .updatedAt(new Date())
-            .definition("test")
-            .environment(ENVIRONMENT_ID)
-            .build();
+        var apiDefinition = anApiV1().id(API_ID).build();
 
-        final io.gravitee.definition.model.Api mockApi = mockApi(api);
-        mockApi.setDefinitionVersion(DefinitionVersion.V1);
-
-        final Event mockEvent = mockEvent(api, EventType.PUBLISH_API);
+        final Event mockEvent = anEvent(apiDefinition, EventType.PUBLISH_API);
         when(
             eventRepository.searchLatest(
                 argThat(
@@ -398,7 +358,7 @@ public class ApiSynchronizerTest {
 
         final Plan plan = new Plan();
         plan.setId("planId");
-        plan.setApi(mockApi.getId());
+        plan.setApi(apiDefinition.getId());
         plan.setStatus(Plan.Status.PUBLISHED);
         when(planRepository.findByApis(anyList())).thenReturn(singletonList(plan));
         mockEnvironmentAndOrganization();
@@ -411,40 +371,26 @@ public class ApiSynchronizerTest {
         SoftAssertions.assertSoftly(
             softly -> {
                 softly.assertThat(verifyApi.getId()).isEqualTo(API_ID);
-                softly.assertThat(verifyApi.getDefinition().getPlan("planId").getApi()).isEqualTo(mockApi.getId());
+                softly.assertThat(verifyApi.getDefinition().getPlan("planId").getApi()).isEqualTo(apiDefinition.getId());
             }
         );
 
         verify(apiManager, never()).unregister(any(String.class));
         verify(planRepository, times(1)).findByApis(anyList());
-        verify(apiKeysCacheService).register(singletonList(new Api(mockApi)));
-        verify(subscriptionsCacheService).register(singletonList(new Api(mockApi)));
+        verify(apiKeysCacheService).register(singletonList(new Api(apiDefinition)));
+        verify(subscriptionsCacheService).register(singletonList(new Api(apiDefinition)));
     }
 
     @Test
     void publishWithPagination() throws Exception {
-        io.gravitee.repository.management.model.Api api = new RepositoryApiBuilder()
-            .id(API_ID)
-            .updatedAt(new Date())
-            .definition(API_ID)
-            .environment(ENVIRONMENT_ID)
-            .build();
-
-        io.gravitee.repository.management.model.Api api2 = new RepositoryApiBuilder()
-            .id("api2-test")
-            .updatedAt(new Date())
-            .definition("api2-test")
-            .environment(ENVIRONMENT_ID)
-            .build();
-
-        final io.gravitee.definition.model.Api mockApi = mockApi(api);
-        final io.gravitee.definition.model.Api mockApi2 = mockApi(api2);
+        var apiDefinition1 = anApiV2().id(API_ID).build();
+        var apiDefinition2 = anApiV2().id("api2-test").build();
 
         // Force bulk size to 1.
         apiSynchronizer.bulkItems = 1;
 
-        final Event mockEvent = mockEvent(api, EventType.PUBLISH_API);
-        final Event mockEvent2 = mockEvent(api2, EventType.PUBLISH_API);
+        final Event mockEvent = anEvent(apiDefinition1, EventType.PUBLISH_API);
+        final Event mockEvent2 = anEvent(apiDefinition2, EventType.PUBLISH_API);
         when(
             eventRepository.searchLatest(
                 argThat(
@@ -483,42 +429,26 @@ public class ApiSynchronizerTest {
 
         apiSynchronizer.synchronize(System.currentTimeMillis() - 5000, System.currentTimeMillis(), ENVIRONMENTS);
 
-        verify(apiManager, times(1)).register(new Api(mockApi));
-        verify(apiManager, times(1)).register(new Api(mockApi2));
+        verify(apiManager, times(1)).register(new Api(apiDefinition1));
+        verify(apiManager, times(1)).register(new Api(apiDefinition2));
         verify(apiManager, never()).unregister(any(String.class));
         verify(planRepository, never()).findByApis(anyList());
-        verify(apiKeysCacheService).register(singletonList(new Api(mockApi)));
-        verify(apiKeysCacheService).register(singletonList(new Api(mockApi2)));
-        verify(subscriptionsCacheService).register(singletonList(new Api(mockApi)));
-        verify(subscriptionsCacheService).register(singletonList(new Api(mockApi2)));
+        verify(apiKeysCacheService).register(singletonList(new Api(apiDefinition1)));
+        verify(apiKeysCacheService).register(singletonList(new Api(apiDefinition2)));
+        verify(subscriptionsCacheService).register(singletonList(new Api(apiDefinition1)));
+        verify(subscriptionsCacheService).register(singletonList(new Api(apiDefinition2)));
     }
 
     @Test
     void publishWithPaginationAndDefinitionV1AndV2() throws Exception {
-        io.gravitee.repository.management.model.Api api = new RepositoryApiBuilder()
-            .id(API_ID)
-            .updatedAt(new Date())
-            .definition(API_ID)
-            .environment(ENVIRONMENT_ID)
-            .build();
-
-        io.gravitee.repository.management.model.Api api2 = new RepositoryApiBuilder()
-            .id("api2-test")
-            .updatedAt(new Date())
-            .definition("api2-test")
-            .environment(ENVIRONMENT_ID)
-            .build();
-
-        final io.gravitee.definition.model.Api mockApi = mockApi(api);
-        mockApi.setDefinitionVersion(DefinitionVersion.V1);
-        final io.gravitee.definition.model.Api mockApi2 = mockApi(api2);
-        mockApi2.setDefinitionVersion(DefinitionVersion.V2);
+        var apiDefinition1 = anApiV1().id(API_ID).build();
+        var apiDefinition2 = anApiV2().id("api2-test").build();
 
         // Force bulk size to 1.
         apiSynchronizer.bulkItems = 1;
 
-        final Event mockEvent = mockEvent(api, EventType.PUBLISH_API);
-        final Event mockEvent2 = mockEvent(api2, EventType.PUBLISH_API);
+        final Event mockEvent = anEvent(apiDefinition1, EventType.PUBLISH_API);
+        final Event mockEvent2 = anEvent(apiDefinition2, EventType.PUBLISH_API);
         when(
             eventRepository.searchLatest(
                 argThat(
@@ -554,33 +484,27 @@ public class ApiSynchronizerTest {
             .thenReturn(singletonList(mockEvent2));
 
         final Plan plan = new Plan();
-        plan.setApi(mockApi.getId());
+        plan.setApi(apiDefinition1.getId());
         when(planRepository.findByApis(singletonList(plan.getApi()))).thenReturn(singletonList(plan));
         mockEnvironmentAndOrganization();
 
         apiSynchronizer.synchronize(System.currentTimeMillis() - 5000, System.currentTimeMillis(), ENVIRONMENTS);
 
-        verify(apiManager, times(1)).register(new Api(mockApi));
-        verify(apiManager, times(1)).register(new Api(mockApi2));
+        verify(apiManager, times(1)).register(new Api(apiDefinition1));
+        verify(apiManager, times(1)).register(new Api(apiDefinition2));
         verify(apiManager, never()).unregister(any(String.class));
         verify(planRepository, times(1)).findByApis(singletonList(plan.getApi()));
-        verify(apiKeysCacheService).register(singletonList(new Api(mockApi)));
-        verify(apiKeysCacheService).register(singletonList(new Api(mockApi2)));
-        verify(subscriptionsCacheService).register(singletonList(new Api(mockApi)));
-        verify(subscriptionsCacheService).register(singletonList(new Api(mockApi2)));
+        verify(apiKeysCacheService).register(singletonList(new Api(apiDefinition1)));
+        verify(apiKeysCacheService).register(singletonList(new Api(apiDefinition2)));
+        verify(subscriptionsCacheService).register(singletonList(new Api(apiDefinition1)));
+        verify(subscriptionsCacheService).register(singletonList(new Api(apiDefinition2)));
     }
 
     @Test
     void unpublish() throws Exception {
-        io.gravitee.repository.management.model.Api api = new RepositoryApiBuilder()
-            .id(API_ID)
-            .updatedAt(new Date())
-            .definition("test")
-            .build();
+        var apiDefinition = anApiV2().id(API_ID).build();
 
-        final io.gravitee.definition.model.Api mockApi = mockApi(api);
-
-        final Event mockEvent = mockEvent(api, EventType.UNPUBLISH_API);
+        final Event mockEvent = anEvent(apiDefinition, EventType.UNPUBLISH_API);
         when(
             eventRepository.searchLatest(
                 argThat(
@@ -600,37 +524,23 @@ public class ApiSynchronizerTest {
 
         apiSynchronizer.synchronize(System.currentTimeMillis() - 5000, System.currentTimeMillis(), ENVIRONMENTS);
 
-        verify(apiManager, never()).register(new Api(mockApi));
-        verify(apiManager).unregister(mockApi.getId());
+        verify(apiManager, never()).register(new Api(apiDefinition));
+        verify(apiManager).unregister(apiDefinition.getId());
         verify(planRepository, never()).findByApis(anyList());
-        verify(apiKeysCacheService, never()).register(singletonList(new Api(mockApi)));
-        verify(subscriptionsCacheService, never()).register(singletonList(new Api(mockApi)));
+        verify(apiKeysCacheService, never()).register(singletonList(new Api(apiDefinition)));
+        verify(subscriptionsCacheService, never()).register(singletonList(new Api(apiDefinition)));
     }
 
     @Test
     void unpublishWithPagination() throws Exception {
-        io.gravitee.repository.management.model.Api api = new RepositoryApiBuilder()
-            .id(API_ID)
-            .updatedAt(new Date())
-            .definition(API_ID)
-            .build();
-
-        io.gravitee.repository.management.model.Api api2 = new RepositoryApiBuilder()
-            .id("api2-test")
-            .updatedAt(new Date())
-            .definition("api2-test")
-            .build();
-
-        final io.gravitee.definition.model.Api mockApi = mockApi(api);
-        mockApi.setDefinitionVersion(DefinitionVersion.V1);
-        final io.gravitee.definition.model.Api mockApi2 = mockApi(api2);
-        mockApi2.setDefinitionVersion(DefinitionVersion.V2);
+        var apiDefinition1 = anApiV1().id(API_ID).build();
+        var apiDefinition2 = anApiV2().id("api2-test").build();
 
         // Force bulk size to 1.
         apiSynchronizer.bulkItems = 1;
 
-        final Event mockEvent = mockEvent(api, EventType.UNPUBLISH_API);
-        final Event mockEvent2 = mockEvent(api2, EventType.UNPUBLISH_API);
+        final Event mockEvent = anEvent(apiDefinition1, EventType.UNPUBLISH_API);
+        final Event mockEvent2 = anEvent(apiDefinition2, EventType.UNPUBLISH_API);
         when(
             eventRepository.searchLatest(
                 argThat(
@@ -667,12 +577,12 @@ public class ApiSynchronizerTest {
 
         apiSynchronizer.synchronize(System.currentTimeMillis() - 5000, System.currentTimeMillis(), ENVIRONMENTS);
 
-        verify(apiManager, never()).register(new Api(mockApi));
-        verify(apiManager).unregister(mockApi.getId());
-        verify(apiManager).unregister(mockApi2.getId());
+        verify(apiManager, never()).register(new Api(apiDefinition1));
+        verify(apiManager).unregister(apiDefinition1.getId());
+        verify(apiManager).unregister(apiDefinition2.getId());
         verify(planRepository, never()).findByApis(anyList());
-        verify(apiKeysCacheService, never()).register(singletonList(new Api(mockApi)));
-        verify(subscriptionsCacheService, never()).register(singletonList(new Api(mockApi)));
+        verify(apiKeysCacheService, never()).register(singletonList(new Api(apiDefinition1)));
+        verify(subscriptionsCacheService, never()).register(singletonList(new Api(apiDefinition1)));
     }
 
     @Test
@@ -681,20 +591,12 @@ public class ApiSynchronizerTest {
         List<Event> eventAccumulator = new ArrayList<>(100);
 
         for (int i = 1; i <= 500; i++) {
-            io.gravitee.repository.management.model.Api api = new RepositoryApiBuilder()
-                .id("api" + i + "-test")
-                .updatedAt(new Date())
-                .definition("api" + i + "-test")
-                .environment(ENVIRONMENT_ID)
-                .build();
-
-            final io.gravitee.definition.model.Api mockApi = mockApi(api);
-            mockApi.setDefinitionVersion(DefinitionVersion.V1);
+            var apiDefinition = anApiV1().id("api" + i + "-test").build();
 
             if (i % 2 == 0) {
-                eventAccumulator.add(mockEvent(api, EventType.START_API));
+                eventAccumulator.add(anEvent(apiDefinition, EventType.START_API));
             } else {
-                eventAccumulator.add(mockEvent(api, EventType.STOP_API));
+                eventAccumulator.add(anEvent(apiDefinition, EventType.STOP_API));
             }
 
             if (i % 100 == 0) {
@@ -740,16 +642,9 @@ public class ApiSynchronizerTest {
     void shouldNotDeployWhichDoesntRequireRedeployment() throws Exception {
         lenient().when(apiManager.requiredActionFor(any())).thenReturn(ActionOnApi.NONE);
 
-        io.gravitee.repository.management.model.Api api = new RepositoryApiBuilder()
-            .id(API_ID)
-            .updatedAt(new Date())
-            .definition("test")
-            .environment(ENVIRONMENT_ID)
-            .build();
+        var apiDefinition = anApiV2().id(API_ID).build();
 
-        final io.gravitee.definition.model.Api mockApi = mockApi(api);
-
-        final Event mockEvent = mockEvent(api, EventType.PUBLISH_API);
+        final Event mockEvent = anEvent(apiDefinition, EventType.PUBLISH_API);
         when(
             eventRepository.searchLatest(
                 argThat(
@@ -771,27 +666,20 @@ public class ApiSynchronizerTest {
 
         apiSynchronizer.synchronize(System.currentTimeMillis() - 5000, System.currentTimeMillis(), ENVIRONMENTS);
 
-        verify(apiManager, never()).register(new Api(mockApi));
+        verify(apiManager, never()).register(new Api(apiDefinition));
         verify(apiManager, never()).unregister(any(String.class));
         verify(planRepository, never()).findByApis(anyList());
-        verify(apiKeysCacheService, never()).register(singletonList(new Api(mockApi)));
-        verify(subscriptionsCacheService, never()).register(singletonList(new Api(mockApi)));
+        verify(apiKeysCacheService, never()).register(singletonList(new Api(apiDefinition)));
+        verify(subscriptionsCacheService, never()).register(singletonList(new Api(apiDefinition)));
     }
 
     @Test
     void shouldUnDeployWhichDoesRequireUndeployment() throws Exception {
         lenient().when(apiManager.requiredActionFor(any())).thenReturn(ActionOnApi.UNDEPLOY);
 
-        io.gravitee.repository.management.model.Api api = new RepositoryApiBuilder()
-            .id(API_ID)
-            .updatedAt(new Date())
-            .definition("test")
-            .environment(ENVIRONMENT_ID)
-            .build();
+        var apiDefinition = anApiV2().id(API_ID).build();
 
-        final io.gravitee.definition.model.Api mockApi = mockApi(api);
-
-        final Event mockEvent = mockEvent(api, EventType.PUBLISH_API);
+        final Event mockEvent = anEvent(apiDefinition, EventType.PUBLISH_API);
         when(
             eventRepository.searchLatest(
                 argThat(
@@ -813,39 +701,33 @@ public class ApiSynchronizerTest {
 
         apiSynchronizer.synchronize(System.currentTimeMillis() - 5000, System.currentTimeMillis(), ENVIRONMENTS);
 
-        verify(apiManager, never()).register(new Api(mockApi));
+        verify(apiManager, never()).register(new Api(apiDefinition));
         verify(apiManager, times(1)).unregister(any(String.class));
         verify(planRepository, never()).findByApis(anyList());
-        verify(apiKeysCacheService, never()).register(singletonList(new Api(mockApi)));
-        verify(subscriptionsCacheService, never()).register(singletonList(new Api(mockApi)));
+        verify(apiKeysCacheService, never()).register(singletonList(new Api(apiDefinition)));
+        verify(subscriptionsCacheService, never()).register(singletonList(new Api(apiDefinition)));
     }
 
-    private io.gravitee.definition.model.Api mockApi(final io.gravitee.repository.management.model.Api api) throws Exception {
-        return mockApi(api, new String[] {});
-    }
-
-    private io.gravitee.definition.model.Api mockApi(final io.gravitee.repository.management.model.Api api, final String[] tags)
-        throws Exception {
-        final io.gravitee.definition.model.Api mockApi = new io.gravitee.definition.model.Api();
-        mockApi.setId(api.getId());
-        mockApi.setTags(new HashSet<>(asList(tags)));
-        mockApi.setDefinitionVersion(DefinitionVersion.V2);
-        lenient().when(objectMapper.readValue(api.getDefinition(), io.gravitee.definition.model.Api.class)).thenReturn(mockApi);
-        return mockApi;
-    }
-
-    private Event mockEvent(final io.gravitee.repository.management.model.Api api, EventType eventType) throws Exception {
+    private Event anEvent(final io.gravitee.definition.model.Api apiDefinition, EventType eventType) throws Exception {
         Map<String, String> properties = new HashMap<>();
-        properties.put(Event.EventProperties.API_ID.getValue(), api.getId());
+        properties.put(Event.EventProperties.API_ID.getValue(), apiDefinition.getId());
 
         Event event = new Event();
         event.setType(eventType);
         event.setCreatedAt(new Date());
         event.setProperties(properties);
-        event.setPayload(api.getId());
+        event.setPayload(apiDefinition.getId());
         event.setEnvironments(singleton(ENVIRONMENT_ID));
-
-        lenient().when(objectMapper.readValue(event.getPayload(), io.gravitee.repository.management.model.Api.class)).thenReturn(api);
+        event.setPayload(
+            objectMapper.writeValueAsString(
+                new RepositoryApiBuilder()
+                    .id(apiDefinition.getId())
+                    .updatedAt(new Date())
+                    .definition(objectMapper.writeValueAsString(apiDefinition))
+                    .environment(ENVIRONMENT_ID)
+                    .build()
+            )
+        );
 
         return event;
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/ApiSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/ApiSynchronizerTest.java
@@ -18,17 +18,7 @@ package io.gravitee.gateway.services.sync.synchronizer;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyList;
-import static org.mockito.Mockito.anyLong;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.argThat;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.DefinitionVersion;
@@ -44,19 +34,8 @@ import io.gravitee.repository.management.api.EnvironmentRepository;
 import io.gravitee.repository.management.api.EventRepository;
 import io.gravitee.repository.management.api.OrganizationRepository;
 import io.gravitee.repository.management.api.PlanRepository;
-import io.gravitee.repository.management.model.Environment;
-import io.gravitee.repository.management.model.Event;
-import io.gravitee.repository.management.model.EventType;
-import io.gravitee.repository.management.model.Organization;
-import io.gravitee.repository.management.model.Plan;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import io.gravitee.repository.management.model.*;
+import java.util.*;
 import java.util.concurrent.Executors;
 import junit.framework.TestCase;
 import org.junit.Before;
@@ -64,7 +43,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -82,8 +60,7 @@ public class ApiSynchronizerTest extends TestCase {
     private static final String ORGANIZATION_HRID = "default-org";
     private static final String API_ID = "api-test";
 
-    @InjectMocks
-    private ApiSynchronizer apiSynchronizer = new ApiSynchronizer();
+    private ApiSynchronizer apiSynchronizer;
 
     @Mock
     private EventRepository eventRepository;
@@ -114,7 +91,20 @@ public class ApiSynchronizerTest extends TestCase {
 
     @Before
     public void setUp() {
-        apiSynchronizer.setExecutor(Executors.newFixedThreadPool(1));
+        apiSynchronizer =
+            new ApiSynchronizer(
+                eventRepository,
+                objectMapper,
+                Executors.newFixedThreadPool(1),
+                100,
+                planRepository,
+                apiKeysCacheService,
+                subscriptionsCacheService,
+                subscriptionService,
+                apiManager,
+                environmentRepository,
+                organizationRepository
+            );
         lenient().when(apiManager.requiredActionFor(any())).thenReturn(ActionOnApi.DEPLOY);
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/ApiSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/ApiSynchronizerTest.java
@@ -31,6 +31,7 @@ import io.gravitee.gateway.reactor.ReactableApi;
 import io.gravitee.gateway.services.sync.builder.RepositoryApiBuilder;
 import io.gravitee.gateway.services.sync.cache.ApiKeysCacheService;
 import io.gravitee.gateway.services.sync.cache.SubscriptionsCacheService;
+import io.gravitee.gateway.services.sync.synchronizer.api.EventToReactableApiAdapter;
 import io.gravitee.repository.management.api.EnvironmentRepository;
 import io.gravitee.repository.management.api.EventRepository;
 import io.gravitee.repository.management.api.OrganizationRepository;
@@ -93,6 +94,8 @@ public class ApiSynchronizerTest {
     void setUp() {
         objectMapper = new ObjectMapper();
 
+        var eventToReactableApiAdapter = new EventToReactableApiAdapter(objectMapper, environmentRepository, organizationRepository);
+
         apiSynchronizer =
             new ApiSynchronizer(
                 eventRepository,
@@ -104,8 +107,7 @@ public class ApiSynchronizerTest {
                 subscriptionsCacheService,
                 subscriptionService,
                 apiManager,
-                environmentRepository,
-                organizationRepository
+                eventToReactableApiAdapter
             );
         lenient().when(apiManager.requiredActionFor(any())).thenReturn(ActionOnApi.DEPLOY);
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/DebugApiSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/DebugApiSynchronizerTest.java
@@ -19,7 +19,6 @@ import static java.util.Collections.singletonList;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.common.event.EventManager;
 import io.gravitee.gateway.reactor.ReactorEvent;
 import io.gravitee.gateway.reactor.impl.ReactableWrapper;
@@ -28,20 +27,17 @@ import io.gravitee.node.api.Node;
 import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.plugin.core.api.Plugin;
 import io.gravitee.plugin.core.api.PluginRegistry;
-import io.gravitee.plugin.core.internal.PluginDependencyImpl;
-import io.gravitee.plugin.core.internal.PluginImpl;
 import io.gravitee.repository.management.api.EventRepository;
-import io.gravitee.repository.management.model.*;
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.repository.management.model.ApiDebugStatus;
+import io.gravitee.repository.management.model.Event;
+import io.gravitee.repository.management.model.EventType;
 import java.util.*;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadPoolExecutor;
 import junit.framework.TestCase;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 
 /**
@@ -76,20 +72,10 @@ public class DebugApiSynchronizerTest extends TestCase {
     public void setup() {
         Plugin debugPlugin = mock(Plugin.class);
         when(debugPlugin.id()).thenReturn("gateway-debug");
-        when(pluginRegistry.plugins()).thenReturn((Collection) List.of(debugPlugin));
+        when(pluginRegistry.plugins()).thenReturn(List.of(debugPlugin));
         when(configuration.getProperty("gravitee.services.gateway-debug.enabled", Boolean.class, true)).thenReturn(true);
 
-        debugApiSynchronizer =
-            new DebugApiSynchronizer(
-                eventRepository,
-                mock(ObjectMapper.class),
-                Executors.newFixedThreadPool(1),
-                100,
-                eventManager,
-                pluginRegistry,
-                configuration,
-                node
-            );
+        debugApiSynchronizer = new DebugApiSynchronizer(eventRepository, 100, eventManager, pluginRegistry, configuration, node);
         when(node.id()).thenReturn(GATEWAY_ID);
     }
 
@@ -128,17 +114,7 @@ public class DebugApiSynchronizerTest extends TestCase {
     @Test
     public void shouldNotSyncIfDebugModeServiceIsDisabled() {
         when(configuration.getProperty("gravitee.services.gateway-debug.enabled", Boolean.class, true)).thenReturn(false);
-        debugApiSynchronizer =
-            new DebugApiSynchronizer(
-                eventRepository,
-                mock(ObjectMapper.class),
-                Executors.newFixedThreadPool(1),
-                100,
-                eventManager,
-                pluginRegistry,
-                configuration,
-                node
-            );
+        debugApiSynchronizer = new DebugApiSynchronizer(eventRepository, 100, eventManager, pluginRegistry, configuration, node);
 
         debugApiSynchronizer.synchronize(System.currentTimeMillis() - 5000, System.currentTimeMillis(), ENVIRONMENTS);
 
@@ -149,17 +125,7 @@ public class DebugApiSynchronizerTest extends TestCase {
     @Test
     public void shouldNotSyncIfDebugModePluginIsAbsent() {
         when(pluginRegistry.plugins()).thenReturn((Collection) List.of());
-        debugApiSynchronizer =
-            new DebugApiSynchronizer(
-                eventRepository,
-                mock(ObjectMapper.class),
-                Executors.newFixedThreadPool(1),
-                100,
-                eventManager,
-                pluginRegistry,
-                configuration,
-                node
-            );
+        debugApiSynchronizer = new DebugApiSynchronizer(eventRepository, 100, eventManager, pluginRegistry, configuration, node);
 
         debugApiSynchronizer.synchronize(System.currentTimeMillis() - 5000, System.currentTimeMillis(), ENVIRONMENTS);
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/DebugApiSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/DebugApiSynchronizerTest.java
@@ -19,6 +19,7 @@ import static java.util.Collections.singletonList;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.common.event.EventManager;
 import io.gravitee.gateway.reactor.ReactorEvent;
 import io.gravitee.gateway.reactor.impl.ReactableWrapper;
@@ -78,9 +79,17 @@ public class DebugApiSynchronizerTest extends TestCase {
         when(pluginRegistry.plugins()).thenReturn((Collection) List.of(debugPlugin));
         when(configuration.getProperty("gravitee.services.gateway-debug.enabled", Boolean.class, true)).thenReturn(true);
 
-        debugApiSynchronizer = new DebugApiSynchronizer(eventManager, pluginRegistry, configuration, node);
-        debugApiSynchronizer.eventRepository = eventRepository;
-        debugApiSynchronizer.setExecutor(Executors.newFixedThreadPool(1));
+        debugApiSynchronizer =
+            new DebugApiSynchronizer(
+                eventRepository,
+                mock(ObjectMapper.class),
+                Executors.newFixedThreadPool(1),
+                100,
+                eventManager,
+                pluginRegistry,
+                configuration,
+                node
+            );
         when(node.id()).thenReturn(GATEWAY_ID);
     }
 
@@ -119,7 +128,17 @@ public class DebugApiSynchronizerTest extends TestCase {
     @Test
     public void shouldNotSyncIfDebugModeServiceIsDisabled() {
         when(configuration.getProperty("gravitee.services.gateway-debug.enabled", Boolean.class, true)).thenReturn(false);
-        debugApiSynchronizer = new DebugApiSynchronizer(eventManager, pluginRegistry, configuration, node);
+        debugApiSynchronizer =
+            new DebugApiSynchronizer(
+                eventRepository,
+                mock(ObjectMapper.class),
+                Executors.newFixedThreadPool(1),
+                100,
+                eventManager,
+                pluginRegistry,
+                configuration,
+                node
+            );
 
         debugApiSynchronizer.synchronize(System.currentTimeMillis() - 5000, System.currentTimeMillis(), ENVIRONMENTS);
 
@@ -130,7 +149,17 @@ public class DebugApiSynchronizerTest extends TestCase {
     @Test
     public void shouldNotSyncIfDebugModePluginIsAbsent() {
         when(pluginRegistry.plugins()).thenReturn((Collection) List.of());
-        debugApiSynchronizer = new DebugApiSynchronizer(eventManager, pluginRegistry, configuration, node);
+        debugApiSynchronizer =
+            new DebugApiSynchronizer(
+                eventRepository,
+                mock(ObjectMapper.class),
+                Executors.newFixedThreadPool(1),
+                100,
+                eventManager,
+                pluginRegistry,
+                configuration,
+                node
+            );
 
         debugApiSynchronizer.synchronize(System.currentTimeMillis() - 5000, System.currentTimeMillis(), ENVIRONMENTS);
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/DictionarySynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/DictionarySynchronizerTest.java
@@ -30,7 +30,6 @@ import junit.framework.TestCase;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -41,8 +40,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class DictionarySynchronizerTest extends TestCase {
 
-    @InjectMocks
-    private DictionarySynchronizer dictionarySynchronizer = new DictionarySynchronizer();
+    private DictionarySynchronizer dictionarySynchronizer;
 
     @Mock
     private EventRepository eventRepository;
@@ -57,7 +55,8 @@ public class DictionarySynchronizerTest extends TestCase {
 
     @Before
     public void setUp() {
-        dictionarySynchronizer.setExecutor(Executors.newFixedThreadPool(1));
+        dictionarySynchronizer =
+            new DictionarySynchronizer(eventRepository, objectMapper, Executors.newFixedThreadPool(1), 100, dictionaryManager);
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/DictionarySynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/DictionarySynchronizerTest.java
@@ -26,19 +26,18 @@ import io.gravitee.repository.management.model.Event;
 import io.gravitee.repository.management.model.EventType;
 import java.util.*;
 import java.util.concurrent.Executors;
-import junit.framework.TestCase;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-@RunWith(MockitoJUnitRunner.class)
-public class DictionarySynchronizerTest extends TestCase {
+@ExtendWith(MockitoExtension.class)
+public class DictionarySynchronizerTest {
 
     private DictionarySynchronizer dictionarySynchronizer;
 
@@ -53,14 +52,14 @@ public class DictionarySynchronizerTest extends TestCase {
 
     static final List<String> ENVIRONMENTS = Arrays.asList("DEFAULT", "OTHER_ENV");
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         dictionarySynchronizer =
             new DictionarySynchronizer(eventRepository, objectMapper, Executors.newFixedThreadPool(1), 100, dictionaryManager);
     }
 
     @Test
-    public void initialSynchronize() throws Exception {
+    void initialSynchronize() throws Exception {
         Dictionary dictionary = new Dictionary();
         dictionary.setId("dictionary-test");
 
@@ -87,7 +86,7 @@ public class DictionarySynchronizerTest extends TestCase {
     }
 
     @Test
-    public void publish() throws Exception {
+    void publish() throws Exception {
         Dictionary dictionary = new Dictionary();
         dictionary.setId("dictionary-test");
 
@@ -114,7 +113,7 @@ public class DictionarySynchronizerTest extends TestCase {
     }
 
     @Test
-    public void publishWithPagination() throws Exception {
+    void publishWithPagination() throws Exception {
         Dictionary dictionary = new Dictionary();
         dictionary.setId("dictionary-test");
 
@@ -164,7 +163,7 @@ public class DictionarySynchronizerTest extends TestCase {
     }
 
     @Test
-    public void unpublish() throws Exception {
+    void unpublish() throws Exception {
         Dictionary dictionary = new Dictionary();
         dictionary.setId("dictionary-test");
 
@@ -191,7 +190,7 @@ public class DictionarySynchronizerTest extends TestCase {
     }
 
     @Test
-    public void unpublishWithPagination() throws Exception {
+    void unpublishWithPagination() throws Exception {
         Dictionary dictionary = new Dictionary();
         dictionary.setId("dictionary-test");
 
@@ -241,7 +240,7 @@ public class DictionarySynchronizerTest extends TestCase {
     }
 
     @Test
-    public void synchronizeWithLotOfDictionaryEvents() throws Exception {
+    void synchronizeWithLotOfDictionaryEvents() throws Exception {
         long page = 0;
         List<Event> eventAccumulator = new ArrayList<>(100);
 
@@ -285,7 +284,7 @@ public class DictionarySynchronizerTest extends TestCase {
     }
 
     @Test
-    public void shouldNotDeployIfProblemWhileReadingFromEvent() throws Exception {
+    void shouldNotDeployIfProblemWhileReadingFromEvent() throws Exception {
         Dictionary dictionary = new Dictionary();
         dictionary.setId("dictionary-test");
 
@@ -320,7 +319,7 @@ public class DictionarySynchronizerTest extends TestCase {
         event.setProperties(properties);
         event.setPayload(dictionary.getId());
 
-        when(objectMapper.readValue(event.getPayload(), Dictionary.class)).thenReturn(dictionary);
+        lenient().when(objectMapper.readValue(event.getPayload(), Dictionary.class)).thenReturn(dictionary);
 
         return event;
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/OrganizationSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/OrganizationSynchronizerTest.java
@@ -20,8 +20,6 @@ import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.Organization;
-import io.gravitee.gateway.dictionary.DictionaryManager;
-import io.gravitee.gateway.dictionary.model.Dictionary;
 import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.platform.manager.OrganizationManager;
 import io.gravitee.repository.management.api.EventRepository;
@@ -29,22 +27,18 @@ import io.gravitee.repository.management.model.Event;
 import io.gravitee.repository.management.model.EventType;
 import java.util.*;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadPoolExecutor;
-import junit.framework.TestCase;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-@RunWith(MockitoJUnitRunner.class)
-public class OrganizationSynchronizerTest extends TestCase {
+@ExtendWith(MockitoExtension.class)
+public class OrganizationSynchronizerTest {
 
     private OrganizationSynchronizer organizationSynchronizer;
 
@@ -64,8 +58,8 @@ public class OrganizationSynchronizerTest extends TestCase {
     static final String ORGANISATION_TEST = "organisation-test";
     static final String ORGANISATION_TEST_2 = "organisation-test_2";
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         organizationSynchronizer =
             new OrganizationSynchronizer(
                 eventRepository,
@@ -78,17 +72,17 @@ public class OrganizationSynchronizerTest extends TestCase {
     }
 
     @Test
-    public void initialSynchronize() throws Exception {
+    void initialSynchronize() throws Exception {
         Organization organization = new Organization();
         organization.setId(ORGANISATION_TEST);
 
-        final Event mockEvent = mockEvent(organization, EventType.PUBLISH_ORGANIZATION);
+        final Event mockEvent = mockEvent(organization);
         when(
             eventRepository.searchLatest(
                 argThat(
                     criteria ->
                         criteria != null &&
-                        criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_ORGANIZATION)) &&
+                        criteria.getTypes().contains(EventType.PUBLISH_ORGANIZATION) &&
                         criteria.getEnvironments().containsAll(ENVIRONMENTS)
                 ),
                 eq(Event.EventProperties.ORGANIZATION_ID),
@@ -105,17 +99,17 @@ public class OrganizationSynchronizerTest extends TestCase {
     }
 
     @Test
-    public void publish() throws Exception {
+    void publish() throws Exception {
         Organization organization = new Organization();
         organization.setId(ORGANISATION_TEST);
 
-        final Event mockEvent = mockEvent(organization, EventType.PUBLISH_ORGANIZATION);
+        final Event mockEvent = mockEvent(organization);
         when(
             eventRepository.searchLatest(
                 argThat(
                     criteria ->
                         criteria != null &&
-                        criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_ORGANIZATION)) &&
+                        criteria.getTypes().contains(EventType.PUBLISH_ORGANIZATION) &&
                         criteria.getEnvironments().containsAll(ENVIRONMENTS)
                 ),
                 eq(Event.EventProperties.ORGANIZATION_ID),
@@ -132,7 +126,7 @@ public class OrganizationSynchronizerTest extends TestCase {
     }
 
     @Test
-    public void publishWithPagination() throws Exception {
+    void publishWithPagination() throws Exception {
         Organization organization = new Organization();
         organization.setId(ORGANISATION_TEST);
 
@@ -142,14 +136,14 @@ public class OrganizationSynchronizerTest extends TestCase {
         // Force bulk size to 1.
         organizationSynchronizer.bulkItems = 1;
 
-        final Event mockEvent = mockEvent(organization, EventType.PUBLISH_ORGANIZATION);
-        final Event mockEvent2 = mockEvent(organization2, EventType.PUBLISH_ORGANIZATION);
+        final Event mockEvent = mockEvent(organization);
+        final Event mockEvent2 = mockEvent(organization2);
         when(
             eventRepository.searchLatest(
                 argThat(
                     criteria ->
                         criteria != null &&
-                        criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_ORGANIZATION)) &&
+                        criteria.getTypes().contains(EventType.PUBLISH_ORGANIZATION) &&
                         criteria.getEnvironments().containsAll(ENVIRONMENTS)
                 ),
                 eq(Event.EventProperties.ORGANIZATION_ID),
@@ -164,7 +158,7 @@ public class OrganizationSynchronizerTest extends TestCase {
                 argThat(
                     criteria ->
                         criteria != null &&
-                        criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_ORGANIZATION)) &&
+                        criteria.getTypes().contains(EventType.PUBLISH_ORGANIZATION) &&
                         criteria.getEnvironments().containsAll(ENVIRONMENTS)
                 ),
                 eq(Event.EventProperties.ORGANIZATION_ID),
@@ -184,7 +178,7 @@ public class OrganizationSynchronizerTest extends TestCase {
     }
 
     @Test
-    public void synchronizeWithLotOfOrganizationEvents() throws Exception {
+    void synchronizeWithLotOfOrganizationEvents() throws Exception {
         long page = 0;
         List<Event> eventAccumulator = new ArrayList<>(100);
 
@@ -192,7 +186,7 @@ public class OrganizationSynchronizerTest extends TestCase {
             Organization organization = new Organization();
             organization.setId("dictionary" + i + "-test");
 
-            eventAccumulator.add(mockEvent(organization, EventType.PUBLISH_ORGANIZATION));
+            eventAccumulator.add(mockEvent(organization));
 
             if (i % 100 == 0) {
                 when(
@@ -200,7 +194,7 @@ public class OrganizationSynchronizerTest extends TestCase {
                         argThat(
                             criteria ->
                                 criteria != null &&
-                                criteria.getTypes().containsAll(Arrays.asList(EventType.PUBLISH_ORGANIZATION)) &&
+                                criteria.getTypes().contains(EventType.PUBLISH_ORGANIZATION) &&
                                 criteria.getEnvironments().containsAll(ENVIRONMENTS)
                         ),
                         eq(Event.EventProperties.ORGANIZATION_ID),
@@ -221,12 +215,12 @@ public class OrganizationSynchronizerTest extends TestCase {
         verify(organizationManager, never()).unregister(anyString());
     }
 
-    private Event mockEvent(final Organization organization, EventType eventType) throws Exception {
+    private Event mockEvent(final Organization organization) throws Exception {
         Map<String, String> properties = new HashMap<>();
         properties.put(Event.EventProperties.ORGANIZATION_ID.getValue(), organization.getId());
 
         Event event = new Event();
-        event.setType(eventType);
+        event.setType(EventType.PUBLISH_ORGANIZATION);
         event.setCreatedAt(new Date());
         event.setProperties(properties);
         event.setPayload(organization.getId());

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/OrganizationSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/OrganizationSynchronizerTest.java
@@ -46,8 +46,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class OrganizationSynchronizerTest extends TestCase {
 
-    @InjectMocks
-    private OrganizationSynchronizer organizationSynchronizer = new OrganizationSynchronizer();
+    private OrganizationSynchronizer organizationSynchronizer;
 
     @Mock
     private EventRepository eventRepository;
@@ -67,7 +66,15 @@ public class OrganizationSynchronizerTest extends TestCase {
 
     @Before
     public void setUp() {
-        organizationSynchronizer.setExecutor(Executors.newFixedThreadPool(1));
+        organizationSynchronizer =
+            new OrganizationSynchronizer(
+                eventRepository,
+                objectMapper,
+                Executors.newFixedThreadPool(1),
+                100,
+                organizationManager,
+                gatewayConfiguration
+            );
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-67

## Description

Subscriptions for Subscription plans were always dispatched even if the tags defined in the plan didn't match with the Gateway.

With this PR, during the Synchronization process, the Gateway will check the tags of the API and Plans before triggering the registration. Doing so will prevent unnecessary work as soon as possible: Subscriptions won't be processed when no plan is available for the Gateway.

I tried to reorganize the tests of the ApiSynchronizer, but I'm not completely satisfied. I didn't find a clean way to handle API V2 and V4 tests without writing them twice.

NOTE: I can't remove the existing code checking the tags in the ApiManager, because [LocalApiDefinitionRegistry](https://github.com/gravitee-io/gravitee-api-management/blob/master/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-localregistry/src/main/java/io/gravitee/gateway/services/localregistry/LocalApiDefinitionRegistry.java) can load API definition by using the ApiManager directly and it would break the existing if we remove the filtering.



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rffecoolav.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim67-synchronizer/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
