### PR TITLE
Revert "fix: execute SubscriptionProcessor only for Message API"

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactory.java
@@ -119,9 +119,7 @@ public class ApiProcessorChainFactory {
                     }
                 });
 
-            if (api.getDefinition().getType() == ApiType.MESSAGE) {
-                processors.add(SubscriptionProcessor.instance(clientIdentifierHeader));
-            }
+            processors.add(SubscriptionProcessor.instance(clientIdentifierHeader));
         }
 
         return new ProcessorChain("processor-chain-before-api-execution", processors, processorHooks);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactoryTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.when;
 
 import io.gravitee.definition.model.Cors;
 import io.gravitee.definition.model.ResponseTemplate;
-import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.analytics.logging.Logging;
 import io.gravitee.definition.model.v4.analytics.logging.LoggingMode;
@@ -137,7 +136,6 @@ class ApiProcessorChainFactoryTest {
     @Test
     void shouldReturnEmptyBeforeApiExecutionProcessorChainWithNoHttpListener() {
         io.gravitee.definition.model.v4.Api apiModel = new io.gravitee.definition.model.v4.Api();
-        apiModel.setType(ApiType.MESSAGE);
         apiModel.setListeners(List.of(new SubscriptionListener()));
         Api api = new Api(apiModel);
         ProcessorChain processorChain = apiProcessorChainFactory.beforeApiExecution(api);
@@ -149,7 +147,6 @@ class ApiProcessorChainFactoryTest {
     @Test
     void shouldReturnCorsBeforeApiExecutionChainWithHttpListenerAndCors() {
         io.gravitee.definition.model.v4.Api apiModel = new io.gravitee.definition.model.v4.Api();
-        apiModel.setType(ApiType.MESSAGE);
         HttpListener httpListener = new HttpListener();
         Cors cors = new Cors();
         cors.setEnabled(true);
@@ -170,7 +167,6 @@ class ApiProcessorChainFactoryTest {
     @Test
     void shouldReturnBeforeApiExecutionChainWithHttpListener() {
         io.gravitee.definition.model.v4.Api apiModel = new io.gravitee.definition.model.v4.Api();
-        apiModel.setType(ApiType.MESSAGE);
         HttpListener httpListener = new HttpListener();
         apiModel.setListeners(List.of(httpListener));
         Api api = new Api(apiModel);
@@ -186,7 +182,6 @@ class ApiProcessorChainFactoryTest {
         apiProcessorChainFactory = new ApiProcessorChainFactory(configuration, node, reporterService);
 
         io.gravitee.definition.model.v4.Api apiModel = new io.gravitee.definition.model.v4.Api();
-        apiModel.setType(ApiType.MESSAGE);
         HttpListener httpListener = new HttpListener();
         apiModel.setListeners(List.of(httpListener));
         Api api = new Api(apiModel);


### PR DESCRIPTION
## Issue

This reverts commit 1ad48f1710f158629cd097923c2f84a711a77774.

## Description

The processor is responsible of setting anonymous values for plan, application, and subscription. It also initializes metrics information and applies template variables for subscription.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/revert-subscriptionprocess-only-on-message/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qdtbiogzuv.chromatic.com)
<!-- Storybook placeholder end -->
