### PR TITLE
Console - Start migration of APIs status page

### DIFF
--- a/gravitee-apim-console-webui/src/entities/api/Api.ts
+++ b/gravitee-apim-console-webui/src/entities/api/Api.ts
@@ -62,6 +62,7 @@ export interface Api {
 
   etag?: string;
   definition_context: ApiDefinitionContext;
+  healthcheck_enabled?: boolean;
 }
 
 export type ApiVisibility = 'PUBLIC' | 'PRIVATE';

--- a/gravitee-apim-console-webui/src/entities/api/ApiMetrics.ts
+++ b/gravitee-apim-console-webui/src/entities/api/ApiMetrics.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './Api';
-export * from './UpdateApi';
-export * from './ApiMembers';
-export * from './ApiMembership';
-export * from './ApiMetrics';
+export interface ApiMetrics {
+  buckets?: Record<string, Record<string, number>>;
+  global?: Record<string, number>;
+  metadata?: Record<string, Record<string, string>>;
+}

--- a/gravitee-apim-console-webui/src/management/home/home-api-status/home-api-status.component.html
+++ b/gravitee-apim-console-webui/src/management/home/home-api-status/home-api-status.component.html
@@ -16,122 +16,149 @@
 
 -->
 
-<gio-table-wrapper
-  [searchLabel]="searchLabel"
-  [length]="apisTableDSUnpaginatedLength"
-  [filters]="filters"
-  (filtersChange)="onFiltersChanged($event)"
->
-  <table mat-table matSort [dataSource]="apisTableDS" id="apisTable" aria-label="Apis table">
-    <!-- Picture Column -->
-    <ng-container matColumnDef="picture">
-      <th mat-header-cell *matHeaderCellDef id="picture"></th>
-      <td mat-cell *matCellDef="let element">
-        <gio-avatar [src]="element.picture" [name]="element.name" size="32" [roundedBorder]="true"></gio-avatar>
-      </td>
-    </ng-container>
+<gio-banner-info>
+  Each API is monitored by routine interrogation of its health-check endpoint. After receiving a health-check request, the API backend
+  performs the necessary verifications via probes to return its status.
+</gio-banner-info>
 
-    <!-- Display Name Column -->
-    <ng-container matColumnDef="name">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header id="name">Name</th>
-      <td mat-cell *matCellDef="let element" (click)="onEditActionClicked(element)" title="{{ element.name }} ({{ element.version }})">
-        {{ element.name }} ({{ element.version }})
-      </td>
-    </ng-container>
+<mat-card>
+  See APIs status for
+  <mat-form-field class="time-frame">
+    <mat-label>Select time range</mat-label>
+    <mat-select [formControl]="timeFrameControl">
+      <mat-option *ngFor="let timeFrame of timeFrames" [value]="timeFrame.id">
+        {{ timeFrame.label }}
+      </mat-option>
+    </mat-select>
+  </mat-form-field>
 
