### PR TITLE
fix(repository): use default application.findAll to have group filled

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApplicationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApplicationRepository.java
@@ -265,6 +265,11 @@ public class JdbcApplicationRepository extends JdbcAbstractCrudRepository<Applic
     }
 
     @Override
+    public Set<Application> findAll() throws TechnicalException {
+        return this.findAll(ApplicationStatus.values());
+    }
+
+    @Override
     public Set<Application> findAll(ApplicationStatus... ass) throws TechnicalException {
         LOGGER.debug("JdbcApplicationRepository.findAll({})", (Object[]) ass);
 


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8876
https://gravitee.atlassian.net/browse/APIM-813

## Description

The upgrader `ApplicationApiKeyModeUpgrader` use the application findAll but by default this find all provide from the abstract JdbcAbstractCrudRepository. So it can get data from join table like groups. 
So the upgrader remove all group on update application. 

This fix override default application.findAll and use the findAll with all statuses


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-flgabaydaz.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/3.18.x-fix-application-findall/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
