### PR TITLE
fix(console): hide listeners form for non http type

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.spec.ts
@@ -265,6 +265,23 @@ describe('ApiCreationV4Component', () => {
         expectApiGetPortalSettings();
       });
 
+      it('should not display context-path form for non http supportedListenerType', async () => {
+        await fillAndValidateStep1ApiDetails('API', '1.0', 'Description');
+        await fillAndValidateStep2Entrypoints0Architecture('async');
+        const step2Harness = await harnessLoader.getHarness(Step2Entrypoints1ListHarness);
+
+        expectEntrypointsGetRequest([{ id: 'sse', supportedApiType: 'async', name: 'SSE', supportedListenerType: 'subscription' }]);
+
+        await step2Harness.getEntrypoints().then((form) => form.selectOptionsByIds(['sse']));
+
+        await step2Harness.clickValidate();
+        exceptEnvironmentGetRequest(fakeEnvironment());
+        expectSchemaGetRequest([{ id: 'sse', name: 'SSE' }]);
+        // expectApiGetPortalSettings();
+        const step21Harness = await harnessLoader.getHarness(Step2Entrypoints2ConfigHarness);
+        expect(await step21Harness.hasListenersForm()).toEqual(false);
+      });
+
       it('should not validate without path', async () => {
         await fillAndValidateStep1ApiDetails('API', '1.0', 'Description');
         await fillAndValidateStep2Entrypoints0Architecture('async');
@@ -280,8 +297,10 @@ describe('ApiCreationV4Component', () => {
         expectSchemaGetRequest([{ id: 'sse', name: 'SSE' }]);
         expectApiGetPortalSettings();
         const step21Harness = await harnessLoader.getHarness(Step2Entrypoints2ConfigHarness);
+        expect(await step21Harness.hasListenersForm()).toEqual(true);
         expect(await step21Harness.hasValidationDisabled()).toEqual(true);
       });
+
       it('should not validate with bad path', async () => {
         await fillAndValidateStep1ApiDetails('API', '1.0', 'Description');
         await fillAndValidateStep2Entrypoints0Architecture('async');

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-2-entrypoints/step-2-entrypoints-2-config.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-2-entrypoints/step-2-entrypoints-2-config.component.html
@@ -23,7 +23,7 @@
   </div>
 
   <form *ngIf="formGroup" [formGroup]="formGroup" (ngSubmit)="save()">
-    <div class="api-creation-v4__form-container" *ngIf="hasListeners">
+    <div id="listeners" class="api-creation-v4__form-container" *ngIf="hasListeners">
       <h3>Configure common entrypoints fields</h3>
       <h4 class="api-creation-v4__form-container__subTitle">Entrypoints context</h4>
       <gio-form-listeners-context-path *ngIf="!this.enableVirtualHost" formControlName="paths"></gio-form-listeners-context-path>

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-2-entrypoints/step-2-entrypoints-2-config.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-2-entrypoints/step-2-entrypoints-2-config.component.ts
@@ -68,7 +68,7 @@ export class Step2Entrypoints2ConfigComponent implements OnInit, OnDestroy {
       )
       .subscribe();
 
-    this.hasListeners = currentStepPayload.selectedEntrypoints.find((entrypoint) => entrypoint.supportedListenerType === 'http') !== null;
+    this.hasListeners = currentStepPayload.selectedEntrypoints.find((entrypoint) => entrypoint.supportedListenerType === 'http') != null;
     this.entrypointInitialValues =
       listener?.entrypoints?.reduce((map, { type, configuration }) => ({ ...map, [type]: configuration }), {}) || {};
     this.formGroup = this.formBuilder.group({});

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-2-entrypoints/step-2-entrypoints-2-config.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-2-entrypoints/step-2-entrypoints-2-config.harness.ts
@@ -40,6 +40,8 @@ export class Step2Entrypoints2ConfigHarness extends ComponentHarness {
     }),
   );
 
+  protected getListenersDiv = this.locatorFor('#listeners');
+
   async clickPrevious(): Promise<void> {
     return this.getPreviousButton().then((elt) => elt.click());
   }
@@ -50,6 +52,12 @@ export class Step2Entrypoints2ConfigHarness extends ComponentHarness {
 
   async hasValidationDisabled(): Promise<boolean> {
     return this.getValidateButton().then((elt) => elt.isDisabled());
+  }
+
+  async hasListenersForm(): Promise<boolean> {
+    return this.getListenersDiv()
+      .then((elt) => elt != null)
+      .catch(() => false);
   }
 
   async clickListenerType() {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-955
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rxfjdzujpp.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-955-hide-contextpath-webhook/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