-    <!-- Display States Column -->
-    <ng-container matColumnDef="states">
-      <th mat-header-cell *matHeaderCellDef id="states"></th>
-      <td mat-cell *matCellDef="let element">
-        <mat-icon
-          *ngIf="element.state === 'STARTED'"
-          matTooltip="Started"
-          class="states__api-started"
-          size="20"
-          svgIcon="gio:play-circle"
-        ></mat-icon>
-        <mat-icon
-          *ngIf="element.state !== 'STARTED'"
-          matTooltip="Stopped"
-          class="states__api-not-started"
-          size="20"
-          svgIcon="gio:stop-circle"
-        ></mat-icon>
-        <mat-icon
-          *ngIf="element.isNotSynced$ | async"
-          matTooltip="API out of sync"
-          class="states__api-is-not-synced"
-          size="20"
-          svgIcon="gio:refresh-cw"
-        ></mat-icon>
-        <mat-icon
-          *ngIf="element.lifecycleState === 'PUBLISHED'"
-          matTooltip="Published"
-          class="states__api-published"
-          size="20"
-          svgIcon="gio:cloud-published"
-        ></mat-icon>
-        <mat-icon
-          *ngIf="element.lifecycleState !== 'PUBLISHED'"
-          matTooltip="Unpublished"
-          class="states__api-not-published"
-          size="20"
-          svgIcon="gio:cloud-unpublished"
-        ></mat-icon>
-        <mat-icon
-          *ngIf="element.origin === 'kubernetes'"
-          matTooltip="Kubernetes Origin"
-          class="states__api-origin"
-          size="20"
-          svgIcon="gio:kubernetes"
-        ></mat-icon>
-        <span
-          *ngIf="element.workflowBadge"
-          [ngClass]="element.workflowBadge.class"
-          class="states__api-workflow-badge"
-          [matTooltip]="element.workflowBadge.text"
-        >
-          {{ element.workflowBadge.text }}
-        </span>
-      </td>
-    </ng-container>
+  <gio-table-wrapper
+    [searchLabel]="searchLabel"
+    [length]="apisTableDSUnpaginatedLength"
+    [filters]="filters"
+    (filtersChange)="onFiltersChanged($event)"
+  >
+    <table mat-table matSort [dataSource]="apisTableDS" id="apisTable" aria-label="Apis table">
+      <!-- Picture Column -->
+      <ng-container matColumnDef="picture">
+        <th mat-header-cell *matHeaderCellDef id="picture"></th>
+        <td mat-cell *matCellDef="let element">
+          <gio-avatar [src]="element.picture" [name]="element.name" size="32" [roundedBorder]="true"></gio-avatar>
+        </td>
+      </ng-container>
 
-    <!-- API Status Column -->
-    <ng-container matColumnDef="status">
-      <th mat-header-cell *matHeaderCellDef id="status">API Status</th>
-      <td mat-cell *matCellDef="let element">
-        <gio-circular-percentage class="status__gauge" [score]="element.statusGaugeValue"></gio-circular-percentage>
-      </td>
-    </ng-container>
+      <!-- Display Name Column -->
+      <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef mat-sort-header id="name">Name</th>
+        <td mat-cell *matCellDef="let element" (click)="onEditActionClicked(element)" title="{{ element.name }} ({{ element.version }})">
+          {{ element.name }} ({{ element.version }})
+        </td>
+      </ng-container>
 
-    <!-- Actions Column -->
-    <ng-container matColumnDef="actions">
-      <th mat-header-cell *matHeaderCellDef id="actions"></th>
-      <td mat-cell *matCellDef="let element">
-        <div class="actions__edit">
-          <button
-            (click)="onViewHealthCheckClicked(element)"
-            mat-icon-button
-            aria-label="Button to view API HealthCheck"
-            matTooltip="View API HealthCheck"
+      <!-- Display States Column -->
+      <ng-container matColumnDef="states">
+        <th mat-header-cell *matHeaderCellDef id="states"></th>
+        <td mat-cell *matCellDef="let element">
+          <mat-icon
+            *ngIf="element.state === 'STARTED'"
+            matTooltip="Started"
+            class="states__api-started"
+            size="20"
+            svgIcon="gio:play-circle"
+          ></mat-icon>
+          <mat-icon
+            *ngIf="element.state !== 'STARTED'"
+            matTooltip="Stopped"
+            class="states__api-not-started"
+            size="20"
+            svgIcon="gio:stop-circle"
+          ></mat-icon>
+          <mat-icon
+            *ngIf="element.isNotSynced$ | async"
+            matTooltip="API out of sync"
+            class="states__api-is-not-synced"
+            size="20"
+            svgIcon="gio:refresh-cw"
+          ></mat-icon>
+          <mat-icon
+            *ngIf="element.lifecycleState === 'PUBLISHED'"
+            matTooltip="Published"
+            class="states__api-published"
+            size="20"
+            svgIcon="gio:cloud-published"
+          ></mat-icon>
+          <mat-icon
+            *ngIf="element.lifecycleState !== 'PUBLISHED'"
+            matTooltip="Unpublished"
+            class="states__api-not-published"
+            size="20"
+            svgIcon="gio:cloud-unpublished"
+          ></mat-icon>
+          <mat-icon
+            *ngIf="element.origin === 'kubernetes'"
+            matTooltip="Kubernetes Origin"
+            class="states__api-origin"
+            size="20"
+            svgIcon="gio:kubernetes"
+          ></mat-icon>
+          <span
+            *ngIf="element.workflowBadge"
+            [ngClass]="element.workflowBadge.class"
+            class="states__api-workflow-badge"
+            [matTooltip]="element.workflowBadge.text"
           >
