### PR TITLE
feat(gateway): inject the DeploymentContext in resource

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/pom.xml
@@ -179,6 +179,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-container</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/v4/DefaultApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/v4/DefaultApiReactor.java
@@ -42,11 +42,7 @@ import io.gravitee.gateway.env.RequestTimeoutConfiguration;
 import io.gravitee.gateway.jupiter.api.ExecutionFailure;
 import io.gravitee.gateway.jupiter.api.ExecutionPhase;
 import io.gravitee.gateway.jupiter.api.connector.entrypoint.EntrypointConnector;
-import io.gravitee.gateway.jupiter.api.context.ContextAttributes;
-import io.gravitee.gateway.jupiter.api.context.DeploymentContext;
-import io.gravitee.gateway.jupiter.api.context.ExecutionContext;
-import io.gravitee.gateway.jupiter.api.context.HttpExecutionContext;
-import io.gravitee.gateway.jupiter.api.context.InternalContextAttributes;
+import io.gravitee.gateway.jupiter.api.context.*;
 import io.gravitee.gateway.jupiter.api.hook.ChainHook;
 import io.gravitee.gateway.jupiter.api.hook.InvokerHook;
 import io.gravitee.gateway.jupiter.api.invoker.Invoker;
@@ -87,6 +83,7 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+import lombok.Getter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -105,8 +102,13 @@ public class DefaultApiReactor extends AbstractLifecycleComponent<ReactorHandler
     protected final List<ChainHook> processorChainHooks;
     protected final List<InvokerHook> invokerHooks;
     private final Api api;
+
+    @Getter
     private final ComponentProvider componentProvider;
+
+    @Getter
     private final List<TemplateVariableProvider> ctxTemplateVariableProviders;
+
     private final PolicyManager policyManager;
     private final DefaultEntrypointConnectorResolver entrypointConnectorResolver;
     private final EndpointManager endpointManager;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/v4/DefaultApiReactorFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/v4/DefaultApiReactorFactoryTest.java
@@ -15,23 +15,57 @@
  */
 package io.gravitee.gateway.jupiter.handlers.api.v4;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.listener.subscription.SubscriptionListener;
 import io.gravitee.definition.model.v4.listener.tcp.TcpListener;
+import io.gravitee.el.TemplateVariableProvider;
+import io.gravitee.gateway.core.component.ComponentProvider;
+import io.gravitee.gateway.core.component.CompositeComponentProvider;
+import io.gravitee.gateway.env.RequestTimeoutConfiguration;
+import io.gravitee.gateway.jupiter.api.service.dlq.DlqServiceFactory;
+import io.gravitee.gateway.jupiter.core.v4.endpoint.EndpointManager;
+import io.gravitee.gateway.jupiter.handlers.api.ApiPolicyManager;
+import io.gravitee.gateway.jupiter.handlers.api.el.ApiTemplateVariableProvider;
+import io.gravitee.gateway.jupiter.handlers.api.v4.flow.resolver.FlowResolverFactory;
+import io.gravitee.gateway.jupiter.handlers.api.v4.processor.ApiProcessorChainFactory;
+import io.gravitee.gateway.jupiter.policy.PolicyChainFactory;
+import io.gravitee.gateway.jupiter.policy.PolicyFactory;
+import io.gravitee.gateway.platform.manager.OrganizationManager;
+import io.gravitee.gateway.policy.impl.PolicyLoader;
+import io.gravitee.gateway.reactor.ReactableApi;
 import io.gravitee.gateway.reactor.handler.ReactorHandler;
