### PR TITLE
feat(console): create gio request stats component

### DIFF
--- a/gravitee-apim-console-webui/src/management/home/widgets/gio-request-stats/gio-request-stats.component.html
+++ b/gravitee-apim-console-webui/src/management/home/widgets/gio-request-stats/gio-request-stats.component.html
@@ -1,0 +1,54 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="gio-request-stats">
+  <div class="mat-subheading-1">Request Stats</div>
+  <div class="gio-request-stats__body">
+    <div class="gio-request-stats__body__title">
+      <span>Response Time</span>
+    </div>
+    <div class="gio-request-stats__body__rows">
+      <div class="gio-request-stats__body__row">
+        <span>Min</span>
+        <span>{{ data.min | number : '.1-2' }} ms</span>
+      </div>
+      <div class="gio-request-stats__body__row">
+        <span>Max</span>
+        <span>{{ data.max | number : '.1-2' }} ms</span>
+      </div>
+      <div class="gio-request-stats__body__row">
+        <span>Average</span>
+        <span>{{ data.avg | number : '.1-2' }} ms</span>
+      </div>
+    </div>
+  </div>
+  <div class="gio-request-stats__body">
+    <div class="gio-request-stats__body__title">
+      <span>Requests</span>
+    </div>
+    <div class="gio-request-stats__body__rows">
+      <div class="gio-request-stats__body__row">
+        <span>Requests per second</span>
+        <span>{{ data.rps | number : '.1-1' }}</span>
+      </div>
+      <div class="gio-request-stats__body__row">
+        <span>Total number of requests</span>
+        <span>{{ data.total | number }}</span>
+      </div>
+    </div>
+  </div>
+</div>

--- a/gravitee-apim-console-webui/src/management/home/widgets/gio-request-stats/gio-request-stats.component.scss
+++ b/gravitee-apim-console-webui/src/management/home/widgets/gio-request-stats/gio-request-stats.component.scss
@@ -1,0 +1,43 @@
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+$typography: map.get(gio.$mat-theme, typography);
+
+.gio-request-stats {
+  display: flex;
+  flex-flow: column;
+  gap: 18px;
+
+  &__body {
+    display: flex;
+    flex-flow: column;
+
+    &__title {
+      @include mat.typography-level($typography, body-2);
+      padding: 4px 0;
+    }
+
+    &__rows {
+      :first-child {
+        border: none;
+      }
+    }
+
+    &__row {
+      gap: 20px;
+      display: flex;
+      border-top: 1px mat.get-color-from-palette(gio.$mat-neutral-palette, 'default') solid;
+      padding: 2px 0;
+
+      > span {
+        flex: 1 1 100%;
+      }
+
+      :last-child {
+        @include mat.typography-level($typography, body-2);
+        color: mat.get-color-from-palette(gio.$mat-accent-palette, 'darker20');
+      }
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/home/widgets/gio-request-stats/gio-request-stats.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/home/widgets/gio-request-stats/gio-request-stats.component.spec.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+
+import { GioRequestStatsModule } from './gio-request-stats.module';
+import { GioRequestStatsHarness } from './gio-request-stats.harness';
+import { GioRequestStatsComponent, RequestStatsSource } from './gio-request-stats.component';
+
+describe('GioRequestStatsComponent', () => {
+  let fixture: ComponentFixture<GioRequestStatsComponent>;
+  let loader: HarnessLoader;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, GioRequestStatsModule],
+      providers: [],
+    });
+
+    fixture = TestBed.createComponent(GioRequestStatsComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+  });
+
+  it('should show given data', async () => {
+    loadData({
+      min: 0.02336,
+      max: 23009.29732,
+      avg: 8.4363,
+      rps: 1.2712334,
+      total: 332981092,
+    });
+    const harness = await loader.getHarness(GioRequestStatsHarness);
+    expect(await harness.getMin()).toEqual('0.02 ms');
+    expect(await harness.getMax()).toEqual('23,009.3 ms');
+    expect(await harness.getAverage()).toEqual('8.44 ms');
+    expect(await harness.getRequestsPerSecond()).toEqual('1.3');
+    expect(await harness.getTotalRequests()).toEqual('332,981,092');
+  });
+
+  function loadData(data: RequestStatsSource) {
+    fixture.componentInstance.source = data;
+    fixture.detectChanges();
+  }
+});