-            <mat-icon svgIcon="gio:bar-chart-2"></mat-icon>
-          </button>
-        </div>
-      </td>
-    </ng-container>
+            {{ element.workflowBadge.text }}
+          </span>
+        </td>
+      </ng-container>
 
-    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-    <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+      <!-- API Status Column -->
+      <ng-container matColumnDef="status">
+        <th mat-header-cell *matHeaderCellDef id="status">API Status</th>
+        <td mat-cell *matCellDef="let element">
+          <ng-container *ngIf="element.status$ | async; let status">
+            <ng-container *ngIf="status.type === 'configured'">
+              <gio-circular-percentage
+                class="status__gauge"
+                matTooltip="HealthCheck availability"
+                [score]="status.healthCheckAvailability"
+              ></gio-circular-percentage>
+            </ng-container>
+            <ng-container *ngIf="status.type === 'no-data'"> No data to display </ng-container>
+            <ng-container *ngIf="status.type === 'not-configured'"> Health-check has not been configured </ng-container>
+          </ng-container>
+        </td>
+      </ng-container>
 
-    <!-- Row shown when there is no data -->
-    <tr class="mat-row" *matNoDataRow>
-      <td *ngIf="!isLoadingData && apisTableDS.length === 0" class="mat-cell" [attr.colspan]="displayedColumns.length">
-        {{ 'There is no API (yet).' }}
-      </td>
-      <td *ngIf="isLoadingData" class="mat-cell" [attr.colspan]="displayedColumns.length">
-        {{ 'Loading...' }}
-      </td>
-    </tr>
-  </table>
-</gio-table-wrapper>
+      <!-- Actions Column -->
+      <ng-container matColumnDef="actions">
+        <th mat-header-cell *matHeaderCellDef id="actions"></th>
+        <td mat-cell *matCellDef="let element">
+          <div class="actions__edit">
+            <button
+              (click)="onViewHealthCheckClicked(element)"
+              mat-icon-button
+              aria-label="Button to view API HealthCheck"
+              matTooltip="View API HealthCheck"
+            >
+              <mat-icon svgIcon="gio:bar-chart-2"></mat-icon>
+            </button>
+          </div>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+
+      <!-- Row shown when there is no data -->
+      <tr class="mat-row" *matNoDataRow>
+        <td *ngIf="!isLoadingData && apisTableDS.length === 0" class="mat-cell" [attr.colspan]="displayedColumns.length">
+          {{ 'No APIs to display.' }}
+        </td>
+        <td *ngIf="isLoadingData" class="mat-cell" [attr.colspan]="displayedColumns.length">
+          {{ 'Loading...' }}
+        </td>
+      </tr>
+    </table>
+  </gio-table-wrapper>
+</mat-card>

--- a/gravitee-apim-console-webui/src/management/home/home-api-status/home-api-status.component.html
+++ b/gravitee-apim-console-webui/src/management/home/home-api-status/home-api-status.component.html
@@ -15,4 +15,123 @@
     limitations under the License.
 
 -->
