### PR TITLE
Handle application with no group when sending notification

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MessageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MessageServiceImpl.java
@@ -322,6 +322,7 @@ public class MessageServiceImpl extends AbstractService implements MessageServic
         List<String> applicationsGroups = applicationService
             .findByIds(context, applicationIds)
             .stream()
+            .filter(application -> application.getGroups() != null)
             .flatMap((ApplicationListItem applicationListItem) -> applicationListItem.getGroups().stream())
             .distinct()
             .collect(Collectors.toList());


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1081
gravitee-io/issues#8939

## Description

Handle applications with no group when sending notifications.
An application has no group when it has been just created, and never updated.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hcvigijguj.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1081-fix-notification-2/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
