### PR TITLE
Update managedEndpoint status with healthcheck service.

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Endpoint.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Endpoint.java
@@ -112,7 +112,20 @@ public class Endpoint implements Serializable {
         return status;
     }
 
+    /**
+     * This method should only be used by listeners to update the status of the endpoint.
+     * Indeed, if listeners call updateStatus, it will end in an infinite loop
+     * @param status
+     */
     public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    /**
+     * This method is used by the HealtchCheck service of the gateway to update the status and notify listeners (actually io.gravitee.gateway.core.endpoint.ManagedEndpoint).
+     * @param status
+     */
+    public void updateStatus(Status status) {
         this.status = status;
         listeners.forEach(endpointStatusListener -> endpointStatusListener.onStatusChanged(status));
     }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Endpoint.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/Endpoint.java
@@ -137,7 +137,7 @@ public class Endpoint implements Serializable {
         this.inherit = inherit;
     }
 
-    public void addEndpointAvailabilityListener(EndpointStatusListener listener) {
+    public void addEndpointStatusListener(EndpointStatusListener listener) {
         listeners.add(listener);
     }
 
@@ -158,7 +158,7 @@ public class Endpoint implements Serializable {
     }
 
     @JsonIgnore
-    public Set<EndpointStatusListener> getEndpointAvailabilityListeners() {
+    public Set<EndpointStatusListener> getEndpointStatusListeners() {
         return this.listeners;
     }
 

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/EndpointTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/test/java/io/gravitee/definition/model/EndpointTest.java
@@ -59,7 +59,7 @@ public class EndpointTest {
         };
 
         Endpoint endpoint = new Endpoint("my-type", "my-name", "my-target");
-        endpoint.addEndpointAvailabilityListener(unserializableStatusListener);
+        endpoint.addEndpointStatusListener(unserializableStatusListener);
 
         String serializedEndpoint = new ObjectMapper().writeValueAsString(endpoint);
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/endpoint/ManagedEndpoint.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/endpoint/ManagedEndpoint.java
@@ -82,6 +82,7 @@ public class ManagedEndpoint extends AbstractEndpoint implements EndpointStatusL
 
     @Override
     public void onStatusChanged(Endpoint.Status status) {
+        this.endpoint.setStatus(status);
         listeners.forEach(listener -> listener.onAvailabilityChange(this, status != Endpoint.Status.DOWN));
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/endpoint/ManagedEndpoint.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/endpoint/ManagedEndpoint.java
@@ -31,7 +31,7 @@ public class ManagedEndpoint extends AbstractEndpoint implements EndpointStatusL
 
     public ManagedEndpoint(final io.gravitee.definition.model.Endpoint endpoint, final Connector connector) {
         this.endpoint = endpoint;
-        this.endpoint.addEndpointAvailabilityListener(this);
+        this.endpoint.addEndpointStatusListener(this);
         this.connector = connector;
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/EndpointHealthcheckResolver.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/EndpointHealthcheckResolver.java
@@ -157,7 +157,7 @@ public class EndpointHealthcheckResolver implements InitializingBean {
                 // the one from the ManagedEndpoint. This is a temporary fix that need to be addressed, for details see
                 // https://github.com/gravitee-io/issues/issues/6437
                 HttpEndpoint httpEndpoint = mapper.readValue(endpoint.getConfiguration(), HttpEndpoint.class);
-                endpoint.getEndpointAvailabilityListeners().forEach(httpEndpoint::addEndpointAvailabilityListener);
+                endpoint.getEndpointStatusListeners().forEach(httpEndpoint::addEndpointStatusListener);
                 return httpEndpoint;
             } catch (JsonProcessingException e) {
                 LOGGER.warn("Cannot convert endpoint to http endpoint", e);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/EndpointStatusDecorator.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/EndpointStatusDecorator.java
@@ -53,7 +53,7 @@ public class EndpointStatusDecorator {
 
         // Set status only if changed
         if (previousStatus == null || previousStatus != counter.status()) {
-            endpoint.setStatus(counter.status());
+            endpoint.updateStatus(counter.status());
             previousStatus = endpoint.getStatus();
         }
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http/DynamicRoutingGatewayTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http/DynamicRoutingGatewayTest.java
@@ -54,7 +54,7 @@ public class DynamicRoutingGatewayTest extends AbstractWiremockGatewayTest {
     public void call_dynamic_api_unavailable() throws Exception {
         String initialTarget = api.getProxy().getGroups().iterator().next().getEndpoints().iterator().next().getTarget();
 
-        api.getProxy().getGroups().iterator().next().getEndpoints().iterator().next().setStatus(Endpoint.Status.DOWN);
+        api.getProxy().getGroups().iterator().next().getEndpoints().iterator().next().updateStatus(Endpoint.Status.DOWN);
 
         HttpResponse response = execute(Request.Get("http://localhost:8082/test/my_team")).returnResponse();
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http/RoundRobinLoadBalancingMultipleTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http/RoundRobinLoadBalancingMultipleTest.java
@@ -65,10 +65,10 @@ public class RoundRobinLoadBalancingMultipleTest extends AbstractWiremockGateway
         Iterator<Endpoint> endpointsIte = api.getProxy().getGroups().iterator().next().getEndpoints().iterator();
 
         // Set the first endpoint with down status
-        endpointsIte.next().setStatus(Endpoint.Status.DOWN);
+        endpointsIte.next().updateStatus(Endpoint.Status.DOWN);
 
         // Set the second endpoint with down status
-        endpointsIte.next().setStatus(Endpoint.Status.DOWN);
+        endpointsIte.next().updateStatus(Endpoint.Status.DOWN);
 
         Request request = Request.Get("http://localhost:8082/api");
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http/RoundRobinLoadBalancingSingleTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http/RoundRobinLoadBalancingSingleTest.java
@@ -40,7 +40,7 @@ public class RoundRobinLoadBalancingSingleTest extends AbstractWiremockGatewayTe
         Request request = Request.Get("http://localhost:8082/api");
 
         // Set the first endpoint with down status
-        api.getProxy().getGroups().iterator().next().getEndpoints().iterator().next().setStatus(Endpoint.Status.DOWN);
+        api.getProxy().getGroups().iterator().next().getEndpoints().iterator().next().updateStatus(Endpoint.Status.DOWN);
 
         int calls = 20;
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http/ServiceUnavailableTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/http/ServiceUnavailableTest.java
@@ -47,7 +47,7 @@ public class ServiceUnavailableTest extends AbstractWiremockGatewayTest {
     @Test
     public void call_unavailable_api() throws Exception {
         // Set the endpoint as down
-        api.getProxy().getGroups().iterator().next().getEndpoints().iterator().next().setStatus(Endpoint.Status.DOWN);
+        api.getProxy().getGroups().iterator().next().getEndpoints().iterator().next().updateStatus(Endpoint.Status.DOWN);
 
         HttpResponse response = execute(Request.Get("http://localhost:8082/test/my_team")).returnResponse();
 
@@ -61,7 +61,7 @@ public class ServiceUnavailableTest extends AbstractWiremockGatewayTest {
         wireMockRule.stubFor(get("/team/my_team").willReturn(ok()));
 
         // Set the endpoint as down
-        api.getProxy().getGroups().iterator().next().getEndpoints().iterator().next().setStatus(Endpoint.Status.DOWN);
+        api.getProxy().getGroups().iterator().next().getEndpoints().iterator().next().updateStatus(Endpoint.Status.DOWN);
 
         HttpResponse response = execute(Request.Get("http://localhost:8082/test/my_team")).returnResponse();
 
@@ -70,7 +70,7 @@ public class ServiceUnavailableTest extends AbstractWiremockGatewayTest {
         wireMockRule.verify(0, getRequestedFor(urlEqualTo("/team/my_team")));
 
         // Set the endpoint as up
-        api.getProxy().getGroups().iterator().next().getEndpoints().iterator().next().setStatus(Endpoint.Status.UP);
+        api.getProxy().getGroups().iterator().next().getEndpoints().iterator().next().updateStatus(Endpoint.Status.UP);
 
         response = execute(Request.Get("http://localhost:8082/test/my_team")).returnResponse();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -11,7 +11,7 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0
-  version: "3.18.19-SNAPSHOT"
+  version: "3.18.20-SNAPSHOT"
 servers:
   - url: http://localhost:8083/portal/environments/{envId}
     description: The portal API for a given environment


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1028
https://github.com/gravitee-io/issues/issues/8919

## Description
When the health-check service of the gateway updates the status of an endpoint, it does not update the `managedEndpoint` used internally by the gateway in the endpoint invoker.
Today, it works because load balancers are listening to the status changes and adding or removing an endpoint from the default group.

But when you use an endpoint reference, for example in the dynamic routing policy, you use directly the `managedEndpoint` instead of relying on the load balancer.

So this PR makes it possible to modify the `managedEndpoint` when the status changes.
It renames the current `setStatus` method to `updateStatus` to differ from a simple `setStatus` setter method.
By doing this, we allow the `managedEndpoint` to update its inner endpoint without notifying itself and ending in an infinite loop.

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1028-health-check-in-dynamic-routing/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
