### PR TITLE
fix(console + management): rewire entrypoints + endpoints

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.spec.ts
@@ -739,13 +739,13 @@ describe('ApiCreationV4Component', () => {
   function expectEntrypointsGetRequest(connectors: Partial<ConnectorListItem>[]) {
     const fullConnectors = connectors.map((partial) => fakeConnectorListItem(partial));
 
-    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.baseURL}/v4/entrypoints`, method: 'GET' }).flush(fullConnectors);
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/v4/entrypoints`, method: 'GET' }).flush(fullConnectors);
   }
 
   function expectSchemaGetRequest(connectors: Partial<ConnectorListItem>[], connectorType: 'entrypoints' | 'endpoints' = 'entrypoints') {
     connectors.forEach((connector) => {
       httpTestingController
-        .expectOne({ url: `${CONSTANTS_TESTING.baseURL}/v4/${connectorType}/${connector.id}/schema`, method: 'GET' })
+        .expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/v4/${connectorType}/${connector.id}/schema`, method: 'GET' })
         .flush(getEntrypointConnectorSchema(connector.id));
     });
   }
@@ -753,7 +753,7 @@ describe('ApiCreationV4Component', () => {
   function expectEndpointsGetRequest(connectors: Partial<ConnectorListItem>[]) {
     const fullConnectors = connectors.map((partial) => fakeConnectorListItem(partial));
 
-    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.baseURL}/v4/endpoints`, method: 'GET' }).flush(fullConnectors);
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/v4/endpoints`, method: 'GET' }).flush(fullConnectors);
   }
 
   async function fillAndValidateStep1ApiDetails(name = 'API name', version = '1.0', description = 'description') {

--- a/gravitee-apim-console-webui/src/services-ngx/endpoint.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/endpoint.service.spec.ts
@@ -45,7 +45,7 @@ describe('EndpointService', () => {
 
       httpTestingController
         .expectOne({
-          url: `${CONSTANTS_TESTING.baseURL}/v4/endpoints`,
+          url: `${CONSTANTS_TESTING.env.baseURL}/v4/endpoints`,
           method: 'GET',
         })
         .flush(fakeConnectors);

--- a/gravitee-apim-console-webui/src/services-ngx/endpoint.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/endpoint.service.ts
@@ -36,7 +36,7 @@ export class EndpointService {
   ) {}
 
   v4ListEndpointPlugins(): Observable<ConnectorListItem[]> {
-    return this.http.get<ConnectorListItem[]>(`${this.constants.baseURL}/v4/endpoints`);
+    return this.http.get<ConnectorListItem[]>(`${this.constants.env.baseURL}/v4/endpoints`);
   }
 
   v4Get(id: string): Observable<ConnectorListItem> {
@@ -44,10 +44,10 @@ export class EndpointService {
   }
 
   v4GetSchema(id: string): Observable<GioJsonSchema> {
-    return this.http.get<GioJsonSchema>(`${this.constants.baseURL}/v4/endpoints/${id}/schema`);
+    return this.http.get<GioJsonSchema>(`${this.constants.env.baseURL}/v4/endpoints/${id}/schema`);
   }
 
   v4GetMoreInformation(endpointId: string): Observable<PluginMoreInformation> {
-    return this.http.get<PluginMoreInformation>(`${this.constants.baseURL}/v4/endpoints/${endpointId}/moreInformation`);
+    return this.http.get<PluginMoreInformation>(`${this.constants.env.baseURL}/v4/endpoints/${endpointId}/moreInformation`);
   }
 }

--- a/gravitee-apim-console-webui/src/services-ngx/entrypoint.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/entrypoint.service.spec.ts
@@ -115,7 +115,7 @@ describe('EntrypointService', () => {
 
       httpTestingController
         .expectOne({
-          url: `${CONSTANTS_TESTING.baseURL}/v4/entrypoints`,
+          url: `${CONSTANTS_TESTING.env.baseURL}/v4/entrypoints`,
           method: 'GET',
         })
         .flush(fakeConnectors);

--- a/gravitee-apim-console-webui/src/services-ngx/entrypoint.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/entrypoint.service.ts
@@ -55,14 +55,14 @@ export class EntrypointService {
   }
 
   v4ListEntrypointPlugins(): Observable<ConnectorListItem[]> {
-    return this.http.get<ConnectorListItem[]>(`${this.constants.baseURL}/v4/entrypoints`);
+    return this.http.get<ConnectorListItem[]>(`${this.constants.env.baseURL}/v4/entrypoints`);
   }
 
   v4GetSchema(entrypointId: string): Observable<GioJsonSchema> {
-    return this.http.get<GioJsonSchema>(`${this.constants.baseURL}/v4/entrypoints/${entrypointId}/schema`);
+    return this.http.get<GioJsonSchema>(`${this.constants.env.baseURL}/v4/entrypoints/${entrypointId}/schema`);
   }
 
   v4GetMoreInformation(entrypointId: string): Observable<PluginMoreInformation> {
-    return this.http.get<PluginMoreInformation>(`${this.constants.baseURL}/v4/entrypoints/${entrypointId}/moreInformation`);
+    return this.http.get<PluginMoreInformation>(`${this.constants.env.baseURL}/v4/entrypoints/${entrypointId}/moreInformation`);
   }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/v4/endpoint/EndpointResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/v4/endpoint/EndpointResource.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.management.rest.resource.v4.endpoint;
 
 import io.gravitee.common.http.MediaType;
+import io.gravitee.plugin.core.api.PluginMoreInformation;
 import io.gravitee.rest.api.management.rest.security.Permission;
 import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.model.permissions.RolePermission;
@@ -105,5 +106,20 @@ public class EndpointResource {
         endpointService.findById(endpoint);
 
         return endpointService.getDocumentation(endpoint);
+    }
+
+    @GET
+    @Path("moreInformation")
+    @ApiResponse(
+        responseCode = "200",
+        description = "Endpoint more information",
+        content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = PluginMoreInformation.class))
+    )
+    @Produces(MediaType.APPLICATION_JSON)
+    public PluginMoreInformation getMoreInformation(@PathParam("endpoint") String endpointId) {
+        // Check that the entrypoint exists
+        endpointService.findById(endpointId);
+
+        return endpointService.getMoreInformation(endpointId);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/v4/entrypoint/EntrypointResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/v4/entrypoint/EntrypointResource.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.management.rest.resource.v4.entrypoint;
 
 import io.gravitee.common.http.MediaType;
+import io.gravitee.plugin.core.api.PluginMoreInformation;
 import io.gravitee.rest.api.management.rest.security.Permission;
 import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.model.permissions.RolePermission;
@@ -136,5 +137,20 @@ public class EntrypointResource {
         entrypointService.findById(entrypoint);
 
         return entrypointService.getSubscriptionSchema(entrypoint);
+    }
+
+    @GET
+    @Path("/moreInformation")
+    @ApiResponse(
+        responseCode = "200",
+        description = "Entrypoint more information",
+        content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = PluginMoreInformation.class))
+    )
+    @Produces(MediaType.APPLICATION_JSON)
+    public PluginMoreInformation getMoreInformation(@PathParam("entrypoint") String entrypointId) {
+        // Check that the entrypoint exists
+        entrypointService.findById(entrypointId);
+
+        return entrypointService.getMoreInformation(entrypointId);
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-995

## Description

Rewire entrypoints and endpoints to use apim instead of apim-v4 module.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fiinexkkda.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-console-revert-entrypoints-endpoints-services/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
