### PR TITLE
Apim 836 disable api v1 creation

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
@@ -291,7 +291,7 @@ public class ApisResource extends AbstractResource {
     )
     public Response importApiDefinition(
         @RequestBody(required = true) @Valid @NotNull JsonNode apiDefinition,
-        @QueryParam("definitionVersion") @DefaultValue("1.0.0") String definitionVersion
+        @QueryParam("definitionVersion") @DefaultValue("2.0.0") String definitionVersion
     ) {
         return importApiDefinitionOrUrl(apiDefinition, definitionVersion);
     }
@@ -318,7 +318,7 @@ public class ApisResource extends AbstractResource {
     )
     public Response importApiDefinitionUrl(
         @RequestBody(required = true) @Valid @NotNull String apiDefinitionOrUrl,
-        @QueryParam("definitionVersion") @DefaultValue("1.0.0") String definitionVersion
+        @QueryParam("definitionVersion") @DefaultValue("2.0.0") String definitionVersion
     ) {
         return importApiDefinitionOrUrl(apiDefinitionOrUrl, definitionVersion);
     }
@@ -346,7 +346,7 @@ public class ApisResource extends AbstractResource {
     )
     public Response deprecatedImportApiDefinitionUrl(
         @RequestBody(required = true) @Valid @NotNull String apiDefinitionOrUrl,
-        @QueryParam("definitionVersion") @DefaultValue("1.0.0") String definitionVersion
+        @QueryParam("definitionVersion") @DefaultValue("2.0.0") String definitionVersion
     ) {
         return importApiDefinitionOrUrl(apiDefinitionOrUrl, definitionVersion);
     }
