### PR TITLE
Add context path on summary

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.spec.ts
@@ -778,9 +778,9 @@ describe('ApiCreationV4Component', () => {
       expect(step1Summary).toContain('Description:' + ' description');
 
       const step2Summary = await step6Harness.getStepSummaryTextContent(2);
-      expect(step2Summary).toContain('Path:' + '/my-new-api');
+      expect(step2Summary).toContain('Path:' + '/api/my-api-3');
       expect(step2Summary).toContain('Type:' + 'Subscription');
-      expect(step2Summary).toContain('EntrypointsPath:/my-new-apiType:SubscriptionEntrypoints');
+      expect(step2Summary).toContain('EntrypointsPath:/api/my-api-3Type:SubscriptionEntrypoints');
 
       const step3Summary = await step6Harness.getStepSummaryTextContent(3);
       expect(step3Summary).toContain('Field' + 'Value');
@@ -929,8 +929,8 @@ describe('ApiCreationV4Component', () => {
 
   async function fillAndValidateStep2Entrypoints1List(
     entrypoints: Partial<ConnectorListItem>[] = [
-      { id: 'entrypoint-1', name: 'initial entrypoint', supportedApiType: 'async' },
-      { id: 'entrypoint-2', name: 'new entrypoint', supportedApiType: 'async' },
+      { id: 'entrypoint-1', name: 'initial entrypoint', supportedApiType: 'async', supportedListenerType: 'http' },
+      { id: 'entrypoint-2', name: 'new entrypoint', supportedApiType: 'async', supportedListenerType: 'subscription' },
     ],
   ) {
     const step21EntrypointsHarness = await harnessLoader.getHarness(Step2Entrypoints1ListHarness);
@@ -960,8 +960,8 @@ describe('ApiCreationV4Component', () => {
 
   async function fillAndValidateStep2Entrypoints2Config(
     entrypoints: Partial<ConnectorListItem>[] = [
-      { id: 'entrypoint-1', name: 'initial entrypoint', supportedApiType: 'async' },
-      { id: 'entrypoint-2', name: 'new entrypoint', supportedApiType: 'async' },
+      { id: 'entrypoint-1', name: 'initial entrypoint', supportedApiType: 'async', supportedListenerType: 'http' },
+      { id: 'entrypoint-2', name: 'new entrypoint', supportedApiType: 'async', supportedListenerType: 'subscription' },
     ],
     paths: string[] = ['/api/my-api-3'],
   ) {

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.spec.ts
@@ -325,14 +325,23 @@ describe('ApiCreationV4Component', () => {
         await fillAndValidateStep2Entrypoints0Architecture('async');
         const step2Harness = await harnessLoader.getHarness(Step2Entrypoints1ListHarness);
 
-        expectEntrypointsGetRequest([{ id: 'sse', supportedApiType: 'async', name: 'SSE' }]);
+        expectEntrypointsGetRequest([
+          { id: 'sse', supportedApiType: 'async', name: 'SSE', supportedListenerType: 'http' },
+          { id: 'webhook', supportedApiType: 'async', name: 'Webhook', supportedListenerType: 'subscription' },
+        ]);
 
-        await step2Harness.getEntrypoints().then((form) => form.selectOptionsByIds(['sse']));
+        await step2Harness.getEntrypoints().then((form) => form.selectOptionsByIds(['sse', 'webhook']));
 
         await step2Harness.clickValidate();
-        expect(component.currentStep.payload.selectedEntrypoints).toEqual([{ id: 'sse', name: 'SSE', supportedListenerType: 'http' }]);
+        expect(component.currentStep.payload.selectedEntrypoints).toEqual([
+          { id: 'sse', name: 'SSE', supportedListenerType: 'http' },
+          { id: 'webhook', name: 'Webhook', supportedListenerType: 'subscription' },
+        ]);
         exceptEnvironmentGetRequest(fakeEnvironment());
-        expectSchemaGetRequest([{ id: 'sse', name: 'SSE' }]);
+        expectSchemaGetRequest([
+          { id: 'sse', name: 'SSE' },
+          { id: 'webhook', name: 'Webhook' },
+        ]);
         expectApiGetPortalSettings();
         const step21Harness = await harnessLoader.getHarness(Step2Entrypoints2ConfigHarness);
         await step21Harness.fillPathsAndValidate('/api/my-api-3');
@@ -356,6 +365,15 @@ describe('ApiCreationV4Component', () => {
               },
             ],
             type: 'http',
+          },
+          {
+            entrypoints: [
+              {
+                configuration: {},
+                type: 'webhook',
+              },
+            ],
+            type: 'subscription',
           },
         ]);
 
@@ -628,6 +646,16 @@ describe('ApiCreationV4Component', () => {
               },
               type: 'entrypoint-1',
             },
+          ],
+          paths: [
+            {
+              path: '/api/my-api-3',
+            },
+          ],
+          type: 'http',
+        },
+        {
+          entrypoints: [
             {
               configuration: {
                 headersInPayload: false,
@@ -638,12 +666,7 @@ describe('ApiCreationV4Component', () => {
               type: 'entrypoint-2',
             },
           ],
-          paths: [
-            {
-              path: '/api/my-api-3',
-            },
-          ],
-          type: 'http',
+          type: 'subscription',
         },
       ]);
     });
@@ -779,8 +802,8 @@ describe('ApiCreationV4Component', () => {
 
       const step2Summary = await step6Harness.getStepSummaryTextContent(2);
       expect(step2Summary).toContain('Path:' + '/api/my-api-3');
-      expect(step2Summary).toContain('Type:' + 'Subscription');
-      expect(step2Summary).toContain('EntrypointsPath:/api/my-api-3Type:SubscriptionEntrypoints');
+      expect(step2Summary).toContain('Type:' + 'http' + 'subscription');
+      expect(step2Summary).toContain('EntrypointsPath:/api/my-api-3Type:httpsubscriptionEntrypoints');
 
       const step3Summary = await step6Harness.getStepSummaryTextContent(3);
       expect(step3Summary).toContain('Field' + 'Value');
@@ -833,7 +856,7 @@ describe('ApiCreationV4Component', () => {
       step6Harness = await harnessLoader.getHarness(Step6SummaryHarness);
       const step2Summary = await step6Harness.getStepSummaryTextContent(2);
 
-      expect(step2Summary).toContain('EntrypointsPath:/my-new-apiType:SubscriptionEntrypoints: new entrypointChange');
+      expect(step2Summary).toContain('EntrypointsPath:/api/my-api-3, /my-api/v4Type:httpEntrypoints: new entrypointChange');
     });
 
     it('should go back to step 3 after clicking Change button', async () => {

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-6-summary/step-6-summary.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-6-summary/step-6-summary.component.html
@@ -53,7 +53,7 @@
         <div class="step-6-summary__step__info">
           <div class="step-6-summary__step__info__row">
             <span class="step-6-summary__step__info__key">Path:</span>
-            <span class="step-6-summary__step__info__value">/my-new-api</span>
+            <span class="step-6-summary__step__info__value">{{ paths.join(', ') }}</span>
           </div>
           <div class="step-6-summary__step__info__row">
             <span class="step-6-summary__step__info__key">Type:</span>

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-6-summary/step-6-summary.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-6-summary/step-6-summary.component.html
@@ -57,7 +57,7 @@
           </div>
           <div class="step-6-summary__step__info__row">
             <span class="step-6-summary__step__info__key">Type:</span>
-            <span class="gio-badge-accent">Subscription</span>
+            <span class="gio-badge-accent" *ngFor="let listener of currentStepPayload.listeners">{{ listener.type }}</span>
           </div>
           <div class="step-6-summary__step__info__row">
             <span class="step-6-summary__step__info__key">Entrypoints:</span>

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-6-summary/step-6-summary.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-6-summary/step-6-summary.component.ts
@@ -18,6 +18,7 @@ import { Component, OnInit } from '@angular/core';
 
 import { ApiCreationStepService } from '../../services/api-creation-step.service';
 import { ApiCreationPayload } from '../../models/ApiCreationPayload';
+import { HttpListener, HttpListenerPath } from '../../../../../../entities/api-v4';
 
 @Component({
   selector: 'step-6-summary',
@@ -26,11 +27,21 @@ import { ApiCreationPayload } from '../../models/ApiCreationPayload';
 })
 export class Step6SummaryComponent implements OnInit {
   public currentStepPayload: ApiCreationPayload;
+  paths: HttpListenerPath[];
 
   constructor(private readonly stepService: ApiCreationStepService) {}
 
   ngOnInit(): void {
     this.currentStepPayload = this.stepService.payload;
+
+    this.paths = this.currentStepPayload.listeners.reduce((pathList, listener) => {
+      if (listener.type === 'http') {
+        const httpListener = listener as HttpListener;
+
+        return [...pathList, ...httpListener.paths.map((p) => p.path)];
+      }
+      return pathList;
+    }, []);
   }
 
   createApi(deploy: boolean) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-970

## Description

Fix context path and subscription type info on summary page

## Additional context

![screenshot-localhost_3000-2023 03 01-15_49_23](https://user-images.githubusercontent.com/1655950/222174854-6444d113-28ff-4cf3-bba4-1ecdcb68a605.png)

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ptbakfabqs.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-970-context-path/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
