### PR TITLE
docs: add dev environment guide in readme file

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -98,3 +98,138 @@ git pull upstream BASE_BRANCH
 # Push the updated branch
 git push origin YOUR_BRANCH
 ----
+
+== Bootstrap Your Dev Environment
+
+// tag::dev-guide[]
+=== Overview
+
+This section explains how to set up your environment to start contributing to APIM.
+
+=== Prerequisites
+
+You will need the following tools installed on your computer:
+
+* Java (JDK >= 11)
+* Maven
+* Docker
+* NPM (preferably NVM)
+
+=== Get the project and prepare your workspace
+
+Clone the project in your workspace::
+[source, bash]
+----
+git clone https://github.com/gravitee-io/gravitee-api-management
+----
+
+Build APIM Management API and Gateway::
+[source, bash]
+----
+mvn clean install -T 2C
+----
+TIP: You can use `-Dskip.validation=true` to skip license validation and prettier checks.
+
+NOTE: This command will build create a `distribution` folder in the `target` folder of each module.
+These folders contain a full distribution of Management API and Gateway, with default plugins.
+These `distribution` folder should be used as the `gravitee.home` environment variable
+
+
+Prepare APIM Console UI and Portal UI::
+Run `npm install` from the `gravitee-api-management/gravitee-apim-console-webui` and `gravitee-api-management/gravitee-apim-portal-webui` directories.
+
+TIP: you can use `nvm use` to switch to the appropriate version of npm to build the UIs.
+
+=== Run Prerequisites
+
+Before starting APIM Management API and Gateway, you need to start MongoDB and ElasticSearch. +
+You can, for instance, use docker.
+
+MongoDB::
+[source, bash]
+----
+docker run -p 27017:27017 --name local-mongo -d mongo:3
+----
+
+ElasticSearch::
+[source, bash]
+----
+docker run -d --name local-es7 -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.7.0
+----
+
+=== Run Configuration
+
+==== APIM Gateway  (gravitee-apim-gateway)
+CLI Version::
+Run `./gravitee` from the `${GRAVITEE_HOME}/bin` directory.
+
+NOTE:  `${GRAVITEE_HOME}` refers to the `target/distribution` folder created before.
+
+IntelliJ configuration::
+The project includes by default the configuration `Gateway - MongoDB` to run the Gateway.
+
+It contains by default the following configuration:
+
+. *Use classpath of module*: `gravitee-apim-gateway-standalone-container`.
+. *Main class*: `io.gravitee.gateway.standalone.GatewayContainer`.
+. In the VM options, add the following (change the path to point to your project):
++
+[source, bash]
+----
+-Dgravitee.home="/home/user/dev/gravitee-api-management/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/target/distribution"
+----
+
+==== APIM Management API (gravitee-apim-rest-api)
+CLI Version::
+Run `./gravitee` from the `${GRAVITEE_HOME}/bin` directory.
+
+NOTE:  `${GRAVITEE_HOME}` refers to the `target/distribution` folder created before.
+
+IntelliJ configuration::
+The project includes by default the configuration `Rest API - MongoDB` to run the Rest API.
+
+It contains by default the following configuration:
+
+. *Use classpath of module*: `gravitee-apim-rest-api-standalone-container`.
+. *Main class*: `io.gravitee.rest.api.standalone.GraviteeApisContainer`.
+. In the VM options, add the following (change the path to point to your project):
+[source, bash]
+----
+-Dgravitee.home="/home/user/dev/gravitee-api-management/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/target/distribution"
+----
+
+
+==== APIM Console (gravitee-apim-console-webui)
+
+CLI Version::
+Run `npm run serve` from the `gravitee-api-management/gravitee-apim-console-webui` directory to start the UI.
+
+IntelliJ configuration::
+Create a new Run configuration in IntelliJ:
+
+. Click *Run -> Edit configurations -> ✚ -> npm*.
+. Name it as required.
+. Choose *package.json: gravitee-api-management/gravitee-apim-console-webui/package.json*.
+. Select *Command: run*.
+. Select *Script: serve*.
+
+To `npm install`, you can duplicate this configuration and choose *Command > Install*.
+
+==== APIM Portal (gravitee-apim-portal-webui)
+
+CLI Version::
+Run `npm run serve` from the `gravitee-api-management/gravitee-apim-portal-webui` directory to start the UI.
+
+IntelliJ Configuration::
+Create a new Run configuration in IntelliJ:
+
+. Click *Run -> Edit configurations -> ✚ -> npm*.
+. Name it as required.
+. Choose *package.json: gravitee-api-management/gravitee-apim-portal-webui/package.json*.
+. Select *Command: run*.
+. Select *Script: serve*.
+
+To `npm install`, you can duplicate this configuration and choose *Command > Install*.
+
+// end::dev-guide[]
+


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1096

## Description

Move developper guide in APIM repo. 
There is an other issue to challenge the doc itself. https://gravitee.atlassian.net/browse/APIM-1097

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1096-add-dev-guide/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ykvwjxwhnu.chromatic.com)
<!-- Storybook placeholder end -->
