### PR TITLE
Enable creation of ephemeral envs based on PR's code on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -312,7 +312,7 @@ commands:
 parameters:
     gio_action:
         type: enum
-        enum: [release, package_bundle, nexus_staging, pull_requests, build_rpm_&_docker_images, release_notes_apim, bridge_e2e]
+        enum: [release, package_bundle, nexus_staging, pull_requests, build_rpm_&_docker_images, release_notes_apim, bridge_e2e, publish_docker_images]
         default: pull_requests
     dry_run:
         type: boolean
@@ -2204,3 +2204,33 @@ workflows:
                 execution_mode: ["v3", "jupiter"]
                 database: ["bridge"]
                 apim_client_tag: ["3.20.x-latest","3.19.x-latest","3.18.x-latest"]
+
+    publish_docker_images:
+      when:
+        and:
+          - equal: [publish_docker_images, << pipeline.parameters.gio_action >>]
+      jobs:
+        - setup:
+            context: cicd-orchestrator
+        - build:
+            context: cicd-orchestrator
+            requires:
+              - setup
+        - build-images:
+            context: cicd-orchestrator
+            requires:
+              - build
+        - webui-build:
+            name: Build APIM Console
+            context: cicd-orchestrator
+            apim-ui-project: gravitee-apim-console-webui
+            docker-image-name: apim-management-ui
+            requires:
+              - setup
+        - webui-build:
+            name: Build APIM Portal
+            context: cicd-orchestrator
+            apim-ui-project: gravitee-apim-portal-webui
+            docker-image-name: apim-portal-ui
+            requires:
+              - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1026,31 +1026,31 @@ jobs:
             - gh/setup
             - compute-sanitize-circleci-branch
             - run:
-                  name: Edit Pull Request Description
-                  command: |
-                      # First check there is an associated pull request, otherwise just stop the job here
-                      if ! gh pr view --json title;
-                      then
-                        echo "No PR found for this branch, stopping the job here."
-                        exit 0
-                      fi
-
-                      # If PR state is different from OPEN
-                      if [ "$(gh pr view --json state --jq .state)" != "OPEN" ];
-                      then
-                        echo "PR is not opened, stopping the job here."
-                        exit 0
-                      fi
-                      export PR_BODY_UI_SECTION="
-                      <!-- UI placeholder -->
-                      🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/${SANITIZED_BRANCH}/index.html)
-                      _Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
-                      <!-- UI placeholder end -->
-                      "
-
-                      export CLEAN_BODY=$(gh pr view --json body --jq .body | sed '/UI placeholder -->/,/UI placeholder end -->/d')
-
-                      gh pr edit --body "$CLEAN_BODY$PR_BODY_UI_SECTION"
+                name: Edit Pull Request Description
+                command: |
+                  # First check there is an associated pull request, otherwise just stop the job here
+                  if ! gh pr view --json title;
+                  then
+                    echo "No PR found for this branch, stopping the job here."
+                    exit 0
+                  fi
+                  
+                  # If PR state is different from OPEN
+                  if [ "$(gh pr view --json state --jq .state)" != "OPEN" ];
+                  then
+                    echo "PR is not opened, stopping the job here."
+                    exit 0
+                  fi
+                  export PR_BODY_UI_SECTION="
+                  <!-- UI placeholder -->
+                  🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/${SANITIZED_BRANCH}/index.html)
+                  _Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
+                  <!-- UI placeholder end -->
+                  "
+                  
+                  export CLEAN_BODY=$(gh pr view --json body --jq .body | sed '/UI placeholder -->/,/UI placeholder end -->/d')
+                  
+                  gh pr edit --body "$CLEAN_BODY$PR_BODY_UI_SECTION"
 
             - notify-on-failure
 
@@ -1776,6 +1776,54 @@ jobs:
                                   ]
                                 }
 
