### PR TITLE
test: improve websocket integration tests

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/reactive/WebsocketBidirectionalJupiterIntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/reactive/WebsocketBidirectionalJupiterIntegrationTest.java
@@ -13,38 +13,43 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.gateway.tests.websocket.jupiter;
+package io.gravitee.gateway.tests.websocket.reactive;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.apim.gateway.tests.sdk.AbstractWebsocketGatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
-import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
 import io.vertx.junit5.VertxTestContext;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
-@GatewayTest
+@GatewayTest(mode = GatewayMode.JUPITER)
 @DeployApi({ "/apis/http/api.json" })
 public class WebsocketBidirectionalJupiterIntegrationTest extends AbstractWebsocketGatewayTest {
 
-    @Override
-    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
-        super.configureGateway(gatewayConfigurationBuilder);
-        gatewayConfigurationBuilder.jupiterModeEnabled(true).jupiterModeDefault("always");
-    }
-
     @Test
     public void websocket_bidirectional_request(VertxTestContext testContext) throws Throwable {
+        var serverConnected = testContext.checkpoint();
+        var serverMessageSent = testContext.checkpoint();
+        var serverMessageChecked = testContext.checkpoint();
+        var clientMessageSent = testContext.checkpoint();
+        var clientMessageChecked = testContext.checkpoint();
+
         httpServer
             .webSocketHandler(serverWebSocket -> {
+                serverConnected.flag();
                 serverWebSocket.exceptionHandler(testContext::failNow);
                 serverWebSocket.accept();
                 serverWebSocket.frameHandler(frame -> {
                     if (frame.isText()) {
                         testContext.verify(() -> assertThat(frame.textData()).isEqualTo("PING"));
-                        serverWebSocket.writeTextMessage("PONG");
+                        clientMessageChecked.flag();
+                        serverWebSocket
+                            .writeTextMessage("PONG")
+                            .doOnComplete(serverMessageSent::flag)
+                            .doOnError(testContext::failNow)
+                            .subscribe();
                     }
                 });
             })
@@ -58,19 +63,19 @@ public class WebsocketBidirectionalJupiterIntegrationTest extends AbstractWebsoc
                             webSocket.frameHandler(frame -> {
                                 if (frame.isText()) {
                                     testContext.verify(() -> assertThat(frame.textData()).isEqualTo("PONG"));
-                                    testContext.completeNow();
+                                    serverMessageChecked.flag();
                                 }
                             });
-                            webSocket.writeTextMessage("PING");
+                            webSocket
+                                .writeTextMessage("PING")
+                                .doOnComplete(clientMessageSent::flag)
+                                .doOnError(testContext::failNow)
+                                .subscribe();
                         },
                         testContext::failNow
                     )
             )
-            .subscribe();
-
-        testContext.awaitCompletion(10, TimeUnit.SECONDS);
-        if (testContext.failed()) {
-            throw testContext.causeOfFailure();
-        }
+            .test()
+            .await();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/reactive/WebsocketCloseJupiterIntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/reactive/WebsocketCloseJupiterIntegrationTest.java
@@ -23,34 +23,30 @@ import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.Test;
 
 @GatewayTest(mode = GatewayMode.JUPITER)
