### PR TITLE
Add different mode for transaction header override - 3.20.x

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandlerFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandlerFactory.java
@@ -45,6 +45,7 @@ import io.gravitee.gateway.handlers.api.definition.Api;
 import io.gravitee.gateway.handlers.api.processor.OnErrorProcessorChainFactory;
 import io.gravitee.gateway.handlers.api.processor.RequestProcessorChainFactory;
 import io.gravitee.gateway.handlers.api.processor.ResponseProcessorChainFactory;
+import io.gravitee.gateway.handlers.api.processor.transaction.TransactionResponseProcessorConfiguration;
 import io.gravitee.gateway.handlers.api.security.PlanBasedAuthenticationHandlerEnhancer;
 import io.gravitee.gateway.jupiter.handlers.api.SyncApiReactor;
 import io.gravitee.gateway.jupiter.handlers.api.adapter.invoker.InvokerAdapter;
@@ -55,11 +56,7 @@ import io.gravitee.gateway.jupiter.handlers.api.processor.ApiProcessorChainFacto
 import io.gravitee.gateway.jupiter.policy.DefaultPolicyChainFactory;
 import io.gravitee.gateway.jupiter.reactor.v4.reactor.ReactorFactory;
 import io.gravitee.gateway.platform.manager.OrganizationManager;
-import io.gravitee.gateway.policy.PolicyChainProviderLoader;
-import io.gravitee.gateway.policy.PolicyConfigurationFactory;
-import io.gravitee.gateway.policy.PolicyFactory;
-import io.gravitee.gateway.policy.PolicyFactoryCreator;
-import io.gravitee.gateway.policy.PolicyManager;
+import io.gravitee.gateway.policy.*;
 import io.gravitee.gateway.policy.impl.CachedPolicyConfigurationFactory;
 import io.gravitee.gateway.reactor.Reactable;
 import io.gravitee.gateway.reactor.ReactableApi;
@@ -587,7 +584,14 @@ public class ApiReactorHandlerFactory implements ReactorFactory<Api> {
         PolicyChainProviderLoader policyChainProviderLoader,
         FlowPolicyResolverFactory flowPolicyResolverFactory
     ) {
-        return new ResponseProcessorChainFactory(api, policyChainFactory, policyChainProviderLoader, node, flowPolicyResolverFactory);
+        return new ResponseProcessorChainFactory(
+            api,
+            policyChainFactory,
+            policyChainProviderLoader,
+            node,
+            flowPolicyResolverFactory,
+            new TransactionResponseProcessorConfiguration(configuration)
+        );
     }
 
     public OnErrorProcessorChainFactory errorProcessorChainFactory(Api api, PolicyChainFactory policyChainFactory) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/ResponseProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/ResponseProcessorChainFactory.java
@@ -23,7 +23,6 @@ import io.gravitee.gateway.core.condition.ConditionEvaluator;
 import io.gravitee.gateway.flow.BestMatchFlowResolver;
 import io.gravitee.gateway.flow.FlowPolicyResolverFactory;
 import io.gravitee.gateway.flow.SimpleFlowPolicyChainProvider;
-import io.gravitee.gateway.flow.SimpleFlowProvider;
 import io.gravitee.gateway.flow.condition.evaluation.ExpressionLanguageFlowConditionEvaluator;
 import io.gravitee.gateway.flow.condition.evaluation.HttpMethodConditionEvaluator;
 import io.gravitee.gateway.flow.condition.evaluation.PathBasedConditionEvaluator;
@@ -39,6 +38,8 @@ import io.gravitee.gateway.handlers.api.policy.plan.PlanPolicyResolver;
 import io.gravitee.gateway.handlers.api.processor.cors.CorsSimpleRequestProcessor;
 import io.gravitee.gateway.handlers.api.processor.pathmapping.PathMappingProcessor;
 import io.gravitee.gateway.handlers.api.processor.shutdown.ShutdownProcessor;
+import io.gravitee.gateway.handlers.api.processor.transaction.TransactionResponseProcessor;
+import io.gravitee.gateway.handlers.api.processor.transaction.TransactionResponseProcessorConfiguration;
 import io.gravitee.gateway.policy.PolicyChainOrder;
 import io.gravitee.gateway.policy.PolicyChainProviderLoader;
 import io.gravitee.gateway.policy.StreamType;
