### PR TITLE
Fix best match flow selector - master

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/main/java/io/gravitee/gateway/jupiter/v4/flow/BestMatchFlowSelector.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/main/java/io/gravitee/gateway/jupiter/v4/flow/BestMatchFlowSelector.java
@@ -149,7 +149,6 @@ public class BestMatchFlowSelector {
                 } else if (scores[i] > selectedFlowScore[i]) {
                     selectedFlow = flow;
                     selectedFlowScore = scores;
-                    break;
                 }
             }
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/jupiter/flow/FlowBaseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/jupiter/flow/FlowBaseTest.java
@@ -254,6 +254,42 @@ public abstract class FlowBaseTest {
                     "/book/:bookId/chapter/:chapterId",
                     "/book/9999/chapter/145",
                 },
+                {
+                    List.of("/", "/api_entrypoint/some_path/:test", "/api_entrypoint/some_path/sub_path"),
+                    Operator.STARTS_WITH,
+                    "/api_entrypoint/some_path/sub_path",
+                    "/api_entrypoint/some_path/sub_path",
+                },
+                {
+                    List.of("/", "/api_entrypoint/some_path/:test", "/api_entrypoint/some_path/sub_path"),
+                    Operator.STARTS_WITH,
+                    "/api_entrypoint/some_path/sub_path",
+                    "/api_entrypoint/some_path/sub_path/sub_sub_path",
+                },
+                {
+                    List.of("/", "/api_entrypoint/some_path/:test", "/api_entrypoint/some_path/sub_path"),
+                    Operator.EQUALS,
+                    "/api_entrypoint/some_path/sub_path",
+                    "/api_entrypoint/some_path/sub_path",
+                },
+                {
+                    List.of("/", "/api_entrypoint/some_path/:test", "/api_entrypoint/some_path/sub_path"),
+                    Operator.STARTS_WITH,
+                    "/api_entrypoint/some_path/:test",
+                    "/api_entrypoint/some_path/145",
+                },
+                {
+                    List.of("/", "/api_entrypoint/some_path/:test", "/api_entrypoint/some_path/sub_path"),
+                    Operator.STARTS_WITH,
+                    "/api_entrypoint/some_path/:test",
+                    "/api_entrypoint/some_path/145/sub_sub_path",
+                },
+                {
+                    List.of("/", "/api_entrypoint/some_path/:test", "/api_entrypoint/some_path/sub_path"),
+                    Operator.EQUALS,
+                    "/api_entrypoint/some_path/:test",
+                    "/api_entrypoint/some_path/145",
+                },
             }
         );
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-924
https://github.com/gravitee-io/issues/issues/8899

## Description

Apply https://github.com/gravitee-io/gravitee-api-management/pull/3190 on master

Avoid early exit because it can lead to "index out of bounds" in some cases (see test cases).

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tymodxufcm.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-924-fix-best-flow-selector-master/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