-@DeployApi({ "/apis/http/api.json" })
 public class WebsocketCloseJupiterIntegrationTest extends AbstractWebsocketGatewayTest {
 
     @Test
+    @DeployApi({ "/apis/http/api.json" })
     public void websocket_closed_request(VertxTestContext testContext) throws Throwable {
         var serverConnected = testContext.checkpoint();
         var serverClosed = testContext.checkpoint();
         var clientClosed = testContext.checkpoint();
 
-        httpServer
-            .webSocketHandler(serverWebSocket -> {
+        websocketServerHandler =
+            serverWebSocket -> {
                 serverConnected.flag();
                 serverWebSocket.exceptionHandler(testContext::failNow);
                 serverWebSocket.accept();
                 serverWebSocket.close().doOnComplete(serverClosed::flag).doOnError(testContext::failNow).subscribe();
+            };
+
+        httpClient
+            .webSocket("/test")
+            .doOnSuccess(webSocket -> {
+                webSocket.exceptionHandler(testContext::failNow);
+                webSocket.closeHandler(__ -> clientClosed.flag());
             })
-            .listen(websocketPort)
-            .map(httpServer ->
-                httpClient
-                    .webSocket("/test")
-                    .subscribe(
-                        webSocket -> {
-                            webSocket.exceptionHandler(testContext::failNow);
-                            webSocket.closeHandler(__ -> clientClosed.flag());
-                        },
-                        testContext::failNow
-                    )
-            )
+            .doOnError(testContext::failNow)
             .test()
             .await();
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/reactive/WebsocketPingFrameJupiterIntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/reactive/WebsocketPingFrameJupiterIntegrationTest.java
@@ -13,39 +13,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.gateway.tests.websocket.jupiter;
+package io.gravitee.gateway.tests.websocket.reactive;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.apim.gateway.tests.sdk.AbstractWebsocketGatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
-import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
 import io.vertx.junit5.VertxTestContext;
 import io.vertx.rxjava3.core.buffer.Buffer;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
-@GatewayTest
+@GatewayTest(mode = GatewayMode.JUPITER)
 @DeployApi({ "/apis/http/api.json" })
 public class WebsocketPingFrameJupiterIntegrationTest extends AbstractWebsocketGatewayTest {
 
-    @Override
-    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
-        super.configureGateway(gatewayConfigurationBuilder);
-        gatewayConfigurationBuilder.jupiterModeEnabled(true).jupiterModeDefault("always");
-    }
-
     @Test
     public void websocket_ping_request(VertxTestContext testContext) throws Throwable {
+        var serverConnected = testContext.checkpoint();
+        var pingReceived = testContext.checkpoint();
+        var pingSent = testContext.checkpoint();
+        var pongReceived = testContext.checkpoint();
+
         httpServer
             .webSocketHandler(serverWebSocket -> {
+                serverConnected.flag();
                 serverWebSocket.exceptionHandler(testContext::failNow);
                 serverWebSocket.accept();
                 serverWebSocket.frameHandler(frame -> {
                     if (frame.isPing()) {
                         testContext.verify(() -> assertThat(frame.textData()).isEqualTo("PING"));
-                        testContext.completeNow();
+                        pingReceived.flag();
                     }
                 });
             })
@@ -56,16 +55,17 @@ public class WebsocketPingFrameJupiterIntegrationTest extends AbstractWebsocketG
                     .subscribe(
                         webSocket -> {
                             webSocket.exceptionHandler(testContext::failNow);
-                            webSocket.writePing(Buffer.buffer("PING"));
+                            webSocket.pongHandler(buffer -> pongReceived.flag());
+                            webSocket
+                                .writePing(Buffer.buffer("PING"))
+                                .doOnComplete(pingSent::flag)
+                                .doOnError(testContext::failNow)
+                                .subscribe();
                         },
                         testContext::failNow
                     )
             )
-            .subscribe();
-
-        testContext.awaitCompletion(10, TimeUnit.SECONDS);
-        if (testContext.failed()) {
-            throw testContext.causeOfFailure();
-        }
+            .test()
+            .await();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3/WebsocketAcceptV3IntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3/WebsocketAcceptV3IntegrationTest.java
@@ -15,24 +15,11 @@
  */
 package io.gravitee.gateway.tests.websocket.v3;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import io.gravitee.apim.gateway.tests.sdk.AbstractWebsocketGatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
-import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
-import io.gravitee.gateway.tests.websocket.jupiter.WebsocketAcceptJupiterIntegrationTest;
-import io.vertx.junit5.VertxTestContext;
-import java.util.concurrent.TimeUnit;
-import org.junit.jupiter.api.Test;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
+import io.gravitee.gateway.tests.websocket.reactive.WebsocketAcceptJupiterIntegrationTest;
 
-@GatewayTest
+@GatewayTest(mode = GatewayMode.V3)
 @DeployApi({ "/apis/http/api.json" })
-public class WebsocketAcceptV3IntegrationTest extends WebsocketAcceptJupiterIntegrationTest {
-
-    @Override
-    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
-        super.configureGateway(gatewayConfigurationBuilder);
-        gatewayConfigurationBuilder.jupiterModeEnabled(false);
-    }
-}
+public class WebsocketAcceptV3IntegrationTest extends WebsocketAcceptJupiterIntegrationTest {}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3/WebsocketAcceptV3IntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3/WebsocketAcceptV3IntegrationTest.java
@@ -15,11 +15,9 @@
  */
 package io.gravitee.gateway.tests.websocket.v3;
 
-import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
 import io.gravitee.gateway.tests.websocket.reactive.WebsocketAcceptJupiterIntegrationTest;
 
 @GatewayTest(mode = GatewayMode.V3)
-@DeployApi({ "/apis/http/api.json" })
 public class WebsocketAcceptV3IntegrationTest extends WebsocketAcceptJupiterIntegrationTest {}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3/WebsocketBidirectionalV3IntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3/WebsocketBidirectionalV3IntegrationTest.java
@@ -15,25 +15,11 @@
  */
 package io.gravitee.gateway.tests.websocket.v3;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import io.gravitee.apim.gateway.tests.sdk.AbstractWebsocketGatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
-import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
-import io.gravitee.gateway.tests.websocket.jupiter.WebsocketAcceptJupiterIntegrationTest;
-import io.gravitee.gateway.tests.websocket.jupiter.WebsocketBidirectionalJupiterIntegrationTest;
-import io.vertx.junit5.VertxTestContext;
-import java.util.concurrent.TimeUnit;
-import org.junit.jupiter.api.Test;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
+import io.gravitee.gateway.tests.websocket.reactive.WebsocketBidirectionalJupiterIntegrationTest;
 
-@GatewayTest
+@GatewayTest(mode = GatewayMode.V3)
 @DeployApi({ "/apis/http/api.json" })
-public class WebsocketBidirectionalV3IntegrationTest extends WebsocketBidirectionalJupiterIntegrationTest {
-
-    @Override
-    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
-        super.configureGateway(gatewayConfigurationBuilder);
-        gatewayConfigurationBuilder.jupiterModeEnabled(false);
-    }
-}
+public class WebsocketBidirectionalV3IntegrationTest extends WebsocketBidirectionalJupiterIntegrationTest {}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3/WebsocketBidirectionalV3IntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3/WebsocketBidirectionalV3IntegrationTest.java
@@ -15,11 +15,9 @@
  */
 package io.gravitee.gateway.tests.websocket.v3;
 
-import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
 import io.gravitee.gateway.tests.websocket.reactive.WebsocketBidirectionalJupiterIntegrationTest;
 
 @GatewayTest(mode = GatewayMode.V3)
-@DeployApi({ "/apis/http/api.json" })
 public class WebsocketBidirectionalV3IntegrationTest extends WebsocketBidirectionalJupiterIntegrationTest {}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3/WebsocketCloseV3IntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3/WebsocketCloseV3IntegrationTest.java
@@ -15,14 +15,10 @@
  */
 package io.gravitee.gateway.tests.websocket.v3;
 
-import io.gravitee.apim.gateway.tests.sdk.AbstractWebsocketGatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
-import io.gravitee.gateway.tests.websocket.jupiter.WebsocketCloseJupiterIntegrationTest;
-import io.vertx.junit5.VertxTestContext;
-import java.util.concurrent.TimeUnit;
-import org.junit.jupiter.api.Test;
+import io.gravitee.gateway.tests.websocket.reactive.WebsocketCloseJupiterIntegrationTest;
 
 @GatewayTest
 @DeployApi({ "/apis/http/api.json" })

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3/WebsocketCloseV3IntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3/WebsocketCloseV3IntegrationTest.java
@@ -15,13 +15,11 @@
  */
 package io.gravitee.gateway.tests.websocket.v3;
 
-import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
 import io.gravitee.gateway.tests.websocket.reactive.WebsocketCloseJupiterIntegrationTest;
 
 @GatewayTest
-@DeployApi({ "/apis/http/api.json" })
 public class WebsocketCloseV3IntegrationTest extends WebsocketCloseJupiterIntegrationTest {
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3/WebsocketHeadersV3IntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3/WebsocketHeadersV3IntegrationTest.java
@@ -15,26 +15,11 @@
  */
 package io.gravitee.gateway.tests.websocket.v3;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import io.gravitee.apim.gateway.tests.sdk.AbstractWebsocketGatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
-import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
-import io.gravitee.gateway.tests.websocket.jupiter.WebsocketHeadersJupiterIntegrationTest;
-import io.vertx.core.MultiMap;
-import io.vertx.core.http.WebSocketConnectOptions;
-import io.vertx.junit5.VertxTestContext;
-import java.util.concurrent.TimeUnit;
-import org.junit.jupiter.api.Test;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
+import io.gravitee.gateway.tests.websocket.reactive.WebsocketHeadersJupiterIntegrationTest;
 
-@GatewayTest
+@GatewayTest(mode = GatewayMode.V3)
 @DeployApi({ "/apis/http/api.json" })
-public class WebsocketHeadersV3IntegrationTest extends WebsocketHeadersJupiterIntegrationTest {
-
-    @Override
-    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
-        super.configureGateway(gatewayConfigurationBuilder);
-        gatewayConfigurationBuilder.jupiterModeEnabled(false);
-    }
-}
+public class WebsocketHeadersV3IntegrationTest extends WebsocketHeadersJupiterIntegrationTest {}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3/WebsocketHeadersV3IntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3/WebsocketHeadersV3IntegrationTest.java
@@ -15,11 +15,9 @@
  */
 package io.gravitee.gateway.tests.websocket.v3;
 
-import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
 import io.gravitee.gateway.tests.websocket.reactive.WebsocketHeadersJupiterIntegrationTest;
 
 @GatewayTest(mode = GatewayMode.V3)
-@DeployApi({ "/apis/http/api.json" })
 public class WebsocketHeadersV3IntegrationTest extends WebsocketHeadersJupiterIntegrationTest {}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3/WebsocketPingFrameV3IntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3/WebsocketPingFrameV3IntegrationTest.java
@@ -15,25 +15,10 @@
  */
 package io.gravitee.gateway.tests.websocket.v3;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import io.gravitee.apim.gateway.tests.sdk.AbstractWebsocketGatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
-import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
-import io.gravitee.gateway.tests.websocket.jupiter.WebsocketPingFrameJupiterIntegrationTest;
-import io.vertx.junit5.VertxTestContext;
-import io.vertx.rxjava3.core.buffer.Buffer;
-import java.util.concurrent.TimeUnit;
-import org.junit.jupiter.api.Test;
+import io.gravitee.gateway.tests.websocket.reactive.WebsocketPingFrameJupiterIntegrationTest;
 
 @GatewayTest
 @DeployApi({ "/apis/http/api.json" })
-public class WebsocketPingFrameV3IntegrationTest extends WebsocketPingFrameJupiterIntegrationTest {
-
-    @Override
-    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
-        super.configureGateway(gatewayConfigurationBuilder);
-        gatewayConfigurationBuilder.jupiterModeEnabled(false);
-    }
-}
+public class WebsocketPingFrameV3IntegrationTest extends WebsocketPingFrameJupiterIntegrationTest {}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3/WebsocketPingFrameV3IntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3/WebsocketPingFrameV3IntegrationTest.java
@@ -15,10 +15,8 @@
  */
 package io.gravitee.gateway.tests.websocket.v3;
 
-import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.gateway.tests.websocket.reactive.WebsocketPingFrameJupiterIntegrationTest;
 
 @GatewayTest
-@DeployApi({ "/apis/http/api.json" })
 public class WebsocketPingFrameV3IntegrationTest extends WebsocketPingFrameJupiterIntegrationTest {}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3/WebsocketRejectV3IntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3/WebsocketRejectV3IntegrationTest.java
@@ -15,11 +15,9 @@
  */
 package io.gravitee.gateway.tests.websocket.v3;
 
-import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
 import io.gravitee.gateway.tests.websocket.reactive.WebsocketRejectJupiterIntegrationTest;
 
 @GatewayTest(mode = GatewayMode.V3)
-@DeployApi({ "/apis/http/api.json" })
 public class WebsocketRejectV3IntegrationTest extends WebsocketRejectJupiterIntegrationTest {}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3/WebsocketRejectV3IntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3/WebsocketRejectV3IntegrationTest.java
@@ -15,26 +15,11 @@
  */
 package io.gravitee.gateway.tests.websocket.v3;
 
-import static io.gravitee.common.http.HttpStatusCode.UNAUTHORIZED_401;
-import static org.assertj.core.api.Assertions.assertThat;
-
-import io.gravitee.apim.gateway.tests.sdk.AbstractWebsocketGatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
-import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
-import io.gravitee.gateway.tests.websocket.jupiter.WebsocketRejectJupiterIntegrationTest;
-import io.vertx.core.http.UpgradeRejectedException;
-import io.vertx.junit5.VertxTestContext;
-import java.util.concurrent.TimeUnit;
-import org.junit.jupiter.api.Test;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
+import io.gravitee.gateway.tests.websocket.reactive.WebsocketRejectJupiterIntegrationTest;
 
-@GatewayTest
+@GatewayTest(mode = GatewayMode.V3)
 @DeployApi({ "/apis/http/api.json" })
-public class WebsocketRejectV3IntegrationTest extends WebsocketRejectJupiterIntegrationTest {
-
-    @Override
-    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
-        super.configureGateway(gatewayConfigurationBuilder);
-        gatewayConfigurationBuilder.jupiterModeEnabled(false);
-    }
-}
+public class WebsocketRejectV3IntegrationTest extends WebsocketRejectJupiterIntegrationTest {}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3Compatibility/WebsocketAcceptV3CompatibilityIntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3Compatibility/WebsocketAcceptV3CompatibilityIntegrationTest.java
@@ -17,27 +17,9 @@ package io.gravitee.gateway.tests.websocket.v3Compatibility;
 
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
-import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
-import io.gravitee.definition.model.Api;
-import io.gravitee.definition.model.ExecutionMode;
-import io.gravitee.gateway.reactor.ReactableApi;
-import io.gravitee.gateway.tests.websocket.jupiter.WebsocketAcceptJupiterIntegrationTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
+import io.gravitee.gateway.tests.websocket.reactive.WebsocketAcceptJupiterIntegrationTest;
 
