### PR TITLE
feat: new component for top APIs widget

### DIFF
--- a/gravitee-apim-console-webui/src/management/home/widgets/gio-top-apis-table/gio-top-apis-table.component.html
+++ b/gravitee-apim-console-webui/src/management/home/widgets/gio-top-apis-table/gio-top-apis-table.component.html
@@ -1,0 +1,42 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<mat-card class="widget">
+  <div class="mat-subheading-1">Top APIs</div>
+  <div class="mat-caption">Ordered by number of API calls</div>
+  <gio-table-wrapper [disableSearchInput]="true" [filters]="tableFilters" [length]="totalLength" (filtersChange)="onFiltersChanged($event)">
+    <table mat-table matSort [dataSource]="filteredTableData" aria-label="Top APIs table">
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>API</th>
+        <td mat-cell *matCellDef="let element">
+          <ng-container *ngIf="element.unknown; else elementLink">{{ element.name }}</ng-container>
+          <ng-template #elementLink
+            ><a (click)="navigateToApi(element.id)">{{ element.name }}</a></ng-template
+          >
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="value">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header>Hits</th>
+        <td mat-cell *matCellDef="let element">{{ element.value }}</td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+  </gio-table-wrapper>
+</mat-card>

--- a/gravitee-apim-console-webui/src/management/home/widgets/gio-top-apis-table/gio-top-apis-table.component.scss
+++ b/gravitee-apim-console-webui/src/management/home/widgets/gio-top-apis-table/gio-top-apis-table.component.scss
@@ -1,0 +1,5 @@
+.widget {
+  .mat-table {
+    width: 100%;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/home/widgets/gio-top-apis-table/gio-top-apis-table.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/home/widgets/gio-top-apis-table/gio-top-apis-table.component.spec.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatTableHarness } from '@angular/material/table/testing';
+import { SimpleChange } from '@angular/core';
+import { MatPaginatorHarness } from '@angular/material/paginator/testing';
+
+import { GioTopApisTableModule } from './gio-top-apis-table.module';
+import { GioTopApisTableComponent, TopApisData } from './gio-top-apis-table.component';
+
+import { UIRouterState } from '../../../../ajs-upgraded-providers';
+
+describe('GioStatsTableComponent', () => {
+  const data: TopApisData = {
+    values: {
+      '?': 2764281,
+      '78416fd0-25ac-4234-816f-d025aca2345c': 351475,
+      '62b7d292-8ee1-3913-8030-c883e01de8a0': 19,
+      '5baa3ce2-5c8a-4a53-aa3c-e25c8a0a53aa': 17,
+      '9cbd6331-fdc7-4362-bd63-31fdc71362ae': 2,
+      'e78f07d4-d6d0-384e-8f8d-8cbe736074ad': 2,
+      'b264ff24-9030-31ae-be7b-cd50e0a88920': 1,
+    },
+    metadata: {
+      '78416fd0-25ac-4234-816f-d025aca2345c': {
+        name: 'Snowcamp',
+        version: '1',
+        order: 1,
+      },
+      '5baa3ce2-5c8a-4a53-aa3c-e25c8a0a53aa': {
+        name: 'Docs - APIM',
+        version: '1.0',
+        order: 3,
+      },
+      'e78f07d4-d6d0-384e-8f8d-8cbe736074ad': {
+        name: 'API 1 with slow backend',
+        version: '1',
+        order: 5,
+      },
+      '62b7d292-8ee1-3913-8030-c883e01de8a0': {
+        name: '4790',
+        version: '1',
+        order: 2,
+      },
+      '9cbd6331-fdc7-4362-bd63-31fdc71362ae': {
+        name: 'test-bad-ssl',
+        version: 'test-bad-ssl',
+        order: 4,
+      },
+      'b264ff24-9030-31ae-be7b-cd50e0a88920': {
+        name: 'API 2, call API 1 with slow backend',
+        version: '1',
+        order: 6,
+      },
+      '?': {
+        name: 'Unknown API (not found)',
+        unknown: true,
+        order: 0,
+      },
+    },
+  };
+  const fakeAjsState = {
+    go: jest.fn(),
+  };
+
+  let fixture: ComponentFixture<GioTopApisTableComponent>;
+  let loader: HarnessLoader;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, GioTopApisTableModule],
+      providers: [{ provide: UIRouterState, useValue: fakeAjsState }],
+    });
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GioTopApisTableComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.detectChanges();
+
+    fixture.componentInstance.data = data;
+    fixture.detectChanges();
+    fixture.componentInstance.ngOnChanges({ data: new SimpleChange(null, data, true) });
+  });
+
+  it('should init', async () => {
+    expect(loader).toBeTruthy();
+    const tableHarness = await loader.getHarness(MatTableHarness);
+    const rows = await tableHarness.getRows();
+    expect(rows.length).toEqual(5);
+
+    // First row must contain name, and no link
+    const firstApi = await rows[0].getCellTextByIndex({ columnName: 'name' });
+    expect(firstApi).toEqual(['Unknown API (not found)']);
+    const cells = await rows[0].getCells();
+    const link = await cells[0].getAllChildLoaders('a');
+    expect(link.length).toEqual(0);
+
+    // Second row must contain name, and a link
+    const secondApi = await rows[1].getCellTextByIndex({ columnName: 'name' });
+    expect(secondApi).toEqual(['Snowcamp']);
+    const cells2 = await rows[1].getCells();
+    const link2 = await cells2[0].getAllChildLoaders('a');
+    expect(link2.length).toEqual(1);
+
+    const nbHits = await rows[0].getCellTextByIndex({ columnName: 'value' });
+    expect(nbHits).toEqual(['2764281']);
+
+    const paginotorHarness = await loader.getHarness(MatPaginatorHarness);
+    expect(paginotorHarness).toBeDefined();
+    expect(await paginotorHarness.getPageSize()).toEqual(5);
+  });
+});