-Home API Status Component
+
+<gio-table-wrapper
+  [searchLabel]="searchLabel"
+  [length]="apisTableDSUnpaginatedLength"
+  [filters]="filters"
+  (filtersChange)="onFiltersChanged($event)"
+>
+  <table mat-table matSort [dataSource]="apisTableDS" id="apisTable" aria-label="Apis table">
+    <!-- Picture Column -->
+    <ng-container matColumnDef="picture">
+      <th mat-header-cell *matHeaderCellDef id="picture"></th>
+      <td mat-cell *matCellDef="let element">
+        <gio-avatar [src]="element.picture" [name]="element.name" size="32" [roundedBorder]="true"></gio-avatar>
+      </td>
+    </ng-container>
+
+    <!-- Display Name Column -->
+    <ng-container matColumnDef="name">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header id="name">Name</th>
+      <td mat-cell *matCellDef="let element" (click)="onEditActionClicked(element)" title="{{ element.name }} ({{ element.version }})">
+        {{ element.name }} ({{ element.version }})
+      </td>
+    </ng-container>
+
+    <!-- Display States Column -->
+    <ng-container matColumnDef="states">
+      <th mat-header-cell *matHeaderCellDef id="states"></th>
+      <td mat-cell *matCellDef="let element">
+        <mat-icon
+          *ngIf="element.state === 'STARTED'"
+          matTooltip="Started"
+          class="states__api-started"
+          size="20"
+          svgIcon="gio:play-circle"
+        ></mat-icon>
+        <mat-icon
+          *ngIf="element.state !== 'STARTED'"
+          matTooltip="Stopped"
+          class="states__api-not-started"
+          size="20"
+          svgIcon="gio:stop-circle"
+        ></mat-icon>
+        <mat-icon
+          *ngIf="element.isNotSynced$ | async"
+          matTooltip="API out of sync"
+          class="states__api-is-not-synced"
+          size="20"
+          svgIcon="gio:refresh-cw"
+        ></mat-icon>
+        <mat-icon
+          *ngIf="element.lifecycleState === 'PUBLISHED'"
+          matTooltip="Published"
+          class="states__api-published"
+          size="20"
+          svgIcon="gio:cloud-published"
+        ></mat-icon>
+        <mat-icon
+          *ngIf="element.lifecycleState !== 'PUBLISHED'"
+          matTooltip="Unpublished"
+          class="states__api-not-published"
+          size="20"
+          svgIcon="gio:cloud-unpublished"
+        ></mat-icon>
+        <mat-icon
+          *ngIf="element.origin === 'kubernetes'"
+          matTooltip="Kubernetes Origin"
+          class="states__api-origin"
+          size="20"
+          svgIcon="gio:kubernetes"
+        ></mat-icon>
+        <span
+          *ngIf="element.workflowBadge"
+          [ngClass]="element.workflowBadge.class"
+          class="states__api-workflow-badge"
+          [matTooltip]="element.workflowBadge.text"
+        >
+          {{ element.workflowBadge.text }}
+        </span>
+      </td>
+    </ng-container>
+
+    <!-- API Status Column -->
+    <ng-container matColumnDef="status">
+      <th mat-header-cell *matHeaderCellDef id="status">API Status</th>
+      <td mat-cell *matCellDef="let element">
+        <gio-circular-percentage class="status__gauge" [score]="element.statusGaugeValue"></gio-circular-percentage>
+      </td>
+    </ng-container>
+
+    <!-- Actions Column -->
+    <ng-container matColumnDef="actions">
+      <th mat-header-cell *matHeaderCellDef id="actions"></th>
+      <td mat-cell *matCellDef="let element">
+        <div class="actions__edit">
+          <button
+            (click)="onViewHealthCheckClicked(element)"
+            mat-icon-button
+            aria-label="Button to view API HealthCheck"
+            matTooltip="View API HealthCheck"
+          >
+            <mat-icon svgIcon="gio:bar-chart-2"></mat-icon>
+          </button>
+        </div>
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+
+    <!-- Row shown when there is no data -->
+    <tr class="mat-row" *matNoDataRow>
+      <td *ngIf="!isLoadingData && apisTableDS.length === 0" class="mat-cell" [attr.colspan]="displayedColumns.length">
+        {{ 'There is no API (yet).' }}
+      </td>
+      <td *ngIf="isLoadingData" class="mat-cell" [attr.colspan]="displayedColumns.length">
+        {{ 'Loading...' }}
+      </td>
+    </tr>
+  </table>
+</gio-table-wrapper>

--- a/gravitee-apim-console-webui/src/management/home/home-api-status/home-api-status.component.scss
+++ b/gravitee-apim-console-webui/src/management/home/home-api-status/home-api-status.component.scss
@@ -3,20 +3,28 @@
 :host {
   @include gio-layout.gio-responsive-margin-container;
 }
