### PR TITLE
fix: bump traffic shadowing version to 2.0.0

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -85,7 +85,7 @@
         <gravitee-policy-retry.version>2.1.0</gravitee-policy-retry.version>
         <gravitee-policy-role-based-access-control.version>1.1.0</gravitee-policy-role-based-access-control.version>
         <gravitee-policy-ssl-enforcement.version>1.2.1</gravitee-policy-ssl-enforcement.version>
-        <gravitee-policy-traffic-shadowing.version>1.1.0</gravitee-policy-traffic-shadowing.version>
+        <gravitee-policy-traffic-shadowing.version>2.0.0</gravitee-policy-traffic-shadowing.version>
         <gravitee-policy-transformheaders.version>1.10.0</gravitee-policy-transformheaders.version>
         <gravitee-policy-transformqueryparams.version>1.6.0</gravitee-policy-transformqueryparams.version>
         <gravitee-policy-url-rewriting.version>1.5.0</gravitee-policy-url-rewriting.version>


### PR DESCRIPTION
## issue

https://gravitee.atlassian.net/browse/APIM-892

see https://github.com/gravitee-io/issues/issues/8385

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/bump-trafic-shadowing/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ijsolvcpbz.chromatic.com)
<!-- Storybook placeholder end -->
