### PR TITLE
Apim 590 make api description optional

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.spec.ts
@@ -123,6 +123,22 @@ describe('ApiCreationV4Component', () => {
       expect(component.currentStep.label).toEqual('Entrypoints');
     });
 
+    it('should save api details and move to next step (description is optional)', async () => {
+      const step1Harness = await harnessLoader.getHarness(Step1ApiDetailsHarness);
+      expect(step1Harness).toBeDefined();
+      expect(component.currentStep.label).toEqual('API details');
+      await step1Harness.setName('API');
+      await step1Harness.setVersion('1.0');
+      await step1Harness.clickValidate();
+      expectEntrypointsGetRequest([]);
+
+      fixture.detectChanges();
+
+      component.stepper.compileStepPayload(component.currentStep);
+      expect(component.currentStep.payload).toEqual({ name: 'API', version: '1.0', description: '' });
+      expect(component.currentStep.label).toEqual('Entrypoints');
+    });
+
     it('should exit without confirmation when no modification', async () => {
       const step1Harness = await harnessLoader.getHarness(Step1ApiDetailsHarness);
       expect(step1Harness).toBeDefined();

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.ts
@@ -148,6 +148,8 @@ export class ApiCreationV4Component implements OnInit, OnDestroy {
           return {
             ...api,
             name: apiCreationPayload.name,
+            apiVersion: apiCreationPayload.version,
+            description: apiCreationPayload.description ?? '',
             listeners: apiCreationPayload.listeners,
           };
         }),

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-1-api-details/step-1-api-details.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-1-api-details/step-1-api-details.component.html
@@ -38,7 +38,7 @@
     </div>
     <div class="step-1-api-details__row">
       <mat-form-field appearance="outline">
-        <textarea id="description" matInput #input maxlength="250" formControlName="description" rows="4" required="true"></textarea>
+        <textarea id="description" matInput #input maxlength="250" formControlName="description" rows="4"></textarea>
         <mat-label>Description</mat-label>
         <mat-hint align="start">Describe how your API works</mat-hint>
         <mat-hint align="end">{{ input.value.length }}/250</mat-hint>

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-1-api-details/step-1-api-details.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-1-api-details/step-1-api-details.component.ts
@@ -44,7 +44,7 @@ export class Step1ApiDetailsComponent implements OnInit {
     this.form = this.formBuilder.group({
       name: this.formBuilder.control(currentStepPayload?.name, [Validators.required]),
       version: this.formBuilder.control(currentStepPayload?.version, [Validators.required]),
-      description: this.formBuilder.control(currentStepPayload?.description, [Validators.required]),
+      description: this.formBuilder.control(currentStepPayload?.description),
     });
     if (currentStepPayload && Object.keys(currentStepPayload).length > 0) {
       this.form.markAsDirty();
@@ -78,7 +78,7 @@ export class Step1ApiDetailsComponent implements OnInit {
     this.stepService.validStepAndGoNext((previousPayload) => ({
       ...previousPayload,
       name: formValue.name,
-      description: formValue.description,
+      description: formValue.description ?? '',
       version: formValue.version,
     }));
   }

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-1-api-details/step-1-api-details.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-1-api-details/step-1-api-details.harness.ts
@@ -75,7 +75,10 @@ export class Step1ApiDetailsHarness extends ComponentHarness {
   }
 
   async clickValidate(): Promise<void> {
-    return this.getValidateButton().then((elt) => elt.click());
+    return this.getValidateButton().then(async (elt) => {
+      expect(await elt.isDisabled()).toEqual(false);
+      return elt.click();
+    });
   }
 
   async clickExit(): Promise<void> {

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-6-summary/step-6-summary.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-6-summary/step-6-summary.component.html
@@ -34,7 +34,7 @@
             <span class="step-6-summary__step__info__key">Version:</span>
             <span class="step-6-summary__step__info__value">{{ currentStepPayload.version }}</span>
           </div>
-          <div class="step-6-summary__step__info__row">
+          <div class="step-6-summary__step__info__row" *ngIf="currentStepPayload.description">
             <span class="step-6-summary__step__info__key">Description:</span>
             <span class="step-6-summary__step__info__value">
               {{ currentStepPayload.description }}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/resources/management-openapi-v4.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/resources/management-openapi-v4.yaml
@@ -636,7 +636,6 @@ components:
                     type: string
                     description: API's description. A short description of your API.
                     example: I can use many characters to describe this API.
-                    minLength: 1
                 disableMembershipNotifications:
                     type: boolean
                     description: Disable membership notifications.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/NewApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/NewApiEntity.java
@@ -18,12 +18,10 @@ package io.gravitee.rest.api.model.v4.api;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.analytics.Analytics;
-import io.gravitee.definition.model.v4.analytics.logging.Logging;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.FlowMode;
 import io.gravitee.definition.model.v4.listener.Listener;
-import io.gravitee.rest.api.model.DeploymentRequired;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import java.util.Set;
@@ -69,7 +67,7 @@ public class NewApiEntity {
     @Schema(description = "API's type", example = "async")
     private ApiType type;
 
-    @NotBlank
+    @NotNull
     @Schema(
         description = "API's description. A short description of your API.",
         example = "I can use a hundred characters to describe this API."

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/UpdateApiEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/UpdateApiEntity.java
@@ -83,7 +83,7 @@ public class UpdateApiEntity {
     @Schema(description = "API's type", example = "async")
     private ApiType type;
 
-    @NotBlank
+    @NotNull
     @Schema(
         description = "API's description. A short description of your API.",
         example = "I can use a hundred characters to describe this API."


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-590

## Description

Make the description of the API optional. 
Change has been made only to v4 API, and description is set to `NotNull` to avoid errors on the backend. Frontend app will send empty string if field is not provided.


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-taypvbqjol.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-590-make-api-description-optional/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