+import io.gravitee.gateway.reactor.handler.context.ApiTemplateVariableProviderFactory;
+import io.gravitee.gateway.report.ReporterService;
+import io.gravitee.gateway.resource.internal.v4.DefaultResourceManager;
+import io.gravitee.node.api.Node;
+import io.gravitee.node.api.configuration.Configuration;
+import io.gravitee.node.container.spring.SpringEnvironmentConfiguration;
+import io.gravitee.plugin.core.api.ConfigurablePluginManager;
+import io.gravitee.plugin.endpoint.EndpointConnectorPluginManager;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPluginManager;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.plugin.resource.ResourcePlugin;
+import io.gravitee.resource.api.ResourceManager;
 import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.env.StandardEnvironment;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -40,70 +74,275 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class DefaultApiReactorFactoryTest {
 
-    private DefaultApiReactorFactory cut;
+    @Mock
+    ApplicationContext applicationContext;
+
+    Configuration configuration = new SpringEnvironmentConfiguration(new StandardEnvironment());
 
     @Mock
-    private Api api;
+    Node node;
+
+    @Mock
+    PolicyFactory policyFactory;
+
+    @Mock
+    EntrypointConnectorPluginManager entrypointConnectorPluginManager;
+
+    @Mock
+    EndpointConnectorPluginManager endpointConnectorPluginManager;
+
+    @Mock
+    PolicyChainFactory platformPolicyChainFactory;
+
+    @Mock
+    OrganizationManager organizationManager;
+
+    @Mock
+    ApiProcessorChainFactory apiProcessorChainFactory;
+
+    @Mock
+    io.gravitee.gateway.jupiter.handlers.api.flow.resolver.FlowResolverFactory flowResolverFactory;
+
+    @Mock
+    FlowResolverFactory v4FlowResolverFactory;
+
+    @Mock
+    RequestTimeoutConfiguration requestTimeoutConfiguration;
+
+    @Mock
+    ReporterService reporterService;
+
+    private DefaultApiReactorFactory cut;
 
     @Mock
     private io.gravitee.definition.model.v4.Api definition;
 
     @BeforeEach
     public void init() {
+        cut =
+            new DefaultApiReactorFactory(
+                applicationContext,
+                configuration,
+                node,
+                policyFactory,
+                entrypointConnectorPluginManager,
+                endpointConnectorPluginManager,
+                platformPolicyChainFactory,
+                organizationManager,
+                apiProcessorChainFactory,
+                flowResolverFactory,
+                v4FlowResolverFactory,
+                requestTimeoutConfiguration,
+                reporterService
+            );
+    }
+
+    @Nested
+    class CanCreate {
+
+        @Test
+        public void should_create_api_with_http_listener() {
+            when(definition.getListeners()).thenReturn(Collections.singletonList(new HttpListener()));
+
+            boolean create = cut.canCreate(anApi());
+            assertTrue(create);
+        }
+
+        @Test
+        public void should_create_api_with_subscription_listener() {
+            when(definition.getListeners()).thenReturn(Collections.singletonList(new SubscriptionListener()));
+
+            boolean create = cut.canCreate(anApi());
+            assertTrue(create);
+        }
+
+        @Test
+        public void should_not_create_api_with_definition_v2() {
+            boolean create = cut.canCreate(anApiV2());
+            assertFalse(create);
+        }
+
+        @Test
+        public void should_not_create_api_if_disabled() {
+            ReactorHandler handler = cut.create(aDisabledApi());
+            assertNull(handler);
+        }
+
+        @Test
+        public void should_not_create_api_with_no_listener() {
+            when(definition.getListeners()).thenReturn(Collections.emptyList());
+
+            boolean create = cut.canCreate(anApi());
+            assertFalse(create);
+        }
+
+        @Test
+        public void should_not_create_api_with_no_http_or_subscription_listener() {
+            when(definition.getListeners()).thenReturn(Collections.singletonList(new TcpListener()));
+
+            boolean create = cut.canCreate(anApi());
+            assertFalse(create);
+        }
+    }
+
+    @Nested
+    class Create {
+
+        ComponentProvider globalComponentProvider;
+        ConfigurablePluginManager<?> resourcePluginManager;
+        ConfigurablePluginManager<?> policyPluginManager;
+        List<TemplateVariableProvider> registeredApiTemplateVariableProvider;
+
+        @BeforeEach
+        void setUp() {
+            globalComponentProvider = registerGlobalComponentProvider();
+            resourcePluginManager = registerResourcePluginManager();
+            policyPluginManager = registerPolicyPluginManager();
+            registeredApiTemplateVariableProvider = registerApiTemplateVariableProvider(List.of(mock(TemplateVariableProvider.class)));
+        }
+
+        @Test
+        void should_create_api_reactor_with_default_configuration() {
+            var api = anApi();
+            var reactor = cut.create(api);
+
+            assertThat(reactor).extracting("node").isSameAs(node);
+            assertThat(reactor).extracting("tracingEnabled").isEqualTo(false);
+            assertThat(reactor).extracting("pendingRequestsTimeout").isEqualTo(10_000L);
+            assertThat(reactor).extracting("loggingExcludedResponseType").isNull();
+            assertThat(reactor).extracting("loggingMaxSize").isNull();
+        }
+
+        @Test
+        void should_create_api_reactor_with_a_ComponentProvider_initialized() {
+            var api = anApi();
+            var reactor = cut.create(api);
+
+            assertThat(reactor).isInstanceOf(DefaultApiReactor.class);
+            var componentProvider = ((DefaultApiReactor) reactor).getComponentProvider();
+
+            assertThat(componentProvider)
+                .isInstanceOf(CompositeComponentProvider.class)
+                .extracting("componentProviders")
+                .asList()
+                .contains(globalComponentProvider);
+
+            assertThat(componentProvider.getComponent(Api.class)).isSameAs(api);
+            assertThat(componentProvider.getComponent(ReactableApi.class)).isSameAs(api);
+            assertThat(componentProvider.getComponent(io.gravitee.definition.model.v4.Api.class)).isSameAs(definition);
+            assertThat(componentProvider.getComponent(ResourceManager.class)).isNotNull();
+            assertThat(componentProvider.getComponent(EndpointManager.class)).isNotNull();
+            assertThat(componentProvider.getComponent(DlqServiceFactory.class)).isNotNull();
+        }
+
+        @Test
+        void should_create_api_reactor_with_ResourceManager() {
+            var api = anApi();
+            var reactor = cut.create(api);
+
+            assertThat(reactor)
+                .extracting("resourceLifecycleManager")
+                .isInstanceOf(DefaultResourceManager.class)
+                .extracting("resourcePluginManager")
+                .isSameAs(resourcePluginManager);
+        }
+
+        @Test
+        void should_create_api_reactor_with_PolicyManager() {
+            var api = anApi();
+            var reactor = cut.create(api);
+
+            assertThat(reactor)
+                .extracting("policyManager")
+                .isInstanceOf(ApiPolicyManager.class)
+                .extracting("policyLoader")
+                .isInstanceOf(PolicyLoader.class)
+                .extracting("policyPluginManager")
+                .isSameAs(policyPluginManager);
+        }
+
+        @Test
+        void should_create_api_reactor_with_TemplateVariableProviders() {
+            var api = anApi();
+            var reactor = cut.create(api);
+
+            assertThat(reactor).isInstanceOf(DefaultApiReactor.class);
+            var templateVariableProviders = ((DefaultApiReactor) reactor).getCtxTemplateVariableProviders();
+
+            assertThat(templateVariableProviders)
+                .hasSize(2 + registeredApiTemplateVariableProvider.size())
+                .satisfies(
+                    list -> {
+                        assertThat(list.stream().filter(p -> p instanceof ApiTemplateVariableProvider).findFirst()).isPresent();
+                        assertThat(list.stream().filter(p -> registeredApiTemplateVariableProvider.contains(p)).findFirst()).isPresent();
+                        assertThat(list.stream().filter(p -> p instanceof EndpointManager).findFirst()).isPresent();
+                    }
+                );
+        }
+
+        private List<TemplateVariableProvider> registerApiTemplateVariableProvider(List<TemplateVariableProvider> providers) {
+            var apiTemplateVariableProviderFactory = mock(ApiTemplateVariableProviderFactory.class);
+            when(apiTemplateVariableProviderFactory.getTemplateVariableProviders()).thenReturn(providers);
+            lenient()
+                .when(applicationContext.getBean(ApiTemplateVariableProviderFactory.class))
+                .thenReturn(apiTemplateVariableProviderFactory);
+            return providers;
+        }
+
+        private ComponentProvider registerGlobalComponentProvider() {
+            var globalComponentProvider = mock(ComponentProvider.class);
+            lenient().when(applicationContext.getBean(ComponentProvider.class)).thenReturn(globalComponentProvider);
+            return globalComponentProvider;
+        }
+
+        private ConfigurablePluginManager<?> registerResourcePluginManager() {
+            var resourcePluginManager = mock(ConfigurablePluginManager.class);
+            lenient()
+                .when(
+                    applicationContext.getBeanNamesForType(
+                        ResolvableType.forClassWithGenerics(ConfigurablePluginManager.class, ResourcePlugin.class)
+                    )
+                )
+                .thenReturn(new String[] { "resourcePluginManager" });
+            lenient().when(applicationContext.getBean("resourcePluginManager")).thenReturn(resourcePluginManager);
+            return resourcePluginManager;
+        }
+
+        private ConfigurablePluginManager<?> registerPolicyPluginManager() {
+            var policyPluginManager = mock(ConfigurablePluginManager.class);
+            lenient()
+                .when(
+                    applicationContext.getBeanNamesForType(
+                        ResolvableType.forClassWithGenerics(ConfigurablePluginManager.class, PolicyPlugin.class)
+                    )
+                )
+                .thenReturn(new String[] { "policyPluginManager" });
+            lenient().when(applicationContext.getBean("policyPluginManager")).thenReturn(policyPluginManager);
+            return policyPluginManager;
+        }
+    }
+
+    private Api anApi() {
+        Api api = mock(Api.class);
+        lenient().when(api.isEnabled()).thenReturn(true);
+        lenient().when(api.getDefinitionVersion()).thenReturn(DefinitionVersion.V4);
         lenient().when(api.getDefinition()).thenReturn(definition);
-
-        cut = new DefaultApiReactorFactory(null, null, null, null, null, null, null, null, null, null, null, null, null);
+        return api;
     }
 
-    @Test
-    public void shouldNotCreateApiWithDefinitionV2() {
-        when(api.getDefinitionVersion()).thenReturn(DefinitionVersion.V2);
-
-        boolean create = cut.canCreate(api);
-        assertFalse(create);
+    private Api aDisabledApi() {
+        Api api = mock(Api.class);
+        lenient().when(api.isEnabled()).thenReturn(false);
+        lenient().when(api.getDefinitionVersion()).thenReturn(DefinitionVersion.V4);
+        lenient().when(api.getDefinition()).thenReturn(definition);
+        return api;
     }
 
-    @Test
-    public void shouldNotCreateApiWithNoListener() {
-        when(api.getDefinitionVersion()).thenReturn(DefinitionVersion.V4);
-        when(definition.getListeners()).thenReturn(Collections.emptyList());
-
-        boolean create = cut.canCreate(api);
-        assertFalse(create);
-    }
-
-    @Test
-    public void shouldNotCreateApiWithNoHttpOrSubscriptionListener() {
-        when(api.getDefinitionVersion()).thenReturn(DefinitionVersion.V4);
-        when(definition.getListeners()).thenReturn(Collections.singletonList(new TcpListener()));
-
-        boolean create = cut.canCreate(api);
-        assertFalse(create);
-    }
-
-    @Test
-    public void shouldCreateApiWithHttpListener() {
-        when(api.getDefinitionVersion()).thenReturn(DefinitionVersion.V4);
-        when(definition.getListeners()).thenReturn(Collections.singletonList(new HttpListener()));
-
-        boolean create = cut.canCreate(api);
-        assertTrue(create);
-    }
-
-    @Test
-    public void shouldCreateApiWithSubscriptionListener() {
-        when(api.getDefinitionVersion()).thenReturn(DefinitionVersion.V4);
-        when(definition.getListeners()).thenReturn(Collections.singletonList(new SubscriptionListener()));
-
-        boolean create = cut.canCreate(api);
-        assertTrue(create);
-    }
-
-    @Test
-    public void shouldNotCreateApiIfDisabled() {
-        when(api.isEnabled()).thenReturn(false);
-
-        ReactorHandler handler = cut.create(api);
-        assertNull(handler);
+    private Api anApiV2() {
+        Api api = mock(Api.class);
+        lenient().when(api.isEnabled()).thenReturn(true);
+        lenient().when(api.getDefinitionVersion()).thenReturn(DefinitionVersion.V2);
+        lenient().when(api.getDefinition()).thenReturn(definition);
+        return api;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/resources/logback-test.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/resources/logback-test.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2015-2016, The Gravitee team (http://www.gravitee.io)
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+
+<configuration debug="true">
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{5} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.gravitee" level="ERROR" />
+    <logger name="io.gravitee.gateway.jupiter.handlers.api.v4" level="ERROR" />
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-platform/src/main/java/io/gravitee/gateway/platform/spring/PlatformConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-platform/src/main/java/io/gravitee/gateway/platform/spring/PlatformConfiguration.java
@@ -181,7 +181,8 @@ public class PlatformConfiguration {
             cpm,
             resourceClassLoaderFactory,
             resourceConfigurationFactory,
-            applicationContext
+            applicationContext,
+            null
         );
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-resource/src/main/java/io/gravitee/gateway/resource/internal/ResourceLoader.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-resource/src/main/java/io/gravitee/gateway/resource/internal/ResourceLoader.java
@@ -16,7 +16,7 @@
 package io.gravitee.gateway.resource.internal;
 
 import io.gravitee.gateway.core.classloader.DefaultClassLoader;
-import io.gravitee.gateway.reactor.Reactable;
+import io.gravitee.gateway.jupiter.api.context.DeploymentContext;
 import io.gravitee.gateway.resource.ResourceConfigurationFactory;
 import io.gravitee.plugin.core.api.ConfigurablePluginManager;
 import io.gravitee.plugin.resource.ResourceClassLoaderFactory;
@@ -43,19 +43,22 @@ public class ResourceLoader {
     private final ResourceClassLoaderFactory resourceClassLoaderFactory;
     private final ResourceConfigurationFactory resourceConfigurationFactory;
     private final ApplicationContext applicationContext;
+    private final DeploymentContext deploymentContext;
 
     public ResourceLoader(
         final DefaultClassLoader classLoader,
         final ConfigurablePluginManager<ResourcePlugin<?>> resourcePluginManager,
         final ResourceClassLoaderFactory resourceClassLoaderFactory,
         final ResourceConfigurationFactory resourceConfigurationFactory,
-        final ApplicationContext applicationContext
+        final ApplicationContext applicationContext,
+        final DeploymentContext deploymentContext
     ) {
         this.classLoader = classLoader;
         this.resourcePluginManager = resourcePluginManager;
         this.resourceClassLoaderFactory = resourceClassLoaderFactory;
         this.resourceConfigurationFactory = resourceConfigurationFactory;
         this.applicationContext = applicationContext;
+        this.deploymentContext = deploymentContext;
     }
 
     @SuppressWarnings("unchecked")
@@ -77,6 +80,7 @@ public class ResourceLoader {
                 classLoader
             );
             Map<Class<?>, Object> injectables = new HashMap<>();
+            injectables.put(DeploymentContext.class, deploymentContext);
 
             if (resourcePlugin.configuration() != null) {
                 Class<? extends ResourceConfiguration> resourceConfigurationClass = (Class<? extends ResourceConfiguration>) ClassUtils.forName(

--- a/gravitee-apim-gateway/gravitee-apim-gateway-resource/src/main/java/io/gravitee/gateway/resource/internal/ResourceManagerImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-resource/src/main/java/io/gravitee/gateway/resource/internal/ResourceManagerImpl.java
@@ -17,13 +17,13 @@ package io.gravitee.gateway.resource.internal;
 
 import io.gravitee.definition.model.plugins.resources.Resource;
 import io.gravitee.gateway.core.classloader.DefaultClassLoader;
+import io.gravitee.gateway.jupiter.api.context.DeploymentContext;
 import io.gravitee.gateway.reactor.Reactable;
 import io.gravitee.gateway.resource.ResourceConfigurationFactory;
 import io.gravitee.gateway.resource.internal.legacy.LegacyResourceManagerImpl;
 import io.gravitee.plugin.core.api.ConfigurablePluginManager;
 import io.gravitee.plugin.resource.ResourceClassLoaderFactory;
 import io.gravitee.plugin.resource.ResourcePlugin;
-import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationContext;
 
@@ -44,7 +44,8 @@ public class ResourceManagerImpl extends LegacyResourceManagerImpl {
         final ConfigurablePluginManager<ResourcePlugin<?>> resourcePluginManager,
         final ResourceClassLoaderFactory resourceClassLoaderFactory,
         final ResourceConfigurationFactory resourceConfigurationFactory,
-        final ApplicationContext applicationContext
+        final ApplicationContext applicationContext,
+        final DeploymentContext deploymentContext
     ) {
         super(reactable, resourcePluginManager, resourceClassLoaderFactory, resourceConfigurationFactory, applicationContext);
         this.legacyMode = legacyMode;
@@ -54,7 +55,8 @@ public class ResourceManagerImpl extends LegacyResourceManagerImpl {
                 resourcePluginManager,
                 resourceClassLoaderFactory,
                 resourceConfigurationFactory,
-                applicationContext
+                applicationContext,
+                deploymentContext
             );
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-resource/src/main/java/io/gravitee/gateway/resource/internal/v4/DefaultResourceManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-resource/src/main/java/io/gravitee/gateway/resource/internal/v4/DefaultResourceManager.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.resource.internal.v4;
 
 import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.gateway.core.classloader.DefaultClassLoader;
+import io.gravitee.gateway.jupiter.api.context.DeploymentContext;
 import io.gravitee.gateway.reactor.Reactable;
 import io.gravitee.gateway.resource.ResourceConfigurationFactory;
 import io.gravitee.gateway.resource.internal.ResourceLoader;
@@ -42,7 +43,8 @@ public class DefaultResourceManager extends LegacyResourceManagerImpl {
         final ConfigurablePluginManager<ResourcePlugin<?>> resourcePluginManager,
         final ResourceClassLoaderFactory resourceClassLoaderFactory,
         final ResourceConfigurationFactory resourceConfigurationFactory,
-        final ApplicationContext applicationContext
+        final ApplicationContext applicationContext,
+        final DeploymentContext deploymentContext
     ) {
         super(reactable, resourcePluginManager, resourceClassLoaderFactory, resourceConfigurationFactory, applicationContext);
         this.resourceLoader =
@@ -51,7 +53,8 @@ public class DefaultResourceManager extends LegacyResourceManagerImpl {
                 resourcePluginManager,
                 resourceClassLoaderFactory,
                 resourceConfigurationFactory,
-                applicationContext
+                applicationContext,
+                deploymentContext
             );
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-resource/src/test/java/io/gravitee/gateway/resource/internal/v4/fake/FakeWithDeploymentContext.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-resource/src/test/java/io/gravitee/gateway/resource/internal/v4/fake/FakeWithDeploymentContext.java
@@ -13,28 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.gateway.core.component;
+package io.gravitee.gateway.resource.internal.v4.fake;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
+import io.gravitee.gateway.jupiter.api.context.DeploymentContext;
+import javax.inject.Inject;
 import lombok.Getter;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class CompositeComponentProvider implements ComponentProvider {
+public class FakeWithDeploymentContext extends io.gravitee.resource.api.AbstractConfigurableResource<FakeConfiguration> {
 
+    @Inject
     @Getter
-    private final List<ComponentProvider> componentProviders;
-
-    public CompositeComponentProvider(ComponentProvider... componentProviders) {
-        this.componentProviders = Arrays.asList(componentProviders);
-    }
-
-    @Override
-    public <T> T getComponent(Class<T> clazz) {
-        return this.componentProviders.stream().map(cp -> cp.getComponent(clazz)).filter(Objects::nonNull).findFirst().orElse(null);
-    }
+    DeploymentContext deploymentContext;
 }


### PR DESCRIPTION
## Issue
N/A

## Description

The DeploymentContext can be injected in Resource using an @Inject annotation.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wgherwtlvo.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/provide-deployment-context-to-resource/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
