### PR TITLE
Display full query param values when they contain `=` in them

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/analytics/logs/log.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/logs/log.component.spec.ts
@@ -49,4 +49,23 @@ describe('LogComponent', () => {
       expect(mimeType).toEqual(null);
     });
   });
+
+  describe('extractQueryParams', () => {
+    it('return different query params', () => {
+      const queryParams = logComponent.extractQueryParams(`/gme?type=monthly&bucket=status_repartition&bucket=status_repartition-2`);
+      expect(queryParams).toEqual([
+        { key: 'type', value: 'monthly' },
+        { key: 'bucket', value: '[ status_repartition, status_repartition-2 ]' },
+      ]);
+    });
+
+    it('return query params with `=` in it', () => {
+      const queryParams = logComponent.extractQueryParams(`/gme?type=monthly=status$test&param2=is=containing=some=equals&param3=value3`);
+      expect(queryParams).toEqual([
+        { key: 'type', value: 'monthly=status$test' },
+        { key: 'param2', value: 'is=containing=some=equals' },
+        { key: 'param3', value: 'value3' },
+      ]);
+    });
+  });
 });

--- a/gravitee-apim-console-webui/src/management/api/analytics/logs/log.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/logs/log.component.ts
@@ -208,8 +208,12 @@ class LogComponentController {
     const queryParamsMap = uri
       .slice(uri.indexOf('?') + 1)
       .split('&')
-      .map((queryParamsAsString) => queryParamsAsString.split('='))
-      // Convert in a map to group query params with the same key (it can happens when sending an array), for the example:
+      .map((queryParamsAsString) => {
+        // A simple `.split` is not enough as query param values can contains `=` themselves
+        const indexOfEqualChar = queryParamsAsString.indexOf('=');
+        return [queryParamsAsString.substring(0, indexOfEqualChar), queryParamsAsString.substring(indexOfEqualChar + 1)];
+      })
+      // Convert in a map to group query params with the same key (it can happen when sending an array), for example:
       // {
       //   type: ['monthly'],
       //   bucket: ['status_repartition', 'status_repartition-2'],


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-928
https://github.com/gravitee-io/issues/issues/8903

## Description

Display full query param values when they contain `=` in them
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zrvjjiuedf.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-928-handle-equals-in-query-params/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
