### PR TITLE
3.20.x - Console - API Endpoint configuration is lost when saving healthcheck configuration

### DIFF
--- a/gravitee-apim-console-webui/src/entities/proxy/Proxy.ts
+++ b/gravitee-apim-console-webui/src/entities/proxy/Proxy.ts
@@ -36,7 +36,7 @@ export interface ProxyConfiguration {
   proxy?: ProxyGroupProxy;
   http?: ProxyGroupHttpClientOptions;
   ssl?: ProxyGroupHttpClientSslOptions;
-  headers?: Record<string, string>;
+  headers?: { name: string; value: string }[];
 }
 
 export interface ProxyGroup extends ProxyConfiguration {
@@ -71,12 +71,12 @@ export interface ProxyGroupLoadBalancer {
 
 export interface ProxyGroupProxy {
   enabled: boolean;
-  useSystemProxy: boolean;
-  host: string;
-  port: number;
-  username: string;
-  password: string;
-  type: 'HTTP' | 'SOCKS4' | 'SOCKS5';
+  useSystemProxy?: boolean;
+  host?: string;
+  port?: number;
+  username?: string;
+  password?: string;
+  type?: 'HTTP' | 'SOCKS4' | 'SOCKS5';
 }
 
 export interface ProxyGroupHttpClientOptions {

--- a/gravitee-apim-console-webui/src/management/api/proxy/components/health-check-form/api-proxy-health-check-form.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/components/health-check-form/api-proxy-health-check-form.component.html
@@ -41,14 +41,19 @@
 
     <mat-divider></mat-divider>
 
-    <gio-banner-info
-      *ngIf="healthCheckForm.get('enabled').value && inheritHealthCheck && healthCheckForm.get('inherit').value"
-      class="health-check-card__banner"
-    >
-      Inherited configuration preview from global health-check settings.
+    <gio-banner-info *ngIf="inheritHealthCheck && healthCheckForm.get('inherit').value" class="health-check-card__banner">
+      {{
+        inheritHealthCheck.enabled
+          ? 'Inherited configuration preview from global health-check settings.'
+          : 'No global health-check settings defined. When defined, they will be inherited.'
+      }}
     </gio-banner-info>
 
-    <div [class.disabled]="isDisabled$ | async" class="health-check-card--forms">
+    <div
+      *ngIf="!inheritHealthCheck || !(inheritHealthCheck && !inheritHealthCheck.enabled && healthCheckForm.get('inherit').value)"
+      [class.disabled]="isDisabled$ | async"
+      class="health-check-card--forms"
+    >
       <!-- Trigger -->
       <h3>Trigger</h3>
       <div class="health-check-card__trigger">

--- a/gravitee-apim-console-webui/src/management/api/proxy/components/health-check-form/api-proxy-health-check-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/components/health-check-form/api-proxy-health-check-form.component.spec.ts
@@ -109,7 +109,7 @@ describe('ApiProxyHealthCheckFormComponent', () => {
 
     expect(component.healthCheckForm.value).toEqual({
       enabled: false,
-      inherit: false,
+      inherit: true,
     });
   });
 
@@ -155,9 +155,8 @@ describe('ApiProxyHealthCheckFormComponent', () => {
     const assertion_1 = await loader.getHarness(MatInputHarness.with({ selector: '[ng-reflect-name="1"]' }));
     await assertion_1.setValue('new assertion');
 
-    expect(ApiProxyHealthCheckFormComponent.HealthCheckFromFormGroup(component.healthCheckForm)).toEqual({
+    expect(ApiProxyHealthCheckFormComponent.HealthCheckFromFormGroup(component.healthCheckForm, false)).toEqual({
       enabled: true,
-      inherit: false,
       schedule: '* * * * *',
       steps: [
         {
@@ -177,7 +176,9 @@ describe('ApiProxyHealthCheckFormComponent', () => {
   });
 
   it('should inherit health check', async () => {
-    initHealthCheckFormComponent();
+    initHealthCheckFormComponent({
+      inherit: false,
+    });
 
     const inheritHealthCheck: HealthCheck = {
       enabled: true,
@@ -207,7 +208,7 @@ describe('ApiProxyHealthCheckFormComponent', () => {
     await enabledSlideToggle.check();
 
     const inheritSlideToggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="inherit"]' }));
-    expect(await inheritSlideToggle.isChecked()).toEqual(false);
+    expect(await inheritSlideToggle.isChecked()).toEqual(true);
     await inheritSlideToggle.check();
 
     // Expect inherit preview :
@@ -241,7 +242,7 @@ describe('ApiProxyHealthCheckFormComponent', () => {
     expect(await assertion_0.isDisabled()).toEqual(true);
     expect(await assertion_0.getValue()).toEqual('inherit');
 
-    expect(ApiProxyHealthCheckFormComponent.HealthCheckFromFormGroup(component.healthCheckForm)).toEqual({
+    expect(ApiProxyHealthCheckFormComponent.HealthCheckFromFormGroup(component.healthCheckForm, true)).toEqual({
       enabled: true,
       inherit: true,
     });
@@ -250,7 +251,6 @@ describe('ApiProxyHealthCheckFormComponent', () => {
   it('should display configured Health Check', async () => {
     const healthCheck: HealthCheck = {
       enabled: true,
-      inherit: false,
       schedule: '* * * * *',
       steps: [
         {
@@ -307,7 +307,7 @@ describe('ApiProxyHealthCheckFormComponent', () => {
     expect(await assertion.isDisabled()).toEqual(false);
     expect(await assertion.getValue()).toEqual('#response.status == 400');
 
-    expect(ApiProxyHealthCheckFormComponent.HealthCheckFromFormGroup(component.healthCheckForm)).toEqual(healthCheck);
+    expect(ApiProxyHealthCheckFormComponent.HealthCheckFromFormGroup(component.healthCheckForm, false)).toEqual(healthCheck);
   });
 
   it('should be readonly', async () => {

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/api-proxy-group-endpoint.adapter.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/api-proxy-group-endpoint.adapter.ts
@@ -36,10 +36,10 @@ export const toProxyGroupEndpoint = (
     updatedEndpoint = {
       ...updatedEndpoint,
       inherit: false,
-      http: configurationData.http,
-      ssl: configurationData.ssl,
-      headers: configurationData.headers,
-      proxy: configurationData.proxy,
+      http: configurationData.proxyConfiguration.http,
+      ssl: configurationData.proxyConfiguration.ssl,
+      headers: configurationData.proxyConfiguration.headers,
+      proxy: configurationData.proxyConfiguration.proxy,
     };
   } else {
     updatedEndpoint = {

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.html
@@ -40,10 +40,7 @@
         <api-proxy-group-endpoint-configuration
           *ngIf="configurationForm && configurationSchema && endpoint"
           [configurationForm]="configurationForm"
-          [endpoint]="endpoint"
           [configurationSchema]="configurationSchema"
-          [isReadOnly]="isReadOnly"
-          (onConfigurationChange)="onConfigurationChange($event)"
         ></api-proxy-group-endpoint-configuration>
       </div>
     </mat-tab>

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.spec.ts
@@ -221,11 +221,11 @@ describe('ApiProxyGroupEndpointEditComponent', () => {
 
       it('should update existing endpoint configuration', async () => {
         const inherit = await loader.getHarness(MatSlideToggleHarness.with({ selector: '[formControlName="inherit"]' }));
-        expect(fixture.debugElement.nativeElement.querySelector('gv-schema-form')).toBeFalsy();
+        expect(fixture.debugElement.nativeElement.querySelector('gv-schema-form-group')).toBeFalsy();
 
         await inherit.toggle();
 
-        expect(fixture.debugElement.nativeElement.querySelector('gv-schema-form')).toBeTruthy();
+        expect(fixture.debugElement.nativeElement.querySelector('gv-schema-form-group')).toBeTruthy();
         expect(fixture.componentInstance.configurationForm.getRawValue().inherit).toStrictEqual(false);
 
         const gioSaveBar = await loader.getHarness(GioSaveBarHarness);
@@ -248,10 +248,10 @@ describe('ApiProxyGroupEndpointEditComponent', () => {
                   backup: false,
                   type: 'HTTP',
                   inherit: false,
-                  headers: undefined,
-                  http: undefined,
-                  proxy: undefined,
-                  ssl: undefined,
+                  headers: [],
+                  http: {},
+                  proxy: { enabled: false },
+                  ssl: {},
                   healthcheck: {
                     enabled: false,
                   },
@@ -268,35 +268,6 @@ describe('ApiProxyGroupEndpointEditComponent', () => {
             },
           ],
         });
-      });
-
-      it('should disable the save bar when the configuration form is invalid', async () => {
-        fixture.componentInstance.onConfigurationChange({
-          isSchemaValid: false,
-          configuration: {},
-        });
-
-        expect(await loader.getHarness(GioSaveBarHarness).then((saveBar) => saveBar.isSubmitButtonInvalid())).toBeTruthy();
-        expect(fixture.componentInstance.endpointForm.valid).toBeFalsy();
-      });
-
-      it('should enable the save bar when the configuration form become valie', async () => {
-        fixture.componentInstance.onConfigurationChange({
-          isSchemaValid: false,
-          configuration: {},
-        });
-        expect(await loader.getHarness(GioSaveBarHarness).then((saveBar) => saveBar.isSubmitButtonInvalid())).toBeTruthy();
-        expect(fixture.componentInstance.endpointForm.valid).toBeFalsy();
-        expect(fixture.componentInstance.endpointForm.hasError('invalidConfiguration')).toBeTruthy();
-
-        fixture.componentInstance.onConfigurationChange({
-          isSchemaValid: true,
-          configuration: {},
-        });
-
-        expect(await loader.getHarness(GioSaveBarHarness).then((saveBar) => saveBar.isSubmitButtonInvalid())).toBeFalsy();
-        expect(fixture.componentInstance.endpointForm.valid).toBeTruthy();
-        expect(fixture.componentInstance.endpointForm.hasError('invalidConfiguration')).toBeFalsy();
       });
     });
   });

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.ts
@@ -121,7 +121,7 @@ export class ApiProxyGroupEndpointEditComponent implements OnInit, OnDestroy {
             api.proxy.groups[groupIndex]?.endpoints[endpointIndex],
             this.generalForm.getRawValue(),
             this.configurationForm.getRawValue(),
-            ApiProxyHealthCheckFormComponent.HealthCheckFromFormGroup(this.healthCheckForm),
+            ApiProxyHealthCheckFormComponent.HealthCheckFromFormGroup(this.healthCheckForm, true),
           );
 
           endpointIndex !== -1

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/configuration/api-proxy-group-endpoint-configuration.component.html
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/configuration/api-proxy-group-endpoint-configuration.component.html
@@ -29,12 +29,13 @@
     </gio-form-slide-toggle>
 
     <div *ngIf="!configurationForm.get('inherit').value">
-      <gv-schema-form
-        [attr.readonly]="isReadOnly ? isReadOnly : null"
+      <gv-schema-form-group
+        ngDefaultControl
+        formControlName="proxyConfiguration"
         [schema]="configurationSchema"
-        [values]="endpoint"
-        (:gv-schema-form:change)="onChange($event)"
-      ></gv-schema-form>
+        [attr.readonly]="configurationForm.get('proxyConfiguration').enabled ? null : true"
+        (:gv-schema-form-group:error)="onProxyConfigurationError($event.detail)"
+      ></gv-schema-form-group>
     </div>
   </mat-card>
 </form>

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/configuration/api-proxy-group-endpoint-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/configuration/api-proxy-group-endpoint-configuration.component.ts
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-
-import { ProxyGroupEndpoint } from '../../../../../../../../entities/proxy';
-import { ConfigurationEvent, SchemaFormEvent } from '../../../api-proxy-groups.model';
 
 @Component({
   selector: 'api-proxy-group-endpoint-configuration',
@@ -27,14 +24,11 @@ import { ConfigurationEvent, SchemaFormEvent } from '../../../api-proxy-groups.m
 export class ApiProxyGroupEndpointConfigurationComponent {
   @Input() configurationForm: FormGroup;
   @Input() configurationSchema: unknown;
-  @Input() endpoint: ProxyGroupEndpoint;
-  @Input() isReadOnly: boolean;
-  @Output() onConfigurationChange = new EventEmitter<ConfigurationEvent>();
 
-  public onChange(event: SchemaFormEvent): void {
-    this.onConfigurationChange.emit({
-      isSchemaValid: !event.detail?.validation?.errors?.length,
-      configuration: event.detail?.values,
-    });
+  public onProxyConfigurationError(error: unknown) {
+    // Set error at the end of js task. Otherwise it will be reset on value change
+    setTimeout(() => {
+      this.configurationForm.get('proxyConfiguration').setErrors(error ? { error: true } : null);
+    }, 0);
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/configuration/api-proxy-group-endpoint-edit-configuration.model.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/endpoints/groups/endpoint/edit/configuration/api-proxy-group-endpoint-edit-configuration.model.ts
@@ -15,4 +15,6 @@
  */
 import { ProxyConfiguration, ProxyGroupEndpoint } from '../../../../../../../../entities/proxy';
 
-export type EndpointConfigurationData = Pick<ProxyGroupEndpoint, 'inherit'> & ProxyConfiguration;
+export type EndpointConfigurationData = Pick<ProxyGroupEndpoint, 'inherit'> & {
+  proxyConfiguration: ProxyConfiguration;
+};

--- a/gravitee-apim-console-webui/src/management/api/proxy/health-check/api-proxy-health-check.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/health-check/api-proxy-health-check.component.spec.ts
@@ -112,7 +112,6 @@ describe('ApiProxyHealthCheckComponent', () => {
     const req = httpTestingController.expectOne({ method: 'PUT', url: `${CONSTANTS_TESTING.env.baseURL}/apis/${API_ID}` });
     expect(req.request.body.services['health-check']).toStrictEqual({
       enabled: true,
-      inherit: false,
       schedule: '* * * * *',
       steps: [
         {

--- a/gravitee-apim-console-webui/src/management/api/proxy/health-check/api-proxy-health-check.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/proxy/health-check/api-proxy-health-check.component.ts
@@ -75,7 +75,7 @@ export class ApiProxyHealthCheckComponent implements OnInit, OnDestroy {
             ...api,
             services: {
               ...api.services,
-              'health-check': ApiProxyHealthCheckFormComponent.HealthCheckFromFormGroup(this.healthCheckForm),
+              'health-check': ApiProxyHealthCheckFormComponent.HealthCheckFromFormGroup(this.healthCheckForm, false),
             },
           }),
         ),


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-1115

## Description

- Do not lose proxyConfig when changing the healthcheck config
- Health check inherit is enable by default

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/3.20.x-fix-endpoint-config/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ldallmgtte.chromatic.com)
<!-- Storybook placeholder end -->
