### PR TITLE
feat(docker): upgrade elastic to version 8

### DIFF
--- a/docker/quick-setup/consul-service-discovery/docker-compose.yml
+++ b/docker/quick-setup/consul-service-discovery/docker-compose.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-version: '3.5'
+version: '3.8'
 
 networks:
   frontend:
@@ -48,6 +48,11 @@ services:
     volumes:
       - data-mongo:/data/db
       - ./.logs/apim-mongodb:/var/log/mongodb
+    healthcheck:
+      test: mongosh --eval 'db.runCommand({serverStatus:1}).ok' --quiet | grep 1
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - storage
 
@@ -70,6 +75,11 @@ services:
         soft: -1
         hard: -1
       nofile: 65536
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - storage
 
@@ -80,8 +90,10 @@ services:
     ports:
       - "8082:8082"
     depends_on:
-      - mongodb
-      - elasticsearch
+      mongodb:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-gateway:/opt/graviteeio-gateway/logs
       - ./.license:/opt/graviteeio-gateway/license
@@ -103,8 +115,10 @@ services:
       - mongodb
       - elasticsearch
     depends_on:
-      - mongodb
-      - elasticsearch
+      mongodb:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-management-api:/opt/graviteeio-management-api/logs
       - ./.license:/opt/graviteeio-management-api/license

--- a/docker/quick-setup/consul-service-discovery/docker-compose.yml
+++ b/docker/quick-setup/consul-service-discovery/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       - storage
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.7.0}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.6.2}
     container_name: gio_apim_elasticsearch
     restart: always
     volumes:
@@ -61,7 +61,6 @@ services:
       - http.host=0.0.0.0
       - transport.host=0.0.0.0
       - xpack.security.enabled=false
-      - xpack.monitoring.enabled=false
       - cluster.name=elasticsearch
       - bootstrap.memory_lock=true
       - discovery.type=single-node

--- a/docker/quick-setup/ee-with-alert-engine/docker-compose.yml
+++ b/docker/quick-setup/ee-with-alert-engine/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - storage
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.7.0}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.6.2}
     container_name: gio_apim_elasticsearch
     restart: always
     volumes:
@@ -47,7 +47,6 @@ services:
       - http.host=0.0.0.0
       - transport.host=0.0.0.0
       - xpack.security.enabled=false
-      - xpack.monitoring.enabled=false
       - cluster.name=elasticsearch
       - bootstrap.memory_lock=true
       - discovery.type=single-node

--- a/docker/quick-setup/ee-with-alert-engine/docker-compose.yml
+++ b/docker/quick-setup/ee-with-alert-engine/docker-compose.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-version: '3.5'
+version: '3.8'
 
 networks:
   frontend:
@@ -34,6 +34,11 @@ services:
     volumes:
       - data-mongo:/data/db
       - ./.logs/apim-mongodb:/var/log/mongodb
+    healthcheck:
+      test: mongosh --eval 'db.runCommand({serverStatus:1}).ok' --quiet | grep 1
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - storage
 
@@ -56,6 +61,11 @@ services:
         soft: -1
         hard: -1
       nofile: 65536
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - storage
 
@@ -77,8 +87,10 @@ services:
     ports:
       - "8082:8082"
     depends_on:
-      - mongodb
-      - elasticsearch
+      mongodb:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-gateway:/opt/graviteeio-gateway/logs
       - ./.license:/opt/graviteeio-gateway/license
@@ -103,8 +115,10 @@ services:
       - mongodb
       - elasticsearch
     depends_on:
-      - mongodb
-      - elasticsearch
+      mongodb:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-management-api:/opt/graviteeio-management-api/logs
       - ./.license:/opt/graviteeio-management-api/license

--- a/docker/quick-setup/gateway-http-bridge-repository-postgresql-heartbeat/docker-compose.yml
+++ b/docker/quick-setup/gateway-http-bridge-repository-postgresql-heartbeat/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     restart: unless-stopped
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.7.0}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.6.2}
     restart: always
     volumes:
       - data-elasticsearch:/usr/share/elasticsearch/data
@@ -61,7 +61,6 @@ services:
       - http.host=0.0.0.0
       - transport.host=0.0.0.0
       - xpack.security.enabled=false
