### PR TITLE
Generate changelog based on Jira's Component field

### DIFF
--- a/release/ci-steps/doc-new-release-notes.mjs
+++ b/release/ci-steps/doc-new-release-notes.mjs
@@ -1,5 +1,6 @@
 import { computeVersion, extractVersion } from '../helpers/version-helper.mjs';
 import { getJiraIssuesOfVersion, getJiraVersion } from '../helpers/jira-helper.mjs';
+import { getChangelogFor } from '../helpers/changelog-helper.mjs';
 
 console.log(chalk.magenta(`#############################################`));
 console.log(chalk.magenta(`# 📰 Open APIM docs PR for new Release Note #`));
@@ -114,35 +115,42 @@ For upgrade instructions, please refer to https://docs.gravitee.io/apim/3.x/apim
 }
 
 const version = await getJiraVersion(releasingVersion);
-const issues = await getJiraIssuesOfVersion(version.id);
-const changelog = issues
-  .map((issue) => {
-    const githubLink = `https://github.com/gravitee-io/issues/issues/${issue.fields.customfield_10115}`;
-    return `* ${issue.fields.summary} ${githubLink}[#${issue.fields.customfield_10115}]`;
-  })
-  .join('\n');
+let issues = await getJiraIssuesOfVersion(version.id);
+
+const gatewayIssues = issues.filter((issue) => issue.fields.components.some((cmp) => cmp.name === 'Gateway'));
+issues = issues.filter((issue) => !gatewayIssues.includes(issue));
+
+const managementAPIIssues = issues.filter((issue) => issue.fields.components.some((cmp) => cmp.name === 'Management API'));
+issues = issues.filter((issue) => !managementAPIIssues.includes(issue));
+
+const consoleIssues = issues.filter((issue) => issue.fields.components.some((cmp) => cmp.name === 'Console'));
+issues = issues.filter((issue) => !consoleIssues.includes(issue));
+
+const portalIssues = issues.filter((issue) => issue.fields.components.some((cmp) => cmp.name === 'Portal'));
+const otherIssues = issues.filter((issue) => !portalIssues.includes(issue));
 
 let changelogPatchTemplate = `
 == APIM - ${releasingVersion} (${new Date().toISOString().slice(0, 10)})
 
-// Move these issues to the right section
-${changelog}
-
 === Gateway
 
-// TODO: List all Bug fixes & Improvements
+${getChangelogFor(gatewayIssues)}
 
 === API
 
-// TODO: List all Bug fixes & Improvements
+${getChangelogFor(managementAPIIssues)}
 
 === Console
 
-// TODO: List all Bug fixes & Improvements
+${getChangelogFor(consoleIssues)}
 
 === Portal
 
-// TODO: List all Bug fixes & Improvements
+${getChangelogFor(portalIssues)}
+
+=== Other
+
+${getChangelogFor(otherIssues)}
 `;
 echo(changelogPatchTemplate);
 

--- a/release/helpers/changelog-helper.mjs
+++ b/release/helpers/changelog-helper.mjs
@@ -1,0 +1,23 @@
+/**
+ * Get the Ascii doc formatted changelog for input issues
+ *
+ * @param issues {Array<{id: string, fields: Array<{customfield_10115: string,summary: string}>}>}
+ */
+export function getChangelogFor(issues) {
+  return issues
+    .sort((issue1, issue2) => {
+      // if null or undefined, put it at the end
+      if (!issue1.fields.customfield_10115) {
+        return 1;
+      } else if (!issue2.fields.customfield_10115) {
+        return -1;
+      } else {
+        return issue1.fields.customfield_10115 - issue2.fields.customfield_10115;
+      }
+    })
+    .map((issue) => {
+      const githubLink = `https://github.com/gravitee-io/issues/issues/${issue.fields.customfield_10115}`;
+      return `* ${issue.fields.summary} ${githubLink}[#${issue.fields.customfield_10115}]`;
+    })
+    .join('\n');
+}


### PR DESCRIPTION
## Issue

NA

## Description

Generate a changelog grouped by Jira's Component field.

![image](https://user-images.githubusercontent.com/4112568/227876545-0649ee7b-2d6f-45c5-8972-90f5d107e929.png)

Issues are now split into 5 categories:
 - Gateway
 - Management API
 - Console
 - Portal
 - Other: anything not in one of the previous categories

GitHub issue ids sort them, and the ones without ids are put at the end.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-azpzsubakg.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/improve-changelog-generation/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
