### PR TITLE
Add different mode for transaction header override - 3.19.x

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandlerFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandlerFactory.java
@@ -46,6 +46,7 @@ import io.gravitee.gateway.handlers.api.definition.Api;
 import io.gravitee.gateway.handlers.api.processor.OnErrorProcessorChainFactory;
 import io.gravitee.gateway.handlers.api.processor.RequestProcessorChainFactory;
 import io.gravitee.gateway.handlers.api.processor.ResponseProcessorChainFactory;
+import io.gravitee.gateway.handlers.api.processor.transaction.TransactionResponseProcessorConfiguration;
 import io.gravitee.gateway.handlers.api.security.PlanBasedAuthenticationHandlerEnhancer;
 import io.gravitee.gateway.jupiter.handlers.api.SyncApiReactor;
 import io.gravitee.gateway.jupiter.handlers.api.adapter.invoker.InvokerAdapter;
@@ -55,11 +56,7 @@ import io.gravitee.gateway.jupiter.handlers.api.processor.ApiProcessorChainFacto
 import io.gravitee.gateway.jupiter.policy.DefaultPolicyChainFactory;
 import io.gravitee.gateway.jupiter.reactor.v4.reactor.ReactorFactory;
 import io.gravitee.gateway.platform.manager.OrganizationManager;
-import io.gravitee.gateway.policy.PolicyChainProviderLoader;
-import io.gravitee.gateway.policy.PolicyConfigurationFactory;
-import io.gravitee.gateway.policy.PolicyFactory;
-import io.gravitee.gateway.policy.PolicyFactoryCreator;
-import io.gravitee.gateway.policy.PolicyManager;
+import io.gravitee.gateway.policy.*;
 import io.gravitee.gateway.policy.impl.CachedPolicyConfigurationFactory;
 import io.gravitee.gateway.reactor.Reactable;
 import io.gravitee.gateway.reactor.ReactableApi;
@@ -588,7 +585,14 @@ public class ApiReactorHandlerFactory implements ReactorFactory<Api> {
         PolicyChainProviderLoader policyChainProviderLoader,
         FlowPolicyResolverFactory flowPolicyResolverFactory
     ) {
-        return new ResponseProcessorChainFactory(api, policyChainFactory, policyChainProviderLoader, node, flowPolicyResolverFactory);
+        return new ResponseProcessorChainFactory(
+            api,
+            policyChainFactory,
+            policyChainProviderLoader,
+            node,
+            flowPolicyResolverFactory,
+            new TransactionResponseProcessorConfiguration(configuration)
+        );
     }
 
     public OnErrorProcessorChainFactory errorProcessorChainFactory(Api api, PolicyChainFactory policyChainFactory) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/ResponseProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/ResponseProcessorChainFactory.java
@@ -23,7 +23,6 @@ import io.gravitee.gateway.core.condition.ConditionEvaluator;
 import io.gravitee.gateway.flow.BestMatchFlowResolver;
 import io.gravitee.gateway.flow.FlowPolicyResolverFactory;
 import io.gravitee.gateway.flow.SimpleFlowPolicyChainProvider;
-import io.gravitee.gateway.flow.SimpleFlowProvider;
 import io.gravitee.gateway.flow.condition.evaluation.ExpressionLanguageFlowConditionEvaluator;
 import io.gravitee.gateway.flow.condition.evaluation.HttpMethodConditionEvaluator;
 import io.gravitee.gateway.flow.condition.evaluation.PathBasedConditionEvaluator;
@@ -39,6 +38,8 @@ import io.gravitee.gateway.handlers.api.policy.plan.PlanPolicyResolver;
 import io.gravitee.gateway.handlers.api.processor.cors.CorsSimpleRequestProcessor;
 import io.gravitee.gateway.handlers.api.processor.pathmapping.PathMappingProcessor;
 import io.gravitee.gateway.handlers.api.processor.shutdown.ShutdownProcessor;
+import io.gravitee.gateway.handlers.api.processor.transaction.TransactionResponseProcessor;
+import io.gravitee.gateway.handlers.api.processor.transaction.TransactionResponseProcessorConfiguration;
 import io.gravitee.gateway.policy.PolicyChainOrder;
 import io.gravitee.gateway.policy.PolicyChainProviderLoader;
 import io.gravitee.gateway.policy.StreamType;
