### PR TITLE
Build branch after a release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1026,7 +1026,7 @@ jobs:
                         sed -i "s#<changelist>.*</changelist>#<changelist>-SNAPSHOT</changelist>#" pom.xml
 
                         git add --update
-                        git commit -m 'chore: prepare next version [skip ci]'
+                        git commit -m 'chore: prepare next version'
 
                         git push -u <<# pipeline.parameters.dry_run >>--dry-run<</ pipeline.parameters.dry_run >> origin ${MAINTENANCE_GIT_BRANCH}
 
@@ -1042,7 +1042,7 @@ jobs:
                       fi;
 
                       git add --update
-                      git commit -m 'chore: prepare next version [skip ci]'
+                      git commit -m 'chore: prepare next version'
 
                       git push -u <<# pipeline.parameters.dry_run >>--dry-run<</ pipeline.parameters.dry_run >> origin ${CIRCLE_BRANCH}
                       git push --tags <<# pipeline.parameters.dry_run >>--dry-run<</ pipeline.parameters.dry_run >> origin ${CIRCLE_BRANCH}


### PR DESCRIPTION
## Issue

N/A

## Description
Do not skip CI after a release, so a new SNAPSHOT version can be generated and deployed on Artifactory for `db_repositories_test_container` CI workflows