### PR TITLE
feat: allow navigation to api details with a href

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
@@ -46,8 +46,8 @@
     <!-- Display Name Column -->
     <ng-container matColumnDef="name">
       <th mat-header-cell *matHeaderCellDef mat-sort-header id="name">Name</th>
-      <td mat-cell *matCellDef="let element" (click)="onEditActionClicked(element)" title="{{ element.name }} ({{ element.version }})">
-        {{ element.name }} ({{ element.version }})
+      <td mat-cell *matCellDef="let element" title="{{ element.name }} ({{ element.version }})">
+        <a [uiSref]="'management.apis.detail.ng-redirect'" [uiParams]="{ apiId: element.id }">{{ element.name }} ({{ element.version }})</a>
       </td>
     </ng-container>
 

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
@@ -23,6 +23,7 @@ import { MatTableHarness } from '@angular/material/table/testing';
 import { HttpTestingController } from '@angular/common/http/testing';
 import { MatSortHeaderHarness } from '@angular/material/sort/testing';
 import { By } from '@angular/platform-browser';
+import { UIRouterModule } from '@uirouter/angular';
 
 import { ApiListModule } from './api-list.module';
 import { ApiListComponent } from './api-list.component';
@@ -53,7 +54,16 @@ describe('ApisListComponent', () => {
   describe('without quality score', () => {
     beforeEach(async () => {
       await TestBed.configureTestingModule({
-        imports: [ApiListModule, MatIconTestingModule, GioUiRouterTestingModule, NoopAnimationsModule, GioHttpTestingModule],
+        imports: [
+          ApiListModule,
+          MatIconTestingModule,
+          GioUiRouterTestingModule,
+          NoopAnimationsModule,
+          GioHttpTestingModule,
+          UIRouterModule.forRoot({
+            useHash: true,
+          }),
+        ],
         providers: [
           { provide: UIRouterState, useValue: fakeUiRouter },
           { provide: UIRouterStateParams, useValue: {} },
@@ -215,7 +225,16 @@ describe('ApisListComponent', () => {
       withQualityEnabled.env.settings.apiQualityMetrics.enabled = true;
 
       await TestBed.configureTestingModule({
-        imports: [ApiListModule, MatIconTestingModule, GioUiRouterTestingModule, NoopAnimationsModule, GioHttpTestingModule],
+        imports: [
+          ApiListModule,
+          MatIconTestingModule,
+          GioUiRouterTestingModule,
+          NoopAnimationsModule,
+          GioHttpTestingModule,
+          UIRouterModule.forRoot({
+            useHash: true,
+          }),
+        ],
         providers: [
           { provide: UIRouterState, useValue: fakeUiRouter },
           { provide: UIRouterStateParams, useValue: {} },

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.module.ts
@@ -21,11 +21,20 @@ import { GioAvatarModule, GioIconsModule } from '@gravitee/ui-particles-angular'
 import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatSortModule } from '@angular/material/sort';
+import { Ng2StateDeclaration, UIRouterModule } from '@uirouter/angular';
 
 import { ApiListComponent } from './api-list.component';
 
 import { GioTableWrapperModule } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
 import { GioPermissionModule } from '../../../shared/components/gio-permission/gio-permission.module';
+
+export const states: Ng2StateDeclaration[] = [
+  {
+    name: 'management.apis.detail.ng-redirect',
+    redirectTo: { state: 'management.apis.detail.portal.general' },
+    url: '/portal',
+  },
+];
 
 @NgModule({
   declarations: [ApiListComponent],
@@ -41,6 +50,7 @@ import { GioPermissionModule } from '../../../shared/components/gio-permission/g
     GioIconsModule,
     GioTableWrapperModule,
     GioPermissionModule,
+    UIRouterModule.forChild({ states }),
   ],
 })
 export class ApiListModule {}

--- a/gravitee-apim-console-webui/src/management/application/environment-application.module.ts
+++ b/gravitee-apim-console-webui/src/management/application/environment-application.module.ts
@@ -27,6 +27,7 @@ import { MatSortModule } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { NgModule } from '@angular/core';
+import { UIRouterModule } from '@uirouter/angular';
 
 import { EnvApplicationListComponent } from './list/env-application-list.component';
 import { ApplicationNavigationModule } from './details/application-navigation/application-navigation.module';
@@ -59,6 +60,7 @@ import { GioPermissionModule } from '../../shared/components/gio-permission/gio-
     MatTooltipModule,
 
     ApplicationNavigationModule,
+    UIRouterModule,
   ],
   declarations: [EnvApplicationListComponent],
   exports: [EnvApplicationListComponent],

--- a/gravitee-apim-console-webui/src/management/application/list/env-application-list.component.html
+++ b/gravitee-apim-console-webui/src/management/application/list/env-application-list.component.html
@@ -63,8 +63,10 @@
     <!-- Display name Column -->
     <ng-container matColumnDef="name">
       <th mat-header-cell *matHeaderCellDef mat-sort-header id="name">Name</th>
-      <td mat-cell *matCellDef="let element" (click)="onEditActionClicked(element)">
-        <a>{{ element.name }}</a>
+      <td mat-cell *matCellDef="let element">
+        <a [uiSref]="'management.applications.application.general'" [uiParams]="{ applicationId: element.applicationId }">{{
+          element.name
+        }}</a>
       </td>
     </ng-container>
 

--- a/gravitee-apim-console-webui/src/management/application/list/env-application-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/application/list/env-application-list.component.spec.ts
@@ -22,11 +22,12 @@ import { HttpTestingController } from '@angular/common/http/testing';
 import { MatDialogHarness } from '@angular/material/dialog/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { InteractivityChecker } from '@angular/cdk/a11y';
+import { UIRouterModule } from '@uirouter/angular';
 
 import { EnvApplicationListComponent } from './env-application-list.component';
 
 import { EnvironmentApplicationModule } from '../environment-application.module';
-import { UIRouterStateParams, UIRouterState, CurrentUserService } from '../../../ajs-upgraded-providers';
+import { CurrentUserService, UIRouterState, UIRouterStateParams } from '../../../ajs-upgraded-providers';
 import { CONSTANTS_TESTING, GioHttpTestingModule } from '../../../shared/testing';
 import { fakePagedResult } from '../../../entities/pagedResult';
 import { User as DeprecatedUser } from '../../../entities/user';
@@ -46,7 +47,14 @@ describe('EnvApplicationListComponent', () => {
       currentUser.roles = [{ scope: 'ORGANIZATION', name: 'ADMIN' }];
 
       TestBed.configureTestingModule({
-        imports: [NoopAnimationsModule, EnvironmentApplicationModule, GioHttpTestingModule],
+        imports: [
+          NoopAnimationsModule,
+          EnvironmentApplicationModule,
+          GioHttpTestingModule,
+          UIRouterModule.forRoot({
+            useHash: true,
+          }),
+        ],
         providers: [
           { provide: UIRouterState, useValue: { go: jest.fn() } },
           { provide: UIRouterStateParams, useValue: {} },
@@ -160,7 +168,14 @@ describe('EnvApplicationListComponent', () => {
       currentUser.roles = [{ scope: 'ORGANIZATION', name: 'ADMIN' }];
 
       TestBed.configureTestingModule({
-        imports: [NoopAnimationsModule, EnvironmentApplicationModule, GioHttpTestingModule],
+        imports: [
+          NoopAnimationsModule,
+          EnvironmentApplicationModule,
+          GioHttpTestingModule,
+          UIRouterModule.forRoot({
+            useHash: true,
+          }),
+        ],
         providers: [
           { provide: UIRouterState, useValue: { go: jest.fn() } },
           { provide: UIRouterStateParams, useValue: { status: 'ARCHIVED' } },


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-900

## Description

From the API list, if we want to be able to open an API in a new link (with right click or CTRL+click), we need to perform navigation with a `<a href="">` tag. 
But our application is a hybrid app, the part running on AngularJS doesn't know the routes from the one running on Angular (and the other way round).
So in this PR, we declare a route in the Angular module that simply redirects to the corresponding state in the AngularJS module.
This way, we are able to use the `uiSref` directive from UIRouter for the navigation.  
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-awjeqvxyxh.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-900-open-api-in-new-tab/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
