### PR TITLE
Display list of API members in the transfer ownership screen

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/portal/userGroupAccess/transferOwnership/transferOwnership.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/userGroupAccess/transferOwnership/transferOwnership.controller.ts
@@ -19,10 +19,11 @@ import * as _ from 'lodash';
 import { ApiService } from '../../../../../services/api.service';
 import ApiPrimaryOwnerModeService from '../../../../../services/apiPrimaryOwnerMode.service';
 import UserService from '../../../../../services/user.service';
+import { MembershipListItem } from '../../../../../entities/role/membershipListItem';
 
 class ApiTransferOwnershipController {
   private api: any;
-  private members: any;
+  private readonly members: MembershipListItem[];
   private groupMembers: any;
   private groupIdsWithMembers: any;
   private roles: any;
@@ -32,7 +33,7 @@ class ApiTransferOwnershipController {
   private displayGroups: any;
   private usersSelected = [];
   private userFilterFn;
-  private defaultUsersList: string[];
+  public defaultUsersList: MembershipListItem[];
   private poGroups: any[];
   private newPrimaryOwnerGroup: string;
   private useGroupAsPrimaryOwner: boolean;
@@ -90,10 +91,7 @@ class ApiTransferOwnershipController {
         }) === -1
       );
     };
-
-    this.defaultUsersList = _.filter(this.members, (member: any) => {
-      return member.role !== 'PRIMARY_OWNER' && member.type === 'USER';
-    });
+    this.defaultUsersList = this.members.filter((member) => member.role !== 'PRIMARY_OWNER');
   }
 
   showTransferOwnershipConfirm(ev) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-895
https://github.com/gravitee-io/issues/issues/8516

## Description

Display a list of API members in the transfer ownership screen.
Due to a lack of types, we were filtering on a non-existing field. 
Also, the data returned by the API are already filtered by type == 'USER'
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-895-display-current-members/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kctnkntmwh.chromatic.com)
<!-- Storybook placeholder end -->
