### PR TITLE
fix: Apply plan tag validation during API update

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/TagsValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/TagsValidationServiceImpl.java
@@ -87,12 +87,17 @@ public class TagsValidationServiceImpl extends AbstractService implements TagsVa
             var apiTags = api.getDefinitionVersion() == DefinitionVersion.V4
                 ? objectMapper.readValue(api.getDefinition(), io.gravitee.definition.model.v4.Api.class).getTags()
                 : objectMapper.readValue(api.getDefinition(), io.gravitee.definition.model.Api.class).getTags();
-            if (!isEmpty(planTags) && (isEmpty(apiTags) || !apiTags.stream().anyMatch(apiTag -> planTags.contains(apiTag)))) {
-                log.debug("Plan rejected, tags {} mismatch the tags defined by the API ({})", planTags, apiTags);
-                throw new TagNotAllowedException(planTags.toArray(new String[planTags.size()]));
-            }
+            validatePlanTagsAgainstApiTags(planTags, apiTags);
         } catch (JsonProcessingException e) {
             throw new TechnicalManagementException("An error occurs while trying load api definition", e);
+        }
+    }
+
+    @Override
+    public void validatePlanTagsAgainstApiTags(Set<String> planTags, Set<String> apiTags) {
+        if (!isEmpty(planTags) && (isEmpty(apiTags) || !apiTags.stream().anyMatch(apiTag -> planTags.contains(apiTag)))) {
+            log.debug("Plan rejected, tags {} mismatch the tags defined by the API ({})", planTags, apiTags);
+            throw new TagNotAllowedException(planTags.toArray(new String[planTags.size()]));
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/TagsValidationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/TagsValidationService.java
@@ -29,7 +29,9 @@ public interface TagsValidationService {
     /**
      * Check if the plan tags are compatible with the tags defined for the API.
      * @param planTags
-     * @param apiTags
+     * @param api
      */
     void validatePlanTagsAgainstApiTags(Set<String> planTags, Api api);
+
+    void validatePlanTagsAgainstApiTags(Set<String> planTags, Set<String> apiTags);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiServiceImplTest.java
@@ -24,6 +24,7 @@ import io.gravitee.rest.api.model.PropertyEntity;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.PrimaryOwnerNotFoundException;
+import io.gravitee.rest.api.service.v4.validation.TagsValidationService;
 import java.security.GeneralSecurityException;
 import java.util.List;
 import java.util.Map;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_CreateTest.java
@@ -179,7 +179,9 @@ public class PlanService_CreateTest {
         when(apiRepository.findById(API_ID)).thenReturn(Optional.of(api));
         when(this.newPlanEntity.getTags()).thenReturn(Set.of("tag1"));
 
-        doThrow(new TagNotAllowedException(new String[0])).when(tagsValidationService).validatePlanTagsAgainstApiTags(any(), any());
+        doThrow(new TagNotAllowedException(new String[0]))
+            .when(tagsValidationService)
+            .validatePlanTagsAgainstApiTags(any(), any(Api.class));
 
         planService.create(GraviteeContext.getExecutionContext(), this.newPlanEntity);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PlanService_UpdateTest.java
@@ -383,7 +383,9 @@ public class PlanService_UpdateTest {
         when(updatePlan.getName()).thenReturn("NameUpdated");
         when(updatePlan.getTags()).thenReturn(Set.of("tag1"));
 
-        doThrow(new TagNotAllowedException(new String[0])).when(tagsValidationService).validatePlanTagsAgainstApiTags(any(), any());
+        doThrow(new TagNotAllowedException(new String[0]))
+            .when(tagsValidationService)
+            .validatePlanTagsAgainstApiTags(any(), any(Api.class));
 
         planService.update(GraviteeContext.getExecutionContext(), updatePlan);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_CreateTest.java
@@ -134,7 +134,9 @@ public class PlanService_CreateTest {
         mockApiDefinitionVersion();
         when(apiRepository.findById(API_ID)).thenReturn(Optional.of(api));
         when(this.newPlanEntity.getTags()).thenReturn(Set.of("tag1"));
-        doThrow(new TagNotAllowedException(new String[0])).when(tagsValidationService).validatePlanTagsAgainstApiTags(any(), any());
+        doThrow(new TagNotAllowedException(new String[0]))
+            .when(tagsValidationService)
+            .validatePlanTagsAgainstApiTags(any(), any(Api.class));
         planService.create(GraviteeContext.getExecutionContext(), this.newPlanEntity);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_UpdateTest.java
@@ -364,7 +364,9 @@ public class PlanService_UpdateTest {
         when(updatePlan.getName()).thenReturn("NameUpdated");
         when(updatePlan.getTags()).thenReturn(Set.of("tag1"));
 
-        doThrow(new TagNotAllowedException(new String[0])).when(tagsValidationService).validatePlanTagsAgainstApiTags(any(), any());
+        doThrow(new TagNotAllowedException(new String[0]))
+            .when(tagsValidationService)
+            .validatePlanTagsAgainstApiTags(any(), any(Api.class));
 
         planService.update(GraviteeContext.getExecutionContext(), updatePlan);
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-587

## Description

The first fix of APIM-587 didn't manage the case here the API is updated with a removed tag used by a plan (Plan A use the tag X and the API is updated without the Tag X)
 
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zypmrenzfp.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-587-fix-api-update-usecase/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
