### PR TITLE
Display API version in APIs list

### DIFF
--- a/gravitee-apim-console-webui/package-lock.json
+++ b/gravitee-apim-console-webui/package-lock.json
@@ -48659,8 +48659,7 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
           "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "import-local": {
           "version": "2.0.0",
@@ -48983,8 +48982,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
           "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "postcss-modules-local-by-default": {
           "version": "4.0.0",
@@ -49178,8 +49176,7 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.2.1.tgz",
           "integrity": "sha512-1k9ZosJCRFaRbY6hH49JFlRB0fVSbmnyq1iTPjNxUmGVjBNEmwrrHPenhlp+Lgo51BojHSf6pl2FcqYaN3PfVg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "tapable": {
           "version": "2.2.0",
@@ -57711,8 +57708,7 @@
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
       "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@mdx-js/util": {
       "version": "1.6.22",
@@ -57734,8 +57730,7 @@
       "version": "12.2.3",
       "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-12.2.3.tgz",
       "integrity": "sha512-Mx8QYCuOlgL0HdX0GDw5I3PLyW/TPJPSrk8VZLW2H5NR1wTHEw6PmqauAnuAMr7npAtOhV4tN9YyeTi8gy6+7A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
@@ -60194,8 +60189,7 @@
           "version": "8.5.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
           "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -62115,8 +62109,7 @@
     "@uirouter/rx": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@uirouter/rx/-/rx-1.0.0.tgz",
-      "integrity": "sha512-dqPmLFC+qqF6RIdJVKktXSON6WILy2oyLhADDk74F3GAUZ/VvOu3QSPLDtZEP3LMSo6vkGQvwcUdjgNVWL3YJA==",
-      "requires": {}
+      "integrity": "sha512-dqPmLFC+qqF6RIdJVKktXSON6WILy2oyLhADDk74F3GAUZ/VvOu3QSPLDtZEP3LMSo6vkGQvwcUdjgNVWL3YJA=="
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -62387,15 +62380,13 @@
       "version": "1.7.6",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.7.6.tgz",
       "integrity": "sha512-FlVvVFA1TX6l3lp8VjDnYYq7R1nyW6x3svAt4nDgrWQ9SBaSh9CnbwgSUTasgfNfOG5HlM1ehugCvM+hjo56LA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -62541,8 +62532,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv-formats": {
       "version": "2.1.0",
@@ -62577,8 +62567,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -62657,14 +62646,12 @@
     "angular-material": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/angular-material/-/angular-material-1.2.2.tgz",
-      "integrity": "sha512-GtrBzYDg5zHYX/OUqxo72zb9bsY0RDuIA+4ZsZjuv1r+L4q9UAtkeIZzMXVGua6CCNgfB58cKep3TmxtAZhNwg==",
-      "requires": {}
+      "integrity": "sha512-GtrBzYDg5zHYX/OUqxo72zb9bsY0RDuIA+4ZsZjuv1r+L4q9UAtkeIZzMXVGua6CCNgfB58cKep3TmxtAZhNwg=="
     },
     "angular-material-data-table": {
       "version": "0.10.10",
       "resolved": "https://registry.npmjs.org/angular-material-data-table/-/angular-material-data-table-0.10.10.tgz",
-      "integrity": "sha1-IptAJ0XsGhRvB9qNHlJr5lQISe4=",
-      "requires": {}
+      "integrity": "sha1-IptAJ0XsGhRvB9qNHlJr5lQISe4="
     },
     "angular-material-icons": {
       "version": "0.7.1",
@@ -64821,8 +64808,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/circular-dependency-plugin/-/circular-dependency-plugin-5.2.2.tgz",
       "integrity": "sha512-g38K9Cm5WRwlaH6g03B9OEz/0qRizI+2I7n+Gz+L5DxXJAPAiWQvwlYNm1V1jkdpUv95bOe/ASm2vfi/G560jQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "cjs-module-lexer": {
       "version": "1.2.2",
@@ -66221,8 +66207,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-2.0.1.tgz",
       "integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "csso": {
       "version": "4.2.0",
@@ -67415,8 +67400,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
       "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -72236,8 +72220,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-preset-angular": {
       "version": "10.1.0",
@@ -74670,8 +74653,7 @@
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.7.tgz",
       "integrity": "sha512-VI3TyyHlGkO8uFle0IOibzpO1c1iJDcXcS/zBrQrXQQvJ2tpdwVzVZ7XdKsyRz1NdRmre4dqQkMZzUHaKIG/1w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "marked": {
       "version": "4.0.16",
@@ -77329,29 +77311,25 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.1.tgz",
       "integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-duplicates": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.1.tgz",
       "integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-empty": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.0.1.tgz",
       "integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-overridden": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.1.tgz",
       "integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-double-position-gradients": {
       "version": "1.0.0",
@@ -77773,8 +77751,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.0.1.tgz",
       "integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-normalize-display-values": {
       "version": "5.0.1",
@@ -78643,8 +78620,7 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.5.1.tgz",
       "integrity": "sha512-M1TJH2X3RXEt12sWkpa6hLc/bbYS0H6F4rIqjQZ+RxNBstpY67d9TrFXtqdZwhpmBXcCwEi7stKqFue3ZRkiOg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "react-dom": {
       "version": "16.14.0",
@@ -82465,15 +82441,13 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.2.1.tgz",
       "integrity": "sha512-6+X1FLlIcjvFMAeAD/hcxDT8tmyrWnbSPMU0EnxQuDLIxokuFzWliXBiYZuGIx+mrAMLBw0WFfCkaPw8ebzAhw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "use-isomorphic-layout-effect": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz",
       "integrity": "sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "use-latest": {
       "version": "1.2.0",
@@ -82971,8 +82945,7 @@
     "web-react-components": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/web-react-components/-/web-react-components-1.4.2.tgz",
-      "integrity": "sha512-//n/7TFHJHSrfDKguLN3kdJHDezQJpStwU6b751up6Nsax5Ry+GpRHsxmpc+BO2TarzakTxLwowvmWiyIbBHbw==",
-      "requires": {}
+      "integrity": "sha512-//n/7TFHJHSrfDKguLN3kdJHDezQJpStwU6b751up6Nsax5Ry+GpRHsxmpc+BO2TarzakTxLwowvmWiyIbBHbw=="
     },
     "webidl-conversions": {
       "version": "6.1.0",
@@ -83159,8 +83132,7 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
           "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "@webpack-cli/info": {
           "version": "1.5.0",
@@ -83175,8 +83147,7 @@
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
           "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "colorette": {
           "version": "2.0.16",
@@ -83683,8 +83654,7 @@
           "version": "8.5.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
           "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -83692,8 +83662,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/webpack-filter-warnings-plugin/-/webpack-filter-warnings-plugin-1.2.1.tgz",
       "integrity": "sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "webpack-hot-middleware": {
       "version": "2.25.1",
@@ -83941,8 +83910,7 @@
     "ws": {
       "version": "7.5.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.1.tgz",
-      "integrity": "sha512-2c6faOUH/nhoQN6abwMloF7Iyl0ZS2E9HGtsiLrWn0zOOMWlhtDmdf/uihDt6jnuCxgtwGBNy6Onsoy2s2O2Ow==",
-      "requires": {}
+      "integrity": "sha512-2c6faOUH/nhoQN6abwMloF7Iyl0ZS2E9HGtsiLrWn0zOOMWlhtDmdf/uihDt6jnuCxgtwGBNy6Onsoy2s2O2Ow=="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
@@ -47,7 +47,7 @@
     <ng-container matColumnDef="name">
       <th mat-header-cell *matHeaderCellDef mat-sort-header id="name">Name</th>
       <td mat-cell *matCellDef="let element" (click)="onEditActionClicked(element)">
-        <a>{{ element.name }}</a>
+        <a title="{{ element.name }} ({{ element.version }})">{{ element.name }} ({{ element.version }})</a>
       </td>
     </ng-container>
 

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
@@ -86,7 +86,7 @@
 
     <!-- Display Context Path Column -->
     <ng-container matColumnDef="contextPath">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header id="contextPath">Context paths</th>
+      <th mat-header-cell *matHeaderCellDef mat-sort-header id="contextPath">Context Path</th>
       <td mat-cell *matCellDef="let element">
         <a>{{ element.contextPath }}</a>
       </td>

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
@@ -102,7 +102,7 @@ describe('ApisListComponent', () => {
           visibility: 'Visibility',
         },
       ]);
-      expect(rowCells).toEqual([['', '🪐 Planets', 'play_circlecloud_done', '/planets', '', 'admin', 'public', 'edit']]);
+      expect(rowCells).toEqual([['', '🪐 Planets (1.0)', 'play_circlecloud_done', '/planets', '', 'admin', 'public', 'edit']]);
     }));
 
     it('should display one row with kubernetes icon', fakeAsync(async () => {
@@ -164,6 +164,7 @@ describe('ApisListComponent', () => {
         const api = {
           id: 'api-id',
           name: 'api#1',
+          version: '1.0.0',
           contextPath: '/api-1',
           tags: null,
           owner: 'admin',
@@ -225,7 +226,7 @@ describe('ApisListComponent', () => {
           visibility: 'Visibility',
         },
       ]);
-      expect(rowCells).toEqual([['', '🪐 Planets', 'play_circlecloud_done', '/planets', '', '100%', 'admin', 'public', 'edit']]);
+      expect(rowCells).toEqual([['', '🪐 Planets (1.0)', 'play_circlecloud_done', '/planets', '', '100%', 'admin', 'public', 'edit']]);
       expect(fixture.debugElement.query(By.css('.quality-score__good'))).toBeTruthy();
     }));
 

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
@@ -73,7 +73,7 @@ describe('ApisListComponent', () => {
       expect(headerCells).toEqual([
         {
           actions: '',
-          contextPath: 'Context paths',
+          contextPath: 'Context Path',
           name: 'Name',
           owner: 'Owner',
           picture: '',
@@ -93,7 +93,7 @@ describe('ApisListComponent', () => {
       expect(headerCells).toEqual([
         {
           actions: '',
-          contextPath: 'Context paths',
+          contextPath: 'Context Path',
           name: 'Name',
           owner: 'Owner',
           picture: '',
@@ -216,7 +216,7 @@ describe('ApisListComponent', () => {
       expect(headerCells).toEqual([
         {
           actions: '',
-          contextPath: 'Context paths',
+          contextPath: 'Context Path',
           name: 'Name',
           owner: 'Owner',
           picture: '',

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
@@ -30,6 +30,7 @@ import { Constants } from '../../../entities/Constants';
 export type ApisTableDS = {
   id: string;
   name: string;
+  version: string;
   contextPath: string;
   tags: string;
   owner: string;
@@ -145,6 +146,7 @@ export class ApiListComponent implements OnInit, OnDestroy {
       ? api.data.map((api) => ({
           id: api.id,
           name: api.name,
+          version: api.version,
           contextPath: api.context_path,
           tags: api.tags.join(', '),
           owner: api?.owner?.displayName,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-942
gravitee-io/issues#8904

## Description

Display API version in APIs list and fix typo on Context Path header

![image](https://user-images.githubusercontent.com/4112568/221585431-6ac5aecd-d036-42e9-bd43-48b0be43999b.png)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uncanbgdmc.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-942-display-apis-version/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