+    publish-pr-env-urls:
+      executor:
+        name: node-lts
+        class: small
+      steps:
+        - checkout
+        - keeper/env-export:
+            secret-url: keeper://TIlcGPFq4rN5GvgnZb9hng/field/password
+            var-name: GITHUB_TOKEN
+        - gh/setup
+        - compute-sanitize-circleci-branch
+        - run:
+            name: Edit Pull Request Description
+            command: |
+              # First check there is an associated pull request, otherwise just stop the job here
+              if ! gh pr view --json title;
+              then
+                echo "No PR found for this branch, stopping the job here."
+                exit 0
+              fi
+              
+              # If PR state is different from OPEN
+              if [ "$(gh pr view --json state --jq .state)" != "OPEN" ];
+              then
+                echo "PR is not opened, stopping the job here."
+                exit 0
+              fi
+              export PR_NUMBER=$(gh pr view --json number --jq .number)
+              export PR_BODY_ENV_SECTION="
+              <!-- Environment placeholder -->
+              
+              🏗️ Your changes can be tested here and will be available soon:
+                    Console: [https://$PR_NUMBER.team-apim.gravitee.dev/console](https://$PR_NUMBER.team-apim.gravitee.dev/console)
+                    Portal: [https://$PR_NUMBER.team-apim.gravitee.dev/portal](https://$PR_NUMBER.team-apim.gravitee.dev/portal)
+                    Management-api: [https://$PR_NUMBER.team-apim.gravitee.dev/api/management](https://$PR_NUMBER.team-apim.gravitee.dev/api/management)
+                    Gateway v4: [https://$PR_NUMBER.team-apim.gravitee.dev](https://$PR_NUMBER.team-apim.gravitee.dev)
+                    Gateway v3: [https://$PR_NUMBER.gateway-v3.team-apim.gravitee.dev](https://$PR_NUMBER.gateway-v3.team-apim.gravitee.dev)
+              
+              <!-- Environment placeholder end -->
+              "
+              
+              export CLEAN_BODY=$(gh pr view --json body --jq .body | sed '/Environment placeholder -->/,/Environment placeholder end -->/d')
+              
+              gh pr edit --body "$CLEAN_BODY$PR_BODY_ENV_SECTION"
+
+        - notify-on-failure
+
+
 workflows:
     pull_requests:
         when:
@@ -2234,3 +2282,10 @@ workflows:
             docker-image-name: apim-portal-ui
             requires:
               - setup
+        - publish-pr-env-urls:
+            name: Publish environment URLs in Github PR
+            context: cicd-orchestrator
+            requires:
+              - build-images
+              - Build APIM Console
+              - Build APIM Portal

--- a/.github/workflows/publish-images-for-test-env.yml
+++ b/.github/workflows/publish-images-for-test-env.yml
@@ -1,0 +1,38 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Publish docker images for test environment
+
+on:
+  pull_request:
+    types: [ labeled ]
+
+jobs:
+  publish-images-for-test-env:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.label.name == 'ready_to_test' }}
+    steps:
+      - name: "Trigger publish_docker_images CircleCI workflow"
+        run: |
+          export JSON_PAYLOAD="{ \"branch\": \"${BRANCH}\", \"parameters\": { \"gio_action\": \"publish_docker_images\" } }"
+          
+          echo "payload = $JSON_PAYLOAD"
+          curl -X POST -d "${JSON_PAYLOAD}" \
+            -H 'Content-Type: application/json' -H 'Accept: application/json' -H "Circle-Token: ${CCI_TOKEN}" \
+            https://circleci.com/api/v2/project/gh/${ORG_NAME}/${REPO_NAME}/pipeline | jq .
+        env:
+          ORG_NAME: gravitee-io
+          REPO_NAME: gravitee-api-management
+          BRANCH: ${{ github.head_ref }}
+          CCI_TOKEN: ${{ secrets.CCI_TOKEN }}

--- a/.github/workflows/remove-ready-to-test-labels.yml
+++ b/.github/workflows/remove-ready-to-test-labels.yml
@@ -1,0 +1,52 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Remove ready to test labels
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  remove-ready-to-test-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Scan pull requests and remove ready_to_test labels"
+        env:
+          ORG_NAME: gravitee-io
+          REPO_NAME: gravitee-api-management
+        run: |
+          PR_NUMBERS=$(curl -s -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/gravitee-io/gravitee-api-management/issues?state=open&labels=ready_to_test&type=pr" | jq -r '.[].number')
+          
+          for PR_NUMBER in $PR_NUMBERS; do
+            # Get all events for the PR
+            # Then, filter on "labeled" events with "ready_to_test" label
+            # Get the last time the PR has been labeled with "ready_to_test"
+            # Finally, remove the double quotes to be able to parse and compare the date
+
+            LAST_TIMESTAMP=$(curl -s "https://api.github.com/repos/gravitee-io/gravitee-api-management/issues/$PR_NUMBER/events?per_page\=1000" | jq '.[] | select(.event == "labeled" and .label.name == "ready_to_test") | .created_at' | tail -n 1 | tr -d '"')
+            echo "PR $PR_NUMBER has been labeled at $LAST_TIMESTAMP"
+
+            ONE_WEEK_AGO=$(($(date +%s) - 7*84600))
+            LAST_TIMESTAMP_EPOCH=$(date -d "$LAST_TIMESTAMP" +%s)
+            
+            if [[ $LAST_TIMESTAMP_EPOCH -lt ONE_WEEK_AGO ]]; then
+              echo "The pull request $PR_NUMBER has been labeled for more than 1 week, removing the label ready_to_test"
+              
+              curl -s -X DELETE \
+                -H "Accept: application/vnd.github.v3+json" \
+                -H 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+                "https://api.github.com/repos/gravitee-io/gravitee-api-management/issues/$PR_NUMBER/labels/ready_to_test"
+            fi
+          done


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1062

## Description

Commits cherry picked from https://github.com/gravitee-io/gravitee-api-management/pull/3446

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1062-add-pr-env-master/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
