### PR TITLE
feat: add sourceTimestamp in kafka messages

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -765,7 +765,7 @@
                 <gravitee-policy-interrupt.version>1.1.0</gravitee-policy-interrupt.version>
                 <gravitee-entrypoint-sse-advanced.version>3.0.0-alpha.1</gravitee-entrypoint-sse-advanced.version>
                 <gravitee-entrypoint-webhook-advanced.version>1.0.0-alpha.3</gravitee-entrypoint-webhook-advanced.version>
-                <gravitee-endpoint-kafka-advanced.version>1.0.1-alpha.2</gravitee-endpoint-kafka-advanced.version>
+                <gravitee-endpoint-kafka-advanced.version>1.0.1-alpha.3</gravitee-endpoint-kafka-advanced.version>
                 <gravitee-endpoint-mqtt5-advanced.version>1.0.0-alpha.4</gravitee-endpoint-mqtt5-advanced.version>
 
                 <!-- Management API Only -->

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/v4/analytics/logging/request/message/MessageLogEndpointRequestTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/v4/analytics/logging/request/message/MessageLogEndpointRequestTest.java
@@ -22,6 +22,7 @@ import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.jupiter.api.message.DefaultMessage;
 import io.gravitee.gateway.jupiter.core.v4.analytics.LoggingContext;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import org.junit.jupiter.api.BeforeEach;
