### PR TITLE
Console: API Endpoint configuration is lost when saving healthcheck configuration

### DIFF
--- a/gravitee-apim-console-webui/src/entities/proxy/Proxy.ts
+++ b/gravitee-apim-console-webui/src/entities/proxy/Proxy.ts
@@ -38,7 +38,7 @@ export interface ProxyConfiguration {
   proxy?: ProxyGroupProxy;
   http?: ProxyGroupHttpClientOptions;
   ssl?: ProxyGroupHttpClientSslOptions;
-  headers?: Record<string, string>;
+  headers?: { name: string;  value:string}[];
 }
 
 export interface ProxyGroup extends ProxyConfiguration {
@@ -73,12 +73,12 @@ export interface ProxyGroupLoadBalancer {
 
 export interface ProxyGroupProxy {
   enabled: boolean;
-  useSystemProxy: boolean;
-  host: string;
-  port: number;
-  username: string;
-  password: string;
-  type: 'HTTP' | 'SOCKS4' | 'SOCKS5';
+  useSystemProxy?: boolean;
+  host?: string;
+  port?: number;
+  username?: string;
+  password?: string;
+  type?: 'HTTP' | 'SOCKS4' | 'SOCKS5';
 }
 
 export interface ProxyGroupHttpClientOptions {

--- a/gravitee-apim-console-webui/src/management/api/proxy/components/health-check-form/api-proxy-health-check-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/components/health-check-form/api-proxy-health-check-form.component.spec.ts
@@ -109,7 +109,7 @@ describe('ApiProxyHealthCheckFormComponent', () => {
 
     expect(component.healthCheckForm.value).toEqual({
       enabled: false,
-      inherit: false,
+      inherit: true,
     });
   });
 
@@ -120,6 +120,11 @@ describe('ApiProxyHealthCheckFormComponent', () => {
     const enabledSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="enabled"]' }));
     expect(await enabledSlideToggle.isChecked()).toEqual(false);
     await enabledSlideToggle.check();
+
+    // Disable inherit
+    const inheritSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="inherit"]' }));
+    expect(await inheritSlideToggle.isChecked()).toEqual(true);
+    await inheritSlideToggle.check();
 
     // Trigger
     component.healthCheckForm.get('schedule').setValue('* * * * *');
@@ -177,7 +182,9 @@ describe('ApiProxyHealthCheckFormComponent', () => {
   });
 
   it('should inherit health check', async () => {
-    initHealthCheckFormComponent();
+    initHealthCheckFormComponent({
+      inherit: false,
+    });
 
     const inheritHealthCheck: HealthCheck = {
       enabled: true,

--- a/gravitee-apim-console-webui/src/management/api/proxy/components/health-check-form/api-proxy-health-check-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/components/health-check-form/api-proxy-health-check-form.component.ts
@@ -39,7 +39,7 @@ export class ApiProxyHealthCheckFormComponent implements OnChanges, OnDestroy {
         disabled: isReadOnly,
       }),
       inherit: new FormControl({
-        value: healthCheck?.inherit ?? false,
+        value: healthCheck?.inherit ?? true,
         disabled: isReadOnly,
       }),
       // Trigger
@@ -171,9 +171,10 @@ export class ApiProxyHealthCheckFormComponent implements OnChanges, OnDestroy {
     }
 
     if (changes.inheritHealthCheck && this.inheritHealthCheck) {
+
       this.healthCheckForm
         .get('inherit')
-        .valueChanges.pipe(takeUntil(this.unsubscribe$))
+        .valueChanges.pipe(takeUntil(this.unsubscribe$), startWith(this.healthCheckForm.get('inherit').value))
         .subscribe((checked) => {
           // Save or restore previous health check value.
           if (checked) {

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/api-proxy-group-endpoint.adapter.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/api-proxy-group-endpoint.adapter.ts
@@ -36,10 +36,10 @@ export const toProxyGroupEndpoint = (
     updatedEndpoint = {
       ...updatedEndpoint,
       inherit: false,
-      http: configurationData.http,
-      ssl: configurationData.ssl,
-      headers: configurationData.headers,
-      proxy: configurationData.proxy,
+      http: configurationData.proxyConfiguration.http,
+      ssl: configurationData.proxyConfiguration.ssl,
+      headers: configurationData.proxyConfiguration.headers,
+      proxy: configurationData.proxyConfiguration.proxy,
     };
   } else {
     updatedEndpoint = {

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.html
@@ -40,10 +40,7 @@
         <api-proxy-group-endpoint-configuration
           *ngIf="configurationForm && configurationSchema && endpoint"
           [configurationForm]="configurationForm"
-          [endpoint]="endpoint"
           [configurationSchema]="configurationSchema"
-          [isReadOnly]="isReadOnly"
-          (onConfigurationChange)="onConfigurationChange($event)"
         ></api-proxy-group-endpoint-configuration>
       </div>
     </mat-tab>

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.spec.ts
@@ -225,7 +225,7 @@ describe('ApiProxyGroupEndpointEditComponent', () => {
 
         await inherit.toggle();
 
-        expect(fixture.debugElement.nativeElement.querySelector('gv-schema-form')).toBeTruthy();
+        expect(fixture.debugElement.nativeElement.querySelector('gv-schema-form-group')).toBeTruthy();
         expect(fixture.componentInstance.configurationForm.getRawValue().inherit).toStrictEqual(false);
 
         const gioSaveBar = await loader.getHarness(GioSaveBarHarness);
@@ -248,10 +248,10 @@ describe('ApiProxyGroupEndpointEditComponent', () => {
                   backup: false,
                   type: 'HTTP',
                   inherit: false,
-                  headers: undefined,
-                  http: undefined,
-                  proxy: undefined,
-                  ssl: undefined,
+                  headers: [],
+                  http: {},
+                  proxy: { enabled: false },
+                  ssl: {},
                   healthcheck: {
                     enabled: false,
                   },

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.ts
@@ -15,7 +15,7 @@
  */
 import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
 import { catchError, map, switchMap, takeUntil, tap } from 'rxjs/operators';
-import { combineLatest, EMPTY, Subject, Subscription } from 'rxjs';
+import { combineLatest, EMPTY, of, Subject, Subscription } from 'rxjs';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { StateService } from '@uirouter/core';
 
@@ -88,6 +88,7 @@ export class ApiProxyGroupEndpointEditComponent implements OnInit, OnDestroy {
           this.configurationSchema = JSON.parse(
             this.connectors.find((connector) => connector.supportedTypes.includes(this.endpoint?.type?.toLowerCase() ?? 'http'))?.schema,
           );
+          console.log('configurationSchema', this.configurationSchema);
         }),
       )
       .subscribe();
@@ -121,10 +122,7 @@ export class ApiProxyGroupEndpointEditComponent implements OnInit, OnDestroy {
           const updatedEndpoint = toProxyGroupEndpoint(
             api.proxy.groups[groupIndex]?.endpoints[endpointIndex],
             this.generalForm.getRawValue(),
-            {
-              ...this.updatedConfiguration,
-              inherit: this.configurationForm.getRawValue().inherit,
-            },
+            this.configurationForm.getRawValue(),
             ApiProxyHealthCheckFormComponent.HealthCheckFromFormGroup(this.healthCheckForm),
           );
 
@@ -198,8 +196,20 @@ export class ApiProxyGroupEndpointEditComponent implements OnInit, OnDestroy {
       backup: [{ value: this.endpoint?.backup ?? false, disabled: this.isReadOnly }],
     });
 
+    const proxyConfigurationValue: ProxyConfiguration = {
+      headers: this.endpoint?.headers ?? [],
+      http: this.endpoint?.http ?? {},
+      proxy: this.endpoint?.proxy ?? { enabled: false},
+      ssl: this.endpoint?.ssl ?? {},
+    };
     this.configurationForm = this.formBuilder.group({
       inherit: [{ value: this.endpoint?.inherit ?? true, disabled: this.isReadOnly }],
+      proxyConfiguration: [
+        {
+          value: proxyConfigurationValue,
+          disabled: this.isReadOnly,
+        },
+      ],
     });
 
     this.healthCheckForm = ApiProxyHealthCheckFormComponent.NewHealthCheckFormGroup(this.endpoint?.healthcheck, this.isReadOnly);

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/configuration/api-proxy-group-endpoint-configuration.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/configuration/api-proxy-group-endpoint-configuration.component.html
@@ -29,12 +29,13 @@
     </gio-form-slide-toggle>
 
     <div *ngIf="!configurationForm.get('inherit').value">
-      <gv-schema-form
-        [attr.readonly]="isReadOnly ? isReadOnly : null"
+      <gv-schema-form-group
+        ngDefaultControl
+        formControlName="proxyConfiguration"
         [schema]="configurationSchema"
-        [values]="endpoint"
-        (:gv-schema-form:change)="onChange($event)"
-      ></gv-schema-form>
+        [attr.readonly]="configurationForm.get('proxyConfiguration').enabled ? null : true"
+        (:gv-schema-form-group:error)="onProxyConfigurationError($event.detail)"
+      ></gv-schema-form-group>
     </div>
   </mat-card>
 </form>

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/configuration/api-proxy-group-endpoint-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/configuration/api-proxy-group-endpoint-configuration.component.ts
@@ -13,11 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 
-import { ProxyGroupEndpoint } from '../../../../../../../../entities/proxy';
-import { ConfigurationEvent, SchemaFormEvent } from '../../../api-proxy-groups.model';
 
 @Component({
   selector: 'api-proxy-group-endpoint-configuration',
@@ -27,14 +25,11 @@ import { ConfigurationEvent, SchemaFormEvent } from '../../../api-proxy-groups.m
 export class ApiProxyGroupEndpointConfigurationComponent {
   @Input() configurationForm: FormGroup;
   @Input() configurationSchema: unknown;
-  @Input() endpoint: ProxyGroupEndpoint;
-  @Input() isReadOnly: boolean;
-  @Output() onConfigurationChange = new EventEmitter<ConfigurationEvent>();
 
-  public onChange(event: SchemaFormEvent): void {
-    this.onConfigurationChange.emit({
-      isSchemaValid: !event.detail?.validation?.errors?.length,
-      configuration: event.detail?.values,
-    });
+  public onProxyConfigurationError(error: unknown) {
+    // Set error at the end of js task. Otherwise it will be reset on value change
+    setTimeout(() => {
+      this.configurationForm.get("proxyConfiguration").setErrors(error ? { error: true } : null);
+    }, 0);
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/configuration/api-proxy-group-endpoint-edit-configuration.model.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/configuration/api-proxy-group-endpoint-edit-configuration.model.ts
@@ -15,4 +15,6 @@
  */
 import { ProxyConfiguration, ProxyGroupEndpoint } from '../../../../../../../../entities/proxy';
 
-export type EndpointConfigurationData = Pick<ProxyGroupEndpoint, 'inherit'> & ProxyConfiguration;
+export type EndpointConfigurationData = Pick<ProxyGroupEndpoint, 'inherit'> & {
+  proxyConfiguration: ProxyConfiguration;
+};


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-1115

## Description

- Do not lose proxyConfig when changing the healthcheck config
- Health check inherit is enable by default

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

