### PR TITLE
fix: match documentation and implementation for attach media api

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/JerseySpringTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/JerseySpringTest.java
@@ -20,6 +20,7 @@ import io.gravitee.rest.api.management.rest.resource.GraviteeManagementApplicati
 import java.io.IOException;
 import java.security.Principal;
 import javax.annotation.Priority;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.container.ContainerRequestContext;
@@ -50,8 +51,13 @@ public abstract class JerseySpringTest {
 
     private String orgBaseURL = "/organizations/DEFAULT";
     private String envBaseURL = orgBaseURL + "/environments/DEFAULT";
+    private HttpServletRequest httpServletRequest;
 
     protected abstract String contextPath();
+
+    public HttpServletRequest httpServletRequest() {
+        return httpServletRequest;
+    }
 
     public final WebTarget envTarget() {
         return envTarget("");
@@ -118,12 +124,14 @@ public abstract class JerseySpringTest {
     protected void decorate(ResourceConfig resourceConfig) {
         resourceConfig.register(AuthenticationFilter.class);
 
+        httpServletRequest = Mockito.spy(HttpServletRequest.class);
         final HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
         resourceConfig.register(
             new AbstractBinder() {
                 @Override
                 protected void configure() {
                     bind(response).to(HttpServletResponse.class);
+                    bind(httpServletRequest).to(HttpServletRequest.class);
                 }
             }
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/AbstractResourceTest.java
@@ -231,6 +231,9 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
     @Autowired
     protected AuditService auditService;
 
+    @Autowired
+    protected MediaService mediaService;
+
     @Configuration
     @PropertySource("classpath:/io/gravitee/rest/api/management/rest/resource/jwt.properties")
     static class ContextConfiguration {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiPageMediaResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiPageMediaResourceTest.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource;
+
+import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.CREATED_201;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.rest.api.model.MediaEntity;
+import io.gravitee.rest.api.model.PageEntity;
+import io.gravitee.rest.api.model.PageMediaEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.UploadUnauthorized;
+import java.io.IOException;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
+import org.glassfish.jersey.media.multipart.MultiPart;
+import org.glassfish.jersey.media.multipart.file.StreamDataBodyPart;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ApiPageMediaResourceTest extends AbstractResourceTest {
+
+    private static final String API = "my-api";
+    private static final String PAGE = "my-page";
+
+    @Override
+    protected String contextPath() {
+        return "apis";
+    }
+
+    @Before
+    public void init() {
+        Mockito.reset(mediaService);
+        GraviteeContext.cleanContext();
+    }
+
+    @After
+    public void tearDown() {
+        GraviteeContext.cleanContext();
+    }
+
+    @Test
+    public void shouldBeBadRequestIfContentLengthGreaterThanMediaMaxSize() throws IOException {
+        StreamDataBodyPart filePart = new StreamDataBodyPart(
+            "file",
+            this.getClass().getResource("/media/logo.svg").openStream(),
+            "logo.svg",
+            MediaType.valueOf("image/svg+xml")
+        );
+        final MultiPart multiPart = new MultiPart(MediaType.MULTIPART_FORM_DATA_TYPE);
+        multiPart.bodyPart(filePart);
+        final FormDataBodyPart fileNameBodyPart = new FormDataBodyPart("fileName", "logo.svg");
+        multiPart.bodyPart(fileNameBodyPart);
+
+        when(httpServletRequest().getContentLength()).thenReturn(15);
+        when(mediaService.getMediaMaxSize(any())).thenReturn(10L);
+
+        final Response response = envTarget()
+            .path(API)
+            .path("pages")
+            .path(PAGE)
+            .path("media")
+            .request()
+            .post(Entity.entity(multiPart, multiPart.getMediaType()));
+
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+        final UploadUnauthorized result = response.readEntity(UploadUnauthorized.class);
+        assertThat(result.getMessage()).isEqualTo("Max size is " + 10L + "bytes. Actual size is " + 15 + "bytes.");
+    }
+
+    @Test
+    public void shouldAttachMediaToApiPage() throws IOException {
+        StreamDataBodyPart filePart = new StreamDataBodyPart(
+            "file",
+            this.getClass().getResource("/media/logo.svg").openStream(),
+            "logo.svg",
+            MediaType.valueOf("image/svg+xml")
+        );
+        final MultiPart multiPart = new MultiPart(MediaType.MULTIPART_FORM_DATA_TYPE);
+        multiPart.bodyPart(filePart);
+        final FormDataBodyPart fileNameBodyPart = new FormDataBodyPart("fileName", "logo.svg");
+        multiPart.bodyPart(fileNameBodyPart);
+
+        when(httpServletRequest().getContentLength()).thenReturn(5);
+        when(mediaService.getMediaMaxSize(any())).thenReturn(10L);
+
+        final String mediaHash = "#MEDIA_HASH";
+        when(mediaService.saveApiMedia(eq(API), any())).thenReturn(mediaHash);
+
+        final Date attachedAt = new Date();
+        PageEntity pageEntity = new PageEntity();
+        PageMediaEntity createdMedia = new PageMediaEntity();
+        createdMedia.setMediaHash(mediaHash);
+        createdMedia.setAttachedAt(attachedAt);
+        pageEntity.setAttachedMedia(List.of(createdMedia));
+        when(pageService.attachMedia(eq(PAGE), eq(mediaHash), any())).thenReturn(Optional.of(pageEntity));
+
+        final Response response = envTarget()
+            .path(API)
+            .path("pages")
+            .path(PAGE)
+            .path("media")
+            .request()
+            .post(Entity.entity(multiPart, multiPart.getMediaType()));
+
+        assertThat(response.getStatus()).isEqualTo(CREATED_201);
+        assertThat(response.getHeaders().getFirst(HttpHeaders.LOCATION))
+            .isEqualTo(envTarget().path(API).path("pages").path(PAGE).path("media").getUri().toString());
+
+        final MediaEntity result = response.readEntity(MediaEntity.class);
+        assertThat(result.getHash()).isEqualTo(mediaHash);
+        assertThat(result.getCreateAt()).isEqualTo(attachedAt);
+        assertThat(result.getData()).isNull();
+        assertThat(result.getType()).isEqualTo("image");
+        assertThat(result.getSubType()).isEqualTo("svg+xml");
+        assertThat(result.getFileName()).isEqualTo("logo.svg");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PortalPageMediaResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PortalPageMediaResourceTest.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource;
+
+import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.CREATED_201;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.rest.api.model.MediaEntity;
+import io.gravitee.rest.api.model.PageEntity;
+import io.gravitee.rest.api.model.PageMediaEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.UploadUnauthorized;
+import java.io.IOException;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
+import org.glassfish.jersey.media.multipart.MultiPart;
+import org.glassfish.jersey.media.multipart.file.StreamDataBodyPart;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class PortalPageMediaResourceTest extends AbstractResourceTest {
+
+    private static final String PAGE = "my-page";
+
+    @Override
+    protected String contextPath() {
+        return "portal";
+    }
+
+    @Before
+    public void init() {
+        Mockito.reset(mediaService);
+        GraviteeContext.cleanContext();
+    }
+
+    @After
+    public void tearDown() {
+        GraviteeContext.cleanContext();
+    }
+
+    @Test
+    public void shouldBeBadRequestIfContentLengthGreaterThanMediaMaxSize() throws IOException {
+        StreamDataBodyPart filePart = new StreamDataBodyPart(
+            "file",
+            this.getClass().getResource("/media/logo.svg").openStream(),
+            "logo.svg",
+            MediaType.valueOf("image/svg+xml")
+        );
+        final MultiPart multiPart = new MultiPart(MediaType.MULTIPART_FORM_DATA_TYPE);
+        multiPart.bodyPart(filePart);
+        final FormDataBodyPart fileNameBodyPart = new FormDataBodyPart("fileName", "logo.svg");
+        multiPart.bodyPart(fileNameBodyPart);
+
+        when(httpServletRequest().getContentLength()).thenReturn(15);
+        when(mediaService.getMediaMaxSize(any())).thenReturn(10L);
+
+        final Response response = envTarget()
+            .path("pages")
+            .path(PAGE)
+            .path("media")
+            .request()
+            .post(Entity.entity(multiPart, multiPart.getMediaType()));
+
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+        final UploadUnauthorized result = response.readEntity(UploadUnauthorized.class);
+        assertThat(result.getMessage()).isEqualTo("Max size is " + 10L + "bytes. Actual size is " + 15 + "bytes.");
+    }
+
+    @Test
+    public void shouldAttachMediaToPortalPage() throws IOException {
+        StreamDataBodyPart filePart = new StreamDataBodyPart(
+            "file",
+            this.getClass().getResource("/media/logo.svg").openStream(),
+            "logo.svg",
+            MediaType.valueOf("image/svg+xml")
+        );
+        final MultiPart multiPart = new MultiPart(MediaType.MULTIPART_FORM_DATA_TYPE);
+        multiPart.bodyPart(filePart);
+        final FormDataBodyPart fileNameBodyPart = new FormDataBodyPart("fileName", "logo.svg");
+        multiPart.bodyPart(fileNameBodyPart);
+
+        when(httpServletRequest().getContentLength()).thenReturn(5);
+        when(mediaService.getMediaMaxSize(any())).thenReturn(10L);
+
+        final String mediaHash = "#MEDIA_HASH";
+        when(mediaService.savePortalMedia(any())).thenReturn(mediaHash);
+
+        final Date attachedAt = new Date();
+        PageEntity pageEntity = new PageEntity();
+        PageMediaEntity createdMedia = new PageMediaEntity();
+        createdMedia.setMediaHash(mediaHash);
+        createdMedia.setAttachedAt(attachedAt);
+        pageEntity.setAttachedMedia(List.of(createdMedia));
+        when(pageService.attachMedia(eq(PAGE), eq(mediaHash), any())).thenReturn(Optional.of(pageEntity));
+
+        final Response response = envTarget()
+            .path("pages")
+            .path(PAGE)
+            .path("media")
+            .request()
+            .post(Entity.entity(multiPart, multiPart.getMediaType()));
+
+        assertThat(response.getStatus()).isEqualTo(CREATED_201);
+        assertThat(response.getHeaders().getFirst(HttpHeaders.LOCATION))
+            .isEqualTo(envTarget().path("pages").path(PAGE).path("media").getUri().toString());
+
+        final MediaEntity result = response.readEntity(MediaEntity.class);
+        assertThat(result.getHash()).isEqualTo(mediaHash);
+        assertThat(result.getCreateAt()).isEqualTo(attachedAt);
+        assertThat(result.getData()).isNull();
+        assertThat(result.getType()).isEqualTo("image");
+        assertThat(result.getSubType()).isEqualTo("svg+xml");
+        assertThat(result.getFileName()).isEqualTo("logo.svg");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/PageService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/PageService.java
@@ -22,6 +22,7 @@ import io.gravitee.rest.api.model.documentation.PageQuery;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
@@ -121,5 +122,5 @@ public interface PageService {
 
     boolean shouldHaveRevision(String pageType);
 
-    void attachMedia(String pageId, String mediaId, String mediaName);
+    Optional<PageEntity> attachMedia(String pageId, String mediaId, String mediaName);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -2566,7 +2566,7 @@ public class PageServiceImpl extends AbstractService implements PageService, App
     }
 
     @Override
-    public void attachMedia(String pageId, String mediaId, String mediaName) {
+    public Optional<PageEntity> attachMedia(String pageId, String mediaId, String mediaName) {
         try {
             final Optional<Page> optPage = pageRepository.findById(pageId);
             if (optPage.isPresent()) {
@@ -2575,7 +2575,10 @@ public class PageServiceImpl extends AbstractService implements PageService, App
                     page.setAttachedMedia(new ArrayList<>());
                 }
                 page.getAttachedMedia().add(new PageMedia(mediaId, mediaName, new Date()));
-                pageRepository.update(page);
+                final Page updatedPage = pageRepository.update(page);
+                return Optional.of(convert(updatedPage));
+            } else {
+                return Optional.empty();
             }
         } catch (TechnicalException ex) {
             throw onUpdateFail(pageId, ex);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-905

## Description

- change swagger documentation 
  - to return a MediaEntity instead of PageEntity
- change implementation
  - to return the hash with the media response
  - to respect documentation and return a 201 instead of 200   
