### PR TITLE
Allow underscore in hostname for HealthCheck service

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/pom.xml
@@ -130,17 +130,6 @@
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
             </plugin>
-            <plugin>
-                <!--
-                io.vertx.core.VertxException: OpenSSL is not available
-                Caused by: java.lang.IllegalArgumentException: Failed to load any of the given libraries: [netty_tcnative_osx_aarch_64, netty_tcnative_aarch_64, netty_tcnative]
-                -->
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <skipTests>true</skipTests>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/grpc/GrpcEndpointRuleHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/grpc/GrpcEndpointRuleHandler.java
@@ -25,7 +25,7 @@ import io.gravitee.gateway.services.healthcheck.http.HttpEndpointRuleHandler;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.*;
-import java.net.URI;
+import java.net.URL;
 import org.springframework.core.env.Environment;
 
 /**
@@ -42,7 +42,7 @@ public class GrpcEndpointRuleHandler extends HttpEndpointRuleHandler<HttpEndpoin
     }
 
     @Override
-    protected Future<HttpClientRequest> createHttpClientRequest(final HttpClient httpClient, URI request, HealthCheckStep step) {
+    protected Future<HttpClientRequest> createHttpClientRequest(final HttpClient httpClient, URL request, HealthCheckStep step) {
         RequestOptions options = prepareHttpClientRequest(request, step);
 
         return httpClient
@@ -57,7 +57,7 @@ public class GrpcEndpointRuleHandler extends HttpEndpointRuleHandler<HttpEndpoin
     }
 
     @Override
-    protected RequestOptions prepareHttpClientRequest(URI request, HealthCheckStep step) {
+    protected RequestOptions prepareHttpClientRequest(URL request, HealthCheckStep step) {
         RequestOptions options = super.prepareHttpClientRequest(request, step);
 
         // Ensure required grpc headers
@@ -68,8 +68,8 @@ public class GrpcEndpointRuleHandler extends HttpEndpointRuleHandler<HttpEndpoin
     }
 
     @Override
-    protected HttpClientOptions createHttpClientOptions(final HttpEndpoint endpoint, final URI requestUri) throws Exception {
-        HttpClientOptions httpClientOptions = super.createHttpClientOptions((HttpEndpoint) endpoint, requestUri);
+    protected HttpClientOptions createHttpClientOptions(final HttpEndpoint endpoint, final URL requestUrl) throws Exception {
+        HttpClientOptions httpClientOptions = super.createHttpClientOptions((HttpEndpoint) endpoint, requestUrl);
 
         // Force HTTP_2 and disable Upgrade
         httpClientOptions.setProtocolVersion(HttpVersion.HTTP_2).setHttp2ClearTextUpgrade(false);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/http/HttpEndpointRuleHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/http/HttpEndpointRuleHandler.java
@@ -35,7 +35,7 @@ import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.http.RequestOptions;
 import io.vertx.core.net.*;
-import java.net.URI;
+import java.net.URL;
 import org.springframework.core.env.Environment;
 
 /**
@@ -54,7 +54,7 @@ public class HttpEndpointRuleHandler<T extends HttpEndpoint> extends EndpointRul
     }
 
     @Override
-    protected RequestOptions prepareHttpClientRequest(URI request, HealthCheckStep step) {
+    protected RequestOptions prepareHttpClientRequest(URL request, HealthCheckStep step) {
         RequestOptions options = super.prepareHttpClientRequest(request, step);
 
         // Set timeout on request
@@ -67,7 +67,7 @@ public class HttpEndpointRuleHandler<T extends HttpEndpoint> extends EndpointRul
     }
 
     @Override
-    protected HttpClientOptions createHttpClientOptions(final HttpEndpoint endpoint, final URI requestUri) throws Exception {
+    protected HttpClientOptions createHttpClientOptions(final HttpEndpoint endpoint, final URL requestUrl) throws Exception {
         // Prepare HTTP client
         HttpClientOptions httpClientOptions = new HttpClientOptions() // The queue size can contain only a single inflight request for HC
             .setMaxWaitQueueSize(1)
@@ -114,9 +114,9 @@ public class HttpEndpointRuleHandler<T extends HttpEndpoint> extends EndpointRul
         HttpClientSslOptions sslOptions = endpoint.getHttpClientSslOptions();
 
         if (
-            HTTPS_SCHEME.equalsIgnoreCase(requestUri.getScheme()) ||
-            WSS_SCHEME.equalsIgnoreCase(requestUri.getScheme()) ||
-            GRPCS_SCHEME.equalsIgnoreCase(requestUri.getScheme())
+            HTTPS_SCHEME.equalsIgnoreCase(requestUrl.getProtocol()) ||
+            WSS_SCHEME.equalsIgnoreCase(requestUrl.getProtocol()) ||
+            GRPCS_SCHEME.equalsIgnoreCase(requestUrl.getProtocol())
         ) {
             // Configure SSL
             httpClientOptions.setSsl(true).setUseAlpn(true);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/test/java/io/gravitee/gateway/services/healthcheck/http/AbstractManagedEndpointRuleHandlerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/test/java/io/gravitee/gateway/services/healthcheck/http/AbstractManagedEndpointRuleHandlerTest.java
@@ -25,6 +25,7 @@ import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.definition.model.Endpoint;
 import io.gravitee.definition.model.HttpClientOptions;
+import io.gravitee.definition.model.HttpProxy;
 import io.gravitee.definition.model.endpoint.HttpEndpoint;
 import io.gravitee.definition.model.services.healthcheck.HealthCheckRequest;
 import io.gravitee.definition.model.services.healthcheck.HealthCheckResponse;
@@ -36,6 +37,7 @@ import io.gravitee.reporter.api.health.EndpointStatus;
 import io.gravitee.reporter.api.health.Step;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
+import io.vertx.core.net.ProxyOptions;
 import io.vertx.junit5.VertxTestContext;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
@@ -57,7 +59,7 @@ public abstract class AbstractManagedEndpointRuleHandlerTest {
     private TemplateEngine templateEngine;
 
     @RegisterExtension
-    static WireMockExtension wm = WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
+    static WireMockExtension wm = WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).proxyMode(true).build();
 
     @BeforeEach
     void setup() {
@@ -220,9 +222,52 @@ public abstract class AbstractManagedEndpointRuleHandlerTest {
         assertTrue(context.completed());
     }
 
-    private Endpoint createEndpoint(String targetPath) {
-        HttpEndpoint aDefault = new HttpEndpoint("default", "http://localhost:" + wm.getPort() + (targetPath != null ? targetPath : ""));
+    @Test
+    void shouldValidateWithUnderscoreInHostname(Vertx vertx, VertxTestContext context) throws Throwable {
+        // Prepare HTTP endpoint
+        wm.stubFor(get(urlEqualTo("/")).withHost(equalTo("my_local_host")).willReturn(ok()));
+
+        // Prepare
+        EndpointRule rule = createEndpointRule("http://my_local_host", null, true);
+
+        HealthCheckStep step = new HealthCheckStep();
+        HealthCheckRequest request = new HealthCheckRequest("/", HttpMethod.GET);
+
+        step.setRequest(request);
+        HealthCheckResponse response = new HealthCheckResponse();
+        response.setAssertions(Collections.singletonList(HealthCheckResponse.DEFAULT_ASSERTION));
+        step.setResponse(response);
+        when(rule.steps()).thenReturn(Collections.singletonList(step));
+
+        HttpEndpointRuleHandler runner = new HttpEndpointRuleHandler(vertx, rule, templateEngine, environment);
+
+        // Verify
+        runner.setStatusHandler(
+            (Handler<EndpointStatus>) status -> {
+                assertTrue(status.isSuccess());
+                wm.verify(getRequestedFor(urlEqualTo("/")));
+                context.completeNow();
+            }
+        );
+
+        // Run
+        runner.handle(null);
+
+        // Wait until completion
+        assertTrue(context.awaitCompletion(5, TimeUnit.SECONDS));
+        assertTrue(context.completed());
+    }
+
+    private Endpoint createEndpoint(String baseUrl, String targetPath, boolean useSystemProxy) {
+        HttpEndpoint aDefault = new HttpEndpoint("default", baseUrl + (targetPath != null ? targetPath : ""));
         aDefault.setHttpClientOptions(new HttpClientOptions());
+        if (useSystemProxy) {
+            HttpProxy httpProxy = new HttpProxy();
+            httpProxy.setUseSystemProxy(true);
+            httpProxy.setEnabled(true);
+            aDefault.setHttpProxy(httpProxy);
+        }
+
         return aDefault;
     }
 
@@ -231,13 +276,30 @@ public abstract class AbstractManagedEndpointRuleHandlerTest {
     }
 
     private EndpointRule createEndpointRule(String targetPath) {
+        return createEndpointRule(wm.baseUrl(), targetPath, false);
+    }
+
+    private EndpointRule createEndpointRule(String baseUrl, String targetPath, boolean useSystemProxy) {
         EndpointRule rule = mock(EndpointRule.class);
         io.gravitee.definition.model.Api apiDefinition = new io.gravitee.definition.model.Api();
         apiDefinition.setId("an-api");
         Api api = new Api(apiDefinition);
-        when(rule.endpoint()).thenReturn(createEndpoint(targetPath));
+        when(rule.endpoint()).thenReturn(createEndpoint(baseUrl, targetPath, useSystemProxy));
         when(rule.api()).thenReturn(api);
         when(rule.schedule()).thenReturn("0 */10 * ? * *");
+        if (useSystemProxy) {
+            String proxyHost = System.getProperty("http.proxyHost", "none");
+            Integer proxyPort = Integer.valueOf(System.getProperty("http.proxyPort", "80"));
+
+            ProxyOptions proxyOptions = null;
+            if (!"none".equalsIgnoreCase(proxyHost)) {
+                proxyOptions = new ProxyOptions();
+                proxyOptions.setHost(proxyHost);
+                proxyOptions.setPort(proxyPort);
+            }
+
+            when(rule.getSystemProxyOptions()).thenReturn(proxyOptions);
+        }
         return rule;
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1108
https://github.com/gravitee-io/issues/issues/8946

## Description

 - add unit test (see https://wiremock.org/docs/junit-jupiter/#proxy-mode)
 - add debug log to help for future investigation
 - use URL java class instead of URI java class which is more tolerant
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1108-fix-healthcheck-url-resolver/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rtcynflgmu.chromatic.com)
<!-- Storybook placeholder end -->
