### PR TITLE
Add different mode for transaction header override

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandlerFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandlerFactory.java
@@ -42,6 +42,7 @@ import io.gravitee.gateway.handlers.api.definition.Api;
 import io.gravitee.gateway.handlers.api.processor.OnErrorProcessorChainFactory;
 import io.gravitee.gateway.handlers.api.processor.RequestProcessorChainFactory;
 import io.gravitee.gateway.handlers.api.processor.ResponseProcessorChainFactory;
+import io.gravitee.gateway.handlers.api.processor.transaction.TransactionResponseProcessorConfiguration;
 import io.gravitee.gateway.handlers.api.security.PlanBasedAuthenticationHandlerEnhancer;
 import io.gravitee.gateway.jupiter.handlers.api.SyncApiReactor;
 import io.gravitee.gateway.jupiter.handlers.api.adapter.invoker.InvokerAdapter;
@@ -49,10 +50,7 @@ import io.gravitee.gateway.jupiter.handlers.api.flow.FlowChainFactory;
 import io.gravitee.gateway.jupiter.handlers.api.processor.ApiProcessorChainFactory;
 import io.gravitee.gateway.jupiter.policy.DefaultPolicyChainFactory;
 import io.gravitee.gateway.platform.manager.OrganizationManager;
-import io.gravitee.gateway.policy.PolicyChainProviderLoader;
-import io.gravitee.gateway.policy.PolicyConfigurationFactory;
-import io.gravitee.gateway.policy.PolicyFactory;
-import io.gravitee.gateway.policy.PolicyManager;
+import io.gravitee.gateway.policy.*;
 import io.gravitee.gateway.policy.impl.CachedPolicyConfigurationFactory;
 import io.gravitee.gateway.reactor.handler.ReactorHandler;
 import io.gravitee.gateway.reactor.handler.ReactorHandlerFactory;
@@ -505,7 +503,14 @@ public class ApiReactorHandlerFactory implements ReactorHandlerFactory<Api> {
         PolicyChainProviderLoader policyChainProviderLoader,
         FlowPolicyResolverFactory flowPolicyResolverFactory
     ) {
-        return new ResponseProcessorChainFactory(api, policyChainFactory, policyChainProviderLoader, node, flowPolicyResolverFactory);
+        return new ResponseProcessorChainFactory(
+            api,
+            policyChainFactory,
+            policyChainProviderLoader,
+            node,
+            flowPolicyResolverFactory,
+            new TransactionResponseProcessorConfiguration(configuration)
+        );
     }
 
     public OnErrorProcessorChainFactory errorProcessorChainFactory(Api api, PolicyChainFactory policyChainFactory) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/ResponseProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/ResponseProcessorChainFactory.java
@@ -23,7 +23,6 @@ import io.gravitee.gateway.core.condition.ConditionEvaluator;
 import io.gravitee.gateway.flow.BestMatchFlowResolver;
 import io.gravitee.gateway.flow.FlowPolicyResolverFactory;
 import io.gravitee.gateway.flow.SimpleFlowPolicyChainProvider;
-import io.gravitee.gateway.flow.SimpleFlowProvider;
 import io.gravitee.gateway.flow.condition.evaluation.ExpressionLanguageFlowConditionEvaluator;
 import io.gravitee.gateway.flow.condition.evaluation.HttpMethodConditionEvaluator;
 import io.gravitee.gateway.flow.condition.evaluation.PathBasedConditionEvaluator;
@@ -39,6 +38,8 @@ import io.gravitee.gateway.handlers.api.policy.plan.PlanPolicyResolver;
 import io.gravitee.gateway.handlers.api.processor.cors.CorsSimpleRequestProcessor;
 import io.gravitee.gateway.handlers.api.processor.pathmapping.PathMappingProcessor;
 import io.gravitee.gateway.handlers.api.processor.shutdown.ShutdownProcessor;
+import io.gravitee.gateway.handlers.api.processor.transaction.TransactionResponseProcessor;
+import io.gravitee.gateway.handlers.api.processor.transaction.TransactionResponseProcessorConfiguration;
 import io.gravitee.gateway.policy.PolicyChainOrder;
 import io.gravitee.gateway.policy.PolicyChainProviderLoader;
 import io.gravitee.gateway.policy.StreamType;
