### PR TITLE
feat: create new service for analytics

### DIFF
--- a/gravitee-apim-console-webui/src/entities/analytics/analyticsRequestParam.ts
+++ b/gravitee-apim-console-webui/src/entities/analytics/analyticsRequestParam.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type AnalyticsRequestType = 'STATS' | 'GROUP_BY' | 'COUNT';
+
+export class AnalyticsRequestParam {
+  field: string;
+  from: Date;
+  to: Date;
+  interval: number;
+}

--- a/gravitee-apim-console-webui/src/entities/analytics/analyticsResponse.ts
+++ b/gravitee-apim-console-webui/src/entities/analytics/analyticsResponse.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export class AnalyticsMetadata {
+  name: string;
+  order: number;
+  version?: number;
+  unknown?: boolean;
+}
+
+export class AnalyticsGroupByResponse {
+  values: { [key: string]: number };
+  metadata: { [key: string]: AnalyticsMetadata };
+}
+
+export class AnalyticsStatsResponse {
+  count: number;
+  min: number;
+  max: number;
+  avg: number;
+  sum: number;
+  rps: number;
+  rpm: number;
+  rph: number;
+}
+
+export class AnalyticsCountResponse {
+  count: number;
+}
+
+export type AnalyticsResponse = AnalyticsCountResponse | AnalyticsGroupByResponse | AnalyticsStatsResponse;

