### PR TITLE
refactor: keep upgrader before initializers

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/node/GraviteeApisNode.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/node/GraviteeApisNode.java
@@ -69,8 +69,8 @@ public class GraviteeApisNode extends AbstractNode {
         components.add(ScheduledCommandService.class);
 
         // Keep it at the end
-        components.addAll(InitializerConfiguration.getComponents());
         components.addAll(UpgraderConfiguration.getComponents());
+        components.addAll(InitializerConfiguration.getComponents());
         return components;
     }
 }


### PR DESCRIPTION

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-epjhevpylv.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-upgrader-initialization-order/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
