### PR TITLE
Bump gravitee-bom to `3.0.1-renovate-jackson-version-SNAPSHOT`

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/test/java/io/gravitee/plugin/entrypoint/webhook/WebhookEntrypointConnectorTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/test/java/io/gravitee/plugin/entrypoint/webhook/WebhookEntrypointConnectorTest.java
@@ -544,7 +544,7 @@ class WebhookEntrypointConnectorTest {
         verify(ctx).setInternalAttribute(INTERNAL_ATTR_WEBHOOK_SUBSCRIPTION_CONFIG, subscriptionConfiguration);
         verify(ctx).setInternalAttribute(eq(INTERNAL_ATTR_WEBHOOK_HTTP_CLIENT), httpClientCaptor.capture());
 
-        HttpClientOptions options = ((HttpClientImpl) httpClientCaptor.getValue().getDelegate()).getOptions();
+        HttpClientOptions options = ((HttpClientImpl) httpClientCaptor.getValue().getDelegate()).options();
         assertThat(options.isSsl()).isTrue();
         assertThat(options.getDefaultHost()).isEqualTo("localhost");
         assertThat(options.getDefaultPort()).isEqualTo(473);
@@ -561,7 +561,7 @@ class WebhookEntrypointConnectorTest {
         verify(ctx).setInternalAttribute(INTERNAL_ATTR_WEBHOOK_SUBSCRIPTION_CONFIG, subscriptionConfiguration);
         verify(ctx).setInternalAttribute(eq(INTERNAL_ATTR_WEBHOOK_HTTP_CLIENT), httpClientCaptor.capture());
 
-        HttpClientOptions options = ((HttpClientImpl) httpClientCaptor.getValue().getDelegate()).getOptions();
+        HttpClientOptions options = ((HttpClientImpl) httpClientCaptor.getValue().getDelegate()).options();
         assertThat(options.isSsl()).isFalse();
         assertThat(options.getDefaultHost()).isEqualTo("localhost");
         assertThat(options.getDefaultPort()).isEqualTo(473);

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <!-- Vert.X version is mandatory for vertx-grpc-protoc-plugin in gravitee-apim-gateway-standalone-container -->
         <vertx.version>4.2.7</vertx.version>
         <!-- Gravitee dependencies version -->
-        <gravitee-bom.version>3.0.0</gravitee-bom.version>
+        <gravitee-bom.version>3.0.1-update-deps-SNAPSHOT</gravitee-bom.version>
         <gravitee-alert-api.version>1.9.1</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>2.0.0</gravitee-cockpit-api.version>
         <gravitee-common.version>2.1.0-alpha.5</gravitee-common.version>


### PR DESCRIPTION
## Issue

NA

## Description

Bump gravitee-bom to `3.0.1-renovate-jackson-version-SNAPSHOT`
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xbxhqruzkj.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/update-jackson-deps-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
