### PR TITLE
fix(plugin): specify schema attributes on each oneOf match

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/resources/schemas/schema-form.json
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/resources/schemas/schema-form.json
@@ -271,10 +271,10 @@
             },
             "oneOf": [
                 {
-                    "properties": { "enabled": { "const": false } }
+                    "properties": { "enabled": { "const": false }, "useSystemProxy": { "const":  false } }
                 },
                 {
-                    "properties": { "useSystemProxy": { "const": true } }
+                    "properties": { "enabled": { "const": true }, "useSystemProxy": { "const": true } }
                 },
                 {
                     "properties": { "enabled": { "const": true }, "useSystemProxy": { "const": false } },


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1054

## Description

Specify `enabled` and `useSystemProxy` attributes on each match for proxy oneOf rules

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1054-http-proxy-error-bug/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xputlojhzo.chromatic.com)
<!-- Storybook placeholder end -->