-@GatewayTest
+@GatewayTest(mode = GatewayMode.COMPATIBILITY)
 @DeployApi({ "/apis/http/api.json" })
-public class WebsocketAcceptV3CompatibilityIntegrationTest extends WebsocketAcceptJupiterIntegrationTest {
-
-    @Override
-    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
-        super.configureGateway(gatewayConfigurationBuilder);
-        gatewayConfigurationBuilder.jupiterModeEnabled(true);
-    }
-
-    public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
-        super.configureApi(api, definitionClass);
-        if (isLegacyApi(definitionClass)) {
-            final Api definition = (Api) api.getDefinition();
-            definition.setExecutionMode(ExecutionMode.V3);
-        }
-    }
-}
+public class WebsocketAcceptV3CompatibilityIntegrationTest extends WebsocketAcceptJupiterIntegrationTest {}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3Compatibility/WebsocketAcceptV3CompatibilityIntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3Compatibility/WebsocketAcceptV3CompatibilityIntegrationTest.java
@@ -15,11 +15,9 @@
  */
 package io.gravitee.gateway.tests.websocket.v3Compatibility;
 
-import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
 import io.gravitee.gateway.tests.websocket.reactive.WebsocketAcceptJupiterIntegrationTest;
 
 @GatewayTest(mode = GatewayMode.COMPATIBILITY)
