### PR TITLE
ci: remove e2e install in cypress step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1521,8 +1521,6 @@ jobs:
             - attach_workspace:
                   at: .
             - get-apim-tag
-            - webui-install:
-                  apim-ui-project: gravitee-apim-e2e
             - docker-azure-login
             - run:
                   name: Run UI tests


### PR DESCRIPTION
## Description

The e2e generates and install is already done and persisted in the previous steps in the ci so we can remove it in the cypress  step

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bntxkmbbqv.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/ci-remove-cypress-install-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
