### PR TITLE
Update `policy-xml-json` to `1.8.2`

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -89,7 +89,7 @@
         <gravitee-policy-transformheaders.version>1.10.0</gravitee-policy-transformheaders.version>
         <gravitee-policy-transformqueryparams.version>1.6.0</gravitee-policy-transformqueryparams.version>
         <gravitee-policy-url-rewriting.version>1.5.0</gravitee-policy-url-rewriting.version>
-        <gravitee-policy-xml-json.version>1.8.1</gravitee-policy-xml-json.version>
+        <gravitee-policy-xml-json.version>1.8.2</gravitee-policy-xml-json.version>
         <gravitee-policy-xml-threat-protection.version>1.3.2</gravitee-policy-xml-threat-protection.version>
         <gravitee-policy-xml-validation.version>1.1.0</gravitee-policy-xml-validation.version>
         <gravitee-policy-xslt.version>2.0.0</gravitee-policy-xslt.version>


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8953
https://gravitee.atlassian.net/browse/APIM-1146

## Description

Update `policy-xml-json` to `1.8.2`
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1146-update-xml-to-json-policy/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-aucflhwvyg.chromatic.com)
<!-- Storybook placeholder end -->
