### PR TITLE
fix(rest-api): return error 401 when no auth used in login

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/CurrentUserResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/CurrentUserResource.java
@@ -436,7 +436,7 @@ public class CurrentUserResource extends AbstractResource {
 
             return ok(tokenEntity).build();
         }
-        return ok().build();
+        return Response.status(Response.Status.UNAUTHORIZED).build();
     }
 
     @POST

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/CurrentUserResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/CurrentUserResourceTest.java
@@ -105,6 +105,20 @@ public class CurrentUserResourceTest extends AbstractResourceTest {
         assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NO_CONTENT_204);
     }
 
+    @Test
+    public void shouldReturn401WithNoAuthAtLogin() {
+        Mockito.reset(userService);
+
+        final Authentication authentication = mock(Authentication.class);
+        when(authentication.getPrincipal()).thenReturn(null);
+
+        SecurityContextHolder.setContext(new SecurityContextImpl(null));
+
+        final Response response = orgTarget().path("/login").request().post(null);
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.UNAUTHORIZED_401);
+        assertThat(response.readEntity(Object.class)).isNull();
+    }
+
     private void setCurrentUserDetails(final UserDetails userDetails) {
         final Authentication authentication = mock(Authentication.class);
         final UserEntity userEntity = new UserEntity();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-726
https://github.com/gravitee-io/issues/issues/8862

## Description

When no auth is sent to login for apim rest-api, the backend responds 401.

Fixes previous behavior: with no auth sent to login endpoint, backend responds 200.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-yaufnjjpsh.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/bug-login-no-auth-returns-200/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
