### PR TITLE
fix: better handle user defined endpoint with special chars

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/v4/invoker/EndpointInvoker.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/jupiter/core/v4/invoker/EndpointInvoker.java
@@ -50,7 +50,7 @@ public class EndpointInvoker implements Invoker {
     private static final String MATCH_GROUP_ENDPOINT = "endpoint";
     private static final String MATCH_GROUP_PATH = "path";
     private static final Pattern ENDPOINT_PATTERN = Pattern.compile(
-        "^(?<" + MATCH_GROUP_ENDPOINT + ">\\w+):(?<" + MATCH_GROUP_PATH + ">.*)$"
+        "^(?<" + MATCH_GROUP_ENDPOINT + ">[^:]+):(?<" + MATCH_GROUP_PATH + ">.*)$"
     );
 
     public static final String NO_ENDPOINT_FOUND_KEY = "NO_ENDPOINT_FOUND";


### PR DESCRIPTION
## Issue

No JIRA ticket, an issue was found while playing with the feature.


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ltthctsfzl.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-user-defined-endpoint/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
