### PR TITLE
add opensearch repo tests in CircleCi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1476,6 +1476,10 @@ jobs:
                 type: string
                 description: version of elasticsearch to test
                 default: ""
+            engineType:
+              type: string
+              description: type of the search engine
+              default: "elasticsearch"
         executor:
             name: ubuntu
         steps:
@@ -1492,7 +1496,7 @@ jobs:
                             name: Run Elasticsearch repository tests with version << parameters.version >>
                             command: |
                                 cd gravitee-apim-repository
-                                mvn -pl 'gravitee-apim-repository-elasticsearch' -am -s ../.gravitee.settings.xml clean package --no-transfer-progress -Dskip.validation=true -Delasticsearch.version=<< parameters.version>> -T 2C
+                                mvn -pl 'gravitee-apim-repository-elasticsearch' -am -s ../.gravitee.settings.xml clean package --no-transfer-progress -Dskip.validation=true -D<< parameters.engineType >>.version=<< parameters.version >> -Dsearch.type=<< parameters.engineType >> -T 2C
                       - run:
                             name: Save test results
                             command: |
@@ -2204,12 +2208,23 @@ workflows:
                       parameters:
                           version: ["4", "5", "6.0"]
             - elastic-test-container:
+                  name: Run ElasticSearch repositories tests << matrix.version >>
                   context: cicd-orchestrator
                   requires:
                       - setup
                   matrix:
                       parameters:
+                          engineType: ["elasticsearch"]
                           version: ["5.6.16", "6.8.23", "7.17.8", "8.7.0"]
+            - elastic-test-container:
+                  name: Run Opensearch repositories tests << matrix.version >>
+                  context: cicd-orchestrator
+                  requires:
+                      - setup
+                  matrix:
+                      parameters:
+                          engineType: ["opensearch"]
+                          version: ["2.6.0", "1.3.9"]
 
     release_notes_apim:
         when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2209,7 +2209,7 @@ workflows:
                       - setup
                   matrix:
                       parameters:
-                          version: ["5.6.16", "6.8.23", "7.17.8"]
+                          version: ["5.6.16", "6.8.23", "7.17.8", "8.7.0"]
 
     release_notes_apim:
         when:

--- a/.run/Repository - ES.run.xml
+++ b/.run/Repository - ES.run.xml
@@ -1,0 +1,26 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Repository - ES" type="JUnit" factoryName="JUnit" folderName="Repository">
+    <classpathModifications>
+      <entry exclude="true" path="$PROJECT_DIR$/gravitee-apim-repository/gravitee-apim-repository-test/target/test-classes" />
+    </classpathModifications>
+    <module name="gravitee-apim-repository-elasticsearch" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <option name="ALTERNATIVE_JRE_PATH" value="11" />
+    <option name="PACKAGE_NAME" value="io.gravitee.repository.elasticsearch" />
+    <option name="MAIN_CLASS_NAME" value="" />
+    <option name="METHOD_NAME" value="" />
+    <option name="TEST_OBJECT" value="package" />
+    <envs>
+      <env name="elasticsearch.version" value="7.17.8" />
+    </envs>
+    <dir value="$PROJECT_DIR$/gravitee-apim-repository/gravitee-apim-repository-mongodb/target/test-classes/io/gravitee/repository" />
+    <patterns>
+      <pattern testClass="io\.gravitee\.repository\..*RepositoryTest" />
+    </patterns>
+    <method v="2">
+      <option name="Make" enabled="true" />
+      <option name="Maven.BeforeRunTask" enabled="true" file="$PROJECT_DIR$/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/pom.xml" goal="clean install -U -DskipTests=true -Dskip.validation" />
+      <option name="Maven.BeforeRunTask" enabled="true" file="$PROJECT_DIR$/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/pom.xml" goal="test " />
+    </method>
+  </configuration>
+</component>

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/README.adoc
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/README.adoc
@@ -7,5 +7,7 @@ To do so you can use the following commands:
 
 * ES 5.x: `mvn clean test -Delasticsearch.version=5.6.16`
 * ES 6.x: `mvn clean test -Delasticsearch.version=6.8.23`
-* ES 7.x: `mvn clean test -Delasticsearch.version=7.17.8` (Default)
-
+* ES 7.x: `mvn clean test -Delasticsearch.version=7.17.8`
+* ES 8.x: `mvn clean test -Delasticsearch.version=8.7.0` (Default)
+* OS 1.x: `mvn clean test -Dsearch.type=opensearch -Dopensearch.version=1.3.9`
+* OS 2.x: `mvn clean test -Dsearch.type=opensearch -Dopensearch.version=2.6.0`

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/pom.xml
@@ -34,6 +34,7 @@
         <elasticsearch.version>5.6.16</elasticsearch.version>
         <gravitee-common-elasticsearch.version>4.1.0</gravitee-common-elasticsearch.version>
         <lucene.version>6.6.1</lucene.version>
+        <opensearch-testcontainers.version>2.0.0</opensearch-testcontainers.version>
     </properties>
 
     <dependencies>
@@ -205,6 +206,13 @@
             <groupId>org.unitils</groupId>
             <artifactId>unitils-core</artifactId>
             <version>3.4.6</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.opensearch</groupId>
+            <artifactId>opensearch-testcontainers</artifactId>
+            <version>${opensearch-testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/spring/ElasticsearchRepositoryConfigurationTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/spring/ElasticsearchRepositoryConfigurationTest.java
@@ -28,6 +28,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.ConfigurableEnvironment;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
 /**
@@ -68,12 +69,11 @@ public class ElasticsearchRepositoryConfigurationTest {
     }
 
     @Bean
-    public RepositoryConfiguration repositoryConfiguration(
-        ElasticsearchContainer elasticSearchContainer,
-        ConfigurableEnvironment environment
-    ) {
+    public RepositoryConfiguration repositoryConfiguration(GenericContainer<?> container, ConfigurableEnvironment environment) {
         RepositoryConfiguration elasticConfiguration = new RepositoryConfiguration();
-        elasticConfiguration.setEndpoints(Collections.singletonList(new Endpoint("http://" + elasticSearchContainer.getHttpHostAddress())));
+        elasticConfiguration.setEndpoints(
+            Collections.singletonList(new Endpoint("http://" + container.getHost() + ":" + container.getMappedPort(9200)))
+        );
         elasticConfiguration.setUsername("elastic");
         elasticConfiguration.setPassword(ElasticsearchContainer.ELASTICSEARCH_DEFAULT_PASSWORD);
         if (elasticsearchVersion.startsWith("5")) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1351

## Description

In this pr we add:

- [x] the ability to run elastic repository tests using Opensearch 1 & 2.
- [x] the version 8 of elasticsearch in our repository test cron job on the ci.

Here is a run I triggered on the CI manually 
https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/17467/workflows/31b1ad0e-5883-4603-bfef-7d5ac94252c0

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

