### PR TITLE
Management API - Expose entrypoints supportedListenerType

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/listener/ListenerType.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/listener/ListenerType.java
@@ -20,7 +20,9 @@ import static io.gravitee.definition.model.v4.listener.Listener.SUBSCRIPTION_LAB
 import static io.gravitee.definition.model.v4.listener.Listener.TCP_LABEL;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import io.gravitee.definition.model.v4.ConnectorMode;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Map;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -36,6 +38,15 @@ public enum ListenerType {
     SUBSCRIPTION(SUBSCRIPTION_LABEL),
     TCP(TCP_LABEL);
 
+    private static final Map<String, ListenerType> LABELS_MAP = Map.of(HTTP.label, HTTP, SUBSCRIPTION.label, SUBSCRIPTION, TCP.label, TCP);
+
     @JsonValue
     private final String label;
+
+    public static ListenerType fromLabel(final String label) {
+        if (label != null) {
+            return LABELS_MAP.get(label);
+        }
+        return null;
+    }
 }

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -763,8 +763,8 @@
                 <gravitee-policy-assign-metrics.version>2.0.1</gravitee-policy-assign-metrics.version>
                 <gravitee-policy-data-logging-masking.version>2.0.1</gravitee-policy-data-logging-masking.version>
                 <gravitee-policy-interrupt.version>1.1.0</gravitee-policy-interrupt.version>
-                <gravitee-entrypoint-sse-advanced.version>2.0.0-alpha.5</gravitee-entrypoint-sse-advanced.version>
-                <gravitee-entrypoint-webhook-advanced.version>1.0.0-alpha.1</gravitee-entrypoint-webhook-advanced.version>
+                <gravitee-entrypoint-sse-advanced.version>3.0.0-alpha.1</gravitee-entrypoint-sse-advanced.version>
+                <gravitee-entrypoint-webhook-advanced.version>1.0.0-alpha.3</gravitee-entrypoint-webhook-advanced.version>
                 <gravitee-endpoint-kafka-advanced.version>1.0.0-alpha.8</gravitee-endpoint-kafka-advanced.version>
                 <gravitee-endpoint-mqtt5-advanced.version>1.0.0-alpha.4</gravitee-endpoint-mqtt5-advanced.version>
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/v4/connector/AbstractConnectorsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/v4/connector/AbstractConnectorsResource.java
@@ -58,6 +58,7 @@ public abstract class AbstractConnectorsResource {
         connectorExpandPluginEntity.setSupportedApiType(endpointPluginEntity.getSupportedApiType());
         connectorExpandPluginEntity.setSupportedModes(endpointPluginEntity.getSupportedModes());
         connectorExpandPluginEntity.setAvailableFeatures(endpointPluginEntity.getAvailableFeatures());
+        connectorExpandPluginEntity.setSupportedListenerType(endpointPluginEntity.getSupportedListenerType());
 
         return connectorExpandPluginEntity;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/v4/entrypoint/EntrypointResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/v4/entrypoint/EntrypointResource.java
@@ -60,7 +60,7 @@ public class EntrypointResource {
     @ApiResponse(
         responseCode = "200",
         description = "Entrypoint plugin",
-        content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = PlatformPluginEntity.class))
+        content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = ConnectorPluginEntity.class))
     )
     @ApiResponse(responseCode = "404", description = "Entrypoint not found")
     @ApiResponse(responseCode = "500", description = "Internal server error")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/v4/entrypoint/EntrypointsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/v4/entrypoint/EntrypointsResourceTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.ConnectorMode;
+import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.rest.api.management.rest.resource.AbstractResourceTest;
 import io.gravitee.rest.api.model.v4.connector.ConnectorPluginEntity;
 import io.gravitee.rest.api.service.common.GraviteeContext;
