### PR TITLE
Remove all entries of a subscription from cache

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionService.java
@@ -103,6 +103,7 @@ public class SubscriptionService implements io.gravitee.gateway.api.service.Subs
             !cachedSubscription.getClientId().equals(subscription.getClientId())
         ) {
             cacheByApiClientId.evict(buildClientIdCacheKey(cachedSubscription));
+            cacheByApiClientId.evict(buildClientIdCacheKey(cachedSubscription.getApi(), cachedSubscription.getClientId(), null));
         }
 
         // put or remove subscription from cache according to its status

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/service/SubscriptionServiceTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/service/SubscriptionServiceTest.java
@@ -151,12 +151,25 @@ public class SubscriptionServiceTest {
         subscriptionService.save(newSubscription);
 
         // should find subscription in cache with its new client id
-        Optional<Subscription> foundSubscription = subscriptionService.getByApiAndClientIdAndPlan(API_ID, "new-client-id", PLAN_ID);
-        assertTrue(foundSubscription.isPresent());
-        assertSame(newSubscription, foundSubscription.get());
+        Optional<Subscription> foundSubscriptionWithFullKey = subscriptionService.getByApiAndClientIdAndPlan(
+            API_ID,
+            "new-client-id",
+            PLAN_ID
+        );
+        assertTrue(foundSubscriptionWithFullKey.isPresent());
+        assertSame(newSubscription, foundSubscriptionWithFullKey.get());
+
+        Optional<Subscription> foundSubscriptionWithNullPlanKey = subscriptionService.getByApiAndClientIdAndPlan(
+            API_ID,
+            "new-client-id",
+            null
+        );
+        assertTrue(foundSubscriptionWithNullPlanKey.isPresent());
+        assertSame(newSubscription, foundSubscriptionWithNullPlanKey.get());
 
         // should not find it with its old client id
         assertFalse(subscriptionService.getByApiAndClientIdAndPlan(API_ID, "old-client-id", PLAN_ID).isPresent());
+        assertFalse(subscriptionService.getByApiAndClientIdAndPlan(API_ID, "old-client-id", null).isPresent());
     }
 
     @Test


### PR DESCRIPTION
## Issue

gravitee-io/issues#8883
https://gravitee.atlassian.net/browse/APIM-838

## Description

When we evict a subscription because clientID has changed, we must remove the 2 existing entries:
 - `apiId-clientId-planId`
 - `apiId-clientId-null`
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vinmuryxcf.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/8883-fix-evict-all-reference-of-a-subscription/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
