### PR TITLE
fix: fix first message which wasn't recordable

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/v4/analytics/sampling/CountMessageSamplingStrategy.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/v4/analytics/sampling/CountMessageSamplingStrategy.java
@@ -51,6 +51,6 @@ public class CountMessageSamplingStrategy implements MessageSamplingStrategy {
 
     @Override
     public boolean isRecordable(final Message message, final int messageCount, final long lastMessageTimestamp) {
-        return messageCount % count == 1;
+        return messageCount == 1 || messageCount % count == 1;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/v4/analytics/sampling/ProbabilityMessageStrategy.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/v4/analytics/sampling/ProbabilityMessageStrategy.java
@@ -53,7 +53,7 @@ public class ProbabilityMessageStrategy implements MessageSamplingStrategy {
 
     @Override
     public boolean isRecordable(final Message message, final int messageCount, final long lastMessageTimestamp) {
-        return matchesProbability(random.nextDouble());
+        return messageCount == 1 || matchesProbability(random.nextDouble());
     }
 
     protected boolean matchesProbability(final Double random) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/v4/analytics/sampling/TemporalMessageSamplingStrategy.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/v4/analytics/sampling/TemporalMessageSamplingStrategy.java
@@ -53,6 +53,6 @@ public class TemporalMessageSamplingStrategy implements MessageSamplingStrategy 
 
     @Override
     public boolean isRecordable(final Message message, final int messageCount, final long lastMessageTimestamp) {
-        return message.timestamp() - lastMessageTimestamp >= periodInMs;
+        return messageCount == 1 || lastMessageTimestamp == -1 || message.timestamp() - lastMessageTimestamp >= periodInMs;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/jupiter/core/v4/analytics/sampling/CountMessageSamplingStrategyTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/jupiter/core/v4/analytics/sampling/CountMessageSamplingStrategyTest.java
@@ -97,4 +97,16 @@ class CountMessageSamplingStrategyTest {
         // Then
         assertThat(recordable).isFalse();
     }
+
+    @Test
+    void should_be_recordable_when_first_message() {
+        // Given
+        CountMessageSamplingStrategy countMessageSamplingStrategy = new CountMessageSamplingStrategy(null);
+
+        // When
+        boolean recordable = countMessageSamplingStrategy.isRecordable(DefaultMessage.builder().build(), 1, -1);
+
+        // Then
+        assertThat(recordable).isTrue();
+    }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/jupiter/core/v4/analytics/sampling/ProbabilityMessageStrategyTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/jupiter/core/v4/analytics/sampling/ProbabilityMessageStrategyTest.java
@@ -105,4 +105,16 @@ class ProbabilityMessageStrategyTest {
         // Then
         assertThat(recordable).isFalse();
     }
+
+    @Test
+    void should_be_recordable_when_first_message() {
+        // Given
+        ProbabilityMessageStrategy probabilityMessageStrategy = new ProbabilityMessageStrategy(null);
+
+        // When
+        boolean recordable = probabilityMessageStrategy.isRecordable(DefaultMessage.builder().build(), 1, -1);
+
+        // Then
+        assertThat(recordable).isTrue();
+    }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/jupiter/core/v4/analytics/sampling/TemporalMessageSamplingStrategyTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/jupiter/core/v4/analytics/sampling/TemporalMessageSamplingStrategyTest.java
@@ -114,4 +114,28 @@ class TemporalMessageSamplingStrategyTest {
         // Then
         assertThat(recordable).isFalse();
     }
+
+    @Test
+    void should_be_recordable_when_first_message() {
+        // Given
+        TemporalMessageSamplingStrategy temporalMessageSamplingStrategy = new TemporalMessageSamplingStrategy(null);
+
+        // When
+        boolean recordable = temporalMessageSamplingStrategy.isRecordable(DefaultMessage.builder().build(), 1, System.currentTimeMillis());
+
+        // Then
+        assertThat(recordable).isTrue();
+    }
+
+    @Test
+    void should_be_recordable_when_last_timestamp_undefined() {
+        // Given
+        TemporalMessageSamplingStrategy temporalMessageSamplingStrategy = new TemporalMessageSamplingStrategy(null);
+
+        // When
+        boolean recordable = temporalMessageSamplingStrategy.isRecordable(DefaultMessage.builder().build(), 46587, -1);
+
+        // Then
+        assertThat(recordable).isTrue();
+    }
 }


### PR DESCRIPTION

## Description

   - for temporal sampling strategy, if count=1 or lastTime=-1 the message will be tagged as recordable
   - for probability & count sampling strategy, if count=1 the message will be tagged as recordable



<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vesfdrbkxp.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/improve-message-sampling/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
