### PR TITLE
Apim 653 migrate api members

### DIFF
--- a/gravitee-apim-console-webui/src/entities/api/ApiMembers.ts
+++ b/gravitee-apim-console-webui/src/entities/api/ApiMembers.ts
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './Api';
-export * from './UpdateApi';
-export * from './ApiMembers';
-export * from './ApiMembership';
+export class ApiMember {
+  id: string;
+  displayName?: string;
+  role: string;
+  username?: string;
+  reference?: string;
+}

--- a/gravitee-apim-console-webui/src/entities/api/ApiMembership.ts
+++ b/gravitee-apim-console-webui/src/entities/api/ApiMembership.ts
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './Api';
-export * from './UpdateApi';
-export * from './ApiMembers';
-export * from './ApiMembership';
+export class ApiMembership {
+  id?: string;
+  reference?: string;
+  role: string;
+}

--- a/gravitee-apim-console-webui/src/management/api/apis.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis.module.ts
@@ -30,8 +30,8 @@ import { ApiPortalUserGroupModule } from './portal/user-group-access/api-portal-
     ApiNavigationModule,
     ApiPortalDetailsModule,
     ApiPortalPlansModule,
-    ApiPortalUserGroupModule,
     ApiProxyModule,
+    ApiPortalUserGroupModule,
   ],
 })
 export class ApisModule {}

--- a/gravitee-apim-console-webui/src/management/api/portal/apis.portal.route.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/apis.portal.route.ts
@@ -226,6 +226,19 @@ function apisPortalRouterConfig($stateProvider) {
         },
       },
     })
