### PR TITLE
Console - Refactor Plan form component - part 2

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/component/plan/2-secure-step/plan-edit-secure-step.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/2-secure-step/plan-edit-secure-step.component.html
@@ -1,13 +1,13 @@
 <!--
 
     Copyright (C) 2015 The Gravitee team (http://gravitee.io)
-    
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-    
+
             http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,9 +16,9 @@
 
 -->
 <ng-container *ngIf="secureForm" [formGroup]="secureForm">
-  <mat-form-field class="securityTypes-field">
+  <mat-form-field class="securityType-field">
     <mat-label>Authentication type</mat-label>
-    <mat-select formControlName="securityTypes" required>
+    <mat-select formControlName="securityType" required>
       <mat-option *ngFor="let type of securityTypes" [value]="type.id">{{ type.name }}</mat-option>
     </mat-select>
   </mat-form-field>

--- a/gravitee-apim-console-webui/src/management/api/component/plan/2-secure-step/plan-edit-secure-step.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/2-secure-step/plan-edit-secure-step.component.ts
@@ -83,22 +83,22 @@ export class PlanEditSecureStepComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.secureForm = new FormGroup({
-      securityTypes: new FormControl(),
+      securityType: new FormControl(),
       securityConfig: new FormControl({}),
       selectionRule: new FormControl(),
     });
 
     this.secureForm
-      .get('securityTypes')
+      .get('securityType')
       .valueChanges.pipe(
         takeUntil(this.unsubscribe$),
         distinctUntilChanged(),
         tap(() => {
           this.securityConfigSchema = undefined;
           // Only reset security config if security type has changed
-          if (this.currentSecurityType !== this.secureForm.get('securityTypes').value) {
+          if (this.currentSecurityType !== this.secureForm.get('securityType').value) {
             this.secureForm.get('securityConfig').reset({});
-            this.currentSecurityType = this.secureForm.get('securityTypes').value;
+            this.currentSecurityType = this.secureForm.get('securityType').value;
           }
         }),
         filter((securityType) => securityType && securityType !== PlanSecurityType.KEY_LESS),

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.html
@@ -15,51 +15,33 @@
     limitations under the License.
 
 -->
-<div>
-  <span class="md-headline">
-    <gio-go-back-button [ajsGo]="{ to: 'management.apis.detail.portal.plans' }"></gio-go-back-button>
-    Plan
-  </span>
-</div>
-<form *ngIf="planForm" [hidden]="isLoadingData" autocomplete="off" gioFormFocusInvalid [formGroup]="planForm">
-  <mat-card>
-    <mat-stepper>
-      <mat-step state="general" [stepControl]="planForm.get('general')">
-        <ng-template matStepperIcon="general">
-          <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
-        </ng-template>
-        <ng-template matStepLabel>General</ng-template>
-        <plan-edit-general-step
-          matStepContent
-          [api]="api"
-          [mode]="mode"
-          [displaySubscriptionsSection]="displaySubscriptionsSection"
-        ></plan-edit-general-step>
-      </mat-step>
+<mat-stepper>
+  <mat-step state="general" [stepControl]="planForm.get('general')">
+    <ng-template matStepperIcon="general">
+      <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
+    </ng-template>
+    <ng-template matStepLabel>General</ng-template>
+    <plan-edit-general-step
+      matStepContent
+      [api]="api"
+      [mode]="mode"
+      [displaySubscriptionsSection]="displaySubscriptionsSection"
+    ></plan-edit-general-step>
+  </mat-step>
 
-      <mat-step state="secure" [stepControl]="planForm.get('secure')">
-        <ng-template matStepperIcon="secure">
-          <mat-icon svgIcon="gio:lock"></mat-icon>
-        </ng-template>
-        <ng-template matStepLabel>Secure</ng-template>
-        <plan-edit-secure-step matStepContent [api]="api"></plan-edit-secure-step>
-      </mat-step>
+  <mat-step state="secure" [stepControl]="planForm.get('secure')">
+    <ng-template matStepperIcon="secure">
+      <mat-icon svgIcon="gio:lock"></mat-icon>
+    </ng-template>
+    <ng-template matStepLabel>Secure</ng-template>
+    <plan-edit-secure-step matStepContent [api]="api"></plan-edit-secure-step>
+  </mat-step>
 
-      <mat-step *ngIf="mode === 'create'" state="restriction" [stepControl]="planForm.get('restriction')">
-        <ng-template matStepperIcon="restriction">
-          <mat-icon svgIcon="gio:shield-cross"></mat-icon>
-        </ng-template>
-        <ng-template matStepLabel>Restriction</ng-template>
-        <plan-edit-restriction-step matStepContent></plan-edit-restriction-step>
-      </mat-step>
-    </mat-stepper>
-  </mat-card>
-
-  <gio-save-bar
-    *ngIf="planForm && !isReadOnly"
-    [creationMode]="mode === 'create'"
-    [form]="planForm"
-    [formInitialValues]="initialPlanFormValue"
-    (submitted)="onSubmit()"
-  ></gio-save-bar>
-</form>
+  <mat-step *ngIf="mode === 'create'" state="restriction" [stepControl]="planForm.get('restriction')">
+    <ng-template matStepperIcon="restriction">
+      <mat-icon svgIcon="gio:shield-cross"></mat-icon>
+    </ng-template>
+    <ng-template matStepLabel>Restriction</ng-template>
+    <plan-edit-restriction-step matStepContent></plan-edit-restriction-step>
+  </mat-step>
+</mat-stepper>

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
@@ -14,24 +14,46 @@
  * limitations under the License.
  */
 import { STEPPER_GLOBAL_OPTIONS } from '@angular/cdk/stepper';
-import { AfterViewInit, ChangeDetectorRef, Component, Inject, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { FormGroup } from '@angular/forms';
-import { EMPTY, of, Subject } from 'rxjs';
-import { catchError, startWith, switchMap, takeUntil, tap } from 'rxjs/operators';
-import { StateService } from '@uirouter/angularjs';
+import { AfterViewInit, ChangeDetectorRef, Component, Host, Input, OnDestroy, OnInit, Optional, ViewChild } from '@angular/core';
+import { AbstractControl, ControlValueAccessor, FormGroup, NgControl, ValidationErrors, Validator } from '@angular/forms';
+import { Subject } from 'rxjs';
+import { distinctUntilChanged, map, startWith, takeUntil } from 'rxjs/operators';
 
 import { PlanEditGeneralStepComponent } from './1-general-step/plan-edit-general-step.component';
 import { PlanEditSecureStepComponent } from './2-secure-step/plan-edit-secure-step.component';
 import { PlanEditRestrictionStepComponent } from './3-restriction-step/plan-edit-restriction-step.component';
 
-import { UIRouterState, UIRouterStateParams } from '../../../../ajs-upgraded-providers';
 import { Api } from '../../../../entities/api';
-import { ApiService } from '../../../../services-ngx/api.service';
-import { PlanService } from '../../../../services-ngx/plan.service';
-import { NewPlan, PlanValidation } from '../../../../entities/plan';
+import { NewPlan, Plan, PlanSecurityType, PlanValidation } from '../../../../entities/plan';
 import { Flow, Step } from '../../../../entities/flow/flow';
-import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
-import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
+
+type InternalPlanFormValue = {
+  general: {
+    name: string;
+    description: string;
+    characteristics: string[];
+    generalConditions: string;
+    shardingTags: string[];
+    commentRequired: boolean;
+    commentMessage: string;
+    validation: string;
+    excludedGroups: string[];
+  };
+  secure: {
+    securityType: string;
+    securityConfig: string;
+    selectionRule: string;
+  };
+
+  restriction?: {
+    rateLimitEnabled?: boolean;
+    rateLimitConfig?: string;
+    quotaEnabled?: boolean;
+    quotaConfig?: string;
+    resourceFilteringEnabled?: boolean;
+    resourceFilteringConfig?: string;
+  };
+};
 
 @Component({
   selector: 'api-plan-form',
@@ -44,81 +66,66 @@ import { GioPermissionService } from '../../../../shared/components/gio-permissi
     },
   ],
 })
-export class ApiPlanFormComponent implements OnInit, AfterViewInit, OnDestroy {
+export class ApiPlanFormComponent implements OnInit, AfterViewInit, OnDestroy, ControlValueAccessor, Validator {
   private unsubscribe$: Subject<boolean> = new Subject<boolean>();
 
-  public mode: 'create' | 'edit' = 'create';
-  public isLoadingData = true;
+  @Input()
+  api?: Api;
+
+  @Input()
+  mode: 'create' | 'edit';
+
+  public isInit = false;
 
   public planForm = new FormGroup({});
   public initialPlanFormValue: unknown;
-  public api: Api;
-  public isReadOnly = false;
   public displaySubscriptionsSection = true;
 
   @ViewChild(PlanEditGeneralStepComponent) planEditGeneralStepComponent: PlanEditGeneralStepComponent;
   @ViewChild(PlanEditSecureStepComponent) planEditSecureStepComponent: PlanEditSecureStepComponent;
   @ViewChild(PlanEditRestrictionStepComponent) planEditRestrictionStepComponent: PlanEditRestrictionStepComponent;
 
-  constructor(
-    private readonly changeDetectorRef: ChangeDetectorRef,
-    @Inject(UIRouterStateParams) private readonly ajsStateParams,
-    @Inject(UIRouterState) private readonly ajsState: StateService,
-    private readonly apiService: ApiService,
-    private readonly planService: PlanService,
-    private readonly snackBarService: SnackBarService,
-    private readonly permissionService: GioPermissionService,
-  ) {}
+  private _onChange: (_: NewPlan | Plan) => void;
+  private _onTouched: () => void;
+
+  private controlValue?: Plan | NewPlan;
+  private isDisabled = false;
+
+  constructor(private readonly changeDetectorRef: ChangeDetectorRef, @Host() @Optional() public readonly ngControl?: NgControl) {
+    if (ngControl) {
+      // Setting the value accessor directly (instead of using
+      // the providers `NG_VALUE_ACCESSOR`) to avoid running into a circular import.
+      ngControl.valueAccessor = this;
+    }
+  }
 
   ngOnInit() {
-    this.mode = this.ajsStateParams.planId ? 'edit' : 'create';
+    if (!this.ngControl?.control) {
+      throw new Error('ApiPlanFormComponent must be used with a form control');
+    }
+    // Add default validator to the form control
+    this.ngControl.control.setValidators(this.validate.bind(this));
+    this.ngControl.control.updateValueAndValidity();
+
+    // When the parent form is touched, mark all the sub formGroup as touched
+    const parentControl = this.ngControl.control.parent;
+    parentControl?.statusChanges
+      ?.pipe(
+        takeUntil(this.unsubscribe$),
+        map(() => parentControl?.touched),
+        distinctUntilChanged(),
+      )
+      .subscribe(() => {
+        this.planForm.markAllAsTouched();
+      });
   }
 
   ngAfterViewInit(): void {
-    this.apiService
-      .get(this.ajsStateParams.apiId)
-      .pipe(
-        takeUntil(this.unsubscribe$),
-        tap((api) => {
-          this.api = api;
-          this.isReadOnly = !this.permissionService.hasAnyMatching(['api-plan-u']) || this.api.definition_context?.origin === 'kubernetes';
-        }),
-        switchMap(() =>
-          this.mode === 'edit' ? this.planService.get(this.ajsStateParams.apiId, this.ajsStateParams.planId) : of(undefined),
-        ),
-        tap((plan) => {
-          this.initPlanForm(
-            plan
-              ? {
-                  general: {
-                    name: plan.name,
-                    description: plan.description,
-                    characteristics: plan.characteristics,
-                    generalConditions: plan.general_conditions,
-                    shardingTags: plan.tags,
-                    commentRequired: plan.comment_required,
-                    commentMessage: plan.comment_message,
-                    validation: plan.validation,
-                    excludedGroups: plan.excluded_groups,
-                  },
-                  secure: {
-                    securityTypes: plan.security,
-                    securityConfig: plan.securityDefinition ? JSON.parse(plan.securityDefinition) : {},
-                    selectionRule: plan.selection_rule,
-                  },
-                }
-              : undefined,
-          );
-          // Manually trigger change detection to avoid ExpressionChangedAfterItHasBeenCheckedError in test
-          // Needed to have only one detectChanges() after load each step child component
-          this.changeDetectorRef.detectChanges();
-        }),
-        catchError((error) => {
-          this.snackBarService.error(error.error?.message ?? 'An ');
-          return EMPTY;
-        }),
-      )
-      .subscribe();
+    this.initPlanForm();
+    this.isInit = true;
+
+    // https://github.com/angular/components/issues/19027
+    this.changeDetectorRef.detectChanges();
   }
 
   ngOnDestroy() {
@@ -126,47 +133,52 @@ export class ApiPlanFormComponent implements OnInit, AfterViewInit, OnDestroy {
     this.unsubscribe$.unsubscribe();
   }
 
-  onSubmit() {
-    const newPlan: NewPlan = {
-      api: this.api.id,
-      // General
-      name: this.planForm.get('general').get('name').value,
-      description: this.planForm.get('general').get('description').value,
-      characteristics: this.planForm.get('general').get('characteristics').value,
-      general_conditions: this.planForm.get('general').get('generalConditions').value,
-      tags: this.planForm.get('general').get('shardingTags').value,
-      comment_required: this.planForm.get('general').get('commentRequired').value,
-      comment_message: this.planForm.get('general').get('commentMessage').value,
-      validation: this.planForm.get('general').get('validation').value ? PlanValidation.AUTO : PlanValidation.MANUAL,
-      excluded_groups: this.planForm.get('general').get('excludedGroups').value,
-
-      // Secure
-      security: this.planForm.get('secure').get('securityTypes').value,
-      securityDefinition: JSON.stringify(this.planForm.get('secure').get('securityConfig').value),
-      selection_rule: this.planForm.get('secure').get('selectionRule').value,
-
-      // Restriction (only for create mode)
-      ...(this.mode === 'edit' ? {} : { flows: this.initFlowsWithRestriction() }),
-    };
-
-    (this.mode === 'edit'
-      ? this.planService
-          .get(this.ajsStateParams.apiId, this.ajsStateParams.planId)
-          .pipe(switchMap((planToUpdate) => this.planService.update(this.api, { ...planToUpdate, ...newPlan })))
-      : this.planService.create(this.api, newPlan)
-    )
-      .pipe(
-        takeUntil(this.unsubscribe$),
-        tap(() => this.snackBarService.success('Configuration successfully saved!')),
-        catchError((error) => {
-          this.snackBarService.error(error.error?.message ?? 'An error occurs while saving configuration');
-          return EMPTY;
-        }),
-      )
-      .subscribe(() => this.ajsState.go('management.apis.detail.portal.plans'));
+  // From ControlValueAccessor interface
+  registerOnChange(fn: any): void {
+    this._onChange = fn;
   }
 
-  private initPlanForm(value?: unknown) {
+  // From ControlValueAccessor interface
+  registerOnTouched(fn: any): void {
+    this._onTouched = fn;
+  }
+
+  // From ControlValueAccessor interface
+  writeValue(obj: Plan | NewPlan): void {
+    this.controlValue = obj;
+
+    // Update if the form is already initialized
+    if (this.isInit) {
+      this.initPlanForm();
+    }
+  }
+
+  // From ControlValueAccessor interface
+  setDisabledState(isDisabled: boolean): void {
+    this.isDisabled = isDisabled;
+
+    // Update if the form is already initialized
+    if (this.isInit) {
+      isDisabled ? this.planForm.disable() : this.planForm.enable();
+    }
+  }
+
+  // From Validator interface
+  validate(_: AbstractControl): ValidationErrors | null {
+    if (!this.isInit) {
+      return { planFormError: 'planForm is not initialized' };
+    }
+
+    if (this.planForm.invalid) {
+      return { planFormError: 'planForm is invalid' };
+    }
+
+    return null;
+  }
+
+  private initPlanForm() {
+    const value = planToInternalFormValue(this.controlValue);
+
     this.planForm = new FormGroup({
       general: this.planEditGeneralStepComponent.generalForm,
       secure: this.planEditSecureStepComponent.secureForm,
@@ -175,20 +187,20 @@ export class ApiPlanFormComponent implements OnInit, AfterViewInit, OnDestroy {
 
     if (value) {
       this.planForm.patchValue(value);
-      this.planForm.get('secure').get('securityTypes').disable();
+      this.planForm.get('secure').get('securityType').disable();
       this.planForm.updateValueAndValidity();
     }
     this.initialPlanFormValue = this.planForm.getRawValue();
-    this.isLoadingData = false;
+    // this.isLoadingData = false;
 
-    if (this.isReadOnly) {
+    if (this.isDisabled) {
       this.planForm.disable();
     }
 
     this.planForm
       .get('secure')
-      .get('securityTypes')
-      .valueChanges.pipe(takeUntil(this.unsubscribe$), startWith(this.planForm.get('secure').get('securityTypes').value))
+      .get('securityType')
+      .valueChanges.pipe(takeUntil(this.unsubscribe$), startWith(this.planForm.get('secure').get('securityType').value))
       .subscribe((securityType) => {
         // Display subscriptions section only for none KEY_LESS security type
         this.displaySubscriptionsSection = securityType !== 'KEY_LESS';
@@ -201,40 +213,76 @@ export class ApiPlanFormComponent implements OnInit, AfterViewInit, OnDestroy {
           this.planForm.get('general').get('validation').setValue(false);
           return;
         }
-        !this.isReadOnly && this.planForm.get('general').get('commentRequired').enable();
-        !this.isReadOnly && this.planForm.get('general').get('validation').enable();
+        !this.isDisabled && this.planForm.get('general').get('commentRequired').enable();
+        !this.isDisabled && this.planForm.get('general').get('validation').enable();
       });
+
+    this.planForm.valueChanges.pipe(takeUntil(this.unsubscribe$)).subscribe(() => {
+      this._onChange(this.getPlan());
+      this._onTouched();
+    });
   }
 
+  private getPlan() {
+    return internalFormValueToPlan(this.planForm.getRawValue(), this.mode);
+  }
+}
+
+const planToInternalFormValue = (plan: Plan | NewPlan | undefined): InternalPlanFormValue | undefined => {
+  if (!plan) {
+    return undefined;
+  }
+
+  return {
+    general: {
+      name: plan.name,
+      description: plan.description,
+      characteristics: plan.characteristics,
+      generalConditions: plan.general_conditions,
+      shardingTags: plan.tags,
+      commentRequired: plan.comment_required,
+      commentMessage: plan.comment_message,
+      validation: plan.validation,
+      excludedGroups: plan.excluded_groups,
+    },
+    secure: {
+      securityType: plan.security,
+      securityConfig: plan.securityDefinition ? JSON.parse(plan.securityDefinition) : {},
+      selectionRule: plan.selection_rule,
+    },
+  };
+};
+
+const internalFormValueToPlan = (value: InternalPlanFormValue, mode: 'create' | 'edit'): Plan | NewPlan => {
   // Init flows with restriction step. Only used in create mode
-  private initFlowsWithRestriction(): Flow[] {
+  const initFlowsWithRestriction = (restriction: InternalPlanFormValue['restriction']): Flow[] => {
     const restrictionPolicies: Step[] = [
-      ...(this.planForm.get('restriction').get('rateLimitEnabled').value
+      ...(restriction.rateLimitEnabled
         ? [
             {
               enabled: true,
               name: 'Rate Limiting',
-              configuration: this.planForm.get('restriction').get('rateLimitConfig').value,
+              configuration: restriction.rateLimitConfig,
               policy: 'rate-limit',
             },
           ]
         : []),
-      ...(this.planForm.get('restriction').get('quotaEnabled').value
+      ...(restriction.quotaEnabled
         ? [
             {
               enabled: true,
               name: 'Quota',
-              configuration: this.planForm.get('restriction').get('quotaConfig').value,
+              configuration: restriction.quotaConfig,
               policy: 'quota',
             },
           ]
         : []),
-      ...(this.planForm.get('restriction').get('resourceFilteringEnabled').value
+      ...(restriction.resourceFilteringEnabled
         ? [
             {
               enabled: true,
               name: 'Resource Filtering',
-              configuration: this.planForm.get('restriction').get('resourceFilteringConfig').value,
+              configuration: restriction.resourceFilteringConfig,
               policy: 'resource-filtering',
             },
           ]
@@ -252,5 +300,25 @@ export class ApiPlanFormComponent implements OnInit, AfterViewInit, OnDestroy {
         post: [],
       },
     ];
-  }
-}
+  };
+
+  return {
+    name: value.general.name,
+    description: value.general.description,
+    characteristics: value.general.characteristics,
+    general_conditions: value.general.generalConditions,
+    tags: value.general.shardingTags,
+    comment_required: value.general.commentRequired,
+    comment_message: value.general.commentMessage,
+    validation: value.general.validation ? PlanValidation.AUTO : PlanValidation.MANUAL,
+    excluded_groups: value.general.excludedGroups,
+
+    // Secure
+    security: value.secure.securityType as PlanSecurityType,
+    securityDefinition: JSON.stringify(value.secure.securityConfig),
+    selection_rule: value.secure.selectionRule,
+
+    // Restriction (only for create mode)
+    ...(mode === 'edit' ? {} : { flows: initFlowsWithRestriction(value.restriction) }),
+  };
+};

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.harness.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+import { GioFormTagsInputHarness } from '@gravitee/ui-particles-angular';
+import { MatSelectHarness } from '@angular/material/select/testing';
+import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
+
+import { Tag } from '../../../../entities/tag/tag';
+import { CONSTANTS_TESTING } from '../../../../shared/testing';
+import { Group } from '../../../../entities/group/group';
+import { Page } from '../../../../entities/page';
+
+export class ApiPlanFormHarness extends ComponentHarness {
+  static hostSelector = 'api-plan-form';
+
+  // 1- General Step
+  public getNameInput = this.locatorFor(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+  public getDescriptionInput = this.locatorFor(MatInputHarness.with({ selector: '[formControlName="description"]' }));
+  public getCharacteristicsInput = this.locatorFor(GioFormTagsInputHarness.with({ selector: '[formControlName="characteristics"]' }));
+  public getGeneralConditionsInput = this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="generalConditions"]' }));
+  public getValidationToggle = this.locatorFor(MatSlideToggleHarness.with({ selector: '[formControlName="validation"]' }));
+  public getCommentRequiredToggle = this.locatorFor(MatSlideToggleHarness.with({ selector: '[formControlName="commentRequired"]' }));
+  public getCommentMessageInput = this.locatorFor(MatInputHarness.with({ selector: '[formControlName="commentMessage"]' }));
+  public getShardingTagsInput = this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="shardingTags"]' }));
+  public getExcludedGroupsInput = this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="excludedGroups"]' }));
+
+  // 2- Secure Step
+  public getSecurityTypeInput = this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="securityType"]' }));
+  public getSelectionRuleInput = this.locatorForOptional(MatInputHarness.with({ selector: '[formControlName="selectionRule"]' }));
+
+  // 3- Restriction Step
+  public getRateLimitEnabledInput = this.locatorFor(MatSlideToggleHarness.with({ selector: '[formControlName="rateLimitEnabled"]' }));
+  public getQuotaEnabledInput = this.locatorFor(MatSlideToggleHarness.with({ selector: '[formControlName="quotaEnabled"]' }));
+  public getResourceFilteringEnabledInput = this.locatorFor(
+    MatSlideToggleHarness.with({ selector: '[formControlName="resourceFilteringEnabled"]' }),
+  );
+
+  async fillRequiredFields(fieldsValue: { name: string; securityTypeLabel: string | RegExp }) {
+    const nameInput = await this.getNameInput();
+    await nameInput.setValue(fieldsValue.name);
+
+    const securityTypeInput = await this.getSecurityTypeInput();
+    await securityTypeInput.clickOptions({ text: fieldsValue.securityTypeLabel });
+  }
+
+  httpRequest(httpTestingController: HttpTestingController) {
+    function expectTagsListRequest(tags: Tag[] = []) {
+      httpTestingController
+        .expectOne({
+          method: 'GET',
+          url: `${CONSTANTS_TESTING.org.baseURL}/configuration/tags`,
+        })
+        .flush(tags);
+    }
+
+    function expectGroupLisRequest(groups: Group[] = []) {
+      httpTestingController
+        .expectOne({
+          method: 'GET',
+          url: `${CONSTANTS_TESTING.env.baseURL}/configuration/groups`,
+        })
+        .flush(groups);
+    }
+
+    function expectDocumentationSearchRequest(apiId: string, groups: Page[] = []) {
+      httpTestingController
+        .expectOne({
+          method: 'GET',
+          url: `${CONSTANTS_TESTING.env.baseURL}/apis/${apiId}/pages?type=MARKDOWN&api=${apiId}`,
+        })
+        .flush(groups);
+    }
+
+    function expectCurrentUserTagsRequest(tags: string[]) {
+      httpTestingController
+        .expectOne({
+          method: 'GET',
+          url: `${CONSTANTS_TESTING.org.baseURL}/user/tags`,
+        })
+        .flush(tags);
+    }
+
+    function expectResourceGetRequest() {
+      httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/resources?expand=icon`, method: 'GET' }).flush([]);
+    }
+
+    return {
+      expectTagsListRequest,
+      expectGroupLisRequest,
+      expectDocumentationSearchRequest,
+      expectCurrentUserTagsRequest,
+      expectResourceGetRequest,
+    };
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.module.ts
@@ -25,14 +25,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatStepperModule } from '@angular/material/stepper';
-import {
-  GioBannerModule,
-  GioFormTagsInputModule,
-  GioIconsModule,
-  GioSaveBarModule,
-  GioFormSlideToggleModule,
-  GioFormFocusInvalidModule,
-} from '@gravitee/ui-particles-angular';
+import { GioBannerModule, GioFormTagsInputModule, GioIconsModule, GioFormSlideToggleModule } from '@gravitee/ui-particles-angular';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatDividerModule } from '@angular/material/divider';
 
@@ -40,8 +33,6 @@ import { PlanEditGeneralStepComponent } from './1-general-step/plan-edit-general
 import { PlanEditSecureStepComponent } from './2-secure-step/plan-edit-secure-step.component';
 import { PlanEditRestrictionStepComponent } from './3-restriction-step/plan-edit-restriction-step.component';
 import { ApiPlanFormComponent } from './api-plan-form.component';
-
-import { GioGoBackButtonModule } from '../../../../shared/components/gio-go-back-button/gio-go-back-button.module';
 
 @NgModule({
   declarations: [ApiPlanFormComponent, PlanEditGeneralStepComponent, PlanEditSecureStepComponent, PlanEditRestrictionStepComponent],
@@ -65,10 +56,7 @@ import { GioGoBackButtonModule } from '../../../../shared/components/gio-go-back
     GioFormSlideToggleModule,
     GioFormTagsInputModule,
     GioIconsModule,
-    GioSaveBarModule,
-    GioFormFocusInvalidModule,
     GioBannerModule,
-    GioGoBackButtonModule,
   ],
 })
 export class ApiPlanFormModule {}

--- a/gravitee-apim-console-webui/src/management/api/portal/apis.portal.route.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/apis.portal.route.ts
@@ -70,6 +70,7 @@ function apisPortalRouterConfig($stateProvider) {
       url: '/new',
       component: 'ngApiPortalPlanEdit',
       data: {
+        useAngularMaterial: true,
         perms: {
           only: ['api-plan-c'],
         },
@@ -82,6 +83,7 @@ function apisPortalRouterConfig($stateProvider) {
       url: '/:planId/edit',
       component: 'ngApiPortalPlanEdit',
       data: {
+        useAngularMaterial: true,
         perms: {
           only: ['api-plan-u'],
         },

--- a/gravitee-apim-console-webui/src/management/api/portal/plans/api-portal-plans.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/plans/api-portal-plans.module.ts
@@ -21,7 +21,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatButtonModule } from '@angular/material/button';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { DragDropModule } from '@angular/cdk/drag-drop';
-import { GioIconsModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
+import { GioFormFocusInvalidModule, GioIconsModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatCardModule } from '@angular/material/card';
@@ -54,6 +54,7 @@ import { GioGoBackButtonModule } from '../../../../shared/components/gio-go-back
     GioPermissionModule,
     GioSaveBarModule,
     GioGoBackButtonModule,
+    GioFormFocusInvalidModule,
 
     ApiPlanFormModule,
   ],

--- a/gravitee-apim-console-webui/src/management/api/portal/plans/edit/api-portal-plan-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/plans/edit/api-portal-plan-edit.component.html
@@ -21,8 +21,10 @@
     Plan
   </span>
 </div>
-<form *ngIf="planForm" [hidden]="isLoadingData" autocomplete="off" gioFormFocusInvalid [formGroup]="planForm">
-  <mat-card> 🚧 Plan form component here </mat-card>
+<form *ngIf="planForm" autocomplete="off" gioFormFocusInvalid [formGroup]="planForm">
+  <mat-card>
+    <api-plan-form formControlName="plan" [mode]="mode" [api]="api"></api-plan-form>
+  </mat-card>
 
   <gio-save-bar
     *ngIf="planForm && !isReadOnly"

--- a/gravitee-apim-console-webui/src/management/api/portal/plans/edit/api-portal-plan-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/plans/edit/api-portal-plan-edit.component.ts
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { STEPPER_GLOBAL_OPTIONS } from '@angular/cdk/stepper';
-import { AfterViewInit, ChangeDetectorRef, Component, Inject, OnDestroy, OnInit } from '@angular/core';
-import { FormGroup } from '@angular/forms';
+import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
 import { EMPTY, of, Subject } from 'rxjs';
 import { catchError, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { StateService } from '@uirouter/angularjs';
@@ -26,32 +25,25 @@ import { ApiService } from '../../../../../services-ngx/api.service';
 import { PlanService } from '../../../../../services-ngx/plan.service';
 import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
 import { GioPermissionService } from '../../../../../shared/components/gio-permission/gio-permission.service';
+import { NewPlan, Plan } from '../../../../../entities/plan';
 
 @Component({
   selector: 'api-portal-plan-edit',
   template: require('./api-portal-plan-edit.component.html'),
   styles: [require('./api-portal-plan-edit.component.scss')],
-  providers: [
-    {
-      provide: STEPPER_GLOBAL_OPTIONS,
-      useValue: { displayDefaultIndicatorType: false, showError: true },
-    },
-  ],
 })
-export class ApiPortalPlanEditComponent implements OnInit, AfterViewInit, OnDestroy {
+export class ApiPortalPlanEditComponent implements OnInit, OnDestroy {
   private unsubscribe$: Subject<boolean> = new Subject<boolean>();
 
   public mode: 'create' | 'edit' = 'create';
-  public isLoadingData = true;
 
-  public planForm = new FormGroup({});
+  public planForm: FormGroup;
   public initialPlanFormValue: unknown;
   public api: Api;
   public isReadOnly = false;
   public displaySubscriptionsSection = true;
 
   constructor(
-    private readonly changeDetectorRef: ChangeDetectorRef,
     @Inject(UIRouterStateParams) private readonly ajsStateParams,
     @Inject(UIRouterState) private readonly ajsState: StateService,
     private readonly apiService: ApiService,
@@ -62,9 +54,7 @@ export class ApiPortalPlanEditComponent implements OnInit, AfterViewInit, OnDest
 
   ngOnInit() {
     this.mode = this.ajsStateParams.planId ? 'edit' : 'create';
-  }
 
-  ngAfterViewInit(): void {
     this.apiService
       .get(this.ajsStateParams.apiId)
       .pipe(
@@ -76,33 +66,13 @@ export class ApiPortalPlanEditComponent implements OnInit, AfterViewInit, OnDest
         switchMap(() =>
           this.mode === 'edit' ? this.planService.get(this.ajsStateParams.apiId, this.ajsStateParams.planId) : of(undefined),
         ),
-        tap((_plan) => {
-          // TODO: 🚧
-          // this.initPlanForm(
-          //   plan
-          //     ? {
-          //         general: {
-          //           name: plan.name,
-          //           description: plan.description,
-          //           characteristics: plan.characteristics,
-          //           generalConditions: plan.general_conditions,
-          //           shardingTags: plan.tags,
-          //           commentRequired: plan.comment_required,
-          //           commentMessage: plan.comment_message,
-          //           validation: plan.validation,
-          //           excludedGroups: plan.excluded_groups,
-          //         },
-          //         secure: {
-          //           securityTypes: plan.security,
-          //           securityConfig: plan.securityDefinition ? JSON.parse(plan.securityDefinition) : {},
-          //           selectionRule: plan.selection_rule,
-          //         },
-          //       }
-          //     : undefined,
-          // );
-          // Manually trigger change detection to avoid ExpressionChangedAfterItHasBeenCheckedError in test
-          // Needed to have only one detectChanges() after load each step child component
-          this.changeDetectorRef.detectChanges();
+        tap((plan) => {
+          this.planForm = new FormGroup({
+            plan: new FormControl({
+              value: plan,
+              disabled: this.isReadOnly,
+            }),
+          });
         }),
         catchError((error) => {
           this.snackBarService.error(error.error?.message ?? 'An ');
@@ -118,43 +88,26 @@ export class ApiPortalPlanEditComponent implements OnInit, AfterViewInit, OnDest
   }
 
   onSubmit() {
-    // TODO 🚧
-    // const newPlan: NewPlan = {
-    //   api: this.api.id,
-    //   // General
-    //   name: this.planForm.get('general').get('name').value,
-    //   description: this.planForm.get('general').get('description').value,
-    //   characteristics: this.planForm.get('general').get('characteristics').value,
-    //   general_conditions: this.planForm.get('general').get('generalConditions').value,
-    //   tags: this.planForm.get('general').get('shardingTags').value,
-    //   comment_required: this.planForm.get('general').get('commentRequired').value,
-    //   comment_message: this.planForm.get('general').get('commentMessage').value,
-    //   validation: this.planForm.get('general').get('validation').value ? PlanValidation.AUTO : PlanValidation.MANUAL,
-    //   excluded_groups: this.planForm.get('general').get('excludedGroups').value,
-    //
-    //   // Secure
-    //   security: this.planForm.get('secure').get('securityTypes').value,
-    //   securityDefinition: JSON.stringify(this.planForm.get('secure').get('securityConfig').value),
-    //   selection_rule: this.planForm.get('secure').get('selectionRule').value,
-    //
-    //   // Restriction (only for create mode)
-    //   ...(this.mode === 'edit' ? {} : { flows: this.initFlowsWithRestriction() }),
-    // };
-    //
-    // (this.mode === 'edit'
-    //   ? this.planService
-    //       .get(this.ajsStateParams.apiId, this.ajsStateParams.planId)
-    //       .pipe(switchMap((planToUpdate) => this.planService.update(this.api, { ...planToUpdate, ...newPlan })))
-    //   : this.planService.create(this.api, newPlan)
-    // )
-    //   .pipe(
-    //     takeUntil(this.unsubscribe$),
-    //     tap(() => this.snackBarService.success('Configuration successfully saved!')),
-    //     catchError((error) => {
-    //       this.snackBarService.error(error.error?.message ?? 'An error occurs while saving configuration');
-    //       return EMPTY;
-    //     }),
-    //   )
-    //   .subscribe(() => this.ajsState.go('management.apis.detail.portal.plans'));
+    const planToSave: NewPlan | Plan = {
+      ...this.planForm.get('plan').value,
+    };
+
+    const savePlan$ =
+      this.mode === 'edit'
+        ? this.planService
+            .get(this.ajsStateParams.apiId, this.ajsStateParams.planId)
+            .pipe(switchMap((planToUpdate) => this.planService.update(this.api, { ...planToUpdate, ...planToSave })))
+        : this.planService.create(this.api, { ...planToSave });
+
+    savePlan$
+      .pipe(
+        takeUntil(this.unsubscribe$),
+        tap(() => this.snackBarService.success('Configuration successfully saved!')),
+        catchError((error) => {
+          this.snackBarService.error(error.error?.message ?? 'An error occurs while saving configuration');
+          return EMPTY;
+        }),
+      )
+      .subscribe(() => this.ajsState.go('management.apis.detail.portal.plans'));
   }
 }

--- a/gravitee-apim-console-webui/src/management/management.module.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/management.module.ajs.ts
@@ -517,7 +517,6 @@ import { ApplicationNavigationComponent } from './application/details/applicatio
 import { ApiNavigationComponent } from './api/api-navigation/api-navigation.component';
 import { ApiProxyHealthCheckComponent } from './api/proxy/health-check/api-proxy-health-check.component';
 import { ApiPortalPlanListComponent } from './api/portal/plans/list/api-portal-plan-list.component';
-import { ApiPlanFormComponent } from './api/component/plan/api-plan-form.component';
 import { TaskService } from '../services-ngx/task.service';
 import { IfMatchEtagInterceptor } from '../shared/interceptors/if-match-etag.interceptor';
 import ApiPortalController from './api/portal/general/apiPortal.controller';
@@ -532,6 +531,7 @@ import { SearchAndSelectController } from '../components/search-and-select/searc
 import { ApiPortalTransferOwnershipComponent } from './api/portal/user-group-access/transfer-ownership/api-portal-transfer-ownership.component';
 import AlertTabsController from '../components/alerts/alertTabs/alert-tabs-component';
 import AlertsActivityController from '../components/alerts/activity/alerts-activity.controller';
+import { ApiPortalPlanEditComponent } from './api/portal/plans/edit/api-portal-plan-edit.component';
 
 (<any>window).moment = moment;
 require('angular-moment-picker');
@@ -880,7 +880,7 @@ graviteeManagementModule.component('gvDashboardTimeframe', DashboardTimeframeCom
 graviteeManagementModule.controller('DashboardTimeframeController', DashboardTimeframeController);
 
 // Plan
-graviteeManagementModule.directive('ngApiPortalPlanEdit', downgradeComponent({ component: ApiPlanFormComponent }));
+graviteeManagementModule.directive('ngApiPortalPlanEdit', downgradeComponent({ component: ApiPortalPlanEditComponent }));
 graviteeManagementModule.component('apiPlan', ApiPlanComponent);
 graviteeManagementModule.directive('ngApiPortalGroups', downgradeComponent({ component: ApiPortalGroupsComponent }));
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-966

## Description

Separate plan form from to a dedicated api shared component `api-plan-form`.
This component is now a custom ControlValueAccessor to be able to work with simple ReactiveForm

"Re create" the ApiPortalPlanEdit to add/edit plan into existing api. 

No feature change (🤞 ) for add/edit a plan into api. 


Next PR : 
- Make plan form work without created api
- Extract next / previous button from form component
- Use in into api creation workflow
- Cleans up some neglected aspects

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ojgifoccbj.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-748-plan-component-1/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
