### PR TITLE
feat(api-v4): add permissions to api resource

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/java/io/gravitee/rest/api/management/v4/rest/filter/PermissionsFilter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/java/io/gravitee/rest/api/management/v4/rest/filter/PermissionsFilter.java
@@ -100,7 +100,7 @@ public class PermissionsFilter implements ContainerRequestFilter {
     }
 
     private String getApiId(ContainerRequestContext requestContext) {
-        return getId("api", requestContext);
+        return getId("apiId", requestContext);
     }
 
     private String getApplicationId(ContainerRequestContext requestContext) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/java/io/gravitee/rest/api/management/v4/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/java/io/gravitee/rest/api/management/v4/rest/resource/api/ApiResource.java
@@ -23,6 +23,8 @@ import io.gravitee.rest.api.exception.InvalidImageException;
 import io.gravitee.rest.api.management.v4.rest.mapper.ApiMapper;
 import io.gravitee.rest.api.management.v4.rest.resource.AbstractResource;
 import io.gravitee.rest.api.management.v4.rest.resource.param.LifecycleAction;
+import io.gravitee.rest.api.management.v4.rest.security.Permission;
+import io.gravitee.rest.api.management.v4.rest.security.Permissions;
 import io.gravitee.rest.api.model.WorkflowState;
 import io.gravitee.rest.api.model.api.ApiDeploymentEntity;
 import io.gravitee.rest.api.model.api.ApiLifecycleState;
@@ -97,6 +99,12 @@ public class ApiResource extends AbstractResource {
     @PUT
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @Permissions(
+        {
+            @Permission(value = RolePermission.API_DEFINITION, acls = RolePermissionAction.UPDATE),
+            @Permission(value = RolePermission.API_GATEWAY_DEFINITION, acls = RolePermissionAction.UPDATE),
+        }
+    )
     public Response updateApi(@Context HttpHeaders headers, @Valid @NotNull final UpdateApiEntity apiToUpdate) {
         if (!apiId.equals(apiToUpdate.getId())) {
             throw new BadRequestException("'apiId' is not the same as the API in payload");
@@ -147,6 +155,7 @@ public class ApiResource extends AbstractResource {
     }
 
     @DELETE
+    @Permissions({ @Permission(value = RolePermission.API_DEFINITION, acls = RolePermissionAction.DELETE) })
     public Response deleteApi(@QueryParam("closePlans") boolean closePlans) {
         apiServiceV4.delete(GraviteeContext.getExecutionContext(), apiId, closePlans);
 
@@ -157,6 +166,7 @@ public class ApiResource extends AbstractResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/deployments")
+    @Permissions({ @Permission(value = RolePermission.API_DEFINITION, acls = RolePermissionAction.UPDATE) })
     public Response deployApi(@Valid final ApiDeploymentEntity apiDeploymentEntity) {
         try {
             ApiEntity apiEntity = apiStateService.deploy(
@@ -177,6 +187,7 @@ public class ApiResource extends AbstractResource {
 
     @Path("/_start")
     @POST
+    @Permissions({ @Permission(value = RolePermission.API_DEFINITION, acls = RolePermissionAction.UPDATE) })
     public Response startAPI(@Context HttpHeaders headers) {
         final Response responseApi = getApiById();
         Response.ResponseBuilder builder = evaluateIfMatch(headers, responseApi.getEntityTag().getValue());
@@ -194,6 +205,7 @@ public class ApiResource extends AbstractResource {
 
     @Path("/_stop")
     @POST
+    @Permissions({ @Permission(value = RolePermission.API_DEFINITION, acls = RolePermissionAction.UPDATE) })
     public Response stopAPI(@Context HttpHeaders headers) {
         final Response responseApi = getApiById();
         Response.ResponseBuilder builder = evaluateIfMatch(headers, responseApi.getEntityTag().getValue());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/test/java/io/gravitee/rest/api/management/v4/rest/filter/PermissionFilterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/test/java/io/gravitee/rest/api/management/v4/rest/filter/PermissionFilterTest.java
@@ -91,7 +91,7 @@ public class PermissionFilterTest {
         when(permissions.value()).thenReturn(new Permission[] { perm });
         UriInfo uriInfo = mock(UriInfo.class);
         MultivaluedHashMap<String, String> map = new MultivaluedHashMap<>();
-        map.put("api", Collections.singletonList(API_ID));
+        map.put("apiId", Collections.singletonList(API_ID));
         when(uriInfo.getPathParameters()).thenReturn(map);
         when(containerRequestContext.getUriInfo()).thenReturn(uriInfo);
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-825

## Description

Add permissions to api resource endpoints

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dzyeahjvnf.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-825-api-action-permissions/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
