### PR TITLE
Handle special characters in user/password of MongoDB uri

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/common/AbstractRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/common/AbstractRepositoryConfiguration.java
@@ -50,7 +50,9 @@ public abstract class AbstractRepositoryConfiguration extends AbstractMongoClien
     protected String getDatabaseName() {
         String uri = environment.getProperty("management.mongodb.uri");
         if (uri != null && !uri.isEmpty()) {
-            return URI.create(uri).getPath().substring(1);
+            // Remove user:password from the URI as it can contain special characters and isn't needed for the database name
+            String uriWithoutCredentials = uri.replaceAll("://.*@", "://");
+            return URI.create(uriWithoutCredentials).getPath().substring(1);
         }
 
         return environment.getProperty("management.mongodb.dbname", "gravitee");

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/common/AbstractRepositoryConfigurationTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/common/AbstractRepositoryConfigurationTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.common;
+
+import static org.junit.Assert.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+public class AbstractRepositoryConfigurationTest {
+
+    private AbstractRepositoryConfiguration abstractRepositoryConfiguration;
+
+    private MockEnvironment environment;
+
+    @Before
+    public void setUp() throws Exception {
+        environment = new MockEnvironment();
+        abstractRepositoryConfiguration = new AbstractRepositoryConfiguration(environment) {};
+    }
+
+    @Test
+    public void getDatabaseNameWithURIEnvVar() {
+        // Default database name is gravitee
+        assertEquals("gravitee", abstractRepositoryConfiguration.getDatabaseName());
+
+        environment.setProperty("management.mongodb.uri", "mongodb://localhost:27017/custom-db");
+        assertEquals("custom-db", abstractRepositoryConfiguration.getDatabaseName());
+
+        environment.setProperty("management.mongodb.uri", "mongodb://user:password@localhost:27017/custom-db?authSource=admin");
+        assertEquals("custom-db", abstractRepositoryConfiguration.getDatabaseName());
+
+        environment.setProperty("management.mongodb.uri", "mongodb://user:pa#ss+wo*rd@localhost:27017/custom-db?authSource=admin");
+        assertEquals("custom-db", abstractRepositoryConfiguration.getDatabaseName());
+    }
+
+    @Test
+    public void getDatabaseNameWithDBNameEnvVar() {
+        // Default database name is gravitee
+        assertEquals("gravitee", abstractRepositoryConfiguration.getDatabaseName());
+
+        environment.setProperty("management.mongodb.dbname", "custom-db");
+        assertEquals("custom-db", abstractRepositoryConfiguration.getDatabaseName());
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-300
https://github.com/gravitee-io/issues/issues/8643

## Description

Handle special characters in user/password of MongoDB URI.
Some special characters like `#` are keywords for the URI parser.
See: https://docs.oracle.com/javase/6/docs/api/java/net/URI.html
So to avoid any issue we can just remove the user/password part before creating the URI instance as we aren't using them anyway.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bqpdskkhww.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-300-handle-special-characters-in-uri/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
