### PR TITLE
Use ApiKeyAuthHandler when ApiKey is provided but invalid

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/security/ApiKeyPlanBasedAuthenticationHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/security/ApiKeyPlanBasedAuthenticationHandler.java
@@ -42,11 +42,17 @@ public class ApiKeyPlanBasedAuthenticationHandler extends PlanBasedAuthenticatio
     @Override
     protected boolean preCheckSubscription(AuthenticationContext authenticationContext) {
         if (!authenticationContext.contains(APIKEY_CONTEXT_ATTRIBUTE)) {
-            // There is no apikey at all, so no subscription to pre check.
+            // There is no apikey at all, so no subscription to pre-check.
             return true;
         }
+
         Optional<ApiKey> optApikey = (Optional<ApiKey>) authenticationContext.get(APIKEY_CONTEXT_ATTRIBUTE);
-        if (optApikey.isEmpty() || !optApikey.get().getPlan().equals(plan.getId())) {
+        if (optApikey.isEmpty()) {
+            // Same here, no api key, consider pre-check is ok and let the policy do its job.
+            return true;
+        }
+
+        if (!optApikey.get().getPlan().equals(plan.getId())) {
             return false;
         }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/security/ApiKeyPlanBasedAuthenticationHandlerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/security/ApiKeyPlanBasedAuthenticationHandlerTest.java
@@ -103,7 +103,7 @@ public class ApiKeyPlanBasedAuthenticationHandlerTest {
 
         boolean canHandle = apiKeyPlanBasedAuthenticationHandler.canHandle(authenticationContext);
 
-        assertFalse(canHandle);
+        assertTrue(canHandle);
         verify(authenticationContext, times(1)).get(APIKEY_CONTEXT_ATTRIBUTE);
         verify(plan, never()).getId();
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1045
https://github.com/gravitee-io/issues/issues/8926

## Description

Use ApiKeyAuthHandler when ApiKey is provided but invalid. 
Unit test for this was there, properly named but with the wrong assertion.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gyzqnblopk.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1045-fix-api-key-handler/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