--- a/gravitee-apim-console-webui/src/services-ngx/analytics.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/analytics.service.spec.ts
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { AnalyticsService } from './analytics.service';
+
+import { CONSTANTS_TESTING, GioHttpTestingModule } from '../shared/testing';
+import { AnalyticsCountResponse, AnalyticsGroupByResponse, AnalyticsStatsResponse } from '../entities/analytics/analyticsResponse';
+import { AnalyticsRequestParam } from '../entities/analytics/analyticsRequestParam';
+
+describe('AnalyticsService', () => {
+  let httpTestingController: HttpTestingController;
+  let analyticsService: AnalyticsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [GioHttpTestingModule],
+    });
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+    analyticsService = TestBed.inject<AnalyticsService>(AnalyticsService);
+  });
+
+  describe('getStats', () => {
+    it('should call the API for STATS analytics', (done) => {
+      const fromTimestamp = 1677339613055;
+      const toTimestamp = 1679931613055;
+      const interval = 86400000;
+      const field = 'response-time';
+
+      const fakeAnalytics: AnalyticsStatsResponse = {
+        count: 44079.0,
+        min: 0.0,
+        max: 338.0,
+        avg: 0.991243,
+        sum: 43693.0,
+        rps: 0.017005786,
+        rpm: 1.0203471,
+        rph: 61.22083,
+      };
+      const params: AnalyticsRequestParam = {
+        field,
+        interval,
+        from: new Date(fromTimestamp),
+        to: new Date(toTimestamp),
+      };
+      analyticsService.getGroupBy(params).subscribe((response) => {
+        expect(response).toMatchObject(fakeAnalytics);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(
+        `${CONSTANTS_TESTING.env.baseURL}/platform/analytics?type=group_by&field=${field}&interval=${interval}&from=${fromTimestamp}&to=${toTimestamp}&timeout=${CONSTANTS_TESTING.env.settings.analytics.clientTimeout}`,
+      );
+      expect(req.request.method).toEqual('GET');
+
+      req.flush(fakeAnalytics);
+    });
+
+    it('should call the API for GROUP_BY analytics', (done) => {
+      const fromTimestamp = 1677339613055;
+      const toTimestamp = 1679931613055;
+      const interval = 86400000;
+      const field = 'api';
+
+      const fakeAnalytics: AnalyticsGroupByResponse = {
+        values: {
+          blue: 12,
+          yellow: 5,
+        },
+        metadata: {
+          blue: {
+            name: 'BLUE',
+            order: 1,
+          },
+          yellow: {
+            name: 'YELLOW',
+            order: 2,
+          },
+        },
+      };
+      const params: AnalyticsRequestParam = {
+        field,
+        interval,
+        from: new Date(fromTimestamp),
+        to: new Date(toTimestamp),
+      };
+      analyticsService.getGroupBy(params).subscribe((response) => {
+        expect(response).toMatchObject(fakeAnalytics);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(
+        `${CONSTANTS_TESTING.env.baseURL}/platform/analytics?type=group_by&field=${field}&interval=${interval}&from=${fromTimestamp}&to=${toTimestamp}&timeout=${CONSTANTS_TESTING.env.settings.analytics.clientTimeout}`,
+      );
+      expect(req.request.method).toEqual('GET');
+
+      req.flush(fakeAnalytics);
+    });
+
+    it('should call the API for COUNT analytics', (done) => {
+      const fromTimestamp = 1677339613055;
+      const toTimestamp = 1679931613055;
+      const interval = 86400000;
+      const field = 'application';
+
+      const fakeAnalytics: AnalyticsCountResponse = {
+        count: 1234,
+      };
+      const params: AnalyticsRequestParam = {
+        field,
+        interval,
+        from: new Date(fromTimestamp),
+        to: new Date(toTimestamp),
+      };
+      analyticsService.getCount(params).subscribe((response) => {
+        expect(response).toMatchObject(fakeAnalytics);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(
+        `${CONSTANTS_TESTING.env.baseURL}/platform/analytics?type=count&field=${field}&interval=${interval}&from=${fromTimestamp}&to=${toTimestamp}&timeout=${CONSTANTS_TESTING.env.settings.analytics.clientTimeout}`,
+      );
+      expect(req.request.method).toEqual('GET');
+
+      req.flush(fakeAnalytics);
+    });
+
+    it('should call the right API depending on type', (done) => {
+      const fromTimestamp = 1677339613055;
+      const toTimestamp = 1679931613055;
+      const interval = 86400000;
+      const field = 'application';
+
+      const fakeAnalytics: AnalyticsCountResponse = {
+        count: 1234,
+      };
+      const params: AnalyticsRequestParam = {
+        field,
+        interval,
+        from: new Date(fromTimestamp),
+        to: new Date(toTimestamp),
+      };
+      analyticsService.get('COUNT', params).subscribe((response) => {
+        expect(response).toMatchObject(fakeAnalytics);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(
+        `${CONSTANTS_TESTING.env.baseURL}/platform/analytics?type=count&field=${field}&interval=${interval}&from=${fromTimestamp}&to=${toTimestamp}&timeout=${CONSTANTS_TESTING.env.settings.analytics.clientTimeout}`,
+      );
+      expect(req.request.method).toEqual('GET');
+
+      req.flush(fakeAnalytics);
+    });
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+});

--- a/gravitee-apim-console-webui/src/services-ngx/analytics.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/analytics.service.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+import { Constants } from '../entities/Constants';
+import { AnalyticsRequestParam, AnalyticsRequestType } from '../entities/analytics/analyticsRequestParam';
+import {
+  AnalyticsCountResponse,
+  AnalyticsGroupByResponse,
+  AnalyticsResponse,
+  AnalyticsStatsResponse,
+} from '../entities/analytics/analyticsResponse';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AnalyticsService {
+  constructor(private readonly http: HttpClient, @Inject('Constants') private readonly constants: Constants) {}
+
+  get(type: AnalyticsRequestType, params: AnalyticsRequestParam): Observable<AnalyticsResponse> {
+    switch (type) {
+      case 'COUNT':
+        return this.getCount(params);
+      case 'GROUP_BY':
+        return this.getGroupBy(params);
+      case 'STATS':
+        return this.getStats(params);
+    }
+  }
+
+  getStats(params: AnalyticsRequestParam): Observable<AnalyticsStatsResponse> {
+    const url =
+      `${this.constants.env.baseURL}/platform/analytics?type=stats` +
+      `&field=${params.field}` +
+      `&interval=${params.interval}` +
+      `&from=${params.from.getTime()}` +
+      `&to=${params.to.getTime()}`;
+    return this.http.get<AnalyticsStatsResponse>(url, { params: { timeout: this.constants.env.settings.analytics.clientTimeout } });
+  }
+
+  getGroupBy(params: AnalyticsRequestParam): Observable<AnalyticsGroupByResponse> {
+    const url =
+      `${this.constants.env.baseURL}/platform/analytics?type=group_by` +
+      `&field=${params.field}` +
+      `&interval=${params.interval}` +
+      `&from=${params.from.getTime()}` +
+      `&to=${params.to.getTime()}`;
+    return this.http.get<AnalyticsGroupByResponse>(url, { params: { timeout: this.constants.env.settings.analytics.clientTimeout } });
+  }
+
+  getCount(params: AnalyticsRequestParam): Observable<AnalyticsCountResponse> {
+    const url =
+      `${this.constants.env.baseURL}/platform/analytics?type=count` +
+      `&field=${params.field}` +
+      `&interval=${params.interval}` +
+      `&from=${params.from.getTime()}` +
+      `&to=${params.to.getTime()}`;
+    return this.http.get<AnalyticsCountResponse>(url, { params: { timeout: this.constants.env.settings.analytics.clientTimeout } });
+  }
+}

--- a/gravitee-apim-console-webui/src/shared/testing/gio-http.testing.module.ts
+++ b/gravitee-apim-console-webui/src/shared/testing/gio-http.testing.module.ts
@@ -36,6 +36,9 @@ export const CONSTANTS_TESTING: Constants = {
   env: {
     baseURL: 'https://url.test:3000/management/organizations/DEFAULT/environments/DEFAULT',
     settings: {
+      analytics: {
+        clientTimeout: 50,
+      },
       apiQualityMetrics: {
         enabled: false,
       },


### PR DESCRIPTION
## Issue

Part of https://gravitee.atlassian.net/browse/APIM-1143

## Description

Add a new Angular service for Analytics.

## Additional context

For now, I prefer avoiding too much generic stuff as we are only building home page. We will probably change this later. 
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-scutgxaqzp.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1140-analytics-service/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
