### PR TITLE
Configure rate limit timeout

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -299,6 +299,11 @@ services:
 #      ssl:
 #        enabled: false
 
+#  ratelimit:
+#    The "timeout" value refers to the default time (in milliseconds) that the system will wait for a response when attempting to access data from the data source.
+#    If the data source does not respond within the allotted time, the system will stop waiting and assume that the data source is not available.
+#    timeout: 100
+
 #handlers:
 #  request:
 #    # manage traceparent header defined by W3C trace-context specification


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-990

## Description

Linked to:
https://github.com/gravitee-io/gravitee-policy-ratelimit/pull/78

TODO 🚧 change policy version in the pom.xml to 1.15.1 after the merge in the policy repo

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-sioysbairn.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-990-ratelimit-timetout/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
