### PR TITLE
feat: disable path based option in settings and api creation page

### DIFF
--- a/gravitee-apim-console-webui/src/entities/consoleSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/consoleSettings.ts
@@ -114,9 +114,6 @@ export interface ConsoleSettingsManagement {
   };
   title?: string;
   url?: string;
-  pathBasedApiCreation?: {
-    enabled: boolean;
-  };
   userCreation?: {
     enabled?: boolean;
   };

--- a/gravitee-apim-console-webui/src/management/api/creation/api-creation-get-started.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation/api-creation-get-started.component.html
@@ -65,10 +65,3 @@
     <button mat-raised-button color="primary" (click)="goToApiImport()">Import an API</button>
   </div>
 </mat-card>
-
-<div class="api-creation-get-started__path-based mat-small" *ngIf="allowsPathBasedCreation">
-  <span
-    >Or you can still use paths based | <a href="javascript:void(0)" (click)="goToApiImport('1.0.0')">Import</a> -
-    <a href="javascript:void(0)" (click)="goToApiCreationWizard('1.0.0')">Create</a></span
-  >
-</div>

--- a/gravitee-apim-console-webui/src/management/api/creation/api-creation-get-started.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/api-creation-get-started.component.ts
@@ -45,10 +45,6 @@ export class ApiCreationGetStartedComponent implements OnInit, OnDestroy {
 
   policies = [];
 
-  get allowsPathBasedCreation() {
-    return this.constants.org.settings.management?.pathBasedApiCreation?.enabled ?? false;
-  }
-
   private unsubscribe$: Subject<void> = new Subject<void>();
 
   constructor(

--- a/gravitee-apim-console-webui/src/management/management.run.ts
+++ b/gravitee-apim-console-webui/src/management/management.run.ts
@@ -95,11 +95,7 @@ function runBlock(
         return;
       }
 
-      const settings = await ConsoleSettingsService.getConsole();
-      const hasPathBasedApiCreation = settings?.data?.management?.pathBasedApiCreation?.enabled;
-      if (!hasPathBasedApiCreation) {
-        return trans.router.stateService.target('management.apis.new');
-      }
+      return trans.router.stateService.target('management.apis.new');
     },
   );
 

--- a/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.html
@@ -75,24 +75,6 @@
 
         <gio-form-slide-toggle
           [matTooltip]="providedConfigurationMessage"
-          [matTooltipDisabled]="!isReadonlySetting('console.pathBasedApiCreation.enabled')"
-          class="settings-general__form__card__form-field"
-          formGroupName="pathBasedApiCreation"
-        >
-          <mat-icon *ngIf="isReadonlySetting('console.pathBasedApiCreation.enabled')" gioFormPrefix>lock</mat-icon>
-          <gio-form-label>Enable path based API creation</gio-form-label>
-          <mat-slide-toggle
-            gioFormSlideToggle
-            formControlName="enabled"
-            aria-label="Enable path based API creation"
-            name="pathBasedApiCreation"
-          ></mat-slide-toggle>
-        </gio-form-slide-toggle>
-
-        <mat-divider></mat-divider>
-
-        <gio-form-slide-toggle
-          [matTooltip]="providedConfigurationMessage"
           [matTooltipDisabled]="!isReadonlySetting('console.userCreation.enabled')"
           class="settings-general__form__card__form-field"
           formGroupName="userCreation"

--- a/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.spec.ts
@@ -96,9 +96,6 @@ describe('ConsoleSettingsComponent', () => {
           support: {
             enabled: false,
           },
-          pathBasedApiCreation: {
-            enabled: true,
-          },
           userCreation: {
             enabled: false,
           },
@@ -119,9 +116,6 @@ describe('ConsoleSettingsComponent', () => {
         management: {
           title: 'New Title',
           support: {
-            enabled: true,
-          },
-          pathBasedApiCreation: {
             enabled: true,
           },
           userCreation: {

--- a/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.ts
@@ -75,7 +75,6 @@ export class OrgSettingsGeneralComponent implements OnInit, OnDestroy {
             title: [toFormState(this.settings, 'management.title')],
             url: [toFormState(this.settings, 'management.url')],
             support: this.fb.group({ enabled: [toFormState(this.settings, 'management.support.enabled')] }),
-            pathBasedApiCreation: this.fb.group({ enabled: [toFormState(this.settings, 'management.pathBasedApiCreation.enabled')] }),
             userCreation: this.fb.group({ enabled: [toFormState(this.settings, 'management.userCreation.enabled')] }),
             automaticValidation: this.fb.group({ enabled: [toFormState(this.settings, 'management.automaticValidation.enabled')] }),
           }),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -306,8 +306,6 @@ public enum Key {
         "true",
         new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))
     ),
-    CONSOLE_PATH_BASED_API_CREATION_ENABLED("console.pathBasedApiCreation.enabled", "false", Set.of(ORGANIZATION, SYSTEM)),
-
     CONSOLE_SYSTEM_ROLE_EDITION_ENABLED("console.systemRoleEdition.enabled", "false", Set.of(SYSTEM)),
 
     CONSOLE_ANALYTICS_PENDO_ENABLED("console.analytics.pendo.enabled", "false", Set.of(SYSTEM)),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/Management.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/Management.java
@@ -35,9 +35,6 @@ public class Management {
     @ParameterKey(Key.MANAGEMENT_URL)
     private String url;
 
-    @ParameterKey(Key.CONSOLE_PATH_BASED_API_CREATION_ENABLED)
-    private Enabled pathBasedApiCreation;
-
     @ParameterKey(Key.CONSOLE_USERCREATION_ENABLED)
     private Enabled userCreation;
 
@@ -69,14 +66,6 @@ public class Management {
 
     public void setUrl(String url) {
         this.url = url;
-    }
-
-    public Enabled getPathBasedApiCreation() {
-        return pathBasedApiCreation;
-    }
-
-    public void setPathBasedApiCreation(Enabled pathBasedApiCreation) {
-        this.pathBasedApiCreation = pathBasedApiCreation;
     }
 
     public Enabled getUserCreation() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-835

## Description

Remove link to create path based API (v1.0.0) from API creation page, and remove the associated setting from organization settings.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ewgqywevmt.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-835-disable-path-based-api-creation/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
