### PR TITLE
Do not throw when sending notif to app owner with multiple subscriptions

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -77,7 +77,7 @@
         <!--    <gravitee-policy-quota.version>1.15.0</gravitee-policy-quota.version>    -->
         <!--    <gravitee-policy-spikearrest.version>1.15.0</gravitee-policy-spikearrest.version>    -->
         <gravitee-policy-ratelimit.version>1.15.0</gravitee-policy-ratelimit.version>
-        <gravitee-policy-regex-threat-protection.version>1.3.2</gravitee-policy-regex-threat-protection.version>
+        <gravitee-policy-regex-threat-protection.version>1.3.3</gravitee-policy-regex-threat-protection.version>
         <gravitee-policy-request-content-limit.version>1.8.0</gravitee-policy-request-content-limit.version>
         <gravitee-policy-request-validation.version>1.13.0</gravitee-policy-request-validation.version>
         <gravitee-policy-resource-filtering.version>1.8.0</gravitee-policy-resource-filtering.version>

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/ApplicationCriteria.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/ApplicationCriteria.java
@@ -84,10 +84,6 @@ public class ApplicationCriteria {
         private ApplicationStatus status;
         private Set<String> groups;
 
-        public ApplicationCriteria.Builder ids(final String... ids) {
-            return ids(Set.of(ids));
-        }
-
         public ApplicationCriteria.Builder ids(final Set<String> ids) {
             this.ids = ids;
             return this;
@@ -110,10 +106,6 @@ public class ApplicationCriteria {
         public ApplicationCriteria.Builder status(final ApplicationStatus status) {
             this.status = status;
             return this;
-        }
-
-        public ApplicationCriteria.Builder groups(final String... groups) {
-            return groups(Set.of(groups));
         }
 
         public ApplicationCriteria.Builder groups(final Set<String> groups) {

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/ApplicationRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/ApplicationRepositoryTest.java
@@ -320,7 +320,7 @@ public class ApplicationRepositoryTest extends AbstractRepositoryTest {
         final Page<Application> appsPage = applicationRepository.search(
             new ApplicationCriteria.Builder()
                 .name("SeArched-app")
-                .ids("searched-app1", "app-with-long-client-id", "app-with-long-name")
+                .ids(Set.of("searched-app1", "app-with-long-client-id", "app-with-long-name"))
                 .status(ApplicationStatus.ACTIVE)
                 .environmentIds("DEV")
                 .build(),
@@ -391,7 +391,7 @@ public class ApplicationRepositoryTest extends AbstractRepositoryTest {
     @Test
     public void shouldSearchByGroups() throws Exception {
         final Page<Application> appsPage = applicationRepository.search(
-            new ApplicationCriteria.Builder().groups("application-group").build(),
+            new ApplicationCriteria.Builder().groups(Set.of("application-group")).build(),
             null
         );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -160,7 +160,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
             }
 
             ApplicationCriteria.Builder criteriaBuilder = new ApplicationCriteria.Builder()
-                .ids(applicationIds.toArray(new String[0]))
+                .ids(new HashSet<>(applicationIds))
                 .status(ApplicationStatus.ACTIVE);
 
             if (executionContext.hasEnvironmentId()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_FindByIdsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApplicationService_FindByIdsTest.java
@@ -131,6 +131,27 @@ public class ApplicationService_FindByIdsTest {
     }
 
     @Test
+    public void shouldFindByIdsWithDuplicatedIds() throws TechnicalException {
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        ApplicationCriteria criteria = new ApplicationCriteria.Builder()
+            .ids(Sets.newHashSet(APPLICATION_IDS))
+            .status(ApplicationStatus.ACTIVE)
+            .environmentIds(executionContext.getEnvironmentId())
+            .build();
+
+        doReturn(new Page<>(Arrays.asList(app1, app2), 1, 2, 2)).when(applicationRepository).search(criteria, null);
+        doReturn(2).when(primaryOwners).size();
+
+        final Set<ApplicationListItem> applications = applicationService.findByIds(
+            executionContext,
+            List.of("id-app-1", "id-app-1", "id-app-2")
+        );
+
+        assertNotNull(applications);
+        assertEquals(APPLICATION_IDS, applications.stream().map(ApplicationListItem::getId).collect(Collectors.toList()));
+    }
+
+    @Test
     public void shouldFindByIdsWithNoEnvironmentCriteria() throws TechnicalException {
         ExecutionContext executionContext = new ExecutionContext("DEFAULT", null);
         ApplicationCriteria criteria = new ApplicationCriteria.Builder()


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1081
gravitee-io/issues#8939

## Description

Do not throw when sending notif to the app owner with multiple subscriptions to the same API.
Build a `HashSet` of ids instead of using `Set.of` to avoid errors in case of duplicated ids.

Also, bump `policy-regex-threat-protection` to `1.3.3`
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-toouudesha.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1081-fix-notification/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
