### PR TITLE
fix: escape uri components in log queries

### DIFF
--- a/gravitee-apim-console-webui/src/services/api.service.ts
+++ b/gravitee-apim-console-webui/src/services/api.service.ts
@@ -782,7 +782,7 @@ export class ApiService {
     Object.keys(query).forEach((key) => {
       const val = query[key];
       if (val !== undefined && val !== '') {
-        url += key + '=' + val + '&';
+        url += key + '=' + encodeURIComponent(val) + '&';
       }
     });
     return url;


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/APIM-851 
see https://github.com/gravitee-io/issues/issues/8470

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-log-body-search/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rrtmysunvv.chromatic.com)
<!-- Storybook placeholder end -->
