### PR TITLE
fix(console): fix user selector search field

### DIFF
--- a/gravitee-apim-console-webui/src/shared/components/gio-users-selector/gio-users-selector.component.html
+++ b/gravitee-apim-console-webui/src/shared/components/gio-users-selector/gio-users-selector.component.html
@@ -24,11 +24,11 @@
 
 <mat-dialog-content>
   <div>
-    <mat-form-field class="gio-users-selector__search-autocomplete">
+    <mat-form-field class="gio-users-selector__search-autocomplete" #searchField>
       <mat-icon matPrefix>search</mat-icon>
       <mat-label>Search a user by name or email</mat-label>
-
-      <input matInput type="search" [matAutocomplete]="auto" [formControl]="userSearchTerm" />
+      <!--Using focus workaround to avoid label overlapping border https://github.com/angular/components/issues/15027#issuecomment-1335147036-->
+      <input matInput type="search" [matAutocomplete]="auto" [formControl]="userSearchTerm" (focus)="searchField.updateOutlineGap()" />
       <button *ngIf="this.userSearchTerm.value" matSuffix mat-icon-button aria-label="Clear" (click)="resetSearchTerm()">
         <mat-icon>close</mat-icon>
       </button>


### PR DESCRIPTION
use workaround to avoid label overlapping field outline border

## Issue

https://gravitee.atlassian.net/browse/APIM-653

## Description

This is a known bug in Angular material 14.
It will be fixed in Angular 15, but in the mean time, I applied the workaround described here 
https://github.com/angular/components/issues/15027#issuecomment-1335147036

![Screenshot 2023-03-15 at 11 08 36](https://user-images.githubusercontent.com/1655950/225277421-adc4ffb2-33d4-4a43-b135-b0855000d089.png)

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fonbqlpair.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-653-fix-border/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
