### PR TITLE
fix: bump elastic reporter to 4.0.1

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -109,7 +109,7 @@
         <gravitee-notifier-slack.version>1.3.0</gravitee-notifier-slack.version>
         <gravitee-notifier-webhook.version>1.1.0</gravitee-notifier-webhook.version>
         <!-- Gateway Only -->
-        <gravitee-reporter-elasticsearch.version>4.0.0</gravitee-reporter-elasticsearch.version>
+        <gravitee-reporter-elasticsearch.version>4.0.1</gravitee-reporter-elasticsearch.version>
         <gravitee-reporter-file.version>2.5.5</gravitee-reporter-file.version>
         <gravitee-reporter-tcp.version>1.4.4</gravitee-reporter-tcp.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->


### PR DESCRIPTION

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-bump-elastic-reporter-3.20/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mdwsijmhvk.chromatic.com)
<!-- Storybook placeholder end -->