-      - xpack.monitoring.enabled=false
       - cluster.name=elasticsearch
       - bootstrap.memory_lock=true
       - discovery.type=single-node

--- a/docker/quick-setup/gateway-http-bridge-repository-postgresql-heartbeat/docker-compose.yml
+++ b/docker/quick-setup/gateway-http-bridge-repository-postgresql-heartbeat/docker-compose.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-version: '3.5'
+version: '3.8'
 
 networks:
   frontend:
@@ -70,6 +70,11 @@ services:
         soft: -1
         hard: -1
       nofile: 65536
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - storage
 
@@ -116,9 +121,12 @@ services:
       # Workaround used because of call to URI.create(uri) in WebClientFactory. If host contains "_", then host is null and the connection cannot be done.
       - "gateway_server:gateway-server"
     depends_on:
-      - elasticsearch
-      - gateway_server
-      - pg_database
+      elasticsearch:
+        condition: service_healthy
+      gateway_server:
+        condition: service_started
+      pg_database:
+        condition: service_started
     volumes:
       - ./.logs/apim-gateway-client:/opt/graviteeio-gateway/logs
       - ./.driver:/opt/graviteeio-gateway/plugins/ext/repository-jdbc
@@ -151,8 +159,10 @@ services:
       - pg_database
       - elasticsearch
     depends_on:
-      - pg_database
-      - elasticsearch
+      elasticsearch:
+        condition: service_healthy
+      pg_database:
+        condition: service_started
     volumes:
       - ./.logs/apim-management-api:/opt/graviteeio-management-api/logs
       - ./.driver:/opt/graviteeio-management-api/plugins/ext/repository-jdbc

--- a/docker/quick-setup/gateway-http-bridge-repository/docker-compose.yml
+++ b/docker/quick-setup/gateway-http-bridge-repository/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - storage
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.7.0}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.6.2}
     container_name: gio_apim_elasticsearch
     restart: always
     volumes:
@@ -47,7 +47,6 @@ services:
       - http.host=0.0.0.0
       - transport.host=0.0.0.0
       - xpack.security.enabled=false
-      - xpack.monitoring.enabled=false
       - cluster.name=elasticsearch
       - bootstrap.memory_lock=true
       - discovery.type=single-node

--- a/docker/quick-setup/gateway-http-bridge-repository/docker-compose.yml
+++ b/docker/quick-setup/gateway-http-bridge-repository/docker-compose.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-version: '3.5'
+version: '3.8'
 
 networks:
   frontend:
@@ -34,6 +34,11 @@ services:
     volumes:
       - data-mongo:/data/db
       - ./.logs/apim-mongodb:/var/log/mongodb
+    healthcheck:
+      test: mongosh --eval 'db.runCommand({serverStatus:1}).ok' --quiet | grep 1
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - storage
 
@@ -56,6 +61,11 @@ services:
         soft: -1
         hard: -1
       nofile: 65536
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - storage
 
@@ -66,7 +76,8 @@ services:
     ports:
       - "18092:18092"
     depends_on:
-      - mongodb
+      mongodb:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-gateway-server:/opt/graviteeio-gateway/logs
       - ./.license:/opt/graviteeio-gateway/license
@@ -97,8 +108,10 @@ services:
       # Workaround used because of call to URI.create(uri) in WebClientFactory. If host contains "_", then host is null and the connection cannot be done.
       - "gateway_server:gateway-server"
     depends_on:
-      - elasticsearch
-      - gateway_server
+      mongodb:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-gateway-client:/opt/graviteeio-gateway/logs
       - ./.license:/opt/graviteeio-gateway/license
@@ -125,8 +138,10 @@ services:
       - mongodb
       - elasticsearch
     depends_on:
-      - mongodb
-      - elasticsearch
+      mongodb:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-management-api:/opt/graviteeio-management-api/logs
       - ./.license:/opt/graviteeio-management-api/license

--- a/docker/quick-setup/https-gateway/docker-compose.yml
+++ b/docker/quick-setup/https-gateway/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - storage
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.7.0}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.6.2}
     container_name: gio_apim_elasticsearch
     restart: always
     volumes:
