### PR TITLE
Allow use of personal token on the Portal API

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-security/src/main/java/io/gravitee/rest/api/portal/security/config/BasicSecurityConfigurerAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-security/src/main/java/io/gravitee/rest/api/portal/security/config/BasicSecurityConfigurerAdapter.java
@@ -33,6 +33,8 @@ import io.gravitee.rest.api.security.listener.AuthenticationSuccessListener;
 import io.gravitee.rest.api.security.utils.AuthoritiesProvider;
 import io.gravitee.rest.api.service.ParameterService;
 import io.gravitee.rest.api.service.ReCaptchaService;
+import io.gravitee.rest.api.service.TokenService;
+import io.gravitee.rest.api.service.UserService;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
@@ -97,6 +99,12 @@ public class BasicSecurityConfigurerAdapter extends WebSecurityConfigurerAdapter
 
     @Autowired
     private EventManager eventManager;
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private TokenService tokenService;
 
     @Override
     protected void configure(AuthenticationManagerBuilder auth) throws Exception {
@@ -197,7 +205,7 @@ public class BasicSecurityConfigurerAdapter extends WebSecurityConfigurerAdapter
         cors(http);
 
         http.addFilterBefore(
-            new TokenAuthenticationFilter(jwtSecret, cookieGenerator, null, null, authoritiesProvider),
+            new TokenAuthenticationFilter(jwtSecret, cookieGenerator, userService, tokenService, authoritiesProvider),
             BasicAuthenticationFilter.class
         );
         http.addFilterBefore(new RecaptchaFilter(reCaptchaService, objectMapper), TokenAuthenticationFilter.class);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-903
https://github.com/gravitee-io/issues/issues/8569

## Description

Allow use of personal token on the Portal API
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-903-portal-api-security-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-blaqxgwidj.chromatic.com)
<!-- Storybook placeholder end -->
