### PR TITLE
Revert "fix: execute security chain after the CORSPreflight Processor"

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/cors/CorsPreflightRequestProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/cors/CorsPreflightRequestProcessor.java
@@ -57,10 +57,9 @@ public class CorsPreflightRequestProcessor extends AbstractCorsRequestProcessor 
             // Test if we are in the context of a preflight request
             if (isPreflightRequest(ctx.request())) {
                 Cors cors = getCors(ctx);
-                boolean isPreflightSuccessful = handlePreflightRequest(cors, ctx);
-
-                // If we don't want to run policies or the preflight fails, exit request processing
-                if (!cors.isRunPolicies() || !isPreflightSuccessful) {
+                handlePreflightRequest(cors, ctx);
+                // If we don't want to run policies, exit request processing
+                if (!cors.isRunPolicies()) {
                     return ctx.interrupt();
                 } else {
                     ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_SECURITY_SKIP, true);
@@ -82,9 +81,8 @@ public class CorsPreflightRequestProcessor extends AbstractCorsRequestProcessor 
      * See <a href="https://www.w3.org/TR/cors/#resource-preflight-requests">Preflight request</a>
      * @param cors Cors settings
      * @param ctx current context
-     * @return true if the Preflight Request pass, false otherwise
      */
-    private boolean handlePreflightRequest(final Cors cors, final GenericExecutionContext ctx) {
+    private void handlePreflightRequest(final Cors cors, final GenericExecutionContext ctx) {
         final GenericRequest request = ctx.request();
         final GenericResponse response = ctx.response();
 
@@ -100,7 +98,7 @@ public class CorsPreflightRequestProcessor extends AbstractCorsRequestProcessor 
         if (!isOriginAllowed(cors, originHeader)) {
             response.status(Cors.DEFAULT_ERROR_STATUS_CODE);
             ctx.metrics().setErrorMessage(String.format("Origin '%s' is not allowed", originHeader));
-            return false;
+            return;
         }
 
         // 3. Let method be the value as result of parsing the Access-Control-Request-Method header.
@@ -110,7 +108,7 @@ public class CorsPreflightRequestProcessor extends AbstractCorsRequestProcessor 
         if (!isRequestMethodsValid(cors, accessControlRequestMethod)) {
             response.status(Cors.DEFAULT_ERROR_STATUS_CODE);
             ctx.metrics().setErrorMessage(String.format("Request method '%s' is not allowed", accessControlRequestMethod));
-            return false;
+            return;
         }
 
         // 4.Let header field-names be the values as result of parsing the Access-Control-Request-Headers headers.
@@ -118,7 +116,7 @@ public class CorsPreflightRequestProcessor extends AbstractCorsRequestProcessor 
         if (!isRequestHeadersValid(cors, accessControlRequestHeaders)) {
             response.status(Cors.DEFAULT_ERROR_STATUS_CODE);
             ctx.metrics().setErrorMessage(String.format("Request headers '%s' are not valid", accessControlRequestHeaders));
-            return false;
+            return;
         }
 
         // 7. If the resource supports credentials add a single Access-Control-Allow-Credentials header with the case-sensitive
@@ -147,7 +145,7 @@ public class CorsPreflightRequestProcessor extends AbstractCorsRequestProcessor 
         } else {
             response.status(Cors.DEFAULT_ERROR_STATUS_CODE);
             ctx.metrics().setErrorMessage("CORS configuration invalid,  Access-Control-Allow-Methods cannot be null or empty.");
-            return false;
+            return;
         }
 
         // 10. If each of the header field-names is a simple header and none is Content-Type, this step may be skipped.
@@ -158,7 +156,6 @@ public class CorsPreflightRequestProcessor extends AbstractCorsRequestProcessor 
                 .set(HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS, String.join(JOINER_CHAR_SEQUENCE, cors.getAccessControlAllowHeaders()));
         }
         response.status(HttpStatusCode.OK_200);
-        return true;
     }
 
     private boolean isRequestMethodsValid(final Cors cors, final String accessControlRequestMethods) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
@@ -247,10 +247,10 @@ public class DefaultApiReactor extends AbstractLifecycleComponent<ReactorHandler
         return new CompletableReactorChain(executeProcessorChain(ctx, beforeHandleProcessors, REQUEST))
             // Execute platform flow chain.
             .chainWith(platformFlowChain.execute(ctx, REQUEST))
-            // Before flows processors.
-            .chainWith(executeProcessorChain(ctx, beforeApiExecutionProcessors, REQUEST))
             // Execute security chain.
             .chainWith(securityChain.execute(ctx))
+            // Before flows processors.
+            .chainWith(executeProcessorChain(ctx, beforeApiExecutionProcessors, REQUEST))
             // Resolve entrypoint and prepare request to be handled.
             .chainWith(handleEntrypointRequest(ctx))
             // After entrypoint response

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/cors/CorsPreflightRequestProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/cors/CorsPreflightRequestProcessorTest.java
@@ -37,7 +37,6 @@ import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.handlers.api.processor.cors.CorsPreflightInvoker;
 import io.gravitee.gateway.reactive.core.context.interruption.InterruptionException;
 import io.gravitee.gateway.reactive.handlers.api.processor.AbstractProcessorTest;
-import java.util.Random;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -111,39 +110,6 @@ class CorsPreflightRequestProcessorTest extends AbstractProcessorTest {
         verify(mockResponse, times(1)).status(eq(200));
         assertThat(spyCtx.<Boolean>getInternalAttribute(ATTR_INTERNAL_SECURITY_SKIP)).isNull();
         assertThat(spyCtx.<CorsPreflightInvoker>getInternalAttribute(ATTR_INTERNAL_INVOKER)).isNull();
-    }
-
-    @Test
-    public void shouldInterruptWithInvalidRequestBadMethodAndPoliciesNotRun() {
-        // if policies are not executed, the context is interrupted what ever is the CORS validation status.
-        // only the absence of CORS Specific Header and the error message assert the right behaviour
-        api.getProxy().getCors().setRunPolicies(false);
-
-        spyRequestHeaders.set(ORIGIN, "origin");
-        spyRequestHeaders.set(ACCESS_CONTROL_REQUEST_METHOD, "POST");
-        corsPreflightRequestProcessor.execute(spyCtx).test().assertError(InterruptionException.class);
-        assertThat(spyCtx.metrics().getApplicationId()).isEqualTo("1");
-        assertThat(spyCtx.metrics().getErrorMessage()).contains("Request method 'POST' is not allowed");
-        verify(mockResponse, times(1)).status(eq(400));
-        assertThat(spyCtx.<Boolean>getInternalAttribute(ATTR_INTERNAL_SECURITY_SKIP)).isNull();
-        assertThat(spyCtx.<CorsPreflightInvoker>getInternalAttribute(ATTR_INTERNAL_INVOKER)).isNull();
-        verify(mockResponse, never()).headers();
-    }
-
-    @Test
-    public void shouldInterruptWithInvalidRequestBadMethodAndRunPolicies() {
-        // if policies are marked as runnable, the context must be interrupted if the CORS validation status fails.
-        api.getProxy().getCors().setRunPolicies(true);
-
-        spyRequestHeaders.set(ORIGIN, "origin");
-        spyRequestHeaders.set(ACCESS_CONTROL_REQUEST_METHOD, "POST");
-        corsPreflightRequestProcessor.execute(spyCtx).test().assertError(InterruptionException.class);
-        assertThat(spyCtx.metrics().getApplicationId()).isEqualTo("1");
-        assertThat(spyCtx.metrics().getErrorMessage()).contains("Request method 'POST' is not allowed");
-        verify(mockResponse, times(1)).status(eq(400));
-        assertThat(spyCtx.<Boolean>getInternalAttribute(ATTR_INTERNAL_SECURITY_SKIP)).isNull();
-        assertThat(spyCtx.<CorsPreflightInvoker>getInternalAttribute(ATTR_INTERNAL_INVOKER)).isNull();
-        verify(mockResponse, never()).headers();
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorTest.java
@@ -494,8 +494,8 @@ class DefaultApiReactorTest {
 
         inOrder.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
+        inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyEntrypointRequest).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlanFlowChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestApiFlowChain).subscribe(any(CompletableObserver.class));
@@ -519,8 +519,8 @@ class DefaultApiReactorTest {
         InOrder inOrder = getInOrder();
         inOrder.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
+        inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyEntrypointRequest).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyAfterEntrypointRequestProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyMessageRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
@@ -557,8 +557,8 @@ class DefaultApiReactorTest {
 
         inOrder.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
+        inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyEntrypointRequest).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlanFlowChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestApiFlowChain).subscribe(any(CompletableObserver.class));
@@ -586,8 +586,8 @@ class DefaultApiReactorTest {
         InOrder inOrder = getInOrder();
         inOrder.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
+        inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyEntrypointRequest).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyAfterEntrypointRequestProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyMessageRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
@@ -625,8 +625,8 @@ class DefaultApiReactorTest {
         InOrder inOrder = getInOrder();
         inOrder.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
+        inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyEntrypointRequest).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyAfterEntrypointRequestProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyMessageRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
@@ -664,8 +664,8 @@ class DefaultApiReactorTest {
         InOrder inOrder = getInOrder();
         inOrder.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
+        inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyEntrypointRequest).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyAfterEntrypointRequestProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyMessageRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
@@ -702,8 +702,8 @@ class DefaultApiReactorTest {
         InOrder inOrder = getInOrder();
         inOrder.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
+        inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyEntrypointRequest).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyAfterEntrypointRequestProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyMessageRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
@@ -742,8 +742,8 @@ class DefaultApiReactorTest {
         InOrder inOrder = getInOrder();
         inOrder.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
+        inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyEntrypointRequest).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyAfterEntrypointRequestProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyMessageRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
@@ -786,8 +786,8 @@ class DefaultApiReactorTest {
         InOrder inOrder = getInOrder();
         inOrder.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
+        inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyEntrypointRequest).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyAfterEntrypointRequestProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyMessageRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
@@ -852,8 +852,8 @@ class DefaultApiReactorTest {
         InOrder inOrder = getInOrder();
         inOrder.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
+        inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyEntrypointRequest).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyAfterEntrypointRequestProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyMessageRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
@@ -919,8 +919,8 @@ class DefaultApiReactorTest {
         InOrder inOrder = getInOrder();
         inOrder.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
+        inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyEntrypointRequest).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyAfterEntrypointRequestProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyMessageRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
@@ -982,8 +982,8 @@ class DefaultApiReactorTest {
         InOrder inOrder = getInOrder();
         inOrder.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
+        inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyEntrypointRequest).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlanFlowChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestApiFlowChain).subscribe(any(CompletableObserver.class));


### PR DESCRIPTION
Reverts gravitee-io/gravitee-api-management#3383

Will be rework because currently it break e2e
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-serjnpjsbl.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/revert-3383-apim-1150/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
