### PR TITLE
feat: implement delete member in migrated api member page

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/portal/user-group-access/api-portal-user-group.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/user-group-access/api-portal-user-group.module.ts
@@ -15,7 +15,7 @@
  */
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { GioAvatarModule, GioIconsModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
+import { GioAvatarModule, GioConfirmDialogModule, GioIconsModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
 import { MatSelectModule } from '@angular/material/select';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatCardModule } from '@angular/material/card';
@@ -24,6 +24,7 @@ import { UIRouterModule } from '@uirouter/angular';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatButtonModule } from '@angular/material/button';
 import { MatTableModule } from '@angular/material/table';
+import { MatDialogModule } from '@angular/material/dialog';
 
 import { ApiPortalGroupsComponent } from './groups/api-portal-groups.component';
 import { ApiPortalMembersComponent } from './members/api-portal-members.component';
@@ -44,11 +45,13 @@ import { GioPermissionModule } from '../../../../shared/components/gio-permissio
     MatSelectModule,
     MatSnackBarModule,
     MatTableModule,
+    MatDialogModule,
 
     GioAvatarModule,
     GioIconsModule,
     GioPermissionModule,
     GioSaveBarModule,
+    GioConfirmDialogModule,
   ],
 })
 export class ApiPortalUserGroupModule {}

--- a/gravitee-apim-console-webui/src/management/api/portal/user-group-access/members/api-portal-members.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/user-group-access/members/api-portal-members.component.html
@@ -50,7 +50,14 @@
           </mat-select>
         </td>
       </ng-container>
-
+      <ng-container matColumnDef="delete">
+        <th mat-header-cell *matHeaderCellDef></th>
+        <td mat-cell *matCellDef="let member">
+          <div class="action-cell" *ngIf="member.role !== 'PRIMARY_OWNER'">
+            <button type="button" mat-icon-button (click)="removeMember(member)"><mat-icon svgIcon="gio:trash"></mat-icon></button>
+          </div>
+        </td>
+      </ng-container>
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
       <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
     </table>

--- a/gravitee-apim-console-webui/src/management/api/portal/user-group-access/members/api-portal-members.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/portal/user-group-access/members/api-portal-members.component.scss
@@ -15,3 +15,9 @@
 .primary-owner-name {
   font-weight: bold;
 }
+
+.action-cell {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}

--- a/gravitee-apim-console-webui/src/management/api/portal/user-group-access/members/api-portal-members.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/user-group-access/members/api-portal-members.harness.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 import { ComponentHarness } from '@angular/cdk/testing';
-import { MatRowHarness, MatTableHarness } from '@angular/material/table/testing';
+import { MatCellHarness, MatRowHarness, MatTableHarness } from '@angular/material/table/testing';
 import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
 import { GioSaveBarHarness } from '@gravitee/ui-particles-angular';
 import { MatSelectHarness } from '@angular/material/select/testing';
 import { MatOptionHarness, OptionHarnessFilters } from '@angular/material/core/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
 
 export class ApiPortalMembersHarness extends ComponentHarness {
   static hostSelector = 'api-portal-members';
@@ -59,6 +60,26 @@ export class ApiPortalMembersHarness extends ComponentHarness {
 
   async isMemberRoleSelectDisabled(rowIndex: number): Promise<boolean> {
     return this.getMemberRoleSelectForRowIndex(rowIndex).then((select) => select.isDisabled());
+  }
+
+  async getMemberDeleteButton(rowIndex: number): Promise<MatButtonHarness> {
+    const deleteCell = await this.getMemberDeleteCell(rowIndex);
+    return deleteCell.getHarness(MatButtonHarness);
+  }
+
+  async getMemberDeleteCell(rowIndex: number): Promise<MatCellHarness> {
+    const rows = await this.getTableRows();
+    expect(rows.length).toBeGreaterThan(rowIndex);
+    const deleteCell = await rows[rowIndex].getCells({ columnName: 'delete' });
+    expect(deleteCell.length).toEqual(1);
+    return deleteCell[0];
+  }
+
+  async isMemberDeleteButtonVisible(rowIndex: number): Promise<boolean> {
+    return this.getMemberDeleteCell(rowIndex).then(async (cell) => {
+      const harnesses = await cell.getAllHarnesses(MatButtonHarness);
+      return harnesses !== null && harnesses.length > 0;
+    });
   }
 
   async isNotificationsCheckboxChecked(): Promise<boolean> {

--- a/gravitee-apim-console-webui/src/services-ngx/api-member.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-member.service.spec.ts
@@ -78,4 +78,20 @@ describe('ApiMemberService', () => {
       req.flush({});
     });
   });
+
+  describe('delete member', () => {
+    it('should call the API', (done) => {
+      const apiId = 'fox';
+      const memberId = 'id';
+      apiMemberService.deleteMember(apiId, memberId).subscribe(() => {
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        method: 'DELETE',
+        url: `${CONSTANTS_TESTING.env.baseURL}/apis/${apiId}/members?user=${memberId}`,
+      });
+      req.flush({});
+    });
+  });
 });

--- a/gravitee-apim-console-webui/src/services-ngx/api-member.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-member.service.ts
@@ -32,11 +32,11 @@ export class ApiMemberService {
     return this.http.post<void>(`${this.constants.env.baseURL}/apis/${api}/members`, membership);
   }
 
+  deleteMember(api: string, userId: string): Observable<void> {
+    return this.http.delete<void>(`${this.constants.env.baseURL}/apis/${api}/members?user=${userId}`);
+  }
+
   // TODO add this when needed
-  // deleteMember(api: string, userId: string): Observable<any> {
-  //   return this.http.delete(`${this.constants.env.baseURL}/apis/${api}/members?user=${userId}`);
-  // }
-  //
   // transferOwnership(api: string, ownership: ApiMembership): Observable<any> {
   //   return this.http.post(`${this.constants.env.baseURL}/apis/${api}/members/transfer_ownership`, ownership);
   // }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-653

## Description

Implement member delete on the new migrated page

## Additional context

Deleting a member will show a confirmation dialog. Action is executed when user confirms (no need to click on save bar). 
![Screenshot 2023-02-16 at 14 17 16](https://user-images.githubusercontent.com/1655950/219375246-f9c0dc94-4141-42d2-a361-8559e77fd3df.png)
![Screenshot 2023-02-16 at 14 17 36](https://user-images.githubusercontent.com/1655950/219375296-77ce9a5b-6e8f-4bc5-974c-7b594aaf2c87.png)

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xadtkwhdnh.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-653-migrate-api-members-delete/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
