### PR TITLE
fix: use the right route to redirect to studio

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/design/policies/policies.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/design/policies/policies.controller.ts
@@ -384,7 +384,7 @@ class ApiPoliciesController {
       .then((response) => {
         if (response) {
           this.ApiService.migrateApiToPolicyStudio(this.$scope.$parent.apiCtrl.api.id).then((response) => {
-            this.$state.go('management.apis.detail.design.flows', { apiId: response.data.id }, { reload: true });
+            this.$state.go('management.apis.detail.design.flowsNg', { apiId: response.data.id }, { reload: true });
           });
         }
       });


### PR DESCRIPTION
## Issue

https://github.com/gravitee-io/issues/issues/8994
https://gravitee.atlassian.net/browse/APIM-1396

## Description

Use the right routing rule after API migration from v1 to v2
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kswgnoffna.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1396-redirection-after-migration/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
