### PR TITLE
fix: make default env and org initializers upgraders

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/initializer/CockpitIdInitializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/initializer/CockpitIdInitializer.java
@@ -38,7 +38,6 @@ public class CockpitIdInitializer implements Initializer {
 
     @Override
     public boolean initialize() {
-        // FIXME : this initializer uses the default ExecutionContext, but should handle all environments/organizations
         ExecutionContext executionContext = GraviteeContext.getExecutionContext();
 
         Collection<OrganizationEntity> organizations = organizationService.findAll();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/initializer/DefaultApiHeaderInitializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/initializer/DefaultApiHeaderInitializer.java
@@ -40,7 +40,7 @@ public class DefaultApiHeaderInitializer extends EnvironmentInitializer {
     @Override
     public void initializeEnvironment(ExecutionContext executionContext) {
         // Initialize default headers
-        if (apiHeaderService.findAll(executionContext.getEnvironmentId()).size() == 0) {
+        if (apiHeaderService.findAll(executionContext.getEnvironmentId()).isEmpty()) {
             logger.info("Create default API Headers configuration for {}", executionContext);
             apiHeaderService.initialize(executionContext);
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/initializer/DefaultCategoryInitializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/initializer/DefaultCategoryInitializer.java
@@ -84,7 +84,7 @@ public class DefaultCategoryInitializer implements Initializer {
                 }
             }
         } catch (TechnicalException e) {
-            logger.error("Error while upgrading categories : {}", e);
+            logger.error("Error while upgrading categories", e);
         }
         return true;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/initializer/EnvironmentInitializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/initializer/EnvironmentInitializer.java
@@ -37,7 +37,7 @@ public abstract class EnvironmentInitializer implements Initializer {
     @Autowired
     private EnvironmentRepository environmentRepository;
 
-    // upgradeEnvironment is called once for each environment
+    // initializeEnvironment is called once for each environment
     protected abstract void initializeEnvironment(ExecutionContext executionContext);
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultEnvironmentUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultEnvironmentUpgrader.java
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.service.impl.upgrade.initializer;
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
 import io.gravitee.node.api.initializer.Initializer;
+import io.gravitee.node.api.upgrader.Upgrader;
 import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import org.slf4j.Logger;
@@ -28,18 +29,18 @@ import org.springframework.stereotype.Component;
  * @author GraviteeSource Team
  */
 @Component
-public class DefaultEnvironmentInitializer implements Initializer {
+public class DefaultEnvironmentUpgrader implements Upgrader {
 
     /**
      * Logger.
      */
-    private final Logger logger = LoggerFactory.getLogger(DefaultEnvironmentInitializer.class);
+    private final Logger logger = LoggerFactory.getLogger(DefaultEnvironmentUpgrader.class);
 
     @Autowired
     private EnvironmentService environmentService;
 
     @Override
-    public boolean initialize() {
+    public boolean upgrade() {
         // initialize roles.
         if (environmentService.findByOrganization(GraviteeContext.getDefaultOrganization()).isEmpty()) {
             logger.info("    No environment found. Add default one.");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultOrganizationUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultOrganizationUpgrader.java
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.service.impl.upgrade.initializer;
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
-import io.gravitee.node.api.initializer.Initializer;
+import io.gravitee.node.api.upgrader.Upgrader;
 import io.gravitee.rest.api.service.OrganizationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,18 +27,18 @@ import org.springframework.stereotype.Component;
  * @author GraviteeSource Team
  */
 @Component
-public class DefaultOrganizationInitializer implements Initializer {
+public class DefaultOrganizationUpgrader implements Upgrader {
 
     /**
      * Logger.
      */
-    private final Logger logger = LoggerFactory.getLogger(DefaultOrganizationInitializer.class);
+    private final Logger logger = LoggerFactory.getLogger(DefaultOrganizationUpgrader.class);
 
     @Autowired
     private OrganizationService organizationService;
 
     @Override
-    public boolean initialize() {
+    public boolean upgrade() {
         // initialize default organization.
         if (organizationService.count().equals(0L)) {
             logger.info("    No organization found. Add default one.");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultEnvironmentUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultEnvironmentUpgraderTest.java
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.service.impl.upgrade.initializer;
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
 import static org.mockito.Mockito.*;
 
-import io.gravitee.rest.api.service.OrganizationService;
-import io.gravitee.rest.api.service.impl.upgrade.initializer.DefaultOrganizationInitializer;
+import io.gravitee.rest.api.service.EnvironmentService;
+import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -29,25 +29,20 @@ import org.mockito.junit.MockitoJUnitRunner;
  * @author GraviteeSource Team
  */
 @RunWith(MockitoJUnitRunner.class)
-public class DefaultOrganizationInitializerTest {
+public class DefaultEnvironmentUpgraderTest {
 
     @Mock
-    private OrganizationService organizationService;
+    private EnvironmentService environmentService;
 
     @InjectMocks
-    private final DefaultOrganizationInitializer initializer = new DefaultOrganizationInitializer();
+    private final DefaultEnvironmentUpgrader upgrader = new DefaultEnvironmentUpgrader();
 
     @Test
-    public void shouldInitializeOrganisation() {
-        when(organizationService.count()).thenReturn(0L);
-        initializer.initialize();
-        verify(organizationService, times(1)).initialize();
-    }
+    public void shouldCreateDefaultEnvironment() {
+        when(environmentService.findByOrganization(any())).thenReturn(List.of());
 
-    @Test
-    public void shouldNotInitializeOrganisation() {
-        when(organizationService.count()).thenReturn(1L);
-        initializer.initialize();
-        verify(organizationService, never()).initialize();
+        upgrader.upgrade();
+
+        verify(environmentService, times(1)).initialize();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultOrganizationUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/DefaultOrganizationUpgraderTest.java
@@ -13,12 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.rest.api.service.impl.upgrade.initializer;
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
 import static org.mockito.Mockito.*;
 
-import io.gravitee.rest.api.service.EnvironmentService;
-import java.util.List;
+import io.gravitee.rest.api.service.OrganizationService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -29,20 +28,25 @@ import org.mockito.junit.MockitoJUnitRunner;
  * @author GraviteeSource Team
  */
 @RunWith(MockitoJUnitRunner.class)
-public class DefaultEnvironmentInitializerTest {
+public class DefaultOrganizationUpgraderTest {
 
     @Mock
-    private EnvironmentService environmentService;
+    private OrganizationService organizationService;
 
     @InjectMocks
-    private final DefaultEnvironmentInitializer initializer = new DefaultEnvironmentInitializer();
+    private final DefaultOrganizationUpgrader upgrader = new DefaultOrganizationUpgrader();
 
     @Test
-    public void shouldCreateDefaultEnvironment() {
-        when(environmentService.findByOrganization(any())).thenReturn(List.of());
+    public void shouldInitializeOrganisation() {
+        when(organizationService.count()).thenReturn(0L);
+        upgrader.upgrade();
+        verify(organizationService, times(1)).initialize();
+    }
 
-        initializer.initialize();
-
-        verify(environmentService, times(1)).initialize();
+    @Test
+    public void shouldNotInitializeOrganisation() {
+        when(organizationService.count()).thenReturn(1L);
+        upgrader.upgrade();
+        verify(organizationService, never()).initialize();
     }
 }


### PR DESCRIPTION

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xpydsjpjiz.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-upgrader-dependencies-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
