### PR TITLE
Update to bom v4 and vertx 4.3.8

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/el/ContentTemplateVariableProviderTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/el/ContentTemplateVariableProviderTest.java
@@ -264,7 +264,8 @@ class ContentTemplateVariableProviderTest {
 
     @Test
     void shouldProvideXmlContentWhenInvalidXmlContent() {
-        when(request.bodyOrEmpty()).thenReturn(Single.just(Buffer.buffer("invalid")));
+        // Provide an invalid xml that can't be successfully parsed by the xml mapper.
+        when(request.bodyOrEmpty()).thenReturn(Single.just(Buffer.buffer("<invalid")));
         when(templateContext.lookupVariable(TEMPLATE_ATTRIBUTE_REQUEST)).thenReturn(evaluableRequest);
 
         cut.provide(ctx);
@@ -276,6 +277,7 @@ class ContentTemplateVariableProviderTest {
         final TestObserver<Void> obs = contentCompletable.test();
         obs.assertComplete();
 
+        // An empty map is expected if the content isn't a valid xml.
         verify(evaluableRequest).setXmlContent(Collections.emptyMap());
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/grpc/jupiter/GrpcUnknownEndpointIntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/grpc/jupiter/GrpcUnknownEndpointIntegrationTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test;
 @GatewayTest
 @DeployApi({ "/apis/grpc/unknown-endpoint.json" })
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-public class GrpcUnkownEndpointIntegrationTest extends AbstractGrpcGatewayTest {
+public class GrpcUnknownEndpointIntegrationTest extends AbstractGrpcGatewayTest {
 
     @Override
     protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
@@ -52,7 +52,7 @@ public class GrpcUnkownEndpointIntegrationTest extends AbstractGrpcGatewayTest {
     @Test
     void should_request_and_not_get_response(VertxTestContext testContext) throws InterruptedException {
         // Prepare gRPC Client
-        ManagedChannel channel = createManagedChannel();
+        ManagedChannel channel = createSecuredManagedChannel(event -> event.setUseAlpn(true).setSsl(true).setTrustAll(true));
 
         // Get a stub to use for interacting with the remote service
         GreeterGrpc.GreeterStub stub = GreeterGrpc.newStub(channel);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/grpc/v3/GrpcUnknownEndpointV3IntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/grpc/v3/GrpcUnknownEndpointV3IntegrationTest.java
@@ -19,13 +19,13 @@ import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuil
 import io.gravitee.definition.model.Api;
 import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.gateway.reactor.ReactableApi;
-import io.gravitee.gateway.tests.grpc.jupiter.GrpcUnkownEndpointIntegrationTest;
+import io.gravitee.gateway.tests.grpc.jupiter.GrpcUnknownEndpointIntegrationTest;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
-class GrpcUnknownEndpointV3IntegrationTest extends GrpcUnkownEndpointIntegrationTest {
+class GrpcUnknownEndpointV3IntegrationTest extends GrpcUnknownEndpointIntegrationTest {
 
     @Override
     protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/grpc/v3Compatibility/GrpcUnknownEndpointV3CompatibilityIntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/grpc/v3Compatibility/GrpcUnknownEndpointV3CompatibilityIntegrationTest.java
@@ -19,13 +19,13 @@ import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuil
 import io.gravitee.definition.model.Api;
 import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.gateway.reactor.ReactableApi;
-import io.gravitee.gateway.tests.grpc.jupiter.GrpcUnkownEndpointIntegrationTest;
+import io.gravitee.gateway.tests.grpc.jupiter.GrpcUnknownEndpointIntegrationTest;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
-class GrpcUnknownEndpointV3CompatibilityIntegrationTest extends GrpcUnkownEndpointIntegrationTest {
+class GrpcUnknownEndpointV3CompatibilityIntegrationTest extends GrpcUnknownEndpointIntegrationTest {
 
     @Override
     protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/test/java/io/gravitee/plugin/entrypoint/webhook/WebhookEntrypointConnectorTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-webhook/src/test/java/io/gravitee/plugin/entrypoint/webhook/WebhookEntrypointConnectorTest.java
@@ -544,7 +544,7 @@ class WebhookEntrypointConnectorTest {
         verify(ctx).setInternalAttribute(INTERNAL_ATTR_WEBHOOK_SUBSCRIPTION_CONFIG, subscriptionConfiguration);
         verify(ctx).setInternalAttribute(eq(INTERNAL_ATTR_WEBHOOK_HTTP_CLIENT), httpClientCaptor.capture());
 
-        HttpClientOptions options = ((HttpClientImpl) httpClientCaptor.getValue().getDelegate()).getOptions();
+        HttpClientOptions options = ((HttpClientImpl) httpClientCaptor.getValue().getDelegate()).options();
         assertThat(options.isSsl()).isTrue();
         assertThat(options.getDefaultHost()).isEqualTo("localhost");
         assertThat(options.getDefaultPort()).isEqualTo(473);
@@ -561,7 +561,7 @@ class WebhookEntrypointConnectorTest {
         verify(ctx).setInternalAttribute(INTERNAL_ATTR_WEBHOOK_SUBSCRIPTION_CONFIG, subscriptionConfiguration);
         verify(ctx).setInternalAttribute(eq(INTERNAL_ATTR_WEBHOOK_HTTP_CLIENT), httpClientCaptor.capture());
 
-        HttpClientOptions options = ((HttpClientImpl) httpClientCaptor.getValue().getDelegate()).getOptions();
+        HttpClientOptions options = ((HttpClientImpl) httpClientCaptor.getValue().getDelegate()).options();
         assertThat(options.isSsl()).isFalse();
         assertThat(options.getDefaultHost()).isEqualTo("localhost");
         assertThat(options.getDefaultPort()).isEqualTo(473);

--- a/pom.xml
+++ b/pom.xml
@@ -51,9 +51,9 @@
         <changelist>-SNAPSHOT</changelist>
 
         <!-- Vert.X version is mandatory for vertx-grpc-protoc-plugin in gravitee-apim-gateway-standalone-container -->
-        <vertx.version>4.2.7</vertx.version>
+        <vertx.version>4.3.8</vertx.version>
         <!-- Gravitee dependencies version -->
-        <gravitee-bom.version>3.0.1-update-deps-SNAPSHOT</gravitee-bom.version>
+        <gravitee-bom.version>4.0.0-alpha.1</gravitee-bom.version>
         <gravitee-alert-api.version>1.9.1</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>2.0.0</gravitee-cockpit-api.version>
         <gravitee-common.version>2.1.0-alpha.5</gravitee-common.version>
@@ -62,7 +62,7 @@
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>2.1.0-alpha.12</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
-        <gravitee-node.version>2.1.0-alpha.2</gravitee-node.version>
+        <gravitee-node.version>3.0.0-alpha.1</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>
         <gravitee-plugin.version>1.25.0</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.2.0</gravitee-platform-repository-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <!-- Vert.X version is mandatory for vertx-grpc-protoc-plugin in gravitee-apim-gateway-standalone-container -->
         <vertx.version>4.2.7</vertx.version>
         <!-- Gravitee dependencies version -->
-        <gravitee-bom.version>3.0.0</gravitee-bom.version>
+        <gravitee-bom.version>3.0.1-update-deps-SNAPSHOT</gravitee-bom.version>
         <gravitee-alert-api.version>1.9.1</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>2.0.0</gravitee-cockpit-api.version>
         <gravitee-common.version>2.1.0-alpha.5</gravitee-common.version>


### PR DESCRIPTION
## Issue

N/A

## Description

Update to bom v4 which comes with vertx 4.3.8 and apply fixes on ByteBuf.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xwwzovajcu.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/update-jackson-deps-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