@@ -55,23 +56,28 @@ public class ResponseProcessorChainFactory extends ApiProcessorChainFactory {
 
     private Node node;
 
+    private TransactionResponseProcessorConfiguration transactionResponseProcessorConfiguration;
+
     public ResponseProcessorChainFactory(
         final Api api,
         final PolicyChainFactory policyChainFactory,
         final PolicyChainProviderLoader policyChainProviderLoader,
         final Node node,
-        FlowPolicyResolverFactory flowPolicyResolverFactory
+        FlowPolicyResolverFactory flowPolicyResolverFactory,
+        final TransactionResponseProcessorConfiguration transactionResponseProcessorConfiguration
     ) {
         super(api, policyChainFactory);
         this.policyChainProviderLoader = policyChainProviderLoader;
         this.node = node;
         this.flowPolicyResolverFactory = flowPolicyResolverFactory;
+        this.transactionResponseProcessorConfiguration = transactionResponseProcessorConfiguration;
 
         this.initialize();
     }
 
     private void initialize() {
         add(() -> new ShutdownProcessor(node));
+        add(() -> new TransactionResponseProcessor(this.transactionResponseProcessorConfiguration));
 
         final ConditionEvaluator<Flow> evaluator = new CompositeConditionEvaluator<>(
             new HttpMethodConditionEvaluator(),

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/transaction/HeaderOverrideMode.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/transaction/HeaderOverrideMode.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.processor.transaction;
+
+/**
+ * The different modes available in the Gateway when it deals with a backend providing a value for the Transaction Id and Request Id headers
+ */
+public enum HeaderOverrideMode {
+    /**
+     * OVERRIDE: The header set by the APIM Gateway will override the one provided by the backend
+     */
+    OVERRIDE,
+    /**
+     * MERGE: Both headers set by the APIM Gateway and the backend will be kept (as headers can be multivalued)
+     */
+    MERGE,
+    /**
+     * KEEP: The header set by the backend will be kept and the one provided by the APIM Gateway discarded
+     */
+    KEEP,
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/transaction/TransactionResponseProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/transaction/TransactionResponseProcessor.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.processor.transaction;
+
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.core.processor.AbstractProcessor;
+
+/**
+ * A {@link Response} processor used to set the transaction ID in the response headers.
+ */
+public class TransactionResponseProcessor extends AbstractProcessor<ExecutionContext> {
+
+    private final TransactionResponseProcessorConfiguration configuration;
+
+    public TransactionResponseProcessor(TransactionResponseProcessorConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public void handle(final ExecutionContext context) {
+        setHeaderAccordingToBackendOverrideMode(
+            context.request().headers(),
+            context.response().headers(),
+            configuration.transactionHeader,
+            configuration.transactionHeaderHeaderOverrideMode
+        );
+
+        setHeaderAccordingToBackendOverrideMode(
+            context.request().headers(),
+            context.response().headers(),
+            configuration.requestHeader,
+            configuration.requestHeaderHeaderOverrideMode
+        );
+
+        next.handle(context);
+    }
+
+    private void setHeaderAccordingToBackendOverrideMode(
+        final HttpHeaders requestHeaders,
+        final HttpHeaders responseHeaders,
+        final String headerName,
+        final HeaderOverrideMode headerOverrideMode
+    ) {
+        String requestHeaderValue = requestHeaders.get(headerName);
+        String backendHeaderValue = responseHeaders.get(headerName);
+
+        if (headerOverrideMode == HeaderOverrideMode.OVERRIDE) {
+            responseHeaders.set(headerName, requestHeaderValue);
+        } else if (headerOverrideMode == HeaderOverrideMode.MERGE) {
+            if (!requestHeaderValue.equals(backendHeaderValue)) {
+                responseHeaders.add(headerName, requestHeaderValue);
+            }
+        } else if (headerOverrideMode == HeaderOverrideMode.KEEP) {
+            responseHeaders.set(headerName, backendHeaderValue);
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/transaction/TransactionResponseProcessorConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/transaction/TransactionResponseProcessorConfiguration.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.processor.transaction;
+
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_REQUEST_ID_HEADER;
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER;
+
+public class TransactionResponseProcessorConfiguration {
+
+    public final String transactionHeader;
+
+    public final HeaderOverrideMode transactionHeaderHeaderOverrideMode;
+
+    public final String requestHeader;
+
+    public final HeaderOverrideMode requestHeaderHeaderOverrideMode;
+
+    public TransactionResponseProcessorConfiguration(io.gravitee.node.api.configuration.Configuration configuration) {
+        this.transactionHeader = configuration.getProperty("handlers.request.transaction.header", DEFAULT_TRANSACTION_ID_HEADER);
+        String transactionOverrideModeString = configuration.getProperty("handlers.request.transaction.overrideMode");
+        this.transactionHeaderHeaderOverrideMode =
+            transactionOverrideModeString != null
+                ? HeaderOverrideMode.valueOf(transactionOverrideModeString.trim().toUpperCase())
+                : HeaderOverrideMode.OVERRIDE;
+
+        this.requestHeader = configuration.getProperty("handlers.request.request.header", DEFAULT_REQUEST_ID_HEADER);
+        String requestOverrideModeString = configuration.getProperty("handlers.request.request.overrideMode");
+        this.requestHeaderHeaderOverrideMode =
+            requestOverrideModeString != null
+                ? HeaderOverrideMode.valueOf(requestOverrideModeString.trim().toUpperCase())
+                : HeaderOverrideMode.OVERRIDE;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/processor/ApiProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/processor/ApiProcessorChainFactory.java
@@ -32,6 +32,8 @@ import io.gravitee.gateway.jupiter.handlers.api.processor.logging.LogResponsePro
 import io.gravitee.gateway.jupiter.handlers.api.processor.pathmapping.PathMappingProcessor;
 import io.gravitee.gateway.jupiter.handlers.api.processor.plan.PlanProcessor;
 import io.gravitee.gateway.jupiter.handlers.api.processor.shutdown.ShutdownProcessor;
+import io.gravitee.gateway.jupiter.handlers.api.processor.transaction.TransactionPostProcessor;
+import io.gravitee.gateway.jupiter.handlers.api.processor.transaction.TransactionPostProcessorConfiguration;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.configuration.Configuration;
 import java.util.ArrayList;
@@ -47,9 +49,12 @@ public class ApiProcessorChainFactory {
 
     private final boolean overrideXForwardedPrefix;
     private final Node node;
+
+    private final Configuration configuration;
     private final List<ProcessorHook> processorHooks = new ArrayList<>();
 
     public ApiProcessorChainFactory(final Configuration configuration, Node node) {
+        this.configuration = configuration;
         this.overrideXForwardedPrefix = configuration.getProperty("handlers.request.headers.x-forwarded-prefix", Boolean.class, false);
         this.node = node;
 
@@ -84,6 +89,7 @@ public class ApiProcessorChainFactory {
     public ProcessorChain postProcessorChain(final Api api) {
         List<Processor> postProcessorList = new ArrayList<>();
         postProcessorList.add(new ShutdownProcessor(node));
+        postProcessorList.add(new TransactionPostProcessor(new TransactionPostProcessorConfiguration(configuration)));
 
         Cors cors = api.getDefinition().getProxy().getCors();
         if (cors != null && cors.isEnabled()) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/processor/transaction/HeaderOverrideMode.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/processor/transaction/HeaderOverrideMode.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.handlers.api.processor.transaction;
+
+/**
+ * The different modes available in the Gateway when it deals with a backend providing a value for the Transaction Id and Request Id headers
+ */
+public enum HeaderOverrideMode {
+    /**
+     * OVERRIDE: The header set by the APIM Gateway will override the one provided by the backend
+     */
+    OVERRIDE,
+    /**
+     * MERGE: Both headers set by the APIM Gateway and the backend will be kept (as headers can be multivalued)
+     */
+    MERGE,
+    /**
+     * KEEP: The header set by the backend will be kept and the one provided by the APIM Gateway discarded
+     */
+    KEEP,
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/processor/transaction/TransactionPostProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/processor/transaction/TransactionPostProcessor.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.handlers.api.processor.transaction;
+
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.jupiter.core.context.MutableExecutionContext;
+import io.gravitee.gateway.jupiter.core.processor.Processor;
+import io.reactivex.Completable;
+
+/**
+ * A {@link Processor} used to set the Transaction and Request ID headers of the response.
+ */
+public class TransactionPostProcessor implements Processor {
+
+    private final TransactionPostProcessorConfiguration configuration;
+
+    public TransactionPostProcessor(TransactionPostProcessorConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public String getId() {
+        return "post-processor-transaction";
+    }
+
+    @Override
+    public Completable execute(final MutableExecutionContext context) {
+        return Completable.fromRunnable(
+            () -> {
+                setHeaderAccordingToBackendOverrideMode(
+                    context.request().headers(),
+                    context.response().headers(),
+                    this.configuration.transactionHeader,
+                    this.configuration.transactionHeaderHeaderOverrideMode
+                );
+
+                setHeaderAccordingToBackendOverrideMode(
+                    context.request().headers(),
+                    context.response().headers(),
+                    this.configuration.requestHeader,
+                    this.configuration.requestHeaderHeaderOverrideMode
+                );
+            }
+        );
+    }
+
+    private void setHeaderAccordingToBackendOverrideMode(
+        final HttpHeaders requestHeaders,
+        final HttpHeaders responseHeaders,
+        final String headerName,
+        final HeaderOverrideMode headerOverrideMode
+    ) {
+        String requestHeaderValue = requestHeaders.get(headerName);
+        String backendHeaderValue = responseHeaders.get(headerName);
+
+        if (headerOverrideMode == HeaderOverrideMode.OVERRIDE) {
+            responseHeaders.set(headerName, requestHeaderValue);
+        } else if (headerOverrideMode == HeaderOverrideMode.MERGE) {
+            if (!requestHeaderValue.equals(backendHeaderValue)) {
+                responseHeaders.add(headerName, requestHeaderValue);
+            }
+        } else if (headerOverrideMode == HeaderOverrideMode.KEEP) {
+            responseHeaders.set(headerName, backendHeaderValue);
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/processor/transaction/TransactionPostProcessorConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/processor/transaction/TransactionPostProcessorConfiguration.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.handlers.api.processor.transaction;
+
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_REQUEST_ID_HEADER;
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER;
+
+import io.gravitee.node.api.configuration.Configuration;
+
+public class TransactionPostProcessorConfiguration {
+
+    public final String transactionHeader;
+
+    public final HeaderOverrideMode transactionHeaderHeaderOverrideMode;
+
+    public final String requestHeader;
+
+    public final HeaderOverrideMode requestHeaderHeaderOverrideMode;
+
+    public TransactionPostProcessorConfiguration(Configuration configuration) {
+        this.transactionHeader = configuration.getProperty("handlers.request.transaction.header", DEFAULT_TRANSACTION_ID_HEADER);
+        String transactionOverrideModeString = configuration.getProperty("handlers.request.transaction.overrideMode");
+        this.transactionHeaderHeaderOverrideMode =
+            transactionOverrideModeString != null
+                ? HeaderOverrideMode.valueOf(transactionOverrideModeString.trim().toUpperCase())
+                : HeaderOverrideMode.OVERRIDE;
+
+        this.requestHeader = configuration.getProperty("handlers.request.request.header", DEFAULT_REQUEST_ID_HEADER);
+        String requestOverrideModeString = configuration.getProperty("handlers.request.request.overrideMode");
+        this.requestHeaderHeaderOverrideMode =
+            requestOverrideModeString != null
+                ? HeaderOverrideMode.valueOf(requestOverrideModeString.trim().toUpperCase())
+                : HeaderOverrideMode.OVERRIDE;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/transaction/TransactionResponseProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/transaction/TransactionResponseProcessorTest.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.processor.transaction;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.api.context.SimpleExecutionContext;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.reactor.processor.transaction.TransactionHeader;
+import io.gravitee.node.api.configuration.Configuration;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+
+class TransactionResponseProcessorTest {
+
+    private TransactionResponseProcessor transactionResponseProcessor;
+
+    @Test
+    @DisplayName("By default should override Transaction Id and Request Id headers set by the backend, by the ones set by APIM")
+    void handleWithOverrideByDefault() {
+        Configuration nodeConfiguration = mock(Configuration.class);
+        when(nodeConfiguration.getProperty(eq("handlers.request.transaction.header"), anyString()))
+                .thenReturn(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER);
+        when(nodeConfiguration.getProperty(eq("handlers.request.request.header"), anyString()))
+                .thenReturn(TransactionHeader.DEFAULT_REQUEST_ID_HEADER);
+
+        TransactionResponseProcessorConfiguration processorConfiguration = new TransactionResponseProcessorConfiguration(nodeConfiguration);
+
+        transactionResponseProcessor = new TransactionResponseProcessor(processorConfiguration);
+        transactionResponseProcessor.handler(context -> {});
+
+        Request request = mock(Request.class);
+        HttpHeaders requestHeaders = HttpHeaders.create();
+        requestHeaders.set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "transaction-id");
+        requestHeaders.set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "request-id");
+        when(request.headers()).thenReturn(requestHeaders);
+
+        Response response = mock(Response.class);
+        HttpHeaders responseHeaders = HttpHeaders.create();
+        responseHeaders.set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "backend-transaction-id");
+        responseHeaders.set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "backend-request-id");
+        when(response.headers()).thenReturn(responseHeaders);
+
+        ExecutionContext context = new SimpleExecutionContext(request, response);
+        transactionResponseProcessor.handle(context);
+
+        assertEquals(List.of("transaction-id"), context.response().headers().getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER));
+        assertEquals(List.of("request-id"), context.response().headers().getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER));
+    }
+
+    @Test
+    @DisplayName("Should override Transaction Id and Request Id headers set by the backend, by the ones set by APIM")
+    void handleWithOverrideModeNone() {
+        instantiateTransactionResponseProcess(HeaderOverrideMode.OVERRIDE, HeaderOverrideMode.OVERRIDE);
+
+        Request request = mock(Request.class);
+        HttpHeaders requestHeaders = HttpHeaders.create();
+        requestHeaders.set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "transaction-id");
+        requestHeaders.set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "request-id");
+        when(request.headers()).thenReturn(requestHeaders);
+
+        Response response = mock(Response.class);
+        HttpHeaders responseHeaders = HttpHeaders.create();
+        responseHeaders.set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "backend-transaction-id");
+        responseHeaders.set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "backend-request-id");
+        when(response.headers()).thenReturn(responseHeaders);
+
+        ExecutionContext context = new SimpleExecutionContext(request, response);
+        transactionResponseProcessor.handle(context);
+
+        assertEquals(List.of("transaction-id"), context.response().headers().getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER));
+        assertEquals(List.of("request-id"), context.response().headers().getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER));
+    }
+
+    @Test
+    @DisplayName("Should merge transaction ID and request ID headers set by APIM and the backend")
+    void handleWithOverrideModeMerge() {
+        instantiateTransactionResponseProcess(HeaderOverrideMode.MERGE, HeaderOverrideMode.MERGE);
+
+        Request request = mock(Request.class);
+        HttpHeaders requestHeaders = HttpHeaders.create();
+        requestHeaders.set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "transaction-id");
+        requestHeaders.set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "request-id");
+        when(request.headers()).thenReturn(requestHeaders);
+
+        Response response = mock(Response.class);
+        HttpHeaders responseHeaders = HttpHeaders.create();
+        responseHeaders.set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "backend-transaction-id");
+        responseHeaders.set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "backend-request-id");
+        when(response.headers()).thenReturn(responseHeaders);
+
+        ExecutionContext context = new SimpleExecutionContext(request, response);
+        transactionResponseProcessor.handle(context);
+
+        assertEquals(
+                List.of("backend-transaction-id", "transaction-id"),
+                context.response().headers().getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER)
+        );
+        assertEquals(
+                List.of("backend-request-id", "request-id"),
+                context.response().headers().getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER)
+        );
+    }
+
+    @Test
+    @DisplayName("Should keep transaction ID and request ID headers set by the backend, discard APIM ones")
+    void handleWithOverrideModeOverride() {
+        instantiateTransactionResponseProcess(HeaderOverrideMode.KEEP, HeaderOverrideMode.KEEP);
+
+        Request request = mock(Request.class);
+        HttpHeaders requestHeaders = HttpHeaders.create();
+        requestHeaders.set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "transaction-id");
+        requestHeaders.set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "request-id");
+        when(request.headers()).thenReturn(requestHeaders);
+
+        Response response = mock(Response.class);
+        HttpHeaders responseHeaders = HttpHeaders.create();
+        responseHeaders.set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "backend-transaction-id");
+        responseHeaders.set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "backend-request-id");
+        when(response.headers()).thenReturn(responseHeaders);
+
+        ExecutionContext context = new SimpleExecutionContext(request, response);
+        transactionResponseProcessor.handle(context);
+
+        assertEquals(
+                List.of("backend-transaction-id"),
+                context.response().headers().getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER)
+        );
+        assertEquals(List.of("backend-request-id"), context.response().headers().getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER));
+    }
+
+    private void instantiateTransactionResponseProcess(
+            HeaderOverrideMode transactionOverrideMode,
+            HeaderOverrideMode requestHeaderOverrideMode
+    ) {
+        Configuration nodeConfiguration = mock(Configuration.class);
+        when(nodeConfiguration.getProperty("handlers.request.transaction.overrideMode")).thenReturn(transactionOverrideMode.name());
+        when(nodeConfiguration.getProperty(eq("handlers.request.transaction.header"), anyString()))
+                .thenReturn(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER);
+
+        when(nodeConfiguration.getProperty("handlers.request.request.overrideMode")).thenReturn(requestHeaderOverrideMode.name());
+        when(nodeConfiguration.getProperty(eq("handlers.request.request.header"), anyString()))
+                .thenReturn(TransactionHeader.DEFAULT_REQUEST_ID_HEADER);
+
+        TransactionResponseProcessorConfiguration processorConfiguration = new TransactionResponseProcessorConfiguration(nodeConfiguration);
+
+        transactionResponseProcessor = new TransactionResponseProcessor(processorConfiguration);
+        transactionResponseProcessor.handler(context -> {});
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/transaction/TransactionResponseProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/transaction/TransactionResponseProcessorTest.java
@@ -32,7 +32,6 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-
 class TransactionResponseProcessorTest {
 
     private TransactionResponseProcessor transactionResponseProcessor;
@@ -42,9 +41,9 @@ class TransactionResponseProcessorTest {
     void handleWithOverrideByDefault() {
         Configuration nodeConfiguration = mock(Configuration.class);
         when(nodeConfiguration.getProperty(eq("handlers.request.transaction.header"), anyString()))
-                .thenReturn(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER);
+            .thenReturn(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER);
         when(nodeConfiguration.getProperty(eq("handlers.request.request.header"), anyString()))
-                .thenReturn(TransactionHeader.DEFAULT_REQUEST_ID_HEADER);
+            .thenReturn(TransactionHeader.DEFAULT_REQUEST_ID_HEADER);
 
         TransactionResponseProcessorConfiguration processorConfiguration = new TransactionResponseProcessorConfiguration(nodeConfiguration);
 
@@ -115,12 +114,12 @@ class TransactionResponseProcessorTest {
         transactionResponseProcessor.handle(context);
 
         assertEquals(
-                List.of("backend-transaction-id", "transaction-id"),
-                context.response().headers().getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER)
+            List.of("backend-transaction-id", "transaction-id"),
+            context.response().headers().getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER)
         );
         assertEquals(
-                List.of("backend-request-id", "request-id"),
-                context.response().headers().getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER)
+            List.of("backend-request-id", "request-id"),
+            context.response().headers().getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER)
         );
     }
 
