### PR TITLE
Add an empty option when selecting the general condition of a plan

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/portal/plans/plan/plan-wizard-general.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/plans/plan/plan-wizard-general.html
@@ -73,6 +73,7 @@
                 <span class="italic warn-general-conditions" ng-if="$ctrl.parent.shouldNotEditConditions()">*</span>
               </label>
               <md-select ng-model="$ctrl.parent.plan.general_conditions">
+                <md-option ng-value="''"></md-option>
                 <md-option ng-repeat="page in $ctrl.parent.pages | orderBy:'name' " ng-value="page.id"> {{page.name}} </md-option>
               </md-select>
               <span class="italic warn-general-conditions" ng-if="$ctrl.parent.shouldNotEditConditions()">


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-858
https://github.com/gravitee-io/issues/issues/8465

## Description

Add an empty option when selecting the general condition of a plan

## Additional context

https://user-images.githubusercontent.com/4112568/226654716-c319b99d-059a-4cca-ab5f-cc4498bdee0e.mp4




<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tfflqixail.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-858-add-empty-general-condition-option/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
