### PR TITLE
fix(kafka-endpoint): add banners in schema form

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/resources/schemas/schema-form.json
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/resources/schemas/schema-form.json
@@ -5,8 +5,14 @@
     "properties": {
         "bootstrapServers": {
             "type": "string",
-            "title": "Bootstrap servers",
-            "description": "A list of host/port pairs, separated by a comma, to use for establishing the initial connection to the Kafka cluster. The client will make use of all servers irrespective of which servers are specified here for bootstrapping—this list only impacts the initial hosts used to discover the full set of servers. This list should be in the form host1:port1,host2:port2,..."
+            "title": "bootstrap.servers",
+            "description": "This list should be in the form host1:port1,host2:port2,...",
+            "gioConfig": {
+                "banner": {
+                    "title": "Bootstrap servers",
+                    "text": "A list of host/port pairs, separated by a comma, to use for establishing the initial connection to the Kafka cluster. The client will make use of all servers irrespective of which servers are specified here for bootstrapping—this list only impacts the initial hosts used to discover the full set of servers. "
+                }
+            }
         },
         "topics": {
             "type": "array",
@@ -35,10 +41,15 @@
                 },
                 "autoOffsetReset": {
                     "title": "Auto offset reset",
-                    "description": "What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server (e.g. because that data has been deleted): <ul><li>earliest: automatically reset the offset to the earliest offset<li>latest: automatically reset the offset to the latest offset</li><li>none: throw exception to the consumer if no previous offset is found for the consumer's group</li><li>anything else: throw exception to the consumer.</li></ul>",
                     "type": "string",
                     "default": "latest",
-                    "enum": ["latest", "earliest", "none"]
+                    "enum": ["latest", "earliest", "none"],
+                    "gioConfig": {
+                        "banner": {
+                            "title": "Auto offset reset",
+                            "text": "What to do when there is no initial offset in Kafka or if the current offset does not exist any more on the server (e.g. because that data has been deleted): <ul><li>earliest: automatically reset the offset to the earliest offset<li>latest: automatically reset the offset to the latest offset</li><li>none: throw exception to the consumer if no previous offset is found for the consumer's group</li><li>anything else: throw exception to the consumer.</li></ul>"
+                        }
+                    }
                 }
             }
         },


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-752

## Description

Update plugin schema form in order to use the new banner capability (see https://particles.gravitee.io/?path=/story/components-form-json-schema-readme--page#banner)

The configuration form will look like this
![screenshot-localhost_9008-2023 02 15-10_26_47](https://user-images.githubusercontent.com/1655950/218987658-4972a78a-b89e-4fc5-a5f1-ca06324ab3ee.png)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bbgxiwifgo.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-752-fix-kafka-schema-form/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
