### PR TITLE
fix: remove banner for shared configuration

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-3-endpoints/step-3-endpoints-2-config.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-3-endpoints/step-3-endpoints-2-config.component.html
@@ -32,9 +32,6 @@
           [jsonSchema]="endpointSchemas[endpoint.id].config"
           [formControlName]="endpoint.id + '-configuration'"
         ></gio-form-json-schema>
-        <gio-banner-info *ngIf="!!endpointSchemas[endpoint.id].sharedConfig"
-          >The following configuration will be shareable for all the endpoints of the group</gio-banner-info
-        >
         <gio-form-json-schema
           [jsonSchema]="endpointSchemas[endpoint.id].sharedConfig"
           [formControlName]="endpoint.id + '-sharedConfiguration'"


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-724

## Description

As discussed with UX team, the banner bring confusion so we remove it.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fqpmbpbbkp.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-724-remove-banner/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
