### PR TITLE
bump swagger version

### DIFF
--- a/gravitee-apim-console-webui/src/components/documentation/edit-page.component.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/edit-page.component.ts
@@ -206,9 +206,7 @@ class EditPageComponentController implements IController {
     this.DocumentationService.update(this.page, this.apiId)
       .then((response) => {
         if (response.data.messages && response.data.messages.length > 0) {
-          this.NotificationService.showError(
-            "'" + this.page.name + "' has been updated (with validation errors - check the bottom of the page for details)",
-          );
+          this.NotificationService.showError("'" + this.page.name + "' has been updated (with validation errors)");
         } else {
           this.NotificationService.show("'" + this.page.name + "' has been updated");
         }

--- a/gravitee-apim-console-webui/src/components/documentation/new-page.component.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/new-page.component.ts
@@ -137,9 +137,7 @@ class NewPageComponentController implements IController {
       .then((response: any) => {
         const page = response.data;
         if (page.messages && page.messages.length > 0) {
-          this.NotificationService.showError(
-            "'" + page.name + "' has been created (with validation errors - check the bottom of the page for details)",
-          );
+          this.NotificationService.showError("'" + page.name + "' has been created (with validation errors)");
         } else {
           this.NotificationService.show("'" + page.name + "' has been created");
         }

--- a/gravitee-apim-e2e/api-test/src/imports/api-import-with-pages.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/imports/api-import-with-pages.spec.ts
@@ -286,7 +286,7 @@ describe('API - Imports with pages', () => {
           definitionVersion,
           importSwaggerDescriptorEntity: { payload: '' },
         }),
-        500,
+        400,
       );
     });
   });

--- a/pom.xml
+++ b/pom.xml
@@ -122,10 +122,9 @@
         <reactor-adapter.version>3.4.6</reactor-adapter.version>
         <slf4j-mock.version>2.2.0</slf4j-mock.version>
         <snakeyaml.version>1.32</snakeyaml.version>
-        <swagger-jaxrs2.version>2.1.13</swagger-jaxrs2.version>
-        <swagger-core.version>2.1.13</swagger-core.version>
-        <swagger-parser.version>2.0.30</swagger-parser.version>
-        <swagger-models.version>1.6.4</swagger-models.version>
+        <swagger-jaxrs2.version>2.2.8</swagger-jaxrs2.version>
+        <swagger-core.version>2.2.8</swagger-core.version>
+        <swagger-parser.version>2.1.11</swagger-parser.version>
         <testcontainers.version>1.17.3</testcontainers.version>
         <xmlbeans.version>3.1.0</xmlbeans.version>
         <wiremock.version>2.27.2</wiremock.version>
@@ -545,12 +544,6 @@
                         <artifactId>validation-api</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>io.swagger</groupId>
-                <artifactId>swagger-models</artifactId>
-                <version>${swagger-models.version}</version>
             </dependency>
 
             <!-- JAXB API & implementation -->


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8858
https://gravitee.atlassian.net/browse/APIM-712

## Description

swagger-core to latest 2.2.8
swagger-parser to latest 2.1.13
remove swagger-model

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tkdjhsuuod.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/upgrade-swagger-lib-version-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