@@ -47,7 +47,6 @@ services:
       - http.host=0.0.0.0
       - transport.host=0.0.0.0
       - xpack.security.enabled=false
-      - xpack.monitoring.enabled=false
       - cluster.name=elasticsearch
       - bootstrap.memory_lock=true
       - discovery.type=single-node

--- a/docker/quick-setup/https-gateway/docker-compose.yml
+++ b/docker/quick-setup/https-gateway/docker-compose.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-version: '3.5'
+version: '3.8'
 
 networks:
   frontend:
@@ -34,6 +34,11 @@ services:
     volumes:
       - data-mongo:/data/db
       - ./.logs/apim-mongodb:/var/log/mongodb
+    healthcheck:
+      test: mongosh --eval 'db.runCommand({serverStatus:1}).ok' --quiet | grep 1
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - storage
 
@@ -56,6 +61,11 @@ services:
         soft: -1
         hard: -1
       nofile: 65536
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - storage
 
@@ -66,8 +76,10 @@ services:
     ports:
       - "8082:8082"
     depends_on:
-      - mongodb
-      - elasticsearch
+      mongodb:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-gateway-internal:/opt/graviteeio-gateway/logs
       - ./.certificates:/opt/graviteeio-gateway/certificates
@@ -98,8 +110,10 @@ services:
       - mongodb
       - elasticsearch
     depends_on:
-      - mongodb
-      - elasticsearch
+      mongodb:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-management-api:/opt/graviteeio-management-api/logs
       - ./.license:/opt/graviteeio-management-api/license

--- a/docker/quick-setup/https-nginx/docker-compose.yml
+++ b/docker/quick-setup/https-nginx/docker-compose.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-version: '3.5'
+version: '3.8'
 
 networks:
   frontend:
@@ -48,6 +48,11 @@ services:
     volumes:
       - data-mongo:/data/db
       - ./.logs/apim-mongodb:/var/log/mongodb
+    healthcheck:
+      test: mongosh --eval 'db.runCommand({serverStatus:1}).ok' --quiet | grep 1
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - storage
 
@@ -70,6 +75,11 @@ services:
         soft: -1
         hard: -1
       nofile: 65536
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - storage
 
@@ -78,8 +88,10 @@ services:
     container_name: gio_apim_gateway
     restart: always
     depends_on:
-      - mongodb
-      - elasticsearch
+      mongodb:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-gateway:/opt/graviteeio-gateway/logs
       - ./.license:/opt/graviteeio-gateway/license
@@ -99,8 +111,10 @@ services:
       - mongodb
       - elasticsearch
     depends_on:
-      - mongodb
-      - elasticsearch
+      mongodb:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-management-api:/opt/graviteeio-management-api/logs
       - ./.license:/opt/graviteeio-management-api/license

--- a/docker/quick-setup/https-nginx/docker-compose.yml
+++ b/docker/quick-setup/https-nginx/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       - storage
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.7.0}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.6.2}
     container_name: gio_apim_elasticsearch
     restart: always
     volumes:
@@ -61,7 +61,6 @@ services:
       - http.host=0.0.0.0
       - transport.host=0.0.0.0
       - xpack.security.enabled=false
-      - xpack.monitoring.enabled=false
       - cluster.name=elasticsearch
       - bootstrap.memory_lock=true
       - discovery.type=single-node

--- a/docker/quick-setup/keycloak/docker-compose.yml
+++ b/docker/quick-setup/keycloak/docker-compose.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-version: '3.5'
+version: '3.8'
 
 networks:
   frontend:
@@ -63,6 +63,11 @@ services:
     volumes:
       - data-mongo:/data/db
       - ./.logs/apim-mongodb:/var/log/mongodb
+    healthcheck:
+      test: mongosh --eval 'db.runCommand({serverStatus:1}).ok' --quiet | grep 1
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - storage
 
@@ -84,6 +89,11 @@ services:
         soft: -1
         hard: -1
       nofile: 65536
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - storage
 
@@ -93,9 +103,12 @@ services:
     ports:
       - "8082:8082"
     depends_on:
-      - mongodb
-      - elasticsearch
-      - keycloak
+      mongodb:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
+      keycloak:
+        condition: service_started
     links:
       - nginx:auth.localhost
     volumes:
@@ -121,8 +134,10 @@ services:
       - mongodb
       - elasticsearch
     depends_on:
-      - mongodb
-      - elasticsearch
+      mongodb:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-management-api:/opt/graviteeio-management-api/logs
       - ./.plugins:/opt/graviteeio-management-api/plugins-ext

--- a/docker/quick-setup/keycloak/docker-compose.yml
+++ b/docker/quick-setup/keycloak/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       - storage
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.7.0}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.6.2}
     restart: always
     volumes:
       - data-elasticsearch:/usr/share/elasticsearch/data
@@ -75,7 +75,6 @@ services:
       - http.host=0.0.0.0
       - transport.host=0.0.0.0
       - xpack.security.enabled=false
-      - xpack.monitoring.enabled=false
       - cluster.name=elasticsearch
       - bootstrap.memory_lock=true
       - discovery.type=single-node

--- a/docker/quick-setup/kibana/docker-compose.yml
+++ b/docker/quick-setup/kibana/docker-compose.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-version: '3.5'
+version: '3.8'
 
 networks:
   frontend:
@@ -35,6 +35,11 @@ services:
     volumes:
       - data-mongo:/data/db
       - ./.logs/apim-mongodb:/var/log/mongodb
+    healthcheck:
+      test: mongosh --eval 'db.runCommand({serverStatus:1}).ok' --quiet | grep 1
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - storage
 
@@ -52,6 +57,11 @@ services:
       - bootstrap.memory_lock=true
       - discovery.type=single-node
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
     ulimits:
       memlock:
         soft: -1
@@ -59,8 +69,9 @@ services:
       nofile: 65536
     networks:
       - storage
+
   kibana:
-    image: docker.elastic.co/kibana/kibana:${KIBANA_VERSION:-7.17.8}
+    image: docker.elastic.co/kibana/kibana:${KIBANA_VERSION:-8.6.2}
     container_name: gio_apim_kibana
     restart: always
     volumes:
@@ -68,7 +79,8 @@ services:
     ports:
       - "5601:5601"
     depends_on:
-      - elasticsearch
+      elasticsearch:
+        condition: service_healthy
     environment:
       ELASTICSEARCH_HOSTS: '["http://elasticsearch:9200"]'
     networks:
@@ -81,8 +93,10 @@ services:
     ports:
       - "8082:8082"
     depends_on:
-      - mongodb
-      - elasticsearch
+      mongodb:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-gateway:/opt/graviteeio-gateway/logs
       - ./.license:/opt/graviteeio-gateway/license
@@ -106,8 +120,10 @@ services:
       - mongodb
       - elasticsearch
     depends_on:
-      - mongodb
-      - elasticsearch
+      mongodb:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-management-api:/opt/graviteeio-management-api/logs
       - ./.license:/opt/graviteeio-management-api/license

--- a/docker/quick-setup/kibana/docker-compose.yml
+++ b/docker/quick-setup/kibana/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - storage
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.17.8}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.6.2}
     container_name: gio_apim_elasticsearch
     restart: always
     volumes:
@@ -48,7 +48,6 @@ services:
       - http.host=0.0.0.0
       - transport.host=0.0.0.0
       - xpack.security.enabled=false
-      - xpack.monitoring.enabled=false
       - cluster.name=elasticsearch
       - bootstrap.memory_lock=true
       - discovery.type=single-node

--- a/docker/quick-setup/mongodb/docker-compose.yml
+++ b/docker/quick-setup/mongodb/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - storage
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.7.0}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.6.2}
     container_name: gio_apim_elasticsearch
     restart: always
     volumes:
@@ -47,7 +47,6 @@ services:
       - http.host=0.0.0.0
       - transport.host=0.0.0.0
       - xpack.security.enabled=false
-      - xpack.monitoring.enabled=false
       - cluster.name=elasticsearch
       - bootstrap.memory_lock=true
       - discovery.type=single-node

--- a/docker/quick-setup/mongodb/docker-compose.yml
+++ b/docker/quick-setup/mongodb/docker-compose.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-version: '3.5'
+version: '3.8'
 
 networks:
   frontend:
@@ -34,6 +34,11 @@ services:
     volumes:
       - data-mongo:/data/db
       - ./.logs/apim-mongodb:/var/log/mongodb
+    healthcheck:
+      test: mongosh --eval 'db.runCommand({serverStatus:1}).ok' --quiet | grep 1
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - storage
 
@@ -56,6 +61,11 @@ services:
         soft: -1
         hard: -1
       nofile: 65536
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - storage
 
@@ -66,8 +76,10 @@ services:
     ports:
       - "8082:8082"
     depends_on:
-      - mongodb
-      - elasticsearch
+      mongodb:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-gateway:/opt/graviteeio-gateway/logs
       - ./.license:/opt/graviteeio-gateway/license
@@ -89,8 +101,10 @@ services:
       - mongodb
       - elasticsearch
     depends_on:
-      - mongodb
-      - elasticsearch
+      mongodb:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-management-api:/opt/graviteeio-management-api/logs
       - ./.license:/opt/graviteeio-management-api/license

--- a/docker/quick-setup/nginx/docker-compose.yml
+++ b/docker/quick-setup/nginx/docker-compose.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-version: '3.5'
+version: '3.8'
 
 networks:
   frontend:
@@ -47,6 +47,11 @@ services:
     volumes:
       - data-mongo:/data/db
       - ./.logs/apim-mongodb:/var/log/mongodb
+    healthcheck:
+      test: mongosh --eval 'db.runCommand({serverStatus:1}).ok' --quiet | grep 1
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - storage
 
@@ -69,6 +74,11 @@ services:
         soft: -1
         hard: -1
       nofile: 65536
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - storage
 
@@ -77,8 +87,10 @@ services:
     container_name: gio_apim_gateway
     restart: always
     depends_on:
-      - mongodb
-      - elasticsearch
+      mongodb:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-gateway:/opt/graviteeio-gateway/logs
       - ./.license:/opt/graviteeio-gateway/license
@@ -98,8 +110,10 @@ services:
       - mongodb
       - elasticsearch
     depends_on:
-      - mongodb
-      - elasticsearch
+      mongodb:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-management-api:/opt/graviteeio-management-api/logs
       - ./.license:/opt/graviteeio-management-api/license

--- a/docker/quick-setup/nginx/docker-compose.yml
+++ b/docker/quick-setup/nginx/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - storage
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.7.0}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.6.2}
     container_name: gio_apim_elasticsearch
     restart: always
     volumes:
@@ -60,7 +60,6 @@ services:
       - http.host=0.0.0.0
       - transport.host=0.0.0.0
       - xpack.security.enabled=false
-      - xpack.monitoring.enabled=false
       - cluster.name=elasticsearch
       - bootstrap.memory_lock=true
       - discovery.type=single-node

--- a/docker/quick-setup/opentracing-jaeger/docker-compose.yml
+++ b/docker/quick-setup/opentracing-jaeger/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - storage
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.7.0}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.6.2}
     container_name: gio_apim_elasticsearch
     restart: always
     volumes:
@@ -49,7 +49,6 @@ services:
       - http.host=0.0.0.0
       - transport.host=0.0.0.0
       - xpack.security.enabled=false
-      - xpack.monitoring.enabled=false
       - cluster.name=elasticsearch
       - bootstrap.memory_lock=true
       - discovery.type=single-node

--- a/docker/quick-setup/opentracing-jaeger/docker-compose.yml
+++ b/docker/quick-setup/opentracing-jaeger/docker-compose.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-version: '3.5'
+version: '3.8'
 
 networks:
   frontend:
@@ -36,6 +36,11 @@ services:
     volumes:
       - data-mongo:/data/db
       - ./.logs/apim-mongodb:/var/log/mongodb
+    healthcheck:
+      test: mongosh --eval 'db.runCommand({serverStatus:1}).ok' --quiet | grep 1
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - storage
 
@@ -58,6 +63,11 @@ services:
         soft: -1
         hard: -1
       nofile: 65536
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - storage
 
@@ -85,9 +95,12 @@ services:
     ports:
       - "8082:8082"
     depends_on:
-      - mongodb
-      - elasticsearch
-      - jaeger
+      mongodb:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
+      jaeger:
+        condition: service_started
     links:
       - "jaeger:jaeger"
     volumes:
