### PR TITLE
fix: isStreaming wasn't properly overridden by Vertx implementation

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractResponse.java
@@ -177,7 +177,7 @@ public abstract class AbstractResponse implements MutableResponse {
         return this.bufferFlow;
     }
 
-    private boolean isStreaming() {
+    public boolean isStreaming() {
         return false;
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/reactive/http/vertx/VertxHttpServerResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/reactive/http/vertx/VertxHttpServerResponse.java
@@ -147,6 +147,7 @@ public class VertxHttpServerResponse extends AbstractResponse {
         }
     }
 
+    @Override
     public boolean isStreaming() {
         if (isStreaming == null) {
             isStreaming = RequestUtils.isStreaming(vertxHttpServerRequest, this);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/reactive/http/vertx/VertxHttpServerResponseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/reactive/http/vertx/VertxHttpServerResponseTest.java
@@ -462,7 +462,7 @@ class VertxHttpServerResponseTest {
 
             obs.assertValue(buffer -> BODY.equals(buffer.toString()));
 
-            verify(metrics).setResponseContentLength(new Long(BODY.length()));
+            verify(metrics).setResponseContentLength(BODY.length());
         }
     }
 


### PR DESCRIPTION
## Description

isStreaming wasn't properly overridden by Vertx implementation which would lead to error when dealing with policies on the response of a websocket connection.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gjptsojler.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-streaming-response/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