-@DeployApi({ "/apis/http/api.json" })
 public class WebsocketAcceptV3CompatibilityIntegrationTest extends WebsocketAcceptJupiterIntegrationTest {}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3Compatibility/WebsocketBidirectionalV3CompatibilityIntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3Compatibility/WebsocketBidirectionalV3CompatibilityIntegrationTest.java
@@ -17,27 +17,9 @@ package io.gravitee.gateway.tests.websocket.v3Compatibility;
 
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
-import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
-import io.gravitee.definition.model.Api;
-import io.gravitee.definition.model.ExecutionMode;
-import io.gravitee.gateway.reactor.ReactableApi;
-import io.gravitee.gateway.tests.websocket.jupiter.WebsocketBidirectionalJupiterIntegrationTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
+import io.gravitee.gateway.tests.websocket.reactive.WebsocketBidirectionalJupiterIntegrationTest;
 
-@GatewayTest
+@GatewayTest(mode = GatewayMode.COMPATIBILITY)
 @DeployApi({ "/apis/http/api.json" })
-public class WebsocketBidirectionalV3CompatibilityIntegrationTest extends WebsocketBidirectionalJupiterIntegrationTest {
-
-    @Override
-    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
-        super.configureGateway(gatewayConfigurationBuilder);
-        gatewayConfigurationBuilder.jupiterModeEnabled(true);
-    }
-
-    public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
-        super.configureApi(api, definitionClass);
-        if (isLegacyApi(definitionClass)) {
-            final Api definition = (Api) api.getDefinition();
-            definition.setExecutionMode(ExecutionMode.V3);
-        }
-    }
-}
+public class WebsocketBidirectionalV3CompatibilityIntegrationTest extends WebsocketBidirectionalJupiterIntegrationTest {}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3Compatibility/WebsocketBidirectionalV3CompatibilityIntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3Compatibility/WebsocketBidirectionalV3CompatibilityIntegrationTest.java
@@ -15,11 +15,9 @@
  */
 package io.gravitee.gateway.tests.websocket.v3Compatibility;
 
