### PR TITLE
feat: allow forcing path/channel matching when executing flow chain

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/Api.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/Api.java
@@ -19,10 +19,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.ResponseTemplate;
 import io.gravitee.definition.model.v4.analytics.Analytics;
-import io.gravitee.definition.model.v4.analytics.logging.Logging;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.definition.model.v4.flow.Flow;
-import io.gravitee.definition.model.v4.flow.FlowMode;
+import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
+import io.gravitee.definition.model.v4.flow.execution.FlowMode;
 import io.gravitee.definition.model.v4.listener.Listener;
 import io.gravitee.definition.model.v4.plan.Plan;
 import io.gravitee.definition.model.v4.property.Property;
@@ -96,7 +96,7 @@ public class Api implements Serializable {
     @NotNull
     private Map<@NotEmpty String, @NotNull Plan> plans;
 
-    private FlowMode flowMode = FlowMode.DEFAULT;
+    private FlowExecution flowExecution = new FlowExecution();
 
     private List<Flow> flows;
 

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/flow/execution/FlowExecution.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/flow/execution/FlowExecution.java
@@ -13,26 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.definition.model.v4.flow;
+package io.gravitee.definition.model.v4.flow.execution;
 
-import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
-import com.fasterxml.jackson.annotation.JsonValue;
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-@RequiredArgsConstructor
+@NoArgsConstructor
 @Getter
-@Schema(name = "FlowModeV4")
-public enum FlowMode {
-    @JsonEnumDefaultValue
-    DEFAULT("default"),
-    BEST_MATCH("best-match");
+@Setter
+@ToString
+@EqualsAndHashCode
+@Schema(name = "FlowExecutionV4")
+public class FlowExecution {
 
-    @JsonValue
-    private final String label;
+    private FlowMode mode = FlowMode.DEFAULT;
+    private boolean matchRequired = false;
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/flow/execution/FlowMode.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/flow/execution/FlowMode.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.model.v4.flow.execution;
+
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RequiredArgsConstructor
+@Getter
+@Schema(name = "FlowModeV4")
+public enum FlowMode {
+    @JsonEnumDefaultValue
+    DEFAULT("default"),
+    BEST_MATCH("best-match");
+
+    @JsonValue
+    private final String label;
+}

--- a/gravitee-apim-e2e/lib/fixtures/management/ApisV4Faker.ts
+++ b/gravitee-apim-e2e/lib/fixtures/management/ApisV4Faker.ts
@@ -15,11 +15,12 @@
  */
 import faker from '@faker-js/faker';
 import {
+  FlowExecutionV4,
+  FlowExecutionV4ModeEnum,
   HttpListenerV4,
   ListenerV4,
   NewApiEntityV4,
   NewApiEntityV4DefinitionVersionEnum,
-  NewApiEntityV4FlowModeEnum,
   NewApiEntityV4TypeEnum,
   SubscriptionListenerV4,
 } from '@gravitee/management-webclient-sdk/src/lib/models';
@@ -43,7 +44,10 @@ export class ApisV4Faker {
       description,
       name,
       endpointGroups: [],
-      flowMode: NewApiEntityV4FlowModeEnum.DEFAULT,
+      flowExecution: {
+        flowMode: FlowExecutionV4ModeEnum.DEFAULT,
+        matchRequired: false,
+      } as FlowExecutionV4,
       flows: [],
       groups: [],
       listeners: [],

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/v4/flow/FlowChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/v4/flow/FlowChainFactory.java
@@ -15,13 +15,12 @@
  */
 package io.gravitee.gateway.jupiter.handlers.api.v4.flow;
 
+import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
 import io.gravitee.gateway.jupiter.api.hook.ChainHook;
 import io.gravitee.gateway.jupiter.core.tracing.TracingHook;
 import io.gravitee.gateway.jupiter.handlers.api.v4.Api;
 import io.gravitee.gateway.jupiter.handlers.api.v4.flow.resolver.FlowResolverFactory;
 import io.gravitee.gateway.jupiter.v4.policy.PolicyChainFactory;
-import io.gravitee.gateway.platform.manager.OrganizationManager;
-import io.gravitee.gateway.reactor.ReactableApi;
 import io.gravitee.node.api.configuration.Configuration;
 import java.util.ArrayList;
 import java.util.List;
@@ -51,13 +50,20 @@ public class FlowChainFactory {
     }
 
     public FlowChain createPlanFlow(final Api api) {
-        FlowChain flowPlanChain = new FlowChain("plan", flowResolverFactory.forApiPlan(api), policyChainFactory);
+        FlowChain flowPlanChain = new FlowChain("plan", flowResolverFactory.forApiPlan(api), policyChainFactory, true, false);
         flowPlanChain.addHooks(flowHooks);
         return flowPlanChain;
     }
 
     public FlowChain createApiFlow(final Api api) {
-        FlowChain flowApiChain = new FlowChain("api", flowResolverFactory.forApi(api), policyChainFactory);
+        FlowExecution flowExecution = api.getDefinition().getFlowExecution();
+        FlowChain flowApiChain = new FlowChain(
+            "api",
+            flowResolverFactory.forApi(api),
+            policyChainFactory,
+            true,
+            flowExecution != null && flowExecution.isMatchRequired()
+        );
         flowApiChain.addHooks(flowHooks);
         return flowApiChain;
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/v4/flow/resolver/FlowResolverFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/v4/flow/resolver/FlowResolverFactory.java
@@ -17,7 +17,8 @@ package io.gravitee.gateway.jupiter.handlers.api.v4.flow.resolver;
 
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.flow.Flow;
-import io.gravitee.definition.model.v4.flow.FlowMode;
+import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
+import io.gravitee.definition.model.v4.flow.execution.FlowMode;
 import io.gravitee.gateway.jupiter.core.condition.ConditionFilter;
 import io.gravitee.gateway.jupiter.handlers.api.v4.Api;
 import io.gravitee.gateway.jupiter.v4.flow.BestMatchFlowResolver;
@@ -42,7 +43,7 @@ public class FlowResolverFactory {
 
     public FlowResolver forApi(Api api) {
         ApiFlowResolver apiFlowResolver = new ApiFlowResolver(api.getDefinition(), getConditionFilter(api));
-        if (isBestMatchFlowMode(api.getDefinition().getFlowMode())) {
+        if (isBestMatchFlowMode(api.getDefinition().getFlowExecution())) {
             return new BestMatchFlowResolver(apiFlowResolver);
         }
         return apiFlowResolver;
@@ -50,7 +51,7 @@ public class FlowResolverFactory {
 
     public FlowResolver forApiPlan(Api api) {
         ApiPlanFlowResolver apiPlanFlowResolver = new ApiPlanFlowResolver(api.getDefinition(), getConditionFilter(api));
-        if (isBestMatchFlowMode(api.getDefinition().getFlowMode())) {
+        if (isBestMatchFlowMode(api.getDefinition().getFlowExecution())) {
             return new BestMatchFlowResolver(apiPlanFlowResolver);
         }
         return apiPlanFlowResolver;
@@ -65,7 +66,7 @@ public class FlowResolverFactory {
         throw new IllegalArgumentException("Api type unsupported");
     }
 
-    private static boolean isBestMatchFlowMode(FlowMode flowMode) {
-        return flowMode == FlowMode.BEST_MATCH;
+    private static boolean isBestMatchFlowMode(final FlowExecution flowExecution) {
+        return flowExecution != null && flowExecution.getMode() == FlowMode.BEST_MATCH;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/v4/flow/resolver/FlowResolverFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/v4/flow/resolver/FlowResolverFactoryTest.java
@@ -20,7 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.flow.Flow;
-import io.gravitee.definition.model.v4.flow.FlowMode;
+import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
+import io.gravitee.definition.model.v4.flow.execution.FlowMode;
 import io.gravitee.gateway.jupiter.core.condition.ConditionFilter;
 import io.gravitee.gateway.jupiter.handlers.api.v4.Api;
 import io.gravitee.gateway.jupiter.v4.flow.FlowResolver;
@@ -54,7 +55,7 @@ class FlowResolverFactoryTest {
         final io.gravitee.definition.model.v4.Api definition = new io.gravitee.definition.model.v4.Api();
         definition.setType(ApiType.SYNC);
         api = new Api(definition);
-        definition.setFlowMode(FlowMode.DEFAULT);
+        definition.setFlowExecution(new FlowExecution());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/ApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/ApiEntity.java
@@ -22,10 +22,10 @@ import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.ResponseTemplate;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.analytics.Analytics;
-import io.gravitee.definition.model.v4.analytics.logging.Logging;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.definition.model.v4.flow.Flow;
-import io.gravitee.definition.model.v4.flow.FlowMode;
+import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
+import io.gravitee.definition.model.v4.flow.execution.FlowMode;
 import io.gravitee.definition.model.v4.listener.Listener;
 import io.gravitee.definition.model.v4.property.Property;
 import io.gravitee.definition.model.v4.resource.Resource;
@@ -124,8 +124,8 @@ public class ApiEntity implements GenericApiEntity {
     @DeploymentRequired
     private Set<PlanEntity> plans = new HashSet<>();
 
-    @Schema(description = "API's flow mode.", example = "BEST_MATCH")
-    private FlowMode flowMode;
+    @Schema(description = "API's flow execution.")
+    private FlowExecution flowExecution;
 
     @Schema(description = "A list of flows containing the policies configuration.")
     @DeploymentRequired

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/NewApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/NewApiEntity.java
@@ -20,7 +20,8 @@ import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.definition.model.v4.flow.Flow;
-import io.gravitee.definition.model.v4.flow.FlowMode;
+import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
+import io.gravitee.definition.model.v4.flow.execution.FlowMode;
 import io.gravitee.definition.model.v4.listener.Listener;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
@@ -90,8 +91,8 @@ public class NewApiEntity {
     @Schema(description = "Analytics configuration")
     private Analytics analytics;
 
-    @Schema(description = "API's flow mode.", example = "BEST_MATCH")
-    private FlowMode flowMode;
+    @Schema(description = "API's flow execution.")
+    private FlowExecution flowExecution;
 
     @Valid
     @Schema(description = "A list of flows containing the policies configuration.")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/UpdateApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/UpdateApiEntity.java
@@ -19,10 +19,10 @@ import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.ResponseTemplate;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.analytics.Analytics;
-import io.gravitee.definition.model.v4.analytics.logging.Logging;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.definition.model.v4.flow.Flow;
-import io.gravitee.definition.model.v4.flow.FlowMode;
+import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
+import io.gravitee.definition.model.v4.flow.execution.FlowMode;
 import io.gravitee.definition.model.v4.listener.Listener;
 import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.definition.model.v4.service.ApiServices;
@@ -124,9 +124,9 @@ public class UpdateApiEntity {
     @DeploymentRequired
     private Set<PlanEntity> plans = new HashSet<>();
 
-    @Schema(description = "API's flow mode.", example = "BEST_MATCH")
+    @Schema(description = "API's flow execution.")
     @DeploymentRequired
-    private FlowMode flowMode;
+    private FlowExecution flowExecution;
 
     @Valid
     @Schema(description = "A list of flows containing the policies configuration.")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
@@ -115,7 +115,7 @@ public class ApiMapper {
                 apiEntity.setProperties(apiDefinition.getProperties());
                 apiEntity.setTags(apiDefinition.getTags());
 
-                apiEntity.setFlowMode(apiDefinition.getFlowMode());
+                apiEntity.setFlowExecution(apiDefinition.getFlowExecution());
                 apiEntity.setFlows(apiDefinition.getFlows());
 
                 apiEntity.setResponseTemplates(apiDefinition.getResponseTemplates());
@@ -226,7 +226,7 @@ public class ApiMapper {
             apiDefinition.setListeners(newApiEntity.getListeners());
             apiDefinition.setEndpointGroups(newApiEntity.getEndpointGroups());
             apiDefinition.setAnalytics(newApiEntity.getAnalytics());
-            apiDefinition.setFlowMode(newApiEntity.getFlowMode());
+            apiDefinition.setFlowExecution(newApiEntity.getFlowExecution());
             apiDefinition.setFlows(newApiEntity.getFlows());
 
             return objectMapper.writeValueAsString(apiDefinition);
@@ -293,7 +293,7 @@ public class ApiMapper {
                     .collect(Collectors.toList())
             );
             apiDefinition.setResources(updateApiEntity.getResources());
-            apiDefinition.setFlowMode(updateApiEntity.getFlowMode());
+            apiDefinition.setFlowExecution(updateApiEntity.getFlowExecution());
             apiDefinition.setFlows(updateApiEntity.getFlows());
             apiDefinition.setResponseTemplates(updateApiEntity.getResponseTemplates());
             apiDefinition.setServices(updateApiEntity.getServices());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/ApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/ApiMapperTest.java
@@ -26,7 +26,8 @@ import io.gravitee.definition.model.ResponseTemplate;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.definition.model.v4.flow.Flow;
-import io.gravitee.definition.model.v4.flow.FlowMode;
+import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
+import io.gravitee.definition.model.v4.flow.execution.FlowMode;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.property.Property;
 import io.gravitee.definition.model.v4.resource.Resource;
@@ -102,7 +103,7 @@ public class ApiMapperTest {
         apiDefinition.setResources(List.of(new Resource()));
         apiDefinition.setProperties(List.of(new Property("key", "value")));
         apiDefinition.setTags(Set.of("tag"));
-        apiDefinition.setFlowMode(FlowMode.DEFAULT);
+        apiDefinition.setFlowExecution(new FlowExecution());
         apiDefinition.setFlows(List.of(new Flow(), new Flow()));
         apiDefinition.setResponseTemplates(Map.of("/", Map.of("/", new ResponseTemplate())));
 
@@ -162,7 +163,8 @@ public class ApiMapperTest {
         assertThat(apiEntity.getProperties().size()).isEqualTo(1);
         assertThat(apiEntity.getTags()).isNotNull();
         assertThat(apiEntity.getTags().size()).isEqualTo(1);
-        assertThat(apiEntity.getFlowMode()).isEqualTo(FlowMode.DEFAULT);
+        assertThat(apiEntity.getFlowExecution()).isNotNull();
+        assertThat(apiEntity.getFlowExecution().getMode()).isEqualTo(FlowMode.DEFAULT);
         assertThat(apiEntity.getFlows()).isNotNull();
         assertThat(apiEntity.getFlows().size()).isEqualTo(2);
         assertThat(apiEntity.getResponseTemplates()).isNotNull();
@@ -236,7 +238,7 @@ public class ApiMapperTest {
         newApiEntity.setGroups(Set.of("group1"));
         newApiEntity.setListeners(List.of(new HttpListener()));
         newApiEntity.setEndpointGroups(List.of(new EndpointGroup()));
-        newApiEntity.setFlowMode(FlowMode.DEFAULT);
+        newApiEntity.setFlowExecution(new FlowExecution());
         newApiEntity.setFlows(List.of(new Flow(), new Flow()));
 
         Api api = apiMapper.toRepository(GraviteeContext.getExecutionContext(), newApiEntity);
@@ -265,7 +267,7 @@ public class ApiMapperTest {
         apiDefinition.setListeners(List.of(new HttpListener()));
         apiDefinition.setEndpointGroups(List.of(new EndpointGroup()));
         apiDefinition.setTags(Set.of("tag"));
-        apiDefinition.setFlowMode(FlowMode.DEFAULT);
+        apiDefinition.setFlowExecution(new FlowExecution());
         apiDefinition.setFlows(List.of(new Flow(), new Flow()));
         assertThat(api.getDefinition()).isEqualTo(objectMapper.writeValueAsString(apiDefinition));
     }
@@ -291,7 +293,7 @@ public class ApiMapperTest {
         updateApiEntity.setGroups(Set.of("group1", "group2"));
         updateApiEntity.setListeners(List.of(new HttpListener()));
         updateApiEntity.setEndpointGroups(List.of(new EndpointGroup()));
-        updateApiEntity.setFlowMode(FlowMode.DEFAULT);
+        updateApiEntity.setFlowExecution(new FlowExecution());
         updateApiEntity.setFlows(List.of(new Flow(), new Flow()));
         updateApiEntity.setMetadata(List.of(new ApiMetadataEntity()));
         updateApiEntity.setLifecycleState(io.gravitee.rest.api.model.api.ApiLifecycleState.UNPUBLISHED);
@@ -341,7 +343,7 @@ public class ApiMapperTest {
         apiDefinition.setEndpointGroups(List.of(new EndpointGroup()));
         apiDefinition.setProperties(List.of(new Property("propKey", "propValue", false)));
         apiDefinition.setResources(List.of(new Resource()));
-        apiDefinition.setFlowMode(FlowMode.DEFAULT);
+        apiDefinition.setFlowExecution(new FlowExecution());
         apiDefinition.setFlows(List.of(new Flow(), new Flow()));
         apiDefinition.setResponseTemplates(new HashMap<>());
         assertThat(api.getDefinition()).isEqualTo(objectMapper.writeValueAsString(apiDefinition));


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-762

## Description

Implement a way to force incoming request to match at least once flow.

## Additional context

Must be merged after https://github.com/gravitee-io/gravitee-api-management/pull/3045

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nfctwnfjlm.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-762-implement-match-required-flow/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