@@ -55,23 +56,28 @@ public class ResponseProcessorChainFactory extends ApiProcessorChainFactory {
 
     private Node node;
 
+    private TransactionResponseProcessorConfiguration transactionResponseProcessorConfiguration;
+
     public ResponseProcessorChainFactory(
         final Api api,
         final PolicyChainFactory policyChainFactory,
         final PolicyChainProviderLoader policyChainProviderLoader,
         final Node node,
-        FlowPolicyResolverFactory flowPolicyResolverFactory
+        FlowPolicyResolverFactory flowPolicyResolverFactory,
+        final TransactionResponseProcessorConfiguration transactionResponseProcessorConfiguration
     ) {
         super(api, policyChainFactory);
         this.policyChainProviderLoader = policyChainProviderLoader;
         this.node = node;
         this.flowPolicyResolverFactory = flowPolicyResolverFactory;
+        this.transactionResponseProcessorConfiguration = transactionResponseProcessorConfiguration;
 
         this.initialize();
     }
 
     private void initialize() {
         add(() -> new ShutdownProcessor(node));
+        add(() -> new TransactionResponseProcessor(this.transactionResponseProcessorConfiguration));
 
         final ConditionEvaluator<Flow> evaluator = new CompositeConditionEvaluator<>(
             new HttpMethodConditionEvaluator(),

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/transaction/TransactionHeaderOverrideMode.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/transaction/TransactionHeaderOverrideMode.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.processor.transaction;
+
+/**
+ * The different modes available in the Gateway when it deals with a backend providing a value for the Transaction Id and Request Id headers
+ */
+public enum TransactionHeaderOverrideMode {
+    /**
+     * OVERRIDE: The header set by the APIM Gateway will override the one provided by the backend
+     */
+    OVERRIDE,
+    /**
+     * MERGE: Both headers set by the APIM Gateway and the backend will be kept (as headers can be multivalued)
+     */
+    MERGE,
+    /**
+     * KEEP: The header set by the backend will be kept and the one provided by the APIM Gateway discarded
+     */
+    KEEP,
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/transaction/TransactionResponseProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/transaction/TransactionResponseProcessor.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.processor.transaction;
+
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.core.processor.AbstractProcessor;
+
+/**
+ * A {@link Response} processor used to set the transaction ID in the response headers.
+ */
+public class TransactionResponseProcessor extends AbstractProcessor<ExecutionContext> {
+
+    private final TransactionResponseProcessorConfiguration configuration;
+
+    public TransactionResponseProcessor(TransactionResponseProcessorConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public void handle(final ExecutionContext context) {
+        setHeaderAccordingToBackendOverrideMode(
+            context.request().headers(),
+            context.response().headers(),
+            configuration.transactionHeader,
+            configuration.transactionHeaderHeaderOverrideMode
+        );
+
+        setHeaderAccordingToBackendOverrideMode(
+            context.request().headers(),
+            context.response().headers(),
+            configuration.requestHeader,
+            configuration.requestHeaderHeaderOverrideMode
+        );
+
+        next.handle(context);
+    }
+
+    private void setHeaderAccordingToBackendOverrideMode(
+        final HttpHeaders requestHeaders,
+        final HttpHeaders responseHeaders,
+        final String headerName,
+        final TransactionHeaderOverrideMode headerOverrideMode
+    ) {
+        String requestHeaderValue = requestHeaders.get(headerName);
+        String backendHeaderValue = responseHeaders.get(headerName);
+
+        if (headerOverrideMode == TransactionHeaderOverrideMode.OVERRIDE) {
+            responseHeaders.set(headerName, requestHeaderValue);
+        } else if (headerOverrideMode == TransactionHeaderOverrideMode.MERGE) {
+            if (requestHeaderValue != null && !requestHeaderValue.equals(backendHeaderValue)) {
+                responseHeaders.add(headerName, requestHeaderValue);
+            }
+        } else if (headerOverrideMode == TransactionHeaderOverrideMode.KEEP) {
+            responseHeaders.set(headerName, backendHeaderValue);
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/transaction/TransactionResponseProcessorConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/transaction/TransactionResponseProcessorConfiguration.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.processor.transaction;
+
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_REQUEST_ID_HEADER;
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER;
+
+import io.gravitee.node.api.configuration.Configuration;
+
+public class TransactionResponseProcessorConfiguration {
+
+    public final String transactionHeader;
+
+    public final TransactionHeaderOverrideMode transactionHeaderHeaderOverrideMode;
+
+    public final String requestHeader;
+
+    public final TransactionHeaderOverrideMode requestHeaderHeaderOverrideMode;
+
+    public TransactionResponseProcessorConfiguration(Configuration configuration) {
+        this.transactionHeader = configuration.getProperty("handlers.request.transaction.header", DEFAULT_TRANSACTION_ID_HEADER);
+        String transactionOverrideModeString = configuration.getProperty("handlers.request.transaction.overrideMode");
+        this.transactionHeaderHeaderOverrideMode =
+            transactionOverrideModeString != null
+                ? TransactionHeaderOverrideMode.valueOf(transactionOverrideModeString.trim().toUpperCase())
+                : TransactionHeaderOverrideMode.OVERRIDE;
+
+        this.requestHeader = configuration.getProperty("handlers.request.request.header", DEFAULT_REQUEST_ID_HEADER);
+        String requestOverrideModeString = configuration.getProperty("handlers.request.request.overrideMode");
+        this.requestHeaderHeaderOverrideMode =
+            requestOverrideModeString != null
+                ? TransactionHeaderOverrideMode.valueOf(requestOverrideModeString.trim().toUpperCase())
+                : TransactionHeaderOverrideMode.OVERRIDE;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/processor/ApiProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/processor/ApiProcessorChainFactory.java
@@ -34,6 +34,8 @@ import io.gravitee.gateway.jupiter.handlers.api.processor.logging.LogResponsePro
 import io.gravitee.gateway.jupiter.handlers.api.processor.pathmapping.PathMappingProcessor;
 import io.gravitee.gateway.jupiter.handlers.api.processor.shutdown.ShutdownProcessor;
 import io.gravitee.gateway.jupiter.handlers.api.processor.subscription.SubscriptionProcessor;
+import io.gravitee.gateway.jupiter.handlers.api.processor.transaction.TransactionPostProcessor;
+import io.gravitee.gateway.jupiter.handlers.api.processor.transaction.TransactionPostProcessorConfiguration;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.configuration.Configuration;
 import java.util.ArrayList;
@@ -50,9 +52,12 @@ public class ApiProcessorChainFactory {
     private final boolean overrideXForwardedPrefix;
     private final String clientIdentifierHeader;
     private final Node node;
+
+    private final Configuration configuration;
     private final List<ProcessorHook> processorHooks = new ArrayList<>();
 
     public ApiProcessorChainFactory(final Configuration configuration, Node node) {
+        this.configuration = configuration;
         this.overrideXForwardedPrefix = configuration.getProperty("handlers.request.headers.x-forwarded-prefix", Boolean.class, false);
         this.clientIdentifierHeader =
             configuration.getProperty("handlers.request.client.header", String.class, DEFAULT_CLIENT_IDENTIFIER_HEADER);
@@ -104,6 +109,7 @@ public class ApiProcessorChainFactory {
     private List<Processor> getAfterApiExecutionProcessors(Api api) {
         List<Processor> postProcessorList = new ArrayList<>();
         postProcessorList.add(new ShutdownProcessor(node));
+        postProcessorList.add(new TransactionPostProcessor(new TransactionPostProcessorConfiguration(configuration)));
 
         Cors cors = api.getDefinition().getProxy().getCors();
         if (cors != null && cors.isEnabled()) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/processor/transaction/TransactionHeaderOverrideMode.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/processor/transaction/TransactionHeaderOverrideMode.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.handlers.api.processor.transaction;
+
+/**
+ * The different modes available in the Gateway when it deals with a backend providing a value for the Transaction Id and Request Id headers
+ */
+public enum TransactionHeaderOverrideMode {
+    /**
+     * OVERRIDE: The header set by the APIM Gateway will override the one provided by the backend
+     */
+    OVERRIDE,
+    /**
+     * MERGE: Both headers set by the APIM Gateway and the backend will be kept (as headers can be multivalued)
+     */
+    MERGE,
+    /**
+     * KEEP: The header set by the backend will be kept and the one provided by the APIM Gateway discarded
+     */
+    KEEP,
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/processor/transaction/TransactionPostProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/processor/transaction/TransactionPostProcessor.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.handlers.api.processor.transaction;
+
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.jupiter.core.context.MutableExecutionContext;
+import io.gravitee.gateway.jupiter.core.processor.Processor;
+import io.reactivex.rxjava3.core.Completable;
+
+/**
+ * A {@link Processor} used to set the Transaction and Request ID headers of the response.
+ */
+public class TransactionPostProcessor implements Processor {
+
+    private final TransactionPostProcessorConfiguration configuration;
+
+    public TransactionPostProcessor(TransactionPostProcessorConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public String getId() {
+        return "post-processor-transaction";
+    }
+
+    @Override
+    public Completable execute(final MutableExecutionContext context) {
+        return Completable.fromRunnable(
+            () -> {
+                setHeaderAccordingToBackendOverrideMode(
+                    context.request().headers(),
+                    context.response().headers(),
+                    this.configuration.transactionHeader,
+                    this.configuration.transactionHeaderHeaderOverrideMode
+                );
+
+                setHeaderAccordingToBackendOverrideMode(
+                    context.request().headers(),
+                    context.response().headers(),
+                    this.configuration.requestHeader,
+                    this.configuration.requestHeaderHeaderOverrideMode
+                );
+            }
+        );
+    }
+
+    private void setHeaderAccordingToBackendOverrideMode(
+        final HttpHeaders requestHeaders,
+        final HttpHeaders responseHeaders,
+        final String headerName,
+        final TransactionHeaderOverrideMode headerOverrideMode
+    ) {
+        String requestHeaderValue = requestHeaders.get(headerName);
+        String backendHeaderValue = responseHeaders.get(headerName);
+
+        if (headerOverrideMode == TransactionHeaderOverrideMode.OVERRIDE) {
+            responseHeaders.set(headerName, requestHeaderValue);
+        } else if (headerOverrideMode == TransactionHeaderOverrideMode.MERGE) {
+            if (requestHeaderValue != null && !requestHeaderValue.equals(backendHeaderValue)) {
+                responseHeaders.add(headerName, requestHeaderValue);
+            }
+        } else if (headerOverrideMode == TransactionHeaderOverrideMode.KEEP) {
+            responseHeaders.set(headerName, backendHeaderValue);
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/processor/transaction/TransactionPostProcessorConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/processor/transaction/TransactionPostProcessorConfiguration.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.handlers.api.processor.transaction;
+
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_REQUEST_ID_HEADER;
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER;
+
+import io.gravitee.node.api.configuration.Configuration;
+
+public class TransactionPostProcessorConfiguration {
+
+    public final String transactionHeader;
+
+    public final TransactionHeaderOverrideMode transactionHeaderHeaderOverrideMode;
+
+    public final String requestHeader;
+
+    public final TransactionHeaderOverrideMode requestHeaderHeaderOverrideMode;
+
+    public TransactionPostProcessorConfiguration(Configuration configuration) {
+        this.transactionHeader = configuration.getProperty("handlers.request.transaction.header", DEFAULT_TRANSACTION_ID_HEADER);
+        String transactionOverrideModeString = configuration.getProperty("handlers.request.transaction.overrideMode");
+        this.transactionHeaderHeaderOverrideMode =
+            transactionOverrideModeString != null
+                ? TransactionHeaderOverrideMode.valueOf(transactionOverrideModeString.trim().toUpperCase())
+                : TransactionHeaderOverrideMode.OVERRIDE;
+
+        this.requestHeader = configuration.getProperty("handlers.request.request.header", DEFAULT_REQUEST_ID_HEADER);
+        String requestOverrideModeString = configuration.getProperty("handlers.request.request.overrideMode");
+        this.requestHeaderHeaderOverrideMode =
+            requestOverrideModeString != null
+                ? TransactionHeaderOverrideMode.valueOf(requestOverrideModeString.trim().toUpperCase())
+                : TransactionHeaderOverrideMode.OVERRIDE;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/transaction/TransactionResponseProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/transaction/TransactionResponseProcessorTest.java
@@ -1,0 +1,171 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.processor.transaction;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.api.context.SimpleExecutionContext;
+import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.reactor.processor.transaction.TransactionHeader;
+import io.gravitee.node.api.configuration.Configuration;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TransactionResponseProcessorTest {
+
+    private TransactionResponseProcessor transactionResponseProcessor;
+
+    @Test
+    @DisplayName("By default should override Transaction Id and Request Id headers set by the backend, by the ones set by APIM")
+    void handleWithOverrideByDefault() {
+        Configuration nodeConfiguration = mock(Configuration.class);
+        when(nodeConfiguration.getProperty(eq("handlers.request.transaction.header"), anyString()))
+                .thenReturn(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER);
+        when(nodeConfiguration.getProperty(eq("handlers.request.request.header"), anyString()))
+                .thenReturn(TransactionHeader.DEFAULT_REQUEST_ID_HEADER);
+
+        TransactionResponseProcessorConfiguration processorConfiguration = new TransactionResponseProcessorConfiguration(nodeConfiguration);
+
+        transactionResponseProcessor = new TransactionResponseProcessor(processorConfiguration);
+        transactionResponseProcessor.handler(context -> {});
+
+        Request request = mock(Request.class);
+        HttpHeaders requestHeaders = HttpHeaders.create();
+        requestHeaders.set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "transaction-id");
+        requestHeaders.set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "request-id");
+        when(request.headers()).thenReturn(requestHeaders);
+
+        Response response = mock(Response.class);
+        HttpHeaders responseHeaders = HttpHeaders.create();
+        responseHeaders.set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "backend-transaction-id");
+        responseHeaders.set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "backend-request-id");
+        when(response.headers()).thenReturn(responseHeaders);
+
+        ExecutionContext context = new SimpleExecutionContext(request, response);
+        transactionResponseProcessor.handle(context);
+
+        assertEquals(List.of("transaction-id"), context.response().headers().getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER));
+        assertEquals(List.of("request-id"), context.response().headers().getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER));
+    }
+
+    @Test
+    @DisplayName("Should override Transaction Id and Request Id headers set by the backend, by the ones set by APIM")
+    void handleWithOverrideModeNone() {
+        instantiateTransactionResponseProcess(TransactionHeaderOverrideMode.OVERRIDE, TransactionHeaderOverrideMode.OVERRIDE);
+
+        Request request = mock(Request.class);
+        HttpHeaders requestHeaders = HttpHeaders.create();
+        requestHeaders.set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "transaction-id");
+        requestHeaders.set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "request-id");
+        when(request.headers()).thenReturn(requestHeaders);
+
+        Response response = mock(Response.class);
+        HttpHeaders responseHeaders = HttpHeaders.create();
+        responseHeaders.set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "backend-transaction-id");
+        responseHeaders.set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "backend-request-id");
+        when(response.headers()).thenReturn(responseHeaders);
+
+        ExecutionContext context = new SimpleExecutionContext(request, response);
+        transactionResponseProcessor.handle(context);
+
+        assertEquals(List.of("transaction-id"), context.response().headers().getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER));
+        assertEquals(List.of("request-id"), context.response().headers().getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER));
+    }
+
+    @Test
+    @DisplayName("Should merge transaction ID and request ID headers set by APIM and the backend")
+    void handleWithOverrideModeMerge() {
+        instantiateTransactionResponseProcess(TransactionHeaderOverrideMode.MERGE, TransactionHeaderOverrideMode.MERGE);
+
+        Request request = mock(Request.class);
+        HttpHeaders requestHeaders = HttpHeaders.create();
+        requestHeaders.set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "transaction-id");
+        requestHeaders.set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "request-id");
+        when(request.headers()).thenReturn(requestHeaders);
+
+        Response response = mock(Response.class);
+        HttpHeaders responseHeaders = HttpHeaders.create();
+        responseHeaders.set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "backend-transaction-id");
+        responseHeaders.set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "backend-request-id");
+        when(response.headers()).thenReturn(responseHeaders);
+
+        ExecutionContext context = new SimpleExecutionContext(request, response);
+        transactionResponseProcessor.handle(context);
+
+        assertEquals(
+                List.of("backend-transaction-id", "transaction-id"),
+                context.response().headers().getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER)
+        );
+        assertEquals(
+                List.of("backend-request-id", "request-id"),
+                context.response().headers().getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER)
+        );
+    }
+
+    @Test
+    @DisplayName("Should keep transaction ID and request ID headers set by the backend, discard APIM ones")
+    void handleWithOverrideModeOverride() {
+        instantiateTransactionResponseProcess(TransactionHeaderOverrideMode.KEEP, TransactionHeaderOverrideMode.KEEP);
+
+        Request request = mock(Request.class);
+        HttpHeaders requestHeaders = HttpHeaders.create();
+        requestHeaders.set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "transaction-id");
+        requestHeaders.set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "request-id");
+        when(request.headers()).thenReturn(requestHeaders);
+
+        Response response = mock(Response.class);
+        HttpHeaders responseHeaders = HttpHeaders.create();
+        responseHeaders.set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "backend-transaction-id");
+        responseHeaders.set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "backend-request-id");
+        when(response.headers()).thenReturn(responseHeaders);
+
+        ExecutionContext context = new SimpleExecutionContext(request, response);
+        transactionResponseProcessor.handle(context);
+
+        assertEquals(
+                List.of("backend-transaction-id"),
+                context.response().headers().getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER)
+        );
+        assertEquals(List.of("backend-request-id"), context.response().headers().getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER));
+    }
+
+    private void instantiateTransactionResponseProcess(
+            TransactionHeaderOverrideMode transactionOverrideMode,
+            TransactionHeaderOverrideMode requestHeaderOverrideMode
+    ) {
+        Configuration nodeConfiguration = mock(Configuration.class);
+        when(nodeConfiguration.getProperty("handlers.request.transaction.overrideMode")).thenReturn(transactionOverrideMode.name());
+        when(nodeConfiguration.getProperty(eq("handlers.request.transaction.header"), anyString()))
+                .thenReturn(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER);
+
+        when(nodeConfiguration.getProperty("handlers.request.request.overrideMode")).thenReturn(requestHeaderOverrideMode.name());
+        when(nodeConfiguration.getProperty(eq("handlers.request.request.header"), anyString()))
+                .thenReturn(TransactionHeader.DEFAULT_REQUEST_ID_HEADER);
+
+        TransactionResponseProcessorConfiguration processorConfiguration = new TransactionResponseProcessorConfiguration(nodeConfiguration);
+
+        transactionResponseProcessor = new TransactionResponseProcessor(processorConfiguration);
+        transactionResponseProcessor.handler(context -> {});
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/transaction/TransactionResponseProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/transaction/TransactionResponseProcessorTest.java
@@ -41,9 +41,9 @@ class TransactionResponseProcessorTest {
     void handleWithOverrideByDefault() {
         Configuration nodeConfiguration = mock(Configuration.class);
         when(nodeConfiguration.getProperty(eq("handlers.request.transaction.header"), anyString()))
-                .thenReturn(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER);
+            .thenReturn(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER);
         when(nodeConfiguration.getProperty(eq("handlers.request.request.header"), anyString()))
-                .thenReturn(TransactionHeader.DEFAULT_REQUEST_ID_HEADER);
+            .thenReturn(TransactionHeader.DEFAULT_REQUEST_ID_HEADER);
 
         TransactionResponseProcessorConfiguration processorConfiguration = new TransactionResponseProcessorConfiguration(nodeConfiguration);
 
@@ -114,12 +114,12 @@ class TransactionResponseProcessorTest {
         transactionResponseProcessor.handle(context);
 
         assertEquals(
-                List.of("backend-transaction-id", "transaction-id"),
-                context.response().headers().getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER)
+            List.of("backend-transaction-id", "transaction-id"),
+            context.response().headers().getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER)
         );
         assertEquals(
-                List.of("backend-request-id", "request-id"),
-                context.response().headers().getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER)
+            List.of("backend-request-id", "request-id"),
+            context.response().headers().getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER)
         );
     }
 