@@ -119,8 +132,10 @@ services:
       - mongodb
       - elasticsearch
     depends_on:
-      - mongodb
-      - elasticsearch
+      mongodb:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-management-api:/opt/graviteeio-management-api/logs
       - ./.license:/opt/graviteeio-management-api/license

--- a/docker/quick-setup/postgresql/docker-compose.yml
+++ b/docker/quick-setup/postgresql/docker-compose.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-version: '3.5'
+version: '3.8'
 
 networks:
   frontend:
@@ -70,6 +70,11 @@ services:
         soft: -1
         hard: -1
       nofile: 65536
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - storage
 
@@ -80,8 +85,10 @@ services:
     ports:
       - "8082:8082"
     depends_on:
-      - pg_database
-      - elasticsearch
+      pg_database:
+        condition: service_started
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-gateway:/opt/graviteeio-gateway/logs
       - ./.driver:/opt/graviteeio-gateway/plugins/ext/repository-jdbc
@@ -110,8 +117,10 @@ services:
       - pg_database
       - elasticsearch
     depends_on:
-      - pg_database
-      - elasticsearch
+      pg_database:
+        condition: service_started
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-management-api:/opt/graviteeio-management-api/logs
       - ./.driver:/opt/graviteeio-management-api/plugins/ext/repository-jdbc

--- a/docker/quick-setup/postgresql/docker-compose.yml
+++ b/docker/quick-setup/postgresql/docker-compose.yml
@@ -52,7 +52,7 @@ services:
     restart: unless-stopped
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.7.0}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.6.2}
     container_name: apim-qs-psql-elasticsearch
     restart: always
     volumes:
@@ -61,7 +61,6 @@ services:
       - http.host=0.0.0.0
       - transport.host=0.0.0.0
       - xpack.security.enabled=false
-      - xpack.monitoring.enabled=false
       - cluster.name=elasticsearch
       - bootstrap.memory_lock=true
       - discovery.type=single-node

--- a/docker/quick-setup/prometheus/docker-compose.yml
+++ b/docker/quick-setup/prometheus/docker-compose.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-version: '3.5'
+version: '3.8'
 
 networks:
   frontend:
@@ -36,6 +36,11 @@ services:
     volumes:
       - data-mongo:/data/db
       - ./.logs/apim-mongodb:/var/log/mongodb
+    healthcheck:
+      test: mongosh --eval 'db.runCommand({serverStatus:1}).ok' --quiet | grep 1
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - storage
 
@@ -58,6 +63,11 @@ services:
         soft: -1
         hard: -1
       nofile: 65536
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - storage
 
@@ -79,9 +89,12 @@ services:
       - "8082:8082"
       - "18082:18082"
     depends_on:
-      - mongodb
-      - elasticsearch
-      - prometheus
+      mongodb:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
+      prometheus:
+        condition: service_started
     links:
       - "prometheus:prometheus"
     volumes:
@@ -109,8 +122,10 @@ services:
       - mongodb
       - elasticsearch
     depends_on:
-      - mongodb
-      - elasticsearch
+      mongodb:
+        condition: service_started
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-management-api:/opt/graviteeio-management-api/logs
       - ./.license:/opt/graviteeio-management-api/license

--- a/docker/quick-setup/prometheus/docker-compose.yml
+++ b/docker/quick-setup/prometheus/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - storage
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.7.0}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.6.2}
     container_name: gio_apim_elasticsearch
     restart: always
     volumes:
@@ -49,7 +49,6 @@ services:
       - http.host=0.0.0.0
       - transport.host=0.0.0.0
       - xpack.security.enabled=false
-      - xpack.monitoring.enabled=false
       - cluster.name=elasticsearch
       - bootstrap.memory_lock=true
       - discovery.type=single-node

--- a/docker/quick-setup/redis-rate-limit/docker-compose.yml
+++ b/docker/quick-setup/redis-rate-limit/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - storage
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.7.0}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.6.2}
     container_name: gio_apim_elasticsearch
     restart: always
     volumes:
@@ -49,7 +49,6 @@ services:
       - http.host=0.0.0.0
       - transport.host=0.0.0.0
       - xpack.security.enabled=false
