### PR TITLE
fix: evaluate the subscription configuration with empty object if a s…

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/EntrypointConnectorPluginServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/EntrypointConnectorPluginServiceImpl.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.rest.api.service.v4.impl;
 
+import static java.util.Optional.ofNullable;
+
 import io.gravitee.gateway.reactive.api.connector.ConnectorFactory;
 import io.gravitee.plugin.core.api.ConfigurablePluginManager;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
@@ -68,9 +70,13 @@ public class EntrypointConnectorPluginServiceImpl
     }
 
     private String validateSubscriptionConfiguration(String pluginId, String configuration) {
-        if (pluginId != null && configuration != null) {
+        if (pluginId != null) {
             String schema = getSubscriptionSchema(pluginId);
-            return jsonSchemaService.validate(schema, configuration);
+            if (schema != null) {
+                // schema maybe null, if not we run the validation against the configuration or an empty object if the config is null
+                // this ensures that a null configuration is acceptable when there is not required fields.
+                return jsonSchemaService.validate(schema, ofNullable(configuration).orElse("{}"));
+            }
         }
         return configuration;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/EntrypointConnectorPluginServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/EntrypointConnectorPluginServiceImplTest.java
@@ -15,26 +15,20 @@
  */
 package io.gravitee.rest.api.service.v4.impl;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-import com.github.fge.jsonschema.main.JsonSchema;
-import com.google.errorprone.annotations.DoNotMock;
 import io.gravitee.gateway.reactive.api.ApiType;
 import io.gravitee.gateway.reactive.api.ConnectorMode;
 import io.gravitee.gateway.reactive.api.ListenerType;
 import io.gravitee.gateway.reactive.api.connector.Connector;
-import io.gravitee.gateway.reactive.api.connector.ConnectorFactory;
 import io.gravitee.gateway.reactive.api.connector.entrypoint.EntrypointConnectorFactory;
 import io.gravitee.gateway.reactive.api.context.DeploymentContext;
-import io.gravitee.plugin.core.api.ConfigurablePluginManager;
-import io.gravitee.plugin.core.api.Plugin;
 import io.gravitee.plugin.core.api.PluginManifest;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPluginManager;
-import io.gravitee.rest.api.model.v4.connector.ConnectorPluginEntity;
 import io.gravitee.rest.api.service.JsonSchemaService;
 import io.gravitee.rest.api.service.exceptions.PluginNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
@@ -43,7 +37,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.Set;
-import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -102,11 +95,23 @@ public class EntrypointConnectorPluginServiceImplTest {
     }
 
     @Test
-    public void shouldReturnNullWhenConfigurationNull() throws IOException {
+    public void shouldReturnNullWhenSchemaAndConfigurationAreNull() throws IOException {
         when(pluginManager.get(CONNECTOR_ID)).thenReturn(new FakePlugin());
         when(pluginManager.getFactoryById(CONNECTOR_ID)).thenReturn(new FakeConnectorFactory());
 
         assertThat(cut.validateEntrypointSubscriptionConfiguration(CONNECTOR_ID, null)).isNull();
+    }
+
+    @Test
+    public void shouldReturnAConfigWhenSchemaNotNullAndConfigurationIsNull() throws IOException {
+        final String expectedConfiguration = "validated_and_sanitized";
+        when(pluginManager.get(CONNECTOR_ID)).thenReturn(new FakePlugin());
+        when(pluginManager.getFactoryById(CONNECTOR_ID)).thenReturn(new FakeConnectorFactory());
+        when(pluginManager.getSubscriptionSchema(CONNECTOR_ID)).thenReturn("subscriptionConfiguration");
+        when(jsonSchemaService.validate(eq("subscriptionConfiguration"), eq("{}"))).thenReturn(expectedConfiguration);
+
+        final String result = cut.validateEntrypointSubscriptionConfiguration(CONNECTOR_ID, null);
+        assertThat(result).isEqualTo(expectedConfiguration);
     }
 
     @Test


### PR DESCRIPTION
…chema is available

  If a schema is available, we check the configuration with an empty object if entrypointConfiguraiton field is null to ensure that no required data are expected

fix APIM-1362

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-sltlmcbmtu.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1362/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