--- a/gravitee-apim-console-webui/src/management/home/widgets/gio-request-stats/gio-request-stats.component.ts
+++ b/gravitee-apim-console-webui/src/management/home/widgets/gio-request-stats/gio-request-stats.component.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, Input, OnInit } from '@angular/core';
+
+export interface RequestStatsSource {
+  min: number;
+  max: number;
+  avg: number;
+  rps: number;
+  total: number;
+}
+
+@Component({
+  selector: 'gio-request-stats',
+  template: require('./gio-request-stats.component.html'),
+  styles: [require('./gio-request-stats.component.scss')],
+})
+export class GioRequestStatsComponent implements OnInit {
+  @Input()
+  public source: RequestStatsSource;
+
+  public data: RequestStatsSource;
+
+  ngOnInit() {
+    if (this.source) {
+      this.data = this.source;
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/home/widgets/gio-request-stats/gio-request-stats.harness.ts
+++ b/gravitee-apim-console-webui/src/management/home/widgets/gio-request-stats/gio-request-stats.harness.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+
+export class GioRequestStatsHarness extends ComponentHarness {
+  static hostSelector = '.gio-request-stats';
+  protected getRows = this.locatorForAll('.gio-request-stats__body__row');
+
+  async getMin(): Promise<string> {
+    return this.getValueByLabel('Min');
+  }
+
+  async getMax(): Promise<string> {
+    return this.getValueByLabel('Max');
+  }
+
+  async getAverage(): Promise<string> {
+    return this.getValueByLabel('Average');
+  }
+
+  async getRequestsPerSecond(): Promise<string> {
+    return this.getValueByLabel('Requests per second');
+  }
+
+  async getTotalRequests(): Promise<string> {
+    return this.getValueByLabel('Total number of requests');
+  }
+
+  private async getValueByLabel(label: string): Promise<string> {
+    return this.getRows()
+      .then((rows) => Promise.all(rows.map((t) => t.text())))
+      .then((res) => res.find((t) => t.includes(label)))
+      .then((found) => found.replace(label, ''));
+  }
+}

--- a/gravitee-apim-console-webui/src/management/home/widgets/gio-request-stats/gio-request-stats.module.ts
+++ b/gravitee-apim-console-webui/src/management/home/widgets/gio-request-stats/gio-request-stats.module.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { GioRequestStatsComponent } from './gio-request-stats.component';
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [GioRequestStatsComponent],
+  exports: [GioRequestStatsComponent],
+})
+export class GioRequestStatsModule {}

--- a/gravitee-apim-console-webui/src/management/home/widgets/gio-request-stats/gio-request-stats.stories.ts
+++ b/gravitee-apim-console-webui/src/management/home/widgets/gio-request-stats/gio-request-stats.stories.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Meta, moduleMetadata } from '@storybook/angular';
+import { Story } from '@storybook/angular/dist/ts3.9/client/preview/types-7-0';
+import { MatCardModule } from '@angular/material/card';
+
+import { GioRequestStatsComponent } from './gio-request-stats.component';
+import { GioRequestStatsModule } from './gio-request-stats.module';
+
+export default {
+  title: 'Home / Widgets / Request stats',
+  component: GioRequestStatsComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [MatCardModule, GioRequestStatsModule],
+    }),
+  ],
+  render: () => ({}),
+} as Meta;
+
+export const Simple: Story = {
+  render: () => {
+    const input = {
+      min: 0.02336,
+      max: 23009.29032,
+      avg: 8.4323,
+      rps: 1.2012334,
+      total: 332981092,
+    };
+
+    return {
+      template: `
+      <mat-card style="width: 500px">
+          <gio-request-stats [source]="source"></gio-request-stats>
+      </mat-card>
+      `,
+      props: { source: input },
+      styles: [],
+    };
+  },
+};


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1137

## Description

Migrate Request Stats Component for new home dashboard

![Screen Shot 2023-03-27 at 11 40 40](https://user-images.githubusercontent.com/42294616/227904508-ddb383b5-40c8-4d87-868c-1f7863a6f5f9.png)

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-cfhoqbchxi.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1137-request-stats-widget/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
