### PR TITLE
tests: remove volumes on apim container

### DIFF
--- a/gravitee-apim-e2e/docker/common/docker-compose-apis.yml
+++ b/gravitee-apim-e2e/docker/common/docker-compose-apis.yml
@@ -31,9 +31,6 @@ services:
         condition: service_healthy
     ports:
       - "8083:8083"
-    volumes:
-      - ./.logs/apim-management-api:/opt/graviteeio-management-api/logs
-      - ./jacoco:/opt/jacoco
     environment:
       - gravitee_analytics_elasticsearch_endpoints_0=http://elasticsearch:9200
       - gravitee_newsletter_enabled=false
@@ -64,9 +61,6 @@ services:
         condition: service_healthy
     ports:
       - "8082:8082"
-    volumes:
-      - ./.logs/apim-gateway:/opt/graviteeio-gateway/logs
-      - ./jacoco:/opt/jacoco
     environment:
       - gravitee_reporters_elasticsearch_endpoints_0=http://elasticsearch:9200
       - gravitee_api_jupiterMode_enabled=${JUPITER_MODE_ENABLED:-false}

--- a/gravitee-apim-e2e/docker/common/docker-compose-bridge.yml
+++ b/gravitee-apim-e2e/docker/common/docker-compose-bridge.yml
@@ -31,9 +31,6 @@ services:
         condition: service_healthy
     ports:
       - "8083:8083"
-    volumes:
-      - ./.logs/apim-management-api:/opt/graviteeio-management-api/logs
-      - ./jacoco:/opt/jacoco
     environment:
       - gravitee_analytics_elasticsearch_endpoints_0=http://elasticsearch:9200
       - gravitee_newsletter_enabled=false
@@ -64,9 +61,6 @@ services:
         condition: service_healthy
     ports:
       - "18082:18082"
-    volumes:
-      - ./.logs/apim-gateway-server:/opt/graviteeio-gateway/logs
-      - ./jacoco:/opt/jacoco
     environment:
       - gravitee_reporters_elasticsearch_endpoints_0=http://elasticsearch:9200
       - gravitee_api_jupiterMode_enabled=${JUPITER_MODE_ENABLED:-false}
@@ -101,7 +95,6 @@ services:
       - elasticsearch
       - gateway
     volumes:
-      - ./.logs/apim-gateway-client:/opt/graviteeio-gateway/logs
       - ./.license:/opt/graviteeio-gateway/license
     environment:
       - gravitee_management_type=http


### PR DESCRIPTION
## Issue

N/A

## Description

Because now APIM docker images are using a non-root user, logs volumes can't be accessed and containers don't start.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kevaksfjoy.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-run-e2e-tests/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