@@ -145,24 +144,24 @@ class TransactionResponseProcessorTest {
         transactionResponseProcessor.handle(context);
 
         assertEquals(
-                List.of("backend-transaction-id"),
-                context.response().headers().getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER)
+            List.of("backend-transaction-id"),
+            context.response().headers().getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER)
         );
         assertEquals(List.of("backend-request-id"), context.response().headers().getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER));
     }
 
     private void instantiateTransactionResponseProcess(
-            HeaderOverrideMode transactionOverrideMode,
-            HeaderOverrideMode requestHeaderOverrideMode
+        HeaderOverrideMode transactionOverrideMode,
+        HeaderOverrideMode requestHeaderOverrideMode
     ) {
         Configuration nodeConfiguration = mock(Configuration.class);
         when(nodeConfiguration.getProperty("handlers.request.transaction.overrideMode")).thenReturn(transactionOverrideMode.name());
         when(nodeConfiguration.getProperty(eq("handlers.request.transaction.header"), anyString()))
-                .thenReturn(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER);
+            .thenReturn(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER);
 
         when(nodeConfiguration.getProperty("handlers.request.request.overrideMode")).thenReturn(requestHeaderOverrideMode.name());
         when(nodeConfiguration.getProperty(eq("handlers.request.request.header"), anyString()))
-                .thenReturn(TransactionHeader.DEFAULT_REQUEST_ID_HEADER);
+            .thenReturn(TransactionHeader.DEFAULT_REQUEST_ID_HEADER);
 
         TransactionResponseProcessorConfiguration processorConfiguration = new TransactionResponseProcessorConfiguration(nodeConfiguration);
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/processor/transaction/TransactionPostProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/processor/transaction/TransactionPostProcessorTest.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.handlers.api.processor.transaction;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.api.context.SimpleExecutionContext;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.handlers.api.processor.transaction.TransactionResponseProcessor;
+import io.gravitee.gateway.handlers.api.processor.transaction.TransactionResponseProcessorConfiguration;
+import io.gravitee.gateway.jupiter.handlers.api.processor.AbstractProcessorTest;
+import io.gravitee.gateway.reactor.processor.transaction.TransactionHeader;
+import io.gravitee.node.api.configuration.Configuration;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TransactionPostProcessorTest extends AbstractProcessorTest {
+
+    private TransactionPostProcessor transactionPostProcessor;
+
+    @Test
+    @DisplayName("By default should override Transaction Id and Request Id headers set by the backend, by the ones set by APIM")
+    void handleWithOverrideByDefault() {
+        Configuration nodeConfiguration = mock(Configuration.class);
+        when(nodeConfiguration.getProperty("handlers.request.transaction.overrideMode")).thenReturn(null);
+        when(nodeConfiguration.getProperty(eq("handlers.request.transaction.header"), anyString()))
+            .thenReturn(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER);
+        when(nodeConfiguration.getProperty("handlers.request.request.overrideMode")).thenReturn(null);
+        when(nodeConfiguration.getProperty(eq("handlers.request.request.header"), anyString()))
+            .thenReturn(TransactionHeader.DEFAULT_REQUEST_ID_HEADER);
+
+        TransactionPostProcessorConfiguration processorConfiguration = new TransactionPostProcessorConfiguration(nodeConfiguration);
+
+        transactionPostProcessor = new TransactionPostProcessor(processorConfiguration);
+
+        ctx.request().headers().set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "transaction-id");
+        ctx.request().headers().set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "request-id");
+
+        ctx.response().headers().set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "backend-transaction-id");
+        ctx.response().headers().set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "backend-request-id");
+
+        transactionPostProcessor.execute(ctx).test().assertResult();
+
+        assertThat(spyResponseHeaders.getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER)).isEqualTo(List.of("transaction-id"));
+        assertThat(spyResponseHeaders.getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER)).isEqualTo(List.of("request-id"));
+    }
+
+    @Test
+    @DisplayName("Should override Transaction Id and Request Id headers set by the backend, by the ones set by APIM")
+    void handleWithOverrideBackendModeNone() {
+        instantiateTransactionPostProcessor(HeaderOverrideMode.OVERRIDE, HeaderOverrideMode.OVERRIDE);
+
+        ctx.request().headers().set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "transaction-id");
+        ctx.request().headers().set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "request-id");
+
+        ctx.response().headers().set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "backend-transaction-id");
+        ctx.response().headers().set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "backend-request-id");
+
+        transactionPostProcessor.execute(ctx).test().assertResult();
+
+        assertThat(spyResponseHeaders.getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER)).isEqualTo(List.of("transaction-id"));
+        assertThat(spyResponseHeaders.getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER)).isEqualTo(List.of("request-id"));
+    }
+
+    @Test
+    @DisplayName("Should merge transaction ID and request ID headers set by APIM and the backend")
+    void handleWithOverrideBackendModeMerge() {
+        instantiateTransactionPostProcessor(HeaderOverrideMode.MERGE, HeaderOverrideMode.MERGE);
+
+        ctx.request().headers().set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "transaction-id");
+        ctx.request().headers().set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "request-id");
+
+        ctx.response().headers().set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "backend-transaction-id");
+        ctx.response().headers().set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "backend-request-id");
+
+        transactionPostProcessor.execute(ctx).test().assertResult();
+
+        assertThat(spyResponseHeaders.getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER))
+            .isEqualTo(List.of("backend-transaction-id", "transaction-id"));
+        assertThat(spyResponseHeaders.getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER))
+            .isEqualTo(List.of("backend-request-id", "request-id"));
+    }
+
+    @Test
+    @DisplayName("Should keep transaction ID and request ID headers set by the backend, discard APIM ones")
+    void handleWithOverrideBackendModeOverride() {
+        instantiateTransactionPostProcessor(HeaderOverrideMode.KEEP, HeaderOverrideMode.KEEP);
+
+        ctx.request().headers().set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "transaction-id");
+        ctx.request().headers().set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "request-id");
+
+        ctx.response().headers().set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "backend-transaction-id");
+        ctx.response().headers().set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "backend-request-id");
+
+        transactionPostProcessor.execute(ctx).test().assertResult();
+
+        assertThat(spyResponseHeaders.getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER)).isEqualTo(List.of("backend-transaction-id"));
+        assertThat(spyResponseHeaders.getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER)).isEqualTo(List.of("backend-request-id"));
+    }
+
+    private void instantiateTransactionPostProcessor(
+        HeaderOverrideMode transactionOverrideMode,
+        HeaderOverrideMode requestHeaderOverrideMode
+    ) {
+        Configuration nodeConfiguration = mock(Configuration.class);
+        when(nodeConfiguration.getProperty("handlers.request.transaction.overrideMode")).thenReturn(transactionOverrideMode.name());
+        when(nodeConfiguration.getProperty(eq("handlers.request.transaction.header"), anyString()))
+            .thenReturn(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER);
+
+        when(nodeConfiguration.getProperty("handlers.request.request.overrideMode")).thenReturn(requestHeaderOverrideMode.name());
+        when(nodeConfiguration.getProperty(eq("handlers.request.request.header"), anyString()))
+            .thenReturn(TransactionHeader.DEFAULT_REQUEST_ID_HEADER);
+
+        TransactionPostProcessorConfiguration processorConfiguration = new TransactionPostProcessorConfiguration(nodeConfiguration);
+
+        transactionPostProcessor = new TransactionPostProcessor(processorConfiguration);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionHeader.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionHeader.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.reactor.processor.transaction;
+
+public abstract class TransactionHeader {
+
+    public static final String DEFAULT_TRANSACTION_ID_HEADER = "X-Gravitee-Transaction-Id";
+    public static final String DEFAULT_REQUEST_ID_HEADER = "X-Gravitee-Request-Id";
+
+    private TransactionHeader() {}
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionPreProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionPreProcessor.java
@@ -27,12 +27,12 @@ import io.reactivex.Completable;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class TransactionProcessor implements Processor {
+public class TransactionPreProcessor implements Processor {
 
     private final String transactionHeader;
     private final String requestHeader;
 
-    TransactionProcessor(final String transactionHeader, final String requestHeader) {
+    TransactionPreProcessor(final String transactionHeader, final String requestHeader) {
         this.transactionHeader = transactionHeader;
         this.requestHeader = requestHeader;
     }
@@ -47,7 +47,7 @@ public class TransactionProcessor implements Processor {
 
     @Override
     public String getId() {
-        return "processor-transaction";
+        return "pre-processor-transaction";
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionPreProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionPreProcessor.java
@@ -63,9 +63,6 @@ public class TransactionPreProcessor implements Processor {
                 ctx.request().headers().set(requestHeader, requestId);
                 ctx.request().metrics().setTransactionId(transactionId);
 
-                ctx.response().headers().set(transactionHeader, transactionId);
-                ctx.response().headers().set(requestHeader, requestId);
-
                 ctx.request().transactionId(transactionId);
             }
         );

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionProcessorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionProcessorFactory.java
@@ -15,15 +15,15 @@
  */
 package io.gravitee.gateway.jupiter.reactor.processor.transaction;
 
+import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionHeader.DEFAULT_REQUEST_ID_HEADER;
+import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER;
+
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
 public class TransactionProcessorFactory {
-
-    public static final String DEFAULT_TRANSACTION_ID_HEADER = "X-Gravitee-Transaction-Id";
-    public static final String DEFAULT_REQUEST_ID_HEADER = "X-Gravitee-Request-Id";
 
     private final String transactionHeader;
     private final String requestHeader;
@@ -33,7 +33,7 @@ public class TransactionProcessorFactory {
         this.requestHeader = requestHeader == null ? DEFAULT_REQUEST_ID_HEADER : requestHeader;
     }
 
-    public TransactionProcessor create() {
-        return new TransactionProcessor(transactionHeader, requestHeader);
+    public TransactionPreProcessor create() {
+        return new TransactionPreProcessor(transactionHeader, requestHeader);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/RequestProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/RequestProcessorChainFactory.java
@@ -22,7 +22,7 @@ import io.gravitee.gateway.core.processor.provider.ProcessorProviderChain;
 import io.gravitee.gateway.core.processor.provider.ProcessorSupplier;
 import io.gravitee.gateway.reactor.processor.forward.XForwardForProcessor;
 import io.gravitee.gateway.reactor.processor.transaction.TraceContextProcessorFactory;
-import io.gravitee.gateway.reactor.processor.transaction.TransactionProcessorFactory;
+import io.gravitee.gateway.reactor.processor.transaction.TransactionRequestProcessorFactory;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.InitializingBean;
@@ -39,8 +39,8 @@ public class RequestProcessorChainFactory implements InitializingBean {
     private final List<ProcessorProvider<ExecutionContext, Processor<ExecutionContext>>> providers = new ArrayList<>();
 
     @Autowired
-    @Qualifier("v3TransactionHandlerFactory")
-    private TransactionProcessorFactory transactionHandlerFactory;
+    @Qualifier("v3TransactionRequestProcessorFactory")
+    private TransactionRequestProcessorFactory transactionRequestProcessorFactory;
 
     @Autowired
     @Qualifier("v3TraceContextProcessorFactory")
@@ -59,7 +59,7 @@ public class RequestProcessorChainFactory implements InitializingBean {
             providers.add(new ProcessorSupplier<>(() -> traceContextHandlerFactory.create()));
         }
 
-        providers.add(new ProcessorSupplier<>(() -> transactionHandlerFactory.create()));
+        providers.add(new ProcessorSupplier<>(() -> transactionRequestProcessorFactory.create()));
     }
 
     public Processor<ExecutionContext> create() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/transaction/TransactionHeader.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/transaction/TransactionHeader.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactor.processor.transaction;
+
+public abstract class TransactionHeader {
+
+    public static final String DEFAULT_TRANSACTION_ID_HEADER = "X-Gravitee-Transaction-Id";
+    public static final String DEFAULT_REQUEST_ID_HEADER = "X-Gravitee-Request-Id";
+
+    private TransactionHeader() {}
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessor.java
@@ -50,10 +50,7 @@ public class TransactionRequestProcessor extends AbstractProcessor<ExecutionCont
             context.request().headers().set(transactionHeader, transactionId);
         }
         context.request().metrics().setTransactionId(transactionId);
-        context.response().headers().set(transactionHeader, transactionId);
-
         context.request().headers().set(requestHeader, requestId);
-        context.response().headers().set(requestHeader, requestId);
 
         ((MutableExecutionContext) context).request(new TransactionRequest(transactionId, context.request()));
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessor.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.gateway.reactor.processor.transaction;
 
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_REQUEST_ID_HEADER;
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER;
+
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.context.MutableExecutionContext;
@@ -26,17 +29,14 @@ import io.gravitee.gateway.core.processor.AbstractProcessor;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class TransactionProcessor extends AbstractProcessor<ExecutionContext> {
-
-    static final String DEFAULT_TRANSACTION_ID_HEADER = "X-Gravitee-Transaction-Id";
-    static final String DEFAULT_REQUEST_ID_HEADER = "X-Gravitee-Request-Id";
+public class TransactionRequestProcessor extends AbstractProcessor<ExecutionContext> {
 
     private String transactionHeader = DEFAULT_TRANSACTION_ID_HEADER;
     private String requestHeader = DEFAULT_REQUEST_ID_HEADER;
 
-    TransactionProcessor() {}
+    TransactionRequestProcessor() {}
 
-    TransactionProcessor(String transactionHeader, String requestHeader) {
+    TransactionRequestProcessor(String transactionHeader, String requestHeader) {
         this.transactionHeader = transactionHeader;
         this.requestHeader = requestHeader;
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessorFactory.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.gateway.reactor.processor.transaction;
 
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_REQUEST_ID_HEADER;
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER;
+
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.core.processor.Processor;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,15 +26,15 @@ import org.springframework.beans.factory.annotation.Value;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class TransactionProcessorFactory {
+public class TransactionRequestProcessorFactory {
 
-    @Value("${handlers.request.transaction.header:" + TransactionProcessor.DEFAULT_TRANSACTION_ID_HEADER + "}")
+    @Value("${handlers.request.transaction.header:" + DEFAULT_TRANSACTION_ID_HEADER + "}")
     private String transactionHeader;
 
-    @Value("${handlers.request.request.header:" + TransactionProcessor.DEFAULT_REQUEST_ID_HEADER + "}")
+    @Value("${handlers.request.request.header:" + DEFAULT_REQUEST_ID_HEADER + "}")
     private String requestHeader;
 
     public Processor<ExecutionContext> create() {
-        return new TransactionProcessor(transactionHeader, requestHeader);
+        return new TransactionRequestProcessor(transactionHeader, requestHeader);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/spring/ReactorConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/spring/ReactorConfiguration.java
@@ -45,7 +45,7 @@ import io.gravitee.gateway.reactor.impl.DefaultReactor;
 import io.gravitee.gateway.reactor.processor.RequestProcessorChainFactory;
 import io.gravitee.gateway.reactor.processor.ResponseProcessorChainFactory;
 import io.gravitee.gateway.reactor.processor.transaction.TraceContextProcessorFactory;
-import io.gravitee.gateway.reactor.processor.transaction.TransactionProcessorFactory;
+import io.gravitee.gateway.reactor.processor.transaction.TransactionRequestProcessorFactory;
 import io.gravitee.gateway.report.ReporterService;
 import io.gravitee.node.api.Node;
 import io.gravitee.plugin.alert.AlertEventProducer;
@@ -202,8 +202,8 @@ public class ReactorConfiguration {
     }
 
     @Bean
-    public TransactionProcessorFactory v3TransactionHandlerFactory() {
-        return new io.gravitee.gateway.reactor.processor.transaction.TransactionProcessorFactory();
+    public TransactionRequestProcessorFactory v3TransactionRequestProcessorFactory() {
+        return new TransactionRequestProcessorFactory();
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/spring/ReactorConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/spring/ReactorConfiguration.java
@@ -15,8 +15,8 @@
  */
 package io.gravitee.gateway.reactor.spring;
 
-import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionProcessorFactory.DEFAULT_REQUEST_ID_HEADER;
-import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionProcessorFactory.DEFAULT_TRANSACTION_ID_HEADER;
+import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionHeader.DEFAULT_REQUEST_ID_HEADER;
+import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER;
 
 import io.gravitee.common.event.EventManager;
 import io.gravitee.common.http.IdGenerator;
@@ -31,6 +31,7 @@ import io.gravitee.gateway.jupiter.reactor.handler.DefaultHttpAcceptorResolver;
 import io.gravitee.gateway.jupiter.reactor.handler.HttpAcceptorResolver;
 import io.gravitee.gateway.jupiter.reactor.processor.NotFoundProcessorChainFactory;
 import io.gravitee.gateway.jupiter.reactor.processor.PlatformProcessorChainFactory;
+import io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionProcessorFactory;
 import io.gravitee.gateway.jupiter.reactor.v4.reactor.ReactorFactory;
 import io.gravitee.gateway.jupiter.reactor.v4.reactor.ReactorFactoryManager;
 import io.gravitee.gateway.jupiter.reactor.v4.subscription.*;
@@ -106,16 +107,16 @@ public class ReactorConfiguration {
     }
 
     @Bean
-    public io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionProcessorFactory transactionHandlerFactory(
+    public TransactionProcessorFactory transactionHandlerFactory(
         @Value("${handlers.request.transaction.header:" + DEFAULT_TRANSACTION_ID_HEADER + "}") String transactionHeader,
         @Value("${handlers.request.request.header:" + DEFAULT_REQUEST_ID_HEADER + "}") String requestHeader
     ) {
-        return new io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionProcessorFactory(transactionHeader, requestHeader);
+        return new TransactionProcessorFactory(transactionHeader, requestHeader);
     }
 
     @Bean
     public PlatformProcessorChainFactory globalProcessorChainFactory(
-        io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionProcessorFactory transactionHandlerFactory,
+        TransactionProcessorFactory transactionHandlerFactory,
         @Value("${handlers.request.trace-context.enabled:false}") boolean traceContext,
         ReporterService reporterService,
         AlertEventProducer eventProducer,

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionPreProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionPreProcessorTest.java
@@ -18,7 +18,6 @@ package io.gravitee.gateway.jupiter.reactor.processor.transaction;
 import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionHeader.DEFAULT_REQUEST_ID_HEADER;
 import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -32,7 +31,7 @@ import org.junit.jupiter.api.Test;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class TransactionPreProcessorTest extends AbstractProcessorTest {
+class TransactionPreProcessorTest extends AbstractProcessorTest {
 
     private static final String CUSTOM_TRANSACTION_ID_HEADER = "X-My-Transaction-Id";
     private static final String CUSTOM_REQUEST_ID_HEADER = "X-My-Request-Id";
@@ -44,64 +43,56 @@ public class TransactionPreProcessorTest extends AbstractProcessorTest {
     }
 
     @Test
-    public void shouldHaveTransactionId() {
+    void shouldHaveTransactionId() {
         String requestId = UUID.toString(UUID.random());
         when(mockRequest.id()).thenReturn(requestId);
         transactionProcessor.execute(ctx).test().assertResult();
-        verify(mockRequest).transactionId(eq(requestId));
+        verify(mockRequest).transactionId(requestId);
         assertThat(spyRequestHeaders.get(DEFAULT_TRANSACTION_ID_HEADER)).isEqualTo(requestId);
         assertThat(spyRequestHeaders.get(DEFAULT_REQUEST_ID_HEADER)).isEqualTo(requestId);
         assertThat(metrics.getTransactionId()).isEqualTo(requestId);
-        assertThat(spyResponseHeaders.get(DEFAULT_TRANSACTION_ID_HEADER)).isEqualTo(requestId);
-        assertThat(spyResponseHeaders.get(DEFAULT_REQUEST_ID_HEADER)).isEqualTo(requestId);
     }
 
     @Test
-    public void shouldPropagateSameTransactionId() {
+    void shouldPropagateSameTransactionId() {
         String transactionId = UUID.toString(UUID.random());
         String requestId = UUID.toString(UUID.random());
         when(mockRequest.id()).thenReturn(requestId);
         spyRequestHeaders.set(DEFAULT_TRANSACTION_ID_HEADER, transactionId);
         transactionProcessor.execute(ctx).test().assertResult();
-        verify(mockRequest).transactionId(eq(transactionId));
+        verify(mockRequest).transactionId(transactionId);
         assertThat(spyRequestHeaders.get(DEFAULT_TRANSACTION_ID_HEADER)).isEqualTo(transactionId);
         assertThat(spyRequestHeaders.get(DEFAULT_REQUEST_ID_HEADER)).isEqualTo(requestId);
         assertThat(metrics.getTransactionId()).isEqualTo(transactionId);
-        assertThat(spyResponseHeaders.get(DEFAULT_TRANSACTION_ID_HEADER)).isEqualTo(transactionId);
-        assertThat(spyResponseHeaders.get(DEFAULT_REQUEST_ID_HEADER)).isEqualTo(requestId);
     }
 
     @Test
-    public void shouldHaveTransactionIdWithCustomHeader() {
+    void shouldHaveTransactionIdWithCustomHeader() {
         transactionProcessor = new TransactionPreProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER);
         String requestId = UUID.toString(UUID.random());
         when(mockRequest.id()).thenReturn(requestId);
         transactionProcessor.execute(ctx).test().assertResult();
-        verify(mockRequest).transactionId(eq(requestId));
+        verify(mockRequest).transactionId(requestId);
         assertThat(spyRequestHeaders.get(CUSTOM_TRANSACTION_ID_HEADER)).isEqualTo(requestId);
         assertThat(spyRequestHeaders.get(DEFAULT_TRANSACTION_ID_HEADER)).isNull();
         assertThat(spyRequestHeaders.get(CUSTOM_REQUEST_ID_HEADER)).isEqualTo(requestId);
         assertThat(spyRequestHeaders.get(DEFAULT_REQUEST_ID_HEADER)).isNull();
         assertThat(metrics.getTransactionId()).isEqualTo(requestId);
-        assertThat(spyResponseHeaders.get(CUSTOM_TRANSACTION_ID_HEADER)).isEqualTo(requestId);
         assertThat(spyRequestHeaders.get(DEFAULT_TRANSACTION_ID_HEADER)).isNull();
-        assertThat(spyResponseHeaders.get(CUSTOM_REQUEST_ID_HEADER)).isEqualTo(requestId);
         assertThat(spyRequestHeaders.get(DEFAULT_REQUEST_ID_HEADER)).isNull();
     }
 
     @Test
-    public void shouldPropagateSameTransactionIdWithCustomHeader() {
+    void shouldPropagateSameTransactionIdWithCustomHeader() {
         transactionProcessor = new TransactionPreProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER);
         String transactionId = UUID.toString(UUID.random());
         String requestId = UUID.toString(UUID.random());
         when(mockRequest.id()).thenReturn(requestId);
         spyRequestHeaders.set(CUSTOM_TRANSACTION_ID_HEADER, transactionId);
         transactionProcessor.execute(ctx).test().assertResult();
-        verify(mockRequest).transactionId(eq(transactionId));
+        verify(mockRequest).transactionId(transactionId);
         assertThat(spyRequestHeaders.get(CUSTOM_TRANSACTION_ID_HEADER)).isEqualTo(transactionId);
         assertThat(spyRequestHeaders.get(CUSTOM_REQUEST_ID_HEADER)).isEqualTo(requestId);
         assertThat(metrics.getTransactionId()).isEqualTo(transactionId);
-        assertThat(spyResponseHeaders.get(CUSTOM_TRANSACTION_ID_HEADER)).isEqualTo(transactionId);
-        assertThat(spyResponseHeaders.get(CUSTOM_REQUEST_ID_HEADER)).isEqualTo(requestId);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionPreProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionPreProcessorTest.java
@@ -15,8 +15,8 @@
  */
 package io.gravitee.gateway.jupiter.reactor.processor.transaction;
 
-import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionProcessorFactory.DEFAULT_REQUEST_ID_HEADER;
-import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionProcessorFactory.DEFAULT_TRANSACTION_ID_HEADER;
+import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionHeader.DEFAULT_REQUEST_ID_HEADER;
+import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -32,15 +32,15 @@ import org.junit.jupiter.api.Test;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class TransactionProcessorTest extends AbstractProcessorTest {
+public class TransactionPreProcessorTest extends AbstractProcessorTest {
 
     private static final String CUSTOM_TRANSACTION_ID_HEADER = "X-My-Transaction-Id";
     private static final String CUSTOM_REQUEST_ID_HEADER = "X-My-Request-Id";
-    private TransactionProcessor transactionProcessor;
+    private TransactionPreProcessor transactionProcessor;
 
     @BeforeEach
     public void setUp() throws Exception {
-        transactionProcessor = new TransactionProcessor(DEFAULT_TRANSACTION_ID_HEADER, DEFAULT_REQUEST_ID_HEADER);
+        transactionProcessor = new TransactionPreProcessor(DEFAULT_TRANSACTION_ID_HEADER, DEFAULT_REQUEST_ID_HEADER);
     }
 
     @Test
@@ -73,7 +73,7 @@ public class TransactionProcessorTest extends AbstractProcessorTest {
 
     @Test
     public void shouldHaveTransactionIdWithCustomHeader() {
-        transactionProcessor = new TransactionProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER);
+        transactionProcessor = new TransactionPreProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER);
         String requestId = UUID.toString(UUID.random());
         when(mockRequest.id()).thenReturn(requestId);
         transactionProcessor.execute(ctx).test().assertResult();
@@ -91,7 +91,7 @@ public class TransactionProcessorTest extends AbstractProcessorTest {
 
     @Test
     public void shouldPropagateSameTransactionIdWithCustomHeader() {
-        transactionProcessor = new TransactionProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER);
+        transactionProcessor = new TransactionPreProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER);
         String transactionId = UUID.toString(UUID.random());
         String requestId = UUID.toString(UUID.random());
         when(mockRequest.id()).thenReturn(requestId);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionProcessorFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionProcessorFactoryTest.java
@@ -15,8 +15,8 @@
  */
 package io.gravitee.gateway.jupiter.reactor.processor.transaction;
 
-import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionProcessorFactory.DEFAULT_REQUEST_ID_HEADER;
-import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionProcessorFactory.DEFAULT_TRANSACTION_ID_HEADER;
+import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionHeader.DEFAULT_REQUEST_ID_HEADER;
+import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import org.junit.jupiter.api.Test;
@@ -33,7 +33,7 @@ public class TransactionProcessorFactoryTest {
             DEFAULT_TRANSACTION_ID_HEADER,
             DEFAULT_REQUEST_ID_HEADER
         );
-        TransactionProcessor transactionProcessor = transactionProcessorFactory.create();
+        TransactionPreProcessor transactionProcessor = transactionProcessorFactory.create();
         assertThat(transactionProcessor.transactionHeader()).isEqualTo(DEFAULT_TRANSACTION_ID_HEADER);
         assertThat(transactionProcessor.requestHeader()).isEqualTo(DEFAULT_REQUEST_ID_HEADER);
     }
@@ -44,7 +44,7 @@ public class TransactionProcessorFactoryTest {
             "CUSTOM_TRANSACTION_ID_HEADER",
             "CUSTOM_REQUEST_ID_HEADER"
         );
-        TransactionProcessor transactionProcessor = transactionProcessorFactory.create();
+        TransactionPreProcessor transactionProcessor = transactionProcessorFactory.create();
         assertThat(transactionProcessor.transactionHeader()).isEqualTo("CUSTOM_TRANSACTION_ID_HEADER");
         assertThat(transactionProcessor.requestHeader()).isEqualTo("CUSTOM_REQUEST_ID_HEADER");
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessorTest.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.gateway.reactor.processor.transaction;
 
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_REQUEST_ID_HEADER;
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER;
+
 import io.gravitee.common.utils.UUID;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
@@ -35,7 +38,7 @@ import org.mockito.MockitoAnnotations;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class TransactionProcessorTest {
+public class TransactionRequestProcessorTest {
 
     private static final String CUSTOM_TRANSACTION_ID_HEADER = "X-My-Transaction-Id";
     private static final String CUSTOM_REQUEST_ID_HEADER = "X-My-Request-Id";
@@ -63,28 +66,19 @@ public class TransactionProcessorTest {
 
         Mockito.when(request.id()).thenReturn(UUID.toString(UUID.random()));
 
-        new TransactionProcessor()
+        new TransactionRequestProcessor()
             .handler(
                 context -> {
                     Assert.assertNotNull(context.request().transactionId());
                     Assert.assertEquals(
                         context.request().transactionId(),
-                        context.request().headers().getFirst(TransactionProcessor.DEFAULT_TRANSACTION_ID_HEADER)
+                        context.request().headers().getFirst(DEFAULT_TRANSACTION_ID_HEADER)
                     );
                     Assert.assertEquals(context.request().transactionId(), context.request().metrics().getTransactionId());
-                    Assert.assertEquals(
-                        context.request().transactionId(),
-                        response.headers().getFirst(TransactionProcessor.DEFAULT_TRANSACTION_ID_HEADER)
-                    );
+                    Assert.assertEquals(context.request().transactionId(), response.headers().getFirst(DEFAULT_TRANSACTION_ID_HEADER));
 
-                    Assert.assertEquals(
-                        context.request().id(),
-                        context.request().headers().getFirst(TransactionProcessor.DEFAULT_REQUEST_ID_HEADER)
-                    );
-                    Assert.assertEquals(
-                        context.request().id(),
-                        response.headers().getFirst(TransactionProcessor.DEFAULT_REQUEST_ID_HEADER)
-                    );
+                    Assert.assertEquals(context.request().id(), context.request().headers().getFirst(DEFAULT_REQUEST_ID_HEADER));
+                    Assert.assertEquals(context.request().id(), response.headers().getFirst(DEFAULT_REQUEST_ID_HEADER));
 
                     lock.countDown();
                 }
@@ -100,32 +94,20 @@ public class TransactionProcessorTest {
 
         String transactionId = UUID.toString(UUID.random());
 
-        request.headers().set(TransactionProcessor.DEFAULT_TRANSACTION_ID_HEADER, transactionId);
-        new TransactionProcessor()
+        request.headers().set(DEFAULT_TRANSACTION_ID_HEADER, transactionId);
+        new TransactionRequestProcessor()
             .handler(
                 context -> {
                     Assert.assertNotNull(context.request().transactionId());
                     Assert.assertEquals(transactionId, context.request().transactionId());
-                    Assert.assertEquals(
-                        transactionId,
-                        context.request().headers().getFirst(TransactionProcessor.DEFAULT_TRANSACTION_ID_HEADER)
-                    );
+                    Assert.assertEquals(transactionId, context.request().headers().getFirst(DEFAULT_TRANSACTION_ID_HEADER));
                     Assert.assertEquals(transactionId, context.request().metrics().getTransactionId());
-                    Assert.assertEquals(
-                        context.request().transactionId(),
-                        response.headers().getFirst(TransactionProcessor.DEFAULT_TRANSACTION_ID_HEADER)
-                    );
+                    Assert.assertEquals(context.request().transactionId(), response.headers().getFirst(DEFAULT_TRANSACTION_ID_HEADER));
 
                     Assert.assertNotEquals(transactionId, context.request().id());
-                    Assert.assertNotEquals(
-                        transactionId,
-                        context.request().headers().getFirst(TransactionProcessor.DEFAULT_REQUEST_ID_HEADER)
-                    );
+                    Assert.assertNotEquals(transactionId, context.request().headers().getFirst(DEFAULT_REQUEST_ID_HEADER));
                     Assert.assertNotEquals(transactionId, context.request().metrics().getRequestId());
-                    Assert.assertEquals(
-                        context.request().id(),
-                        response.headers().getFirst(TransactionProcessor.DEFAULT_REQUEST_ID_HEADER)
-                    );
+                    Assert.assertEquals(context.request().id(), response.headers().getFirst(DEFAULT_REQUEST_ID_HEADER));
 
                     lock.countDown();
                 }
@@ -141,7 +123,7 @@ public class TransactionProcessorTest {
 
         Mockito.when(request.id()).thenReturn(UUID.toString(UUID.random()));
 
-        new TransactionProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER)
+        new TransactionRequestProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER)
             .handler(
                 context -> {
                     Assert.assertNotNull(context.request().transactionId());
@@ -166,7 +148,7 @@ public class TransactionProcessorTest {
         String transactionId = UUID.toString(UUID.random());
 
         request.headers().set(CUSTOM_TRANSACTION_ID_HEADER, transactionId);
-        new TransactionProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER)
+        new TransactionRequestProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER)
             .handler(
                 context -> {
                     Assert.assertNotNull(context.request().transactionId());

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessorTest.java
@@ -25,8 +25,6 @@ import io.gravitee.gateway.api.context.MutableExecutionContext;
 import io.gravitee.gateway.api.context.SimpleExecutionContext;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.reporter.api.http.Metrics;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,111 +54,59 @@ public class TransactionRequestProcessorTest {
         MockitoAnnotations.initMocks(this);
         context = new SimpleExecutionContext(request, response);
         Mockito.when(request.headers()).thenReturn(HttpHeaders.create());
-        Mockito.when(response.headers()).thenReturn(HttpHeaders.create());
         Mockito.when(request.metrics()).thenReturn(Metrics.on(System.currentTimeMillis()).build());
     }
 
     @Test
     public void shouldHaveTransactionId() throws InterruptedException {
-        final CountDownLatch lock = new CountDownLatch(1);
-
         Mockito.when(request.id()).thenReturn(UUID.toString(UUID.random()));
 
-        new TransactionRequestProcessor()
-            .handler(
-                context -> {
-                    Assert.assertNotNull(context.request().transactionId());
-                    Assert.assertEquals(
-                        context.request().transactionId(),
-                        context.request().headers().getFirst(DEFAULT_TRANSACTION_ID_HEADER)
-                    );
-                    Assert.assertEquals(context.request().transactionId(), context.request().metrics().getTransactionId());
-                    Assert.assertEquals(context.request().transactionId(), response.headers().getFirst(DEFAULT_TRANSACTION_ID_HEADER));
+        new TransactionRequestProcessor().handler(context -> {}).handle(context);
 
-                    Assert.assertEquals(context.request().id(), context.request().headers().getFirst(DEFAULT_REQUEST_ID_HEADER));
-                    Assert.assertEquals(context.request().id(), response.headers().getFirst(DEFAULT_REQUEST_ID_HEADER));
-
-                    lock.countDown();
-                }
-            )
-            .handle(context);
-
-        Assert.assertTrue(lock.await(10000, TimeUnit.MILLISECONDS));
+        Assert.assertNotNull(context.request().transactionId());
+        Assert.assertEquals(context.request().transactionId(), context.request().headers().get(DEFAULT_TRANSACTION_ID_HEADER));
+        Assert.assertEquals(context.request().transactionId(), context.request().metrics().getTransactionId());
+        Assert.assertEquals(context.request().id(), context.request().headers().get(DEFAULT_REQUEST_ID_HEADER));
     }
 
     @Test
-    public void shouldPropagateSameTransactionId() throws InterruptedException {
-        final CountDownLatch lock = new CountDownLatch(1);
-
+    public void shouldPropagateSameTransactionId() {
         String transactionId = UUID.toString(UUID.random());
 
         request.headers().set(DEFAULT_TRANSACTION_ID_HEADER, transactionId);
-        new TransactionRequestProcessor()
-            .handler(
-                context -> {
-                    Assert.assertNotNull(context.request().transactionId());
-                    Assert.assertEquals(transactionId, context.request().transactionId());
-                    Assert.assertEquals(transactionId, context.request().headers().getFirst(DEFAULT_TRANSACTION_ID_HEADER));
-                    Assert.assertEquals(transactionId, context.request().metrics().getTransactionId());
-                    Assert.assertEquals(context.request().transactionId(), response.headers().getFirst(DEFAULT_TRANSACTION_ID_HEADER));
+        new TransactionRequestProcessor().handler(context -> {}).handle(context);
 
-                    Assert.assertNotEquals(transactionId, context.request().id());
-                    Assert.assertNotEquals(transactionId, context.request().headers().getFirst(DEFAULT_REQUEST_ID_HEADER));
-                    Assert.assertNotEquals(transactionId, context.request().metrics().getRequestId());
-                    Assert.assertEquals(context.request().id(), response.headers().getFirst(DEFAULT_REQUEST_ID_HEADER));
+        Assert.assertNotNull(context.request().transactionId());
+        Assert.assertEquals(transactionId, context.request().transactionId());
+        Assert.assertEquals(transactionId, context.request().headers().get(DEFAULT_TRANSACTION_ID_HEADER));
+        Assert.assertEquals(transactionId, context.request().metrics().getTransactionId());
 
-                    lock.countDown();
-                }
-            )
-            .handle(context);
-
-        Assert.assertTrue(lock.await(10000, TimeUnit.MILLISECONDS));
+        Assert.assertNotEquals(transactionId, context.request().id());
+        Assert.assertNotEquals(transactionId, context.request().headers().get(DEFAULT_REQUEST_ID_HEADER));
+        Assert.assertNotEquals(transactionId, context.request().metrics().getRequestId());
     }
 
     @Test
-    public void shouldHaveTransactionIdWithCustomHeader() throws InterruptedException {
-        final CountDownLatch lock = new CountDownLatch(1);
-
+    public void shouldHaveTransactionIdWithCustomHeader() {
         Mockito.when(request.id()).thenReturn(UUID.toString(UUID.random()));
 
-        new TransactionRequestProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER)
-            .handler(
-                context -> {
-                    Assert.assertNotNull(context.request().transactionId());
-                    Assert.assertEquals(
-                        context.request().transactionId(),
-                        context.request().headers().getFirst(CUSTOM_TRANSACTION_ID_HEADER)
-                    );
-                    Assert.assertEquals(context.request().transactionId(), context.request().metrics().getTransactionId());
-                    Assert.assertEquals(context.request().transactionId(), response.headers().getFirst(CUSTOM_TRANSACTION_ID_HEADER));
-                    lock.countDown();
-                }
-            )
-            .handle(context);
+        new TransactionRequestProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER).handler(context -> {}).handle(context);
 
-        Assert.assertTrue(lock.await(10000, TimeUnit.MILLISECONDS));
+        Assert.assertNotNull(context.request().transactionId());
+        Assert.assertEquals(context.request().transactionId(), context.request().headers().get(CUSTOM_TRANSACTION_ID_HEADER));
+        Assert.assertEquals(context.request().transactionId(), context.request().metrics().getTransactionId());
     }
 
     @Test
     public void shouldPropagateSameTransactionIdWithCustomHeader() throws InterruptedException {
-        final CountDownLatch lock = new CountDownLatch(1);
-
         String transactionId = UUID.toString(UUID.random());
 
         request.headers().set(CUSTOM_TRANSACTION_ID_HEADER, transactionId);
-        new TransactionRequestProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER)
-            .handler(
-                context -> {
-                    Assert.assertNotNull(context.request().transactionId());
-                    Assert.assertEquals(transactionId, context.request().transactionId());
-                    Assert.assertEquals(transactionId, context.request().headers().getFirst(CUSTOM_TRANSACTION_ID_HEADER));
-                    Assert.assertEquals(transactionId, context.request().metrics().getTransactionId());
-                    Assert.assertEquals(context.request().transactionId(), response.headers().getFirst(CUSTOM_TRANSACTION_ID_HEADER));
-                    lock.countDown();
-                }
-            )
-            .handle(context);
+        new TransactionRequestProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER).handler(context -> {}).handle(context);
 
-        Assert.assertTrue(lock.await(10000, TimeUnit.MILLISECONDS));
+        Assert.assertNotNull(context.request().transactionId());
+        Assert.assertEquals(transactionId, context.request().transactionId());
+        Assert.assertEquals(transactionId, context.request().headers().get(CUSTOM_TRANSACTION_ID_HEADER));
+        Assert.assertEquals(transactionId, context.request().metrics().getTransactionId());
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -76,12 +76,12 @@
 # For more information about MongoDB configuration, please have a look to:
 # - http://mongodb.github.io/mongo-java-driver/4.1/apidocs/mongodb-driver-core/com/mongodb/MongoClientSettings.Builder.html
 management:
-  type: mongodb                  # repository type
-  mongodb:                       # mongodb repository
-#    prefix:                      # collections prefix
-    dbname: ${ds.mongodb.dbname} # mongodb name (default gravitee)
-    host: ${ds.mongodb.host}     # mongodb host (default localhost)
-    port: ${ds.mongodb.port}     # mongodb port (default 27017)
+    type: mongodb # repository type
+    mongodb: # mongodb repository
+        #    prefix:                      # collections prefix
+        dbname: ${ds.mongodb.dbname} # mongodb name (default gravitee)
+        host: ${ds.mongodb.host} # mongodb host (default localhost)
+        port: ${ds.mongodb.port} # mongodb port (default 27017)
 
 ## Client settings
 #    description:                 # mongodb description (default gravitee.io)
@@ -151,67 +151,67 @@ management:
 # When defining rate-limiting policy, the gateway has to store data to share with other gateway instances.
 # In this example, we are using MongoDB to store counters.
 ratelimit:
-  type: mongodb
-  mongodb:
-    uri: mongodb://${ds.mongodb.host}:${ds.mongodb.port}/${ds.mongodb.dbname}
+    type: mongodb
+    mongodb:
+        uri: mongodb://${ds.mongodb.host}:${ds.mongodb.port}/${ds.mongodb.dbname}
 
 cache:
-  type: ehcache
+    type: ehcache
 
 # Reporters configuration (used to store reporting monitoring data, request metrics, healthchecks and others...
 # All reporters are enabled by default. To stop one of them, you have to add the property 'enabled: false'
 reporters:
-  # logging configuration
-#  logging:
-#    max_size: -1 # max size per API log content respectively : client-request, client-response, proxy-request and proxy-response in MB (-1 means no limit)
-#    excluded_response_types: video.*|audio.*|image.*|application\/octet-stream|application\/pdf # Response content types to exclude in logging (must be a regular expression)
-  # Elasticsearch reporter
-  elasticsearch:
-    enabled: true # Is the reporter enabled or not (default to true)
-    endpoints:
-      - http://${ds.elastic.host}:${ds.elastic.port}
-#    lifecycle:
-#      policy_property_name: index.lifecycle.name   #for openDistro, use 'opendistro.index_state_management.policy_id' instead of 'index.lifecycle.name'
-#      policies:
-#        monitor: my_policy ## ILM policy for the gravitee-monitor-* indexes
-#        request: my_policy ## ILM policy for the gravitee-request-* indexes
-#        health: my_policy ## ILM policy for the gravitee-health-* indexes
-#        log: my_policy ## ILM policy for the gravitee-log-* indexes
-#    index: gravitee
-#    index_per_type: true
-#    index_mode: daily         # "daily" indexes, suffixed with date. Or "ilm" managed indexes, without date
-#    bulk:
-#      actions: 1000           # Number of requests action before flush
-#      flush_interval: 5       # Flush interval in seconds
-#    settings:
-#      number_of_shards: 1
-#      number_of_replicas: 1
-#      refresh_interval: 5s
-#    pipeline:
-#      plugins:
-#        ingest: geoip, user_agent      # geoip and user_agent are enabled by default
-#    security:
-#      username: user
-#      password: secret
-#    http:
-#      timeout: 30000 # in milliseconds
-#      proxy:
-#        type: HTTP #HTTP, SOCK4, SOCK5
-#        http:
-#          host: localhost
-#          port: 3128
-#          username: user
-#          password: secret
-#        https:
-#          host: localhost
-#          port: 3128
-#          username: user
-#          password: secret
-#    template_mapping:
-#      path: ${gravitee.home}/config/reporter/elasticsearch/templates
-#      extended_request_mapping: request.ftl
-  file:
-    enabled: false # Is the reporter enabled or not (default to false)
+    # logging configuration
+    #  logging:
+    #    max_size: -1 # max size per API log content respectively : client-request, client-response, proxy-request and proxy-response in MB (-1 means no limit)
+    #    excluded_response_types: video.*|audio.*|image.*|application\/octet-stream|application\/pdf # Response content types to exclude in logging (must be a regular expression)
+    # Elasticsearch reporter
+    elasticsearch:
+        enabled: true # Is the reporter enabled or not (default to true)
+        endpoints:
+            - http://${ds.elastic.host}:${ds.elastic.port}
+    #    lifecycle:
+    #      policy_property_name: index.lifecycle.name   #for openDistro, use 'opendistro.index_state_management.policy_id' instead of 'index.lifecycle.name'
+    #      policies:
+    #        monitor: my_policy ## ILM policy for the gravitee-monitor-* indexes
+    #        request: my_policy ## ILM policy for the gravitee-request-* indexes
+    #        health: my_policy ## ILM policy for the gravitee-health-* indexes
+    #        log: my_policy ## ILM policy for the gravitee-log-* indexes
+    #    index: gravitee
+    #    index_per_type: true
+    #    index_mode: daily         # "daily" indexes, suffixed with date. Or "ilm" managed indexes, without date
+    #    bulk:
+    #      actions: 1000           # Number of requests action before flush
+    #      flush_interval: 5       # Flush interval in seconds
+    #    settings:
+    #      number_of_shards: 1
+    #      number_of_replicas: 1
+    #      refresh_interval: 5s
+    #    pipeline:
+    #      plugins:
+    #        ingest: geoip, user_agent      # geoip and user_agent are enabled by default
+    #    security:
+    #      username: user
+    #      password: secret
+    #    http:
+    #      timeout: 30000 # in milliseconds
+    #      proxy:
+    #        type: HTTP #HTTP, SOCK4, SOCK5
+    #        http:
+    #          host: localhost
+    #          port: 3128
+    #          username: user
+    #          password: secret
+    #        https:
+    #          host: localhost
+    #          port: 3128
+    #          username: user
+    #          password: secret
+    #    template_mapping:
+    #      path: ${gravitee.home}/config/reporter/elasticsearch/templates
+    #      extended_request_mapping: request.ftl
+    file:
+        enabled: false # Is the reporter enabled or not (default to false)
 #    fileName: ${gravitee.home}/metrics/%s-yyyy_mm_dd
 #    output: json # Can be csv, json, elasticsearch or message_pack
 #    request: # (Following mapping section is also available for other types: node, health-check, log)
@@ -228,82 +228,84 @@ reporters:
 # All services are enabled by default. To stop one of them, you have to add the property 'enabled: false' (See the
 # 'local' service for an example).
 services:
-  core:
-    http:
-      enabled: true
-      port: 18082
-      host: localhost
-      authentication:
-        # authentication type to be used for the core services
-        # - none : to disable authentication
-        # - basic : to use basic authentication
-        # default is "basic"
-        type: basic
-        users:
-          admin: adminadmin
+    core:
+        http:
+            enabled: true
+            port: 18082
+            host: localhost
+            authentication:
+                # authentication type to be used for the core services
+                # - none : to disable authentication
+                # - basic : to use basic authentication
+                # default is "basic"
+                type: basic
+                users:
+                    admin: adminadmin
 
-  # The thresholds to determine if a probe is healthy or not
-#  health:
-#    threshold:
-#      cpu: # Default is 80%
-#      memory: # Default is 80%
+    # The thresholds to determine if a probe is healthy or not
+    #  health:
+    #    threshold:
+    #      cpu: # Default is 80%
+    #      memory: # Default is 80%
 
-  # Synchronization daemon used to keep the gateway state in sync with the configuration from the management repository
-  # Be aware that, by disabling it, the gateway will not be sync with the configuration done through management API
-  # and management UI
-  sync:
-    # Synchronization is done each 5 seconds
-    delay: 5000
-    unit: MILLISECONDS
-    distributed: false # By enabling this mode, data synchronization process is distributed over clustered API gateways.
-    bulk_items: 100 # Defines the number of items to retrieve during synchronization (events, plans, api keys, ...).
+    # Synchronization daemon used to keep the gateway state in sync with the configuration from the management repository
+    # Be aware that, by disabling it, the gateway will not be sync with the configuration done through management API
+    # and management UI
+    sync:
+        # Synchronization is done each 5 seconds
+        delay: 5000
+        unit: MILLISECONDS
+        distributed: false # By enabling this mode, data synchronization process is distributed over clustered API gateways.
+        bulk_items:
+            100 # Defines the number of items to retrieve during synchronization (events, plans, api keys, ...).
 
-     # [Alpha] Enable Kubernetes Synchronization
-     # This sync service requires to install Gravitee Kubernetes Operator
-#    kubernetes:
-#      enabled: false
 
-  # Local registry service.
-  # This registry is used to load API Definition with json format from the file system. By doing so, you do not need
-  # to configure your API using the web console or the rest API (but you need to know and understand the json descriptor
-  # format to make it work....)
-  local:
-    enabled: false
-    path: ${gravitee.home}/apis # The path to API descriptors
+            # [Alpha] Enable Kubernetes Synchronization
+            # This sync service requires to install Gravitee Kubernetes Operator
+    #    kubernetes:
+    #      enabled: false
 
-  # Gateway monitoring service.
-  # This service retrieves metrics like os / process / jvm metrics and send them to an underlying reporting service.
-  monitoring:
-    delay: 5000
-    unit: MILLISECONDS
-    distributed: false # By enabling this mode, data monitoring gathering process is distributed over clustered API gateways.
+    # Local registry service.
+    # This registry is used to load API Definition with json format from the file system. By doing so, you do not need
+    # to configure your API using the web console or the rest API (but you need to know and understand the json descriptor
+    # format to make it work....)
+    local:
+        enabled: false
+        path: ${gravitee.home}/apis # The path to API descriptors
 
-  # metrics service
-  metrics:
-    enabled: false
-# default: local, http_method, http_code
-#    labels:
-#      - local
-#      - remote
-#      - http_method
-#      - http_code
-#      - http_path
-    prometheus:
-      enabled: true
+    # Gateway monitoring service.
+    # This service retrieves metrics like os / process / jvm metrics and send them to an underlying reporting service.
+    monitoring:
+        delay: 5000
+        unit: MILLISECONDS
+        distributed: false # By enabling this mode, data monitoring gathering process is distributed over clustered API gateways.
 
-  # heartbeat
-#  heartbeat:
-#    enabled: true
-#    delay: 5000
-#    unit: MILLISECONDS
-#    storeSystemProperties: true
+    # metrics service
+    metrics:
+        enabled: false
+        # default: local, http_method, http_code
+        #    labels:
+        #      - local
+        #      - remote
+        #      - http_method
+        #      - http_code
+        #      - http_path
+        prometheus:
+            enabled: true
 
-  tracing:
-    enabled: false
-    type: jaeger
-    jaeger:
-      host: localhost
-      port: 14250
+    # heartbeat
+    #  heartbeat:
+    #    enabled: true
+    #    delay: 5000
+    #    unit: MILLISECONDS
+    #    storeSystemProperties: true
+
+    tracing:
+        enabled: false
+        type: jaeger
+        jaeger:
+            host: localhost
+            port: 14250
 #      ssl:
 #        enabled: false
 
@@ -314,25 +316,35 @@ services:
 #      enabled: false
 #    # possible values: hex, uuid. Default: uuid.
 #    format: uuid
-#    transaction:
-#      # Default: X-Gravitee-Transaction-Id.
-#      header: X-Gravitee-Transaction-Id
 #    headers:
 #      # Override X-Forwarded-Prefix with context path. Disabled by default.
 #      x-forwarded-prefix: false
+#    transaction:
+#      # Default: X-Gravitee-Transaction-Id.
+#      header: X-Gravitee-Transaction-Id
+#      # Possible values of overrideMode are:
+#      #   - override: The header set by the APIM Gateway will override the one provided by the backend
+#      #   - merge: Both headers set by the APIM Gateway and the backend will be kept (as headers can be multivalued)
+#      #   - keep: The header set by the backend will be kept and the one provided by the APIM Gateway discarded
+#      overrideMode: override
 #    request:
 #      # Default: X-Gravitee-Request-Id.
 #      header: X-Gravitee-Request-Id
+#      # Possible values of overrideMode are:
+#      #   - override: The header set by the APIM Gateway will override the one provided by the backend
+#      #   - merge: Both headers set by the APIM Gateway and the backend will be kept (as headers can be multivalued)
+#      #   - keep: The header set by the backend will be kept and the one provided by the APIM Gateway discarded
+#      overrideMode: override
 
 # Referenced properties
 ds:
-  mongodb:
-    dbname: gravitee
-    host: localhost
-    port: 27017
-  elastic:
-    host: localhost
-    port: 9200
+    mongodb:
+        dbname: gravitee
+        host: localhost
+        port: 27017
+    elastic:
+        host: localhost
+        port: 9200
 
 #system:
 #  # Proxy configuration that can be used to proxy request to api endpoints (see endpoint http configuration -> Use system proxy).
@@ -365,43 +377,43 @@ ds:
 #    param: api-key
 
 #el:
-  # Allows to define which methods or classes are accessible to the Expression Language engine (/!\ caution, changing default whitelist may expose you to security issues).
-  # A complete list of default whitelist methods can be found here (https://raw.githubusercontent.com/gravitee-io/gravitee-expression-language/master/src/main/resources/whitelist).
+# Allows to define which methods or classes are accessible to the Expression Language engine (/!\ caution, changing default whitelist may expose you to security issues).
+# A complete list of default whitelist methods can be found here (https://raw.githubusercontent.com/gravitee-io/gravitee-expression-language/master/src/main/resources/whitelist).
 #  whitelist:
-    # Allows to define if the specified list of method or classes should be append to the default one or should replace it.
-    # We recommend you to always choose 'append' unless you absolutely know what you are doing.
+# Allows to define if the specified list of method or classes should be append to the default one or should replace it.
+# We recommend you to always choose 'append' unless you absolutely know what you are doing.
 #    mode: append
-    # Define the list of classes or methods to append (or set) to made accessible to the Expression Language.
-    # start with 'method' to allow a specific method (complete signature).
-    # start with 'class' to allow a complete class. All methods of the class will then be accessible.
+# Define the list of classes or methods to append (or set) to made accessible to the Expression Language.
+# start with 'method' to allow a specific method (complete signature).
+# start with 'class' to allow a complete class. All methods of the class will then be accessible.
 #    list:
-      # Ex: allow access to DateTimeFormatter.ofLocalizedDate(FormatStyle) method
-      # - method java.time.format.DateTimeFormatter ofLocalizedDate java.time.format.FormatStyle
-      # Ex: allow access to all methods of DateTimeFormatter class
-      # - class java.time.format.DateTimeFormatter
+# Ex: allow access to DateTimeFormatter.ofLocalizedDate(FormatStyle) method
+# - method java.time.format.DateTimeFormatter ofLocalizedDate java.time.format.FormatStyle
+# Ex: allow access to all methods of DateTimeFormatter class
+# - class java.time.format.DateTimeFormatter
 
 #groovy:
-  # Allows to define which methods, fields, constructors, annotations or classes are accessible to the Groovy Script (/!\ caution, changing default whitelist may expose you to security issues).
-  # A complete list of default whitelist methods can be found here (https://raw.githubusercontent.com/gravitee-io/gravitee-policy-groovy/master/src/main/resources/groovy-whitelist).
+# Allows to define which methods, fields, constructors, annotations or classes are accessible to the Groovy Script (/!\ caution, changing default whitelist may expose you to security issues).
+# A complete list of default whitelist methods can be found here (https://raw.githubusercontent.com/gravitee-io/gravitee-policy-groovy/master/src/main/resources/groovy-whitelist).
 #  whitelist:
-    # Allows to define if the specified list of methods, fields, constructors or classes should be append to the default one or should replace it.
-    # We recommend you to always choose 'append' unless you absolutely know what you are doing.
+# Allows to define if the specified list of methods, fields, constructors or classes should be append to the default one or should replace it.
+# We recommend you to always choose 'append' unless you absolutely know what you are doing.
 #    mode: append
-    # Define the list of classes, methods, constructors, fields or annotations to append (or set) to made accessible to the Groovy Script.
-    # start with 'method' to allow a specific method (complete signature).
-    # start with 'class' to allow a complete class. All methods, constructors and fields of the class will then be accessible.
-    # start with 'new' to allow a specific constructor (complete signature).
-    # start with 'field' to allow access to a specific field of a class.
-    # start with 'annotation' to allow use of a specific annotation.
+# Define the list of classes, methods, constructors, fields or annotations to append (or set) to made accessible to the Groovy Script.
+# start with 'method' to allow a specific method (complete signature).
+# start with 'class' to allow a complete class. All methods, constructors and fields of the class will then be accessible.
+# start with 'new' to allow a specific constructor (complete signature).
+# start with 'field' to allow access to a specific field of a class.
+# start with 'annotation' to allow use of a specific annotation.
 #    list:
-      # Ex: allow access to DateTimeFormatter.ofLocalizedDate(FormatStyle) method
-      # - method java.time.format.DateTimeFormatter ofLocalizedDate java.time.format.FormatStyle
-      # Ex: allow access to all methods, constructors and fields of DateTimeFormatter class
-      # - class java.time.format.DateTimeFormatter
-      # Ex: allow usage of field Integer.MAX_VALUE
-      # - field java.lang.Integer MAX_VALUE
-      # Ex: allow usage of @Override annotation
-      # - annotation java.lang.Override
+# Ex: allow access to DateTimeFormatter.ofLocalizedDate(FormatStyle) method
+# - method java.time.format.DateTimeFormatter ofLocalizedDate java.time.format.FormatStyle
+# Ex: allow access to all methods, constructors and fields of DateTimeFormatter class
+# - class java.time.format.DateTimeFormatter
+# Ex: allow usage of field Integer.MAX_VALUE
+# - field java.lang.Integer MAX_VALUE
+# Ex: allow usage of @Override annotation
+# - annotation java.lang.Override
 
 # If you want to create cluster of nodes, you can change the Hazelcast file to configure the Hz network
 # Clustering capabilities can be used for:
@@ -422,25 +434,25 @@ ds:
 #        capacity: 8200  #if null defaults to 4096
 
 api:
-  # Encrypt API properties using this secret
-  properties:
-    encryption:
-      secret: vvLJ4Q8Khvv9tm2tIPdkGEdmgKUruAL6
-  # when an API is un-deployed (either because it has been stopped or because it has restarted due to a configuration
-  # change), this timeout will be the maximum time (in milliseconds) to wait for all pending requests to terminate
+    # Encrypt API properties using this secret
+    properties:
+        encryption:
+            secret: vvLJ4Q8Khvv9tm2tIPdkGEdmgKUruAL6
+    # when an API is un-deployed (either because it has been stopped or because it has restarted due to a configuration
+    # change), this timeout will be the maximum time (in milliseconds) to wait for all pending requests to terminate
 #  pending_requests_timeout: 10000
 
 # Graceful shutdown.
 #gracefulShutdown:
-  # Default delay is 0 but it can be useful to set it to an adequate value depending on how much time the load balancer takes to stop routing traffic to a gateway instance which is shutting down.
-  # When SIGTERM is sent to the gateway, the shutdown process begin, each client will be explicitly asked for closing connection and the shutdown delay will be applied.
-  # The shutdown delay should allow enough time to client to close their current active connections and create new one. In the same time the load balancer should progressively stop routing traffic to the gateway.
-  # After the delay is expired, the gateway continue the shutdown process. Any pending request will have a chance to finish gracefully and the gateway will stop normally unless it takes too much time and a SIGKILL signal is sent to the gateway.
+# Default delay is 0 but it can be useful to set it to an adequate value depending on how much time the load balancer takes to stop routing traffic to a gateway instance which is shutting down.
+# When SIGTERM is sent to the gateway, the shutdown process begin, each client will be explicitly asked for closing connection and the shutdown delay will be applied.
+# The shutdown delay should allow enough time to client to close their current active connections and create new one. In the same time the load balancer should progressively stop routing traffic to the gateway.
+# After the delay is expired, the gateway continue the shutdown process. Any pending request will have a chance to finish gracefully and the gateway will stop normally unless it takes too much time and a SIGKILL signal is sent to the gateway.
 #  delay: 0
 #  unit: MILLISECONDS
 
 # Since v3.15.0, a new internal classloader used to load api policies is in place.
 # Setting it to true will switch back to the legacy mode used prior the v3.15.0.
 classloader:
-  legacy:
-    enabled: false
+    legacy:
+        enabled: false


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-75
https://github.com/gravitee-io/issues/issues/7618

## Description

Apply https://github.com/gravitee-io/gravitee-api-management/pull/3169 on 3.19.x + jupiter mode
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-75-add-backendoverridemode-3-19-x/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vybzkslaoo.chromatic.com)
<!-- Storybook placeholder end -->
