### PR TITLE
fix: properly configure http-proxy connector with custom https endpoint

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/VertxHttpClientHelper.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/VertxHttpClientHelper.java
@@ -62,10 +62,12 @@ public class VertxHttpClientHelper {
 
     public static RequestOptions configureAbsoluteUri(RequestOptions requestOptions, String uri, MultiValueMap<String, String> parameters) {
         final URL target = VertxHttpClient.buildUrl(buildFinalUri(uri, parameters));
+        final boolean secureProtocol = VertxHttpClient.isSecureProtocol(target.getProtocol());
 
         return requestOptions
             .setURI(target.getQuery() == null ? target.getPath() : target.getPath() + URI_QUERY_DELIMITER_CHAR + target.getQuery())
-            .setPort(VertxHttpClient.getPort(target, VertxHttpClient.isSecureProtocol(target.getProtocol())))
+            .setPort(VertxHttpClient.getPort(target, secureProtocol))
+            .setSsl(secureProtocol)
             .setHost(target.getHost());
     }
 

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/client/VertxHttpClientHelperTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/client/VertxHttpClientHelperTest.java
@@ -87,10 +87,25 @@ class VertxHttpClientHelperTest {
         final LinkedMultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
 
         parameters.put("foo", List.of("bar"));
+        VertxHttpClientHelper.configureAbsoluteUri(requestOptions, "http://api.gravitee.io/echo?foo=bar1&hello=gravitee", parameters);
+
+        assertThat(requestOptions.getURI()).isEqualTo("/echo?foo=bar1&hello=gravitee&foo=bar");
+        assertThat(requestOptions.getHost()).isEqualTo("api.gravitee.io");
+        assertThat(requestOptions.getPort()).isEqualTo(80);
+        assertThat(requestOptions.isSsl()).isFalse();
+    }
+
+    @Test
+    void shouldConfigureAbsoluteUriWithSslEnabled() {
+        final RequestOptions requestOptions = new RequestOptions();
+        final LinkedMultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+
+        parameters.put("foo", List.of("bar"));
         VertxHttpClientHelper.configureAbsoluteUri(requestOptions, "https://api.gravitee.io/echo?foo=bar1&hello=gravitee", parameters);
 
         assertThat(requestOptions.getURI()).isEqualTo("/echo?foo=bar1&hello=gravitee&foo=bar");
         assertThat(requestOptions.getHost()).isEqualTo("api.gravitee.io");
         assertThat(requestOptions.getPort()).isEqualTo(443);
+        assertThat(requestOptions.isSsl()).isTrue();
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-455

## Description

When overriding the endpoint url with an `https` url and the endpoint is configured with an `http` target, the request wasn't properly set up (ssl wasn't forced to true).
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zhezcczeah.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-455-fix-http-proxy-https-user-defined-endpoint/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
