### PR TITLE
fix: make debug mode work with ssl or haproxy enabled

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/vertx/VertxDebugConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/vertx/VertxDebugConfiguration.java
@@ -33,6 +33,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
 import org.springframework.core.env.Environment;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.StandardEnvironment;
 
 @Configuration
 public class VertxDebugConfiguration {
@@ -47,10 +49,12 @@ public class VertxDebugConfiguration {
             .withEnvironment(environment)
             .withPort(Integer.parseInt(environment.getProperty("debug.port", "8482")))
             .withHost(environment.getProperty("debug.host", "localhost"))
-            .withDefaultSecured(Boolean.TRUE.equals(environment.getProperty("http.secured", Boolean.class)))
-            .withDefaultAlpn(Boolean.TRUE.equals(environment.getProperty("http.alpn", Boolean.class)))
-            .withDefaultOpenssl(Boolean.TRUE.equals(environment.getProperty("http.ssl.openssl", Boolean.class)))
-            .build();
+            .build()
+            // We can't use the default withDefaultProxyProtocol because the implementation of HttpServerConfiguration rely on the environment value and not the one passed in builder
+            .withSecured(Boolean.TRUE.equals(environment.getProperty("http.secured", Boolean.class)))
+            .withAlpn(Boolean.TRUE.equals(environment.getProperty("http.alpn", Boolean.class)))
+            .withOpenssl(Boolean.TRUE.equals(environment.getProperty("http.ssl.openssl", Boolean.class)))
+            .withProxyProtocol(false);
     }
 
     @Bean("debugGatewayHttpServer")

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/DebugReactorEventListener.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/DebugReactorEventListener.java
@@ -185,6 +185,7 @@ public class DebugReactorEventListener extends ReactorEventListener {
         options.setConnectTimeout(debugHttpClientConfiguration.getConnectTimeout());
         options.setTryUseCompression(debugHttpClientConfiguration.isCompressionSupported());
         options.setUseAlpn(debugHttpClientConfiguration.isAlpn());
+        options.setVerifyHost(false);
         if (debugHttpClientConfiguration.isSecured()) {
             options.setSsl(debugHttpClientConfiguration.isSecured());
             options.setTrustAll(true);

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>2.1.0</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
-        <gravitee-node.version>3.0.2</gravitee-node.version>
+        <gravitee-node.version>3.0.3</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-plugin.version>1.26.1</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.2.0</gravitee-platform-repository-api.version>


### PR DESCRIPTION
Issue

https://gravitee.atlassian.net/browse/APIM-1381

Description

HttpServerConfiguration builder implementation was only relying on Environment so set default values.
Add lombok's @With to be able to set fields after builds with an immutable object.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-iofojbzxhn.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1381-debugmode-secured-master/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
