### PR TITLE
fix: avoid adding Redoc script in dom dynamically [ 3.20.x ]

### DIFF
--- a/gravitee-apim-portal-webui/src/app/components/gv-page-redoc/gv-page-redoc.component.ts
+++ b/gravitee-apim-portal-webui/src/app/components/gv-page-redoc/gv-page-redoc.component.ts
@@ -39,9 +39,12 @@ export class GvPageRedocComponent implements OnInit, OnDestroy {
 
   constructor(private notificationService: NotificationService, private pageService: PageService) {}
 
+  /**
+   * Redoc script is automatically loaded. See `angular.json` scripts section.
+   */
   ngOnInit() {
     const page = this.pageService.getCurrentPage();
-    this.loadScript().then(() => this.refresh(page));
+    this.refresh(page);
   }
 
   @HostListener('window:resize')
@@ -49,22 +52,6 @@ export class GvPageRedocComponent implements OnInit, OnDestroy {
   onScroll() {
     window.requestAnimationFrame(() => {
       GvDocumentationComponent.updateMenuPosition(this.redocMenu);
-    });
-  }
-
-  loadScript() {
-    return new Promise(resolve => {
-      const scriptId = 'redoc-standalone';
-      if (document.getElementById(scriptId) == null) {
-        const scriptElement = document.createElement('script');
-        scriptElement.async = true;
-        scriptElement.src = 'redoc.js';
-        scriptElement.onload = resolve;
-        scriptElement.id = scriptId;
-        document.body.appendChild(scriptElement);
-      } else {
-        resolve({});
-      }
     });
   }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-426

## Description

cherry pick of commit https://github.com/gravitee-io/gravitee-api-management/commit/e458d097d37e73ab2d61bc5eb73a8b5dc697ddfc on 3.18.x

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nmstkttdio.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-426-redoc-320x/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
