### PR TITLE
fix(dockerfiles): move user to base image

### DIFF
--- a/gravitee-apim-gateway/docker/Dockerfile
+++ b/gravitee-apim-gateway/docker/Dockerfile
@@ -18,11 +18,13 @@
 FROM graviteeio/java:17 as base
 ENV GRAVITEEIO_HOME /opt/graviteeio-gateway
 
+RUN addgroup -g 1000 graviteeio \
+    && adduser -D -H -u 1001 graviteeio --ingroup graviteeio
+
 # Second stage to add the folder and change the permissions and ownership
 FROM base as builder
 ADD ./distribution ${GRAVITEEIO_HOME}/
-RUN addgroup -g 1000 graviteeio \
-    && adduser -D -H -u 1001 graviteeio --ingroup graviteeio
+
 RUN chgrp -R graviteeio ${GRAVITEEIO_HOME} && \
     chmod -R g=u ${GRAVITEEIO_HOME}
 

--- a/gravitee-apim-rest-api/docker/Dockerfile
+++ b/gravitee-apim-rest-api/docker/Dockerfile
@@ -18,11 +18,13 @@
 FROM graviteeio/java:17 as base
 ENV GRAVITEEIO_HOME /opt/graviteeio-management-api
 
+RUN addgroup -g 1000 graviteeio \
+    && adduser -D -H -u 1001 graviteeio --ingroup graviteeio
+
 # Second stage to add the folder and change the permissions and ownership
 FROM base as builder
 ADD ./distribution ${GRAVITEEIO_HOME}/
-RUN addgroup -g 1000 graviteeio \
-    && adduser -D -H -u 1001 graviteeio --ingroup graviteeio
+
 RUN chgrp -R graviteeio ${GRAVITEEIO_HOME} && \
     chmod -R g=u ${GRAVITEEIO_HOME}
 


### PR DESCRIPTION
Move user from builder to base image

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kuzfdqejsf.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-dockerfiles/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
