### PR TITLE
Use correct permission to display transfer app ownership section

### DIFF
--- a/gravitee-apim-console-webui/src/management/application/details/members/application-members.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/members/application-members.controller.ts
@@ -196,7 +196,7 @@ class ApplicationMembersController {
   }
 
   isAllowedToTransferOwnership() {
-    return this.UserService.currentUser.isOrganizationAdmin() || this.UserService.currentUser.allowedTo(['api-member-u']);
+    return this.UserService.currentUser.isOrganizationAdmin() || this.UserService.currentUser.allowedTo(['application-member-u']);
   }
 
   toggleDisableMembershipNotifications() {

--- a/gravitee-apim-console-webui/src/management/application/details/members/application-members.html
+++ b/gravitee-apim-console-webui/src/management/application/details/members/application-members.html
@@ -113,7 +113,7 @@
     </div>
   </div>
 
-  <div class="gv-form" ng-if="$ctrl.isAllowedToTransferOwnership()" permission permission-only="'application-member-u'">
+  <div class="gv-form" ng-if="$ctrl.isAllowedToTransferOwnership()">
     <h2>Transfer ownership</h2>
     <div class="gv-form-content" layout="column">
       <p>Give full access to this application to an other user.</p>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-911
https://github.com/gravitee-io/issues/issues/8455

## Description

Use correct permission to display transfer app ownership section
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-911-fix-permission-3-18-x/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-udyexufkjz.chromatic.com)
<!-- Storybook placeholder end -->
