### PR TITLE
Update validation spec in API proxy config schema form

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/http-connector.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/http-connector.json
@@ -254,7 +254,7 @@
           "properties": { "enabled": { "const": false } }
         },
         {
-          "properties": { "useSystemProxy": { "const": true } }
+          "properties": { "enabled": { "const": true }, "useSystemProxy": { "const": true } }
         },
         {
           "properties": { "enabled": { "const": true }, "useSystemProxy": { "const": false } },


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8698
https://gravitee.atlassian.net/browse/APIM-415

## Description

To validate against oneOf, the given data must be valid against exactly one of the given subschemas.
See https://json-schema.org/understanding-json-schema/reference/combining.html#oneof
It's like a XOR, if it's valid against multiple subschemas then it's reported invalid. 
This was the case when proxy was disabled but system proxy enabled. 
So I strengthen the subschemas related to system proxy.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8698-fix-proxy-settings-validation/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zzbywkglpd.chromatic.com)
<!-- Storybook placeholder end -->
