### PR TITLE
fix(console): mark context-path as required

### DIFF
--- a/gravitee-apim-console-webui/src/components/gio-form-listeners/gio-form-listeners-context-path/gio-form-listeners-context-path.component.ts
+++ b/gravitee-apim-console-webui/src/components/gio-form-listeners/gio-form-listeners-context-path/gio-form-listeners-context-path.component.ts
@@ -61,7 +61,6 @@ export class GioFormListenersContextPathComponent implements OnInit, OnDestroy, 
   public listenerFormArray = new FormArray([this.newListenerFormGroup({})], [this.listenersValidator()], [this.listenersAsyncValidator()]);
   public contextPathPrefix: string;
   private unsubscribe$: Subject<void> = new Subject<void>();
-  private verifiedPath: Record<string, ValidationErrors | null> = {};
 
   public onDelete(pathIndex: number): void {
     this.listenerFormArray.controls.forEach((control) => {

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.spec.ts
@@ -239,6 +239,23 @@ describe('ApiCreationV4Component', () => {
       expectApiGetPortalSettings();
     });
 
+    it('should not validate without path', async () => {
+      await fillAndValidateStep1ApiDetails('API', '1.0', 'Description');
+      const step2Harness = await harnessLoader.getHarness(Step2Entrypoints1ListHarness);
+
+      expectEntrypointsGetRequest([{ id: 'sse', supportedApiType: 'async', name: 'SSE' }]);
+
+      await step2Harness.getEntrypoints().then((form) => form.selectOptionsByIds(['sse']));
+
+      await step2Harness.clickValidate();
+      expect(component.currentStep.payload.selectedEntrypoints).toEqual([{ id: 'sse', name: 'SSE', supportedListenerType: 'http' }]);
+      exceptEnvironmentGetRequest(fakeEnvironment());
+      expectSchemaGetRequest([{ id: 'sse', name: 'SSE' }]);
+      expectApiGetPortalSettings();
+      const step21Harness = await harnessLoader.getHarness(Step2Entrypoints2ConfigHarness);
+      expect(await step21Harness.hasValidationDisabled()).toEqual(true);
+    });
+
     it('should not validate with bad path', async () => {
       await fillAndValidateStep1ApiDetails('API', '1.0', 'Description');
       const step2Harness = await harnessLoader.getHarness(Step2Entrypoints1ListHarness);

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-2-entrypoints/step-2-entrypoints-2-config.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-2-entrypoints/step-2-entrypoints-2-config.component.ts
@@ -15,7 +15,7 @@
  */
 
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { FormBuilder, FormGroup } from '@angular/forms';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { forkJoin, Observable, Subject } from 'rxjs';
 import { GioJsonSchema } from '@gravitee/ui-particles-angular';
 import { takeUntil, tap } from 'rxjs/operators';
@@ -74,7 +74,7 @@ export class Step2Entrypoints2ConfigComponent implements OnInit, OnDestroy {
       listener?.entrypoints?.reduce((map, { type, configuration }) => ({ ...map, [type]: configuration }), {}) || {};
     this.formGroup = this.formBuilder.group({});
     if (this.hasListeners) {
-      this.formGroup.addControl('paths', this.formBuilder.control(paths));
+      this.formGroup.addControl('paths', this.formBuilder.control(paths, Validators.required));
     }
     currentStepPayload.selectedEntrypoints.forEach(({ id }) => {
       this.formGroup.addControl(id, this.formBuilder.group({}));


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-951


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bqfjjrimfd.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-951-mark-context-path-as-required/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