+    .state('management.apis.detail.portal.ngmembers', {
+      url: '/ng-members',
+      component: 'ngApiMembers',
+      data: {
+        useAngularMaterial: true,
+        perms: {
+          only: ['api-member-r'],
+        },
+        docs: {
+          page: 'management-api-members',
+        },
+      },
+    })
     .state('management.apis.detail.portal.groups', {
       url: '/groups',
       component: 'ngApiPortalGroups',

--- a/gravitee-apim-console-webui/src/management/api/portal/user-group-access/api-portal-user-group.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/user-group-access/api-portal-user-group.module.ts
@@ -15,27 +15,37 @@
  */
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { GioIconsModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
+import { GioAvatarModule, GioIconsModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
 import { MatSelectModule } from '@angular/material/select';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatCardModule } from '@angular/material/card';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { UIRouterModule } from '@uirouter/angular';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatButtonModule } from '@angular/material/button';
+import { MatTableModule } from '@angular/material/table';
 
 import { ApiPortalGroupsComponent } from './groups/api-portal-groups.component';
+import { ApiPortalMembersComponent } from './members/api-portal-members.component';
 
 import { GioPermissionModule } from '../../../../shared/components/gio-permission/gio-permission.module';
 
 @NgModule({
-  declarations: [ApiPortalGroupsComponent],
-  exports: [ApiPortalGroupsComponent],
+  declarations: [ApiPortalGroupsComponent, ApiPortalMembersComponent],
+  exports: [ApiPortalGroupsComponent, ApiPortalMembersComponent],
   imports: [
     CommonModule,
+    UIRouterModule,
     ReactiveFormsModule,
 
-    MatSelectModule,
+    MatButtonModule,
     MatCardModule,
+    MatCheckboxModule,
+    MatSelectModule,
     MatSnackBarModule,
+    MatTableModule,
 
+    GioAvatarModule,
     GioIconsModule,
     GioPermissionModule,
     GioSaveBarModule,

--- a/gravitee-apim-console-webui/src/management/api/portal/user-group-access/members/api-portal-members.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/user-group-access/members/api-portal-members.component.html
@@ -1,0 +1,60 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h3>{{ members?.length }} direct members</h3>
+<mat-card>
+  <form [formGroup]="form" *ngIf="form">
+    <mat-checkbox formControlName="isNotificationsEnabled">Enable notifications when members are added to this API</mat-checkbox>
+
+    <table
+      mat-table
+      *ngIf="dataSource"
+      [dataSource]="dataSource"
+      class="api-portal-members__table"
+      formGroupName="members"
+      aria-label="members table"
+    >
+      <ng-container matColumnDef="picture">
+        <th mat-header-cell *matHeaderCellDef></th>
+        <td mat-cell *matCellDef="let member">
+          <gio-avatar [src]="member.picture" [name]="member.displayName" size="24"></gio-avatar>
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="displayName">
+        <th mat-header-cell *matHeaderCellDef>Name</th>
+        <td mat-cell *matCellDef="let member" [class.primary-owner-name]="member.role === 'PRIMARY_OWNER'">
+          {{ member.name }}
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="role">
+        <th mat-header-cell *matHeaderCellDef>Role</th>
+        <td mat-cell *matCellDef="let member">
+          <mat-select [formControlName]="member.id">
+            <mat-option *ngFor="let role of roles" [value]="role.name" [disabled]="role.name === 'PRIMARY_OWNER'">{{
+              role.name
+            }}</mat-option>
+          </mat-select>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+  </form>
+</mat-card>
+
+<gio-save-bar [form]="form" [formInitialValues]="formInitialValues" (submitted)="onSubmit()"></gio-save-bar>

--- a/gravitee-apim-console-webui/src/management/api/portal/user-group-access/members/api-portal-members.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/portal/user-group-access/members/api-portal-members.component.scss
@@ -1,0 +1,17 @@
+@use '../../../../../scss/gio-layout' as gio-layout;
+
+:host {
+  @include gio-layout.gio-responsive-content-container;
+}
+
+.api-portal-members__table {
+  width: 100%;
+}
+
+.mat-column-picture {
+  padding: 0 4px;
+}
+
+.primary-owner-name {
+  font-weight: bold;
+}

--- a/gravitee-apim-console-webui/src/management/api/portal/user-group-access/members/api-portal-members.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/user-group-access/members/api-portal-members.component.spec.ts
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { of } from 'rxjs';
+import { MatOptionHarness } from '@angular/material/core/testing';
+
+import { ApiPortalMembersComponent } from './api-portal-members.component';
+import { ApiPortalMembersHarness } from './api-portal-members.harness';
+
+import { CONSTANTS_TESTING, GioHttpTestingModule } from '../../../../../shared/testing';
+import { ApiPortalUserGroupModule } from '../api-portal-user-group.module';
+import { fakeApi } from '../../../../../entities/api/Api.fixture';
+import { Api, ApiMember } from '../../../../../entities/api';
+import { UsersService } from '../../../../../services-ngx/users.service';
+import { UIRouterStateParams } from '../../../../../ajs-upgraded-providers';
+import { RoleService } from '../../../../../services-ngx/role.service';
+import { Role } from '../../../../../entities/role/role';
+import { fakeRole } from '../../../../../entities/role/role.fixture';
+
+describe('ApiPortalMembersComponent', () => {
+  let fixture: ComponentFixture<ApiPortalMembersComponent>;
+  let httpTestingController: HttpTestingController;
+  let harness: ApiPortalMembersHarness;
+  const apiId = 'apiId';
+  const roles: Role[] = [fakeRole({ name: 'PRIMARY_OWNER' }), fakeRole({ name: 'OWNER' }), fakeRole({ name: 'USER' })];
+
+  beforeEach(async () => {
+    TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, GioHttpTestingModule, ApiPortalUserGroupModule],
+      providers: [
+        { provide: UIRouterStateParams, useValue: { apiId } },
+        { provide: UsersService, useValue: { getUserAvatar: () => 'avatar' } },
+        { provide: RoleService, useValue: { list: () => of(roles) } },
+      ],
+    });
+
+    fixture = TestBed.createComponent(ApiPortalMembersComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiPortalMembersHarness);
+
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    httpTestingController.verify();
+  });
+
+  describe('API member change notification', () => {
+    it('should uncheck box when notifications are off', async () => {
+      const api = fakeApi({ id: apiId, disable_membership_notifications: true });
+      expectApiGetRequest(api);
+      expectApiMembersGetRequest();
+
+      expect(await harness.isNotificationsCheckboxChecked()).toEqual(false);
+    });
+
+    it('should show save bar when checkbox is toggles', async () => {
+      const api = fakeApi({ id: apiId, disable_membership_notifications: false });
+      expectApiGetRequest(api);
+      expectApiMembersGetRequest();
+
+      expect(await harness.isNotificationsCheckboxChecked()).toEqual(true);
+      await harness.toggleNotificationCheckbox();
+
+      expect(await harness.isSaveBarVisible()).toEqual(true);
+    });
+
+    it('should save notifications modifications when clicking on save bar', async () => {
+      const api = fakeApi({ id: apiId, disable_membership_notifications: false });
+      expectApiGetRequest(api);
+      expectApiMembersGetRequest();
+
+      await harness.toggleNotificationCheckbox();
+
+      await harness.clickOnSave();
+
+      // Setup all http calls for save + new OnInit execution
+      // save
+      expectApiGetRequest(api);
+      const req = httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/apis/${apiId}`, method: 'PUT' });
+      expect(req.request.body.disable_membership_notifications).toEqual(true);
+      req.flush(api);
+      // init
+      expectApiGetRequest(api);
+      expectApiMembersGetRequest();
+    });
+  });
+
+  describe('List members', () => {
+    it('should show all api members with roles', async () => {
+      const api = fakeApi({ id: apiId });
+      const members: ApiMember[] = [
+        { id: '1', displayName: 'Mufasa', role: 'King' },
+        { id: '2', displayName: 'Simba', role: 'Prince' },
+      ];
+      expectApiGetRequest(api);
+      expectApiMembersGetRequest(members);
+
+      expect((await harness.getTableRows()).length).toEqual(2);
+      expect(await harness.getMembersName()).toEqual(['Mufasa', 'Simba']);
+    });
+
+    it('should show username when no display name', async () => {
+      const api = fakeApi({ id: apiId });
+      const members: ApiMember[] = [{ id: '1', username: 'bot', role: 'USER' }];
+      expectApiGetRequest(api);
+      expectApiMembersGetRequest(members);
+
+      expect(await harness.getMembersName()).toEqual(['bot']);
+    });
+
+    it('should show username next to displayName when no display name', async () => {
+      const api = fakeApi({ id: apiId });
+      const members: ApiMember[] = [{ id: '1', displayName: 'Regular user', username: 'bot', role: 'USER' }];
+      expectApiGetRequest(api);
+      expectApiMembersGetRequest(members);
+
+      expect(await harness.getMembersName()).toEqual(['Regular user (bot)']);
+    });
+
+    it('should make role readonly when user is PRIMARY OWNER', async () => {
+      const api = fakeApi({ id: apiId, disable_membership_notifications: false });
+      const members: ApiMember[] = [{ id: '1', displayName: 'admin', role: 'PRIMARY_OWNER' }];
+      expectApiGetRequest(api);
+      expectApiMembersGetRequest(members);
+
+      expect(await harness.isMemberRoleSelectDisabled(0)).toEqual(true);
+    });
+
+    it('should make role editable when user is not PRIMARY OWNER', async () => {
+      const api = fakeApi({ id: apiId, disable_membership_notifications: false });
+      const members: ApiMember[] = [{ id: '1', displayName: 'owner', role: 'OWNER' }];
+      expectApiGetRequest(api);
+      expectApiMembersGetRequest(members);
+
+      expect(await harness.isMemberRoleSelectDisabled(0)).toEqual(false);
+      const roleOptions: MatOptionHarness[] = await harness.getMemberRoleSelectOptions(0);
+
+      const options: string[] = await Promise.all(roleOptions.map(async (opt) => await opt.getText()));
+      expect(options).toEqual(['PRIMARY_OWNER', 'OWNER', 'USER']);
+
+      const poOption = await harness.getMemberRoleSelectOptions(0, { text: 'PRIMARY_OWNER' });
+      expect(poOption.length).toEqual(1);
+      expect(await poOption[0].isDisabled()).toEqual(true);
+    });
+
+    it('should call API to change role when clicking on save', async () => {
+      const api = fakeApi({ id: apiId, disable_membership_notifications: false });
+      const members: ApiMember[] = [
+        { id: '1', displayName: 'owner', role: 'PRIMARY_OWNER' },
+        { id: '2', displayName: 'other', role: 'OWNER' },
+      ];
+      expectApiGetRequest(api);
+      expectApiMembersGetRequest(members);
+
+      await harness.getMemberRoleSelectForRowIndex(1).then(async (select) => {
+        await select.open();
+        return await select.clickOptions({ text: 'USER' });
+      });
+
+      await harness.clickOnSave();
+
+      // Setup all http calls for save + new OnInit execution
+      // save
+      const req = httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/apis/${apiId}/members`, method: 'POST' });
+      req.flush({});
+      expect(req.request.body).toEqual({ id: '2', reference: undefined, role: 'USER' });
+      // init
+      expectApiGetRequest(api);
+      expectApiMembersGetRequest();
+    });
+  });
+
+  function expectApiGetRequest(api: Api) {
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/apis/${apiId}`, method: 'GET' }).flush(api);
+    fixture.detectChanges();
+  }
+
+  function expectApiMembersGetRequest(members: ApiMember[] = []) {
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/apis/${apiId}/members`, method: 'GET' }).flush(members);
+    fixture.detectChanges();
+  }
+});