@@ -55,23 +56,28 @@ public class ResponseProcessorChainFactory extends ApiProcessorChainFactory {
 
     private Node node;
 
+    private TransactionResponseProcessorConfiguration transactionResponseProcessorConfiguration;
+
     public ResponseProcessorChainFactory(
         final Api api,
         final PolicyChainFactory policyChainFactory,
         final PolicyChainProviderLoader policyChainProviderLoader,
         final Node node,
-        FlowPolicyResolverFactory flowPolicyResolverFactory
+        FlowPolicyResolverFactory flowPolicyResolverFactory,
+        final TransactionResponseProcessorConfiguration transactionResponseProcessorConfiguration
     ) {
         super(api, policyChainFactory);
         this.policyChainProviderLoader = policyChainProviderLoader;
         this.node = node;
         this.flowPolicyResolverFactory = flowPolicyResolverFactory;
+        this.transactionResponseProcessorConfiguration = transactionResponseProcessorConfiguration;
 
         this.initialize();
     }
 
     private void initialize() {
         add(() -> new ShutdownProcessor(node));
+        add(() -> new TransactionResponseProcessor(this.transactionResponseProcessorConfiguration));
 
         final ConditionEvaluator<Flow> evaluator = new CompositeConditionEvaluator<>(
             new HttpMethodConditionEvaluator(),

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/transaction/HeaderOverrideMode.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/transaction/HeaderOverrideMode.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.processor.transaction;
+
+/**
+ * The different modes available in the Gateway when it deals with a backend providing a value for the Transaction Id and Request Id headers
+ */
+public enum HeaderOverrideMode {
+    /**
+     * OVERRIDE: The header set by the APIM Gateway will override the one provided by the backend
+     */
+    OVERRIDE,
+    /**
+     * MERGE: Both headers set by the APIM Gateway and the backend will be kept (as headers can be multivalued)
+     */
+    MERGE,
+    /**
+     * KEEP: The header set by the backend will be kept and the one provided by the APIM Gateway discarded
+     */
+    KEEP,
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/transaction/TransactionResponseProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/transaction/TransactionResponseProcessor.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.processor.transaction;
+
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.core.processor.AbstractProcessor;
+
+/**
+ * A {@link Response} processor used to set the Transaction Id and Request Id in the response headers.
+ */
+public class TransactionResponseProcessor extends AbstractProcessor<ExecutionContext> {
+
+    private final TransactionResponseProcessorConfiguration configuration;
+
+    public TransactionResponseProcessor(TransactionResponseProcessorConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public void handle(final ExecutionContext context) {
+        setHeaderAccordingToBackendOverrideMode(
+            context.request().headers(),
+            context.response().headers(),
+            configuration.transactionHeader,
+            configuration.transactionHeaderHeaderOverrideMode
+        );
+
+        setHeaderAccordingToBackendOverrideMode(
+            context.request().headers(),
+            context.response().headers(),
+            configuration.requestHeader,
+            configuration.requestHeaderHeaderOverrideMode
+        );
+
+        next.handle(context);
+    }
+
+    private void setHeaderAccordingToBackendOverrideMode(
+        final HttpHeaders requestHeaders,
+        final HttpHeaders responseHeaders,
+        final String headerName,
+        final HeaderOverrideMode headerOverrideMode
+    ) {
+        String requestHeaderValue = requestHeaders.get(headerName);
+        String backendHeaderValue = responseHeaders.get(headerName);
+
+        if (headerOverrideMode == HeaderOverrideMode.OVERRIDE) {
+            responseHeaders.set(headerName, requestHeaderValue);
+        } else if (headerOverrideMode == HeaderOverrideMode.MERGE) {
+            if (!requestHeaderValue.equals(backendHeaderValue)) {
+                responseHeaders.add(headerName, requestHeaderValue);
+            }
+        } else if (headerOverrideMode == HeaderOverrideMode.KEEP) {
+            responseHeaders.set(headerName, backendHeaderValue);
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/transaction/TransactionResponseProcessorConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/transaction/TransactionResponseProcessorConfiguration.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.processor.transaction;
+
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_REQUEST_ID_HEADER;
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER;
+
+public class TransactionResponseProcessorConfiguration {
+
+    public final String transactionHeader;
+
+    public final HeaderOverrideMode transactionHeaderHeaderOverrideMode;
+
+    public final String requestHeader;
+
+    public final HeaderOverrideMode requestHeaderHeaderOverrideMode;
+
+    public TransactionResponseProcessorConfiguration(io.gravitee.node.api.configuration.Configuration configuration) {
+        this.transactionHeader = configuration.getProperty("handlers.request.transaction.header", DEFAULT_TRANSACTION_ID_HEADER);
+        String transactionOverrideModeString = configuration.getProperty("handlers.request.transaction.overrideMode");
+        this.transactionHeaderHeaderOverrideMode =
+            transactionOverrideModeString != null
+                ? HeaderOverrideMode.valueOf(transactionOverrideModeString.trim().toUpperCase())
+                : HeaderOverrideMode.OVERRIDE;
+
+        this.requestHeader = configuration.getProperty("handlers.request.request.header", DEFAULT_REQUEST_ID_HEADER);
+        String requestOverrideModeString = configuration.getProperty("handlers.request.request.overrideMode");
+        this.requestHeaderHeaderOverrideMode =
+            requestOverrideModeString != null
+                ? HeaderOverrideMode.valueOf(requestOverrideModeString.trim().toUpperCase())
+                : HeaderOverrideMode.OVERRIDE;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/transaction/TransactionResponseProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/transaction/TransactionResponseProcessorTest.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.processor.transaction;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.api.context.SimpleExecutionContext;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.reactor.processor.transaction.TransactionHeader;
+import io.gravitee.node.api.configuration.Configuration;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TransactionResponseProcessorTest {
+
+    private TransactionResponseProcessor transactionResponseProcessor;
+
+    @Test
+    @DisplayName("By default should override Transaction Id and Request Id headers set by the backend, by the ones set by APIM")
+    void handleWithOverrideByDefault() {
+        Configuration nodeConfiguration = mock(Configuration.class);
+        when(nodeConfiguration.getProperty(eq("handlers.request.transaction.header"), anyString()))
+            .thenReturn(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER);
+        when(nodeConfiguration.getProperty(eq("handlers.request.request.header"), anyString()))
+            .thenReturn(TransactionHeader.DEFAULT_REQUEST_ID_HEADER);
+
+        TransactionResponseProcessorConfiguration processorConfiguration = new TransactionResponseProcessorConfiguration(nodeConfiguration);
+
+        transactionResponseProcessor = new TransactionResponseProcessor(processorConfiguration);
+        transactionResponseProcessor.handler(context -> {});
+
+        Request request = mock(Request.class);
+        HttpHeaders requestHeaders = HttpHeaders.create();
+        requestHeaders.set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "transaction-id");
+        requestHeaders.set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "request-id");
+        when(request.headers()).thenReturn(requestHeaders);
+
+        Response response = mock(Response.class);
+        HttpHeaders responseHeaders = HttpHeaders.create();
+        responseHeaders.set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "backend-transaction-id");
+        responseHeaders.set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "backend-request-id");
+        when(response.headers()).thenReturn(responseHeaders);
+
+        ExecutionContext context = new SimpleExecutionContext(request, response);
+        transactionResponseProcessor.handle(context);
+
+        assertEquals(List.of("transaction-id"), context.response().headers().getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER));
+        assertEquals(List.of("request-id"), context.response().headers().getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER));
+    }
+
+    @Test
+    @DisplayName("Should override Transaction Id and Request Id headers set by the backend, by the ones set by APIM")
+    void handleWithOverrideModeNone() {
+        instantiateTransactionResponseProcess(HeaderOverrideMode.OVERRIDE, HeaderOverrideMode.OVERRIDE);
+
+        Request request = mock(Request.class);
+        HttpHeaders requestHeaders = HttpHeaders.create();
+        requestHeaders.set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "transaction-id");
+        requestHeaders.set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "request-id");
+        when(request.headers()).thenReturn(requestHeaders);
+
+        Response response = mock(Response.class);
+        HttpHeaders responseHeaders = HttpHeaders.create();
+        responseHeaders.set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "backend-transaction-id");
+        responseHeaders.set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "backend-request-id");
+        when(response.headers()).thenReturn(responseHeaders);
+
+        ExecutionContext context = new SimpleExecutionContext(request, response);
+        transactionResponseProcessor.handle(context);
+
+        assertEquals(List.of("transaction-id"), context.response().headers().getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER));
+        assertEquals(List.of("request-id"), context.response().headers().getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER));
+    }
+
+    @Test
+    @DisplayName("Should merge transaction ID and request ID headers set by APIM and the backend")
+    void handleWithOverrideModeMerge() {
+        instantiateTransactionResponseProcess(HeaderOverrideMode.MERGE, HeaderOverrideMode.MERGE);
+
+        Request request = mock(Request.class);
+        HttpHeaders requestHeaders = HttpHeaders.create();
+        requestHeaders.set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "transaction-id");
+        requestHeaders.set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "request-id");
+        when(request.headers()).thenReturn(requestHeaders);
+
+        Response response = mock(Response.class);
+        HttpHeaders responseHeaders = HttpHeaders.create();
+        responseHeaders.set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "backend-transaction-id");
+        responseHeaders.set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "backend-request-id");
+        when(response.headers()).thenReturn(responseHeaders);
+
+        ExecutionContext context = new SimpleExecutionContext(request, response);
+        transactionResponseProcessor.handle(context);
+
+        assertEquals(
+            List.of("backend-transaction-id", "transaction-id"),
+            context.response().headers().getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER)
+        );
+        assertEquals(
+            List.of("backend-request-id", "request-id"),
+            context.response().headers().getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER)
+        );
+    }
+
+    @Test
+    @DisplayName("Should keep transaction ID and request ID headers set by the backend, discard APIM ones")
+    void handleWithOverrideModeOverride() {
+        instantiateTransactionResponseProcess(HeaderOverrideMode.KEEP, HeaderOverrideMode.KEEP);
+
+        Request request = mock(Request.class);
+        HttpHeaders requestHeaders = HttpHeaders.create();
+        requestHeaders.set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "transaction-id");
+        requestHeaders.set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "request-id");
+        when(request.headers()).thenReturn(requestHeaders);
+
+        Response response = mock(Response.class);
+        HttpHeaders responseHeaders = HttpHeaders.create();
+        responseHeaders.set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "backend-transaction-id");
+        responseHeaders.set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "backend-request-id");
+        when(response.headers()).thenReturn(responseHeaders);
+
+        ExecutionContext context = new SimpleExecutionContext(request, response);
+        transactionResponseProcessor.handle(context);
+
+        assertEquals(
+            List.of("backend-transaction-id"),
+            context.response().headers().getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER)
+        );
+        assertEquals(List.of("backend-request-id"), context.response().headers().getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER));
+    }
+
+    private void instantiateTransactionResponseProcess(
+        HeaderOverrideMode transactionOverrideMode,
+        HeaderOverrideMode requestHeaderOverrideMode
+    ) {
+        Configuration nodeConfiguration = mock(Configuration.class);
+        when(nodeConfiguration.getProperty("handlers.request.transaction.overrideMode")).thenReturn(transactionOverrideMode.name());
+        when(nodeConfiguration.getProperty(eq("handlers.request.transaction.header"), anyString()))
+            .thenReturn(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER);
+
+        when(nodeConfiguration.getProperty("handlers.request.request.overrideMode")).thenReturn(requestHeaderOverrideMode.name());
+        when(nodeConfiguration.getProperty(eq("handlers.request.request.header"), anyString()))
+            .thenReturn(TransactionHeader.DEFAULT_REQUEST_ID_HEADER);
+
+        TransactionResponseProcessorConfiguration processorConfiguration = new TransactionResponseProcessorConfiguration(nodeConfiguration);
+
+        transactionResponseProcessor = new TransactionResponseProcessor(processorConfiguration);
+        transactionResponseProcessor.handler(context -> {});
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/RequestProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/RequestProcessorChainFactory.java
@@ -22,7 +22,7 @@ import io.gravitee.gateway.core.processor.provider.ProcessorProviderChain;
 import io.gravitee.gateway.core.processor.provider.ProcessorSupplier;
 import io.gravitee.gateway.reactor.processor.forward.XForwardForProcessor;
 import io.gravitee.gateway.reactor.processor.transaction.TraceContextProcessorFactory;
-import io.gravitee.gateway.reactor.processor.transaction.TransactionProcessorFactory;
+import io.gravitee.gateway.reactor.processor.transaction.TransactionRequestProcessorFactory;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.InitializingBean;
@@ -39,8 +39,8 @@ public class RequestProcessorChainFactory implements InitializingBean {
     private final List<ProcessorProvider<ExecutionContext, Processor<ExecutionContext>>> providers = new ArrayList<>();
 
     @Autowired
-    @Qualifier("v3TransactionHandlerFactory")
-    private TransactionProcessorFactory transactionHandlerFactory;
+    @Qualifier("v3TransactionRequestProcessorFactory")
+    private TransactionRequestProcessorFactory transactionRequestProcessorFactory;
 
     @Autowired
     @Qualifier("v3TraceContextProcessorFactory")
@@ -59,7 +59,7 @@ public class RequestProcessorChainFactory implements InitializingBean {
             providers.add(new ProcessorSupplier<>(() -> traceContextHandlerFactory.create()));
         }
 
-        providers.add(new ProcessorSupplier<>(() -> transactionHandlerFactory.create()));
+        providers.add(new ProcessorSupplier<>(() -> transactionRequestProcessorFactory.create()));
     }
 
     public Processor<ExecutionContext> create() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/transaction/TransactionHeader.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/transaction/TransactionHeader.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactor.processor.transaction;
+
+public abstract class TransactionHeader {
+
+    public static final String DEFAULT_TRANSACTION_ID_HEADER = "X-Gravitee-Transaction-Id";
+    public static final String DEFAULT_REQUEST_ID_HEADER = "X-Gravitee-Request-Id";
+
+    private TransactionHeader() {}
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessor.java
@@ -50,10 +50,7 @@ public class TransactionRequestProcessor extends AbstractProcessor<ExecutionCont
             context.request().headers().set(transactionHeader, transactionId);
         }
         context.request().metrics().setTransactionId(transactionId);
-        context.response().headers().set(transactionHeader, transactionId);
-
         context.request().headers().set(requestHeader, requestId);
-        context.response().headers().set(requestHeader, requestId);
 
         ((MutableExecutionContext) context).request(new TransactionRequest(transactionId, context.request()));
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessor.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.gateway.reactor.processor.transaction;
 
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_REQUEST_ID_HEADER;
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER;
+
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.context.MutableExecutionContext;
@@ -26,17 +29,14 @@ import io.gravitee.gateway.core.processor.AbstractProcessor;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class TransactionProcessor extends AbstractProcessor<ExecutionContext> {
-
-    static final String DEFAULT_TRANSACTION_ID_HEADER = "X-Gravitee-Transaction-Id";
-    static final String DEFAULT_REQUEST_ID_HEADER = "X-Gravitee-Request-Id";
+public class TransactionRequestProcessor extends AbstractProcessor<ExecutionContext> {
 
     private String transactionHeader = DEFAULT_TRANSACTION_ID_HEADER;
     private String requestHeader = DEFAULT_REQUEST_ID_HEADER;
 
-    TransactionProcessor() {}
+    TransactionRequestProcessor() {}
 
-    TransactionProcessor(String transactionHeader, String requestHeader) {
+    TransactionRequestProcessor(String transactionHeader, String requestHeader) {
         this.transactionHeader = transactionHeader;
         this.requestHeader = requestHeader;
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessorFactory.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.gateway.reactor.processor.transaction;
 
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_REQUEST_ID_HEADER;
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER;
+
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.core.processor.Processor;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,15 +26,15 @@ import org.springframework.beans.factory.annotation.Value;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class TransactionProcessorFactory {
+public class TransactionRequestProcessorFactory {
 
-    @Value("${handlers.request.transaction.header:" + TransactionProcessor.DEFAULT_TRANSACTION_ID_HEADER + "}")
+    @Value("${handlers.request.transaction.header:" + DEFAULT_TRANSACTION_ID_HEADER + "}")
     private String transactionHeader;
 
-    @Value("${handlers.request.request.header:" + TransactionProcessor.DEFAULT_REQUEST_ID_HEADER + "}")
+    @Value("${handlers.request.request.header:" + DEFAULT_REQUEST_ID_HEADER + "}")
     private String requestHeader;
 
     public Processor<ExecutionContext> create() {
-        return new TransactionProcessor(transactionHeader, requestHeader);
+        return new TransactionRequestProcessor(transactionHeader, requestHeader);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/spring/ReactorConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/spring/ReactorConfiguration.java
@@ -39,11 +39,10 @@ import io.gravitee.gateway.reactor.impl.DefaultReactor;
 import io.gravitee.gateway.reactor.processor.RequestProcessorChainFactory;
 import io.gravitee.gateway.reactor.processor.ResponseProcessorChainFactory;
 import io.gravitee.gateway.reactor.processor.transaction.TraceContextProcessorFactory;
-import io.gravitee.gateway.reactor.processor.transaction.TransactionProcessorFactory;
+import io.gravitee.gateway.reactor.processor.transaction.TransactionRequestProcessorFactory;
 import io.gravitee.gateway.report.ReporterService;
 import io.gravitee.node.api.Node;
 import io.gravitee.plugin.alert.AlertEventProducer;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -167,8 +166,8 @@ public class ReactorConfiguration {
     }
 
     @Bean
-    public TransactionProcessorFactory v3TransactionHandlerFactory() {
-        return new io.gravitee.gateway.reactor.processor.transaction.TransactionProcessorFactory();
+    public TransactionRequestProcessorFactory v3TransactionRequestProcessorFactory() {
+        return new TransactionRequestProcessorFactory();
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/ReactorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/ReactorTest.java
@@ -27,7 +27,7 @@ import io.gravitee.gateway.reactor.handler.context.ExecutionContextFactory;
 import io.gravitee.gateway.reactor.impl.DefaultReactor;
 import io.gravitee.gateway.reactor.processor.RequestProcessorChainFactory;
 import io.gravitee.gateway.reactor.processor.ResponseProcessorChainFactory;
-import io.gravitee.gateway.reactor.processor.transaction.TransactionProcessorFactory;
+import io.gravitee.gateway.reactor.processor.transaction.TransactionRequestProcessorFactory;
 import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
@@ -69,7 +69,7 @@ public class ReactorTest {
     private DummyReactorHandler dummyReactorHandler = new DummyReactorHandler();
 
     @Spy
-    private TransactionProcessorFactory transactionHandlerFactory = new TransactionProcessorFactory();
+    private TransactionRequestProcessorFactory transactionHandlerFactory = new TransactionRequestProcessorFactory();
 
     @Before
     public void setUp() throws Exception {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessorTest.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.gateway.reactor.processor.transaction;
 
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_REQUEST_ID_HEADER;
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER;
+
 import io.gravitee.common.utils.UUID;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
@@ -35,7 +38,7 @@ import org.mockito.MockitoAnnotations;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class TransactionProcessorTest {
+public class TransactionRequestProcessorTest {
 
     private static final String CUSTOM_TRANSACTION_ID_HEADER = "X-My-Transaction-Id";
     private static final String CUSTOM_REQUEST_ID_HEADER = "X-My-Request-Id";
@@ -63,28 +66,19 @@ public class TransactionProcessorTest {
 
         Mockito.when(request.id()).thenReturn(UUID.toString(UUID.random()));
 
-        new TransactionProcessor()
+        new TransactionRequestProcessor()
             .handler(
                 context -> {
                     Assert.assertNotNull(context.request().transactionId());
                     Assert.assertEquals(
                         context.request().transactionId(),
-                        context.request().headers().getFirst(TransactionProcessor.DEFAULT_TRANSACTION_ID_HEADER)
+                        context.request().headers().getFirst(DEFAULT_TRANSACTION_ID_HEADER)
                     );
                     Assert.assertEquals(context.request().transactionId(), context.request().metrics().getTransactionId());
-                    Assert.assertEquals(
-                        context.request().transactionId(),
-                        response.headers().getFirst(TransactionProcessor.DEFAULT_TRANSACTION_ID_HEADER)
-                    );
+                    Assert.assertEquals(context.request().transactionId(), response.headers().getFirst(DEFAULT_TRANSACTION_ID_HEADER));
 
-                    Assert.assertEquals(
-                        context.request().id(),
-                        context.request().headers().getFirst(TransactionProcessor.DEFAULT_REQUEST_ID_HEADER)
-                    );
-                    Assert.assertEquals(
-                        context.request().id(),
-                        response.headers().getFirst(TransactionProcessor.DEFAULT_REQUEST_ID_HEADER)
-                    );
+                    Assert.assertEquals(context.request().id(), context.request().headers().getFirst(DEFAULT_REQUEST_ID_HEADER));
+                    Assert.assertEquals(context.request().id(), response.headers().getFirst(DEFAULT_REQUEST_ID_HEADER));
 
                     lock.countDown();
                 }
@@ -100,32 +94,20 @@ public class TransactionProcessorTest {
 
         String transactionId = UUID.toString(UUID.random());
 
-        request.headers().set(TransactionProcessor.DEFAULT_TRANSACTION_ID_HEADER, transactionId);
-        new TransactionProcessor()
+        request.headers().set(DEFAULT_TRANSACTION_ID_HEADER, transactionId);
+        new TransactionRequestProcessor()
             .handler(
                 context -> {
                     Assert.assertNotNull(context.request().transactionId());
                     Assert.assertEquals(transactionId, context.request().transactionId());
-                    Assert.assertEquals(
-                        transactionId,
-                        context.request().headers().getFirst(TransactionProcessor.DEFAULT_TRANSACTION_ID_HEADER)
-                    );
+                    Assert.assertEquals(transactionId, context.request().headers().getFirst(DEFAULT_TRANSACTION_ID_HEADER));
                     Assert.assertEquals(transactionId, context.request().metrics().getTransactionId());
-                    Assert.assertEquals(
-                        context.request().transactionId(),
-                        response.headers().getFirst(TransactionProcessor.DEFAULT_TRANSACTION_ID_HEADER)
-                    );
+                    Assert.assertEquals(context.request().transactionId(), response.headers().getFirst(DEFAULT_TRANSACTION_ID_HEADER));
 
                     Assert.assertNotEquals(transactionId, context.request().id());
-                    Assert.assertNotEquals(
-                        transactionId,
-                        context.request().headers().getFirst(TransactionProcessor.DEFAULT_REQUEST_ID_HEADER)
-                    );
+                    Assert.assertNotEquals(transactionId, context.request().headers().getFirst(DEFAULT_REQUEST_ID_HEADER));
                     Assert.assertNotEquals(transactionId, context.request().metrics().getRequestId());
-                    Assert.assertEquals(
-                        context.request().id(),
-                        response.headers().getFirst(TransactionProcessor.DEFAULT_REQUEST_ID_HEADER)
-                    );
+                    Assert.assertEquals(context.request().id(), response.headers().getFirst(DEFAULT_REQUEST_ID_HEADER));
 
                     lock.countDown();
                 }
@@ -141,7 +123,7 @@ public class TransactionProcessorTest {
 
         Mockito.when(request.id()).thenReturn(UUID.toString(UUID.random()));
 
-        new TransactionProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER)
+        new TransactionRequestProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER)
             .handler(
                 context -> {
                     Assert.assertNotNull(context.request().transactionId());
@@ -166,7 +148,7 @@ public class TransactionProcessorTest {
         String transactionId = UUID.toString(UUID.random());
 
         request.headers().set(CUSTOM_TRANSACTION_ID_HEADER, transactionId);
-        new TransactionProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER)
+        new TransactionRequestProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER)
             .handler(
                 context -> {
                     Assert.assertNotNull(context.request().transactionId());

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/vertx/VertxDebugConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/vertx/VertxDebugConfiguration.java
@@ -24,7 +24,7 @@ import io.gravitee.gateway.reactor.processor.NotFoundProcessorChainFactory;
 import io.gravitee.gateway.reactor.processor.RequestProcessorChainFactory;
 import io.gravitee.gateway.reactor.processor.ResponseProcessorChainFactory;
 import io.gravitee.gateway.reactor.processor.transaction.TraceContextProcessorFactory;
-import io.gravitee.gateway.reactor.processor.transaction.TransactionProcessorFactory;
+import io.gravitee.gateway.reactor.processor.transaction.TransactionRequestProcessorFactory;
 import io.gravitee.node.certificates.KeyStoreLoaderManager;
 import io.gravitee.node.vertx.VertxHttpServerFactory;
 import io.gravitee.node.vertx.configuration.HttpServerConfiguration;
@@ -56,8 +56,8 @@ public class VertxDebugConfiguration {
     }
 
     @Bean
-    public TransactionProcessorFactory transactionHandlerFactory() {
-        return new TransactionProcessorFactory();
+    public TransactionRequestProcessorFactory transactionHandlerFactory() {
+        return new TransactionRequestProcessorFactory();
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -306,15 +306,25 @@ services:
 #      enabled: false
 #    # possible values: hex, uuid. Default: uuid.
 #    format: uuid
-#    transaction:
-#      # Default: X-Gravitee-Transaction-Id.
-#      header: X-Gravitee-Transaction-Id
 #    headers:
 #      # Override X-Forwarded-Prefix with context path. Disabled by default.
 #      x-forwarded-prefix: false
+#    transaction:
+#      # Default: X-Gravitee-Transaction-Id.
+#      header: X-Gravitee-Transaction-Id
+#      # Possible values of overrideMode are:
+#      #   - override: The header set by the APIM Gateway will override the one provided by the backend
+#      #   - merge: Both headers set by the APIM Gateway and the backend will be kept (as headers can be multivalued)
+#      #   - keep: The header set by the backend will be kept and the one provided by the APIM Gateway discarded
+#      overrideMode: override
 #    request:
 #      # Default: X-Gravitee-Request-Id.
 #      header: X-Gravitee-Request-Id
+#      # Possible values of overrideMode are:
+#      #   - override: The header set by the APIM Gateway will override the one provided by the backend
+#      #   - merge: Both headers set by the APIM Gateway and the backend will be kept (as headers can be multi-valued)
+#      #   - keep: The header set by the backend will be kept and the one provided by the APIM Gateway discarded
+#      overrideMode: override
 
 # Referenced properties
 ds:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-75
https://github.com/gravitee-io/issues/issues/7618

## Description

Response headers were previously handled in the TransactionRequestProcessor. 
They are now processed in the TransactionResponseProcessor with specific configuration keys, see below for details ⬇️ 

To avoid introducing another breaking change it would be interesting to let the users pick the behavior they want when the backend of the API is also setting the `request` or `transaction` header. So, the configuration will be updated to something like this:

```yaml
gravitee:
  handlers:
    request:
      format: uuid
      request:
        header: X-CUSTOM-Flow-ID
        # ⬇️ This is a new attribute
        overrideMode: none 
      transaction:
        header: X-CUSTOM-Flow-ID
        # ⬇️  This is a new attribute
        overrideMode: none
```

Possible values of `overrideMode` are the following:
 - `override`: The header set by the APIM Gateway will be kept and the one provided by the backend discarded 
 - `merge`: Both headers set by the APIM Gateway and the backend will be kept (as headers can be multi-valued)
 - `keep`: The header set by the APIM Gateway will be overridden by the one provided by the backend

The `override` mode will be set by default.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-75-add-backendoverridemode/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lracixmayq.chromatic.com)
<!-- Storybook placeholder end -->