-      - xpack.monitoring.enabled=false
       - cluster.name=elasticsearch
       - bootstrap.memory_lock=true
       - discovery.type=single-node

--- a/docker/quick-setup/redis-rate-limit/docker-compose.yml
+++ b/docker/quick-setup/redis-rate-limit/docker-compose.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-version: '3.5'
+version: '3.8'
 
 networks:
   frontend:
@@ -36,6 +36,11 @@ services:
     volumes:
       - data-mongo:/data/db
       - ./.logs/apim-mongodb:/var/log/mongodb
+    healthcheck:
+      test: mongosh --eval 'db.runCommand({serverStatus:1}).ok' --quiet | grep 1
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - storage
 
@@ -58,6 +63,11 @@ services:
         soft: -1
         hard: -1
       nofile: 65536
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - storage
 
@@ -90,9 +100,12 @@ services:
     ports:
       - "8082:8082"
     depends_on:
-      - mongodb
-      - elasticsearch
-      - redis_rate_limit
+      mongodb:
+        condition: service_started
+      elasticsearch:
+        condition: service_healthy
+      redis_rate_limit:
+        condition: service_started
     links:
       - "redis_rate_limit:redis-rate-limit"
     volumes:
@@ -122,8 +135,10 @@ services:
       - mongodb
       - elasticsearch
     depends_on:
-      - mongodb
-      - elasticsearch
+      mongodb:
+        condition: service_started
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-management-api:/opt/graviteeio-management-api/logs
       - ./.license:/opt/graviteeio-management-api/license

--- a/docker/quick-setup/tags-internal-external/docker-compose.yml
+++ b/docker/quick-setup/tags-internal-external/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - storage
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.7.0}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.6.2}
     container_name: gio_apim_elasticsearch
     restart: always
     volumes:
@@ -47,7 +47,6 @@ services:
       - http.host=0.0.0.0
       - transport.host=0.0.0.0
       - xpack.security.enabled=false
-      - xpack.monitoring.enabled=false
       - cluster.name=elasticsearch
       - bootstrap.memory_lock=true
       - discovery.type=single-node

--- a/docker/quick-setup/tags-internal-external/docker-compose.yml
+++ b/docker/quick-setup/tags-internal-external/docker-compose.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-version: '3.5'
+version: '3.8'
 
 networks:
   frontend:
@@ -34,6 +34,11 @@ services:
     volumes:
       - data-mongo:/data/db
       - ./.logs/apim-mongodb:/var/log/mongodb
+    healthcheck:
+      test: mongosh --eval 'db.runCommand({serverStatus:1}).ok' --quiet | grep 1
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - storage
 
@@ -56,6 +61,11 @@ services:
         soft: -1
         hard: -1
       nofile: 65536
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - storage
 
@@ -66,8 +76,10 @@ services:
     ports:
       - "8082:8082"
     depends_on:
-      - mongodb
-      - elasticsearch
+      mongodb:
+        condition: service_started
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-gateway-internal:/opt/graviteeio-gateway/logs
       - ./.license:/opt/graviteeio-gateway/license
@@ -87,8 +99,10 @@ services:
     ports:
       - "8081:8082"
     depends_on:
-      - mongodb
-      - elasticsearch
+      mongodb:
+        condition: service_started
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-gateway-external:/opt/graviteeio-gateway/logs
       - ./.license:/opt/graviteeio-gateway/license
@@ -111,8 +125,10 @@ services:
       - mongodb
       - elasticsearch
     depends_on:
-      - mongodb
-      - elasticsearch
+      mongodb:
+        condition: service_started
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-management-api:/opt/graviteeio-management-api/logs
       - ./.license:/opt/graviteeio-management-api/license

--- a/gravitee-apim-e2e/docker/common/docker-compose-base.yml
+++ b/gravitee-apim-e2e/docker/common/docker-compose-base.yml
@@ -27,7 +27,7 @@ volumes:
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.17.7}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.6.2}
     container_name: gravitee-apim-e2e-elasticsearch
     restart: always
     volumes:
@@ -36,7 +36,6 @@ services:
       - http.host=0.0.0.0
       - transport.host=0.0.0.0
       - xpack.security.enabled=false
