### PR TITLE
Bump `@gravitee/ui-components` to `3.38.8`

### DIFF
--- a/gravitee-apim-console-webui/package-lock.json
+++ b/gravitee-apim-console-webui/package-lock.json
@@ -22,7 +22,7 @@
         "@asyncapi/web-component": "1.0.0-next.15",
         "@fontsource/libre-franklin": "4.4.5",
         "@gravitee/ui-analytics": "3.5.0",
-        "@gravitee/ui-components": "3.36.2",
+        "@gravitee/ui-components": "3.38.8",
         "@gravitee/ui-particles-angular": "3.4.0",
         "@gravitee/ui-policy-studio-angular": "3.0.1",
         "@highcharts/map-collection": "1.1.4",
@@ -11185,9 +11185,9 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@gravitee/ui-components": {
-      "version": "3.36.2",
-      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.36.2.tgz",
-      "integrity": "sha512-DhWoIyZ1YggSqnb+fNN/h4+q1+Cmj8z+CUD0ckaQULT1KTynqx9V1mcU23k5Hy6CVYC5Dl8euHlVHTFI0GoJXA==",
+      "version": "3.38.8",
+      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.38.8.tgz",
+      "integrity": "sha512-rjUR8qpTG/7XATRZ86Xkzz1wSuxir5HwekiDUV7ZdSEXwm35VVaOlR8YXC4thMRUJUXSQJ+EFWv4cN+mrWew1g==",
       "dependencies": {
         "@codemirror/basic-setup": "^0.19.1",
         "@codemirror/language-data": "^0.19.1",
@@ -48658,8 +48658,7 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
           "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "import-local": {
           "version": "2.0.0",
@@ -48982,8 +48981,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
           "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "postcss-modules-local-by-default": {
           "version": "4.0.0",
@@ -49177,8 +49175,7 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.2.1.tgz",
           "integrity": "sha512-1k9ZosJCRFaRbY6hH49JFlRB0fVSbmnyq1iTPjNxUmGVjBNEmwrrHPenhlp+Lgo51BojHSf6pl2FcqYaN3PfVg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "tapable": {
           "version": "2.2.0",
@@ -55975,9 +55972,9 @@
       }
     },
     "@gravitee/ui-components": {
-      "version": "3.36.2",
-      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.36.2.tgz",
-      "integrity": "sha512-DhWoIyZ1YggSqnb+fNN/h4+q1+Cmj8z+CUD0ckaQULT1KTynqx9V1mcU23k5Hy6CVYC5Dl8euHlVHTFI0GoJXA==",
+      "version": "3.38.8",
+      "resolved": "https://registry.npmjs.org/@gravitee/ui-components/-/ui-components-3.38.8.tgz",
+      "integrity": "sha512-rjUR8qpTG/7XATRZ86Xkzz1wSuxir5HwekiDUV7ZdSEXwm35VVaOlR8YXC4thMRUJUXSQJ+EFWv4cN+mrWew1g==",
       "requires": {
         "@codemirror/basic-setup": "^0.19.1",
         "@codemirror/language-data": "^0.19.1",
@@ -57710,8 +57707,7 @@
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
       "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@mdx-js/util": {
       "version": "1.6.22",
@@ -57733,8 +57729,7 @@
       "version": "12.2.3",
       "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-12.2.3.tgz",
       "integrity": "sha512-Mx8QYCuOlgL0HdX0GDw5I3PLyW/TPJPSrk8VZLW2H5NR1wTHEw6PmqauAnuAMr7npAtOhV4tN9YyeTi8gy6+7A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
@@ -60193,8 +60188,7 @@
           "version": "8.5.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
           "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -62114,8 +62108,7 @@
     "@uirouter/rx": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@uirouter/rx/-/rx-1.0.0.tgz",
-      "integrity": "sha512-dqPmLFC+qqF6RIdJVKktXSON6WILy2oyLhADDk74F3GAUZ/VvOu3QSPLDtZEP3LMSo6vkGQvwcUdjgNVWL3YJA==",
-      "requires": {}
+      "integrity": "sha512-dqPmLFC+qqF6RIdJVKktXSON6WILy2oyLhADDk74F3GAUZ/VvOu3QSPLDtZEP3LMSo6vkGQvwcUdjgNVWL3YJA=="
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -62386,15 +62379,13 @@
       "version": "1.7.6",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.7.6.tgz",
       "integrity": "sha512-FlVvVFA1TX6l3lp8VjDnYYq7R1nyW6x3svAt4nDgrWQ9SBaSh9CnbwgSUTasgfNfOG5HlM1ehugCvM+hjo56LA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -62540,8 +62531,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv-formats": {
       "version": "2.1.0",
@@ -62576,8 +62566,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -62656,14 +62645,12 @@
     "angular-material": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/angular-material/-/angular-material-1.2.2.tgz",
-      "integrity": "sha512-GtrBzYDg5zHYX/OUqxo72zb9bsY0RDuIA+4ZsZjuv1r+L4q9UAtkeIZzMXVGua6CCNgfB58cKep3TmxtAZhNwg==",
-      "requires": {}
+      "integrity": "sha512-GtrBzYDg5zHYX/OUqxo72zb9bsY0RDuIA+4ZsZjuv1r+L4q9UAtkeIZzMXVGua6CCNgfB58cKep3TmxtAZhNwg=="
     },
     "angular-material-data-table": {
       "version": "0.10.10",
       "resolved": "https://registry.npmjs.org/angular-material-data-table/-/angular-material-data-table-0.10.10.tgz",
-      "integrity": "sha1-IptAJ0XsGhRvB9qNHlJr5lQISe4=",
-      "requires": {}
+      "integrity": "sha1-IptAJ0XsGhRvB9qNHlJr5lQISe4="
     },
     "angular-material-icons": {
       "version": "0.7.1",
@@ -64820,8 +64807,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/circular-dependency-plugin/-/circular-dependency-plugin-5.2.2.tgz",
       "integrity": "sha512-g38K9Cm5WRwlaH6g03B9OEz/0qRizI+2I7n+Gz+L5DxXJAPAiWQvwlYNm1V1jkdpUv95bOe/ASm2vfi/G560jQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "cjs-module-lexer": {
       "version": "1.2.2",
@@ -66220,8 +66206,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-2.0.1.tgz",
       "integrity": "sha512-i8vLRZTnEH9ubIyfdZCAdIdgnHAUeQeByEeQ2I7oTilvP9oHO6RScpeq3GsFUVqeB8uZgOQ9pw8utofNn32hhQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "csso": {
       "version": "4.2.0",
@@ -67414,8 +67399,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
       "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -72235,8 +72219,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-preset-angular": {
       "version": "10.1.0",
@@ -74669,8 +74652,7 @@
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.7.tgz",
       "integrity": "sha512-VI3TyyHlGkO8uFle0IOibzpO1c1iJDcXcS/zBrQrXQQvJ2tpdwVzVZ7XdKsyRz1NdRmre4dqQkMZzUHaKIG/1w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "marked": {
       "version": "4.0.16",
@@ -77328,29 +77310,25 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.1.tgz",
       "integrity": "sha512-lgZBPTDvWrbAYY1v5GYEv8fEO/WhKOu/hmZqmCYfrpD6eyDWWzAOsl2rF29lpvziKO02Gc5GJQtlpkTmakwOWg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-duplicates": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.1.tgz",
       "integrity": "sha512-svx747PWHKOGpAXXQkCc4k/DsWo+6bc5LsVrAsw+OU+Ibi7klFZCyX54gjYzX4TH+f2uzXjRviLARxkMurA2bA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-empty": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.0.1.tgz",
       "integrity": "sha512-vfU8CxAQ6YpMxV2SvMcMIyF2LX1ZzWpy0lqHDsOdaKKLQVQGVP1pzhrI9JlsO65s66uQTfkQBKBD/A5gp9STFw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-overridden": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.1.tgz",
       "integrity": "sha512-Y28H7y93L2BpJhrdUR2SR2fnSsT+3TVx1NmVQLbcnZWwIUpJ7mfcTC6Za9M2PG6w8j7UQRfzxqn8jU2VwFxo3Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-double-position-gradients": {
       "version": "1.0.0",
@@ -77772,8 +77750,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.0.1.tgz",
       "integrity": "sha512-6J40l6LNYnBdPSk+BHZ8SF+HAkS4q2twe5jnocgd+xWpz/mx/5Sa32m3W1AA8uE8XaXN+eg8trIlfu8V9x61eg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-normalize-display-values": {
       "version": "5.0.1",
@@ -78642,8 +78619,7 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.5.1.tgz",
       "integrity": "sha512-M1TJH2X3RXEt12sWkpa6hLc/bbYS0H6F4rIqjQZ+RxNBstpY67d9TrFXtqdZwhpmBXcCwEi7stKqFue3ZRkiOg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "react-dom": {
       "version": "16.14.0",
@@ -82464,15 +82440,13 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.2.1.tgz",
       "integrity": "sha512-6+X1FLlIcjvFMAeAD/hcxDT8tmyrWnbSPMU0EnxQuDLIxokuFzWliXBiYZuGIx+mrAMLBw0WFfCkaPw8ebzAhw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "use-isomorphic-layout-effect": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz",
       "integrity": "sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "use-latest": {
       "version": "1.2.0",
@@ -82970,8 +82944,7 @@
     "web-react-components": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/web-react-components/-/web-react-components-1.4.2.tgz",
-      "integrity": "sha512-//n/7TFHJHSrfDKguLN3kdJHDezQJpStwU6b751up6Nsax5Ry+GpRHsxmpc+BO2TarzakTxLwowvmWiyIbBHbw==",
-      "requires": {}
+      "integrity": "sha512-//n/7TFHJHSrfDKguLN3kdJHDezQJpStwU6b751up6Nsax5Ry+GpRHsxmpc+BO2TarzakTxLwowvmWiyIbBHbw=="
     },
     "webidl-conversions": {
       "version": "6.1.0",
@@ -83158,8 +83131,7 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
           "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "@webpack-cli/info": {
           "version": "1.5.0",
@@ -83174,8 +83146,7 @@
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
           "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "colorette": {
           "version": "2.0.16",
@@ -83682,8 +83653,7 @@
           "version": "8.5.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
           "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -83691,8 +83661,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/webpack-filter-warnings-plugin/-/webpack-filter-warnings-plugin-1.2.1.tgz",
       "integrity": "sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "webpack-hot-middleware": {
       "version": "2.25.1",
@@ -83940,8 +83909,7 @@
     "ws": {
       "version": "7.5.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.1.tgz",
-      "integrity": "sha512-2c6faOUH/nhoQN6abwMloF7Iyl0ZS2E9HGtsiLrWn0zOOMWlhtDmdf/uihDt6jnuCxgtwGBNy6Onsoy2s2O2Ow==",
-      "requires": {}
+      "integrity": "sha512-2c6faOUH/nhoQN6abwMloF7Iyl0ZS2E9HGtsiLrWn0zOOMWlhtDmdf/uihDt6jnuCxgtwGBNy6Onsoy2s2O2Ow=="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/gravitee-apim-console-webui/package.json
+++ b/gravitee-apim-console-webui/package.json
@@ -16,7 +16,7 @@
     "@asyncapi/web-component": "1.0.0-next.15",
     "@fontsource/libre-franklin": "4.4.5",
     "@gravitee/ui-analytics": "3.5.0",
-    "@gravitee/ui-components": "3.36.2",
+    "@gravitee/ui-components": "3.38.8",
     "@gravitee/ui-particles-angular": "3.4.0",
     "@gravitee/ui-policy-studio-angular": "3.0.1",
     "@highcharts/map-collection": "1.1.4",


### PR DESCRIPTION
## Description

Bump `@gravitee/ui-components` to `3.38.8`

Fix pagination in API properties table:
https://gravitee.atlassian.net/browse/APIM-867
https://github.com/gravitee-io/issues/issues/7048

Fix chart tooltip when there are a lot of series: 
https://gravitee.atlassian.net/browse/APIM-878
https://github.com/gravitee-io/issues/issues/5852

Fix flow creation on Plans named with a special character:
https://gravitee.atlassian.net/browse/APIM-983
https://github.com/gravitee-io/issues/issues/8909

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/update-ui-components/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qsxdsjsezn.chromatic.com)
<!-- Storybook placeholder end -->
