### PR TITLE
ci(release): fix release note group by PR number

### DIFF
--- a/release/ci-steps/doc-new-release-notes.mjs
+++ b/release/ci-steps/doc-new-release-notes.mjs
@@ -34,7 +34,7 @@ const computeCommitInfo = async (gitLogOutput) => {
   return Array.from(
     fetchPrInfo
       // Group by PR number
-      .reduce((entryMap, e) => entryMap.set(e, [...(entryMap.get(e.number) || []), e]), new Map())
+      .reduce((entryMap, e) => entryMap.set(e.number, [...(entryMap.get(e.number) || []), e]), new Map())
       .values(),
   ).map((pr) => {
     const info = pr[0].title ? `### [${pr[0].title} [${pr[0].number}]](${pr[0].url})\n` : '### Commit without found PR\n';


### PR DESCRIPTION
## Issue
n/a

## Description

Bug found with last release : fix release note group by PR number 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vttuaxnpiy.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/3.18.x-fix-release/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
