### PR TITLE
refactor(plugin): make SUPPORTED_LISTENER_TYPE public to be able to use in advanced plugin

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-sse/src/main/java/io/gravitee/plugin/entrypoint/sse/SseEntrypointConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-sse/src/main/java/io/gravitee/plugin/entrypoint/sse/SseEntrypointConnector.java
@@ -56,7 +56,7 @@ public class SseEntrypointConnector extends EntrypointAsyncConnector {
     public static final String HEADER_LAST_EVENT_ID = "Last-Event-ID";
     public static final Set<ConnectorMode> SUPPORTED_MODES = Set.of(ConnectorMode.SUBSCRIBE);
     static final Set<Qos> SUPPORTED_QOS = Set.of(Qos.NONE, Qos.AUTO);
-    static final ListenerType SUPPORTED_LISTENER_TYPE = ListenerType.HTTP;
+    public static final ListenerType SUPPORTED_LISTENER_TYPE = ListenerType.HTTP;
     private static final String ENTRYPOINT_ID = "sse";
     private static final int RETRY_MIN_VALUE = 1000;
     private static final int RETRY_MAX_VALUE = 30000;

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/main/java/io/gravitee/plugin/entrypoint/webhook/WebhookEntrypointConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/main/java/io/gravitee/plugin/entrypoint/webhook/WebhookEntrypointConnector.java
@@ -65,7 +65,7 @@ public class WebhookEntrypointConnector extends EntrypointAsyncConnector {
     public static final String ENTRYPOINT_ID = "webhook";
     public static final Set<ConnectorMode> SUPPORTED_MODES = Set.of(ConnectorMode.SUBSCRIBE);
     public static final Set<Qos> SUPPORTED_QOS = Set.of(Qos.NONE, Qos.AUTO, Qos.AT_MOST_ONCE, Qos.AT_LEAST_ONCE);
-    static final ListenerType SUPPORTED_LISTENER_TYPE = ListenerType.SUBSCRIPTION;
+    public static final ListenerType SUPPORTED_LISTENER_TYPE = ListenerType.SUBSCRIPTION;
     public static final String INTERNAL_ATTR_WEBHOOK_HTTP_CLIENT = "webhook.httpClient";
     public static final String INTERNAL_ATTR_WEBHOOK_SUBSCRIPTION_CONFIG = "webhook.subscriptionConfiguration";
     public static final String STOPPING_MESSAGE = "Stopping, please reconnect";


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-574

## Description

make SUPPORTED_LISTENER_TYPE public to be able to use in advanced plugin

Sad to see it too late 😢 I thought that the factory was extend as for the Connector but in fact it is implement 


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-exbhvvrthl.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-574-listenertype/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
