### PR TITLE
fix: update user password policy regex

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/validator/RegexPasswordValidator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/validator/RegexPasswordValidator.java
@@ -30,7 +30,9 @@ public class RegexPasswordValidator implements PasswordValidator, InitializingBe
     private Pattern pattern;
     private Matcher matcher;
 
-    @Value("${user.password.policy.pattern:^(?=\\s*\\S).*$}")
+    @Value(
+        "${user.password.policy.pattern:^(?:(?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))(?!.*(.)\\1{2,})[A-Za-z0-9!~<>,;:_\\-=?*+#.\"'&§`£€%°()\\\\\\|\\[\\]\\-\\$\\^\\@\\/]{8,32}$}"
+    )
     private String passwordPattern;
 
     public RegexPasswordValidator() {}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-954

## Description

Align the user password policy regex default value with the gravitee.yml default value.
see https://github.com/gravitee-io/gravitee-api-management/blob/master/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml#L433
Another PR is coming to update the helm charts

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-954-password-regex/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qibexiqglg.chromatic.com)
<!-- Storybook placeholder end -->