--- a/gravitee-apim-console-webui/src/management/home/widgets/gio-top-apis-table/gio-top-apis-table.component.ts
+++ b/gravitee-apim-console-webui/src/management/home/widgets/gio-top-apis-table/gio-top-apis-table.component.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AfterViewInit, Component, Inject, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { sortBy } from 'lodash';
+import { StateService } from '@uirouter/angularjs';
+
+import { UIRouterState } from '../../../../ajs-upgraded-providers';
+import { GioTableWrapperFilters } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
+import { gioTableFilterCollection } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.util';
+
+export type TopApisData = {
+  values: { [key: string]: number };
+  metadata: { [key: string]: { name: string; version?: string; order: number; unknown?: boolean } };
+};
+
+type TableDataSource = {
+  id: string;
+  name: string;
+  value: number;
+  order: number;
+  unknown?: boolean;
+};
+@Component({
+  selector: 'gio-top-apis-table',
+  template: require('./gio-top-apis-table.component.html'),
+  styles: [require('./gio-top-apis-table.component.scss')],
+})
+export class GioTopApisTableComponent implements AfterViewInit, OnChanges {
+  @Input()
+  data: TopApisData;
+
+  displayedColumns = ['name', 'value'];
+  dataSource: TableDataSource[];
+  filteredTableData: TableDataSource[];
+  tableFilters: GioTableWrapperFilters = { pagination: { index: 0, size: 5 }, searchTerm: '' };
+
+  totalLength: number;
+
+  constructor(@Inject(UIRouterState) private readonly ajsState: StateService) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.data) this.buildDataSource();
+  }
+  ngAfterViewInit(): void {
+    if (this.data) this.buildDataSource();
+  }
+
+  navigateToApi(apiKey: string): void {
+    this.ajsState.go('management.apis.detail.analytics.overview', {
+      apiId: apiKey,
+    });
+  }
+
+  private buildDataSource() {
+    this.dataSource = sortBy(
+      Object.entries(this.data.values).map(([key, value]) => {
+        return {
+          id: key,
+          name: this.data.metadata[key].name,
+          value,
+          order: this.data.metadata[key].order,
+          unknown: this.data.metadata[key].unknown,
+        };
+      }),
+      'order',
+    );
+    this.totalLength = this.dataSource.length;
+    this.filteredTableData = this.dataSource.slice(0, 5);
+  }
+
+  onFiltersChanged(filters: GioTableWrapperFilters) {
+    const filtered = gioTableFilterCollection(this.dataSource, filters);
+    this.filteredTableData = filtered.filteredCollection;
+    this.totalLength = filtered.unpaginatedLength;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/home/widgets/gio-top-apis-table/gio-top-apis-table.module.ts
+++ b/gravitee-apim-console-webui/src/management/home/widgets/gio-top-apis-table/gio-top-apis-table.module.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTableModule } from '@angular/material/table';
+import { MatCardModule } from '@angular/material/card';
+import { MatSortModule } from '@angular/material/sort';
+
+import { GioTopApisTableComponent } from './gio-top-apis-table.component';
+
+import { GioTableWrapperModule } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
+
+@NgModule({
+  imports: [CommonModule, MatTableModule, MatCardModule, MatSortModule, GioTableWrapperModule],
+  declarations: [GioTopApisTableComponent],
+  exports: [GioTopApisTableComponent],
+})
+export class GioTopApisTableModule {}