--- a/gravitee-apim-console-webui/src/management/api/portal/user-group-access/members/api-portal-members.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/user-group-access/members/api-portal-members.component.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, Inject, OnInit } from '@angular/core';
+import { combineLatest, EMPTY, Observable, Subject } from 'rxjs';
+import { catchError, switchMap, takeUntil, tap } from 'rxjs/operators';
+import { FormBuilder, FormControl, FormGroup } from '@angular/forms';
+
+import { Api, ApiMember } from '../../../../../entities/api';
+import { UIRouterStateParams } from '../../../../../ajs-upgraded-providers';
+import { ApiMemberService } from '../../../../../services-ngx/api-member.service';
+import { ApiService } from '../../../../../services-ngx/api.service';
+import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
+import { UsersService } from '../../../../../services-ngx/users.service';
+import { RoleService } from '../../../../../services-ngx/role.service';
+import { Role } from '../../../../../entities/role/role';
+
+class MembersDataSource extends ApiMember {
+  picture: string;
+  name: string;
+}
+@Component({
+  selector: 'api-portal-members',
+  template: require('./api-portal-members.component.html'),
+  styles: [require('./api-portal-members.component.scss')],
+})
+export class ApiPortalMembersComponent implements OnInit {
+  private unsubscribe$: Subject<boolean> = new Subject<boolean>();
+
+  form: FormGroup;
+  dataSource: MembersDataSource[];
+  members: ApiMember[];
+  displayedColumns = ['picture', 'displayName', 'role'];
+  roles: Role[];
+  formInitialValues: { isNotificationsEnabled: boolean; members: { [memberId: string]: string } };
+  private apiId: string;
+
+  constructor(
+    @Inject(UIRouterStateParams) private readonly ajsStateParams,
+    private readonly apiService: ApiService,
+    private readonly apiMembersService: ApiMemberService,
+    private readonly userService: UsersService,
+    private readonly roleService: RoleService,
+    private readonly snackBarService: SnackBarService,
+    private readonly formBuilder: FormBuilder,
+  ) {}
+
+  ngOnInit(): void {
+    this.apiId = this.ajsStateParams.apiId;
+    combineLatest([this.apiService.get(this.apiId), this.apiMembersService.getMembers(this.apiId), this.roleService.list('API')])
+      .pipe(
+        takeUntil(this.unsubscribe$),
+        tap(([api, members, roles]) => {
+          this.members = members;
+          this.roles = roles;
+          this.dataSource = members.map((member) => {
+            return {
+              ...member,
+              name: this.getMemberName(member),
+              picture: this.userService.getUserAvatar(member.id),
+            };
+          });
+          this.initForm(api, members);
+        }),
+      )
+      .subscribe();
+  }
+
+  ngOnDestroy() {
+    this.unsubscribe$.next(true);
+    this.unsubscribe$.complete();
+  }
+
+  public onSubmit() {
+    const queries = [];
+    if (this.form.controls['isNotificationsEnabled'].dirty) {
+      queries.push(this.saveChangeOnApiNotifications());
+    }
+    if (this.form.controls['members'].dirty) {
+      queries.push(
+        ...Object.entries((this.form.controls['members'] as FormGroup).controls)
+          .filter(([_, formControl]) => formControl.dirty)
+          .map(([memberId, roleFormControl]) => {
+            return this.updateMember(memberId, roleFormControl.value);
+          }),
+      );
+    }
+    combineLatest(queries)
+      .pipe(
+        takeUntil(this.unsubscribe$),
+        tap(() => {
+          this.snackBarService.success('Changes successfully saved!');
+        }),
+        catchError(({ error }) => {
+          this.snackBarService.error(error.message);
+          return EMPTY;
+        }),
+        tap(() => this.ngOnInit()),
+      )
+      .subscribe();
+  }
+
+  public getMemberName(member: ApiMember): string {
+    if (!member.displayName) {
+      return member.username;
+    }
+
+    return member.username ? member.displayName + ' (' + member.username + ')' : member.displayName;
+  }
+
+  public updateMember(memberId: string, newRole: string): Observable<void> {
+    const memberToUpdate = this.members.find((m) => m.id === memberId);
+    return this.apiMembersService.addOrUpdateMember(this.apiId, {
+      id: memberToUpdate.id,
+      role: newRole,
+      reference: memberToUpdate.reference,
+    });
+  }
+
+  public saveChangeOnApiNotifications(): Observable<Api> {
+    return this.apiService.get(this.apiId).pipe(
+      switchMap((api) => {
+        const updatedApi = {
+          ...api,
+          disable_membership_notifications: !this.form.value.isNotificationsEnabled,
+        };
+        return this.apiService.update(updatedApi);
+      }),
+    );
+  }
+
+  private initForm(api: Api, members: ApiMember[]) {
+    this.form = new FormGroup({
+      isNotificationsEnabled: new FormControl(!api.disable_membership_notifications),
+      members: this.formBuilder.group(
+        members.reduce((formGroup, member) => {
+          return {
+            ...formGroup,
+            [member.id]: this.formBuilder.control({ value: member.role, disabled: member.role === 'PRIMARY_OWNER' }),
+          };
+        }, {}),
+      ),
+    });
+    this.formInitialValues = this.form.value;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/portal/user-group-access/members/api-portal-members.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/user-group-access/members/api-portal-members.harness.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatRowHarness, MatTableHarness } from '@angular/material/table/testing';
+import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
+import { GioSaveBarHarness } from '@gravitee/ui-particles-angular';
+import { MatSelectHarness } from '@angular/material/select/testing';
+import { MatOptionHarness, OptionHarnessFilters } from '@angular/material/core/testing';
+
+export class ApiPortalMembersHarness extends ComponentHarness {
+  static hostSelector = 'api-portal-members';
+
+  protected getMemberTableElement = this.locatorFor(MatTableHarness);
+  protected getNotificationsCheckbox = this.locatorFor(MatCheckboxHarness);
+  protected getSaveBarElement = this.locatorFor(GioSaveBarHarness);
+
+  async getTableRows(): Promise<MatRowHarness[]> {
+    return this.getMemberTableElement().then((table) => table.getRows());
+  }
+
+  async getMembersName(): Promise<string[]> {
+    const rows = await this.getTableRows();
+    return Promise.all(
+      rows.map(async (row) => {
+        return await row.getCells().then(async (cells) => {
+          return await cells[1].getText();
+        });
+      }),
+    );
+  }
+
+  async getMemberRoleSelectForRowIndex(i: number): Promise<MatSelectHarness> {
+    const rows = await this.getTableRows();
+    expect(rows.length).toBeGreaterThan(i);
+    const roleCell = await rows[i].getCells({ columnName: 'role' });
+    expect(roleCell.length).toEqual(1);
+    return roleCell[0].getHarness(MatSelectHarness);
+  }
+
+  async getMemberRoleSelectOptions(rowIndex: number, options: OptionHarnessFilters = {}): Promise<MatOptionHarness[]> {
+    return this.getMemberRoleSelectForRowIndex(rowIndex).then(async (select) => {
+      await select.open();
+      return await select.getOptions(options);
+    });
+  }
+
+  async isMemberRoleSelectDisabled(rowIndex: number): Promise<boolean> {
+    return this.getMemberRoleSelectForRowIndex(rowIndex).then((select) => select.isDisabled());
+  }
+
+  async isNotificationsCheckboxChecked(): Promise<boolean> {
+    return this.getNotificationsCheckbox().then((cb) => cb.isChecked());
+  }
+
+  async toggleNotificationCheckbox(): Promise<void> {
+    return this.getNotificationsCheckbox().then((cb) => cb.toggle());
+  }
+
+  async isSaveBarVisible(): Promise<boolean> {
+    return this.getSaveBarElement().then((sb) => sb.isVisible());
+  }
+
+  async clickOnSave(): Promise<void> {
+    return this.getSaveBarElement().then((sb) => sb.clickSubmit());
+  }
+}

--- a/gravitee-apim-console-webui/src/management/management.module.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/management.module.ajs.ts
@@ -531,6 +531,7 @@ import { ApiCreationV4Component } from './api/creation/v4/api-creation-v4.compon
 import { ApiPathMappingsComponent } from './api/analytics/pathMappings/api-path-mappings.component';
 import { ApiCreationV4ConfirmationComponent } from './api/creation/v4/api-creation-v4-confirmation.component';
 import { ApiPortalGroupsComponent } from './api/portal/user-group-access/groups/api-portal-groups.component';
+import { ApiPortalMembersComponent } from './api/portal/user-group-access/members/api-portal-members.component';
 
 (<any>window).moment = moment;
 require('angular-moment-picker');
@@ -696,6 +697,7 @@ graviteeManagementModule.controller('ApiAnalyticsController', ApiAnalyticsContro
 graviteeManagementModule.controller('ApiPoliciesController', ApiPoliciesController);
 graviteeManagementModule.controller('AddPoliciesPathController', AddPoliciesPathController);
 graviteeManagementModule.controller('ApiMembersController', ApiMembersController);
+graviteeManagementModule.directive('ngApiMembers', downgradeComponent({ component: ApiPortalMembersComponent }));
 graviteeManagementModule.controller('ApiTransferOwnershipController', ApiTransferOwnershipController);
 graviteeManagementModule.controller('ApiHealthCheckController', ApiHealthCheckController);
 graviteeManagementModule.controller('ApiPropertiesController', ApiPropertiesController);

--- a/gravitee-apim-console-webui/src/services-ngx/api-member.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-member.service.spec.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { ApiMemberService } from './api-member.service';
+
+import { CONSTANTS_TESTING, GioHttpTestingModule } from '../shared/testing';
+import { AjsRootScope } from '../ajs-upgraded-providers';
+import { ApiMember, ApiMembership } from '../entities/api';
+
+describe('ApiMemberService', () => {
+  let httpTestingController: HttpTestingController;
+  let apiMemberService: ApiMemberService;
+  const fakeRootScope = { $broadcast: jest.fn(), $on: jest.fn() };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [GioHttpTestingModule],
+      providers: [{ provide: AjsRootScope, useValue: fakeRootScope }],
+    });
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+    apiMemberService = TestBed.inject<ApiMemberService>(ApiMemberService);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  describe('get members', () => {
+    it('should call the API', (done) => {
+      const apiId = 'fox';
+      const mockApiMembers: ApiMember[] = [
+        { id: '1', role: 'king', displayName: 'Mufasa' },
+        { id: '1', role: 'prince', displayName: 'Simba' },
+      ];
+
+      apiMemberService.getMembers(apiId).subscribe((response) => {
+        expect(response).toMatchObject(mockApiMembers);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        method: 'GET',
+        url: `${CONSTANTS_TESTING.env.baseURL}/apis/${apiId}/members`,
+      });
+
+      req.flush(mockApiMembers);
+    });
+  });
+
+  describe('update member', () => {
+    it('should call the API', (done) => {
+      const apiId = 'fox';
+      const membership: ApiMembership = { id: '1', role: 'king', reference: 'ref' };
+      apiMemberService.addOrUpdateMember(apiId, membership).subscribe(() => {
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.baseURL}/apis/${apiId}/members`,
+      });
+      req.flush({});
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/services-ngx/api-member.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-member.service.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+import { Constants } from '../entities/Constants';
+import { ApiMember, ApiMembership } from '../entities/api';
+
+@Injectable({ providedIn: 'root' })
+export class ApiMemberService {
+  constructor(private readonly http: HttpClient, @Inject('Constants') private readonly constants: Constants) {}
+
+  getMembers(api: string): Observable<ApiMember[]> {
+    return this.http.get<ApiMember[]>(`${this.constants.env.baseURL}/apis/${api}/members`);
+  }
+
+  addOrUpdateMember(api: string, membership: ApiMembership): Observable<void> {
+    return this.http.post<void>(`${this.constants.env.baseURL}/apis/${api}/members`, membership);
+  }
+
+  // TODO add this when needed
+  // deleteMember(api: string, userId: string): Observable<any> {
+  //   return this.http.delete(`${this.constants.env.baseURL}/apis/${api}/members?user=${userId}`);
+  // }
+  //
+  // transferOwnership(api: string, ownership: ApiMembership): Observable<any> {
+  //   return this.http.post(`${this.constants.env.baseURL}/apis/${api}/members/transfer_ownership`, ownership);
+  // }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-653

## Description

New page visible with the URL [http://localhost:3000/#!/environments/default/apis/<apiId>/ng-members]()

What has been implemented so far  

- [x] enable / disable notifications 
- [x] view list of members with roles
- [x] update member role

Still left to do 

- [ ] delete a member
- [ ] add a member
- [ ] add permission handling

When it’s done we can

- [ ] change menu item to target this new page
- [ ] remove old components

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-muwytsmrnt.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-653-migrate-api-members/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
