### PR TITLE
fix(api-v4): replace api service with v4 api search service

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/java/io/gravitee/rest/api/management/v4/rest/resource/api/ApiPlansResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/java/io/gravitee/rest/api/management/v4/rest/resource/api/ApiPlansResource.java
@@ -135,7 +135,7 @@ public class ApiPlansResource extends AbstractResource {
     public Response getApiPlan(@PathParam("plan") String plan) {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         if (
-            Visibility.PUBLIC.equals(apiService.findById(executionContext, apiId).getVisibility()) ||
+            Visibility.PUBLIC.equals(apiSearchService.findById(executionContext, apiId).getVisibility()) ||
             hasPermission(GraviteeContext.getExecutionContext(), RolePermission.API_PLAN, apiId, RolePermissionAction.READ)
         ) {
             PlanEntity planEntity = planService.findById(executionContext, plan);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/v4/api/ApiPlansResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/v4/api/ApiPlansResource.java
@@ -220,7 +220,7 @@ public class ApiPlansResource extends AbstractResource {
     public Response getApiPlan(@PathParam("plan") String plan) {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         if (
-            Visibility.PUBLIC.equals(apiService.findById(executionContext, apiId).getVisibility()) ||
+            Visibility.PUBLIC.equals(apiSearchService.findById(executionContext, apiId).getVisibility()) ||
             hasPermission(GraviteeContext.getExecutionContext(), API_PLAN, apiId, READ)
         ) {
             PlanEntity planEntity = planService.findById(executionContext, plan);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/AbstractResourceTest.java
@@ -190,6 +190,9 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
     protected PlanService planService;
 
     @Autowired
+    protected io.gravitee.rest.api.service.v4.PlanService planServiceV4;
+
+    @Autowired
     protected PlanSearchService planSearchService;
 
     @Autowired
@@ -515,6 +518,11 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
         @Bean
         public PlanService planService() {
             return mock(PlanService.class);
+        }
+
+        @Bean
+        public io.gravitee.rest.api.service.v4.PlanService planServiceV4() {
+            return mock(io.gravitee.rest.api.service.v4.PlanService.class);
         }
 
         @Bean


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1027

## Description

Replace ApiService with ApiSearchService to return v4 ApiEntity

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tuwsgaxdzi.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1027-plan-mapping-error/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
