### PR TITLE
Sanitize some fields of new ExternalUser, Application, Plan - 3.19.x

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/pom.xml
@@ -79,6 +79,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+			<artifactId>owasp-java-html-sanitizer</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.glassfish.jersey.ext</groupId>
 			<artifactId>jersey-bean-validation</artifactId>
 			<scope>test</scope>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/pom.xml
@@ -74,11 +74,6 @@
         </dependency>
 
 		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-text</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
 			<artifactId>owasp-java-html-sanitizer</artifactId>
 		</dependency>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/GroupMemberEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/GroupMemberEntity.java
@@ -19,8 +19,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewApplicationEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewApplicationEntity.java
@@ -21,6 +21,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Set;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.PolicyFactory;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -28,6 +30,11 @@ import javax.validation.constraints.NotNull;
  * @author GraviteeSource Team
  */
 public class NewApplicationEntity {
+
+    /**
+     * OWASP HTML sanitizer to prevent XSS attacks.
+     */
+    private static final PolicyFactory HTML_SANITIZER = new HtmlPolicyBuilder().toFactory();
 
     @NotNull(message = "Application's name must not be null")
     @NotEmpty(message = "Application's name must not be empty")
@@ -77,7 +84,7 @@ public class NewApplicationEntity {
     }
 
     public void setDescription(String description) {
-        this.description = description;
+        this.description = HTML_SANITIZER.sanitize(description);
     }
 
     public String getName() {
@@ -85,7 +92,7 @@ public class NewApplicationEntity {
     }
 
     public void setName(String name) {
-        this.name = name;
+        this.name = HTML_SANITIZER.sanitize(name);
     }
 
     public Set<String> getGroups() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewExternalUserEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewExternalUserEntity.java
@@ -17,13 +17,19 @@ package io.gravitee.rest.api.model;
 
 import java.util.Map;
 import javax.validation.constraints.NotNull;
-import org.apache.commons.text.StringEscapeUtils;
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.PolicyFactory;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
 public class NewExternalUserEntity {
+
+    /**
+     * OWASP HTML sanitizer to prevent XSS attacks.
+     */
+    private static final PolicyFactory HTML_SANITIZER = new HtmlPolicyBuilder().toFactory();
 
     /**
      * The user first name
@@ -81,7 +87,7 @@ public class NewExternalUserEntity {
     }
 
     public void setFirstname(String firstname) {
-        this.firstname = StringEscapeUtils.escapeHtml4(firstname);
+        this.firstname = firstname != null ? HTML_SANITIZER.sanitize(firstname) : null;
     }
 
     public String getLastname() {
@@ -89,7 +95,7 @@ public class NewExternalUserEntity {
     }
 
     public void setLastname(String lastname) {
-        this.lastname = StringEscapeUtils.escapeHtml4(lastname);
+        this.lastname = lastname != null ? HTML_SANITIZER.sanitize(lastname) : null;
     }
 
     public String getPicture() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewPlanEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/NewPlanEntity.java
@@ -20,12 +20,19 @@ import io.gravitee.definition.model.Rule;
 import io.gravitee.definition.model.flow.Flow;
 import java.util.*;
 import javax.validation.constraints.NotNull;
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.PolicyFactory;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
 public class NewPlanEntity {
+
+    /**
+     * OWASP HTML sanitizer to prevent XSS attacks.
+     */
+    private static final PolicyFactory HTML_SANITIZER = new HtmlPolicyBuilder().toFactory();
 
     private String id;
 
@@ -97,7 +104,7 @@ public class NewPlanEntity {
     }
 
     public void setName(String name) {
-        this.name = name;
+        this.name = HTML_SANITIZER.sanitize(name);
     }
 
     public String getDescription() {
@@ -105,7 +112,7 @@ public class NewPlanEntity {
     }
 
     public void setDescription(String description) {
-        this.description = description;
+        this.description = HTML_SANITIZER.sanitize(description);
     }
 
     public PlanValidationType getValidation() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/NewApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/NewApiEntity.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.Set;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.PolicyFactory;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -32,6 +34,11 @@ import javax.validation.constraints.NotNull;
  * @author GraviteeSource Team
  */
 public class NewApiEntity {
+
+    /**
+     * OWASP HTML sanitizer to prevent XSS attacks.
+     */
+    private static final PolicyFactory HTML_SANITIZER = new HtmlPolicyBuilder().toFactory();
 
     @NotNull
     @NotEmpty(message = "Api's name must not be empty")
@@ -79,7 +86,7 @@ public class NewApiEntity {
     }
 
     public void setName(String name) {
-        this.name = name;
+        this.name = HTML_SANITIZER.sanitize(name);
     }
 
     public String getVersion() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/NewApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/NewApiEntity.java
@@ -22,7 +22,6 @@ import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.FlowMode;
 import io.gravitee.definition.model.v4.listener.Listener;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import javax.validation.Valid;
@@ -32,6 +31,8 @@ import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.PolicyFactory;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -42,6 +43,11 @@ import lombok.ToString;
 @ToString
 @Schema(name = "NewApiEntityV4")
 public class NewApiEntity {
+
+    /**
+     * OWASP HTML sanitizer to prevent XSS attacks.
+     */
+    private static final PolicyFactory HTML_SANITIZER = new HtmlPolicyBuilder().toFactory();
 
     @NotBlank
     @NotEmpty(message = "API's name must not be empty")
@@ -89,4 +95,8 @@ public class NewApiEntity {
 
     @Schema(description = "API's groups. Used to add team in your API.", example = "['MY_GROUP1', 'MY_GROUP2']")
     private Set<@NotBlank String> groups;
+
+    public void setName(String name) {
+        this.name = HTML_SANITIZER.sanitize(name);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/plan/NewPlanEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/plan/NewPlanEntity.java
@@ -30,6 +30,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.PolicyFactory;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -42,6 +44,11 @@ import lombok.ToString;
 @EqualsAndHashCode
 @Schema(name = "NewPlanEntityV4")
 public class NewPlanEntity {
+
+    /**
+     * OWASP HTML sanitizer to prevent XSS attacks.
+     */
+    private static final PolicyFactory HTML_SANITIZER = new HtmlPolicyBuilder().toFactory();
 
     private String id;
     /**
@@ -87,4 +94,12 @@ public class NewPlanEntity {
     private String generalConditions;
 
     private int order;
+
+    public void setName(String name) {
+        this.name = HTML_SANITIZER.sanitize(name);
+    }
+
+    public void setDescription(String description) {
+        this.description = HTML_SANITIZER.sanitize(description);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/validator/NewPreRegisterUserEntityValidator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/validator/NewPreRegisterUserEntityValidator.java
@@ -18,7 +18,6 @@ package io.gravitee.rest.api.validator;
 import io.gravitee.rest.api.model.NewPreRegisterUserEntity;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/NewApplicationEntityTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/NewApplicationEntityTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class NewApplicationEntityTest {
+
+    @Test
+    public void setNameShouldSanitizeInput() {
+        NewApplicationEntity newApplicationEntity = new NewApplicationEntity();
+        newApplicationEntity.setName("A Test Application");
+        assertEquals("A Test Application", newApplicationEntity.getName());
+
+        newApplicationEntity.setName("A <img src=\"../../../image.png\">Test Application");
+        assertEquals("A Test Application", newApplicationEntity.getName());
+
+        newApplicationEntity.setName("A Test <script>alert()</script>Application");
+        assertEquals("A Test Application", newApplicationEntity.getName());
+
+        newApplicationEntity.setName("<h1>A Test</h1> Application");
+        assertEquals("A Test Application", newApplicationEntity.getName());
+
+        newApplicationEntity.setName("A <a href=\"https://www.gravitee.io\">Test</a> Application");
+        assertEquals("A Test Application", newApplicationEntity.getName());
+    }
+
+    @Test
+    public void setDescriptionShouldSanitizeInput() {
+        NewApplicationEntity newApplicationEntity = new NewApplicationEntity();
+        newApplicationEntity.setDescription("A Test Application");
+        assertEquals("A Test Application", newApplicationEntity.getDescription());
+
+        newApplicationEntity.setDescription("A <img src=\"../../../image.png\">Test Application");
+        assertEquals("A Test Application", newApplicationEntity.getDescription());
+
+        newApplicationEntity.setDescription("A Test <script>alert()</script>Application");
+        assertEquals("A Test Application", newApplicationEntity.getDescription());
+
+        newApplicationEntity.setDescription("<h1>A Test</h1> Application");
+        assertEquals("A Test Application", newApplicationEntity.getDescription());
+
+        newApplicationEntity.setDescription("A <a href=\"https://www.gravitee.io\">Test</a> Application");
+        assertEquals("A Test Application", newApplicationEntity.getDescription());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/NewExternalUserEntityTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/NewExternalUserEntityTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.model;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 
@@ -24,26 +25,50 @@ public class NewExternalUserEntityTest {
     @Test
     public void setFirstnameShouldEscapeInput() {
         NewExternalUserEntity newExternalUserEntity = new NewExternalUserEntity();
-        newExternalUserEntity.setFirstname("firstname");
-        assertEquals("firstname", newExternalUserEntity.getFirstname());
+        newExternalUserEntity.setFirstname("A Test Firstname");
+        assertEquals("A Test Firstname", newExternalUserEntity.getFirstname());
 
-        newExternalUserEntity.setFirstname("<img src=\"../../../image.png\">");
-        assertEquals("&lt;img src=&quot;../../../image.png&quot;&gt;", newExternalUserEntity.getFirstname());
+        newExternalUserEntity.setFirstname("A <img src=\"../../../image.png\">Test Firstname");
+        assertEquals("A Test Firstname", newExternalUserEntity.getFirstname());
 
-        newExternalUserEntity.setFirstname("<script>alert()</script>");
-        assertEquals("&lt;script&gt;alert()&lt;/script&gt;", newExternalUserEntity.getFirstname());
+        newExternalUserEntity.setFirstname("A Test <script>alert()</script>Firstname");
+        assertEquals("A Test Firstname", newExternalUserEntity.getFirstname());
+
+        newExternalUserEntity.setFirstname("A <h1>Test</h1> Firstname");
+        assertEquals("A Test Firstname", newExternalUserEntity.getFirstname());
+
+        newExternalUserEntity.setFirstname("A <a href=\"https://www.gravitee.io\">Test</a> Firstname");
+        assertEquals("A Test Firstname", newExternalUserEntity.getFirstname());
+
+        newExternalUserEntity.setFirstname("A Firstname Wïth Accènt");
+        assertEquals("A Firstname Wïth Accènt", newExternalUserEntity.getFirstname());
+
+        newExternalUserEntity.setFirstname(null);
+        assertNull(newExternalUserEntity.getFirstname());
     }
 
     @Test
     public void setLastnameShouldEscapeInput() {
         NewExternalUserEntity newExternalUserEntity = new NewExternalUserEntity();
-        newExternalUserEntity.setLastname("lastname");
-        assertEquals("lastname", newExternalUserEntity.getLastname());
+        newExternalUserEntity.setLastname("A Test Lastname");
+        assertEquals("A Test Lastname", newExternalUserEntity.getLastname());
 
-        newExternalUserEntity.setLastname("<img src=\"../../../image.png\">");
-        assertEquals("&lt;img src=&quot;../../../image.png&quot;&gt;", newExternalUserEntity.getLastname());
+        newExternalUserEntity.setLastname("A <img src=\"../../../image.png\">Test Lastname");
+        assertEquals("A Test Lastname", newExternalUserEntity.getLastname());
 
-        newExternalUserEntity.setLastname("<script>alert()</script>");
-        assertEquals("&lt;script&gt;alert()&lt;/script&gt;", newExternalUserEntity.getLastname());
+        newExternalUserEntity.setLastname("A Test <script>alert()</script>Lastname");
+        assertEquals("A Test Lastname", newExternalUserEntity.getLastname());
+
+        newExternalUserEntity.setLastname("A <h1>Test</h1> Lastname");
+        assertEquals("A Test Lastname", newExternalUserEntity.getLastname());
+
+        newExternalUserEntity.setLastname("A <a href=\"https://www.gravitee.io\">Test</a> Lastname");
+        assertEquals("A Test Lastname", newExternalUserEntity.getLastname());
+
+        newExternalUserEntity.setLastname("A Lastname Wïth Accènt");
+        assertEquals("A Lastname Wïth Accènt", newExternalUserEntity.getLastname());
+
+        newExternalUserEntity.setLastname(null);
+        assertNull(newExternalUserEntity.getLastname());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/NewPlanEntityTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/NewPlanEntityTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class NewPlanEntityTest {
+
+    @Test
+    public void setNameShouldSanitizeInput() {
+        NewPlanEntity newPlanEntity = new NewPlanEntity();
+        newPlanEntity.setName("A Test Plan");
+        assertEquals("A Test Plan", newPlanEntity.getName());
+
+        newPlanEntity.setName("A <img src=\"../../../image.png\">Test Plan");
+        assertEquals("A Test Plan", newPlanEntity.getName());
+
+        newPlanEntity.setName("A Test <script>alert()</script>Plan");
+        assertEquals("A Test Plan", newPlanEntity.getName());
+
+        newPlanEntity.setName("<h1>A Test</h1> Plan");
+        assertEquals("A Test Plan", newPlanEntity.getName());
+
+        newPlanEntity.setName("A <a href=\"https://www.gravitee.io\">Test</a> Plan");
+        assertEquals("A Test Plan", newPlanEntity.getName());
+    }
+
+    @Test
+    public void setDescriptionShouldSanitizeInput() {
+        NewPlanEntity newPlanEntity = new NewPlanEntity();
+        newPlanEntity.setDescription("A Test Plan");
+        assertEquals("A Test Plan", newPlanEntity.getDescription());
+
+        newPlanEntity.setDescription("A <img src=\"../../../image.png\">Test Plan");
+        assertEquals("A Test Plan", newPlanEntity.getDescription());
+
+        newPlanEntity.setDescription("A Test <script>alert()</script>Plan");
+        assertEquals("A Test Plan", newPlanEntity.getDescription());
+
+        newPlanEntity.setDescription("<h1>A Test</h1> Plan");
+        assertEquals("A Test Plan", newPlanEntity.getDescription());
+
+        newPlanEntity.setDescription("A <a href=\"https://www.gravitee.io\">Test</a> Plan");
+        assertEquals("A Test Plan", newPlanEntity.getDescription());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/api/NewApiEntityTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/api/NewApiEntityTest.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.api;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class NewApiEntityTest {
+
+    @Test
+    public void setNameShouldSanitizeInput() {
+        NewApiEntity newApiEntity = new NewApiEntity();
+        newApiEntity.setName("A Test API");
+        assertEquals("A Test API", newApiEntity.getName());
+
+        newApiEntity.setName("A <img src=\"../../../image.png\">Test API");
+        assertEquals("A Test API", newApiEntity.getName());
+
+        newApiEntity.setName("A Test <script>alert()</script>API");
+        assertEquals("A Test API", newApiEntity.getName());
+
+        newApiEntity.setName("<h1>A Test</h1> API");
+        assertEquals("A Test API", newApiEntity.getName());
+
+        newApiEntity.setName("A <a href=\"https://www.gravitee.io\">Test</a> API");
+        assertEquals("A Test API", newApiEntity.getName());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/v4/api/NewApiEntityTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/v4/api/NewApiEntityTest.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.v4.api;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class NewApiEntityTest {
+
+    @Test
+    public void setNameShouldSanitizeInput() {
+        NewApiEntity newApiEntity = new NewApiEntity();
+        newApiEntity.setName("A Test API");
+        assertEquals("A Test API", newApiEntity.getName());
+
+        newApiEntity.setName("A <img src=\"../../../image.png\">Test API");
+        assertEquals("A Test API", newApiEntity.getName());
+
+        newApiEntity.setName("A Test <script>alert()</script>API");
+        assertEquals("A Test API", newApiEntity.getName());
+
+        newApiEntity.setName("<h1>A Test</h1> API");
+        assertEquals("A Test API", newApiEntity.getName());
+
+        newApiEntity.setName("A <a href=\"https://www.gravitee.io\">Test</a> API");
+        assertEquals("A Test API", newApiEntity.getName());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/v4/plan/NewPlanEntityTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/test/java/io/gravitee/rest/api/model/v4/plan/NewPlanEntityTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.v4.plan;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class NewPlanEntityTest {
+
+    @Test
+    public void setNameShouldSanitizeInput() {
+        NewPlanEntity newPlanEntity = new NewPlanEntity();
+        newPlanEntity.setName("A Test Plan");
+        assertEquals("A Test Plan", newPlanEntity.getName());
+
+        newPlanEntity.setName("A <img src=\"../../../image.png\">Test Plan");
+        assertEquals("A Test Plan", newPlanEntity.getName());
+
+        newPlanEntity.setName("A Test <script>alert()</script>Plan");
+        assertEquals("A Test Plan", newPlanEntity.getName());
+
+        newPlanEntity.setName("<h1>A Test</h1> Plan");
+        assertEquals("A Test Plan", newPlanEntity.getName());
+
+        newPlanEntity.setName("A <a href=\"https://www.gravitee.io\">Test</a> Plan");
+        assertEquals("A Test Plan", newPlanEntity.getName());
+    }
+
+    @Test
+    public void setDescriptionShouldSanitizeInput() {
+        NewPlanEntity newPlanEntity = new NewPlanEntity();
+        newPlanEntity.setDescription("A Test Plan");
+        assertEquals("A Test Plan", newPlanEntity.getDescription());
+
+        newPlanEntity.setDescription("A <img src=\"../../../image.png\">Test Plan");
+        assertEquals("A Test Plan", newPlanEntity.getDescription());
+
+        newPlanEntity.setDescription("A Test <script>alert()</script>Plan");
+        assertEquals("A Test Plan", newPlanEntity.getDescription());
+
+        newPlanEntity.setDescription("<h1>A Test</h1> Plan");
+        assertEquals("A Test Plan", newPlanEntity.getDescription());
+
+        newPlanEntity.setDescription("A <a href=\"https://www.gravitee.io\">Test</a> Plan");
+        assertEquals("A Test Plan", newPlanEntity.getDescription());
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-650
https://github.com/gravitee-io/issues/issues/7560
https://github.com/gravitee-io/issues/issues/8847

## Description

Apply https://github.com/gravitee-io/gravitee-api-management/pull/3035 on 3.19.x to take care of v4 models manually.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ozzsvmfdjm.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/sanitize-user-application-inputs-3-19-x/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
