### PR TITLE
feat: move analytics to its own page

### DIFF
--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
@@ -95,6 +95,13 @@ export class GioSideNavComponent implements OnInit {
         displayName: 'Messages',
         permissions: ['environment-message-c'],
       },
+      {
+        icon: 'gio:bar-chart-2',
+        targetRoute: 'management.analytics',
+        baseRoute: 'management.analytics',
+        displayName: 'Analytics',
+        permissions: ['environment-platform-r'],
+      },
     ];
 
     if (this.constants.org.settings.alert && this.constants.org.settings.alert.enabled) {

--- a/gravitee-apim-console-webui/src/components/widget/table/widget-data-table.component.ts
+++ b/gravitee-apim-console-webui/src/components/widget/table/widget-data-table.component.ts
@@ -92,7 +92,7 @@ const WidgetDataTableComponent: ng.IComponentOptions = {
 
     this.isClickable = function (result) {
       return (
-        ($state.current.name === 'management.dashboard.analytics' || $state.current.name === 'management.dashboard.home') &&
+        ($state.current.name === 'management.analytics' || $state.current.name === 'management.dashboard.home') &&
         !result.metadata.unknown &&
         (this.widget.chart.request.field === 'api' || this.widget.chart.request.field === 'application')
       );
@@ -100,7 +100,7 @@ const WidgetDataTableComponent: ng.IComponentOptions = {
 
     this.goto = function (key) {
       // only on platform analytics
-      if ($state.current.name === 'management.dashboard.analytics' || $state.current.name === 'management.dashboard.home') {
+      if ($state.current.name === 'management.analytics' || $state.current.name === 'management.dashboard.home') {
         if (this.widget.chart.request.field === 'api') {
           this.$state.go('management.apis.detail.analytics.overview', {
             apiId: key,

--- a/gravitee-apim-console-webui/src/management/dashboard-ajs/dashboard.controller.ts
+++ b/gravitee-apim-console-webui/src/management/dashboard-ajs/dashboard.controller.ts
@@ -18,7 +18,6 @@ import { StateService } from '@uirouter/core';
 import UserService from '../../services/user.service';
 
 class DashboardController {
-  private canViewAnalytics: boolean;
   private canViewApiStatus: boolean;
   private selectedIndex: number;
   private canViewAlerts: boolean;
@@ -29,13 +28,9 @@ class DashboardController {
   $onInit() {
     const tabs = ['management.dashboard.home'];
     this.canViewApiStatus = this.Constants.env.settings.dashboards.apiStatus.enabled;
-    this.canViewAnalytics = this.UserService.isUserHasAllPermissions(['environment-platform-r']);
     this.canViewAlerts = this.Constants.org.settings.alert.enabled && this.UserService.isUserHasPermissions(['environment-alert-r']);
     if (this.canViewApiStatus) {
       tabs.push('management.dashboard.apis-status');
-    }
-    if (this.canViewAnalytics) {
-      tabs.push('management.dashboard.analytics');
     }
     if (this.canViewAlerts) {
       tabs.push('management.dashboard.alerts');

--- a/gravitee-apim-console-webui/src/management/dashboard-ajs/dashboard.html
+++ b/gravitee-apim-console-webui/src/management/dashboard-ajs/dashboard.html
@@ -25,10 +25,6 @@
       <md-tab-label><ng-md-icon icon="favorite" style="fill: var(--gv-theme-color-darker)"></ng-md-icon> APIs Status</md-tab-label>
       <md-tab-body></md-tab-body>
     </md-tab>
-    <md-tab ui-sref="management.dashboard.analytics" ng-if="$ctrl.canViewAnalytics">
-      <md-tab-label><ng-md-icon icon="insert_chart" style="fill: var(--gv-theme-color-darker)"></ng-md-icon> Analytics</md-tab-label>
-      <md-tab-body></md-tab-body>
-    </md-tab>
     <md-tab ng-if="$ctrl.canViewAlerts" ui-sref="management.dashboard.alerts">
       <md-tab-label><ng-md-icon icon="alarm" style="fill: var(--gv-theme-color-darker)"></ng-md-icon> Alerts</md-tab-label>
       <md-tab-body></md-tab-body>

--- a/gravitee-apim-console-webui/src/management/management.route.ts
+++ b/gravitee-apim-console-webui/src/management/management.route.ts
@@ -77,41 +77,6 @@ function managementRouterConfig($stateProvider) {
         },
       },
     })
-    .state('management.dashboard.analytics', {
-      url: '/platform?from&to&q&dashboard',
-      template: require('./dashboard-ajs/analytics-dashboard/analytics-dashboard.html'),
-      controller: 'AnalyticsDashboardController',
-      controllerAs: '$ctrl',
-      resolve: {
-        dashboards: (DashboardService: DashboardService) => DashboardService.list('PLATFORM').then((response) => response.data),
-      },
-      data: {
-        perms: {
-          only: ['environment-platform-r'],
-        },
-        docs: {
-          page: 'management-dashboard-analytics',
-        },
-      },
-      params: {
-        from: {
-          type: 'int',
-          dynamic: true,
-        },
-        to: {
-          type: 'int',
-          dynamic: true,
-        },
-        q: {
-          type: 'string',
-          dynamic: true,
-        },
-        dashboard: {
-          type: 'string',
-          dynamic: true,
-        },
-      },
-    })
     .state('management.dashboard.alerts', {
       url: '/alerts',
       template: require('./dashboard-ajs/alerts-dashboard/platform-alerts-dashboard.html'),
@@ -274,6 +239,41 @@ function managementRouterConfig($stateProvider) {
       resolve: {
         ticket: ($stateParams: StateParams, TicketService: TicketService) =>
           TicketService.getTicket($stateParams.ticketId).then((response) => response.data),
+      },
+    })
+    .state('management.analytics', {
+      url: '/platform?from&to&q&dashboard',
+      template: require('./dashboard-ajs/analytics-dashboard/analytics-dashboard.html'),
+      controller: 'AnalyticsDashboardController',
+      controllerAs: '$ctrl',
+      resolve: {
+        dashboards: (DashboardService: DashboardService) => DashboardService.list('PLATFORM').then((response) => response.data),
+      },
+      data: {
+        perms: {
+          only: ['environment-platform-r'],
+        },
+        docs: {
+          page: 'management-dashboard-analytics',
+        },
+      },
+      params: {
+        from: {
+          type: 'int',
+          dynamic: true,
+        },
+        to: {
+          type: 'int',
+          dynamic: true,
+        },
+        q: {
+          type: 'string',
+          dynamic: true,
+        },
+        dashboard: {
+          type: 'string',
+          dynamic: true,
+        },
       },
     });
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1142

## Description

Move Analytics to its own page, outside of the Home dashboard

![screenshot-localhost_3000-2023 03 22-16_53_29](https://user-images.githubusercontent.com/1655950/226963140-c68091be-0304-411e-9680-79f5154123ae.png)

![screenshot-localhost_3000-2023 03 22-16_54_04](https://user-images.githubusercontent.com/1655950/226963296-504cfa9c-1751-4494-b09a-4e824f8f1388.png)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zaiytqwnjn.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1142-move-analytics-in-sidenav/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