@@ -95,7 +96,7 @@ class MessageLogEndpointRequestTest {
         @Test
         void should_log_metadata_when_metadata_logging_is_enabled() {
             when(loggingContext.endpointRequestMessageMetadata()).thenReturn(true);
-            Map<String, Object> metadata = Map.of();
+            Map<String, Object> metadata = new HashMap<>();
             DefaultMessage message = DefaultMessage.builder().metadata(metadata).build();
             MessageLogEndpointRequest cut = new MessageLogEndpointRequest(loggingContext, message);
             assertThat(cut.getMetadata()).isEqualTo(metadata);
@@ -104,7 +105,7 @@ class MessageLogEndpointRequestTest {
         @Test
         void should_not_log_metadata_when_metadata_logging_is_disabled() {
             when(loggingContext.endpointRequestMessageMetadata()).thenReturn(false);
-            Map<String, Object> metadata = Map.of();
+            Map<String, Object> metadata = new HashMap<>();
             DefaultMessage message = DefaultMessage.builder().metadata(metadata).build();
             MessageLogEndpointRequest cut = new MessageLogEndpointRequest(loggingContext, message);
             assertThat(cut.getMetadata()).isNull();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/v4/analytics/logging/request/message/MessageLogEntrypointRequestTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/v4/analytics/logging/request/message/MessageLogEntrypointRequestTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.jupiter.api.message.DefaultMessage;
 import io.gravitee.gateway.jupiter.core.v4.analytics.LoggingContext;
+import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -93,7 +94,7 @@ class MessageLogEntrypointRequestTest {
         @Test
         void should_log_metadata_when_metadata_logging_is_enabled() {
             when(loggingContext.entrypointRequestMessageMetadata()).thenReturn(true);
-            Map<String, Object> metadata = Map.of();
+            Map<String, Object> metadata = new HashMap<>();
             DefaultMessage message = DefaultMessage.builder().metadata(metadata).build();
             MessageLogEntrypointRequest cut = new MessageLogEntrypointRequest(loggingContext, message);
             assertThat(cut.getMetadata()).isEqualTo(metadata);
@@ -102,7 +103,7 @@ class MessageLogEntrypointRequestTest {
         @Test
         void should_not_log_metadata_when_metadata_logging_is_disabled() {
             when(loggingContext.entrypointRequestMessageMetadata()).thenReturn(false);
-            Map<String, Object> metadata = Map.of();
+            Map<String, Object> metadata = new HashMap<>();
             DefaultMessage message = DefaultMessage.builder().metadata(metadata).build();
             MessageLogEntrypointRequest cut = new MessageLogEntrypointRequest(loggingContext, message);
             assertThat(cut.getMetadata()).isNull();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/v4/analytics/logging/response/message/MessageLogEndpointResponseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/v4/analytics/logging/response/message/MessageLogEndpointResponseTest.java
@@ -23,6 +23,7 @@ import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.jupiter.api.message.DefaultMessage;
 import io.gravitee.gateway.jupiter.core.v4.analytics.LoggingContext;
 import io.gravitee.gateway.jupiter.handlers.api.v4.analytics.logging.response.message.MessageLogEndpointResponse;
+import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -95,7 +96,7 @@ class MessageLogEndpointResponseTest {
         @Test
         void should_log_metadata_when_metadata_logging_is_enabled() {
             when(loggingContext.endpointResponseMessageMetadata()).thenReturn(true);
-            Map<String, Object> metadata = Map.of();
+            Map<String, Object> metadata = new HashMap<>();
             DefaultMessage message = DefaultMessage.builder().metadata(metadata).build();
             MessageLogEndpointResponse cut = new MessageLogEndpointResponse(loggingContext, message);
             assertThat(cut.getMetadata()).isEqualTo(metadata);
@@ -104,7 +105,7 @@ class MessageLogEndpointResponseTest {
         @Test
         void should_not_log_metadata_when_metadata_logging_is_disabled() {
             when(loggingContext.endpointResponseMessageMetadata()).thenReturn(false);
-            Map<String, Object> metadata = Map.of();
+            Map<String, Object> metadata = new HashMap<>();
             DefaultMessage message = DefaultMessage.builder().metadata(metadata).build();
             MessageLogEndpointResponse cut = new MessageLogEndpointResponse(loggingContext, message);
             assertThat(cut.getMetadata()).isNull();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/v4/analytics/logging/response/message/MessageLogEntrypointResponseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/v4/analytics/logging/response/message/MessageLogEntrypointResponseTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.jupiter.api.message.DefaultMessage;
 import io.gravitee.gateway.jupiter.core.v4.analytics.LoggingContext;
+import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -93,7 +94,7 @@ class MessageLogEntrypointResponseTest {
         @Test
         void should_log_metadata_when_metadata_logging_is_enabled() {
             when(loggingContext.entrypointResponseMessageMetadata()).thenReturn(true);
-            Map<String, Object> metadata = Map.of();
+            Map<String, Object> metadata = new HashMap<>();
             DefaultMessage message = DefaultMessage.builder().metadata(metadata).build();
             MessageLogEntrypointResponse cut = new MessageLogEntrypointResponse(loggingContext, message);
             assertThat(cut.getMetadata()).isEqualTo(metadata);
@@ -102,7 +103,7 @@ class MessageLogEntrypointResponseTest {
         @Test
         void should_not_log_metadata_when_metadata_logging_is_disabled() {
             when(loggingContext.entrypointResponseMessageMetadata()).thenReturn(false);
-            Map<String, Object> metadata = Map.of();
+            Map<String, Object> metadata = new HashMap<>();
             DefaultMessage message = DefaultMessage.builder().metadata(metadata).build();
             MessageLogEntrypointResponse cut = new MessageLogEntrypointResponse(loggingContext, message);
             assertThat(cut.getMetadata()).isNull();

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mqtt5/src/test/java/io/gravitee/plugin/endpoint/mqtt5/Mqtt5EndpointConnectorTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mqtt5/src/test/java/io/gravitee/plugin/endpoint/mqtt5/Mqtt5EndpointConnectorTest.java
@@ -20,6 +20,7 @@ import static io.gravitee.plugin.endpoint.mqtt5.Mqtt5EndpointConnector.CONTEXT_A
 import static io.gravitee.plugin.endpoint.mqtt5.Mqtt5EndpointConnector.CONTEXT_ATTRIBUTE_MQTT5_TOPIC;
 import static io.gravitee.plugin.endpoint.mqtt5.Mqtt5EndpointConnector.INTERNAL_CONTEXT_ATTRIBUTE_MQTT_CLIENT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
@@ -181,7 +182,16 @@ class Mqtt5EndpointConnectorTest {
 
         testSubscriber.await(10, TimeUnit.SECONDS);
         testSubscriber.assertValueCount(1);
-        testSubscriber.assertValue(message -> message.content().toString().equals("message") && message.id() == null);
+        testSubscriber.assertValue(
+            message -> {
+                assertThat(message.content()).hasToString("message");
+                assertThat(message.id()).isNull();
+                assertThat(message.metadata())
+                    .containsKey(DefaultMessage.SOURCE_TIMESTAMP)
+                    .contains(entry(DefaultMessage.SOURCE_TIMESTAMP, message.timestamp()));
+                return true;
+            }
+        );
 
         client.disconnect().subscribe();
     }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/test/java/io/gravitee/plugin/entrypoint/http/post/HttpPostEntrypointConnectorTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-entrypoint/gravitee-apim-plugin-entrypoint-http-post/src/test/java/io/gravitee/plugin/entrypoint/http/post/HttpPostEntrypointConnectorTest.java
@@ -43,6 +43,7 @@ import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.schedulers.TestScheduler;
 import io.reactivex.rxjava3.subscribers.TestSubscriber;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
@@ -167,6 +168,8 @@ class HttpPostEntrypointConnectorTest {
     @Test
     void shouldCompleteWhenResponseMessagesContainsFullError() {
         responseHeaders = HttpHeaders.create();
+        final Map<String, Object> metadata = new HashMap<>();
+        metadata.put("statusCode", HttpResponseStatus.NOT_FOUND.code());
         when(response.headers()).thenReturn(responseHeaders);
         when(response.messages())
             .thenReturn(
@@ -174,7 +177,7 @@ class HttpPostEntrypointConnectorTest {
                     DefaultMessage
                         .builder()
                         .error(true)
-                        .metadata(Map.of("statusCode", HttpResponseStatus.NOT_FOUND.code()))
+                        .metadata(metadata)
                         .headers(
                             HttpHeaders
                                 .create()

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <gravitee-connector-api.version>1.1.4</gravitee-connector-api.version>
         <gravitee-expression-language.version>2.0.1</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>2.1.0-alpha.12</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>2.1.0-alpha.13</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>3.0.0-alpha.2</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-790

## Description

Add the consumer record's timestamp into `sourceTimestamp` metadata for kafka messages.

Add a test in MQTT connector to verify that this value is set to the default message timestamp (because MQTT do not set it's own timestamp)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nntcwulgwp.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-790-source-timestamp-message/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
