### PR TITLE
fix: bump advanced plugins to test their latest version

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -770,10 +770,10 @@
                 <gravitee-policy-assign-metrics.version>2.0.1</gravitee-policy-assign-metrics.version>
                 <gravitee-policy-data-logging-masking.version>2.0.3</gravitee-policy-data-logging-masking.version>
                 <gravitee-policy-interrupt.version>1.1.0</gravitee-policy-interrupt.version>
-                <gravitee-entrypoint-sse-advanced.version>3.0.0-alpha.5</gravitee-entrypoint-sse-advanced.version>
-                <gravitee-entrypoint-webhook-advanced.version>1.0.0-alpha.7</gravitee-entrypoint-webhook-advanced.version>
-                <gravitee-endpoint-kafka-advanced.version>1.2.0-alpha.5</gravitee-endpoint-kafka-advanced.version>
-                <gravitee-endpoint-mqtt5-advanced.version>1.1.0-alpha.5</gravitee-endpoint-mqtt5-advanced.version>
+                <gravitee-entrypoint-sse-advanced.version>3.0.0-alpha.6</gravitee-entrypoint-sse-advanced.version>
+                <gravitee-entrypoint-webhook-advanced.version>1.0.0-alpha.8</gravitee-entrypoint-webhook-advanced.version>
+                <gravitee-endpoint-kafka-advanced.version>1.2.0-alpha.6</gravitee-endpoint-kafka-advanced.version>
+                <gravitee-endpoint-mqtt5-advanced.version>1.1.0-alpha.6</gravitee-endpoint-mqtt5-advanced.version>
 
                 <!-- Management API Only -->
                 <!-- Gateway Only -->


### PR DESCRIPTION
## Issue

N/A

## Description

bump advanced plugins to test their latest version
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-aabflzknyt.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/use-latest-advanced-plugins/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
