### PR TITLE
Apim 822 entrypoint permissions

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/java/io/gravitee/rest/api/management/v4/rest/GraviteeManagementV4Application.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/java/io/gravitee/rest/api/management/v4/rest/GraviteeManagementV4Application.java
@@ -22,10 +22,7 @@ import io.gravitee.rest.api.management.v4.rest.exceptionMapper.NotAllowedExcepti
 import io.gravitee.rest.api.management.v4.rest.exceptionMapper.NotFoundExceptionMapper;
 import io.gravitee.rest.api.management.v4.rest.exceptionMapper.ThrowableMapper;
 import io.gravitee.rest.api.management.v4.rest.exceptionMapper.UnrecognizedPropertyExceptionMapper;
-import io.gravitee.rest.api.management.v4.rest.filter.GraviteeContextRequestFilter;
-import io.gravitee.rest.api.management.v4.rest.filter.GraviteeContextResponseFilter;
-import io.gravitee.rest.api.management.v4.rest.filter.SecurityContextFilter;
-import io.gravitee.rest.api.management.v4.rest.filter.UriBuilderRequestFilter;
+import io.gravitee.rest.api.management.v4.rest.filter.*;
 import io.gravitee.rest.api.management.v4.rest.provider.ByteArrayOutputStreamWriter;
 import io.gravitee.rest.api.management.v4.rest.provider.ObjectMapperResolver;
 import io.gravitee.rest.api.management.v4.rest.resource.OpenAPIResource;
