### PR TITLE
fix(kafka-connector): remove sender from pool when closing

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/KafkaEndpointConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/KafkaEndpointConnector.java
@@ -148,7 +148,7 @@ public class KafkaEndpointConnector extends EndpointAsyncConnector {
                                                             )
                                                 )
                                             )
-                                            .transform(KafkaSenderErrorTransformer.transform(kafkaSender))
+                                            .transform(KafkaSenderErrorTransformer.transform(kafkaSender, kafkaSenderFactory))
                                             .map(SenderResult::correlationMetadata)
                                     )
                                     .onErrorResumeNext(throwable -> interruptMessagesWith(ctx, throwable))

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/factory/KafkaSenderFactory.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-kafka/src/main/java/io/gravitee/plugin/endpoint/kafka/factory/KafkaSenderFactory.java
@@ -26,7 +26,7 @@ import reactor.kafka.sender.SenderOptions;
 @NoArgsConstructor
 public class KafkaSenderFactory {
 
-    private final Map<Integer, KafkaSender<?, ?>> senders = new ConcurrentHashMap<>();
+    final Map<Integer, KafkaSender<?, ?>> senders = new ConcurrentHashMap<>();
 
     public <K, V> KafkaSender<K, V> createSender(final SenderOptions<K, V> senderOptions) {
         return (KafkaSender<K, V>) senders.computeIfAbsent(
@@ -45,5 +45,10 @@ public class KafkaSenderFactory {
     public void clear() {
         senders.forEach((integer, consumer) -> consumer.close());
         senders.clear();
+    }
+
+    public void clear(KafkaSender<?, ?> sender) {
+        senders.values().remove(sender);
+        sender.close();
     }
 }


### PR DESCRIPTION
## Issue

N/A

## Description

When an error was thrown during the message publishing, the sender is closed. However, it was not removed from the "pool" in the factory. Then, all subsequents calls on the same API were failing because the sender closed (the scheduler was closed)

This commit ensure that we only close the sender when we detect a connection failure and in that case the closed sender is removed from the pool.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-flziipgvjo.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-remove-kafka-sender-from-pool-when-closing/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
