### PR TITLE
fix(console): correctly initialise the security part of a plan in edition

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/portal/plans/edit/2-secure-step/plan-edit-secure-step.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/plans/edit/2-secure-step/plan-edit-secure-step.component.ts
@@ -17,7 +17,7 @@ import { Component, Inject, Input, OnDestroy, OnInit } from '@angular/core';
 import { camelCase } from 'lodash';
 import { EMPTY, Subject } from 'rxjs';
 import { FormControl, FormGroup } from '@angular/forms';
-import { catchError, filter, map, switchMap, takeUntil, tap } from 'rxjs/operators';
+import { catchError, distinctUntilChanged, filter, map, switchMap, takeUntil, tap } from 'rxjs/operators';
 import '@gravitee/ui-components/wc/gv-schema-form-group';
 
 import { Constants } from '../../../../../../entities/Constants';
@@ -67,6 +67,7 @@ export class PlanEditSecureStepComponent implements OnInit, OnDestroy {
   });
 
   public securityConfigSchema: unknown;
+  private currentSecurityType: string;
 
   private resourceTypes: ResourceListItem[];
 
@@ -91,7 +92,15 @@ export class PlanEditSecureStepComponent implements OnInit, OnDestroy {
       .get('securityTypes')
       .valueChanges.pipe(
         takeUntil(this.unsubscribe$),
-        tap(() => (this.securityConfigSchema = undefined)),
+        distinctUntilChanged(),
+        tap(() => {
+          this.securityConfigSchema = undefined;
+          // Only reset security config if security type has changed
+          if (this.currentSecurityType !== this.secureForm.get('securityTypes').value) {
+            this.secureForm.get('securityConfig').reset({});
+            this.currentSecurityType = this.secureForm.get('securityTypes').value;
+          }
+        }),
         filter((securityType) => securityType && securityType !== PlanSecurityType.KEY_LESS),
         map((securityType) => this.securityTypes.find((type) => type.id === securityType).policy),
         switchMap((securityTypePolicy) => this.policyService.getSchema(securityTypePolicy)),
@@ -101,7 +110,6 @@ export class PlanEditSecureStepComponent implements OnInit, OnDestroy {
         }),
       )
       .subscribe((schema) => {
-        this.secureForm.get('securityConfig').reset({});
         this.securityConfigSchema = schema;
       });
 

--- a/gravitee-apim-console-webui/src/management/api/portal/plans/edit/api-portal-plan-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/plans/edit/api-portal-plan-edit.component.spec.ts
@@ -24,6 +24,7 @@ import { MatSelectHarness } from '@angular/material/select/testing';
 import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { set } from 'lodash';
+import { By } from '@angular/platform-browser';
 
 import { ApiPortalPlanEditComponent } from './api-portal-plan-edit.component';
 import { ApiPortalPlanEditModule } from './api-portal-plan-edit.module';
@@ -38,7 +39,7 @@ import { fakeTag } from '../../../../../entities/tag/tag.fixture';
 import { Page } from '../../../../../entities/page';
 import { fakeApi } from '../../../../../entities/api/Api.fixture';
 import { Api } from '../../../../../entities/api';
-import { Plan } from '../../../../../entities/plan';
+import { Plan, PlanSecurityType } from '../../../../../entities/plan';
 import { fakePlan } from '../../../../../entities/plan/plan.fixture';
 
 describe('ApiPortalPlanEditComponent', () => {
@@ -300,6 +301,55 @@ describe('ApiPortalPlanEditComponent', () => {
       });
       req.flush({});
       expect(fakeUiRouter.go).toHaveBeenCalled();
+    });
+
+    it('should display api-key plan', async () => {
+      const TAG_1_ID = 'tag-1';
+      const planToUpdate = fakePlan({
+        id: PLAN_ID,
+        name: 'Old 🗺',
+        description: 'Old Description',
+        security: PlanSecurityType.API_KEY,
+        securityDefinition: JSON.stringify({ propagateApiKey: true }),
+        tags: [TAG_1_ID],
+      });
+
+      expectApiGetRequest(fakeApi({ id: API_ID, tags: [TAG_1_ID] }));
+      expectPlanGetRequest(API_ID, planToUpdate);
+
+      expectTagsListRequest([fakeTag({ id: TAG_1_ID, name: 'Tag 1' }), fakeTag({ id: 'tag-2', name: 'Tag 2' })]);
+      expectGroupLisRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
+      expectDocumentationSearchRequest(API_ID, [{ id: 'doc-1', name: 'Doc 1' }]);
+      expectCurrentUserTagsRequest([TAG_1_ID]);
+      expectResourceGetRequest();
+      expectPolicySchemaGetRequest('api-key', {});
+      fixture.detectChanges();
+
+      const saveBar = await loader.getHarness(GioSaveBarHarness);
+      expect(await saveBar.isVisible()).toBe(false);
+
+      // 1- General Step
+      const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+      expect(await nameInput.getValue()).toBe('Old 🗺');
+
+      const descriptionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="description"]' }));
+      expect(await descriptionInput.getValue()).toBe('Old Description');
+
+      const shardingTagsInput = await loader.getHarness(MatSelectHarness.with({ selector: '[formControlName="shardingTags"]' }));
+      expect(await shardingTagsInput.getValueText()).toContain('Tag 1');
+
+      // 2- Secure Step
+      const securityTypesInput = await loader.getHarness(MatSelectHarness.with({ selector: '[formControlName="securityTypes"]' }));
+      expect(await securityTypesInput.isDisabled()).toEqual(true);
+      expect(await securityTypesInput.getValueText()).toEqual('API Key');
+
+      // Expect the security config value to be completed correctly
+      expect(fixture.debugElement.query(By.css('.securityConfigSchema-form')).componentInstance.secureForm.value.securityConfig).toEqual({
+        propagateApiKey: true,
+      });
+
+      const selectionRuleInput = await loader.getAllHarnesses(MatInputHarness.with({ selector: '[formControlName="selectionRule"]' }));
+      expect(selectionRuleInput.length).toEqual(1); // no selection rule for keyless
     });
   });
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-670
https://gravitee.atlassian.net/browse/APIM-673
https://gravitee.atlassian.net/browse/APIM-1144

## Description

A small description of what you did in that PR.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-miysaqpctp.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/3.21.x-fix-plan/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