@@ -69,6 +66,7 @@ public class GraviteeManagementV4Application extends ResourceConfig {
         register(BadRequestExceptionMapper.class);
 
         register(SecurityContextFilter.class);
+        register(PermissionsFilter.class);
         register(GraviteeContextRequestFilter.class);
         register(GraviteeContextResponseFilter.class);
         register(UriBuilderRequestFilter.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/java/io/gravitee/rest/api/management/v4/rest/filter/GraviteeContextRequestFilter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/java/io/gravitee/rest/api/management/v4/rest/filter/GraviteeContextRequestFilter.java
@@ -52,7 +52,9 @@ public class GraviteeContextRequestFilter implements ContainerRequestFilter {
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
         MultivaluedMap<String, String> pathsParams = requestContext.getUriInfo().getPathParameters();
-        GraviteeContext.setCurrentOrganization(pathsParams.getFirst("orgId"));
+        if (pathsParams.containsKey("orgId")) {
+            GraviteeContext.setCurrentOrganization(pathsParams.getFirst("orgId"));
+        }
         if (pathsParams.containsKey("envId")) {
             GraviteeContext.setCurrentEnvironment(pathsParams.getFirst("envId"));
         } else if (pathsParams.containsKey("apiId")) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/java/io/gravitee/rest/api/management/v4/rest/filter/PermissionsFilter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/java/io/gravitee/rest/api/management/v4/rest/filter/PermissionsFilter.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v4.rest.filter;
+
+import io.gravitee.rest.api.management.v4.rest.security.Permission;
+import io.gravitee.rest.api.management.v4.rest.security.Permissions;
+import io.gravitee.rest.api.service.PermissionService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
+import io.gravitee.rest.api.service.exceptions.UnauthorizedAccessException;
+import java.security.Principal;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Provider
+@Priority(200)
+public class PermissionsFilter implements ContainerRequestFilter {
+
+    @Context
+    protected ResourceInfo resourceInfo;
+
+    @Inject
+    private SecurityContext securityContext;
+
+    @Inject
+    private PermissionService permissionService;
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+        findRequiredPermissions()
+            .ifPresent(
+                requiredPermissions -> {
+                    mustBeAuthenticated();
+                    filter(requiredPermissions, requestContext, GraviteeContext.getExecutionContext());
+                }
+            );
+    }
+
+    protected void filter(Permissions permissions, ContainerRequestContext requestContext, ExecutionContext executionContext) {
+        Stream
+            .of(permissions.value())
+            .filter(permission -> hasPermission(permission, requestContext, executionContext))
+            .findAny()
+            .orElseThrow(ForbiddenAccessException::new);
+    }
+
+    private boolean hasPermission(Permission permission, ContainerRequestContext requestContext, ExecutionContext executionContext) {
+        switch (permission.value().getScope()) {
+            case ORGANIZATION:
+                return hasPermission(executionContext, permission, executionContext.getOrganizationId());
+            case ENVIRONMENT:
+                return (
+                    executionContext.hasEnvironmentId() && hasPermission(executionContext, permission, executionContext.getEnvironmentId())
+                );
+            case APPLICATION:
+                return hasPermission(executionContext, permission, getApplicationId(requestContext));
+            case API:
+                return hasPermission(executionContext, permission, getApiId(requestContext));
+            case GROUP:
+                return hasPermission(executionContext, permission, getGroupId(requestContext));
+            default:
+                return false;
+        }
+    }
+
+    private boolean hasPermission(final ExecutionContext executionContext, Permission permission, String referenceId) {
+        return permissionService.hasPermission(executionContext, permission.value(), referenceId, permission.acls());
+    }
+
+    private String getGroupId(ContainerRequestContext requestContext) {
+        return getId("group", requestContext);
+    }
+
+    private String getApiId(ContainerRequestContext requestContext) {
+        return getId("api", requestContext);
+    }
+
+    private String getApplicationId(ContainerRequestContext requestContext) {
+        return getId("application", requestContext);
+    }
+
+    private String getId(String key, ContainerRequestContext requestContext) {
+        List<String> pathParams = requestContext.getUriInfo().getPathParameters().get(key);
+        if (pathParams != null) {
+            return pathParams.iterator().next();
+        }
+        List<String> queryParams = requestContext.getUriInfo().getQueryParameters().get(key);
+        if (queryParams != null) {
+            return queryParams.iterator().next();
+        }
+        return null;
+    }
+
+    private Optional<Permissions> findRequiredPermissions() {
+        return Optional
+            .ofNullable(resourceInfo.getResourceMethod().getDeclaredAnnotation(Permissions.class))
+            .or(() -> Optional.ofNullable(resourceInfo.getResourceClass().getDeclaredAnnotation(Permissions.class)));
+    }
+
+    private void mustBeAuthenticated() {
+        Principal principal = securityContext.getUserPrincipal();
+        if (principal == null) {
+            throw new UnauthorizedAccessException();
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/java/io/gravitee/rest/api/management/v4/rest/resource/connector/EntrypointsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/java/io/gravitee/rest/api/management/v4/rest/resource/connector/EntrypointsResource.java
@@ -18,6 +18,10 @@ package io.gravitee.rest.api.management.v4.rest.resource.connector;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.management.v4.rest.mapper.ConnectorPluginMapper;
 import io.gravitee.rest.api.management.v4.rest.model.ConnectorPlugin;
+import io.gravitee.rest.api.management.v4.rest.security.Permission;
+import io.gravitee.rest.api.management.v4.rest.security.Permissions;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.v4.connector.ConnectorPluginEntity;
 import io.gravitee.rest.api.service.v4.EntrypointConnectorPluginService;
 import java.util.Set;
@@ -46,6 +50,7 @@ public class EntrypointsResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ORGANIZATION_ENTRYPOINT, acls = RolePermissionAction.READ) })
     public Set<ConnectorPlugin> getEntrypoints() {
         return ConnectorPluginMapper.INSTANCE.convertSet(entrypointService.findAll());
     }
@@ -53,6 +58,7 @@ public class EntrypointsResource {
     @Path("/{entrypointId}")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ORGANIZATION_ENTRYPOINT, acls = RolePermissionAction.READ) })
     public ConnectorPlugin getEntrypoint(@PathParam("entrypointId") String entrypointId) {
         return ConnectorPluginMapper.INSTANCE.convert(entrypointService.findById(entrypointId));
     }