-      - xpack.monitoring.enabled=false
       - cluster.name=elasticsearch
       - bootstrap.memory_lock=true
       - discovery.type=single-node

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mqtt5/docker/quick-setup/apim-hivemq/docker-compose.yml
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mqtt5/docker/quick-setup/apim-hivemq/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - backend
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.7.0}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.6.2}
     container_name: gio_apim_elasticsearch
     restart: always
     volumes:
@@ -48,7 +48,6 @@ services:
       - http.host=0.0.0.0
       - transport.host=0.0.0.0
       - xpack.security.enabled=false
-      - xpack.monitoring.enabled=false
       - cluster.name=elasticsearch
       - bootstrap.memory_lock=true
       - discovery.type=single-node

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mqtt5/docker/quick-setup/apim-hivemq/docker-compose.yml
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mqtt5/docker/quick-setup/apim-hivemq/docker-compose.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-version: '3.5'
+version: '3.8'
 
 networks:
   frontend:
@@ -35,6 +35,11 @@ services:
     volumes:
       - data-mongo:/data/db
       - ./.logs/apim-mongodb:/var/log/mongodb
+    healthcheck:
+      test: mongosh --eval 'db.runCommand({serverStatus:1}).ok' --quiet | grep 1
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - backend
 
@@ -57,6 +62,11 @@ services:
         soft: -1
         hard: -1
       nofile: 65536
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
     networks:
       - backend
 
@@ -67,8 +77,10 @@ services:
     ports:
       - "8082:8082"
     depends_on:
-      - mongodb
-      - elasticsearch
+      mongodb:
+        condition: service_started
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-gateway:/opt/graviteeio-gateway/logs
       - ./.license:/opt/graviteeio-gateway/license
@@ -94,8 +106,10 @@ services:
       - mongodb
       - elasticsearch
     depends_on:
-      - mongodb
-      - elasticsearch
+      mongodb:
+        condition: service_started
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./.logs/apim-management-api:/opt/graviteeio-management-api/logs
       - ./.license:/opt/graviteeio-management-api/license

--- a/gravitee-apim-rest-api/docker/compose/docker-compose-dev.yml
+++ b/gravitee-apim-rest-api/docker/compose/docker-compose-dev.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-version: '3.5'
+version: '3.8'
 
 volumes:
   data-elasticsearch:
@@ -24,6 +24,11 @@ services:
   mongodb:
     image: mongo:${MONGODB_VERSION:-6.0}
     container_name: gio_apim_mongodb
+    healthcheck:
+      test: mongosh --eval 'db.runCommand({serverStatus:1}).ok' --quiet | grep 1
+      interval: 5s
+      timeout: 3s
+      retries: 10
     volumes:
       - ./logs/apim-mongodb:/var/log/mongodb
 
@@ -40,6 +45,11 @@ services:
       - bootstrap.memory_lock=true
       - discovery.type=single-node
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s" ]
+      interval: 5s
+      timeout: 3s
+      retries: 10
     ulimits:
       memlock:
         soft: -1
@@ -55,8 +65,10 @@ services:
       - mongodb
       - elasticsearch
     depends_on:
-      - mongodb
-      - elasticsearch
+      mongodb:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ./logs/apim-management-api:/opt/graviteeio-management-api/logs
     environment:

--- a/gravitee-apim-rest-api/docker/compose/docker-compose-dev.yml
+++ b/gravitee-apim-rest-api/docker/compose/docker-compose-dev.yml
@@ -28,7 +28,7 @@ services:
       - ./logs/apim-mongodb:/var/log/mongodb
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-7.7.0}
+    image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION:-8.6.2}
     container_name: gio_apim_elasticsearch
     volumes:
       - ./data/data-elasticsearch:/usr/share/elasticsearch/data
@@ -36,7 +36,6 @@ services:
       - http.host=0.0.0.0
       - transport.host=0.0.0.0
       - xpack.security.enabled=false
-      - xpack.monitoring.enabled=false
       - cluster.name=elasticsearch
       - bootstrap.memory_lock=true
       - discovery.type=single-node


### PR DESCRIPTION
## Description

Upgrade Elasticsearch version to 8 in docker-compose files

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wdnqrfflfp.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/upgrade-to-es8-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