--- a/gravitee-apim-console-webui/src/management/home/widgets/gio-top-apis-table/gio-top-apis-table.stories.ts
+++ b/gravitee-apim-console-webui/src/management/home/widgets/gio-top-apis-table/gio-top-apis-table.stories.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Meta, moduleMetadata } from '@storybook/angular';
+import { Story } from '@storybook/angular/dist/ts3.9/client/preview/types-7-0';
+import { action } from '@storybook/addon-actions';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+import { GioTopApisTableComponent } from './gio-top-apis-table.component';
+import { GioTopApisTableModule } from './gio-top-apis-table.module';
+
+import { UIRouterState } from '../../../../ajs-upgraded-providers';
+
+export default {
+  title: 'Home / Widgets / Top APIs table',
+  component: GioTopApisTableComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [GioTopApisTableModule, BrowserAnimationsModule],
+      providers: [{ provide: UIRouterState, useValue: { go: (...args) => action('Ajs state go')(args) } }],
+    }),
+  ],
+  render: ({ data }) => ({
+    props: { data },
+  }),
+} as Meta;
+
+export const Default: Story = {};
+Default.args = {
+  data: {
+    values: {
+      '?': 2764281,
+      '78416fd0-25ac-4234-816f-d025aca2345c': 351475,
+      '62b7d292-8ee1-3913-8030-c883e01de8a0': 19,
+      '5baa3ce2-5c8a-4a53-aa3c-e25c8a0a53aa': 17,
+      '9cbd6331-fdc7-4362-bd63-31fdc71362ae': 2,
+      'e78f07d4-d6d0-384e-8f8d-8cbe736074ad': 2,
+      'b264ff24-9030-31ae-be7b-cd50e0a88920': 1,
+    },
+    metadata: {
+      '78416fd0-25ac-4234-816f-d025aca2345c': {
+        name: 'Snowcamp',
+        version: '1',
+        order: '1',
+      },
+      '5baa3ce2-5c8a-4a53-aa3c-e25c8a0a53aa': {
+        name: 'Docs - APIM',
+        version: '1.0',
+        order: '3',
+      },
+      'e78f07d4-d6d0-384e-8f8d-8cbe736074ad': {
+        name: 'API 1 with slow backend',
+        version: '1',
+        order: '5',
+      },
+      '62b7d292-8ee1-3913-8030-c883e01de8a0': {
+        name: '4790',
+        version: '1',
+        order: '2',
+      },
+      '9cbd6331-fdc7-4362-bd63-31fdc71362ae': {
+        name: 'test-bad-ssl',
+        version: 'test-bad-ssl',
+        order: '4',
+      },
+      'b264ff24-9030-31ae-be7b-cd50e0a88920': {
+        name: 'API 2, call API 1 with slow backend',
+        version: '1',
+        order: '6',
+      },
+      '?': {
+        name: 'Unknown API (not found)',
+        unknown: 'true',
+        order: '0',
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1136

## Description

Add a new component for Top APIs widget in the dashboard

![screenshot-localhost_6006-2023 03 21-15_55_48](https://user-images.githubusercontent.com/1655950/226646525-b79a06c2-53e5-4c16-9d93-a52c75d24e24.png)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zodsvbcxoj.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1136-top-apis-table-component/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
