### PR TITLE
3.18.x improve jdbc audit liquidebase

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_18_0/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_18_0/schema.yml
@@ -1,12 +1,18 @@
 databaseChangeLog:
+  # ################
+  # Alert - Add column
+  # ################
   - changeSet:
-      id: 3.18.0
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            columnExists:
+              tableName: ${gravitee_prefix}alert_triggers
+              columnName: environment_id
+      id: 3.18.0_alert
       author: GraviteeSource Team
       validCheckSum: ANY
       changes:
-        # ################
-        # Alert Changes
-        # ################
         - addColumn:
             tableName: ${gravitee_prefix}alert_triggers
             columns:
@@ -15,36 +21,63 @@ databaseChangeLog:
                   type: nvarchar(64)
                   constraints:
                     nullable: true
-        # ################
-        # Commands Changes
-        # ################
+
+  # ################
+  # Commands - Add column
+  # ################
+  - changeSet:
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            columnExists:
+              tableName: ${gravitee_prefix}commands
+              columnName: organization_id
+      id: 3.18.0_commands
+      author: GraviteeSource Team
+      validCheckSum: ANY
+      changes:
         - addColumn:
             tableName: ${gravitee_prefix}commands
             columns:
               - column:
                   name: organization_id
                   type: nvarchar(64)
-                  defaultValue: DEFAULT
+                  value: 'DEFAULT'
                   constraints:
                     nullable: false
               - dropNotNullConstraint:
                   columnDataType: nvarchar(64)
                   columnName: environment_id
                   tableName: ${gravitee_prefix}commands
-        # ################
-        # Audits Changes
-        # ################
+
+
+  # ################
+  # Audits - Add column
+  # ################
+  - changeSet:
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            columnExists:
+              tableName: ${gravitee_prefix}audits
+              columnName: environment_id
+      id: 3.18.0_audits_add_column
+      author: GraviteeSource Team
+      validCheckSum: ANY
+      changes:
         - addColumn:
             tableName: ${gravitee_prefix}audits
             columns:
               - column:
                   name: organization_id
                   type: nvarchar(64)
+                  value: 'DEFAULT'
                   constraints:
                     nullable: true
               - column:
                   name: environment_id
                   type: nvarchar(64)
+                  value: 'DEFAULT'
                   constraints:
                     nullable: true
         - createIndex:
@@ -57,6 +90,20 @@ databaseChangeLog:
               - column:
                   name: environment_id
                   type: nvarchar(64)
+  # ################
+  # Audits - Update organization_id & environment_id if needed
+  # ################
+  - changeSet:
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            sqlCheck:
+              expectedResult: 1
+              sql: select count(*) from ${gravitee_prefix}environments
+      id: 3.18.0
+      author: GraviteeSource Team
+      validCheckSum: ANY
+      changes:
         # mssql
         - sql:
             dbms: mssql
@@ -144,21 +191,30 @@ databaseChangeLog:
               LEFT JOIN ${gravitee_prefix}environments e on e.id = app.environment_id
               SET a.organization_id = coalesce(e.organization_id, 'DEFAULT'), a.environment_id = coalesce(e.id, 'DEFAULT')
               WHERE a.reference_type = 'APPLICATION';
-        # ################
-        # ClientRegistrationProvider Changes
-        # ################
+
+  # ################
+  # ClientRegistrationProvider - Add new column
+  # ################
+  - changeSet:
+      preConditions:
+        - onFail: MARK_RAN
+        - not:
+            columnExists:
+              tableName: ${gravitee_prefix}client_registration_providers
+              columnName: environment_id
+      id: 3.18.0_client_registration_providers
+      author: GraviteeSource Team
+      validCheckSum: ANY
+      changes:
         - addColumn:
               tableName: ${gravitee_prefix}client_registration_providers
               columns:
                   - column:
                         name: environment_id
                         type: nvarchar(64)
+                        value: 'DEFAULT'
                         constraints:
                             nullable: true
-        - addDefaultValue:
-              tableName: ${gravitee_prefix}client_registration_providers
-              columnName: environment_id
-              defaultValue: DEFAULT
         - createIndex:
               tableName: ${gravitee_prefix}client_registration_providers
               indexName: idx_${gravitee_prefix}environment


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-914

## Description

Improve perf to run audit script
- split in several changeSet
- add preConditions to not run if already apply
- prefer value instead of defaultValue (To not add default value in the SQL schema)
- for audits update env & org ids only if apim have more than 1 environments


### Test to do : 
Apim with 1 env 
- [ ] Test with 3.18.x apim already migrated -> expect new input in databasechangelog with MARK_RAN 
- [ ] Test with 3.15.x and migrate it with this change -> expect new input in databasechangelog with MARK_RAN 

Apim with more than 1 env 
- [ ] Test with 3.18.x apim already migrated -> expect new input in databasechangelog with MARK_RAN 
- [ ] Test with 3.15.x and migrate it with this change -> expect new input in databasechangelog with EXECUTED 


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-thadaywfbl.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/3.18.x-improve-jdbc-audit-liquidebase/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