@@ -378,7 +378,7 @@ public class ApisResource extends AbstractResource {
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = RolePermissionAction.CREATE) })
     public Response importSwaggerApi(
         @Parameter(name = "swagger", required = true) @Valid @NotNull ImportSwaggerDescriptorEntity swaggerDescriptor,
-        @QueryParam("definitionVersion") @DefaultValue("1.0.0") String definitionVersion
+        @QueryParam("definitionVersion") @DefaultValue("2.0.0") String definitionVersion
     ) {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         final SwaggerApiEntity swaggerApiEntity = swaggerService.createAPI(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApisResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApisResourceTest.java
@@ -113,7 +113,7 @@ public class ApisResourceTest extends AbstractResourceTest {
     }
 
     @Test
-    public void shouldImportApiFromSwager() {
+    public void shouldImportApiFromSwagger() {
         reset(apiService, swaggerService);
         ImportSwaggerDescriptorEntity swaggerDescriptor = new ImportSwaggerDescriptorEntity();
         swaggerDescriptor.setPayload("my-payload");
@@ -122,7 +122,12 @@ public class ApisResourceTest extends AbstractResourceTest {
         createdApi.setId("my-beautiful-api");
         doReturn(createdApi).when(apiService).createFromSwagger(eq(GraviteeContext.getExecutionContext()), any(), any(), any());
 
-        final Response response = envTarget().path("import").path("swagger").request().post(Entity.json(swaggerDescriptor));
+        final Response response = envTarget()
+            .path("import")
+            .path("swagger")
+            .queryParam("definitionVersion", "2.0.0")
+            .request()
+            .post(Entity.json(swaggerDescriptor));
         assertEquals(HttpStatusCode.CREATED_201, response.getStatus());
         assertEquals(envTarget().path("my-beautiful-api").getUri().toString(), response.getHeaders().getFirst(HttpHeaders.LOCATION));
 
@@ -130,24 +135,8 @@ public class ApisResourceTest extends AbstractResourceTest {
             .createAPI(
                 eq(GraviteeContext.getExecutionContext()),
                 argThat(argument -> argument.getPayload().equalsIgnoreCase(swaggerDescriptor.getPayload())),
-                eq(DefinitionVersion.valueOfLabel("1.0.0"))
+                eq(DefinitionVersion.valueOfLabel("2.0.0"))
             );
-    }
-
-    @Test
-    public void shouldImportApiFromGraviteeIODefinitionV1() {
-        reset(apiService, swaggerService);
-        String apiDefinition = "{}";
-
-        ApiEntity createdApi = new ApiEntity();
-        createdApi.setGraviteeDefinitionVersion("1.0.0");
-        createdApi.setId("my-beautiful-api");
-        doReturn(createdApi).when(apiDuplicatorService).createWithImportedDefinition(eq(GraviteeContext.getExecutionContext()), any());
-
-        final Response response = envTarget().path("import").request().post(Entity.json(apiDefinition));
-        assertEquals(HttpStatusCode.OK_200, response.getStatus());
-
-        verify(apiService, times(0)).migrate(eq(GraviteeContext.getExecutionContext()), any());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/ApiDefinitionVersionNotSupportedException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/ApiDefinitionVersionNotSupportedException.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.exceptions;
+
+import io.gravitee.common.http.HttpStatusCode;
+import java.util.Collections;
+import java.util.Map;
+
+public class ApiDefinitionVersionNotSupportedException extends AbstractManagementException {
+
+    private final String version;
+
+    public ApiDefinitionVersionNotSupportedException(String version) {
+        this.version = version;
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "api.definitionVersionNotSupported";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return Collections.singletonMap("definitionVersion", version);
+    }
+
+    @Override
+    public String getMessage() {
+        return "The definition versions " + version + " is not supported anymore.";
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
@@ -41,10 +41,7 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.converter.PlanConverter;
-import io.gravitee.rest.api.service.exceptions.ApiImportException;
-import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
-import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
-import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
+import io.gravitee.rest.api.service.exceptions.*;
 import io.gravitee.rest.api.service.imports.ImportApiJsonNode;
 import io.gravitee.rest.api.service.imports.ImportJsonNode;
 import io.gravitee.rest.api.service.imports.ImportJsonNodeWithIds;
@@ -168,6 +165,12 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
                 urlApiId
             );
 
+            UpdateApiEntity importedApi = convertToEntity(executionContext, apiJsonNode.toString(), apiJsonNode);
+
+            if (DefinitionVersion.V1.equals(DefinitionVersion.valueOfLabel(importedApi.getGraviteeDefinitionVersion()))) {
+                throw new ApiDefinitionVersionNotSupportedException(importedApi.getGraviteeDefinitionVersion());
+            }
+
             // ensure user has required permission to update target API
             if (
                 !isAuthenticated() ||
@@ -180,7 +183,6 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
             checkApiJsonConsistency(executionContext, apiJsonNode, urlApiId);
 
             // import
-            UpdateApiEntity importedApi = convertToEntity(executionContext, apiJsonNode.toString(), apiJsonNode);
             ApiEntity updatedApiEntity = apiService.update(executionContext, apiJsonNode.getId(), importedApi);
             createOrUpdateApiNestedEntities(executionContext, updatedApiEntity, apiJsonNode);
             return updatedApiEntity;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -15,30 +15,18 @@
  */
 package io.gravitee.rest.api.service.impl;
 
-import static io.gravitee.repository.management.model.Api.AuditEvent.API_CREATED;
-import static io.gravitee.repository.management.model.Api.AuditEvent.API_DELETED;
-import static io.gravitee.repository.management.model.Api.AuditEvent.API_ROLLBACKED;
-import static io.gravitee.repository.management.model.Api.AuditEvent.API_UPDATED;
+import static io.gravitee.repository.management.model.Api.AuditEvent.*;
 import static io.gravitee.repository.management.model.Visibility.PUBLIC;
-import static io.gravitee.repository.management.model.Workflow.AuditEvent.API_REVIEW_ACCEPTED;
-import static io.gravitee.repository.management.model.Workflow.AuditEvent.API_REVIEW_ASKED;
-import static io.gravitee.repository.management.model.Workflow.AuditEvent.API_REVIEW_REJECTED;
+import static io.gravitee.repository.management.model.Workflow.AuditEvent.*;
 import static io.gravitee.rest.api.model.EventType.PUBLISH_API;
 import static io.gravitee.rest.api.model.PageType.SWAGGER;
 import static io.gravitee.rest.api.model.WorkflowState.DRAFT;
 import static io.gravitee.rest.api.model.WorkflowType.REVIEW;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_DEFINITION_VERSION;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singleton;
-import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
+import static java.util.Collections.*;
 import static java.util.Comparator.comparing;
 import static java.util.Optional.of;
-import static java.util.stream.Collectors.counting;
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
-import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Collectors.*;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -49,15 +37,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Strings;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.common.util.DataEncryptor;
-import io.gravitee.definition.model.DefinitionContext;
-import io.gravitee.definition.model.DefinitionVersion;
-import io.gravitee.definition.model.Endpoint;
-import io.gravitee.definition.model.EndpointGroup;
-import io.gravitee.definition.model.Logging;
-import io.gravitee.definition.model.LoggingMode;
-import io.gravitee.definition.model.Proxy;
-import io.gravitee.definition.model.Rule;
-import io.gravitee.definition.model.VirtualHost;
+import io.gravitee.definition.model.*;
 import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.definition.model.flow.Step;
 import io.gravitee.definition.model.plugins.resources.Resource;
@@ -69,54 +49,20 @@ import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldFilter;
 import io.gravitee.repository.management.api.search.builder.PageableBuilder;
+import io.gravitee.repository.management.model.*;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.ApiLifecycleState;
-import io.gravitee.repository.management.model.Audit;
-import io.gravitee.repository.management.model.Event;
-import io.gravitee.repository.management.model.GroupEvent;
-import io.gravitee.repository.management.model.LifecycleState;
-import io.gravitee.repository.management.model.NotificationReferenceType;
 import io.gravitee.repository.management.model.Visibility;
-import io.gravitee.repository.management.model.Workflow;
 import io.gravitee.repository.management.model.flow.FlowReferenceType;
-import io.gravitee.rest.api.model.ApiMetadataEntity;
-import io.gravitee.rest.api.model.CategoryEntity;
-import io.gravitee.rest.api.model.EventEntity;
-import io.gravitee.rest.api.model.EventQuery;
+import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.EventType;
-import io.gravitee.rest.api.model.GroupEntity;
-import io.gravitee.rest.api.model.ImportSwaggerDescriptorEntity;
-import io.gravitee.rest.api.model.InlinePictureEntity;
-import io.gravitee.rest.api.model.MembershipEntity;
 import io.gravitee.rest.api.model.MembershipMemberType;
 import io.gravitee.rest.api.model.MembershipReferenceType;
 import io.gravitee.rest.api.model.MetadataFormat;
-import io.gravitee.rest.api.model.NewApiMetadataEntity;
-import io.gravitee.rest.api.model.PageEntity;
-import io.gravitee.rest.api.model.PlanEntity;
-import io.gravitee.rest.api.model.PlanStatus;
-import io.gravitee.rest.api.model.PolicyEntity;
-import io.gravitee.rest.api.model.PrimaryOwnerEntity;
-import io.gravitee.rest.api.model.PropertiesEntity;
-import io.gravitee.rest.api.model.PropertyEntity;
-import io.gravitee.rest.api.model.ReviewEntity;
-import io.gravitee.rest.api.model.RoleEntity;
-import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.model.TagReferenceType;
-import io.gravitee.rest.api.model.UpdateApiMetadataEntity;
-import io.gravitee.rest.api.model.UserEntity;
-import io.gravitee.rest.api.model.WorkflowReferenceType;
-import io.gravitee.rest.api.model.WorkflowState;
 import io.gravitee.rest.api.model.alert.AlertReferenceType;
 import io.gravitee.rest.api.model.alert.AlertTriggerEntity;
-import io.gravitee.rest.api.model.api.ApiDeploymentEntity;
-import io.gravitee.rest.api.model.api.ApiEntity;
-import io.gravitee.rest.api.model.api.ApiEntrypointEntity;
-import io.gravitee.rest.api.model.api.ApiQuery;
-import io.gravitee.rest.api.model.api.NewApiEntity;
-import io.gravitee.rest.api.model.api.RollbackApiEntity;
-import io.gravitee.rest.api.model.api.SwaggerApiEntity;
-import io.gravitee.rest.api.model.api.UpdateApiEntity;
+import io.gravitee.rest.api.model.api.*;
 import io.gravitee.rest.api.model.api.header.ApiHeaderEntity;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.common.PageableImpl;
@@ -131,58 +77,15 @@ import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.model.settings.ApiPrimaryOwnerMode;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.model.v4.api.GenericApiModel;
-import io.gravitee.rest.api.service.AlertService;
-import io.gravitee.rest.api.service.ApiDuplicatorService;
-import io.gravitee.rest.api.service.ApiHeaderService;
-import io.gravitee.rest.api.service.ApiMetadataService;
+import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.ApiService;
-import io.gravitee.rest.api.service.AuditService;
-import io.gravitee.rest.api.service.CategoryService;
-import io.gravitee.rest.api.service.ConnectorService;
-import io.gravitee.rest.api.service.EmailService;
-import io.gravitee.rest.api.service.EnvironmentService;
-import io.gravitee.rest.api.service.EventService;
-import io.gravitee.rest.api.service.GenericNotificationConfigService;
-import io.gravitee.rest.api.service.GroupService;
-import io.gravitee.rest.api.service.JupiterModeService;
-import io.gravitee.rest.api.service.MediaService;
-import io.gravitee.rest.api.service.MembershipService;
-import io.gravitee.rest.api.service.NotifierService;
-import io.gravitee.rest.api.service.PageService;
-import io.gravitee.rest.api.service.ParameterService;
 import io.gravitee.rest.api.service.PlanService;
-import io.gravitee.rest.api.service.PolicyService;
-import io.gravitee.rest.api.service.PortalNotificationConfigService;
-import io.gravitee.rest.api.service.ResourceService;
-import io.gravitee.rest.api.service.RoleService;
-import io.gravitee.rest.api.service.SubscriptionService;
-import io.gravitee.rest.api.service.SwaggerService;
-import io.gravitee.rest.api.service.TagService;
-import io.gravitee.rest.api.service.TopApiService;
-import io.gravitee.rest.api.service.UserService;
-import io.gravitee.rest.api.service.VirtualHostService;
-import io.gravitee.rest.api.service.WorkflowService;
 import io.gravitee.rest.api.service.builder.EmailNotificationBuilder;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.configuration.flow.FlowService;
 import io.gravitee.rest.api.service.converter.ApiConverter;
-import io.gravitee.rest.api.service.exceptions.ApiAlreadyExistsException;
-import io.gravitee.rest.api.service.exceptions.ApiMetadataNotFoundException;
-import io.gravitee.rest.api.service.exceptions.ApiNotDeletableException;
-import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
-import io.gravitee.rest.api.service.exceptions.ApiNotManagedException;
-import io.gravitee.rest.api.service.exceptions.ApiRunningStateException;
-import io.gravitee.rest.api.service.exceptions.DefinitionVersionException;
-import io.gravitee.rest.api.service.exceptions.EndpointMissingException;
-import io.gravitee.rest.api.service.exceptions.EndpointNameInvalidException;
-import io.gravitee.rest.api.service.exceptions.GroupsNotFoundException;
-import io.gravitee.rest.api.service.exceptions.HealthcheckInheritanceException;
-import io.gravitee.rest.api.service.exceptions.InvalidDataException;
-import io.gravitee.rest.api.service.exceptions.LifecycleStateChangeNotAllowedException;
-import io.gravitee.rest.api.service.exceptions.PaginationInvalidException;
-import io.gravitee.rest.api.service.exceptions.TagNotAllowedException;
-import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import io.gravitee.rest.api.service.exceptions.*;
 import io.gravitee.rest.api.service.impl.search.SearchResult;
 import io.gravitee.rest.api.service.impl.upgrade.DefaultMetadataUpgrader;
 import io.gravitee.rest.api.service.jackson.ser.api.ApiSerializer;
@@ -195,31 +98,14 @@ import io.gravitee.rest.api.service.processor.SynchronizationService;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.search.query.Query;
 import io.gravitee.rest.api.service.search.query.QueryBuilder;
-import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
-import io.gravitee.rest.api.service.v4.ApiEntrypointService;
-import io.gravitee.rest.api.service.v4.ApiNotificationService;
-import io.gravitee.rest.api.service.v4.ApiTemplateService;
-import io.gravitee.rest.api.service.v4.PrimaryOwnerService;
+import io.gravitee.rest.api.service.v4.*;
 import io.gravitee.rest.api.service.v4.validation.AnalyticsValidationService;
 import io.gravitee.rest.api.service.v4.validation.CorsValidationService;
 import io.gravitee.rest.api.service.v4.validation.TagsValidationService;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -453,7 +339,11 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
     @Override
     public ApiEntity create(ExecutionContext executionContext, final NewApiEntity newApiEntity, final String userId)
-        throws ApiAlreadyExistsException {
+        throws ApiAlreadyExistsException, ApiDefinitionVersionNotSupportedException {
+        if (DefinitionVersion.V1.equals(DefinitionVersion.valueOfLabel(newApiEntity.getGraviteeDefinitionVersion()))) {
+            throw new ApiDefinitionVersionNotSupportedException(newApiEntity.getGraviteeDefinitionVersion());
+        }
+
         UpdateApiEntity apiEntity = new UpdateApiEntity();
 
         apiEntity.setName(newApiEntity.getName());
@@ -507,6 +397,10 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     @Override
     public ApiEntity createWithApiDefinition(ExecutionContext executionContext, UpdateApiEntity api, String userId, JsonNode apiDefinition)
         throws ApiAlreadyExistsException {
+        if (DefinitionVersion.V1.equals(DefinitionVersion.valueOfLabel(api.getGraviteeDefinitionVersion()))) {
+            throw new ApiDefinitionVersionNotSupportedException(api.getGraviteeDefinitionVersion());
+        }
+
         try {
             LOGGER.debug("Create {} for user {}", api, userId);
 
@@ -972,6 +866,10 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         ImportSwaggerDescriptorEntity swaggerDescriptor
     ) {
         final ApiEntity apiEntityToUpdate = this.findById(executionContext, apiId);
+        if (DefinitionVersion.V1.equals(DefinitionVersion.valueOfLabel(apiEntityToUpdate.getGraviteeDefinitionVersion()))) {
+            throw new ApiDefinitionVersionNotSupportedException(apiEntityToUpdate.getGraviteeDefinitionVersion());
+        }
+
         final UpdateApiEntity updateApiEntity = apiConverter.toUpdateApiEntity(apiEntityToUpdate);
 
         // Overwrite from swagger
@@ -1084,6 +982,9 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             LOGGER.debug("Update API {}", apiId);
 
             Api apiToUpdate = apiRepository.findById(apiId).orElseThrow(() -> new ApiNotFoundException(apiId));
+            if (DefinitionVersion.V1.equals(apiToUpdate.getDefinitionVersion())) {
+                throw new ApiDefinitionVersionNotSupportedException(apiToUpdate.getDefinitionVersion().getLabel());
+            }
 
             // check if entrypoints are unique
             final Collection<VirtualHost> sanitizedVirtualHosts = virtualHostService.sanitizeAndValidate(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_UpdateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorService_UpdateWithDefinitionTest.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
+import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.ApiLifecycleState;
 import io.gravitee.rest.api.idp.api.authentication.UserDetails;
@@ -36,6 +37,7 @@ import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.converter.PlanConverter;
+import io.gravitee.rest.api.service.exceptions.ApiDefinitionVersionNotSupportedException;
 import io.gravitee.rest.api.service.exceptions.ApiImportException;
 import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
 import io.gravitee.rest.api.service.spring.ImportConfiguration;
@@ -594,5 +596,17 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         apiDuplicatorService.updateWithImportedDefinition(GraviteeContext.getExecutionContext(), apiEntity.getId(), toBeImport);
 
         verify(planService, times(2)).findByApi(GraviteeContext.getExecutionContext(), apiEntity.getId());
+    }
+
+    @Test(expected = ApiDefinitionVersionNotSupportedException.class)
+    public void shouldNotUpdateIfDefinitionV1() throws TechnicalException, IOException {
+        URL url = Resources.getResource("io/gravitee/rest/api/management/service/import-api.v1.definition.json");
+        String toBeImport = Resources.toString(url, Charsets.UTF_8);
+        ApiEntity apiEntity = new ApiEntity();
+        Api api = new Api();
+        api.setId(API_ID);
+        apiEntity.setId(API_ID);
+
+        apiDuplicatorService.updateWithImportedDefinition(GraviteeContext.getExecutionContext(), apiEntity.getId(), toBeImport);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_CreateTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
+import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.repository.exceptions.TechnicalException;
@@ -68,6 +69,7 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.configuration.flow.FlowService;
 import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.exceptions.ApiAlreadyExistsException;
+import io.gravitee.rest.api.service.exceptions.ApiDefinitionVersionNotSupportedException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.impl.upgrade.DefaultMetadataUpgrader;
 import io.gravitee.rest.api.service.notification.NotificationTemplateService;
@@ -214,6 +216,12 @@ public class ApiService_CreateTest {
         UserEntity admin = new UserEntity();
         admin.setId(USER_NAME);
         when(primaryOwnerService.getPrimaryOwner(any(), any(), any())).thenReturn(new PrimaryOwnerEntity(admin));
+    }
+
+    @Test(expected = ApiDefinitionVersionNotSupportedException.class)
+    public void shouldNotCreateWithOldDefinitionVersion() {
+        when(newApi.getGraviteeDefinitionVersion()).thenReturn(DefinitionVersion.V1.getLabel());
+        apiService.create(GraviteeContext.getExecutionContext(), newApi, USER_NAME);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_CreateWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_CreateWithDefinitionTest.java
@@ -34,6 +34,7 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.configuration.flow.FlowService;
 import io.gravitee.rest.api.service.converter.ApiConverter;
+import io.gravitee.rest.api.service.exceptions.ApiDefinitionVersionNotSupportedException;
 import io.gravitee.rest.api.service.notification.NotificationTemplateService;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.v4.PrimaryOwnerService;
@@ -145,6 +146,14 @@ public class ApiService_CreateWithDefinitionTest {
         apiService.createWithApiDefinition(EXECUTION_CONTEXT, api, "", definition);
 
         verify(apiRepository, times(1)).create(argThat(arg -> arg.getLifecycleState().equals(LifecycleState.STARTED)));
+    }
+
+    @Test(expected = ApiDefinitionVersionNotSupportedException.class)
+    public void shouldNotCreateIfDefinitionV1() throws Exception {
+        UpdateApiEntity api = new UpdateApiEntity();
+        api.setGraviteeDefinitionVersion("1.0.0");
+
+        apiService.createWithApiDefinition(EXECUTION_CONTEXT, api, "", null);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import-api.v1.definition.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import-api.v1.definition.json
@@ -1,0 +1,108 @@
+{
+  "name": "test",
+  "version": "1",
+  "description": "bmll",
+  "visibility": "PRIVATE",
+  "lifecycle_state": "CREATED",
+  "tags": [],
+  "gravitee": "1.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://google.fr",
+        "weight": 1,
+        "backup": false,
+        "healthcheck": true
+      }
+    ],
+    "load_balancing": {
+      "type": "ROUND_ROBIN"
+    },
+    "failover": {
+      "maxAttempts": 1,
+      "retryTimeout": 0,
+      "cases": [
+        "TIMEOUT"
+      ]
+    },
+    "strip_context_path": false,
+    "http": {
+      "configuration": {
+        "connectTimeout": 5000,
+        "idleTimeout": 60000,
+        "keepAlive": true,
+        "dumpRequest": false,
+        "readTimeout": 10000,
+        "pipelining": false,
+        "maxConcurrentConnections": 100,
+        "useCompression": false
+      }
+    }
+  },
+  "paths": {
+    "/": [
+      {
+        "methods": [
+          "CONNECT",
+          "DELETE",
+          "GET",
+          "HEAD",
+          "OPTIONS",
+          "PATCH",
+          "POST",
+          "PUT",
+          "TRACE"
+        ],
+        "api-key": {}
+      },
+      {
+        "methods": [
+          "GET",
+          "POST",
+          "PUT",
+          "DELETE",
+          "HEAD",
+          "PATCH",
+          "OPTIONS",
+          "TRACE",
+          "CONNECT"
+        ],
+        "cache": {
+          "cacheName": null,
+          "key": null,
+          "timeToLiveSeconds": null,
+          "useResponseCacheHeaders": null,
+          "scope": null
+        },
+        "description": "Description of the Cache Gravitee Policy"
+      }
+    ]
+  },
+  "properties": {
+    "prop1": "value1"
+  },
+  "services": {},
+  "resources": [
+    {
+      "name": "cache_name",
+      "type": "cache",
+      "enabled": true,
+      "configuration": {
+        "name": "my-cache",
+        "timeToIdleSeconds": 1,
+        "timeToLiveSeconds": 2,
+        "maxEntriesLocalHeap": 1000
+      }
+    }
+  ],
+  "response_templates": {
+    "API_KEY_MISSING": {
+      "*/*": {
+        "status": 400,
+        "body": "{\"bad\":\"news\"}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-836

## Description

Reply with 400 - Bad request each time we try to create / update or import API with a definition version equal to v1.0.0 

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-836-disable-apip-v1-creation/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kucwfnbaoh.chromatic.com)
<!-- Storybook placeholder end -->