+.time-frame {
+  padding-bottom: 0;
+}
 
 .mat-column-picture {
   width: 0%;
   padding-right: 16px;
 }
-
-.mat-column-actions {
-  width: 0%;
+.mat-column-name {
+  padding-right: 16px;
 }
-
+.mat-column-states {
+  padding-right: 16px;
+}
 .mat-column-status {
+  padding-right: 16px;
   .status__gauge {
     width: 56px;
     height: 56px;
-    padding: 8px;
+    margin: 2px 0;
   }
+}
+.mat-column-actions {
+  width: 0%;
 }

--- a/gravitee-apim-console-webui/src/management/home/home-api-status/home-api-status.component.scss
+++ b/gravitee-apim-console-webui/src/management/home/home-api-status/home-api-status.component.scss
@@ -3,3 +3,20 @@
 :host {
   @include gio-layout.gio-responsive-margin-container;
 }
+
+.mat-column-picture {
+  width: 0%;
+  padding-right: 16px;
+}
+
+.mat-column-actions {
+  width: 0%;
+}
+
+.mat-column-status {
+  .status__gauge {
+    width: 56px;
+    height: 56px;
+    padding: 8px;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/home/home-api-status/home-api-status.component.ts
+++ b/gravitee-apim-console-webui/src/management/home/home-api-status/home-api-status.component.ts
@@ -13,8 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, OnDestroy, OnInit } from '@angular/core';
-import { Subject } from 'rxjs';
+import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import { StateService } from '@uirouter/core';
+import { isEqual } from 'lodash';
+import { BehaviorSubject, of, Subject } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, switchMap, takeUntil, tap } from 'rxjs/operators';
+
+import { UIRouterState, UIRouterStateParams } from '../../../ajs-upgraded-providers';
+import { Api, ApiOrigin, ApiState } from '../../../entities/api';
+import { Constants } from '../../../entities/Constants';
+import { PagedResult } from '../../../entities/pagedResult';
+import { ApiService } from '../../../services-ngx/api.service';
+import { GioTableWrapperFilters } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
+import { toOrder, toSort } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.util';
+
+export type ApisTableDS = {
+  id: string;
+  name: string;
+  version: string;
+  contextPath: string;
+  tags: string;
+  owner: string;
+  ownerEmail: string;
+  picture: string;
+  state: ApiState;
+  origin: ApiOrigin;
+  statusGaugeValue: number;
+};
 
 @Component({
   selector: 'home-api-status',
@@ -22,16 +47,117 @@ import { Subject } from 'rxjs';
   styles: [require('./home-api-status.component.scss')],
 })
 export class HomeApiStatusComponent implements OnInit, OnDestroy {
+  displayedColumns = ['picture', 'name', 'states', 'status', 'actions'];
+  apisTableDSUnpaginatedLength = 0;
+  apisTableDS: ApisTableDS[] = [];
+  filters: GioTableWrapperFilters = {
+    pagination: { index: 1, size: 10 },
+    searchTerm: '',
+  };
+  isLoadingData = true;
+
   private unsubscribe$: Subject<boolean> = new Subject<boolean>();
+  private filters$ = new BehaviorSubject<GioTableWrapperFilters>(this.filters);
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  constructor() {}
+  constructor(
+    @Inject(UIRouterStateParams) private ajsStateParams,
+    @Inject(UIRouterState) private readonly ajsState: StateService,
+    @Inject('Constants') private readonly constants: Constants,
+    private readonly apiService: ApiService,
+  ) {}
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.filters$
+      .pipe(
+        takeUntil(this.unsubscribe$),
+        debounceTime(200),
+        distinctUntilChanged(isEqual),
+        tap(({ pagination, searchTerm, sort }) => {
+          // Change url params
+          this.ajsState.go(
+            'home.apiStatus',
+            { q: searchTerm, page: pagination.index, size: pagination.size, order: toOrder(sort) },
+            { notify: false },
+          );
+        }),
+        switchMap(({ pagination, searchTerm, sort }) => this.apiService.list(searchTerm, toOrder(sort), pagination.index, pagination.size)),
+        tap((apisPage) => {
+          this.apisTableDS = this.toApisTableDS(apisPage);
+          this.apisTableDSUnpaginatedLength = apisPage.page.total_elements;
+          this.isLoadingData = false;
+        }),
+        catchError(() => of(new PagedResult<Api>())),
+      )
+      .subscribe();
+
+    this.initFilters();
+  }
 
   ngOnDestroy() {
     this.unsubscribe$.next(true);
     this.unsubscribe$.unsubscribe();
+  }
+
+  onFiltersChanged(filters: GioTableWrapperFilters) {
+    this.filters = { ...this.filters, ...filters };
+    this.filters$.next(this.filters);
+  }
+
+  onViewHealthCheckClicked() {
+    this.ajsState.go('management.apis.detail.proxy.healthCheckDashboard');
+  }
+
+  private initFilters() {
+    const initialSearchValue = this.ajsStateParams.q ?? this.filters.searchTerm;
+    const initialPageNumber = this.ajsStateParams.page ? Number(this.ajsStateParams.page) : this.filters.pagination.index;
+    const initialPageSize = this.ajsStateParams.size ? Number(this.ajsStateParams.size) : this.filters.pagination.size;
+    const initialSort = toSort(this.ajsStateParams.order, this.filters.sort);
+    this.filters = {
+      searchTerm: initialSearchValue,
+      sort: initialSort,
+      pagination: {
+        ...this.filters$.value.pagination,
+        index: initialPageNumber,
+        size: initialPageSize,
+      },
+    };
+    this.filters$.next(this.filters);
+  }
+
+  private toApisTableDS(api: PagedResult<Api>): ApisTableDS[] {
+    if (api.page.total_elements === 0) {
+      return [];
+    }
+
+    return api.data.map(
+      (api) =>
+        ({
+          id: api.id,
+          name: api.name,
+          version: api.version,
+          contextPath: api.context_path,
+          tags: api.tags.join(', '),
+          owner: api?.owner?.displayName,
+          ownerEmail: api?.owner?.email,
+          picture: api.picture_url,
+          state: api.state,
+          lifecycleState: api.lifecycle_state,
+          workflowBadge: this.getWorkflowBadge(api),
+          healthcheck_enabled: api.healthcheck_enabled,
+          origin: api.definition_context.origin,
+          statusGaugeValue: 0.7,
+        } as ApisTableDS),
+    );
+  }
+
+  private getWorkflowBadge(api) {
+    const state = api.lifecycle_state === 'DEPRECATED' ? api.lifecycle_state : api.workflow_state;
+    const toReadableState = {
+      DEPRECATED: { text: 'Deprecated', class: 'gio-badge-error' },
+      DRAFT: { text: 'Draft', class: 'gio-badge-primary' },
+      IN_REVIEW: { text: 'In Review', class: 'gio-badge-error' },
+      REQUEST_FOR_CHANGES: { text: 'Need changes', class: 'gio-badge-error' },
+    };
+    return toReadableState[state];
   }
 }

