### PR TITLE
fix(gateway): configure stream before handling connection

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/invoker/EndpointInvoker.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/invoker/EndpointInvoker.java
@@ -73,8 +73,6 @@ public class EndpointInvoker implements Invoker {
                                 context
                             );
 
-                            connectionHandler.handle(decoratedProxyConnection);
-
                             // Plug underlying stream to connection stream
                             stream
                                 .bodyHandler(
@@ -88,6 +86,8 @@ public class EndpointInvoker implements Invoker {
                                     }
                                 )
                                 .endHandler(aVoid -> decoratedProxyConnection.end());
+
+                            connectionHandler.handle(decoratedProxyConnection);
 
                             // Inbound request could only be resume once we succeed to connect to the underlying backend
                             // otherwise, the endHandler will be called first (seems to be a breaking change since Vert.x 4.x)


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/APIM-892
see https://github.com/gravitee-io/issues/issues/8385 
see https://github.com/gravitee-io/gravitee-policy-traffic-shadowing/pull/21
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-trafic-shadowing/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mmpnerwqlr.chromatic.com)
<!-- Storybook placeholder end -->