@@ -60,6 +66,7 @@ public class EntrypointsResource {
     @GET
     @Path("/{entrypointId}/schema")
     @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ORGANIZATION_ENTRYPOINT, acls = RolePermissionAction.READ) })
     public String getEntrypointSchema(@PathParam("entrypointId") String entrypointId) {
         // Check that the entrypoint exists
         entrypointService.findById(entrypointId);
@@ -70,6 +77,7 @@ public class EntrypointsResource {
     @GET
     @Path("/{entrypointId}/documentation")
     @Produces(MediaType.TEXT_PLAIN)
+    @Permissions({ @Permission(value = RolePermission.ORGANIZATION_ENTRYPOINT, acls = RolePermissionAction.READ) })
     public String getEntrypointDoc(@PathParam("entrypointId") String entrypointId) {
         // Check that the entrypoint exists
         entrypointService.findById(entrypointId);
@@ -80,6 +88,7 @@ public class EntrypointsResource {
     @GET
     @Path("/{entrypointId}/subscriptionSchema")
     @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ORGANIZATION_ENTRYPOINT, acls = RolePermissionAction.READ) })
     public String getEntrypointSubscriptionSchema(@PathParam("entrypointId") String entrypointId) {
         // Check that the entrypoint exists
         entrypointService.findById(entrypointId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/java/io/gravitee/rest/api/management/v4/rest/security/Permission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/java/io/gravitee/rest/api/management/v4/rest/security/Permission.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v4.rest.security;
+
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Permission {
+    RolePermission value();
+
+    RolePermissionAction[] acls();
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/java/io/gravitee/rest/api/management/v4/rest/security/Permissions.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/java/io/gravitee/rest/api/management/v4/rest/security/Permissions.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v4.rest.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.ws.rs.NameBinding;
+
+/**
+ * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@NameBinding
+@Target({ ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Permissions {
+    Permission[] value();
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/test/java/io/gravitee/rest/api/management/v4/rest/filter/PermissionFilterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/test/java/io/gravitee/rest/api/management/v4/rest/filter/PermissionFilterTest.java
@@ -1,0 +1,260 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v4.rest.filter;
+
+import static io.gravitee.rest.api.model.permissions.RolePermission.*;
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.DELETE;
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.UPDATE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.rest.api.management.v4.rest.security.Permission;
+import io.gravitee.rest.api.management.v4.rest.security.Permissions;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.PermissionService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
+import java.util.Collections;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class PermissionFilterTest {
+
+    @InjectMocks
+    protected PermissionsFilter permissionFilter;
+
+    @Mock
+    protected SecurityContext securityContext;
+
+    @Mock
+    protected PermissionService permissionService;
+
+    @Mock
+    protected Permissions permissions;
+
+    @Mock
+    protected ContainerRequestContext containerRequestContext;
+
+    private static final String API_ID = "API_ID";
+
+    private static final String APPLICATION_ID = "APPLICATION_ID";
+
+    private static final String ENVIRONMENT_ID = "DEFAULT";
+
+    private static final String ORGANIZATION_ID = "ORG_ID";
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        GraviteeContext.setCurrentOrganization(ORGANIZATION_ID);
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
+    }
+
+    @After
+    public void tearDown() {
+        GraviteeContext.cleanContext();
+    }
+
+    /**
+     * API Tests
+     */
+    private void initApiMock() {
+        Permission perm = mock(Permission.class);
+        when(perm.value()).thenReturn(API_ANALYTICS);
+        when(perm.acls()).thenReturn(new RolePermissionAction[] { UPDATE });
+        when(permissions.value()).thenReturn(new Permission[] { perm });
+        UriInfo uriInfo = mock(UriInfo.class);
+        MultivaluedHashMap<String, String> map = new MultivaluedHashMap<>();
+        map.put("api", Collections.singletonList(API_ID));
+        when(uriInfo.getPathParameters()).thenReturn(map);
+        when(containerRequestContext.getUriInfo()).thenReturn(uriInfo);
+    }
+
+    @Test(expected = ForbiddenAccessException.class)
+    public void shouldThrowForbiddenExceptionWhenNoApiPermissions() {
+        initApiMock();
+        when(permissionService.hasPermission(any(), any(), any())).thenReturn(false);
+
+        try {
+            permissionFilter.filter(permissions, containerRequestContext, GraviteeContext.getExecutionContext());
+        } catch (ForbiddenAccessException e) {
+            verify(permissionService, times(1)).hasPermission(any(), eq(API_ANALYTICS), eq(API_ID), eq(UPDATE));
+            throw e;
+        }
+
+        Assert.fail("Should throw a ForbiddenAccessException");
+    }
+
+    @Test
+    public void shouldBeAuthorizedWhenApiPermissions() {
+        initApiMock();
+        when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(true);
+        permissionFilter.filter(permissions, containerRequestContext, GraviteeContext.getExecutionContext());
+        verify(permissionService, times(1)).hasPermission(any(), eq(API_ANALYTICS), eq(API_ID), eq(UPDATE));
+    }
+
+    /**
+     * APPLICATION Tests
+     */
+    private void initApplicationMock() {
+        Permission perm = mock(Permission.class);
+        when(perm.value()).thenReturn(APPLICATION_ANALYTICS);
+        when(perm.acls()).thenReturn(new RolePermissionAction[] { UPDATE });
+        when(permissions.value()).thenReturn(new Permission[] { perm });
+        UriInfo uriInfo = mock(UriInfo.class);
+        MultivaluedHashMap<String, String> map = new MultivaluedHashMap<>();
+        map.put("application", Collections.singletonList(APPLICATION_ID));
+        when(uriInfo.getPathParameters()).thenReturn(map);
+        when(containerRequestContext.getUriInfo()).thenReturn(uriInfo);
+    }
+
+    @Test(expected = ForbiddenAccessException.class)
+    public void shouldThrowForbiddenExceptionWhenNoApplicationPermissions() {
+        initApplicationMock();
+        when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(false);
+
+        try {
+            permissionFilter.filter(permissions, containerRequestContext, GraviteeContext.getExecutionContext());
+        } catch (ForbiddenAccessException e) {
+            verify(permissionService, times(1)).hasPermission(any(), eq(APPLICATION_ANALYTICS), eq(APPLICATION_ID), eq(UPDATE));
+            throw e;
+        }
+
+        Assert.fail("Should throw a ForbiddenAccessException");
+    }
+
+    @Test
+    public void shouldBeAuthorizedWhenApplicationPermissions() {
+        initApplicationMock();
+        when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(true);
+
+        permissionFilter.filter(permissions, containerRequestContext, GraviteeContext.getExecutionContext());
+
+        verify(permissionService, times(1)).hasPermission(any(), eq(APPLICATION_ANALYTICS), eq(APPLICATION_ID), eq(UPDATE));
+    }
+
+    /**
+     * ENVIRONMENT Tests
+     */
+
+    private void initManagementMocks() {
+        Permission perm = mock(Permission.class);
+        when(perm.value()).thenReturn(ENVIRONMENT_API);
+        when(perm.acls()).thenReturn(new RolePermissionAction[] { UPDATE });
+        when(permissions.value()).thenReturn(new Permission[] { perm });
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(containerRequestContext.getUriInfo()).thenReturn(uriInfo);
+    }
+
+    @Test(expected = ForbiddenAccessException.class)
+    public void shouldThrowForbiddenExceptionWhenNoManagementPermissions() {
+        initManagementMocks();
+        when(permissionService.hasPermission(any(), any(), any())).thenReturn(false);
+
+        try {
+            permissionFilter.filter(permissions, containerRequestContext, GraviteeContext.getExecutionContext());
+        } catch (ForbiddenAccessException e) {
+            verify(permissionService, times(1)).hasPermission(any(), eq(ENVIRONMENT_API), eq(ENVIRONMENT_ID), eq(UPDATE));
+            throw e;
+        }
+
+        Assert.fail("Should throw a ForbiddenAccessException");
+    }
+
+    @Test
+    public void shouldBeAuthorizedWhenManagementPermissions() {
+        initManagementMocks();
+        when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(true);
+
+        permissionFilter.filter(permissions, containerRequestContext, GraviteeContext.getExecutionContext());
+
+        verify(permissionService, times(1)).hasPermission(any(), eq(ENVIRONMENT_API), eq(ENVIRONMENT_ID), eq(UPDATE));
+    }
+
+    /**
+     * ORGANIZATION Tests
+     */
+
+    private void initOrganizationMocks() {
+        GraviteeContext.setCurrentEnvironment(null);
+
+        Permission perm = mock(Permission.class);
+        when(perm.value()).thenReturn(ORGANIZATION_TENANT);
+        when(perm.acls()).thenReturn(new RolePermissionAction[] { DELETE });
+        when(permissions.value()).thenReturn(new Permission[] { perm });
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(containerRequestContext.getUriInfo()).thenReturn(uriInfo);
+    }
+
+    @Test(expected = ForbiddenAccessException.class)
+    public void shouldThrowForbiddenExceptionWhenNoOrganizationPermissions() {
+        initOrganizationMocks();
+        when(permissionService.hasPermission(any(), any(), any())).thenReturn(false);
+
+        try {
+            permissionFilter.filter(permissions, containerRequestContext, GraviteeContext.getExecutionContext());
+        } catch (ForbiddenAccessException e) {
+            verify(permissionService, times(1)).hasPermission(any(), eq(ORGANIZATION_TENANT), eq(ORGANIZATION_ID), eq(DELETE));
+            throw e;
+        }
+
+        Assert.fail("Should throw a ForbiddenAccessException");
+    }
+
+    @Test
+    public void shouldBeAuthorizedWhenOrganizationPermissions() {
+        initOrganizationMocks();
+        when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(true);
+
+        permissionFilter.filter(permissions, containerRequestContext, GraviteeContext.getExecutionContext());
+
+        verify(permissionService, times(1)).hasPermission(any(), eq(ORGANIZATION_TENANT), eq(ORGANIZATION_ID), eq(DELETE));
+    }
+
+    @Test
+    public void shouldBeAuthorizedWhenOrganizationAndEnvironmentPermissions() {
+        GraviteeContext.setCurrentEnvironment(null);
+        Permission orgPerm = mock(Permission.class);
+        when(orgPerm.value()).thenReturn(ORGANIZATION_TENANT);
+        when(orgPerm.acls()).thenReturn(new RolePermissionAction[] { DELETE });
+        Permission envPerm = mock(Permission.class);
+        when(envPerm.value()).thenReturn(ENVIRONMENT_API);
+        when(envPerm.acls()).thenReturn(new RolePermissionAction[] { UPDATE });
+        when(permissions.value()).thenReturn(new Permission[] { envPerm, orgPerm });
+
+        UriInfo uriInfo = mock(UriInfo.class);
+        when(containerRequestContext.getUriInfo()).thenReturn(uriInfo);
+
+        when(permissionService.hasPermission(any(), eq(ORGANIZATION_TENANT), any(), any())).thenReturn(true);
+
+        permissionFilter.filter(permissions, containerRequestContext, GraviteeContext.getExecutionContext());
+
+        verify(permissionService, times(1)).hasPermission(any(), eq(ORGANIZATION_TENANT), eq(ORGANIZATION_ID), eq(DELETE));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/test/java/io/gravitee/rest/api/management/v4/rest/resource/connector/EntrypointsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/test/java/io/gravitee/rest/api/management/v4/rest/resource/connector/EntrypointsResourceTest.java
@@ -35,7 +35,6 @@ import io.gravitee.rest.api.service.exceptions.PluginNotFoundException;
 import java.util.*;
 import javax.ws.rs.core.Response;
 import org.assertj.core.api.Assertions;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -45,7 +44,7 @@ import org.junit.Test;
  */
 public class EntrypointsResourceTest extends AbstractResourceTest {
 
-    public static final String FAKE_ENTRYPOINT_ID = "fake-entrypoint";
+    public static final String ENTRYPOINT_ID = "fake-entrypoint";
 
     @Override
     protected String contextPath() {
@@ -87,15 +86,15 @@ public class EntrypointsResourceTest extends AbstractResourceTest {
     @Test
     public void shouldGetEntrypointSchema() {
         ConnectorPluginEntity connectorPlugin = new ConnectorPluginEntity();
-        connectorPlugin.setId(FAKE_ENTRYPOINT_ID);
+        connectorPlugin.setId(ENTRYPOINT_ID);
         connectorPlugin.setName("Fake Entrypoint");
         connectorPlugin.setVersion("1.0");
         connectorPlugin.setSupportedApiType(ApiType.ASYNC);
         connectorPlugin.setSupportedModes(Set.of(ConnectorMode.SUBSCRIBE));
-        when(entrypointConnectorPluginService.findById(FAKE_ENTRYPOINT_ID)).thenReturn(connectorPlugin);
-        when(entrypointConnectorPluginService.getSchema(FAKE_ENTRYPOINT_ID)).thenReturn("schemaResponse");
+        when(entrypointConnectorPluginService.findById(ENTRYPOINT_ID)).thenReturn(connectorPlugin);
+        when(entrypointConnectorPluginService.getSchema(ENTRYPOINT_ID)).thenReturn("schemaResponse");
 
-        final Response response = rootTarget(FAKE_ENTRYPOINT_ID).path("schema").request().get();
+        final Response response = rootTarget(ENTRYPOINT_ID).path("schema").request().get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
         final String result = response.readEntity(String.class);
         Assertions.assertThat(result).isEqualTo("schemaResponse");
@@ -104,22 +103,22 @@ public class EntrypointsResourceTest extends AbstractResourceTest {
     @Test
     public void shouldNotGetEntrypointSchemaWhenPluginNotFound() {
         ConnectorPluginEntity connectorPlugin = new ConnectorPluginEntity();
-        connectorPlugin.setId(FAKE_ENTRYPOINT_ID);
+        connectorPlugin.setId(ENTRYPOINT_ID);
         connectorPlugin.setName("Fake Entrypoint");
         connectorPlugin.setVersion("1.0");
         connectorPlugin.setSupportedApiType(ApiType.ASYNC);
         connectorPlugin.setSupportedModes(Set.of(ConnectorMode.SUBSCRIBE));
-        when(entrypointConnectorPluginService.findById(FAKE_ENTRYPOINT_ID)).thenThrow(new PluginNotFoundException(FAKE_ENTRYPOINT_ID));
+        when(entrypointConnectorPluginService.findById(ENTRYPOINT_ID)).thenThrow(new PluginNotFoundException(ENTRYPOINT_ID));
 
-        final Response response = rootTarget(FAKE_ENTRYPOINT_ID).path("schema").request().get();
+        final Response response = rootTarget(ENTRYPOINT_ID).path("schema").request().get();
         assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
         final ErrorEntity errorEntity = response.readEntity(ErrorEntity.class);
 
         final ErrorEntity expectedErrorEntity = new ErrorEntity();
         expectedErrorEntity.setHttpStatus(HttpStatusCode.NOT_FOUND_404);
-        expectedErrorEntity.setMessage("Plugin [" + FAKE_ENTRYPOINT_ID + "] can not be found.");
+        expectedErrorEntity.setMessage("Plugin [" + ENTRYPOINT_ID + "] can not be found.");
         expectedErrorEntity.setTechnicalCode("plugin.notFound");
-        expectedErrorEntity.setParameters(Map.of("plugin", FAKE_ENTRYPOINT_ID));
+        expectedErrorEntity.setParameters(Map.of("plugin", ENTRYPOINT_ID));
 
         Assertions.assertThat(errorEntity).isEqualTo(expectedErrorEntity);
     }
@@ -127,15 +126,15 @@ public class EntrypointsResourceTest extends AbstractResourceTest {
     @Test
     public void shouldGetEntrypointDocumentation() {
         ConnectorPluginEntity connectorPlugin = new ConnectorPluginEntity();
-        connectorPlugin.setId(FAKE_ENTRYPOINT_ID);
+        connectorPlugin.setId(ENTRYPOINT_ID);
         connectorPlugin.setName("Fake Entrypoint");
         connectorPlugin.setVersion("1.0");
         connectorPlugin.setSupportedApiType(ApiType.ASYNC);
         connectorPlugin.setSupportedModes(Set.of(ConnectorMode.SUBSCRIBE));
-        when(entrypointConnectorPluginService.findById(FAKE_ENTRYPOINT_ID)).thenReturn(connectorPlugin);
-        when(entrypointConnectorPluginService.getDocumentation(FAKE_ENTRYPOINT_ID)).thenReturn("documentationResponse");
+        when(entrypointConnectorPluginService.findById(ENTRYPOINT_ID)).thenReturn(connectorPlugin);
+        when(entrypointConnectorPluginService.getDocumentation(ENTRYPOINT_ID)).thenReturn("documentationResponse");
 
-        final Response response = rootTarget(FAKE_ENTRYPOINT_ID).path("documentation").request().get();
+        final Response response = rootTarget(ENTRYPOINT_ID).path("documentation").request().get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
         final String result = response.readEntity(String.class);
         Assertions.assertThat(result).isEqualTo("documentationResponse");
@@ -144,23 +143,23 @@ public class EntrypointsResourceTest extends AbstractResourceTest {
     @Test
     public void shouldNotGetEntrypointDocumentationWhenPluginNotFound() {
         ConnectorPluginEntity connectorPlugin = new ConnectorPluginEntity();
-        connectorPlugin.setId(FAKE_ENTRYPOINT_ID);
+        connectorPlugin.setId(ENTRYPOINT_ID);
         connectorPlugin.setName("Fake Entrypoint");
         connectorPlugin.setVersion("1.0");
         connectorPlugin.setSupportedApiType(ApiType.ASYNC);
         connectorPlugin.setSupportedModes(Set.of(ConnectorMode.SUBSCRIBE));
-        when(entrypointConnectorPluginService.findById(FAKE_ENTRYPOINT_ID)).thenThrow(new PluginNotFoundException(FAKE_ENTRYPOINT_ID));
+        when(entrypointConnectorPluginService.findById(ENTRYPOINT_ID)).thenThrow(new PluginNotFoundException(ENTRYPOINT_ID));
 
-        final Response response = rootTarget(FAKE_ENTRYPOINT_ID).path("documentation").request().get();
+        final Response response = rootTarget(ENTRYPOINT_ID).path("documentation").request().get();
         assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
 
         final ErrorEntity errorEntity = response.readEntity(ErrorEntity.class);
 
         final ErrorEntity expectedErrorEntity = new ErrorEntity();
         expectedErrorEntity.setHttpStatus(HttpStatusCode.NOT_FOUND_404);
-        expectedErrorEntity.setMessage("Plugin [" + FAKE_ENTRYPOINT_ID + "] can not be found.");
+        expectedErrorEntity.setMessage("Plugin [" + ENTRYPOINT_ID + "] can not be found.");
         expectedErrorEntity.setTechnicalCode("plugin.notFound");
-        expectedErrorEntity.setParameters(Map.of("plugin", FAKE_ENTRYPOINT_ID));
+        expectedErrorEntity.setParameters(Map.of("plugin", ENTRYPOINT_ID));
 
         Assertions.assertThat(errorEntity).isEqualTo(expectedErrorEntity);
     }
@@ -168,15 +167,15 @@ public class EntrypointsResourceTest extends AbstractResourceTest {
     @Test
     public void shouldGetEntrypointSubscriptionSchema() {
         ConnectorPluginEntity connectorPlugin = new ConnectorPluginEntity();
-        connectorPlugin.setId(FAKE_ENTRYPOINT_ID);
+        connectorPlugin.setId(ENTRYPOINT_ID);
         connectorPlugin.setName("Fake Entrypoint");
         connectorPlugin.setVersion("1.0");
         connectorPlugin.setSupportedApiType(ApiType.ASYNC);
         connectorPlugin.setSupportedModes(Set.of(ConnectorMode.SUBSCRIBE));
-        when(entrypointConnectorPluginService.findById(FAKE_ENTRYPOINT_ID)).thenReturn(connectorPlugin);
-        when(entrypointConnectorPluginService.getSubscriptionSchema(FAKE_ENTRYPOINT_ID)).thenReturn("subscriptionSchemaResponse");
+        when(entrypointConnectorPluginService.findById(ENTRYPOINT_ID)).thenReturn(connectorPlugin);
+        when(entrypointConnectorPluginService.getSubscriptionSchema(ENTRYPOINT_ID)).thenReturn("subscriptionSchemaResponse");
 
-        final Response response = rootTarget(FAKE_ENTRYPOINT_ID).path("subscriptionSchema").request().get();
+        final Response response = rootTarget(ENTRYPOINT_ID).path("subscriptionSchema").request().get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
         final String result = response.readEntity(String.class);
         Assertions.assertThat(result).isEqualTo("subscriptionSchemaResponse");
@@ -185,22 +184,22 @@ public class EntrypointsResourceTest extends AbstractResourceTest {
     @Test
     public void shouldNotGetEntrypointSubscriptionSchemaWhenPluginNotFound() {
         ConnectorPluginEntity connectorPlugin = new ConnectorPluginEntity();
-        connectorPlugin.setId(FAKE_ENTRYPOINT_ID);
+        connectorPlugin.setId(ENTRYPOINT_ID);
         connectorPlugin.setName("Fake Entrypoint");
         connectorPlugin.setVersion("1.0");
         connectorPlugin.setSupportedApiType(ApiType.ASYNC);
         connectorPlugin.setSupportedModes(Set.of(ConnectorMode.SUBSCRIBE));
-        when(entrypointConnectorPluginService.findById(FAKE_ENTRYPOINT_ID)).thenThrow(new PluginNotFoundException(FAKE_ENTRYPOINT_ID));
+        when(entrypointConnectorPluginService.findById(ENTRYPOINT_ID)).thenThrow(new PluginNotFoundException(ENTRYPOINT_ID));
 
-        final Response response = rootTarget(FAKE_ENTRYPOINT_ID).path("subscriptionSchema").request().get();
+        final Response response = rootTarget(ENTRYPOINT_ID).path("subscriptionSchema").request().get();
         assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
         final ErrorEntity errorEntity = response.readEntity(ErrorEntity.class);
 
         final ErrorEntity expectedErrorEntity = new ErrorEntity();
         expectedErrorEntity.setHttpStatus(HttpStatusCode.NOT_FOUND_404);
-        expectedErrorEntity.setMessage("Plugin [" + FAKE_ENTRYPOINT_ID + "] can not be found.");
+        expectedErrorEntity.setMessage("Plugin [" + ENTRYPOINT_ID + "] can not be found.");
         expectedErrorEntity.setTechnicalCode("plugin.notFound");
-        expectedErrorEntity.setParameters(Map.of("plugin", FAKE_ENTRYPOINT_ID));
+        expectedErrorEntity.setParameters(Map.of("plugin", ENTRYPOINT_ID));
 
         Assertions.assertThat(errorEntity).isEqualTo(expectedErrorEntity);
     }
@@ -208,19 +207,19 @@ public class EntrypointsResourceTest extends AbstractResourceTest {
     @Test
     public void shouldGetEndpointById() {
         ConnectorPluginEntity connectorPlugin = new ConnectorPluginEntity();
-        connectorPlugin.setId(FAKE_ENTRYPOINT_ID);
+        connectorPlugin.setId(ENTRYPOINT_ID);
         connectorPlugin.setName("Fake Entrypoint");
         connectorPlugin.setVersion("1.0");
         connectorPlugin.setSupportedApiType(ApiType.ASYNC);
         connectorPlugin.setSupportedModes(Set.of(ConnectorMode.SUBSCRIBE));
-        when(entrypointConnectorPluginService.findById(FAKE_ENTRYPOINT_ID)).thenReturn(connectorPlugin);
+        when(entrypointConnectorPluginService.findById(ENTRYPOINT_ID)).thenReturn(connectorPlugin);
 
-        final Response response = rootTarget(FAKE_ENTRYPOINT_ID).request().get();
+        final Response response = rootTarget(ENTRYPOINT_ID).request().get();
 
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
         final ConnectorPlugin entrypoint = response.readEntity(ConnectorPlugin.class);
         assertNotNull(entrypoint);
-        assertEquals(FAKE_ENTRYPOINT_ID, entrypoint.getId());
+        assertEquals(ENTRYPOINT_ID, entrypoint.getId());
         assertEquals("Fake Entrypoint", entrypoint.getName());
         assertEquals("1.0", entrypoint.getVersion());
         assertEquals(io.gravitee.rest.api.management.v4.rest.model.ApiType.ASYNC, entrypoint.getSupportedApiType());
@@ -229,10 +228,17 @@ public class EntrypointsResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldNotAllowUnauthorizedUserForGetById() {
-        // TODO: Add orgId to mock
-        when(permissionService.hasPermission(any(), eq(RolePermission.ORGANIZATION_ENTRYPOINT), any(), any())).thenReturn(false);
+        when(
+            permissionService.hasPermission(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(RolePermission.ORGANIZATION_ENTRYPOINT),
+                eq(GraviteeContext.getDefaultOrganization()),
+                any()
+            )
+        )
+            .thenReturn(false);
 
-        final Response response = rootTarget(FAKE_ENTRYPOINT_ID).request().get();
+        final Response response = rootTarget(ENTRYPOINT_ID).request().get();
         assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/test/java/io/gravitee/rest/api/management/v4/rest/resource/connector/EntrypointsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/test/java/io/gravitee/rest/api/management/v4/rest/resource/connector/EntrypointsResourceTest.java
@@ -17,8 +17,9 @@ package io.gravitee.rest.api.management.v4.rest.resource.connector;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.definition.model.v4.ApiType;
@@ -27,13 +28,11 @@ import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.rest.api.management.v4.rest.model.ConnectorPlugin;
 import io.gravitee.rest.api.management.v4.rest.model.ErrorEntity;
 import io.gravitee.rest.api.management.v4.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.v4.connector.ConnectorPluginEntity;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.PluginNotFoundException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import javax.ws.rs.core.Response;
 import org.assertj.core.api.Assertions;
 import org.junit.After;
@@ -226,5 +225,14 @@ public class EntrypointsResourceTest extends AbstractResourceTest {
         assertEquals("1.0", entrypoint.getVersion());
         assertEquals(io.gravitee.rest.api.management.v4.rest.model.ApiType.ASYNC, entrypoint.getSupportedApiType());
         assertEquals(Set.of(io.gravitee.rest.api.management.v4.rest.model.ConnectorMode.SUBSCRIBE), entrypoint.getSupportedModes());
+    }
+
+    @Test
+    public void shouldNotAllowUnauthorizedUserForGetById() {
+        // TODO: Add orgId to mock
+        when(permissionService.hasPermission(any(), eq(RolePermission.ORGANIZATION_ENTRYPOINT), any(), any())).thenReturn(false);
+
+        final Response response = rootTarget(FAKE_ENTRYPOINT_ID).request().get();
+        assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/test/java/io/gravitee/rest/api/management/v4/rest/resource/installation/EnvironmentResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/test/java/io/gravitee/rest/api/management/v4/rest/resource/installation/EnvironmentResourceTest.java
@@ -59,8 +59,9 @@ public class EnvironmentResourceTest extends AbstractResourceTest {
 
     @Before
     public void init() {
-        GraviteeContext.setCurrentOrganization(null);
+        GraviteeContext.cleanContext();
         GraviteeContext.setCurrentEnvironment(FAKE_ENVIRONMENT_ID);
+        GraviteeContext.setCurrentOrganization(GraviteeContext.getDefaultOrganization());
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-822

## Description

Add `@Permissions` to v4.
All entrypoint resources controlled by: Scope = organization, rights = read

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rjgajjrxnv.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-822-entrypoint-permissions/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
