### PR TITLE
fix: bump elastic reporter to 3.12.5

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -108,7 +108,7 @@
         <gravitee-notifier-slack.version>1.3.0</gravitee-notifier-slack.version>
         <gravitee-notifier-webhook.version>1.1.0</gravitee-notifier-webhook.version>
         <!-- Gateway Only -->
-        <gravitee-reporter-elasticsearch.version>3.12.4</gravitee-reporter-elasticsearch.version>
+        <gravitee-reporter-elasticsearch.version>3.12.5</gravitee-reporter-elasticsearch.version>
         <gravitee-reporter-file.version>2.5.5</gravitee-reporter-file.version>
         <gravitee-reporter-tcp.version>1.4.4</gravitee-reporter-tcp.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-851
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-bump-elastic-reporter-3.18/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-olmngpglis.chromatic.com)
<!-- Storybook placeholder end -->
