### PR TITLE
Display redundant spaces in API, Application and Plan deletion popup

### DIFF
--- a/gravitee-apim-console-webui/src/components/dialog/confirmAndValidate.dialog.html
+++ b/gravitee-apim-console-webui/src/components/dialog/confirmAndValidate.dialog.html
@@ -17,14 +17,14 @@
 -->
 <md-dialog aria-label="warning-dialog">
   <md-dialog-content layout-padding>
-    <h4>{{title}}</h4>
+    <h4 style="white-space: pre-wrap">{{title}}</h4>
     <div class="gv-page-draft-banner" style="background-color: rgba(206, 72, 68, 0.1)">
       <ng-md-icon icon="warning" class="gv-warning"></ng-md-icon>
       {{warning}}
     </div>
     <p style="margin: 35px 0" ng-bind-html="msg"></p>
     <hr style="margin: 0" />
-    <p ng-bind-html="validationMessage"></p>
+    <p style="white-space: pre-wrap" ng-bind-html="validationMessage"></p>
     <input type="text" style="width: 100%" autofocus ng-model="confirmValue" />
   </md-dialog-content>
   <md-dialog-actions layout="row">


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8867
https://gravitee.atlassian.net/browse/APIM-779


## Description

Display redundant spaces in API, Application and Plan deletion popup.

**Do not blame me for the inline style, the whole popup is like this** and will be deleted with the angular migration

I will open the PR for all the branches to be sure it's properly handled with the migration

## Screenshots

Before
![Capture d’écran 2023-02-15 à 16 39 30](https://user-images.githubusercontent.com/4112568/219079835-347f7cca-1335-4acf-b9a5-e2ddfc0d2fe0.png)


After
![image](https://user-images.githubusercontent.com/4112568/219082205-436b3806-8b9e-4d52-9a72-4cc451af0ef2.png)

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-multiple-spaces-display/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kscbcdamrc.chromatic.com)
<!-- Storybook placeholder end -->
