### PR TITLE
test: add gateway mode for gatewaytest annotation

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/AbstractGatewayTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/AbstractGatewayTest.java
@@ -240,6 +240,10 @@ public abstract class AbstractGatewayTest implements PluginRegister, ApiConfigur
         }
     }
 
+    public Map<String, ReactableApi<?>> getDeployedForTestClass() {
+        return Collections.unmodifiableMap(deployedForTestClass);
+    }
+
     /**
      * Called by the {@link GatewayTestingExtension} when apis wanted for the test class are deployed.
      * @param deployedForTestClass is the list of deployed apis.

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/annotations/GatewayTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/annotations/GatewayTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.gateway.tests.sdk.annotations;
 
 import io.gravitee.apim.gateway.tests.sdk.GatewayTestingExtension;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
 import io.vertx.junit5.VertxExtension;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
@@ -64,4 +65,6 @@ public @interface GatewayTest {
      * @return the config folder.
      */
     String configFolder() default "/gravitee-default";
+
+    GatewayMode mode() default GatewayMode.JUPITER;
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/configuration/GatewayMode.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/configuration/GatewayMode.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.gateway.tests.sdk.configuration;
+
+import io.gravitee.definition.model.ExecutionMode;
+import lombok.Getter;
+
+@Getter
+public enum GatewayMode {
+    JUPITER(true, ExecutionMode.JUPITER),
+    V3(false, ExecutionMode.V3),
+    COMPATIBILITY(true, ExecutionMode.V3);
+
+    private final Boolean jupiterEnabled;
+    private final ExecutionMode executionMode;
+
+    GatewayMode(Boolean jupiterEnabled, ExecutionMode executionMode) {
+        this.jupiterEnabled = jupiterEnabled;
+        this.executionMode = executionMode;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/runner/GatewayRunner.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/runner/GatewayRunner.java
@@ -21,6 +21,7 @@ import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
 import io.gravitee.apim.gateway.tests.sdk.connector.ConnectorBuilder;
 import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
 import io.gravitee.apim.gateway.tests.sdk.container.GatewayTestContainer;
@@ -106,6 +107,7 @@ public class GatewayRunner {
 
     private final GatewayConfigurationBuilder gatewayConfigurationBuilder;
     private final AbstractGatewayTest testInstance;
+    private final GatewayMode gatewayMode;
     private final ObjectMapper graviteeMapper;
     private final Map<String, ReactableApi<?>> deployedForTestClass;
     private final Map<String, ReactableApi<?>> deployedForTest;
@@ -120,6 +122,7 @@ public class GatewayRunner {
     public GatewayRunner(GatewayConfigurationBuilder gatewayConfigurationBuilder, AbstractGatewayTest testInstance) {
         this.gatewayConfigurationBuilder = gatewayConfigurationBuilder;
         this.testInstance = testInstance;
+        this.gatewayMode = testInstance.getClass().getAnnotation(GatewayTest.class).mode();
         graviteeMapper = new GraviteeMapper();
         deployedForTestClass = new HashMap<>();
         deployedForTest = new HashMap<>();
@@ -196,6 +199,8 @@ public class GatewayRunner {
         System.setProperty("gravitee.conf", graviteeHome + File.separator + "config" + File.separator + "gravitee.yml");
 
         registerCustomProtocolHandlers(Handler.class);
+
+        System.setProperty("api.jupiterMode.enabled", gatewayMode.getJupiterEnabled().toString());
 
         gatewayConfigurationBuilder
             .build()
@@ -335,6 +340,7 @@ public class GatewayRunner {
 
         if (!DefinitionVersion.V4.equals(reactableApi.getDefinitionVersion())) {
             final Api api = (Api) reactableApi.getDefinition();
+            api.setExecutionMode(gatewayMode.getExecutionMode());
             testInstance.configureApi(api);
         }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/GatewayTestingExtensionTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/GatewayTestingExtensionTest.java
@@ -60,9 +60,7 @@ class GatewayTestingExtensionTest {
             .selectors(selectClass(SuccessTestCase.class))
             .execute()
             .testEvents()
-            .assertStatistics(stats -> {
-                stats.started(1).succeeded(1);
-            });
+            .assertStatistics(stats -> stats.started(1).succeeded(1));
     }
 
     @Test
@@ -73,9 +71,7 @@ class GatewayTestingExtensionTest {
             .selectors(selectClass(Http2HeadersTestCase.class))
             .execute()
             .testEvents()
-            .assertStatistics(stats -> {
-                stats.started(2).succeeded(2);
-            });
+            .assertStatistics(stats -> stats.started(2).succeeded(2));
     }
 
     /**
@@ -89,9 +85,7 @@ class GatewayTestingExtensionTest {
             .selectors(selectClass(ClientAuthenticationPEMInlineTestCase.class))
             .execute()
             .testEvents()
-            .assertStatistics(stats -> {
-                stats.started(1).succeeded(1);
-            });
+            .assertStatistics(stats -> stats.started(1).succeeded(1));
     }
 
     @Test
@@ -102,9 +96,7 @@ class GatewayTestingExtensionTest {
             .selectors(selectClass(ConditionalPolicyTestCase.class))
             .execute()
             .testEvents()
-            .assertStatistics(stats -> {
-                stats.succeeded(2).failed(1);
-            });
+            .assertStatistics(stats -> stats.succeeded(2).failed(1));
     }
 
     @Test
@@ -115,9 +107,7 @@ class GatewayTestingExtensionTest {
             .selectors(selectClass(InvalidApiClassLevelTestCase.class))
             .execute()
             .testEvents()
-            .assertStatistics(stats -> {
-                stats.started(0);
-            });
+            .assertStatistics(stats -> stats.started(0));
     }
 
     @Test
@@ -128,9 +118,7 @@ class GatewayTestingExtensionTest {
             .selectors(selectClass(InvalidGatewayConfigFolderTestCase.class))
             .execute()
             .testEvents()
-            .assertStatistics(stats -> {
-                stats.started(0);
-            });
+            .assertStatistics(stats -> stats.started(0));
     }
 
     @Test
@@ -141,9 +129,7 @@ class GatewayTestingExtensionTest {
             .selectors(selectClass(RegisterTwiceSameApiClassLevelTestCase.class))
             .execute()
             .testEvents()
-            .assertStatistics(stats -> {
-                stats.started(0);
-            });
+            .assertStatistics(stats -> stats.started(0));
     }
 
     @Test
@@ -154,9 +140,7 @@ class GatewayTestingExtensionTest {
             .selectors(selectClass(RegisterTwiceSameApiMethodLevelTestCase.class))
             .execute()
             .testEvents()
-            .assertStatistics(stats -> {
-                stats.started(2).succeeded(1).failed(1);
-            });
+            .assertStatistics(stats -> stats.started(2).succeeded(1).failed(1));
     }
 
     @Test
@@ -167,9 +151,7 @@ class GatewayTestingExtensionTest {
             .selectors(selectClass(NotExtendingAbstractClassTestCase.class))
             .execute()
             .testEvents()
-            .assertStatistics(stats -> {
-                stats.started(0);
-            });
+            .assertStatistics(stats -> stats.started(0));
     }
 
     @Test
@@ -180,9 +162,7 @@ class GatewayTestingExtensionTest {
             .selectors(selectClass(OrganizationDeploymentTestCase.class))
             .execute()
             .testEvents()
-            .assertStatistics(stats -> {
-                stats.started(3).succeeded(3).failed(0);
-            });
+            .assertStatistics(stats -> stats.started(3).succeeded(3).failed(0));
     }
 
     @Test
@@ -193,8 +173,6 @@ class GatewayTestingExtensionTest {
             .selectors(selectClass(GrpcTestCase.class))
             .execute()
             .testEvents()
-            .assertStatistics(stats -> {
-                stats.started(1).succeeded(1).failed(0);
-            });
+            .assertStatistics(stats -> stats.started(1).succeeded(1).failed(0));
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/GatewayTestingExtensionTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/GatewayTestingExtensionTest.java
@@ -20,17 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.testkit.engine.EngineTestKit;
-import testcases.ClientAuthenticationPEMInlineTestCase;
-import testcases.ConditionalPolicyTestCase;
-import testcases.GrpcTestCase;
-import testcases.Http2HeadersTestCase;
-import testcases.InvalidApiClassLevelTestCase;
-import testcases.InvalidGatewayConfigFolderTestCase;
-import testcases.NotExtendingAbstractClassTestCase;
-import testcases.OrganizationDeploymentTestCase;
-import testcases.RegisterTwiceSameApiClassLevelTestCase;
-import testcases.RegisterTwiceSameApiMethodLevelTestCase;
-import testcases.SuccessTestCase;
+import testcases.*;
 
 /**
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
@@ -174,5 +164,15 @@ class GatewayTestingExtensionTest {
             .execute()
             .testEvents()
             .assertStatistics(stats -> stats.started(1).succeeded(1).failed(0));
+    }
+
+    @Test
+    void should_start_gateway_and_apis_with_selected_mode() {
+        EngineTestKit
+            .engine("junit-jupiter")
+            .selectors(selectClass(GatewayModeTestCase.class))
+            .execute()
+            .testEvents()
+            .assertStatistics(stats -> stats.succeeded(9).aborted(0).skipped(0).failed(0));
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/GatewayModeTestCase.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/testcases/GatewayModeTestCase.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package testcases;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.ExecutionMode;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.Environment;
+
+@EnableForGatewayTestingExtensionTesting
+public class GatewayModeTestCase {
+
+    @Nested
+    @GatewayTest(mode = GatewayMode.JUPITER)
+    @DeployApi({ "/apis/nothing.json" })
+    class JupiterMode extends AbstractGatewayTest {
+
+        @Test
+        void should_set_the_api_execution_mode_for_api_deployed_on_class() {
+            var a = getDeployedForTestClass().get("my-api");
+            final Api api = (Api) a.getDefinition();
+            assertThat(api.getExecutionMode()).isEqualTo(ExecutionMode.JUPITER);
+        }
+
+        @Test
+        @DeployApi({ "/apis/teams.json" })
+        void should_set_the_api_execution_mode_for_api_deployed_on_method() {
+            var a = deployedApis.get("api-test");
+            final Api api = (Api) a.getDefinition();
+            assertThat(api.getExecutionMode()).isEqualTo(ExecutionMode.JUPITER);
+        }
+
+        @Test
+        void should_enable_jupiter_mode() {
+            var env = getBean(Environment.class);
+            assertThat(env).isNotNull().extracting(e -> e.getProperty("api.jupiterMode.enabled")).isEqualTo("true");
+        }
+    }
+
+    @Nested
+    @GatewayTest(mode = GatewayMode.COMPATIBILITY)
+    @DeployApi({ "/apis/nothing.json" })
+    class CompatibilityMode extends AbstractGatewayTest {
+
+        @Test
+        void should_set_the_api_execution_mode_for_api_deployed_on_class() {
+            var a = getDeployedForTestClass().get("my-api");
+            final Api api = (Api) a.getDefinition();
+            assertThat(api.getExecutionMode()).isEqualTo(ExecutionMode.V3);
+        }
+
+        @Test
+        @DeployApi({ "/apis/teams.json" })
+        void should_set_the_api_execution_mode_for_api_deployed_on_method() {
+            var a = deployedApis.get("api-test");
+            final Api api = (Api) a.getDefinition();
+            assertThat(api.getExecutionMode()).isEqualTo(ExecutionMode.V3);
+        }
+
+        @Test
+        void should_enable_jupiter_mode() {
+            var env = getBean(Environment.class);
+            assertThat(env).isNotNull().extracting(e -> e.getProperty("api.jupiterMode.enabled")).isEqualTo("true");
+        }
+    }
+
+    @Nested
+    @GatewayTest(mode = GatewayMode.V3)
+    @DeployApi({ "/apis/nothing.json" })
+    class V3Mode extends AbstractGatewayTest {
+
+        @Test
+        void should_set_the_api_execution_mode_for_api_deployed_on_class() {
+            var a = getDeployedForTestClass().get("my-api");
+            final Api api = (Api) a.getDefinition();
+            assertThat(api.getExecutionMode()).isEqualTo(ExecutionMode.V3);
+        }
+
+        @Test
+        @DeployApi({ "/apis/teams.json" })
+        void should_set_the_api_execution_mode_for_api_deployed_on_method() {
+            var a = deployedApis.get("api-test");
+            final Api api = (Api) a.getDefinition();
+            assertThat(api.getExecutionMode()).isEqualTo(ExecutionMode.V3);
+        }
+
+        @Test
+        void should_disable_jupiter_mode() {
+            var env = getBean(Environment.class);
+            assertThat(env).isNotNull().extracting(e -> e.getProperty("api.jupiterMode.enabled")).isEqualTo("false");
+        }
+    }
+}


### PR DESCRIPTION
## Issue
N/A

## Description

Add an option in the GatewayTest annotation to configure the mode:
- JUPITER: enable `jupiter` mode on the Gateway and set the jupiter ExecutionMode on apis
- COMPATIBILITY: enable `jupiter` mode on the Gateway and set the V3 ExecutionMode on apis
- V3: disable `jupiter` mode on the Gateway and set the v3 ExecutionMode on apis
 
## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rjuysjfsku.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/make-gatewaytest-annotation-parametrable/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
