### PR TITLE
fix: use group default roles if exists when adding members

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResource.java
@@ -267,12 +267,16 @@ public class GroupMembersResource extends AbstractResource {
                 if (apiRoleEntity != null && !apiRoleEntity.equals(previousApiRole)) {
                     String roleName = apiRoleEntity.getName();
                     if (!hasPermission && groupEntity.isLockApiRole()) {
-                        final List<RoleEntity> defaultRoles = roleService.findDefaultRoleByScopes(
-                            GraviteeContext.getCurrentOrganization(),
-                            RoleScope.API
-                        );
-                        if (defaultRoles != null && !defaultRoles.isEmpty()) {
-                            roleName = defaultRoles.get(0).getName();
+                        if (groupEntity.getRoles() != null && !groupEntity.getRoles().isEmpty()) {
+                            roleName = groupEntity.getRoles().get(RoleScope.API);
+                        } else {
+                            final List<RoleEntity> defaultRoles = roleService.findDefaultRoleByScopes(
+                                GraviteeContext.getCurrentOrganization(),
+                                RoleScope.API
+                            );
+                            if (defaultRoles != null && !defaultRoles.isEmpty()) {
+                                roleName = defaultRoles.get(0).getName();
+                            }
                         }
                     }
                     updatedMembership =
@@ -306,12 +310,16 @@ public class GroupMembersResource extends AbstractResource {
                 if (applicationRoleEntity != null && !applicationRoleEntity.equals(previousApplicationRole)) {
                     String roleName = applicationRoleEntity.getName();
                     if (!hasPermission && groupEntity.isLockApplicationRole()) {
-                        final List<RoleEntity> defaultRoles = roleService.findDefaultRoleByScopes(
-                            GraviteeContext.getCurrentOrganization(),
-                            RoleScope.APPLICATION
-                        );
-                        if (defaultRoles != null && !defaultRoles.isEmpty()) {
-                            roleName = defaultRoles.get(0).getName();
+                        if (groupEntity.getRoles() != null && !groupEntity.getRoles().isEmpty()) {
+                            roleName = groupEntity.getRoles().get(RoleScope.APPLICATION);
+                        } else {
+                            final List<RoleEntity> defaultRoles = roleService.findDefaultRoleByScopes(
+                                GraviteeContext.getCurrentOrganization(),
+                                RoleScope.APPLICATION
+                            );
+                            if (defaultRoles != null && !defaultRoles.isEmpty()) {
+                                roleName = defaultRoles.get(0).getName();
+                            }
                         }
                     }
                     updatedMembership =


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-871
https://github.com/gravitee-io/issues/issues/7362

## Description

When a user is a simple group admin and is not allowed to update the group or the default role
then when this user add a member, the roles were replaced by the default roles defined at organization levels.
If a group has default roles, they should be used instead.