-import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
 import io.gravitee.gateway.tests.websocket.reactive.WebsocketBidirectionalJupiterIntegrationTest;
 
 @GatewayTest(mode = GatewayMode.COMPATIBILITY)
-@DeployApi({ "/apis/http/api.json" })
 public class WebsocketBidirectionalV3CompatibilityIntegrationTest extends WebsocketBidirectionalJupiterIntegrationTest {}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3Compatibility/WebsocketCloseV3CompatibilityIntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3Compatibility/WebsocketCloseV3CompatibilityIntegrationTest.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.gateway.tests.websocket.v3Compatibility;
 
-import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
 import io.gravitee.definition.model.Api;
@@ -24,7 +23,6 @@ import io.gravitee.gateway.reactor.ReactableApi;
 import io.gravitee.gateway.tests.websocket.reactive.WebsocketCloseJupiterIntegrationTest;
 
 @GatewayTest
-@DeployApi({ "/apis/http/api.json" })
 public class WebsocketCloseV3CompatibilityIntegrationTest extends WebsocketCloseJupiterIntegrationTest {
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3Compatibility/WebsocketCloseV3CompatibilityIntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3Compatibility/WebsocketCloseV3CompatibilityIntegrationTest.java
@@ -21,7 +21,7 @@ import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuil
 import io.gravitee.definition.model.Api;
 import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.gateway.reactor.ReactableApi;
-import io.gravitee.gateway.tests.websocket.jupiter.WebsocketCloseJupiterIntegrationTest;
+import io.gravitee.gateway.tests.websocket.reactive.WebsocketCloseJupiterIntegrationTest;
 
 @GatewayTest
 @DeployApi({ "/apis/http/api.json" })

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3Compatibility/WebsocketHeadersV3CompatibilityIntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3Compatibility/WebsocketHeadersV3CompatibilityIntegrationTest.java
@@ -15,11 +15,9 @@
  */
 package io.gravitee.gateway.tests.websocket.v3Compatibility;
 
-import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
 import io.gravitee.gateway.tests.websocket.reactive.WebsocketHeadersJupiterIntegrationTest;
 
 @GatewayTest(mode = GatewayMode.COMPATIBILITY)
-@DeployApi({ "/apis/http/api.json" })
 public class WebsocketHeadersV3CompatibilityIntegrationTest extends WebsocketHeadersJupiterIntegrationTest {}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3Compatibility/WebsocketHeadersV3CompatibilityIntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3Compatibility/WebsocketHeadersV3CompatibilityIntegrationTest.java
@@ -17,27 +17,9 @@ package io.gravitee.gateway.tests.websocket.v3Compatibility;
 
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
-import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
-import io.gravitee.definition.model.Api;
-import io.gravitee.definition.model.ExecutionMode;
-import io.gravitee.gateway.reactor.ReactableApi;
-import io.gravitee.gateway.tests.websocket.jupiter.WebsocketHeadersJupiterIntegrationTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
+import io.gravitee.gateway.tests.websocket.reactive.WebsocketHeadersJupiterIntegrationTest;
 
-@GatewayTest
+@GatewayTest(mode = GatewayMode.COMPATIBILITY)
 @DeployApi({ "/apis/http/api.json" })
-public class WebsocketHeadersV3CompatibilityIntegrationTest extends WebsocketHeadersJupiterIntegrationTest {
-
-    @Override
-    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
-        super.configureGateway(gatewayConfigurationBuilder);
-        gatewayConfigurationBuilder.jupiterModeEnabled(true);
-    }
-
-    public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
-        super.configureApi(api, definitionClass);
-        if (isLegacyApi(definitionClass)) {
-            final Api definition = (Api) api.getDefinition();
-            definition.setExecutionMode(ExecutionMode.V3);
-        }
-    }
-}
+public class WebsocketHeadersV3CompatibilityIntegrationTest extends WebsocketHeadersJupiterIntegrationTest {}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3Compatibility/WebsocketPingFrameV3CompatibilityIntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3Compatibility/WebsocketPingFrameV3CompatibilityIntegrationTest.java
@@ -17,27 +17,9 @@ package io.gravitee.gateway.tests.websocket.v3Compatibility;
 
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
-import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
-import io.gravitee.definition.model.Api;
-import io.gravitee.definition.model.ExecutionMode;
-import io.gravitee.gateway.reactor.ReactableApi;
-import io.gravitee.gateway.tests.websocket.jupiter.WebsocketPingFrameJupiterIntegrationTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
+import io.gravitee.gateway.tests.websocket.reactive.WebsocketPingFrameJupiterIntegrationTest;
 