@@ -144,24 +144,24 @@ class TransactionResponseProcessorTest {
         transactionResponseProcessor.handle(context);
 
         assertEquals(
-                List.of("backend-transaction-id"),
-                context.response().headers().getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER)
+            List.of("backend-transaction-id"),
+            context.response().headers().getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER)
         );
         assertEquals(List.of("backend-request-id"), context.response().headers().getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER));
     }
 
     private void instantiateTransactionResponseProcess(
-            TransactionHeaderOverrideMode transactionOverrideMode,
-            TransactionHeaderOverrideMode requestHeaderOverrideMode
+        TransactionHeaderOverrideMode transactionOverrideMode,
+        TransactionHeaderOverrideMode requestHeaderOverrideMode
     ) {
         Configuration nodeConfiguration = mock(Configuration.class);
         when(nodeConfiguration.getProperty("handlers.request.transaction.overrideMode")).thenReturn(transactionOverrideMode.name());
         when(nodeConfiguration.getProperty(eq("handlers.request.transaction.header"), anyString()))
-                .thenReturn(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER);
+            .thenReturn(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER);
 
         when(nodeConfiguration.getProperty("handlers.request.request.overrideMode")).thenReturn(requestHeaderOverrideMode.name());
         when(nodeConfiguration.getProperty(eq("handlers.request.request.header"), anyString()))
-                .thenReturn(TransactionHeader.DEFAULT_REQUEST_ID_HEADER);
+            .thenReturn(TransactionHeader.DEFAULT_REQUEST_ID_HEADER);
 
         TransactionResponseProcessorConfiguration processorConfiguration = new TransactionResponseProcessorConfiguration(nodeConfiguration);
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/processor/ApiProcessorChainFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/processor/ApiProcessorChainFactoryTest.java
@@ -35,6 +35,7 @@ import io.gravitee.gateway.jupiter.handlers.api.processor.logging.LogResponsePro
 import io.gravitee.gateway.jupiter.handlers.api.processor.pathmapping.PathMappingProcessor;
 import io.gravitee.gateway.jupiter.handlers.api.processor.shutdown.ShutdownProcessor;
 import io.gravitee.gateway.jupiter.handlers.api.processor.subscription.SubscriptionProcessor;
+import io.gravitee.gateway.jupiter.handlers.api.processor.transaction.TransactionPostProcessor;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.configuration.Configuration;
 import io.reactivex.rxjava3.core.Flowable;
@@ -196,9 +197,10 @@ class ApiProcessorChainFactoryTest {
         processors
             .test()
             .assertComplete()
-            .assertValueCount(2)
+            .assertValueCount(3)
             .assertValueAt(0, processor -> processor instanceof ShutdownProcessor)
-            .assertValueAt(1, processor -> processor instanceof CorsSimpleRequestProcessor);
+            .assertValueAt(1, processor -> processor instanceof TransactionPostProcessor)
+            .assertValueAt(2, processor -> processor instanceof CorsSimpleRequestProcessor);
     }
 
     @Test
@@ -213,7 +215,12 @@ class ApiProcessorChainFactoryTest {
         ProcessorChain processorChain = apiProcessorChainFactory.afterApiExecution(api);
         assertThat(processorChain.getId()).isEqualTo("processor-chain-after-api-execution");
         Flowable<Processor> processors = extractProcessorChain(processorChain);
-        processors.test().assertComplete().assertValueCount(1).assertValueAt(0, processor -> processor instanceof ShutdownProcessor);
+        processors
+            .test()
+            .assertComplete()
+            .assertValueCount(2)
+            .assertValueAt(0, processor -> processor instanceof ShutdownProcessor)
+            .assertValueAt(1, processor -> processor instanceof TransactionPostProcessor);
     }
 
     @Test
@@ -229,9 +236,10 @@ class ApiProcessorChainFactoryTest {
         processors
             .test()
             .assertComplete()
-            .assertValueCount(2)
+            .assertValueCount(3)
             .assertValueAt(0, processor -> processor instanceof ShutdownProcessor)
-            .assertValueAt(1, processor -> processor instanceof PathMappingProcessor);
+            .assertValueAt(1, processor -> processor instanceof TransactionPostProcessor)
+            .assertValueAt(2, processor -> processor instanceof PathMappingProcessor);
     }
 
     @Test
@@ -247,10 +255,11 @@ class ApiProcessorChainFactoryTest {
         processors
             .test()
             .assertComplete()
-            .assertValueCount(3)
+            .assertValueCount(4)
             .assertValueAt(0, processor -> processor instanceof ShutdownProcessor)
-            .assertValueAt(1, processor -> processor instanceof PathMappingProcessor)
-            .assertValueAt(2, processor -> processor instanceof SimpleFailureProcessor);
+            .assertValueAt(1, processor -> processor instanceof TransactionPostProcessor)
+            .assertValueAt(2, processor -> processor instanceof PathMappingProcessor)
+            .assertValueAt(3, processor -> processor instanceof SimpleFailureProcessor);
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/processor/transaction/TransactionPostProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/processor/transaction/TransactionPostProcessorTest.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.handlers.api.processor.transaction;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.gateway.jupiter.handlers.api.processor.AbstractProcessorTest;
+import io.gravitee.gateway.reactor.processor.transaction.TransactionHeader;
+import io.gravitee.node.api.configuration.Configuration;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TransactionPostProcessorTest extends AbstractProcessorTest {
+
+    private TransactionPostProcessor transactionPostProcessor;
+
+    @Test
+    @DisplayName("By default should override Transaction Id and Request Id headers set by the backend, by the ones set by APIM")
+    void handleWithOverrideByDefault() {
+        Configuration nodeConfiguration = mock(Configuration.class);
+        when(nodeConfiguration.getProperty("handlers.request.transaction.overrideMode")).thenReturn(null);
+        when(nodeConfiguration.getProperty(eq("handlers.request.transaction.header"), anyString()))
+            .thenReturn(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER);
+        when(nodeConfiguration.getProperty("handlers.request.request.overrideMode")).thenReturn(null);
+        when(nodeConfiguration.getProperty(eq("handlers.request.request.header"), anyString()))
+            .thenReturn(TransactionHeader.DEFAULT_REQUEST_ID_HEADER);
+
+        TransactionPostProcessorConfiguration processorConfiguration = new TransactionPostProcessorConfiguration(nodeConfiguration);
+
+        transactionPostProcessor = new TransactionPostProcessor(processorConfiguration);
+
+        spyCtx.request().headers().set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "transaction-id");
+        spyCtx.request().headers().set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "request-id");
+
+        spyCtx.response().headers().set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "backend-transaction-id");
+        spyCtx.response().headers().set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "backend-request-id");
+
+        transactionPostProcessor.execute(spyCtx).test().assertResult();
+
+        assertThat(spyResponseHeaders.getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER)).isEqualTo(List.of("transaction-id"));
+        assertThat(spyResponseHeaders.getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER)).isEqualTo(List.of("request-id"));
+    }
+
+    @Test
+    @DisplayName("Should override Transaction Id and Request Id headers set by the backend, by the ones set by APIM")
+    void handleWithOverrideBackendModeNone() {
+        instantiateTransactionPostProcessor(TransactionHeaderOverrideMode.OVERRIDE, TransactionHeaderOverrideMode.OVERRIDE);
+
+        spyCtx.request().headers().set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "transaction-id");
+        spyCtx.request().headers().set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "request-id");
+
+        spyCtx.response().headers().set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "backend-transaction-id");
+        spyCtx.response().headers().set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "backend-request-id");
+
+        transactionPostProcessor.execute(spyCtx).test().assertResult();
+
+        assertThat(spyResponseHeaders.getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER)).isEqualTo(List.of("transaction-id"));
+        assertThat(spyResponseHeaders.getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER)).isEqualTo(List.of("request-id"));
+    }
+
+    @Test
+    @DisplayName("Should merge transaction ID and request ID headers set by APIM and the backend")
+    void handleWithOverrideBackendModeMerge() {
+        instantiateTransactionPostProcessor(TransactionHeaderOverrideMode.MERGE, TransactionHeaderOverrideMode.MERGE);
+
+        spyCtx.request().headers().set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "transaction-id");
+        spyCtx.request().headers().set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "request-id");
+
+        spyCtx.response().headers().set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "backend-transaction-id");
+        spyCtx.response().headers().set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "backend-request-id");
+
+        transactionPostProcessor.execute(spyCtx).test().assertResult();
+
+        assertThat(spyResponseHeaders.getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER))
+            .isEqualTo(List.of("backend-transaction-id", "transaction-id"));
+        assertThat(spyResponseHeaders.getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER))
+            .isEqualTo(List.of("backend-request-id", "request-id"));
+    }
+
+    @Test
+    @DisplayName("Should keep transaction ID and request ID headers set by the backend, discard APIM ones")
+    void handleWithOverrideBackendModeOverride() {
+        instantiateTransactionPostProcessor(TransactionHeaderOverrideMode.KEEP, TransactionHeaderOverrideMode.KEEP);
+
+        spyCtx.request().headers().set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "transaction-id");
+        spyCtx.request().headers().set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "request-id");
+
+        spyCtx.response().headers().set(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER, "backend-transaction-id");
+        spyCtx.response().headers().set(TransactionHeader.DEFAULT_REQUEST_ID_HEADER, "backend-request-id");
+
+        transactionPostProcessor.execute(spyCtx).test().assertResult();
+
+        assertThat(spyResponseHeaders.getAll(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER)).isEqualTo(List.of("backend-transaction-id"));
+        assertThat(spyResponseHeaders.getAll(TransactionHeader.DEFAULT_REQUEST_ID_HEADER)).isEqualTo(List.of("backend-request-id"));
+    }
+
+    private void instantiateTransactionPostProcessor(
+        TransactionHeaderOverrideMode transactionOverrideMode,
+        TransactionHeaderOverrideMode requestHeaderOverrideMode
+    ) {
+        Configuration nodeConfiguration = mock(Configuration.class);
+        when(nodeConfiguration.getProperty("handlers.request.transaction.overrideMode")).thenReturn(transactionOverrideMode.name());
+        when(nodeConfiguration.getProperty(eq("handlers.request.transaction.header"), anyString()))
+            .thenReturn(TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER);
+
+        when(nodeConfiguration.getProperty("handlers.request.request.overrideMode")).thenReturn(requestHeaderOverrideMode.name());
+        when(nodeConfiguration.getProperty(eq("handlers.request.request.header"), anyString()))
+            .thenReturn(TransactionHeader.DEFAULT_REQUEST_ID_HEADER);
+
+        TransactionPostProcessorConfiguration processorConfiguration = new TransactionPostProcessorConfiguration(nodeConfiguration);
+
+        transactionPostProcessor = new TransactionPostProcessor(processorConfiguration);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionHeader.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionHeader.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.reactor.processor.transaction;
+
+public abstract class TransactionHeader {
+
+    public static final String DEFAULT_TRANSACTION_ID_HEADER = "X-Gravitee-Transaction-Id";
+    public static final String DEFAULT_REQUEST_ID_HEADER = "X-Gravitee-Request-Id";
+
+    private TransactionHeader() {}
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionPreProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionPreProcessor.java
@@ -63,9 +63,6 @@ public class TransactionPreProcessor implements Processor {
                 ctx.request().headers().set(requestHeader, requestId);
                 ctx.request().metrics().setTransactionId(transactionId);
 
-                ctx.response().headers().set(transactionHeader, transactionId);
-                ctx.response().headers().set(requestHeader, requestId);
-
                 ctx.request().transactionId(transactionId);
             }
         );

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionPreProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionPreProcessor.java
@@ -27,12 +27,12 @@ import io.reactivex.rxjava3.core.Completable;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class TransactionProcessor implements Processor {
+public class TransactionPreProcessor implements Processor {
 
     private final String transactionHeader;
     private final String requestHeader;
 
-    TransactionProcessor(final String transactionHeader, final String requestHeader) {
+    TransactionPreProcessor(final String transactionHeader, final String requestHeader) {
         this.transactionHeader = transactionHeader;
         this.requestHeader = requestHeader;
     }
@@ -47,7 +47,7 @@ public class TransactionProcessor implements Processor {
 
     @Override
     public String getId() {
-        return "processor-transaction";
+        return "pre-processor-transaction";
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionProcessorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionProcessorFactory.java
@@ -15,15 +15,15 @@
  */
 package io.gravitee.gateway.jupiter.reactor.processor.transaction;
 
+import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionHeader.DEFAULT_REQUEST_ID_HEADER;
+import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER;
+
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
 public class TransactionProcessorFactory {
-
-    public static final String DEFAULT_TRANSACTION_ID_HEADER = "X-Gravitee-Transaction-Id";
-    public static final String DEFAULT_REQUEST_ID_HEADER = "X-Gravitee-Request-Id";
 
     private final String transactionHeader;
     private final String requestHeader;
@@ -33,7 +33,7 @@ public class TransactionProcessorFactory {
         this.requestHeader = requestHeader == null ? DEFAULT_REQUEST_ID_HEADER : requestHeader;
     }
 
-    public TransactionProcessor create() {
-        return new TransactionProcessor(transactionHeader, requestHeader);
+    public TransactionPreProcessor create() {
+        return new TransactionPreProcessor(transactionHeader, requestHeader);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/RequestProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/RequestProcessorChainFactory.java
@@ -22,7 +22,7 @@ import io.gravitee.gateway.core.processor.provider.ProcessorProviderChain;
 import io.gravitee.gateway.core.processor.provider.ProcessorSupplier;
 import io.gravitee.gateway.reactor.processor.forward.XForwardForProcessor;
 import io.gravitee.gateway.reactor.processor.transaction.TraceContextProcessorFactory;
-import io.gravitee.gateway.reactor.processor.transaction.TransactionProcessorFactory;
+import io.gravitee.gateway.reactor.processor.transaction.TransactionRequestProcessorFactory;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.InitializingBean;
@@ -39,8 +39,8 @@ public class RequestProcessorChainFactory implements InitializingBean {
     private final List<ProcessorProvider<ExecutionContext, Processor<ExecutionContext>>> providers = new ArrayList<>();
 
     @Autowired
-    @Qualifier("v3TransactionHandlerFactory")
-    private TransactionProcessorFactory transactionHandlerFactory;
+    @Qualifier("v3TransactionRequestProcessorFactory")
+    private TransactionRequestProcessorFactory transactionRequestProcessorFactory;
 
     @Autowired
     @Qualifier("v3TraceContextProcessorFactory")
@@ -59,7 +59,7 @@ public class RequestProcessorChainFactory implements InitializingBean {
             providers.add(new ProcessorSupplier<>(() -> traceContextHandlerFactory.create()));
         }
 
-        providers.add(new ProcessorSupplier<>(() -> transactionHandlerFactory.create()));
+        providers.add(new ProcessorSupplier<>(() -> transactionRequestProcessorFactory.create()));
     }
 
     public Processor<ExecutionContext> create() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/transaction/TransactionHeader.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/transaction/TransactionHeader.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactor.processor.transaction;
+
+public abstract class TransactionHeader {
+
+    public static final String DEFAULT_TRANSACTION_ID_HEADER = "X-Gravitee-Transaction-Id";
+    public static final String DEFAULT_REQUEST_ID_HEADER = "X-Gravitee-Request-Id";
+
+    private TransactionHeader() {}
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessor.java
@@ -50,10 +50,7 @@ public class TransactionRequestProcessor extends AbstractProcessor<ExecutionCont
             context.request().headers().set(transactionHeader, transactionId);
         }
         context.request().metrics().setTransactionId(transactionId);
-        context.response().headers().set(transactionHeader, transactionId);
-
         context.request().headers().set(requestHeader, requestId);
-        context.response().headers().set(requestHeader, requestId);
 
         ((MutableExecutionContext) context).request(new TransactionRequest(transactionId, context.request()));
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessor.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.gateway.reactor.processor.transaction;
 
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_REQUEST_ID_HEADER;
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER;
+
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.context.MutableExecutionContext;
@@ -26,17 +29,14 @@ import io.gravitee.gateway.core.processor.AbstractProcessor;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class TransactionProcessor extends AbstractProcessor<ExecutionContext> {
-
-    static final String DEFAULT_TRANSACTION_ID_HEADER = "X-Gravitee-Transaction-Id";
-    static final String DEFAULT_REQUEST_ID_HEADER = "X-Gravitee-Request-Id";
+public class TransactionRequestProcessor extends AbstractProcessor<ExecutionContext> {
 
     private String transactionHeader = DEFAULT_TRANSACTION_ID_HEADER;
     private String requestHeader = DEFAULT_REQUEST_ID_HEADER;
 
-    TransactionProcessor() {}
+    TransactionRequestProcessor() {}
 
-    TransactionProcessor(String transactionHeader, String requestHeader) {
+    TransactionRequestProcessor(String transactionHeader, String requestHeader) {
         this.transactionHeader = transactionHeader;
         this.requestHeader = requestHeader;
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessorFactory.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.gateway.reactor.processor.transaction;
 
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_REQUEST_ID_HEADER;
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER;
+
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.core.processor.Processor;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,15 +26,15 @@ import org.springframework.beans.factory.annotation.Value;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class TransactionProcessorFactory {
+public class TransactionRequestProcessorFactory {
 
-    @Value("${handlers.request.transaction.header:" + TransactionProcessor.DEFAULT_TRANSACTION_ID_HEADER + "}")
+    @Value("${handlers.request.transaction.header:" + DEFAULT_TRANSACTION_ID_HEADER + "}")
     private String transactionHeader;
 
-    @Value("${handlers.request.request.header:" + TransactionProcessor.DEFAULT_REQUEST_ID_HEADER + "}")
+    @Value("${handlers.request.request.header:" + DEFAULT_REQUEST_ID_HEADER + "}")
     private String requestHeader;
 
     public Processor<ExecutionContext> create() {
-        return new TransactionProcessor(transactionHeader, requestHeader);
+        return new TransactionRequestProcessor(transactionHeader, requestHeader);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/spring/ReactorConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/spring/ReactorConfiguration.java
@@ -45,7 +45,7 @@ import io.gravitee.gateway.reactor.impl.DefaultReactor;
 import io.gravitee.gateway.reactor.processor.RequestProcessorChainFactory;
 import io.gravitee.gateway.reactor.processor.ResponseProcessorChainFactory;
 import io.gravitee.gateway.reactor.processor.transaction.TraceContextProcessorFactory;
-import io.gravitee.gateway.reactor.processor.transaction.TransactionProcessorFactory;
+import io.gravitee.gateway.reactor.processor.transaction.TransactionRequestProcessorFactory;
 import io.gravitee.gateway.report.ReporterService;
 import io.gravitee.node.api.Node;
 import io.gravitee.plugin.alert.AlertEventProducer;
@@ -202,8 +202,8 @@ public class ReactorConfiguration {
     }
 
     @Bean
-    public TransactionProcessorFactory v3TransactionHandlerFactory() {
-        return new io.gravitee.gateway.reactor.processor.transaction.TransactionProcessorFactory();
+    public TransactionRequestProcessorFactory v3TransactionRequestProcessorFactory() {
+        return new TransactionRequestProcessorFactory();
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/spring/ReactorConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/spring/ReactorConfiguration.java
@@ -15,8 +15,8 @@
  */
 package io.gravitee.gateway.reactor.spring;
 
-import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionProcessorFactory.DEFAULT_REQUEST_ID_HEADER;
-import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionProcessorFactory.DEFAULT_TRANSACTION_ID_HEADER;
+import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionHeader.DEFAULT_REQUEST_ID_HEADER;
+import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER;
 
 import io.gravitee.common.event.EventManager;
 import io.gravitee.common.http.IdGenerator;
@@ -31,6 +31,7 @@ import io.gravitee.gateway.jupiter.reactor.handler.DefaultHttpAcceptorResolver;
 import io.gravitee.gateway.jupiter.reactor.handler.HttpAcceptorResolver;
 import io.gravitee.gateway.jupiter.reactor.processor.NotFoundProcessorChainFactory;
 import io.gravitee.gateway.jupiter.reactor.processor.PlatformProcessorChainFactory;
+import io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionProcessorFactory;
 import io.gravitee.gateway.jupiter.reactor.v4.reactor.ReactorFactory;
 import io.gravitee.gateway.jupiter.reactor.v4.reactor.ReactorFactoryManager;
 import io.gravitee.gateway.jupiter.reactor.v4.subscription.*;
@@ -106,16 +107,16 @@ public class ReactorConfiguration {
     }
 
     @Bean
-    public io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionProcessorFactory transactionHandlerFactory(
+    public TransactionProcessorFactory transactionHandlerFactory(
         @Value("${handlers.request.transaction.header:" + DEFAULT_TRANSACTION_ID_HEADER + "}") String transactionHeader,
         @Value("${handlers.request.request.header:" + DEFAULT_REQUEST_ID_HEADER + "}") String requestHeader
     ) {
-        return new io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionProcessorFactory(transactionHeader, requestHeader);
+        return new TransactionProcessorFactory(transactionHeader, requestHeader);
     }
 
     @Bean
     public PlatformProcessorChainFactory globalProcessorChainFactory(
-        io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionProcessorFactory transactionHandlerFactory,
+        TransactionProcessorFactory transactionHandlerFactory,
         @Value("${handlers.request.trace-context.enabled:false}") boolean traceContext,
         ReporterService reporterService,
         AlertEventProducer eventProducer,

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionPreProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionPreProcessorTest.java
@@ -18,7 +18,6 @@ package io.gravitee.gateway.jupiter.reactor.processor.transaction;
 import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionHeader.DEFAULT_REQUEST_ID_HEADER;
 import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -32,7 +31,7 @@ import org.junit.jupiter.api.Test;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class TransactionPreProcessorTest extends AbstractProcessorTest {
+class TransactionPreProcessorTest extends AbstractProcessorTest {
 
     private static final String CUSTOM_TRANSACTION_ID_HEADER = "X-My-Transaction-Id";
     private static final String CUSTOM_REQUEST_ID_HEADER = "X-My-Request-Id";
@@ -44,64 +43,56 @@ public class TransactionPreProcessorTest extends AbstractProcessorTest {
     }
 
     @Test
-    public void shouldHaveTransactionId() {
+    void shouldHaveTransactionId() {
         String requestId = UUID.toString(UUID.random());
         when(mockRequest.id()).thenReturn(requestId);
         transactionProcessor.execute(ctx).test().assertResult();
-        verify(mockRequest).transactionId(eq(requestId));
+        verify(mockRequest).transactionId(requestId);
         assertThat(spyRequestHeaders.get(DEFAULT_TRANSACTION_ID_HEADER)).isEqualTo(requestId);
         assertThat(spyRequestHeaders.get(DEFAULT_REQUEST_ID_HEADER)).isEqualTo(requestId);
         assertThat(metrics.getTransactionId()).isEqualTo(requestId);
-        assertThat(spyResponseHeaders.get(DEFAULT_TRANSACTION_ID_HEADER)).isEqualTo(requestId);
-        assertThat(spyResponseHeaders.get(DEFAULT_REQUEST_ID_HEADER)).isEqualTo(requestId);
     }
 
     @Test
-    public void shouldPropagateSameTransactionId() {
+    void shouldPropagateSameTransactionId() {
         String transactionId = UUID.toString(UUID.random());
         String requestId = UUID.toString(UUID.random());
         when(mockRequest.id()).thenReturn(requestId);
         spyRequestHeaders.set(DEFAULT_TRANSACTION_ID_HEADER, transactionId);
         transactionProcessor.execute(ctx).test().assertResult();
-        verify(mockRequest).transactionId(eq(transactionId));
+        verify(mockRequest).transactionId(transactionId);
         assertThat(spyRequestHeaders.get(DEFAULT_TRANSACTION_ID_HEADER)).isEqualTo(transactionId);
         assertThat(spyRequestHeaders.get(DEFAULT_REQUEST_ID_HEADER)).isEqualTo(requestId);
         assertThat(metrics.getTransactionId()).isEqualTo(transactionId);
-        assertThat(spyResponseHeaders.get(DEFAULT_TRANSACTION_ID_HEADER)).isEqualTo(transactionId);
-        assertThat(spyResponseHeaders.get(DEFAULT_REQUEST_ID_HEADER)).isEqualTo(requestId);
     }
 
     @Test
-    public void shouldHaveTransactionIdWithCustomHeader() {
+    void shouldHaveTransactionIdWithCustomHeader() {
         transactionProcessor = new TransactionPreProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER);
         String requestId = UUID.toString(UUID.random());
         when(mockRequest.id()).thenReturn(requestId);
         transactionProcessor.execute(ctx).test().assertResult();
-        verify(mockRequest).transactionId(eq(requestId));
+        verify(mockRequest).transactionId(requestId);
         assertThat(spyRequestHeaders.get(CUSTOM_TRANSACTION_ID_HEADER)).isEqualTo(requestId);
         assertThat(spyRequestHeaders.get(DEFAULT_TRANSACTION_ID_HEADER)).isNull();
         assertThat(spyRequestHeaders.get(CUSTOM_REQUEST_ID_HEADER)).isEqualTo(requestId);
         assertThat(spyRequestHeaders.get(DEFAULT_REQUEST_ID_HEADER)).isNull();
         assertThat(metrics.getTransactionId()).isEqualTo(requestId);
-        assertThat(spyResponseHeaders.get(CUSTOM_TRANSACTION_ID_HEADER)).isEqualTo(requestId);
         assertThat(spyRequestHeaders.get(DEFAULT_TRANSACTION_ID_HEADER)).isNull();
-        assertThat(spyResponseHeaders.get(CUSTOM_REQUEST_ID_HEADER)).isEqualTo(requestId);
         assertThat(spyRequestHeaders.get(DEFAULT_REQUEST_ID_HEADER)).isNull();
     }
 
     @Test
-    public void shouldPropagateSameTransactionIdWithCustomHeader() {
+    void shouldPropagateSameTransactionIdWithCustomHeader() {
         transactionProcessor = new TransactionPreProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER);
         String transactionId = UUID.toString(UUID.random());
         String requestId = UUID.toString(UUID.random());
         when(mockRequest.id()).thenReturn(requestId);
         spyRequestHeaders.set(CUSTOM_TRANSACTION_ID_HEADER, transactionId);
         transactionProcessor.execute(ctx).test().assertResult();
-        verify(mockRequest).transactionId(eq(transactionId));
+        verify(mockRequest).transactionId(transactionId);
         assertThat(spyRequestHeaders.get(CUSTOM_TRANSACTION_ID_HEADER)).isEqualTo(transactionId);
         assertThat(spyRequestHeaders.get(CUSTOM_REQUEST_ID_HEADER)).isEqualTo(requestId);
         assertThat(metrics.getTransactionId()).isEqualTo(transactionId);
-        assertThat(spyResponseHeaders.get(CUSTOM_TRANSACTION_ID_HEADER)).isEqualTo(transactionId);
-        assertThat(spyResponseHeaders.get(CUSTOM_REQUEST_ID_HEADER)).isEqualTo(requestId);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionPreProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionPreProcessorTest.java
@@ -15,8 +15,8 @@
  */
 package io.gravitee.gateway.jupiter.reactor.processor.transaction;
 
-import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionProcessorFactory.DEFAULT_REQUEST_ID_HEADER;
-import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionProcessorFactory.DEFAULT_TRANSACTION_ID_HEADER;
+import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionHeader.DEFAULT_REQUEST_ID_HEADER;
+import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -32,15 +32,15 @@ import org.junit.jupiter.api.Test;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class TransactionProcessorTest extends AbstractProcessorTest {
+public class TransactionPreProcessorTest extends AbstractProcessorTest {
 
     private static final String CUSTOM_TRANSACTION_ID_HEADER = "X-My-Transaction-Id";
     private static final String CUSTOM_REQUEST_ID_HEADER = "X-My-Request-Id";
-    private TransactionProcessor transactionProcessor;
+    private TransactionPreProcessor transactionProcessor;
 
     @BeforeEach
     public void setUp() throws Exception {
-        transactionProcessor = new TransactionProcessor(DEFAULT_TRANSACTION_ID_HEADER, DEFAULT_REQUEST_ID_HEADER);
+        transactionProcessor = new TransactionPreProcessor(DEFAULT_TRANSACTION_ID_HEADER, DEFAULT_REQUEST_ID_HEADER);
     }
 
     @Test
@@ -73,7 +73,7 @@ public class TransactionProcessorTest extends AbstractProcessorTest {
 
     @Test
     public void shouldHaveTransactionIdWithCustomHeader() {
-        transactionProcessor = new TransactionProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER);
+        transactionProcessor = new TransactionPreProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER);
         String requestId = UUID.toString(UUID.random());
         when(mockRequest.id()).thenReturn(requestId);
         transactionProcessor.execute(ctx).test().assertResult();
@@ -91,7 +91,7 @@ public class TransactionProcessorTest extends AbstractProcessorTest {
 
     @Test
     public void shouldPropagateSameTransactionIdWithCustomHeader() {
-        transactionProcessor = new TransactionProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER);
+        transactionProcessor = new TransactionPreProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER);
         String transactionId = UUID.toString(UUID.random());
         String requestId = UUID.toString(UUID.random());
         when(mockRequest.id()).thenReturn(requestId);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionProcessorFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/jupiter/reactor/processor/transaction/TransactionProcessorFactoryTest.java
@@ -15,8 +15,8 @@
  */
 package io.gravitee.gateway.jupiter.reactor.processor.transaction;
 
-import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionProcessorFactory.DEFAULT_REQUEST_ID_HEADER;
-import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionProcessorFactory.DEFAULT_TRANSACTION_ID_HEADER;
+import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionHeader.DEFAULT_REQUEST_ID_HEADER;
+import static io.gravitee.gateway.jupiter.reactor.processor.transaction.TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import org.junit.jupiter.api.Test;
@@ -33,7 +33,7 @@ public class TransactionProcessorFactoryTest {
             DEFAULT_TRANSACTION_ID_HEADER,
             DEFAULT_REQUEST_ID_HEADER
         );
-        TransactionProcessor transactionProcessor = transactionProcessorFactory.create();
+        TransactionPreProcessor transactionProcessor = transactionProcessorFactory.create();
         assertThat(transactionProcessor.transactionHeader()).isEqualTo(DEFAULT_TRANSACTION_ID_HEADER);
         assertThat(transactionProcessor.requestHeader()).isEqualTo(DEFAULT_REQUEST_ID_HEADER);
     }
@@ -44,7 +44,7 @@ public class TransactionProcessorFactoryTest {
             "CUSTOM_TRANSACTION_ID_HEADER",
             "CUSTOM_REQUEST_ID_HEADER"
         );
-        TransactionProcessor transactionProcessor = transactionProcessorFactory.create();
+        TransactionPreProcessor transactionProcessor = transactionProcessorFactory.create();
         assertThat(transactionProcessor.transactionHeader()).isEqualTo("CUSTOM_TRANSACTION_ID_HEADER");
         assertThat(transactionProcessor.requestHeader()).isEqualTo("CUSTOM_REQUEST_ID_HEADER");
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessorTest.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.gateway.reactor.processor.transaction;
 
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_REQUEST_ID_HEADER;
+import static io.gravitee.gateway.reactor.processor.transaction.TransactionHeader.DEFAULT_TRANSACTION_ID_HEADER;
+
 import io.gravitee.common.utils.UUID;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
@@ -35,7 +38,7 @@ import org.mockito.MockitoAnnotations;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class TransactionProcessorTest {
+public class TransactionRequestProcessorTest {
 
     private static final String CUSTOM_TRANSACTION_ID_HEADER = "X-My-Transaction-Id";
     private static final String CUSTOM_REQUEST_ID_HEADER = "X-My-Request-Id";
@@ -63,28 +66,19 @@ public class TransactionProcessorTest {
 
         Mockito.when(request.id()).thenReturn(UUID.toString(UUID.random()));
 
-        new TransactionProcessor()
+        new TransactionRequestProcessor()
             .handler(
                 context -> {
                     Assert.assertNotNull(context.request().transactionId());
                     Assert.assertEquals(
                         context.request().transactionId(),
-                        context.request().headers().getFirst(TransactionProcessor.DEFAULT_TRANSACTION_ID_HEADER)
+                        context.request().headers().getFirst(DEFAULT_TRANSACTION_ID_HEADER)
                     );
                     Assert.assertEquals(context.request().transactionId(), context.request().metrics().getTransactionId());
-                    Assert.assertEquals(
-                        context.request().transactionId(),
-                        response.headers().getFirst(TransactionProcessor.DEFAULT_TRANSACTION_ID_HEADER)
-                    );
+                    Assert.assertEquals(context.request().transactionId(), response.headers().getFirst(DEFAULT_TRANSACTION_ID_HEADER));
 
-                    Assert.assertEquals(
-                        context.request().id(),
-                        context.request().headers().getFirst(TransactionProcessor.DEFAULT_REQUEST_ID_HEADER)
-                    );
-                    Assert.assertEquals(
-                        context.request().id(),
-                        response.headers().getFirst(TransactionProcessor.DEFAULT_REQUEST_ID_HEADER)
-                    );
+                    Assert.assertEquals(context.request().id(), context.request().headers().getFirst(DEFAULT_REQUEST_ID_HEADER));
+                    Assert.assertEquals(context.request().id(), response.headers().getFirst(DEFAULT_REQUEST_ID_HEADER));
 
                     lock.countDown();
                 }
@@ -100,32 +94,20 @@ public class TransactionProcessorTest {
 
         String transactionId = UUID.toString(UUID.random());
 
-        request.headers().set(TransactionProcessor.DEFAULT_TRANSACTION_ID_HEADER, transactionId);
-        new TransactionProcessor()
+        request.headers().set(DEFAULT_TRANSACTION_ID_HEADER, transactionId);
+        new TransactionRequestProcessor()
             .handler(
                 context -> {
                     Assert.assertNotNull(context.request().transactionId());
                     Assert.assertEquals(transactionId, context.request().transactionId());
-                    Assert.assertEquals(
-                        transactionId,
-                        context.request().headers().getFirst(TransactionProcessor.DEFAULT_TRANSACTION_ID_HEADER)
-                    );
+                    Assert.assertEquals(transactionId, context.request().headers().getFirst(DEFAULT_TRANSACTION_ID_HEADER));
                     Assert.assertEquals(transactionId, context.request().metrics().getTransactionId());
-                    Assert.assertEquals(
-                        context.request().transactionId(),
-                        response.headers().getFirst(TransactionProcessor.DEFAULT_TRANSACTION_ID_HEADER)
-                    );
+                    Assert.assertEquals(context.request().transactionId(), response.headers().getFirst(DEFAULT_TRANSACTION_ID_HEADER));
 
                     Assert.assertNotEquals(transactionId, context.request().id());
-                    Assert.assertNotEquals(
-                        transactionId,
-                        context.request().headers().getFirst(TransactionProcessor.DEFAULT_REQUEST_ID_HEADER)
-                    );
+                    Assert.assertNotEquals(transactionId, context.request().headers().getFirst(DEFAULT_REQUEST_ID_HEADER));
                     Assert.assertNotEquals(transactionId, context.request().metrics().getRequestId());
-                    Assert.assertEquals(
-                        context.request().id(),
-                        response.headers().getFirst(TransactionProcessor.DEFAULT_REQUEST_ID_HEADER)
-                    );
+                    Assert.assertEquals(context.request().id(), response.headers().getFirst(DEFAULT_REQUEST_ID_HEADER));
 
                     lock.countDown();
                 }
@@ -141,7 +123,7 @@ public class TransactionProcessorTest {
 
         Mockito.when(request.id()).thenReturn(UUID.toString(UUID.random()));
 
-        new TransactionProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER)
+        new TransactionRequestProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER)
             .handler(
                 context -> {
                     Assert.assertNotNull(context.request().transactionId());
@@ -166,7 +148,7 @@ public class TransactionProcessorTest {
         String transactionId = UUID.toString(UUID.random());
 
         request.headers().set(CUSTOM_TRANSACTION_ID_HEADER, transactionId);
-        new TransactionProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER)
+        new TransactionRequestProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER)
             .handler(
                 context -> {
                     Assert.assertNotNull(context.request().transactionId());

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/processor/transaction/TransactionRequestProcessorTest.java
@@ -25,8 +25,6 @@ import io.gravitee.gateway.api.context.MutableExecutionContext;
 import io.gravitee.gateway.api.context.SimpleExecutionContext;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.reporter.api.http.Metrics;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,111 +54,59 @@ public class TransactionRequestProcessorTest {
         MockitoAnnotations.initMocks(this);
         context = new SimpleExecutionContext(request, response);
         Mockito.when(request.headers()).thenReturn(HttpHeaders.create());
-        Mockito.when(response.headers()).thenReturn(HttpHeaders.create());
         Mockito.when(request.metrics()).thenReturn(Metrics.on(System.currentTimeMillis()).build());
     }
 
     @Test
     public void shouldHaveTransactionId() throws InterruptedException {
-        final CountDownLatch lock = new CountDownLatch(1);
-
         Mockito.when(request.id()).thenReturn(UUID.toString(UUID.random()));
 
-        new TransactionRequestProcessor()
-            .handler(
-                context -> {
-                    Assert.assertNotNull(context.request().transactionId());
-                    Assert.assertEquals(
-                        context.request().transactionId(),
-                        context.request().headers().getFirst(DEFAULT_TRANSACTION_ID_HEADER)
-                    );
-                    Assert.assertEquals(context.request().transactionId(), context.request().metrics().getTransactionId());
-                    Assert.assertEquals(context.request().transactionId(), response.headers().getFirst(DEFAULT_TRANSACTION_ID_HEADER));
+        new TransactionRequestProcessor().handler(context -> {}).handle(context);
 
-                    Assert.assertEquals(context.request().id(), context.request().headers().getFirst(DEFAULT_REQUEST_ID_HEADER));
-                    Assert.assertEquals(context.request().id(), response.headers().getFirst(DEFAULT_REQUEST_ID_HEADER));
-
-                    lock.countDown();
-                }
-            )
-            .handle(context);
-
-        Assert.assertTrue(lock.await(10000, TimeUnit.MILLISECONDS));
+        Assert.assertNotNull(context.request().transactionId());
+        Assert.assertEquals(context.request().transactionId(), context.request().headers().get(DEFAULT_TRANSACTION_ID_HEADER));
+        Assert.assertEquals(context.request().transactionId(), context.request().metrics().getTransactionId());
+        Assert.assertEquals(context.request().id(), context.request().headers().get(DEFAULT_REQUEST_ID_HEADER));
     }
 
     @Test
-    public void shouldPropagateSameTransactionId() throws InterruptedException {
-        final CountDownLatch lock = new CountDownLatch(1);
-
+    public void shouldPropagateSameTransactionId() {
         String transactionId = UUID.toString(UUID.random());
 
         request.headers().set(DEFAULT_TRANSACTION_ID_HEADER, transactionId);
-        new TransactionRequestProcessor()
-            .handler(
-                context -> {
-                    Assert.assertNotNull(context.request().transactionId());
-                    Assert.assertEquals(transactionId, context.request().transactionId());
-                    Assert.assertEquals(transactionId, context.request().headers().getFirst(DEFAULT_TRANSACTION_ID_HEADER));
-                    Assert.assertEquals(transactionId, context.request().metrics().getTransactionId());
-                    Assert.assertEquals(context.request().transactionId(), response.headers().getFirst(DEFAULT_TRANSACTION_ID_HEADER));
+        new TransactionRequestProcessor().handler(context -> {}).handle(context);
 
-                    Assert.assertNotEquals(transactionId, context.request().id());
-                    Assert.assertNotEquals(transactionId, context.request().headers().getFirst(DEFAULT_REQUEST_ID_HEADER));
-                    Assert.assertNotEquals(transactionId, context.request().metrics().getRequestId());
-                    Assert.assertEquals(context.request().id(), response.headers().getFirst(DEFAULT_REQUEST_ID_HEADER));
+        Assert.assertNotNull(context.request().transactionId());
+        Assert.assertEquals(transactionId, context.request().transactionId());
+        Assert.assertEquals(transactionId, context.request().headers().get(DEFAULT_TRANSACTION_ID_HEADER));
+        Assert.assertEquals(transactionId, context.request().metrics().getTransactionId());
 
-                    lock.countDown();
-                }
-            )
-            .handle(context);
-
-        Assert.assertTrue(lock.await(10000, TimeUnit.MILLISECONDS));
+        Assert.assertNotEquals(transactionId, context.request().id());
+        Assert.assertNotEquals(transactionId, context.request().headers().get(DEFAULT_REQUEST_ID_HEADER));
+        Assert.assertNotEquals(transactionId, context.request().metrics().getRequestId());
     }
 
     @Test
-    public void shouldHaveTransactionIdWithCustomHeader() throws InterruptedException {
-        final CountDownLatch lock = new CountDownLatch(1);
-
+    public void shouldHaveTransactionIdWithCustomHeader() {
         Mockito.when(request.id()).thenReturn(UUID.toString(UUID.random()));
 
-        new TransactionRequestProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER)
-            .handler(
-                context -> {
-                    Assert.assertNotNull(context.request().transactionId());
-                    Assert.assertEquals(
-                        context.request().transactionId(),
-                        context.request().headers().getFirst(CUSTOM_TRANSACTION_ID_HEADER)
-                    );
-                    Assert.assertEquals(context.request().transactionId(), context.request().metrics().getTransactionId());
-                    Assert.assertEquals(context.request().transactionId(), response.headers().getFirst(CUSTOM_TRANSACTION_ID_HEADER));
-                    lock.countDown();
-                }
-            )
-            .handle(context);
+        new TransactionRequestProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER).handler(context -> {}).handle(context);
 
-        Assert.assertTrue(lock.await(10000, TimeUnit.MILLISECONDS));
+        Assert.assertNotNull(context.request().transactionId());
+        Assert.assertEquals(context.request().transactionId(), context.request().headers().get(CUSTOM_TRANSACTION_ID_HEADER));
+        Assert.assertEquals(context.request().transactionId(), context.request().metrics().getTransactionId());
     }
 
     @Test
     public void shouldPropagateSameTransactionIdWithCustomHeader() throws InterruptedException {
-        final CountDownLatch lock = new CountDownLatch(1);
-
         String transactionId = UUID.toString(UUID.random());
 
         request.headers().set(CUSTOM_TRANSACTION_ID_HEADER, transactionId);
-        new TransactionRequestProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER)
-            .handler(
-                context -> {
-                    Assert.assertNotNull(context.request().transactionId());
-                    Assert.assertEquals(transactionId, context.request().transactionId());
-                    Assert.assertEquals(transactionId, context.request().headers().getFirst(CUSTOM_TRANSACTION_ID_HEADER));
-                    Assert.assertEquals(transactionId, context.request().metrics().getTransactionId());
-                    Assert.assertEquals(context.request().transactionId(), response.headers().getFirst(CUSTOM_TRANSACTION_ID_HEADER));
-                    lock.countDown();
-                }
-            )
-            .handle(context);
+        new TransactionRequestProcessor(CUSTOM_TRANSACTION_ID_HEADER, CUSTOM_REQUEST_ID_HEADER).handler(context -> {}).handle(context);
 
-        Assert.assertTrue(lock.await(10000, TimeUnit.MILLISECONDS));
+        Assert.assertNotNull(context.request().transactionId());
+        Assert.assertEquals(transactionId, context.request().transactionId());
+        Assert.assertEquals(transactionId, context.request().headers().get(CUSTOM_TRANSACTION_ID_HEADER));
+        Assert.assertEquals(transactionId, context.request().metrics().getTransactionId());
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -314,15 +314,25 @@ services:
 #      enabled: false
 #    # possible values: hex, uuid. Default: uuid.
 #    format: uuid
-#    transaction:
-#      # Default: X-Gravitee-Transaction-Id.
-#      header: X-Gravitee-Transaction-Id
 #    headers:
 #      # Override X-Forwarded-Prefix with context path. Disabled by default.
 #      x-forwarded-prefix: false
+#    transaction:
+#      # Default: X-Gravitee-Transaction-Id.
+#      header: X-Gravitee-Transaction-Id
+#      # Possible values of overrideMode are:
+#      #   - override: The header set by the APIM Gateway will override the one provided by the backend
+#      #   - merge: Both headers set by the APIM Gateway and the backend will be kept (as headers can be multivalued)
+#      #   - keep: The header set by the backend will be kept and the one provided by the APIM Gateway discarded
+#      overrideMode: override
 #    request:
 #      # Default: X-Gravitee-Request-Id.
 #      header: X-Gravitee-Request-Id
+#      # Possible values of overrideMode are:
+#      #   - override: The header set by the APIM Gateway will override the one provided by the backend
+#      #   - merge: Both headers set by the APIM Gateway and the backend will be kept (as headers can be multivalued)
+#      #   - keep: The header set by the backend will be kept and the one provided by the APIM Gateway discarded
+#      overrideMode: override
 
 # Referenced properties
 ds:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-75
https://github.com/gravitee-io/issues/issues/7618

## Description

Apply https://github.com/gravitee-io/gravitee-api-management/pull/3169 on 3.20.x + jupiter mode
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qbjonfjqvb.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-75-add-backendoverridemode-3-20-x/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
