### PR TITLE
ci: update ingress gateway deployment name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1106,7 +1106,7 @@ jobs:
                       kubectl rollout restart deployment/${K8S_NAMESPACE}-gateway -n ${K8S_NAMESPACE}
                       kubectl rollout restart deployment/${K8S_NAMESPACE}-apim-v3-gateway -n ${K8S_NAMESPACE}
                       kubectl rollout restart deployment/${K8S_NAMESPACE}-apim-v3-bridge-gateway -n ${K8S_NAMESPACE}
-                      kubectl rollout restart deployment/${K8S_NAME}-ingress-apim3-gateway -n ${K8S_NAMESPACE}
+                      kubectl rollout restart deployment/${K8S_NAME}-apim-v3-ingress-gateway -n ${K8S_NAMESPACE}
             - keeper/env-export:
                   secret-url: keeper://G4hBnFUDBYb9Sw3TxhvjHg/custom_field/token
                   var-name: CIRCLE_TOKEN


### PR DESCRIPTION

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ypfqqwkrcv.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/ci-ingress-name/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
