### PR TITLE
Exclude Flow Ids from API Sync check

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ts
@@ -431,13 +431,14 @@ class ApiHistoryController {
     delete payload.path_mappings;
     delete payload.tags;
     delete payload.workflow_state;
-    delete payload.response_templates;
+    delete payload.crossId;
+
+    if (payload.response_templates && _.isEmpty(payload.response_templates)) {
+      delete payload.response_templates;
+    }
 
     if (payload.flows && _.isEmpty(payload.flows)) {
       delete payload.flows;
-    }
-    if (payload.plans && _.isEmpty(payload.plans)) {
-      delete payload.plans;
     }
     if (payload.resources && _.isEmpty(payload.resources)) {
       delete payload.resources;
@@ -446,8 +447,9 @@ class ApiHistoryController {
       delete payload.services;
     }
 
-    if (payload.plans) {
-      _.forEach(payload.plans, (plan) => {
+    payload.plans = (payload.plans ?? [])
+      .filter((plan) => plan.status !== 'CLOSED')
+      .map((plan) => {
         delete plan.characteristics;
         delete plan.comment_message;
         delete plan.comment_required;
@@ -463,8 +465,9 @@ class ApiHistoryController {
         delete plan.updated_at;
         delete plan.closed_at;
         delete plan.validation;
-      });
-    }
+        return plan;
+      })
+      .sort((plan) => plan.id);
 
     return JSON.stringify({ definition: JSON.stringify(payload) });
   }
@@ -496,7 +499,7 @@ class ApiHistoryController {
       tags: eventPayloadDefinition.tags,
       proxy: eventPayloadDefinition.proxy,
       paths: eventPayloadDefinition.paths,
-      plans: eventPayloadDefinition.plans,
+      plans: (eventPayloadDefinition.plans ?? []).sort((plan) => plan.id),
       flows: eventPayloadDefinition.flows,
       properties: eventPayloadDefinition.properties,
       services: eventPayloadDefinition.services,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -2160,6 +2160,13 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                     removeDescriptionFromPolicies(api);
                     removeDescriptionFromPolicies(deployedApi);
 
+                    // FIXME: Dirty hack due to ec1abe6c8560ff5da7284191ff72e4e54b7630e3, after this change the
+                    //  payloadEntity doesn't contain the flow ids yet as there were no upgrader to update the last
+                    //  publish_api event. So we need to remove the flow ids before comparing the deployed API and the
+                    //  current one.
+                    removeIdsFromFlows(api);
+                    removeIdsFromFlows(deployedApi);
+
                     sync = apiSynchronizationProcessor.processCheckSynchronization(deployedApi, api);
 
                     // 2_ If API definition is synchronized, check if there is any modification for API's plans
@@ -2182,6 +2189,11 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         }
 
         return false;
+    }
+
+    private void removeIdsFromFlows(ApiEntity api) {
+        api.getFlows().forEach(flow -> flow.setId(null));
+        api.getPlans().forEach(plan -> plan.getFlows().forEach(flow -> flow.setId(null)));
     }
 
     private void removeDescriptionFromPolicies(final ApiEntity api) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1147
https://github.com/gravitee-io/issues/issues/8954

## Description

Dirty hack due to ec1abe6c8560ff5da7284191ff72e4e54b7630e3; after this change, the payloadEntity doesn't contain the flow ids yet as there was no upgrader to update the last publish_api event. So we need to remove the flow ids before comparing the deployed API and the current one.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qwbuqtqohi.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1147-remove-flow-id-from-diff/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
