### PR TITLE
chore: bump gravitee-node to 1.25.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>1.44.2</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
-        <gravitee-node.version>1.25.0</gravitee-node.version>
+        <gravitee-node.version>1.25.1</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>
         <gravitee-plugin.version>1.24.3</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.2.0</gravitee-platform-repository-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-616

## Description

Fixes /_node/monitor technical API.

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/support-616-internal-monitor-apim-3-19/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fbxzichqyj.chromatic.com)
<!-- Storybook placeholder end -->
