### PR TITLE
feat: support mongo 6 as default version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2154,7 +2154,7 @@ workflows:
                       - setup
                   matrix:
                       parameters:
-                          version: ["3", "4", "5"]
+                          version: ["4", "5", "6.0"]
             - elastic-test-container:
                   context: cicd-orchestrator
                   requires:

--- a/docker/quick-setup/consul-service-discovery/docker-compose.yml
+++ b/docker/quick-setup/consul-service-discovery/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       - frontend
 
   mongodb:
-    image: mongo:${MONGODB_VERSION:-4.0.28}
+    image: mongo:${MONGODB_VERSION:-6.0}
     container_name: gio_apim_mongodb
     restart: always
     volumes:

--- a/docker/quick-setup/ee-with-alert-engine/docker-compose.yml
+++ b/docker/quick-setup/ee-with-alert-engine/docker-compose.yml
@@ -28,7 +28,7 @@ volumes:
 
 services:
   mongodb:
-    image: mongo:${MONGODB_VERSION:-5}
+    image: mongo:${MONGODB_VERSION:-6.0}
     container_name: gio_apim_mongodb
     restart: always
     volumes:

--- a/docker/quick-setup/gateway-http-bridge-repository/docker-compose.yml
+++ b/docker/quick-setup/gateway-http-bridge-repository/docker-compose.yml
@@ -28,7 +28,7 @@ volumes:
 
 services:
   mongodb:
-    image: mongo:${MONGODB_VERSION:-5}
+    image: mongo:${MONGODB_VERSION:-6.0}
     container_name: gio_apim_mongodb
     restart: always
     volumes:

--- a/docker/quick-setup/https-gateway/docker-compose.yml
+++ b/docker/quick-setup/https-gateway/docker-compose.yml
@@ -28,7 +28,7 @@ volumes:
 
 services:
   mongodb:
-    image: mongo:${MONGODB_VERSION:-5}
+    image: mongo:${MONGODB_VERSION:-6.0}
     container_name: gio_apim_mongodb
     restart: always
     volumes:

--- a/docker/quick-setup/https-nginx/docker-compose.yml
+++ b/docker/quick-setup/https-nginx/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     networks:
       - frontend
   mongodb:
-    image: mongo:${MONGODB_VERSION:-5}
+    image: mongo:${MONGODB_VERSION:-6.0}
     container_name: gio_apim_mongodb
     restart: always
     volumes:

--- a/docker/quick-setup/keycloak/docker-compose.yml
+++ b/docker/quick-setup/keycloak/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       - frontend
 
   mongodb:
-    image: mongo:${MONGODB_VERSION:-5}
+    image: mongo:${MONGODB_VERSION:-6.0}
     restart: always
     volumes:
       - data-mongo:/data/db

--- a/docker/quick-setup/kibana/docker-compose.yml
+++ b/docker/quick-setup/kibana/docker-compose.yml
@@ -29,7 +29,7 @@ volumes:
 
 services:
   mongodb:
-    image: mongo:${MONGODB_VERSION:-4.0.28}
+    image: mongo:${MONGODB_VERSION:-6.0}
     container_name: gio_apim_mongodb
     restart: always
     volumes:

--- a/docker/quick-setup/mongodb/docker-compose.yml
+++ b/docker/quick-setup/mongodb/docker-compose.yml
@@ -28,7 +28,7 @@ volumes:
 
 services:
   mongodb:
-    image: mongo:${MONGODB_VERSION:-5}
+    image: mongo:${MONGODB_VERSION:-6.0}
     container_name: gio_apim_mongodb
     restart: always
     volumes:

--- a/docker/quick-setup/nginx/docker-compose.yml
+++ b/docker/quick-setup/nginx/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     networks:
       - frontend
   mongodb:
-    image: mongo:${MONGODB_VERSION:-5}
+    image: mongo:${MONGODB_VERSION:-6.0}
     container_name: gio_apim_mongodb
     restart: always
     volumes:

--- a/docker/quick-setup/opensearch/docker-compose.yml
+++ b/docker/quick-setup/opensearch/docker-compose.yml
@@ -28,7 +28,7 @@ volumes:
 
 services:
   mongodb:
-    image: mongo:${MONGODB_VERSION:-5}
+    image: mongo:${MONGODB_VERSION:-6.0}
     container_name: gio_apim_mongodb
     restart: always
     volumes:

