### PR TITLE
Display API version in APIs list - Backport #3170 on 3.20.x

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
@@ -46,8 +46,8 @@
     <!-- Display Name Column -->
     <ng-container matColumnDef="name">
       <th mat-header-cell *matHeaderCellDef mat-sort-header id="name">Name</th>
-      <td mat-cell *matCellDef="let element" (click)="onEditActionClicked(element)">
-        {{ element.name }}
+      <td mat-cell *matCellDef="let element" (click)="onEditActionClicked(element)" title="{{ element.name }} ({{ element.version }})">
+        {{ element.name }} ({{ element.version }})
       </td>
     </ng-container>
 

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
@@ -104,7 +104,7 @@ describe('ApisListComponent', () => {
           visibility: 'Visibility',
         },
       ]);
-      expect(rowCells).toEqual([['', '🪐 Planets', '', '/planets', '', 'admin', 'Policy studio', 'public', 'edit']]);
+      expect(rowCells).toEqual([['', '🪐 Planets (1.0)', '', '/planets', '', 'admin', 'Policy studio', 'public', 'edit']]);
       expect(await loader.getHarness(MatIconHarness.with({ selector: '.states__api-started' }))).toBeTruthy();
     }));
 
@@ -167,6 +167,7 @@ describe('ApisListComponent', () => {
         const api = {
           id: 'api-id',
           name: 'api#1',
+          version: '1.0.0',
           contextPath: '/api-1',
           tags: null,
           owner: 'admin',
@@ -231,7 +232,7 @@ describe('ApisListComponent', () => {
           visibility: 'Visibility',
         },
       ]);
-      expect(rowCells).toEqual([['', '🪐 Planets', '', '/planets', '', '100%', 'admin', 'Policy studio', 'public', 'edit']]);
+      expect(rowCells).toEqual([['', '🪐 Planets (1.0)', '', '/planets', '', '100%', 'admin', 'Policy studio', 'public', 'edit']]);
       expect(fixture.debugElement.query(By.css('.quality-score__good'))).toBeTruthy();
       expect(await loader.getHarness(MatIconHarness.with({ selector: '.states__api-started' }))).toBeTruthy();
     }));

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
@@ -30,6 +30,7 @@ import { Constants } from '../../../entities/Constants';
 export type ApisTableDS = {
   id: string;
   name: string;
+  version: string;
   contextPath: string;
   tags: string;
   owner: string;
@@ -147,6 +148,7 @@ export class ApiListComponent implements OnInit, OnDestroy {
       ? api.data.map((api) => ({
           id: api.id,
           name: api.name,
+          version: api.version,
           contextPath: api.context_path,
           tags: api.tags.join(', '),
           owner: api?.owner?.displayName,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-942
gravitee-io/issues#8904

## Description

Display API version in APIs list 
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-942-display-apis-version-3-20-x/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cayydrgndp.chromatic.com)
<!-- Storybook placeholder end -->
