### PR TITLE
tests: use the right command for mongo healthcheck

### DIFF
--- a/gravitee-apim-e2e/docker/common/docker-compose-mongo.yml
+++ b/gravitee-apim-e2e/docker/common/docker-compose-mongo.yml
@@ -30,7 +30,7 @@ services:
       - data-mongo:/data/db
       - ./.logs/apim-mongodb:/var/log/mongodb
     healthcheck:
-      test: echo 'db.runCommand({serverStatus:1}).ok' | mongo admin --quiet | grep 1
+      test: mongosh --eval 'db.runCommand({serverStatus:1}).ok' --quiet | grep 1
       interval: 2s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1092

## Description

Fix broken e2e tests introduced with https://github.com/gravitee-io/gravitee-api-management/pull/3344
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gxhpugyxdv.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-run-e2e-tests/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