--- a/docker/quick-setup/opentracing-jaeger/docker-compose.yml
+++ b/docker/quick-setup/opentracing-jaeger/docker-compose.yml
@@ -30,7 +30,7 @@ volumes:
 
 services:
   mongodb:
-    image: mongo:${MONGODB_VERSION:-4.4.6}
+    image: mongo:${MONGODB_VERSION:-6.0}
     container_name: gio_apim_mongodb
     restart: always
     volumes:

--- a/docker/quick-setup/prometheus/docker-compose.yml
+++ b/docker/quick-setup/prometheus/docker-compose.yml
@@ -30,7 +30,7 @@ volumes:
 
 services:
   mongodb:
-    image: mongo:${MONGODB_VERSION:-4.4.6}
+    image: mongo:${MONGODB_VERSION:-6.0}
     container_name: gio_apim_mongodb
     restart: always
     volumes:

--- a/docker/quick-setup/redis-rate-limit/docker-compose.yml
+++ b/docker/quick-setup/redis-rate-limit/docker-compose.yml
@@ -30,7 +30,7 @@ volumes:
 
 services:
   mongodb:
-    image: mongo:${MONGODB_VERSION:-5}
+    image: mongo:${MONGODB_VERSION:-6.0}
     container_name: gio_apim_mongodb
     restart: always
     volumes:

--- a/docker/quick-setup/tags-internal-external/docker-compose.yml
+++ b/docker/quick-setup/tags-internal-external/docker-compose.yml
@@ -28,7 +28,7 @@ volumes:
 
 services:
   mongodb:
-    image: mongo:${MONGODB_VERSION:-5}
+    image: mongo:${MONGODB_VERSION:-6.0}
     container_name: gio_apim_mongodb
     restart: always
     volumes:

--- a/gravitee-apim-e2e/docker/common/docker-compose-mongo.yml
+++ b/gravitee-apim-e2e/docker/common/docker-compose-mongo.yml
@@ -21,7 +21,7 @@ volumes:
 
 services:
   database:
-    image: mongo:${MONGODB_VERSION:-5}
+    image: mongo:${MONGODB_VERSION:-6.0}
     container_name: gravitee-apim-e2e-mongodb
     restart: always
     ports:

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mqtt5/docker/quick-setup/apim-hivemq/docker-compose.yml
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mqtt5/docker/quick-setup/apim-hivemq/docker-compose.yml
@@ -29,7 +29,7 @@ volumes:
 
 services:
   mongodb:
-    image: mongo:${MONGODB_VERSION:-5}
+    image: mongo:${MONGODB_VERSION:-6.0}
     container_name: gio_apim_mongodb
     restart: always
     volumes:

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/README.md
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/README.md
@@ -8,7 +8,7 @@ Mongo repository based on MongoDB
 
 The minimum requirements are:
 * Maven3
-* Jdk8
+* Jdk11
 
 To use Gravitee.io snapshots, you need to declare the following repository in your maven settings:
 `https://oss.sonatype.org/content/repositories/snapshots`
@@ -27,6 +27,7 @@ To do so you can use the following commands:
 - Mongo 3: `mvn clean install -DmongoVersion=3`
 - Mongo 4: `mvn clean install -DmongoVersion=4`
 - Mongo 5: `mvn clean install -DmongoVersion=5`
+- Mongo 6.0: `mvn clean install -DmongoVersion=6.0` (Default version)
 
 You can use the version of Mongo you want to test by using the docker image tag in the `-DmongoVersion` parameter. For example, for Mongo 4.4.4, you will use `-DmongoVersion=4.4.4` .
 
@@ -38,34 +39,34 @@ Unzip the gravitee-repository-mongodb-x.y.z-SNAPSHOT.zip in the gravitee home di
 
 repository.mongodb options : 
 