--- a/gravitee-apim-console-webui/src/management/home/home.module.ts
+++ b/gravitee-apim-console-webui/src/management/home/home.module.ts
@@ -20,8 +20,11 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatTableModule } from '@angular/material/table';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { GioAvatarModule } from '@gravitee/ui-particles-angular';
+import { GioAvatarModule, GioBannerModule } from '@gravitee/ui-particles-angular';
 import { Ng2StateDeclaration, UIRouterModule } from '@uirouter/angular';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { ReactiveFormsModule } from '@angular/forms';
 import { MatCardModule } from '@angular/material/card';
 
 import { HomeApiStatusComponent } from './home-api-status/home-api-status.component';
@@ -66,6 +69,7 @@ export const states: Ng2StateDeclaration[] = [
 @NgModule({
   imports: [
     CommonModule,
+    ReactiveFormsModule,
     UIRouterModule.forChild({ states }),
 
     MatTabsModule,
@@ -74,10 +78,14 @@ export const states: Ng2StateDeclaration[] = [
     MatButtonModule,
     MatIconModule,
     MatTooltipModule,
+    MatFormFieldModule,
+    MatSelectModule,
+    MatCardModule,
 
     GioAvatarModule,
     GioTableWrapperModule,
     GioCircularPercentageModule,
+    GioBannerModule,
   ],
   declarations: [HomeLayoutComponent, HomeOverviewComponent, HomeApiStatusComponent],
 })

--- a/gravitee-apim-console-webui/src/management/home/home.module.ts
+++ b/gravitee-apim-console-webui/src/management/home/home.module.ts
@@ -15,13 +15,21 @@
  */
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTableModule } from '@angular/material/table';
 import { MatTabsModule } from '@angular/material/tabs';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { GioAvatarModule } from '@gravitee/ui-particles-angular';
 import { Ng2StateDeclaration, UIRouterModule } from '@uirouter/angular';
 import { MatCardModule } from '@angular/material/card';
 
 import { HomeApiStatusComponent } from './home-api-status/home-api-status.component';
 import { HomeLayoutComponent } from './home-layout/home-layout.component';
 import { HomeOverviewComponent } from './home-overview/home-overview.component';
+
+import { GioCircularPercentageModule } from '../../shared/components/gio-circular-percentage/gio-circular-percentage.module';
+import { GioTableWrapperModule } from '../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
 
 export const states: Ng2StateDeclaration[] = [
   {
@@ -46,7 +54,7 @@ export const states: Ng2StateDeclaration[] = [
   },
   {
     name: 'home.apiStatus',
-    url: '/api-status',
+    url: '/api-status?{q:string}{page:int}{size:int}{order:string}',
     data: {
       useAngularMaterial: true,
       docs: null,
@@ -56,7 +64,21 @@ export const states: Ng2StateDeclaration[] = [
 ];
 
 @NgModule({
-  imports: [CommonModule, MatCardModule, MatTabsModule, UIRouterModule.forChild({ states })],
+  imports: [
+    CommonModule,
+    UIRouterModule.forChild({ states }),
+
+    MatTabsModule,
+    MatCardModule,
+    MatTableModule,
+    MatButtonModule,
+    MatIconModule,
+    MatTooltipModule,
+
+    GioAvatarModule,
+    GioTableWrapperModule,
+    GioCircularPercentageModule,
+  ],
   declarations: [HomeLayoutComponent, HomeOverviewComponent, HomeApiStatusComponent],
 })
 export class HomeModule {}

--- a/gravitee-apim-console-webui/src/services-ngx/api.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api.service.ts
@@ -21,7 +21,7 @@ import { catchError, map, mapTo } from 'rxjs/operators';
 import { IScope } from 'angular';
 import { AbstractControl, AsyncValidatorFn, ValidationErrors, ValidatorFn } from '@angular/forms';
 
-import { Api, ApiQualityMetrics, ApiStateEntity, UpdateApi } from '../entities/api';
+import { Api, ApiMetrics, ApiQualityMetrics, ApiStateEntity, UpdateApi } from '../entities/api';
 import { Constants } from '../entities/Constants';
 import { FlowSchema } from '../entities/flow/flowSchema';
 import { PagedResult } from '../entities/pagedResult';
@@ -278,5 +278,19 @@ export class ApiService {
 
   getGroupIdsWithMembers(apiId: string): Observable<Record<string, GroupMember[]>> {
     return this.http.get<Record<string, GroupMember[]>>(`${this.constants.env.baseURL}/apis/${apiId}/groups`);
+  }
+
+  apiHealth(api: string, type?: 'availability' | 'response_time', field?: 'endpoint' | 'gateway'): Observable<ApiMetrics> {
+    const params = [];
+    if (type !== undefined) {
+      params.push(`type=${type}`);
+    }
+    if (field !== undefined) {
+      params.push(`field=${field}`);
+    }
+
+    const paramsStr = params.length > 0 ? `?${params.join('&')}` : '';
+
+    return this.http.get<ApiMetrics>(`${this.constants.env.baseURL}/apis/${api}/health${paramsStr}`);
   }
 }

--- a/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.component.scss
+++ b/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.component.scss
@@ -78,6 +78,13 @@ $typography: map.get(gio.$mat-theme, typography);
     // Remove form field padding provided to display mat-hint and mat-error. Not used here
     // For search field and mat-paginator
     .gio-table-wrapper__header-bar {
+      .mat-paginator-page-size {
+        align-items: center;
+        .mat-form-field {
+          margin: 0 4px;
+        }
+      }
+
       .mat-form-field-wrapper {
         padding-bottom: 0;
       }

--- a/gravitee-apim-console-webui/src/shared/components/widgets/gio-chart-pie/gio-chart-pie.component.scss
+++ b/gravitee-apim-console-webui/src/shared/components/widgets/gio-chart-pie/gio-chart-pie.component.scss
@@ -1,7 +1,5 @@
 .gio-chart-pie {
   &__chart {
-    width: 100%;
-    height: 400px;
     display: block;
   }
   &__no-data {

--- a/gravitee-apim-console-webui/src/shared/components/widgets/gio-chart-pie/gio-chart-pie.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/widgets/gio-chart-pie/gio-chart-pie.component.ts
@@ -15,7 +15,7 @@
  */
 
 import { Component, Input, OnInit } from '@angular/core';
-import Highcharts from 'highcharts';
+import * as Highcharts from 'highcharts';
 
 export interface GioChartPieInput {
   label: string;

--- a/gravitee-apim-console-webui/src/shared/components/widgets/gio-chart-pie/gio-chart-pie.stories.ts
+++ b/gravitee-apim-console-webui/src/shared/components/widgets/gio-chart-pie/gio-chart-pie.stories.ts
@@ -28,12 +28,25 @@ export default {
       imports: [MatCardModule, GioChartPieComponentModule],
     }),
   ],
-  render: () => ({}),
+  render: ({ data, dataDescription, title }) => {
+    return {
+      template: `
+      <mat-card style="width: 500px">
+            <gio-chart-pie [data]="data" [dataDescription]="dataDescription" [title]="title"></gio-chart-pie>
+      </mat-card>
+      `,
+      props: {
+        data,
+        dataDescription,
+        title,
+      },
+    };
+  },
 } as Meta;
 
 export const Simple: Story = {
-  render: () => {
-    const data = [
+  args: {
+    data: [
       {
         color: '#bbb',
         label: '1xx',
@@ -59,43 +72,16 @@ export const Simple: Story = {
         label: '5xx',
         value: 300,
       },
-    ];
-
-    const title = 'A Sample Title';
-    const dataDescription = 'Nb hits';
-    return {
-      template: `
-      <mat-card style="width: 500px">
-            <gio-chart-pie [data]="data" [dataDescription]="dataDescription" [title]="title"></gio-chart-pie>
-      </mat-card>
-      `,
-      props: {
-        data,
-        dataDescription,
-        title,
-      },
-      styles: [],
-    };
+    ],
+    title: 'A Sample Title',
+    dataDescription: 'Nb hits',
   },
 };
 
 export const NoData: Story = {
-  render: () => {
-    const data = [];
-    const title = 'A Sample Title';
-    const dataDescription = 'Nb hits';
-    return {
-      template: `
-      <mat-card style="width: 500px">
-            <gio-chart-pie [data]="data" [dataDescription]="dataDescription" [title]="title"></gio-chart-pie>
-      </mat-card>
-      `,
-      props: {
-        data,
-        dataDescription,
-        title,
-      },
-      styles: [],
-    };
+  args: {
+    data: [],
+    title: 'A Sample Title',
+    dataDescription: 'Nb hits',
   },
 };


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1071
https://gravitee.atlassian.net/browse/APIM-1140

## Description

Start migration of APIs status page 

Just a first PR with 
- paginated api table like the api list one
- simple HC availability gauge with time frame selection


## Additional context
![image](https://user-images.githubusercontent.com/4974420/227599333-0e38bd07-2daf-4cbb-b33c-ed857f5183a5.png)

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-aqmjnzoysu.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/api-status/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
