### PR TITLE
Use JSON schema with JS-YAML lib to convert YAML to JSON

### DIFF
--- a/gravitee-apim-portal-webui/src/app/utils/yaml-parser.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/utils/yaml-parser.spec.ts
@@ -32,10 +32,10 @@ describe('yamlToJson', () => {
           example: john@doe.com
       home_phone:
           type: integer
-          example: 0606060606
+          example: "0606060606"
       mobile_phone:
           type: string
-          example: +33606060606
+          example: "+33606060606"
       budget_balance:
           type: integer
           example: -300
@@ -47,18 +47,18 @@ describe('yamlToJson', () => {
           example: -0.1
       rank:
           type: number
-          example: 05
+          example: "05"
     `;
 
     const expected = JSON.stringify({
       birthdate: { type: 'string', format: 'date', example: '1980-12-12' },
-      active: { type: 'boolean', example: 'TRUE' },
+      active: { type: 'boolean', example: true },
       email: { type: 'string', format: 'email', example: 'john@doe.com' },
       home_phone: { type: 'integer', example: '0606060606' },
       mobile_phone: { type: 'string', example: '+33606060606' },
-      budget_balance: { type: 'integer', example: '-300' },
-      error_rate: { type: 'number', example: '0.8' },
-      forecast_error_rate: { type: 'number', example: '-0.1' },
+      budget_balance: { type: 'integer', example: -300 },
+      error_rate: { type: 'number', example: 0.8 },
+      forecast_error_rate: { type: 'number', example: -0.1 },
       rank: { type: 'number', example: '05' },
     });
 

--- a/gravitee-apim-portal-webui/src/app/utils/yaml-parser.ts
+++ b/gravitee-apim-portal-webui/src/app/utils/yaml-parser.ts
@@ -15,7 +15,7 @@
  */
 import * as jsYAML from 'js-yaml';
 
-const schema = jsYAML.FAILSAFE_SCHEMA.extend([]);
+const schema = jsYAML.JSON_SCHEMA.extend([]);
 
 export function readYaml(content: string): any {
   return jsYAML.load(content, { schema });


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-840
https://github.com/gravitee-io/issues/issues/7099

## Description

According to the [documentation](https://github.com/nodeca/js-yaml#load-string---options-)
FAILSAFE_SCHEMA will generate only strings, arrays and plain objects.

We need JSON_SCHEMA.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-840-fix-yaml-parsing/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xnwqozoeln.chromatic.com)
<!-- Storybook placeholder end -->
