### PR TITLE
chore: addition of migration script to update ApiType with mongo

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.21.0/README.adoc
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.21.0/README.adoc
@@ -1,0 +1,10 @@
+= ApiType Migration
+
+Starting from 3.21.0, when you create a v4 API the expected values for the ApiType are :
+
+* PROXY instead of SYNC
+* MESSAGE instead of ASYNC
+
+The script api-type-migration.js aims to update the ApiType for V4 API.
+
+NOTE: If you are not using V4 APIs (currently in beta) you don't have to execute this script.

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.21.0/api-type-migration.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/3.21.0/api-type-migration.js
@@ -1,0 +1,29 @@
+print('Rename ApiType from SYNC & ASYNC to PROXY & MESSAGE');
+// Override this variable if you use prefix
+const prefix = "";
+
+print('Update apis collection');
+let apisCollection = db.getCollection(`${prefix}apis`);
+apisCollection.find({"definitionVersion": "V4"}).forEach((api) => {
+	if (api.type == "SYNC") {
+		api.definition = api.definition.replace('"type" : "sync"', '"type" : "proxy"');
+		api.type = "PROXY";
+        apisCollection.replaceOne({ _id: api._id }, api);
+	}
+	if (api.type == "ASYNC") {
+		api.definition = api.definition.replace('"type" : "async"', '"type" : "message"');
+		api.type = "MESSAGE";
+	    apisCollection.replaceOne({ _id: api._id }, api);
+	}
+});
+
+print('Update events collection');
+let eventsCollection = db.getCollection(`${prefix}events`);
+eventsCollection.find({"type": "PUBLISH_API"}).forEach((event) => {
+    event.payload = event.payload.replace('\\"type\\" : \\"sync\\"', '\\"type\\" : \\"proxy\\"');
+    event.payload = event.payload.replace('\\"type\\" : \\"async\\"', '\\"type\\" : \\"message\\"');
+	event.payload = event.payload.replace('"type" : "sync"', '"type" : "proxy"');
+	event.payload = event.payload.replace('"type" : "async"', '"type" : "message"');
+		
+    eventsCollection.replaceOne({ _id: event._id }, event);
+});


### PR DESCRIPTION
related-to APIM-718

## Description

Addition of a MongoDB script to manage the migration of ApiType values in V4 APIs.
Only Mongo is managed as V4 APIs are in beta.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-sietbehsox.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/chore-migration-script-3-21/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
