### PR TITLE
fix: fix broken test for ES5

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/spring/ElasticsearchRepositoryConfigurationTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/spring/ElasticsearchRepositoryConfigurationTest.java
@@ -76,6 +76,9 @@ public class ElasticsearchRepositoryConfigurationTest {
         elasticConfiguration.setEndpoints(Collections.singletonList(new Endpoint("http://" + elasticSearchContainer.getHttpHostAddress())));
         elasticConfiguration.setUsername("elastic");
         elasticConfiguration.setPassword(ElasticsearchContainer.ELASTICSEARCH_DEFAULT_PASSWORD);
+        if (elasticsearchVersion.startsWith("5")) {
+            environment.getSystemProperties().put("analytics.elasticsearch.index_per_type", "true");
+        }
         return elasticConfiguration;
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-427

## Description

This small change will just fix the broken test for ES5



<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ksfiheqxsa.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/es8-support/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
