### PR TITLE
Add missing PK on `subscriptions_metadata` table 

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_20_4/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v3_20_4/schema.yml
@@ -1,0 +1,16 @@
+databaseChangeLog:
+  - changeSet:
+      id: 3.20.4
+      author: GraviteeSource Team
+      changes:
+        # Create a new auto increment column and set it as a PK
+        - addColumn:
+            tableName: ${gravitee_prefix}subscriptions_metadata
+            columns:
+              - column:
+                  name: id
+                  type: bigint
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -143,3 +143,5 @@ databaseChangeLog:
       - file: liquibase/changelogs/v3_19_0/schema_gko.yml
   - include:
       - file: liquibase/changelogs/v3_20_0/schema.yml
+  - include:
+      - file: liquibase/changelogs/v3_20_4/schema.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/TableConstraintsTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/TableConstraintsTest.java
@@ -72,9 +72,12 @@ public class TableConstraintsTest extends AbstractRepositoryTest {
             "order by tab.table_schema,\n" +
             "         tab.table_name;",
             rs -> {
-                while (rs.next()) {
-                    tables.add(rs.getString("table_name").replace(prefix, ""));
+                if (rs.wasNull()) {
+                    return;
                 }
+                do {
+                    tables.add(rs.getString("table_name").replace(prefix, ""));
+                } while (rs.next());
             }
         );
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1335
https://github.com/gravitee-io/issues/issues/8967

## Description

Add missing PK on `subscriptions_metadata` table.
Also, fix the test we are using to ensure all tables have a PK. 
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-koytolmfna.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1335-add-missing-pk/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
