### PR TITLE
fix: put backend host in proxy request headers log

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/hook/logging/LoggingHook.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/hook/logging/LoggingHook.java
@@ -47,8 +47,8 @@ public class LoggingHook implements InvokerHook {
             final LoggingContext loggingContext = ctx.getInternalAttribute(LoggingContext.ATTR_INTERNAL_LOGGING_CONTEXT);
 
             if (log != null && loggingContext.proxyMode()) {
-                final LogProxyRequest logRequest = new LogProxyRequest(loggingContext, ctx.request());
-                log.setProxyRequest(logRequest);
+                log.setProxyRequest(new LogProxyRequest(loggingContext, ctx.request()));
+
                 ((MutableExecutionContext) ctx).response().setHeaders(new LogHeadersCaptor(ctx.response().headers()));
             }
         });
@@ -61,6 +61,8 @@ public class LoggingHook implements InvokerHook {
             final LoggingContext loggingContext = ctx.getInternalAttribute(LoggingContext.ATTR_INTERNAL_LOGGING_CONTEXT);
 
             if (log != null && loggingContext.proxyMode()) {
+                log.getProxyRequest().setHeaders(ctx.request().headers());
+
                 final LogProxyResponse logResponse = new LogProxyResponse(loggingContext, ctx.response());
                 log.setProxyResponse(logResponse);
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/logging/request/LogProxyRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/logging/request/LogProxyRequest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.jupiter.handlers.api.logging.request;
 
+import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.core.logging.LoggingContext;
 import io.gravitee.gateway.jupiter.api.context.HttpRequest;
 
@@ -32,6 +33,11 @@ public class LogProxyRequest extends LogRequest {
         request.chunks(
             request.chunks().doOnSubscribe(s -> this.setUri(request.metrics().getEndpoint() != null ? request.metrics().getEndpoint() : ""))
         );
+    }
+
+    @Override
+    public void setHeaders(HttpHeaders headers) {
+        super.setHeaders(HttpHeaders.create(headers));
     }
 
     protected boolean isLogPayload() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/hook/logging/LoggingHookTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/hook/logging/LoggingHookTest.java
@@ -27,6 +27,7 @@ import io.gravitee.gateway.jupiter.core.context.MutableExecutionContext;
 import io.gravitee.gateway.jupiter.core.context.MutableRequest;
 import io.gravitee.gateway.jupiter.core.context.MutableResponse;
 import io.gravitee.gateway.jupiter.handlers.api.logging.LogHeadersCaptor;
+import io.gravitee.reporter.api.common.Request;
 import io.gravitee.reporter.api.http.Metrics;
 import io.gravitee.reporter.api.log.Log;
 import io.reactivex.rxjava3.core.Flowable;
@@ -128,9 +129,12 @@ class LoggingHookTest {
     @Test
     void shouldSetProxyResponseWhenProxyMode() {
         final Log log = new Log(System.currentTimeMillis());
+        log.setProxyRequest(new Request());
 
         when(metrics.getLog()).thenReturn(log);
         when(loggingContext.proxyMode()).thenReturn(true);
+
+        when(request.headers()).thenReturn(HttpHeaders.create());
         when(response.headers()).thenReturn(new LogHeadersCaptor(HttpHeaders.create()));
 
         final TestObserver<Void> obs = cut.post("test", ctx, ExecutionPhase.REQUEST).test();
@@ -140,11 +144,30 @@ class LoggingHookTest {
     }
 
     @Test
-    void shouldSetProxyResponseWhenProxyModeAndInterrupt() {
+    void shouldSetProxyRequestHeadersWhenProxyMode() {
         final Log log = new Log(System.currentTimeMillis());
+        log.setProxyRequest(new Request());
 
         when(metrics.getLog()).thenReturn(log);
         when(loggingContext.proxyMode()).thenReturn(true);
+
+        when(request.headers()).thenReturn(HttpHeaders.create());
+        when(response.headers()).thenReturn(new LogHeadersCaptor(HttpHeaders.create()));
+
+        final TestObserver<Void> obs = cut.post("test", ctx, ExecutionPhase.REQUEST).test();
+        obs.assertComplete();
+
+        assertNotNull(log.getProxyRequest().getHeaders());
+    }
+
+    @Test
+    void shouldSetProxyResponseWhenProxyModeAndInterrupt() {
+        final Log log = new Log(System.currentTimeMillis());
+        log.setProxyRequest(new Request());
+
+        when(metrics.getLog()).thenReturn(log);
+        when(loggingContext.proxyMode()).thenReturn(true);
+        when(request.headers()).thenReturn(HttpHeaders.create());
         when(response.headers()).thenReturn(new LogHeadersCaptor(HttpHeaders.create()));
 
         final TestObserver<Void> obs = cut.interrupt("test", ctx, ExecutionPhase.REQUEST).test();
@@ -156,15 +179,33 @@ class LoggingHookTest {
     @Test
     void shouldSetProxyResponseWhenProxyModeAndInterruptWith() {
         final Log log = new Log(System.currentTimeMillis());
+        log.setProxyRequest(new Request());
 
         when(metrics.getLog()).thenReturn(log);
         when(loggingContext.proxyMode()).thenReturn(true);
+        when(request.headers()).thenReturn(new LogHeadersCaptor(HttpHeaders.create()));
         when(response.headers()).thenReturn(new LogHeadersCaptor(HttpHeaders.create()));
 
         final TestObserver<Void> obs = cut.interruptWith("test", ctx, ExecutionPhase.REQUEST, new ExecutionFailure(500)).test();
         obs.assertComplete();
 
         assertNotNull(log.getProxyResponse());
+    }
+
+    @Test
+    void shouldSetProxyRequestHeadersWhenProxyModeAndInterruptWith() {
+        final Log log = new Log(System.currentTimeMillis());
+        log.setProxyRequest(new Request());
+
+        when(metrics.getLog()).thenReturn(log);
+        when(loggingContext.proxyMode()).thenReturn(true);
+        when(request.headers()).thenReturn(HttpHeaders.create());
+        when(response.headers()).thenReturn(new LogHeadersCaptor(HttpHeaders.create()));
+
+        final TestObserver<Void> obs = cut.interruptWith("test", ctx, ExecutionPhase.REQUEST, new ExecutionFailure(500)).test();
+        obs.assertComplete();
+
+        assertNotNull(log.getProxyRequest().getHeaders());
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/logging/request/LogProxyRequestTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/logging/request/LogProxyRequestTest.java
@@ -102,6 +102,7 @@ class LogProxyRequestTest {
         when(request.chunks()).thenReturn(Flowable.empty()).thenAnswer(i -> chunksCaptor.getValue());
 
         final LogProxyRequest logRequest = new LogProxyRequest(loggingContext, request);
+        logRequest.setHeaders(headers);
         verify(request).chunks(chunksCaptor.capture());
 
         final TestSubscriber<Buffer> obs = chunksCaptor.getValue().test();


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1157

## Description

The issue was due to a reference problem. We are snapshotting the
request before calling the backend. However, in our case, the connector
is updating the `Host` header, and we didn't have this change in the log
object.

To fix that, we update the proxy request log object with the request
header in the post step to have all the headers, even those added by the
connector.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jwcsxgqyrd.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim1157/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