-@GatewayTest
+@GatewayTest(mode = GatewayMode.COMPATIBILITY)
 @DeployApi({ "/apis/http/api.json" })
-public class WebsocketPingFrameV3CompatibilityIntegrationTest extends WebsocketPingFrameJupiterIntegrationTest {
-
-    @Override
-    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
-        super.configureGateway(gatewayConfigurationBuilder);
-        gatewayConfigurationBuilder.jupiterModeEnabled(true);
-    }
-
-    public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
-        super.configureApi(api, definitionClass);
-        if (isLegacyApi(definitionClass)) {
-            final Api definition = (Api) api.getDefinition();
-            definition.setExecutionMode(ExecutionMode.V3);
-        }
-    }
-}
+public class WebsocketPingFrameV3CompatibilityIntegrationTest extends WebsocketPingFrameJupiterIntegrationTest {}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3Compatibility/WebsocketPingFrameV3CompatibilityIntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3Compatibility/WebsocketPingFrameV3CompatibilityIntegrationTest.java
@@ -15,11 +15,9 @@
  */
 package io.gravitee.gateway.tests.websocket.v3Compatibility;
 
-import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
 import io.gravitee.gateway.tests.websocket.reactive.WebsocketPingFrameJupiterIntegrationTest;
 
 @GatewayTest(mode = GatewayMode.COMPATIBILITY)
-@DeployApi({ "/apis/http/api.json" })
 public class WebsocketPingFrameV3CompatibilityIntegrationTest extends WebsocketPingFrameJupiterIntegrationTest {}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3Compatibility/WebsocketRejectV3CompatibilityIntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3Compatibility/WebsocketRejectV3CompatibilityIntegrationTest.java
@@ -17,27 +17,9 @@ package io.gravitee.gateway.tests.websocket.v3Compatibility;
 
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
-import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
-import io.gravitee.definition.model.Api;
-import io.gravitee.definition.model.ExecutionMode;
-import io.gravitee.gateway.reactor.ReactableApi;
-import io.gravitee.gateway.tests.websocket.jupiter.WebsocketRejectJupiterIntegrationTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
+import io.gravitee.gateway.tests.websocket.reactive.WebsocketRejectJupiterIntegrationTest;
 
-@GatewayTest
+@GatewayTest(mode = GatewayMode.COMPATIBILITY)
 @DeployApi({ "/apis/http/api.json" })
-public class WebsocketRejectV3CompatibilityIntegrationTest extends WebsocketRejectJupiterIntegrationTest {
-
-    @Override
-    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
-        super.configureGateway(gatewayConfigurationBuilder);
-        gatewayConfigurationBuilder.jupiterModeEnabled(true);
-    }
-
-    public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
-        super.configureApi(api, definitionClass);
-        if (isLegacyApi(definitionClass)) {
-            final Api definition = (Api) api.getDefinition();
-            definition.setExecutionMode(ExecutionMode.V3);
-        }
-    }
-}
+public class WebsocketRejectV3CompatibilityIntegrationTest extends WebsocketRejectJupiterIntegrationTest {}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3Compatibility/WebsocketRejectV3CompatibilityIntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v3Compatibility/WebsocketRejectV3CompatibilityIntegrationTest.java
@@ -15,11 +15,9 @@
  */
 package io.gravitee.gateway.tests.websocket.v3Compatibility;
 
