### PR TITLE
Path based API deprecation - fix e2e tests

### DIFF
--- a/gravitee-apim-e2e/api-test/src/apis/api-definition.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/api-definition.spec.ts
@@ -718,7 +718,7 @@ describe('API definition', () => {
         jsonPatch,
       }),
       400,
-      'You are not allowed to downgrade definition version',
+      'The definition versions 1.0.0 is not supported anymore.',
     );
   });
 

--- a/gravitee-apim-e2e/api-test/src/export/api-export.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/export/api-export.spec.ts
@@ -33,39 +33,6 @@ const apisResourceAdmin = new APIsApi(forManagementAsAdminUser());
 let userApi: ApiEntity;
 
 describe('API - Exports', () => {
-  describe('Export path based api from current version to 3.0 to 3.6 version and import it', () => {
-    let importedApi: ApiEntity;
-    beforeAll(async () => {
-      userApi = await apisResourceAdmin.createApi({
-        orgId,
-        envId,
-        newApiEntity: ApisFaker.newApi({ paths: ['/'], gravitee: '1.0.0' }),
-      });
-    });
-
-    it('should export the api without flow', async () => {
-      const exportedApi = JSON.parse(
-        await succeed(apisResourceAdmin.exportApiDefinitionRaw({ api: userApi.id, envId, orgId, version: '3.0' })),
-      );
-      expect(exportedApi).toBeTruthy();
-      expect(exportedApi).not.toHaveProperty('flows');
-      expect(exportedApi).toHaveProperty('paths');
-
-      await noContent(apisResourceAdmin.deleteApiRaw({ orgId, envId, api: userApi.id }));
-
-      importedApi = await succeed(apisResourceAdmin.importApiDefinitionRaw({ orgId, envId, body: exportedApi }));
-      expect(importedApi).toBeTruthy();
-      expect(importedApi.crossId).toStrictEqual(exportedApi.crossId);
-      expect(importedApi.flows).toHaveLength(0);
-      expect(importedApi.paths).toMatchObject({ '/': [] });
-      expect(importedApi.gravitee).toStrictEqual(exportedApi.gravitee);
-    });
-
-    afterEach(async () => {
-      await apisResourceAdmin.deleteApi({ orgId, envId, api: importedApi.id });
-    });
-  });
-
   describe('Export flow based api from current version to 3.0 to 3.6 and import it', () => {
     const flow: Flow = {
       condition: '',


### PR DESCRIPTION
## Issue

N/A

## Description

Fix e2e tests following merged PR on path based APIs deprecation
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xdwmfakrzw.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-run-e2e-tests/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
