### PR TITLE
allow gravitee kubernetes operator to deploy apis

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -1660,10 +1660,6 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     ) throws Exception {
         Api api = apiRepository.findById(apiId).orElseThrow(() -> new ApiNotFoundException(apiId));
 
-        if (DefinitionContext.isKubernetes(api.getOrigin())) {
-            throw new ApiNotManagedException("The api is managed externally (" + api.getOrigin() + "). Unable to deploy it.");
-        }
-
         // add deployment date
         api.setUpdatedAt(new Date());
         api.setDeployedAt(api.getUpdatedAt());


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1034

## Description

Allow GKO to deploy APIs using the Management API.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1034-deploy-kub-api/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gvgjmhxrwd.chromatic.com)
<!-- Storybook placeholder end -->
