### PR TITLE
Apply some magic default values to ensure pie chart graphs display the correct colors and labels

### DIFF
--- a/gravitee-apim-console-webui/src/components/widget/pie/widget-chart-pie.component.ts
+++ b/gravitee-apim-console-webui/src/components/widget/pie/widget-chart-pie.component.ts
@@ -35,19 +35,21 @@ const WidgetChartPieComponent: ng.IComponentOptions = {
         this.gvChartPie = $element.children()[0];
         this.options = {
           name: this.parent.widget.title,
-          data: Object.keys(changes.data.currentValue.values || {}).map((label) => {
+          data: Object.keys(changes.data.currentValue.values || {}).map((label, idx) => {
             // The next lines are weird and would need a complete refactor, it
             // will happen with the Angular migration of this component
-            if (!this.parent.widget.chart.labels || !this.parent.widget.chart.labels.includes(label)) {
+            if (this.parent.widget.chart.labels && this.parent.widget.chart.labels.includes(label)) {
+              const index = this.parent.widget.chart.labels.indexOf(label);
               return {
-                name: label,
+                name: this.parent.widget.chart.labels[index],
+                color: this.parent.widget.chart.colors[index],
               };
             }
 
-            const index = this.parent.widget.chart.labels.indexOf(label);
             return {
-              name: this.parent.widget.chart.labels[index],
-              color: this.parent.widget.chart.colors[index],
+              // Set the color and name based on the chart config (coming from the parent)
+              name: idx < this.parent.widget.chart.colors.length ? this.parent.widget.chart.labels[idx] : label,
+              color: idx < this.parent.widget.chart.colors.length ? this.parent.widget.chart.colors[idx] : undefined,
             };
           }),
         };


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1390
https://github.com/gravitee-io/issues/issues/8989

## Description

Apply some magic default values to ensure pie chart graphs display the correct colors and labels

## Screenshot

Before
![image](https://user-images.githubusercontent.com/4112568/229531462-2908a2d6-eadf-4f05-b43d-51bb220cca73.png)

After
![image](https://user-images.githubusercontent.com/4112568/229531178-cf34529e-b2ab-45bd-9fc2-b7691b22b1ad.png)
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1390-fix-pie-chart/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wqcxdspfil.chromatic.com)
<!-- Storybook placeholder end -->