-import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
 import io.gravitee.gateway.tests.websocket.reactive.WebsocketRejectJupiterIntegrationTest;
 
 @GatewayTest(mode = GatewayMode.COMPATIBILITY)
-@DeployApi({ "/apis/http/api.json" })
 public class WebsocketRejectV3CompatibilityIntegrationTest extends WebsocketRejectJupiterIntegrationTest {}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v4/WebsocketBidirectionalTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v4/WebsocketBidirectionalTest.java
@@ -23,10 +23,10 @@ import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.Test;
 
 @GatewayTest
-@DeployApi({ "/apis/v4/http/api.json" })
 public class WebsocketBidirectionalTest extends AbstractWebsocketV4GatewayTest {
 
     @Test
+    @DeployApi({ "/apis/v4/http/api.json" })
     public void websocket_bidirectional_request(VertxTestContext testContext) throws Throwable {
         var serverConnected = testContext.checkpoint();
         var serverMessageSent = testContext.checkpoint();
@@ -34,8 +34,8 @@ public class WebsocketBidirectionalTest extends AbstractWebsocketV4GatewayTest {
         var clientMessageSent = testContext.checkpoint();
         var clientMessageChecked = testContext.checkpoint();
 
-        httpServer
-            .webSocketHandler(serverWebSocket -> {
+        websocketServerHandler =
+            serverWebSocket -> {
                 serverConnected.flag();
                 serverWebSocket.exceptionHandler(testContext::failNow);
                 serverWebSocket.accept();
@@ -50,29 +50,21 @@ public class WebsocketBidirectionalTest extends AbstractWebsocketV4GatewayTest {
                             .subscribe();
                     }
                 });
+            };
+
+        httpClient
+            .webSocket("/test")
+            .doOnSuccess(webSocket -> {
+                webSocket.exceptionHandler(testContext::failNow);
+                webSocket.frameHandler(frame -> {
+                    if (frame.isText()) {
+                        testContext.verify(() -> assertThat(frame.textData()).isEqualTo("PONG"));
+                        serverMessageChecked.flag();
+                    }
+                });
+                webSocket.writeTextMessage("PING").doOnComplete(clientMessageSent::flag).doOnError(testContext::failNow).subscribe();
             })
-            .listen(websocketPort)
-            .map(httpServer ->
-                httpClient
-                    .webSocket("/test")
-                    .subscribe(
-                        webSocket -> {
-                            webSocket.exceptionHandler(testContext::failNow);
-                            webSocket.frameHandler(frame -> {
-                                if (frame.isText()) {
-                                    testContext.verify(() -> assertThat(frame.textData()).isEqualTo("PONG"));
-                                    serverMessageChecked.flag();
-                                }
-                            });
-                            webSocket
-                                .writeTextMessage("PING")
-                                .doOnComplete(clientMessageSent::flag)
-                                .doOnError(testContext::failNow)
-                                .subscribe();
-                        },
-                        testContext::failNow
-                    )
-            )
+            .doOnError(testContext::failNow)
             .test()
             .await();
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v4/WebsocketPingFrameTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v4/WebsocketPingFrameTest.java
@@ -24,45 +24,39 @@ import io.vertx.rxjava3.core.buffer.Buffer;
 import org.junit.jupiter.api.Test;
 
 @GatewayTest
-@DeployApi({ "/apis/v4/http/api.json" })
 public class WebsocketPingFrameTest extends AbstractWebsocketV4GatewayTest {
 
     @Test
+    @DeployApi({ "/apis/v4/http/api.json" })
     public void websocket_ping_request(VertxTestContext testContext) throws Throwable {
         var serverConnected = testContext.checkpoint();
         var pingReceived = testContext.checkpoint();
         var pingSent = testContext.checkpoint();
         var pongReceived = testContext.checkpoint();
 
-        httpServer
-            .webSocketHandler(serverWebSocket -> {
-                serverConnected.flag();
-                serverWebSocket.exceptionHandler(testContext::failNow);
-                serverWebSocket.accept();
-                serverWebSocket.frameHandler(frame -> {
-                    if (frame.isPing()) {
-                        testContext.verify(() -> assertThat(frame.textData()).isEqualTo("PING"));
-                        pingReceived.flag();
-                    }
-                });
+        websocketServerHandler =
+            (
+                serverWebSocket -> {
+                    serverConnected.flag();
+                    serverWebSocket.exceptionHandler(testContext::failNow);
+                    serverWebSocket.accept();
+                    serverWebSocket.frameHandler(frame -> {
+                        if (frame.isPing()) {
+                            testContext.verify(() -> assertThat(frame.textData()).isEqualTo("PING"));
+                            pingReceived.flag();
+                        }
+                    });
+                }
+            );
+
+        httpClient
+            .webSocket("/test")
+            .doOnSuccess(webSocket -> {
+                webSocket.exceptionHandler(testContext::failNow);
+                webSocket.pongHandler(buffer -> pongReceived.flag());
+                webSocket.writePing(Buffer.buffer("PING")).doOnComplete(pingSent::flag).doOnError(testContext::failNow).subscribe();
             })
-            .listen(websocketPort)
-            .map(httpServer ->
-                httpClient
-                    .webSocket("/test")
-                    .subscribe(
-                        webSocket -> {
-                            webSocket.exceptionHandler(testContext::failNow);
-                            webSocket.pongHandler(buffer -> pongReceived.flag());
-                            webSocket
-                                .writePing(Buffer.buffer("PING"))
-                                .doOnComplete(pingSent::flag)
-                                .doOnError(testContext::failNow)
-                                .subscribe();
-                        },
-                        testContext::failNow
-                    )
-            )
+            .doOnError(testContext::failNow)
             .test()
             .await();
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v4/WebsocketRejectTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v4/WebsocketRejectTest.java
@@ -25,30 +25,22 @@ import io.vertx.junit5.VertxTestContext;
 import org.junit.jupiter.api.Test;
 
 @GatewayTest
-@DeployApi({ "/apis/v4/http/api.json" })
 public class WebsocketRejectTest extends AbstractWebsocketV4GatewayTest {
 
     @Test
+    @DeployApi({ "/apis/v4/http/api.json" })
     public void websocket_rejected_request(VertxTestContext testContext) throws Throwable {
-        httpServer
-            .webSocketHandler(webSocket -> webSocket.reject(UNAUTHORIZED_401))
-            .listen(websocketPort)
-            .map(httpServer ->
-                httpClient
-                    .webSocket("/test")
-                    .subscribe(
-                        webSocket -> testContext.failNow("Websocket connection should not succeed"),
-                        error -> {
-                            testContext.verify(() ->
-                                assertThat(error)
-                                    .isInstanceOf(UpgradeRejectedException.class)
-                                    .extracting("status")
-                                    .isEqualTo(UNAUTHORIZED_401)
-                            );
-                            testContext.completeNow();
-                        }
-                    )
-            )
+        websocketServerHandler = (webSocket -> webSocket.reject(UNAUTHORIZED_401));
+
+        httpClient
+            .webSocket("/test")
+            .doOnSuccess(webSocket -> testContext.failNow("Websocket connection should not succeed"))
+            .doOnError(error -> {
+                testContext.verify(() ->
+                    assertThat(error).isInstanceOf(UpgradeRejectedException.class).extracting("status").isEqualTo(UNAUTHORIZED_401)
+                );
+                testContext.completeNow();
+            })
             .test()
             .await();
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v4/WebsocketRejectTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/websocket/v4/WebsocketRejectTest.java
@@ -18,12 +18,10 @@ package io.gravitee.gateway.tests.websocket.v4;
 import static io.gravitee.common.http.HttpStatusCode.UNAUTHORIZED_401;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.gravitee.apim.gateway.tests.sdk.AbstractWebsocketGatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.vertx.core.http.UpgradeRejectedException;
 import io.vertx.junit5.VertxTestContext;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 @GatewayTest
@@ -39,22 +37,19 @@ public class WebsocketRejectTest extends AbstractWebsocketV4GatewayTest {
                 httpClient
                     .webSocket("/test")
                     .subscribe(
-                        webSocket -> {
-                            testContext.failNow("Websocket connection should not succeed");
-                        },
+                        webSocket -> testContext.failNow("Websocket connection should not succeed"),
                         error -> {
-                            testContext.verify(() -> assertThat(error.getClass()).isEqualTo(UpgradeRejectedException.class));
-                            testContext.verify(() -> assertThat(((UpgradeRejectedException) error).getStatus()).isEqualTo(UNAUTHORIZED_401)
+                            testContext.verify(() ->
+                                assertThat(error)
+                                    .isInstanceOf(UpgradeRejectedException.class)
+                                    .extracting("status")
+                                    .isEqualTo(UNAUTHORIZED_401)
                             );
                             testContext.completeNow();
                         }
                     )
             )
-            .subscribe();
-
-        testContext.awaitCompletion(10, TimeUnit.SECONDS);
-        if (testContext.failed()) {
-            throw testContext.causeOfFailure();
-        }
+            .test()
+            .await();
     }
 }


### PR DESCRIPTION
## Issue

## Description

I've updated the websocket integration tests with the following:
- add checkpoints to check all the steps
- remove explicit check of the test context. This is already done by the Vertx extension
- use the new mode attribute of GatewayTest annotation
- 
## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-iscfrkvblt.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/refactor-websocket-it/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
