### PR TITLE
chore: bump json-to-json version

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -61,7 +61,7 @@
         <gravitee-policy-http-signature.version>1.5.0</gravitee-policy-http-signature.version>
         <gravitee-policy-ipfiltering.version>1.9.0</gravitee-policy-ipfiltering.version>
         <gravitee-policy-json-threat-protection.version>1.3.3</gravitee-policy-json-threat-protection.version>
-        <gravitee-policy-json-to-json.version>2.0.0</gravitee-policy-json-to-json.version>
+        <gravitee-policy-json-to-json.version>2.0.1</gravitee-policy-json-to-json.version>
         <gravitee-policy-json-validation.version>1.6.1</gravitee-policy-json-validation.version>
         <gravitee-policy-json-xml.version>2.1.0</gravitee-policy-json-xml.version>
         <gravitee-policy-jws.version>1.3.2</gravitee-policy-jws.version>


### PR DESCRIPTION
## Description
Upgrade json-to-json policy to 2.0.1
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gdtzwixsbg.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/bump-jsontojson/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
