### PR TITLE
fix: add missing libc6-compat for kafka compression feature

### DIFF
--- a/gravitee-apim-gateway/docker/Dockerfile
+++ b/gravitee-apim-gateway/docker/Dockerfile
@@ -18,6 +18,9 @@
 FROM graviteeio/java:17 as base
 ENV GRAVITEEIO_HOME /opt/graviteeio-gateway
 
+RUN apk update && apk add --no-cache libc6-compat && \
+ln -s /lib/libc.musl-x86_64.so.1 /lib/ld-linux-x86-64.so.2
+
 RUN addgroup -g 1000 graviteeio \
     && adduser -D -H -u 1001 graviteeio --ingroup graviteeio
 


### PR DESCRIPTION
## Issue

A customer raised an issue while using the compression feature with Snappy and Kafka. Snappy was using native lib to uncompress incoming data without success.

This is due to a limitation of OpenJDK images on alpine: https://github.com/docker-library/openjdk/issues/439

## Description

This add to only the gateway images the missing libc library.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ufmnncotal.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-missing-native-libc-compat/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
