### PR TITLE
Fix best match flow selector

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/main/java/io/gravitee/gateway/jupiter/flow/BestMatchFlowSelector.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/main/java/io/gravitee/gateway/jupiter/flow/BestMatchFlowSelector.java
@@ -138,7 +138,6 @@ public class BestMatchFlowSelector {
                 } else if (scores[i] > selectedFlowScore[i]) {
                     selectedFlow = flow;
                     selectedFlowScore = scores;
-                    break;
                 }
             }
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/jupiter/flow/BestMatchFlowBaseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/jupiter/flow/BestMatchFlowBaseTest.java
@@ -263,6 +263,42 @@ public abstract class BestMatchFlowBaseTest {
                     "/book/:bookId/chapter/:chapterId",
                     "/book/9999/chapter/145",
                 },
+                {
+                    List.of("/", "/api_entrypoint/some_path/:test", "/api_entrypoint/some_path/sub_path"),
+                    Operator.STARTS_WITH,
+                    "/api_entrypoint/some_path/sub_path",
+                    "/api_entrypoint/some_path/sub_path",
+                },
+                {
+                    List.of("/", "/api_entrypoint/some_path/:test", "/api_entrypoint/some_path/sub_path"),
+                    Operator.STARTS_WITH,
+                    "/api_entrypoint/some_path/sub_path",
+                    "/api_entrypoint/some_path/sub_path/sub_sub_path",
+                },
+                {
+                    List.of("/", "/api_entrypoint/some_path/:test", "/api_entrypoint/some_path/sub_path"),
+                    Operator.EQUALS,
+                    "/api_entrypoint/some_path/sub_path",
+                    "/api_entrypoint/some_path/sub_path",
+                },
+                {
+                    List.of("/", "/api_entrypoint/some_path/:test", "/api_entrypoint/some_path/sub_path"),
+                    Operator.STARTS_WITH,
+                    "/api_entrypoint/some_path/:test",
+                    "/api_entrypoint/some_path/145",
+                },
+                {
+                    List.of("/", "/api_entrypoint/some_path/:test", "/api_entrypoint/some_path/sub_path"),
+                    Operator.STARTS_WITH,
+                    "/api_entrypoint/some_path/:test",
+                    "/api_entrypoint/some_path/145/sub_sub_path",
+                },
+                {
+                    List.of("/", "/api_entrypoint/some_path/:test", "/api_entrypoint/some_path/sub_path"),
+                    Operator.EQUALS,
+                    "/api_entrypoint/some_path/:test",
+                    "/api_entrypoint/some_path/145",
+                },
             }
         );
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-924
https://github.com/gravitee-io/issues/issues/8899

## Description

Avoid early exit because it can lead to "index out of bounds" in some cases (see test cases).
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tdtkhhkzyh.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-924-fix-best-flow-selector/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
