### PR TITLE
Remove definition context from api history

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ts
@@ -432,6 +432,7 @@ class ApiHistoryController {
     delete payload.tags;
     delete payload.workflow_state;
     delete payload.crossId;
+    delete payload.definition_context;
 
     if (payload.response_templates && _.isEmpty(payload.response_templates)) {
       delete payload.response_templates;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1147

## Description

Remove definition context from api history. Commit cherry picked from https://github.com/gravitee-io/gravitee-api-management/pull/3470

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mdgndefzsy.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1147-sync-api-318x/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
