### PR TITLE
fix: add client response in logs with jupiter

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/DefaultHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/jupiter/reactor/DefaultHttpRequestDispatcher.java
@@ -232,7 +232,11 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
             requestProcessorChainFactory
                 .create()
                 .handler(ctx -> {
-                    reactorHandler.handle(ctx, executionContext -> processResponse(executionContext, endHandler));
+                    reactorHandler.handle(
+                        ctx,
+                        executionContext ->
+                            executionContext.response().endHandler(aVoid -> processResponse(executionContext, endHandler)).end()
+                    );
                 })
                 .errorHandler(result -> processResponse(simpleExecutionContext, endHandler))
                 .exitHandler(result -> processResponse(simpleExecutionContext, endHandler))

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/jupiter/reactor/DefaultHttpRequestDispatcherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/jupiter/reactor/DefaultHttpRequestDispatcherTest.java
@@ -40,6 +40,7 @@ import io.gravitee.gateway.report.ReporterService;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.observers.TestObserver;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpVersion;
@@ -147,6 +148,7 @@ class DefaultHttpRequestDispatcherTest {
 
         lenient().when(response.headers()).thenReturn(io.vertx.core.MultiMap.caseInsensitiveMultiMap());
         lenient().when(response.trailers()).thenReturn(io.vertx.core.MultiMap.caseInsensitiveMultiMap());
+        lenient().when(response.end()).thenReturn(Future.succeededFuture());
 
         lenient().when(requestProcessorChainFactory.create()).thenReturn(new ProcessorProviderChain<>(List.of()));
         lenient().when(responseProcessorChainFactory.create()).thenReturn(new ProcessorProviderChain<>(List.of()));

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/http/logging/LoggingIntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/http/logging/LoggingIntegrationTest.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.tests.http.logging;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.apim.gateway.tests.sdk.reporter.FakeReporter;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.Logging;
+import io.gravitee.definition.model.LoggingContent;
+import io.gravitee.definition.model.LoggingMode;
+import io.gravitee.definition.model.LoggingScope;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.reporter.api.log.Log;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonObject;
+import io.vertx.rxjava3.core.http.HttpClient;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@DeployApi({ "/apis/http/api.json" })
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class LoggingIntegrationTest extends AbstractGatewayTest {
+
+    @Override
+    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
+        super.configureGateway(gatewayConfigurationBuilder);
+        gatewayConfigurationBuilder.set("api.jupiterMode.enabled", "true");
+    }
+
+    @Override
+    public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+        final Logging logging = new Logging();
+        logging.setMode(LoggingMode.CLIENT_PROXY);
+        logging.setContent(LoggingContent.HEADERS_PAYLOADS);
+        logging.setScope(LoggingScope.REQUEST_RESPONSE);
+        logging.setCondition("{#response.status == 200}");
+        if (api.getDefinition() instanceof Api) {
+            ((Api) api.getDefinition()).getProxy().setLogging(logging);
+        }
+    }
+
+    @Test
+    void should_log_everything(HttpClient httpClient) throws Exception {
+        JsonObject mockResponseBody = new JsonObject().put("response", "body");
+        wiremock.stubFor(get("/endpoint").willReturn(okJson(mockResponseBody.toString())));
+
+        FakeReporter fakeReporter = getBean(FakeReporter.class);
+        AtomicReference<Log> logRef = new AtomicReference<>();
+        fakeReporter.setReportableHandler(reportable -> {
+            if (reportable instanceof Log) {
+                logRef.set((Log) reportable);
+            }
+        });
+
+        AtomicReference<String> requestHostAndPortRef = new AtomicReference<>();
+
+        JsonObject requestBody = new JsonObject().put("field", "of the pelennor");
+
+        httpClient
+            .rxRequest(HttpMethod.GET, "/test")
+            .flatMap(request -> {
+                requestHostAndPortRef.set(request.getHost() + ":" + request.getPort());
+                return request.rxSend(requestBody.toString());
+            })
+            .flatMapPublisher(response -> {
+                assertThat(response.statusCode()).isEqualTo(HttpStatusCode.OK_200);
+                return response.toFlowable();
+            })
+            .test()
+            .await()
+            .assertComplete()
+            .assertValue(body -> {
+                assertThat(body).hasToString(mockResponseBody.toString());
+                return true;
+            });
+
+        wiremock.verify(getRequestedFor(urlPathEqualTo("/endpoint")));
+        final Log log = logRef.get();
+        final String transactionAndRequestId = wiremock
+            .getAllServeEvents()
+            .get(0)
+            .getRequest()
+            .getHeaders()
+            .getHeader("X-Gravitee-Transaction-Id")
+            .firstValue();
+
+        assertThat(log.getClientRequest().getBody()).isEqualTo(requestBody.toString());
+        assertThat(log.getClientRequest().getUri()).isEqualTo("/test");
+        assertThat(log.getClientRequest().getHeaders().toSingleValueMap())
+            .contains(
+                entry("host", requestHostAndPortRef.get()),
+                entry("X-Gravitee-Transaction-Id", transactionAndRequestId),
+                entry("X-Gravitee-Request-Id", transactionAndRequestId),
+                entry("content-length", String.valueOf(requestBody.toString().length()))
+            );
+
+        assertThat(log.getProxyRequest().getBody()).isEqualTo(requestBody.toString());
+        assertThat(log.getProxyRequest().getUri()).isEqualTo("http://localhost:" + wiremock.port() + "/endpoint");
+        assertThat(log.getProxyRequest().getHeaders().toSingleValueMap())
+            .contains(
+                entry("Host", "localhost:" + wiremock.port()),
+                entry("X-Gravitee-Transaction-Id", transactionAndRequestId),
+                entry("X-Gravitee-Request-Id", transactionAndRequestId),
+                entry("content-length", String.valueOf(requestBody.toString().length()))
+            );
+
+        assertThat(log.getProxyResponse().getBody()).isEqualTo(mockResponseBody.toString());
+        assertThat(log.getProxyResponse().getStatus()).isEqualTo(200);
+        assertThat(log.getProxyResponse().getHeaders().toSingleValueMap())
+            .doesNotContainKeys("X-Gravitee-Transaction-Id", "X-Gravitee-Request-Id")
+            .contains(entry("Content-Type", "application/json"));
+
+        assertThat(log.getClientResponse().getBody()).isEqualTo(mockResponseBody.toString());
+        assertThat(log.getClientResponse().getStatus()).isEqualTo(200);
+        assertThat(log.getClientResponse().getHeaders().toSingleValueMap())
+            .contains(
+                entry("X-Gravitee-Transaction-Id", transactionAndRequestId),
+                entry("X-Gravitee-Request-Id", transactionAndRequestId),
+                entry("Content-Type", "application/json")
+            );
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/http/logging/LoggingV3CompatibilityIntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/http/logging/LoggingV3CompatibilityIntegrationTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.tests.http.logging;
+
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.ExecutionMode;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class LoggingV3CompatibilityIntegrationTest extends LoggingIntegrationTest {
+
+    @Override
+    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
+        super.configureGateway(gatewayConfigurationBuilder);
+        gatewayConfigurationBuilder.set("api.jupiterMode.enabled", "true");
+    }
+
+    @Override
+    public void configureApi(Api api) {
+        super.configureApi(api);
+        api.setExecutionMode(ExecutionMode.V3);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/http/logging/LoggingV3IntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/http/logging/LoggingV3IntegrationTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.tests.http.logging;
+
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.ExecutionMode;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class LoggingV3IntegrationTest extends LoggingIntegrationTest {
+
+    @Override
+    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
+        super.configureGateway(gatewayConfigurationBuilder);
+        gatewayConfigurationBuilder.set("api.jupiterMode.enabled", "false");
+    }
+
+    @Override
+    public void configureApi(Api api) {
+        super.configureApi(api);
+        api.setExecutionMode(ExecutionMode.V3);
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1087

## Description

With Jupiter mode enabled, client response body was not logged.
This was due to logging writing Log object during the end phase of the response.

To resolve this, solution was to process the response in the endHandler itself.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qsclajziaz.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1087-missing-client-response-logs/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
