### PR TITLE
fix: rename ApiType in K6 simulation

### DIFF
--- a/gravitee-apim-perf/src/lib/fixtures/v4/apis.v4.fixture.ts
+++ b/gravitee-apim-perf/src/lib/fixtures/v4/apis.v4.fixture.ts
@@ -39,7 +39,7 @@ export class ApisV4Fixture {
       groups: [],
       listeners: [],
       tags: [],
-      type: NewApiEntityV4TypeEnum.ASYNC,
+      type: NewApiEntityV4TypeEnum.MESSAGE,
       ...attributes,
     };
   }

--- a/gravitee-apim-perf/src/lib/models/v4/ApiEntityV4.ts
+++ b/gravitee-apim-perf/src/lib/models/v4/ApiEntityV4.ts
@@ -302,8 +302,8 @@ export interface ApiServicesV4 {
 }
 
 export const enum ApiEntityV4TypeEnum {
-  SYNC = 'SYNC',
-  ASYNC = 'ASYNC',
+  PROXY = 'PROXY',
+  MESSAGE = 'MESSAGE',
 }
 
 export const enum ApiEntityV4StateEnum {

--- a/gravitee-apim-perf/src/lib/models/v4/NewApiEntityV4.ts
+++ b/gravitee-apim-perf/src/lib/models/v4/NewApiEntityV4.ts
@@ -98,6 +98,6 @@ export const enum NewApiEntityV4FlowModeEnum {
 }
 
 export const enum NewApiEntityV4TypeEnum {
-  SYNC = 'SYNC',
-  ASYNC = 'ASYNC',
+  PROXY = 'PROXY',
+  MESSAGE = 'MESSAGE',
 }


### PR DESCRIPTION
Related-To APIM-718

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-anhbvnhrui.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/perf-adapt-simulation-after-apim718/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
