### PR TITLE
refactor: revert crd export to non bc version

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/kubernetes/v1alpha1/ApiDefinitionResource.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/kubernetes/v1alpha1/ApiDefinitionResource.java
@@ -55,7 +55,7 @@ public class ApiDefinitionResource extends CustomResource<ObjectNode> {
 
     private static final String VERSION_FIELD = "version";
 
-    private static final String CONTEXTS_FIELD = "contexts";
+    private static final String CONTEXT_REF_FIELD = "contextRef";
 
     private static final String CONTEXT_NAME_FIELD = "name";
 
@@ -85,7 +85,7 @@ public class ApiDefinitionResource extends CustomResource<ObjectNode> {
     }
 
     public void setContextRef(String name, String namespace) {
-        getSpec().putArray(CONTEXTS_FIELD).addObject().put(CONTEXT_NAME_FIELD, name).put(CONTEXT_NAMESPACE_FIELD, namespace);
+        getSpec().putObject(CONTEXT_REF_FIELD).put(CONTEXT_NAME_FIELD, name).put(CONTEXT_NAMESPACE_FIELD, namespace);
     }
 
     public void removeIds() {

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/kubernetes/v1alpha1/ApiDefinitionResourceTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/kubernetes/v1alpha1/ApiDefinitionResourceTest.java
@@ -73,7 +73,7 @@ public class ApiDefinitionResourceTest {
     }
 
     @Test
-    public void ShouldAddContextRef() throws Exception {
+    public void ShouldSetContextRef() throws Exception {
         String contextRefName = "apim-dev-ctx";
         String contextRefNamespace = "default";
 
@@ -81,13 +81,9 @@ public class ApiDefinitionResourceTest {
 
         resource.setContextRef(contextRefName, contextRefNamespace);
 
-        assertTrue(resource.getSpec().has("contexts"));
+        assertTrue(resource.getSpec().has("contextRef"));
 
-        ArrayNode contexts = ((ArrayNode) resource.getSpec().get("contexts"));
-
-        assertEquals(contexts.size(), 1);
-
-        JsonNode contextRef = contexts.get(0);
+        ObjectNode contextRef = ((ObjectNode) resource.getSpec().get("contextRef"));
 
         assertTrue(contextRef.has("name"));
         assertTrue(contextRef.has("namespace"));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsCustomResource-contextRef.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsCustomResource-contextRef.yml
@@ -62,6 +62,6 @@ spec:
       '*/*':
         status: 400
         body: "{\"bad\":\"news\"}"
-  contexts:
-  - name: "apim-dev-ctx"
+  contextRef:
+    name: "apim-dev-ctx"
     namespace: "default"


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/APIM-715
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kclaisyqjz.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/refactor-reverse-gko-bc/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