@@ -58,6 +59,7 @@ public class EntrypointsResourceTest extends AbstractResourceTest {
         connectorPlugin.setVersion("1.0");
         connectorPlugin.setSupportedApiType(ApiType.ASYNC);
         connectorPlugin.setSupportedModes(Set.of(ConnectorMode.SUBSCRIBE));
+        connectorPlugin.setSupportedListenerType(ListenerType.HTTP);
         when(entrypointConnectorPluginService.findAll()).thenReturn(Set.of(connectorPlugin));
 
         final Response response = envTarget().request().get();
@@ -69,6 +71,7 @@ public class EntrypointsResourceTest extends AbstractResourceTest {
         assertEquals("name", pluginEntity.get("name"));
         assertEquals("1.0", pluginEntity.get("version"));
         assertEquals(ApiType.ASYNC.getLabel(), pluginEntity.get("supportedApiType"));
+        assertEquals(ListenerType.HTTP.getLabel(), pluginEntity.get("supportedListenerType"));
         ArrayList<String> arrayList = new ArrayList<>();
         arrayList.add(ConnectorMode.SUBSCRIBE.getLabel());
         assertEquals(arrayList, pluginEntity.get("supportedModes"));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/connector/ConnectorPluginEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/connector/ConnectorPluginEntity.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.model.v4.connector;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.ConnectorFeature;
 import io.gravitee.definition.model.v4.ConnectorMode;
+import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.definition.model.v4.listener.entrypoint.Qos;
 import io.gravitee.rest.api.model.platform.plugin.PlatformPluginEntity;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -47,4 +48,6 @@ public class ConnectorPluginEntity extends PlatformPluginEntity {
     private Set<Qos> supportedQos;
 
     private Set<ConnectorFeature> availableFeatures;
+
+    private ListenerType supportedListenerType;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/exception/ListenerEntrypointUnsupportedListenerTypeException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/exception/ListenerEntrypointUnsupportedListenerTypeException.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.exception;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.service.exceptions.AbstractManagementException;
+import java.util.Collections;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+
+@RequiredArgsConstructor
+public class ListenerEntrypointUnsupportedListenerTypeException extends AbstractManagementException {
+
+    private final String type;
+    private final String unsupportedListenerType;
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "listeners.entrypoints.type.unsupported";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public String getMessage() {
+        return "The entrypoint [" + type + "] doesn't support given listener type [" + unsupportedListenerType + "].";
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/AbstractConnectorPluginService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/AbstractConnectorPluginService.java
@@ -18,9 +18,11 @@ package io.gravitee.rest.api.service.v4.impl;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.ConnectorFeature;
 import io.gravitee.definition.model.v4.ConnectorMode;
+import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.definition.model.v4.listener.entrypoint.Qos;
 import io.gravitee.gateway.jupiter.api.connector.ConnectorFactory;
 import io.gravitee.gateway.jupiter.api.connector.endpoint.async.EndpointAsyncConnectorFactory;
+import io.gravitee.gateway.jupiter.api.connector.entrypoint.EntrypointConnectorFactory;
 import io.gravitee.gateway.jupiter.api.connector.entrypoint.async.EntrypointAsyncConnectorFactory;
 import io.gravitee.plugin.core.api.ConfigurablePlugin;
 import io.gravitee.plugin.core.api.ConfigurablePluginManager;
@@ -96,6 +98,14 @@ public abstract class AbstractConnectorPluginService<T extends ConfigurablePlugi
         if (connectorFactory.supportedApi() != null) {
             entity.setSupportedApiType(ApiType.fromLabel(connectorFactory.supportedApi().getLabel()));
         }
+
+        if (connectorFactory instanceof EntrypointConnectorFactory) {
+            EntrypointConnectorFactory entrypointConnectorFactory = (EntrypointConnectorFactory) connectorFactory;
+            if (entrypointConnectorFactory.supportedListenerType() != null) {
+                entity.setSupportedListenerType(ListenerType.fromLabel(entrypointConnectorFactory.supportedListenerType().getLabel()));
+            }
+        }
+
         if (
             plugin.manifest().properties() != null &&
             plugin.manifest().properties().get("features") != null &&

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ListenerValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ListenerValidationServiceImpl.java
@@ -150,6 +150,7 @@ public class ListenerValidationServiceImpl extends TransactionalService implemen
                 }
                 final ConnectorPluginEntity connectorPlugin = entrypointService.findById(entrypoint.getType());
 
+                checkEntrypointListenerType(type, connectorPlugin);
                 checkEntrypointQos(entrypoint, connectorPlugin);
                 checkEntrypointDlq(entrypoint, endpointGroups, connectorPlugin);
                 checkEntrypointConfiguration(entrypoint);
@@ -212,6 +213,12 @@ public class ListenerValidationServiceImpl extends TransactionalService implemen
             entrypointConfiguration = entrypoint.getConfiguration();
         }
         entrypoint.setConfiguration(entrypointService.validateConnectorConfiguration(entrypoint.getType(), entrypointConfiguration));
+    }
+
+    private void checkEntrypointListenerType(final ListenerType type, final ConnectorPluginEntity connectorPlugin) {
+        if (connectorPlugin.getSupportedListenerType() != null && type != connectorPlugin.getSupportedListenerType()) {
+            throw new ListenerEntrypointUnsupportedListenerTypeException(connectorPlugin.getId(), type.getLabel());
+        }
     }
 
     private void checkDuplicatedEntrypoints(final ListenerType type, final List<Entrypoint> entrypoints) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/EntrypointPluginServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/EntrypointPluginServiceImplTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 
 import io.gravitee.definition.model.v4.ConnectorMode;
 import io.gravitee.gateway.jupiter.api.ApiType;
+import io.gravitee.gateway.jupiter.api.ListenerType;
 import io.gravitee.gateway.jupiter.api.connector.entrypoint.EntrypointConnectorFactory;
 import io.gravitee.plugin.core.api.PluginManifest;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
@@ -73,6 +74,7 @@ public class EntrypointPluginServiceImplTest {
         when(pluginManager.get(PLUGIN_ID)).thenReturn(mockPlugin);
         when(mockFactory.supportedApi()).thenReturn(ApiType.ASYNC);
         when(mockFactory.supportedModes()).thenReturn(Set.of(io.gravitee.gateway.jupiter.api.ConnectorMode.REQUEST_RESPONSE));
+        when(mockFactory.supportedListenerType()).thenReturn(ListenerType.HTTP);
     }
 
     @Test
@@ -101,10 +103,11 @@ public class EntrypointPluginServiceImplTest {
 
     @Test
     public void shouldFindById() {
-        PlatformPluginEntity result = entrypointService.findById(PLUGIN_ID);
+        ConnectorPluginEntity result = entrypointService.findById(PLUGIN_ID);
 
         assertNotNull(result);
         assertEquals(PLUGIN_ID, result.getId());
+        assertEquals(io.gravitee.definition.model.v4.listener.ListenerType.HTTP, result.getSupportedListenerType());
     }
 
     @Test(expected = PluginNotFoundException.class)


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-574

## Description


Now that each entrypoints plugin exposes the supported listener type this PR uses it to 
- Validate api listeners[].entrypoints[] for Api Creation
- Expose it to rest api


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gyukzvfowi.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-574-listenertype/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
