### PR TITLE
Bump `connector-http` to `3.0.0`

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -47,7 +47,7 @@
         <!-- Versions of the plugins for the full distribution -->
         <!-- Management API & Gateway -->
         <gravitee-alert-engine-connectors-ws.version>2.0.0</gravitee-alert-engine-connectors-ws.version>
-        <gravitee-connector-http.version>2.1.1</gravitee-connector-http.version>
+        <gravitee-connector-http.version>3.0.0</gravitee-connector-http.version>
         <gravitee-policy-apikey.version>3.1.0</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>1.5.1</gravitee-policy-assign-attributes.version>
         <gravitee-policy-assign-content.version>1.7.0</gravitee-policy-assign-content.version>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/pom.xml
@@ -32,7 +32,7 @@
 
     <properties>
         <jetty94.wiremock.version>9.4.44.v20210927</jetty94.wiremock.version>
-        <gravitee-connector-http.version>2.1.1</gravitee-connector-http.version>
+        <gravitee-connector-http.version>3.0.0</gravitee-connector-http.version>
     </properties>
 
     <dependencyManagement>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <gravitee-connector-http.version>2.1.1</gravitee-connector-http.version>
+        <gravitee-connector-http.version>3.0.0</gravitee-connector-http.version>
         <junit-jupiter.version>5.8.2</junit-jupiter.version>
         <reactiverse-junit5-rx-java2-web-client.version>0.3.0</reactiverse-junit5-rx-java2-web-client.version>
         <jetty94.wiremock.version>9.4.44.v20210927</jetty94.wiremock.version>


### PR DESCRIPTION
## Issue

NA

## Description

Bump `connector-http` to `3.0.0`
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dekfmqubzz.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/bump-http-connector/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