-| Parameter                                        |   default  |
-| ------------------------------------------------ | ---------: |
-| host                                             |  localhost |
-| port                                             |      9200  |
-| username                                         |            |
-| password                                         |            |
-| connectionPerHost                                |            |
-| connectTimeout                                   |            |
-| writeConcern                                     |      1     |
-| wtimeout                                         |    0       |
-| journal                                          |            |
-| maxWaitTime                                      |            |
-| socketTimeout                                    |            |
-| socketKeepAlive                                  |            |
-| maxConnectionLifeTime                            |            |
-| maxConnectionIdleTime                            |            |
-| minHeartbeatFrequency                            |            |
-| description                                      |            |
-| heartbeatConnectTimeout                          |            |
-| heartbeatFrequency 	                           |            |
-| heartbeatsocketTimeout                           |            |
-| localThreshold 	                               |            |
-| minConnectionsPerHost                            |            |
-| sslEnabled 		                               |            |
-| threadsAllowedToBlockForConnectionMultiplier     |            |
-| cursorFinalizerEnabled                           |            |
-| keystorePassword                                 |            |
-| keystore                                         |            |
-| keyPassword                                      |            |
+| Parameter                                    |   default |
+|----------------------------------------------|----------:|
+| host                                         | localhost |
+| port                                         |      9200 |
+| username                                     |           |
+| password                                     |           |
+| connectionPerHost                            |           |
+| connectTimeout                               |           |
+| writeConcern                                 |         1 |
+| wtimeout                                     |         0 |
+| journal                                      |           |
+| maxWaitTime                                  |           |
+| socketTimeout                                |           |
+| socketKeepAlive                              |           |
+| maxConnectionLifeTime                        |           |
+| maxConnectionIdleTime                        |           |
+| minHeartbeatFrequency                        |           |
+| description                                  |           |
+| heartbeatConnectTimeout                      |           |
+| heartbeatFrequency 	                         |           |
+| heartbeatsocketTimeout                       |           |
+| localThreshold 	                             |           |
+| minConnectionsPerHost                        |           |
+| sslEnabled 		                                |           |
+| threadsAllowedToBlockForConnectionMultiplier |           |
+| cursorFinalizerEnabled                       |           |
+| keystorePassword                             |           |
+| keystore                                     |           |
+| keyPassword                                  |           |
 
 NB: writeConcern possible value are 1,2,3... (the number of node) or 'majority' 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/pom.xml
@@ -33,10 +33,13 @@
 	<properties>
         <!--
             According to https://docs.spring.io/spring-data/mongodb/docs/current/reference/html/#compatibility.matrix
-            spring data 3.4.x is compatible with mongo driver 4.6.x
+            and https://www.mongodb.com/docs/drivers/java/sync/current/compatibility/
+            spring data 3.4.x is compatible with mongo driver 4.6.x and up to mongo server 5.0.x
+            But "You can use newer server versions unless your application uses functionality that is affected by changes in the MongoDB server"
+            Meaning that we can use mongo server 6.0.x if we use basic functionalities.
         -->
-        <mongo.version>4.6.0</mongo.version>
-        <spring.data.mongodb.version>3.4.1</spring.data.mongodb.version>
+        <mongo.version>4.6.1</mongo.version>
+        <spring.data.mongodb.version>3.4.10</spring.data.mongodb.version>
         <jna.version>5.11.0</jna.version>
     </properties>
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/MongoTestRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/MongoTestRepositoryConfiguration.java
@@ -51,7 +51,7 @@ public class MongoTestRepositoryConfiguration extends AbstractRepositoryConfigur
 
     private static final Logger LOG = LoggerFactory.getLogger(MongoTestRepositoryConfiguration.class);
 
-    @Value("${mongoVersion:4.4.6}")
+    @Value("${mongoVersion:6.0}")
     private String mongoVersion;
 
     @Inject

--- a/gravitee-apim-rest-api/docker/compose/docker-compose-dev.yml
+++ b/gravitee-apim-rest-api/docker/compose/docker-compose-dev.yml
@@ -22,7 +22,7 @@ volumes:
 
 services:
   mongodb:
-    image: mongo:${MONGODB_VERSION:-5}
+    image: mongo:${MONGODB_VERSION:-6.0}
     container_name: gio_apim_mongodb
     volumes:
       - ./logs/apim-mongodb:/var/log/mongodb


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1092

## Description

According to https://www.mongodb.com/docs/drivers/java/sync/current/compatibility/ and https://docs.spring.io/spring-data/mongodb/docs/current/reference/html/#compatibility.matrix, if we want to use the latest version of spring-data, we need JDK 17 and Spring 6, which is not planned yet.
However, as we don't use specific features of MongoDB Server 6.x, we can continue to use the same minor version as today.

However, this PR changes the default version used for TestContainer, adds the 6.0 version in the CI job that tests DB, and removes version 3.
It also updates all docker-compose with the 6.0 version of mongodb.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gkpdronazv.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/support-mongodb6/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
