### PR TITLE
fix: bump notifier-api & notifier email

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -104,7 +104,7 @@
         <gravitee-fetcher-github.version>1.6.0</gravitee-fetcher-github.version>
         <gravitee-fetcher-gitlab.version>1.11.0</gravitee-fetcher-gitlab.version>
         <gravitee-fetcher-http.version>1.12.0</gravitee-fetcher-http.version>
-        <gravitee-notifier-email.version>1.5.0</gravitee-notifier-email.version>
+        <gravitee-notifier-email.version>1.5.1</gravitee-notifier-email.version>
         <gravitee-notifier-slack.version>1.3.0</gravitee-notifier-slack.version>
         <gravitee-notifier-webhook.version>1.1.0</gravitee-notifier-webhook.version>
         <!-- Gateway Only -->

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <gravitee-gateway-api.version>1.34.2</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>1.24.5</gravitee-node.version>
-        <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>
+        <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-plugin.version>1.24.3</gravitee-plugin.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>1.23.1</gravitee-reporter-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-481
https://github.com/gravitee-io/issues/issues/8752

## Description

bump versions of notifier-api and notifier-email
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-481-fix-new-line/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qcuhmagadp.chromatic.com)
<!-- Storybook placeholder end -->
