### PR TITLE
fix: remove use of `ApiRepository.findAll`

### DIFF
--- a/.run/Rest API - JDBC.run.xml
+++ b/.run/Rest API - JDBC.run.xml
@@ -4,10 +4,10 @@
       <env name="GRAVITEE_MANAGEMENT_JDBC_DATABASE" value="gravitee" />
       <env name="GRAVITEE_MANAGEMENT_JDBC_DRIVER" value="postgresql" />
       <env name="GRAVITEE_MANAGEMENT_JDBC_HOST" value="localhost" />
-      <env name="GRAVITEE_MANAGEMENT_JDBC_PASSWORD" value="password" />
+      <env name="GRAVITEE_MANAGEMENT_JDBC_PASSWORD" value="admin" />
       <env name="GRAVITEE_MANAGEMENT_JDBC_PORT" value="5432" />
       <env name="GRAVITEE_MANAGEMENT_JDBC_URL" value="jdbc:postgresql://localhost:5432/gravitee" />
-      <env name="GRAVITEE_MANAGEMENT_JDBC_USERNAME" value="postgres" />
+      <env name="GRAVITEE_MANAGEMENT_JDBC_USERNAME" value="admin" />
       <env name="GRAVITEE_MANAGEMENT_TYPE" value="jdbc" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="io.gravitee.rest.api.standalone.GraviteeApisContainer" />

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
@@ -96,15 +96,14 @@ public class JdbcApiRepository extends JdbcAbstractPageableRepository<Api> imple
     };
 
     @Override
