### PR TITLE
filter gateway started expired events 

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/InstanceServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/InstanceServiceImpl.java
@@ -95,12 +95,15 @@ public class InstanceServiceImpl implements InstanceService {
         }
 
         ExpiredPredicate filter = new ExpiredPredicate(Duration.ofSeconds(unknownExpireAfterInSec));
+        long from = Instant.now().minus(unknownExpireAfterInSec, ChronoUnit.SECONDS).toEpochMilli();
+        long to = Instant.now().toEpochMilli();
+
         return eventService.search(
             executionContext,
             types,
             query.getProperties(),
-            query.getFrom(),
-            query.getTo(),
+            from,
+            to,
             query.getPage(),
             query.getSize(),
             new Function<EventEntity, InstanceListItem>() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-923

## Description

When the user tries to access the Gateway instances page on the console we try to fetch all event with the type 'GATEWAY_STARTED' and then filter it. Here we will limit the search and exclude expired events.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-umervenfqe.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-923-filter-gateway-started-events/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
