### PR TITLE
fix: fixing duplicated listeners checks

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/exception/ListenersDuplicatedException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/exception/ListenersDuplicatedException.java
@@ -41,7 +41,7 @@ public class ListenersDuplicatedException extends AbstractManagementException {
 
     @Override
     public String getMessage() {
-        return "The api contains duplicated listeners type [" + duplicatedListeners + "].";
+        return "The api contains duplicated listeners type " + duplicatedListeners + ".";
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ListenerValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ListenerValidationServiceImpl.java
@@ -31,8 +31,15 @@ import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.impl.TransactionalService;
 import io.gravitee.rest.api.service.v4.EndpointConnectorPluginService;
 import io.gravitee.rest.api.service.v4.EntrypointConnectorPluginService;
-import io.gravitee.rest.api.service.v4.exception.*;
-import io.gravitee.rest.api.service.v4.validation.AnalyticsValidationService;
+import io.gravitee.rest.api.service.v4.exception.ListenerEntrypointDuplicatedException;
+import io.gravitee.rest.api.service.v4.exception.ListenerEntrypointInvalidDlqException;
+import io.gravitee.rest.api.service.v4.exception.ListenerEntrypointInvalidQosException;
+import io.gravitee.rest.api.service.v4.exception.ListenerEntrypointMissingException;
+import io.gravitee.rest.api.service.v4.exception.ListenerEntrypointMissingTypeException;
+import io.gravitee.rest.api.service.v4.exception.ListenerEntrypointUnsupportedDlqException;
+import io.gravitee.rest.api.service.v4.exception.ListenerEntrypointUnsupportedListenerTypeException;
+import io.gravitee.rest.api.service.v4.exception.ListenerEntrypointUnsupportedQosException;
+import io.gravitee.rest.api.service.v4.exception.ListenersDuplicatedException;
 import io.gravitee.rest.api.service.v4.validation.CorsValidationService;
 import io.gravitee.rest.api.service.v4.validation.ListenerValidationService;
 import io.gravitee.rest.api.service.v4.validation.PathValidationService;
@@ -96,10 +103,10 @@ public class ListenerValidationServiceImpl extends TransactionalService implemen
     }
 
     private void checkDuplicatedListeners(final List<Listener> listeners) {
-        Set<Listener> seenListeners = new HashSet<>();
+        Set<ListenerType> seenListeners = new HashSet<>();
         Set<String> duplicatedListeners = listeners
             .stream()
-            .filter(e -> !seenListeners.add(e))
+            .filter(e -> !seenListeners.add(e.getType()))
             .map(selector -> selector.getType().getLabel())
             .collect(Collectors.toSet());
         if (!duplicatedListeners.isEmpty()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ListenerValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ListenerValidationServiceImplTest.java
@@ -45,8 +45,15 @@ import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.v4.EndpointConnectorPluginService;
 import io.gravitee.rest.api.service.v4.EntrypointConnectorPluginService;
-import io.gravitee.rest.api.service.v4.exception.*;
-import io.gravitee.rest.api.service.v4.validation.AnalyticsValidationService;
+import io.gravitee.rest.api.service.v4.exception.HttpListenerPathMissingException;
+import io.gravitee.rest.api.service.v4.exception.ListenerEntrypointDuplicatedException;
+import io.gravitee.rest.api.service.v4.exception.ListenerEntrypointInvalidDlqException;
+import io.gravitee.rest.api.service.v4.exception.ListenerEntrypointMissingException;
+import io.gravitee.rest.api.service.v4.exception.ListenerEntrypointMissingTypeException;
+import io.gravitee.rest.api.service.v4.exception.ListenerEntrypointUnsupportedDlqException;
+import io.gravitee.rest.api.service.v4.exception.ListenerEntrypointUnsupportedListenerTypeException;
+import io.gravitee.rest.api.service.v4.exception.ListenerEntrypointUnsupportedQosException;
+import io.gravitee.rest.api.service.v4.exception.ListenersDuplicatedException;
 import io.gravitee.rest.api.service.v4.validation.CorsValidationService;
 import java.util.ArrayList;
 import java.util.List;
@@ -114,7 +121,13 @@ public class ListenerValidationServiceImplTest {
     public void shouldThrowDuplicatedExceptionWithDuplicatedType() {
         // Given
         Listener httpListener1 = new HttpListener();
+        Entrypoint e1 = new Entrypoint();
+        e1.setType("e1");
+        httpListener1.setEntrypoints(List.of(e1));
         Listener httpListener2 = new HttpListener();
+        Entrypoint e2 = new Entrypoint();
+        e2.setType("e2");
+        httpListener1.setEntrypoints(List.of(e2));
         List<Listener> listeners = List.of(httpListener1, httpListener2);
         // When
         assertThatExceptionOfType(ListenersDuplicatedException.class)


### PR DESCRIPTION
## Issue

Fix how duplicated listeners are checked to make sure it is not possible.
 - compare seeing type instead of the object instance


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xigrrzrybp.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-duplicated-listener/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