+    /**
+     * DO NOT USE THIS METHOD
+     * @deprecated use {@link #search(ApiCriteria, Sortable, ApiFieldFilter, int)} instead
+     */
     public Set<Api> findAll() throws TechnicalException {
-        LOGGER.debug("JdbcApiRepository.findAll()");
-        try {
-            return new HashSet<>(jdbcTemplate.query(getOrm().getSelectAllSql(), getOrm().getRowMapper()));
-        } catch (final Exception ex) {
-            final String error = "Failed to find all api";
-            LOGGER.error(error, ex);
-            throw new TechnicalException(error, ex);
-        }
+        throw new IllegalStateException(
+            "Too many results, please use search(ApiCriteria, Sortable, ApiFieldFilter, int) returning a Stream instead."
+        );
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/OrphanCategoryUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/OrphanCategoryUpgrader.java
@@ -18,6 +18,8 @@ package io.gravitee.rest.api.service.impl.upgrade;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.CategoryRepository;
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.api.search.ApiFieldFilter;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.Category;
 import io.gravitee.rest.api.service.InstallationService;
@@ -63,8 +65,7 @@ public class OrphanCategoryUpgrader extends OneShotUpgrader {
         Set<String> existingCategoryIds = getExistingCategoryIds();
 
         return apiRepository
-            .findAll()
-            .stream()
+            .search(new ApiCriteria.Builder().build(), null, ApiFieldFilter.allFields())
             .filter(api -> hasOrphanCategories(api, existingCategoryIds))
             .peek(api -> removeOrphanCategories(api, existingCategoryIds))
             .collect(Collectors.toSet());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/PlansDataFixUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/PlansDataFixUpgrader.java
@@ -25,6 +25,8 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.EnvironmentRepository;
 import io.gravitee.repository.management.api.PlanRepository;
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.api.search.ApiFieldFilter;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.Plan;
 import io.gravitee.rest.api.service.ApiService;
@@ -94,19 +96,23 @@ public class PlansDataFixUpgrader extends OneShotUpgrader {
 
     @Override
     protected void processOneShotUpgrade() throws Exception {
-        for (Api api : apiRepository.findAll()) {
-            io.gravitee.definition.model.Api apiDefinition = objectMapper.readValue(
-                api.getDefinition(),
-                io.gravitee.definition.model.Api.class
-            );
-
-            if (DefinitionVersion.V2 == apiDefinition.getDefinitionVersion()) {
-                ExecutionContext executionContext = getApiExecutionContext(api);
-                if (executionContext != null) {
-                    fixApiPlans(executionContext, api, apiDefinition);
+        apiRepository
+            .search(new ApiCriteria.Builder().build(), null, ApiFieldFilter.allFields())
+            .forEach(api -> {
+                try {
+                    io.gravitee.definition.model.Api apiDefinition = objectMapper.readValue(
+                        api.getDefinition(),
+                        io.gravitee.definition.model.Api.class
+                    );
+                    ExecutionContext executionContext = getApiExecutionContext(api);
+                    if (DefinitionVersion.V2 == apiDefinition.getDefinitionVersion() && executionContext != null) {
+                        fixApiPlans(executionContext, api, apiDefinition);
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
                 }
-            }
-        }
+            });
+
         if (!anomalyFound) {
             LOGGER.info("No plan data anomaly found");
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/PlansFlowsDefinitionUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/PlansFlowsDefinitionUpgrader.java
@@ -21,10 +21,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.PlanRepository;
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.api.search.ApiFieldFilter;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.Plan;
 import io.gravitee.repository.management.model.flow.FlowReferenceType;
 import io.gravitee.rest.api.service.InstallationService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.configuration.flow.FlowService;
 import java.util.Map;
 import java.util.function.Function;
@@ -65,17 +68,22 @@ public class PlansFlowsDefinitionUpgrader extends OneShotUpgrader {
     }
 
     @Override
-    protected void processOneShotUpgrade() throws Exception {
-        for (Api api : apiRepository.findAll()) {
-            io.gravitee.definition.model.Api apiDefinition = objectMapper.readValue(
-                api.getDefinition(),
-                io.gravitee.definition.model.Api.class
-            );
-
-            if (DefinitionVersion.V2 == apiDefinition.getDefinitionVersion()) {
-                migrateApiFlows(api.getId(), apiDefinition);
-            }
-        }
+    protected void processOneShotUpgrade() {
+        apiRepository
+            .search(new ApiCriteria.Builder().build(), null, ApiFieldFilter.allFields())
+            .forEach(api -> {
+                try {
+                    io.gravitee.definition.model.Api apiDefinition = objectMapper.readValue(
+                        api.getDefinition(),
+                        io.gravitee.definition.model.Api.class
+                    );
+                    if (DefinitionVersion.V2 == apiDefinition.getDefinitionVersion()) {
+                        migrateApiFlows(api.getId(), apiDefinition);
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
     }
 
     protected void migrateApiFlows(String apiId, io.gravitee.definition.model.Api apiDefinition) throws Exception {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/SearchIndexUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/SearchIndexUpgrader.java
@@ -22,6 +22,8 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.EnvironmentRepository;
 import io.gravitee.repository.management.api.UserRepository;
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.api.search.ApiFieldFilter;
 import io.gravitee.repository.management.api.search.UserCriteria;
 import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.model.Api;
@@ -153,7 +155,10 @@ public class SearchIndexUpgrader implements Upgrader, Ordered {
     }
 
     protected List<CompletableFuture<?>> runApisIndexationAsync(ExecutorService executorService) throws TechnicalException {
-        return apiRepository.findAll().stream().map(api -> runApiIndexationAsync(executorService, api)).collect(toList());
+        return apiRepository
+            .search(new ApiCriteria.Builder().build(), null, ApiFieldFilter.allFields())
+            .map(api -> runApiIndexationAsync(executorService, api))
+            .collect(toList());
     }
 
     private CompletableFuture<?> runApiIndexationAsync(ExecutorService executorService, Api api) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/OrphanCategoryUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/OrphanCategoryUpgraderTest.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.*;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.CategoryRepository;
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.api.search.ApiFieldFilter;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.Category;
 import io.gravitee.rest.api.model.InstallationEntity;
@@ -30,6 +32,7 @@ import io.gravitee.rest.api.service.common.UuidString;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -84,7 +87,8 @@ public class OrphanCategoryUpgraderTest {
 
         Api apiWithOrphanCategory = new Api();
         apiWithOrphanCategory.setCategories(Set.of(orphanCategoryId, existingCategory.getId()));
-        when(apiRepository.findAll()).thenReturn(Set.of(apiWithOrphanCategory));
+        when(apiRepository.search(any(ApiCriteria.class), eq(null), any(ApiFieldFilter.class)))
+            .thenReturn(Stream.of(apiWithOrphanCategory));
 
         setUpgradeStatus(null);
         assertTrue(upgrader.upgrade());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/PlansDataFixUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/PlansDataFixUpgraderTest.java
@@ -23,6 +23,9 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.EnvironmentRepository;
 import io.gravitee.repository.management.api.PlanRepository;
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.api.search.ApiFieldFilter;
+import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.Environment;
 import io.gravitee.repository.management.model.Plan;
@@ -33,6 +36,7 @@ import io.gravitee.rest.api.service.EmailService;
 import io.gravitee.rest.api.service.InstallationService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.*;
+import java.util.stream.Stream;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -163,7 +167,8 @@ public class PlansDataFixUpgraderTest {
         apiv2_2.setId("api4");
         apiv2_2.setDefinition("{\"gravitee\": \"2.0.0\"}");
         apiv2_2.setEnvironmentId("envId");
-        when(apiRepository.findAll()).thenReturn(Set.of(apiv1_1, apiv2_1, apiv1_2, apiv2_2));
+        when(apiRepository.search(any(ApiCriteria.class), eq(null), any(ApiFieldFilter.class)))
+            .thenReturn(Stream.of(apiv1_1, apiv2_1, apiv1_2, apiv2_2));
 
         upgrader.processOneShotUpgrade();
 
@@ -191,7 +196,7 @@ public class PlansDataFixUpgraderTest {
         api3.setEnvironmentId("env1");
         api3.setDefinition("{\"gravitee\": \"2.0.0\"}");
 
-        when(apiRepository.findAll()).thenReturn(Set.of(api1, api2, api3));
+        when(apiRepository.search(any(ApiCriteria.class), eq(null), any(ApiFieldFilter.class))).thenReturn(Stream.of(api1, api2, api3));
 
         when(environmentRepository.findById("env1")).thenReturn(Optional.of(buildTestEnvironment("env1", "org1")));
         when(environmentRepository.findById("env2")).thenReturn(Optional.of(buildTestEnvironment("env2", "org2")));
@@ -221,7 +226,7 @@ public class PlansDataFixUpgraderTest {
         api1.setEnvironmentId("env1");
         api1.setDefinition("{\"gravitee\": \"2.0.0\"}");
 
-        when(apiRepository.findAll()).thenReturn(Set.of(api1));
+        when(apiRepository.search(any(ApiCriteria.class), eq(null), any(ApiFieldFilter.class))).thenReturn(Stream.of(api1));
         when(environmentRepository.findById(any())).thenThrow(new TechnicalException("this is a test exception"));
 
         upgrader.processOneShotUpgrade();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/PlansFlowsDefinitionUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/PlansFlowsDefinitionUpgraderTest.java
@@ -21,12 +21,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.PlanRepository;
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.api.search.ApiFieldFilter;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.Plan;
 import io.gravitee.repository.management.model.flow.FlowReferenceType;
 import io.gravitee.rest.api.service.configuration.flow.FlowService;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -67,7 +70,8 @@ public class PlansFlowsDefinitionUpgraderTest {
         Api api2 = buildApi("api2", "2.0.0");
         Api api3 = buildApi("api3", "1.0.0");
         Api api4 = buildApi("api4", "2.0.0");
-        when(apiRepository.findAll()).thenReturn(Set.of(api1, api2, api3, api4));
+        when(apiRepository.search(any(ApiCriteria.class), eq(null), any(ApiFieldFilter.class)))
+            .thenReturn(Stream.of(api1, api2, api3, api4));
 
         upgrader.processOneShotUpgrade();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/SearchIndexUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/SearchIndexUpgraderTest.java
@@ -24,6 +24,8 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.EnvironmentRepository;
 import io.gravitee.repository.management.api.UserRepository;
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.api.search.ApiFieldFilter;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.Environment;
 import io.gravitee.repository.management.model.User;
@@ -43,6 +45,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
+import java.util.stream.Stream;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -201,13 +204,13 @@ public class SearchIndexUpgraderTest {
     }
 
     private void mockTestApis() throws Exception {
-        Set<Api> apis = Set.of(
+        Stream<Api> apis = Stream.of(
             mockTestApi("api1", "env1"),
             mockTestApi("api2", "env2"),
             mockTestApi("api3", "env1"),
             mockTestApi("api4", "env3")
         );
-        when(apiRepository.findAll()).thenReturn(apis);
+        when(apiRepository.search(any(ApiCriteria.class), eq(null), any(ApiFieldFilter.class))).thenReturn(apis);
     }
 
     private Api mockTestApi(String apiId, String environmentId) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1371
https://github.com/gravitee-io/issues/issues/8980

## Description

This `findAll` method is not returning "complete" APIs causing issues if they are later used to perform some update.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nllpttsfni.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1371-fix-upgraders/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
