### PR TITLE
refactor(api-v4): add environments + envId to all api resources

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/java/io/gravitee/rest/api/management/v4/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/java/io/gravitee/rest/api/management/v4/rest/resource/api/ApiResource.java
@@ -40,6 +40,7 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
 import io.gravitee.rest.api.service.v4.ApiStateService;
+import io.swagger.v3.oas.annotations.Parameter;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -69,7 +70,6 @@ import javax.ws.rs.core.UriBuilder;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Path("/apis/{apiId}")
 public class ApiResource extends AbstractResource {
 
     @Context
@@ -82,6 +82,7 @@ public class ApiResource extends AbstractResource {
     private ApiStateService apiStateService;
 
     @PathParam("apiId")
+    @Parameter(name = "apiId", required = true, description = "The ID of the API")
     private String apiId;
 
     @GET

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/java/io/gravitee/rest/api/management/v4/rest/resource/api/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/java/io/gravitee/rest/api/management/v4/rest/resource/api/ApisResource.java
@@ -55,4 +55,9 @@ public class ApisResource extends AbstractResource {
         ApiEntity newApi = apiServiceV4.create(GraviteeContext.getExecutionContext(), newApiEntity, getAuthenticatedUser());
         return Response.created(this.getLocationHeader(newApi.getId())).entity(ApiMapper.INSTANCE.convert(newApi)).build();
     }
+
+    @Path("{apiId}")
+    public ApiResource getApiResource() {
+        return resourceContext.getResource(ApiResource.class);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/java/io/gravitee/rest/api/management/v4/rest/resource/installation/EnvironmentResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/java/io/gravitee/rest/api/management/v4/rest/resource/installation/EnvironmentResource.java
@@ -20,35 +20,17 @@ import io.gravitee.rest.api.management.v4.rest.mapper.EnvironmentMapper;
 import io.gravitee.rest.api.management.v4.rest.model.Environment;
 import io.gravitee.rest.api.management.v4.rest.resource.AbstractResource;
 import io.gravitee.rest.api.management.v4.rest.resource.api.ApisResource;
-import io.gravitee.rest.api.management.v4.rest.security.Permission;
-import io.gravitee.rest.api.management.v4.rest.security.Permissions;
-import io.gravitee.rest.api.model.permissions.RolePermission;
-import io.gravitee.rest.api.model.permissions.RolePermissionAction;
-import io.gravitee.rest.api.model.v4.api.ApiEntity;
-import io.gravitee.rest.api.model.v4.api.NewApiEntity;
 import io.gravitee.rest.api.service.EnvironmentService;
-import io.gravitee.rest.api.service.common.GraviteeContext;
-import java.util.Collection;
+import io.swagger.v3.oas.annotations.Parameter;
 import javax.inject.Inject;
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
 import javax.ws.rs.container.ResourceContext;
 import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Response;
 
-/**
- * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
- * @author GraviteeSource Team
- */
-@Path("/environments")
-public class EnvironmentsResource extends AbstractResource {
+public class EnvironmentResource extends AbstractResource {
 
     @Context
     private ResourceContext resourceContext;
@@ -56,16 +38,18 @@ public class EnvironmentsResource extends AbstractResource {
     @Inject
     private EnvironmentService environmentService;
 
+    @PathParam("envId")
+    @Parameter(name = "envId", required = true, description = "The environment ID")
+    private String envId;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public Collection<Environment> getEnvironments() {
-        //FIXME: get user's organization
-        String organizationId = GraviteeContext.getCurrentOrganization();
-        return EnvironmentMapper.INSTANCE.convertCollection(this.environmentService.findByOrganization(organizationId));
+    public Environment getEnvironment() {
+        return EnvironmentMapper.INSTANCE.convert(environmentService.findById(envId));
     }
 
-    @Path("{envId}")
-    public EnvironmentResource getEnvironmentResource() {
-        return resourceContext.getResource(EnvironmentResource.class);
+    @Path("/apis")
+    public ApisResource getApisResource() {
+        return resourceContext.getResource(ApisResource.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/resources/management-openapi-v4.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/main/resources/management-openapi-v4.yaml
@@ -122,8 +122,9 @@ paths:
                                 $ref: "#/components/schemas/Api"
                 default:
                     $ref: "#/components/responses/Error"
-    /apis/{apiId}:
+    /environments/{envId}/apis/{apiId}:
         parameters:
+            - $ref: "#/components/parameters/envIdParam"
             - $ref: "#/components/parameters/apiIdParam"
         get:
             tags:
@@ -182,8 +183,9 @@ paths:
                     description: API successfully deleted
                 default:
                     $ref: "#/components/responses/Error"
-    /apis/{apiId}/_start:
+    /environments/{envId}/apis/{apiId}/_start:
         parameters:
+            - $ref: "#/components/parameters/envIdParam"
             - $ref: "#/components/parameters/apiIdParam"
         post:
             tags:
@@ -197,7 +199,7 @@ paths:
                     description: API successfully started
                 default:
                     $ref: "#/components/responses/Error"
-    /apis/{apiId}/_stop:
+    /environments/{envId}/apis/{apiId}/_stop:
         parameters:
             - $ref: "#/components/parameters/apiIdParam"
         post:
@@ -212,8 +214,9 @@ paths:
                     description: API successfully stopped
                 default:
                     $ref: "#/components/responses/Error"
-    /apis/{apiId}/deployments:
+    /environments/{envId}/apis/{apiId}/deployments:
         parameters:
+            - $ref: "#/components/parameters/envIdParam"
             - $ref: "#/components/parameters/apiIdParam"
         post:
             tags:
@@ -236,8 +239,9 @@ paths:
                                 $ref: "#/components/schemas/ApiDeployment"
                 default:
                     $ref: "#/components/responses/Error"
-    /apis/{apiId}/plans:
+    /environments/{envId}/apis/{apiId}/plans:
         parameters:
+            - $ref: "#/components/parameters/envIdParam"
             - $ref: "#/components/parameters/apiIdParam"
         get:
             parameters:
@@ -299,8 +303,9 @@ paths:
                 default:
                     $ref: "#/components/responses/Error"
 
-    /apis/{apiId}/plans/{planId}:
+    /environments/{envId}/apis/{apiId}/plans/{planId}:
         parameters:
+            - $ref: "#/components/parameters/envIdParam"
             - $ref: "#/components/parameters/apiIdParam"
             - $ref: "#/components/parameters/planIdParam"
         get:
@@ -351,8 +356,9 @@ paths:
                 default:
                     $ref: "#/components/responses/Error"
 
-    /apis/{apiId}/plans/{planId}/_close:
+    /environments/{envId}/apis/{apiId}/plans/{planId}/_close:
         parameters:
+            - $ref: "#/components/parameters/envIdParam"
             - $ref: "#/components/parameters/apiIdParam"
             - $ref: "#/components/parameters/planIdParam"
         post:
@@ -372,8 +378,9 @@ paths:
                                 $ref: "#/components/schemas/Plan"
                 default:
                     $ref: "#/components/responses/Error"
-    /apis/{apiId}/plans/{planId}/_publish:
+    /environments/{envId}/apis/{apiId}/plans/{planId}/_publish:
         parameters:
+            - $ref: "#/components/parameters/envIdParam"
             - $ref: "#/components/parameters/apiIdParam"
             - $ref: "#/components/parameters/planIdParam"
         post:
@@ -393,8 +400,9 @@ paths:
                                 $ref: "#/components/schemas/Plan"
                 default:
                     $ref: "#/components/responses/Error"
-    /apis/{apiId}/plans/{planId}/_deprecate:
+    /environments/{envId}/apis/{apiId}/plans/{planId}/_deprecate:
         parameters:
+            - $ref: "#/components/parameters/envIdParam"
             - $ref: "#/components/parameters/apiIdParam"
             - $ref: "#/components/parameters/planIdParam"
         post:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/test/java/io/gravitee/rest/api/management/v4/rest/resource/api/ApiPlansResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/test/java/io/gravitee/rest/api/management/v4/rest/resource/api/ApiPlansResourceTest.java
@@ -56,7 +56,7 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
 
     @Override
     protected String contextPath() {
-        return "apis";
+        return "environments/" + ENVIRONMENT + "/apis";
     }
 
     @Before

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/test/java/io/gravitee/rest/api/management/v4/rest/resource/api/ApiResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/test/java/io/gravitee/rest/api/management/v4/rest/resource/api/ApiResourceTest.java
@@ -95,7 +95,7 @@ public class ApiResourceTest extends AbstractResourceTest {
 
     @Override
     protected String contextPath() {
-        return "/apis";
+        return "/environments/" + ENVIRONMENT + "/apis";
     }
 
     @Before
@@ -391,8 +391,8 @@ public class ApiResourceTest extends AbstractResourceTest {
     }
 
     @Test
-    public void shouldNotDeleteApiBecauseNotfound() throws TechnicalException {
-        doThrow(ApiNotFoundException.class).when(apiRepository).findById(UNKNOWN_API);
+    public void shouldNotDeleteApiBecauseNotfound() {
+        doThrow(ApiNotFoundException.class).when(apiServiceV4).delete(GraviteeContext.getExecutionContext(), UNKNOWN_API, false);
 
         final Response response = rootTarget(UNKNOWN_API).request().delete();
         assertEquals(NOT_FOUND_404, response.getStatus());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/test/java/io/gravitee/rest/api/management/v4/rest/resource/api/ApisResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/test/java/io/gravitee/rest/api/management/v4/rest/resource/api/ApisResourceTest.java
@@ -49,7 +49,7 @@ public class ApisResourceTest extends AbstractResourceTest {
 
     @Override
     protected String contextPath() {
-        return "/environments";
+        return "/environments/" + FAKE_ENVIRONMENT_ID;
     }
 
     @Before
@@ -67,7 +67,7 @@ public class ApisResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldNotCreateApiWithNoContent() {
-        final Response response = rootTarget(FAKE_ENVIRONMENT_ID).path("/apis").request().post(null);
+        final Response response = rootTarget().path("/apis").request().post(null);
         assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
     }
 
@@ -84,7 +84,7 @@ public class ApisResourceTest extends AbstractResourceTest {
             .when(apiServiceV4)
             .create(eq(GraviteeContext.getExecutionContext()), Mockito.any(NewApiEntity.class), Mockito.eq(USER_NAME));
 
-        final Response response = rootTarget(FAKE_ENVIRONMENT_ID).path("/apis").request().post(Entity.json(apiEntity));
+        final Response response = rootTarget().path("/apis").request().post(Entity.json(apiEntity));
         assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
     }
 
@@ -101,7 +101,7 @@ public class ApisResourceTest extends AbstractResourceTest {
             .when(apiServiceV4)
             .create(eq(GraviteeContext.getExecutionContext()), Mockito.any(NewApiEntity.class), Mockito.eq(USER_NAME));
 
-        final Response response = rootTarget(FAKE_ENVIRONMENT_ID).path("/apis").request().post(Entity.json(apiEntity));
+        final Response response = rootTarget().path("/apis").request().post(Entity.json(apiEntity));
         assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
     }
 
@@ -124,7 +124,7 @@ public class ApisResourceTest extends AbstractResourceTest {
             .when(apiServiceV4)
             .create(eq(GraviteeContext.getExecutionContext()), Mockito.any(NewApiEntity.class), Mockito.eq(USER_NAME));
 
-        final Response response = rootTarget(FAKE_ENVIRONMENT_ID).path("/apis").request().post(Entity.json(apiEntity));
+        final Response response = rootTarget().path("/apis").request().post(Entity.json(apiEntity));
         assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
     }
 
@@ -148,7 +148,7 @@ public class ApisResourceTest extends AbstractResourceTest {
 
         when(apiServiceV4.create(eq(GraviteeContext.getExecutionContext()), Mockito.any(NewApiEntity.class), Mockito.eq(USER_NAME)))
             .thenThrow(new TechnicalManagementException());
-        final Response response = rootTarget(FAKE_ENVIRONMENT_ID).path("/apis").request().post(Entity.json(apiEntity));
+        final Response response = rootTarget().path("/apis").request().post(Entity.json(apiEntity));
         assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
     }
 
@@ -172,7 +172,7 @@ public class ApisResourceTest extends AbstractResourceTest {
         endpoint.setType("http");
         apiEntity.setEndpointGroups(List.of(endpoint));
 
-        final Response response = rootTarget(FAKE_ENVIRONMENT_ID).path("/apis").request().post(Entity.json(apiEntity));
+        final Response response = rootTarget().path("/apis").request().post(Entity.json(apiEntity));
         assertEquals(HttpStatusCode.NOT_FOUND_404, response.getStatus());
     }
 
@@ -203,10 +203,10 @@ public class ApisResourceTest extends AbstractResourceTest {
             .when(apiServiceV4)
             .create(eq(GraviteeContext.getExecutionContext()), Mockito.any(NewApiEntity.class), Mockito.eq(USER_NAME));
 
-        final Response response = rootTarget(FAKE_ENVIRONMENT_ID).path("/apis").request().post(Entity.json(apiEntity));
+        final Response response = rootTarget().path("/apis").request().post(Entity.json(apiEntity));
         assertEquals(HttpStatusCode.CREATED_201, response.getStatus());
         assertEquals(
-            rootTarget(FAKE_ENVIRONMENT_ID).path("/apis").path("my-beautiful-api").getUri().toString(),
+            rootTarget().path("/apis").path("my-beautiful-api").getUri().toString(),
             response.getHeaders().getFirst(HttpHeaders.LOCATION)
         );
     }
@@ -242,7 +242,7 @@ public class ApisResourceTest extends AbstractResourceTest {
         )
             .thenReturn(false);
 
-        final Response response = rootTarget(FAKE_ENVIRONMENT_ID).path("/apis").request().post(Entity.json(apiEntity));
+        final Response response = rootTarget().path("/apis").request().post(Entity.json(apiEntity));
         assertEquals(HttpStatusCode.FORBIDDEN_403, response.getStatus());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/test/java/io/gravitee/rest/api/management/v4/rest/resource/installation/EnvironmentResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v4/gravitee-apim-rest-api-management-v4-rest/src/test/java/io/gravitee/rest/api/management/v4/rest/resource/installation/EnvironmentResourceTest.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v4.rest.resource.installation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+
+import io.gravitee.rest.api.management.v4.rest.model.Environment;
+import io.gravitee.rest.api.management.v4.rest.model.ErrorEntity;
+import io.gravitee.rest.api.management.v4.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.EnvironmentNotFoundException;
+import java.util.List;
+import javax.ws.rs.core.Response;
+import org.junit.Before;
+import org.junit.Test;
+
+public class EnvironmentResourceTest extends AbstractResourceTest {
+
+    public static final String FAKE_ENVIRONMENT_ID = "fake-environment";
+
+    @Override
+    protected String contextPath() {
+        return "/environments";
+    }
+
+    @Before
+    public void init() {
+        GraviteeContext.cleanContext();
+        GraviteeContext.setCurrentEnvironment(FAKE_ENVIRONMENT_ID);
+    }
+
+    @Test
+    public void shouldReturnEnvironmentWithId() {
+        EnvironmentEntity env = new EnvironmentEntity();
+        env.setId("my-env-id");
+        env.setName("env-name");
+        env.setOrganizationId("DEFAULT");
+        env.setDescription("A nice description");
+        env.setHrids(List.of("hrid-1"));
+        env.setCockpitId("cockpit-id");
+        env.setDomainRestrictions(List.of("restriction-1"));
+
+        doReturn(env).when(environmentService).findById(eq("my-env-id"));
+
+        final Response response = rootTarget("my-env-id").request().get();
+        assertEquals(200, response.getStatus());
+
+        Environment body = response.readEntity(Environment.class);
+        assertNotNull(body);
+        assertEquals("my-env-id", body.getId());
+        assertEquals("env-name", body.getName());
+        assertEquals("A nice description", body.getDescription());
+    }
+
+    @Test
+    public void shouldReturn404WhenEnvNotFound() {
+        EnvironmentEntity env = new EnvironmentEntity();
+        env.setId("my-env-id");
+
+        doThrow(new EnvironmentNotFoundException("my-env-id")).when(environmentService).findById(eq("my-env-id"));
+
+        final Response response = rootTarget("my-env-id").request().get();
+        assertEquals(404, response.getStatus());
+
+        var body = response.readEntity(ErrorEntity.class);
+        assertNotNull(body);
+        assertEquals(404, body.getHttpStatus());
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

- For API resources, have `/environments/{envId}` at the root
- Create EnvironmentsResource 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qtekxdurzi.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/refactor-v4/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
