### PR TITLE
fix: set sync probe to true when caches are fully loaded

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncManager.java
@@ -170,8 +170,6 @@ public class SyncManager extends AbstractService<SyncManager> {
             }
         }
 
-        logger.debug("Synchronization #{} ended at {}", counter.get(), Instant.now().toString());
-
         // If there was no error during the sync process, let's continue it with the next period of time
         if (!error) {
             allApisSync = true;
@@ -187,6 +185,13 @@ public class SyncManager extends AbstractService<SyncManager> {
             // soon as the node is becoming the master later.
             lastRefreshAt = nextLastRefreshAt;
         }
+
+        logger.debug(
+            "Synchronization #{} ended at {} (took {}ms}",
+            counter.get(),
+            Instant.now().toString(),
+            System.currentTimeMillis() - nextLastRefreshAt
+        );
     }
 
     public boolean isDistributed() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/AbstractSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/AbstractSynchronizer.java
@@ -28,6 +28,7 @@ import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -48,7 +49,7 @@ public abstract class AbstractSynchronizer extends AbstractService<AbstractSynch
 
     @Autowired
     @Qualifier("syncExecutor")
-    protected ExecutorService executor;
+    protected ThreadPoolExecutor executor;
 
     @Value("${services.sync.bulk_items:100}")
     protected int bulkItems;
@@ -113,7 +114,7 @@ public abstract class AbstractSynchronizer extends AbstractService<AbstractSynch
         return bulkItems > 0 ? bulkItems : DEFAULT_BULK_SIZE;
     }
 
-    public void setExecutor(ExecutorService executor) {
+    public void setExecutor(ThreadPoolExecutor executor) {
         this.executor = executor;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/SyncManagerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/SyncManagerTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.*;
 
 import io.gravitee.gateway.services.sync.synchronizer.ApiSynchronizer;
+import io.gravitee.gateway.services.sync.synchronizer.DebugApiSynchronizer;
 import io.gravitee.gateway.services.sync.synchronizer.DictionarySynchronizer;
 import io.gravitee.gateway.services.sync.synchronizer.OrganizationSynchronizer;
 import io.gravitee.node.api.cluster.ClusterManager;
@@ -57,6 +58,9 @@ public class SyncManagerTest {
 
     @Mock
     private OrganizationSynchronizer organizationSynchronizer;
+
+    @Mock
+    private DebugApiSynchronizer debugApiSynchronizer;
 
     private List<String> environments;
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/DebugApiSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/DebugApiSynchronizerTest.java
@@ -75,12 +75,12 @@ public class DebugApiSynchronizerTest extends TestCase {
     public void setup() {
         Plugin debugPlugin = mock(Plugin.class);
         when(debugPlugin.id()).thenReturn("gateway-debug");
-        when(pluginRegistry.plugins()).thenReturn((Collection) List.of(debugPlugin));
+        when(pluginRegistry.plugins()).thenReturn(List.of(debugPlugin));
         when(configuration.getProperty("gravitee.services.gateway-debug.enabled", Boolean.class, true)).thenReturn(true);
 
         debugApiSynchronizer = new DebugApiSynchronizer(eventManager, pluginRegistry, configuration, node);
         debugApiSynchronizer.eventRepository = eventRepository;
-        debugApiSynchronizer.setExecutor(Executors.newFixedThreadPool(1));
+        debugApiSynchronizer.setExecutor((ThreadPoolExecutor) Executors.newFixedThreadPool(1));
         when(node.id()).thenReturn(GATEWAY_ID);
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/DictionarySynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/DictionarySynchronizerTest.java
@@ -26,6 +26,7 @@ import io.gravitee.repository.management.model.Event;
 import io.gravitee.repository.management.model.EventType;
 import java.util.*;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
 import junit.framework.TestCase;
 import org.junit.Before;
 import org.junit.Test;
@@ -57,7 +58,7 @@ public class DictionarySynchronizerTest extends TestCase {
 
     @Before
     public void setUp() {
-        dictionarySynchronizer.setExecutor(Executors.newFixedThreadPool(1));
+        dictionarySynchronizer.setExecutor((ThreadPoolExecutor) Executors.newFixedThreadPool(1));
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/OrganizationSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/synchronizer/OrganizationSynchronizerTest.java
@@ -67,7 +67,7 @@ public class OrganizationSynchronizerTest extends TestCase {
 
     @Before
     public void setUp() {
-        organizationSynchronizer.setExecutor(Executors.newFixedThreadPool(1));
+        organizationSynchronizer.setExecutor((ThreadPoolExecutor) Executors.newFixedThreadPool(1));
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-777

## Description

When the gateway starts, it populates the api key and subscription caches but does not wait until it completes before moving the "api sync" probe to true. This leads to 401 errors under certain circumstances.

This PR just ensure that all background tasks launched by the initial api sync process are fully completed before moving the api sync probe to true.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jgiylvvbxw.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-777-gateway-startup-sync-probe/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
