### PR TITLE
feat: implement a new noop repository

### DIFF
--- a/.circleci/package_bundles.py
+++ b/.circleci/package_bundles.py
@@ -146,6 +146,11 @@ def get_repositories(release_json):
             "artifact_id": "gravitee-apim-repository-elasticsearch",
             "group_id": "io.gravitee.apim.repository",
             "version": apim_version
+        },
+        {
+            "artifact_id": "gravitee-apim-repository-noop",
+            "group_id": "io.gravitee.apim.repository",
+            "version": apim_version
         }
     ]
     return repositories

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -649,6 +649,13 @@
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-noop</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <scope>runtime</scope>
+        </dependency>
 
         <!-- Resources -->
         <dependency>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
@@ -144,6 +144,7 @@
                 <exclude>io.gravitee.cockpit:gravitee-cockpit-connectors-ws:zip</exclude>
                 <exclude>io.gravitee.notifier:*:zip</exclude>
                 <exclude>io.gravitee.repository:gravitee-apim-repository-elasticsearch:zip</exclude>
+                <exclude>io.gravitee.repository:gravitee-apim-repository-noop:zip</exclude>
             </excludes>
             <useProjectArtifact>false</useProjectArtifact>
             <fileMode>755</fileMode>

--- a/gravitee-apim-repository/gravitee-apim-repository-coverage/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-coverage/pom.xml
@@ -82,6 +82,12 @@
 
         <dependency>
             <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-noop</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.apim.repository</groupId>
             <artifactId>gravitee-apim-repository-redis</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/monitoring/ElasticsearchMonitoringRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/monitoring/ElasticsearchMonitoringRepository.java
@@ -46,7 +46,7 @@ public class ElasticsearchMonitoringRepository extends AbstractElasticsearchRepo
     /**
      * Logger.
      */
-    private final Logger logger = LoggerFactory.getLogger(ElasticsearchAnalyticsRepository.class);
+    private final Logger logger = LoggerFactory.getLogger(ElasticsearchMonitoringRepository.class);
 
     /**
      * Name of the FreeMarker template used to query monitoring document types.

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/README.adoc
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/README.adoc
@@ -1,0 +1,11 @@
+
+= APIM NoOp Repository
+
+This repository is just a dummy implementation of the following APIs from gravitee-apim-repository-api module
+
+- AnalyticsRepository
+- HealthCheckRepository
+- LogRepository
+- MonitoringRepository
+
+The return value is always NULL

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/pom.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.gravitee.apim.repository</groupId>
+        <artifactId>gravitee-apim-repository</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+    </parent>
+
+    <artifactId>gravitee-apim-repository-noop</artifactId>
+
+    <name>Gravitee.io APIM - Repository - NoOp</name>
+
+    <dependencies>
+        <!-- Gravitee.io dependencies -->
+        <dependency>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-api</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.platform</groupId>
+            <artifactId>gravitee-platform-repository-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Spring dependencies -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-rx-java3</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Unit Tests -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Used to load configuration file -->
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/assembly/plugin-assembly.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/assembly/plugin-assembly.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly>
+	<id>plugin</id>
+	<formats>
+		<format>zip</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+
+	<!-- Include the main plugin Jar file -->
+	<files>
+		<file>
+			<source>${project.build.directory}/${project.build.finalName}.jar</source>
+		</file>
+	</files>
+
+	<!-- Finally include plugin dependencies -->
+	<dependencySets>
+		<dependencySet>
+			<outputDirectory>lib</outputDirectory>
+			<useProjectArtifact>false</useProjectArtifact>
+		</dependencySet>
+	</dependencySets>
+</assembly>

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpAnalyticsRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpAnalyticsRepository.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.noop;
+
+import io.gravitee.repository.analytics.AnalyticsException;
+import io.gravitee.repository.analytics.api.AnalyticsRepository;
+import io.gravitee.repository.analytics.query.Query;
+import io.gravitee.repository.analytics.query.response.Response;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class NoOpAnalyticsRepository implements AnalyticsRepository {
+
+    @Override
+    public <T extends Response> T query(final Query<T> query) throws AnalyticsException {
+        return null;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpHealthCheckRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpHealthCheckRepository.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.noop;
+
+import io.gravitee.repository.analytics.AnalyticsException;
+import io.gravitee.repository.healthcheck.api.HealthCheckRepository;
+import io.gravitee.repository.healthcheck.query.Query;
+import io.gravitee.repository.healthcheck.query.Response;
+import io.gravitee.repository.healthcheck.query.log.ExtendedLog;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class NoOpHealthCheckRepository implements HealthCheckRepository {
+
+    @Override
+    public <T extends Response> T query(final Query<T> query) throws AnalyticsException {
+        return null;
+    }
+
+    @Override
+    public ExtendedLog findById(String id) throws AnalyticsException {
+        return null;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpLogRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpLogRepository.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.noop;
+
+import io.gravitee.repository.analytics.AnalyticsException;
+import io.gravitee.repository.analytics.query.tabular.TabularQuery;
+import io.gravitee.repository.analytics.query.tabular.TabularResponse;
+import io.gravitee.repository.log.api.LogRepository;
+import io.gravitee.repository.log.model.ExtendedLog;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class NoOpLogRepository implements LogRepository {
+
+    /**
+     * Logger.
+     */
+    private final Logger logger = LoggerFactory.getLogger(NoOpLogRepository.class);
+
+    @Override
+    public TabularResponse query(final TabularQuery query) throws AnalyticsException {
+        return null;
+    }
+
+    @Override
+    public ExtendedLog findById(String logId, Long timestamp) throws AnalyticsException {
+        return null;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpMonitoringRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpMonitoringRepository.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.noop;
+
+import io.gravitee.repository.monitoring.MonitoringRepository;
+import io.gravitee.repository.monitoring.model.MonitoringResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class NoOpMonitoringRepository implements MonitoringRepository {
+
+    /**
+     * Logger.
+     */
+    private final Logger logger = LoggerFactory.getLogger(NoOpMonitoringRepository.class);
+
+    @Override
+    public MonitoringResponse query(final String gatewayId) {
+        return null;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpRepositoryConfiguration.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.noop;
+
+import io.gravitee.repository.analytics.api.AnalyticsRepository;
+import io.gravitee.repository.healthcheck.api.HealthCheckRepository;
+import io.gravitee.repository.log.api.LogRepository;
+import io.gravitee.repository.monitoring.MonitoringRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Configuration
+public class NoOpRepositoryConfiguration {
+
+    @Bean
+    public AnalyticsRepository analyticsRepository() {
+        return new NoOpAnalyticsRepository();
+    }
+
+    @Bean
+    public HealthCheckRepository healthCheckRepository() {
+        return new NoOpHealthCheckRepository();
+    }
+
+    @Bean
+    public LogRepository logRepository() {
+        return new NoOpLogRepository();
+    }
+
+    @Bean
+    public MonitoringRepository monitoringRepository() {
+        return new NoOpMonitoringRepository();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpRepositoryProvider.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpRepositoryProvider.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.noop;
+
+import io.gravitee.platform.repository.api.RepositoryProvider;
+import io.gravitee.platform.repository.api.Scope;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class NoOpRepositoryProvider implements RepositoryProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NoOpRepositoryProvider.class);
+
+    @Override
+    public String type() {
+        return "none";
+    }
+
+    @Override
+    public Scope[] scopes() {
+        return new Scope[] { Scope.ANALYTICS };
+    }
+
+    @Override
+    public Class<?> configuration(Scope scope) {
+        if (scope == Scope.ANALYTICS) {
+            return NoOpRepositoryConfiguration.class;
+        }
+        LOGGER.debug("Skipping unhandled repository scope {}", scope);
+        return null;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/resources/plugin.properties
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/resources/plugin.properties
@@ -1,0 +1,6 @@
+id=repository-noop
+name=${project.name}
+version=${project.version}
+description=${project.description}
+class=io.gravitee.repository.noop.NoOpRepositoryProvider
+type=repository

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/AbstractNoOpRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/AbstractNoOpRepositoryTest.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.noop;
+
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = { NoOpRepositoryConfigurationTest.class })
+public abstract class AbstractNoOpRepositoryTest {}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/NoOpAnalyticsRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/NoOpAnalyticsRepositoryTest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.noop;
+
+import static io.gravitee.repository.analytics.query.DateRangeBuilder.lastDays;
+import static io.gravitee.repository.analytics.query.IntervalBuilder.hours;
+import static io.gravitee.repository.analytics.query.QueryBuilders.dateHistogram;
+
+import io.gravitee.repository.analytics.api.AnalyticsRepository;
+import io.gravitee.repository.analytics.query.response.histogram.DateHistogramResponse;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class NoOpAnalyticsRepositoryTest extends AbstractNoOpRepositoryTest {
+
+    @Autowired
+    private AnalyticsRepository analyticsRepository;
+
+    @Test
+    public void testQuery() throws Exception {
+        Assert.assertNotNull(analyticsRepository);
+
+        DateHistogramResponse response = analyticsRepository.query(dateHistogram().timeRange(lastDays(30), hours(1)).build());
+
+        Assert.assertNull(response);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/NoOpHealthCheckRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/NoOpHealthCheckRepositoryTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.noop;
+
+import static io.gravitee.repository.healthcheck.query.QueryBuilders.dateHistogram;
+
+import io.gravitee.repository.analytics.AnalyticsException;
+import io.gravitee.repository.healthcheck.api.HealthCheckRepository;
+import io.gravitee.repository.healthcheck.query.log.ExtendedLog;
+import io.gravitee.repository.healthcheck.query.response.histogram.DateHistogramResponse;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Teaom
+ */
+public class NoOpHealthCheckRepositoryTest extends AbstractNoOpRepositoryTest {
+
+    @Autowired
+    private HealthCheckRepository healthCheckRepository;
+
+    @Test
+    public void testQuery() throws AnalyticsException {
+        Assert.assertNotNull(healthCheckRepository);
+
+        DateHistogramResponse response = healthCheckRepository.query(dateHistogram().query("any_query").build());
+
+        Assert.assertNull(response);
+    }
+
+    @Test
+    public void testFindById() throws AnalyticsException {
+        Assert.assertNotNull(healthCheckRepository);
+
+        ExtendedLog response = healthCheckRepository.findById("any_id");
+
+        Assert.assertNull(response);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/NoOpLogRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/NoOpLogRepositoryTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.noop;
+
+import static io.gravitee.repository.analytics.query.DateRangeBuilder.lastDays;
+import static io.gravitee.repository.analytics.query.IntervalBuilder.hours;
+import static io.gravitee.repository.analytics.query.QueryBuilders.tabular;
+import static org.junit.Assert.*;
+
+import io.gravitee.repository.analytics.query.tabular.TabularResponse;
+import io.gravitee.repository.log.api.LogRepository;
+import io.gravitee.repository.log.model.ExtendedLog;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class NoOpLogRepositoryTest extends AbstractNoOpRepositoryTest {
+
+    @Autowired
+    private LogRepository logRepository;
+
+    @Test
+    public void testFindById() throws Exception {
+        Assert.assertNotNull(logRepository);
+
+        ExtendedLog log = logRepository.findById("29381bce-df59-47b2-b81b-cedf59c7b23e", System.currentTimeMillis() - 24 * 60 * 60 * 1000);
+
+        assertNull(log);
+    }
+
+    @Test
+    public void testTabular_withQuery() throws Exception {
+        Assert.assertNotNull(logRepository);
+
+        TabularResponse response = logRepository.query(
+            tabular().timeRange(lastDays(60), hours(1)).query("api:be0aa9c9-ca1c-4d0a-8aa9-c9ca1c5d0aab").page(1).size(20).build()
+        );
+
+        assertNull(response);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/NoOpMonitoringRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/NoOpMonitoringRepositoryTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.noop;
+
+import io.gravitee.repository.analytics.AnalyticsException;
+import io.gravitee.repository.monitoring.MonitoringRepository;
+import io.gravitee.repository.monitoring.model.MonitoringResponse;
+import java.io.IOException;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class NoOpMonitoringRepositoryTest extends AbstractNoOpRepositoryTest {
+
+    @Autowired
+    private MonitoringRepository monitoringRepository;
+
+    @Test
+    public void testQuery() throws AnalyticsException, IOException {
+        Assert.assertNotNull(monitoringRepository);
+
+        final MonitoringResponse monitoringResponse = monitoringRepository.query("1876c024-c6a2-409a-b6c0-24c6a2e09a5f");
+
+        Assert.assertNull(monitoringResponse);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/NoOpRepositoryConfigurationTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/NoOpRepositoryConfigurationTest.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.noop;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Configuration
+@Import(NoOpRepositoryConfiguration.class)
+public class NoOpRepositoryConfigurationTest {}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/NoOpRepositoryProviderTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/NoOpRepositoryProviderTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.noop;
+
+import static org.junit.Assert.*;
+
+import io.gravitee.platform.repository.api.Scope;
+import org.junit.Test;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class NoOpRepositoryProviderTest {
+
+    private final NoOpRepositoryProvider provider = new NoOpRepositoryProvider();
+
+    @Test
+    public void shouldReturnNoOpType() {
+        assertEquals("none", provider.type());
+    }
+
+    @Test
+    public void shouldReturnAnalyticsScope() {
+        assertArrayEquals(new Scope[] { Scope.ANALYTICS }, provider.scopes());
+    }
+
+    @Test
+    public void shouldReturnNoOpConfigurationClass() {
+        Class<?> configClass = provider.configuration(Scope.ANALYTICS);
+        assertEquals(NoOpRepositoryConfiguration.class, configClass);
+    }
+
+    @Test
+    public void shouldReturnNullClass() {
+        Class<?> configClass = provider.configuration(Scope.MANAGEMENT);
+        assertNull(configClass);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/resources/logback.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/resources/logback.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2015-2016, The Gravitee team (http://www.gravitee.io)
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+
+<configuration debug="true">
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.gravitee" level="INFO" />
+    <logger name="org.springframework" level="INFO" additivity="false"/>
+    <logger name="org.eclipse.jetty" level="INFO" additivity="false"/>
+    <logger name="org.apache.http" level="INFO" additivity="false"/>
+
+    <!-- Strictly speaking, the level attribute is not necessary since -->
+    <!-- the level of the root level is set to DEBUG by default.       -->
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>

--- a/gravitee-apim-repository/pom.xml
+++ b/gravitee-apim-repository/pom.xml
@@ -35,6 +35,7 @@
     <modules>
         <module>gravitee-apim-repository-api</module>
         <module>gravitee-apim-repository-elasticsearch</module>
+        <module>gravitee-apim-repository-noop</module>
         <module>gravitee-apim-repository-test</module>
         <module>gravitee-apim-repository-mongodb</module>
         <module>gravitee-apim-repository-jdbc</module>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AnalyticsServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AnalyticsServiceImpl.java
@@ -135,7 +135,7 @@ public class AnalyticsServiceImpl implements AnalyticsService {
                     .build()
             );
 
-            return convert(response, query);
+            return response != null ? convert(response, query) : null;
         } catch (AnalyticsException ae) {
             logger.error("Unable to calculate analytics: ", ae);
             throw new AnalyticsCalculateException("Unable to calculate analytics");
@@ -154,7 +154,7 @@ public class AnalyticsServiceImpl implements AnalyticsService {
                     .build()
             );
 
-            return convert(response);
+            return response != null ? convert(response) : null;
         } catch (AnalyticsException ae) {
             logger.error("Unable to calculate analytics: ", ae);
             throw new AnalyticsCalculateException("Unable to calculate analytics");
@@ -180,7 +180,7 @@ public class AnalyticsServiceImpl implements AnalyticsService {
             }
 
             DateHistogramResponse response = analyticsRepository.query(queryBuilder.build());
-            return convert(executionContext, response);
+            return response != null ? convert(executionContext, response) : null;
         } catch (AnalyticsException ae) {
             logger.error("Unable to calculate analytics: ", ae);
             throw new AnalyticsCalculateException("Unable to calculate analytics");
@@ -213,7 +213,7 @@ public class AnalyticsServiceImpl implements AnalyticsService {
             }
 
             GroupByResponse response = analyticsRepository.query(queryBuilder.build());
-            return convert(executionContext, response);
+            return response != null ? convert(executionContext, response) : null;
         } catch (AnalyticsException ae) {
             logger.error("Unable to calculate analytics: ", ae);
             throw new AnalyticsCalculateException("Unable to calculate analytics");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/HealthCheckServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/HealthCheckServiceImpl.java
@@ -108,7 +108,8 @@ public class HealthCheckServiceImpl implements HealthCheckService {
                     );
             }
 
-            return convert(healthCheckRepository.query(queryBuilder.build()));
+            DateHistogramResponse response = healthCheckRepository.query(queryBuilder.build());
+            return response != null ? convert(response) : null;
         } catch (AnalyticsException ae) {
             logger.error("Unable to calculate analytics: ", ae);
             throw new AnalyticsCalculateException("Unable to calculate analytics");
@@ -187,7 +188,7 @@ public class HealthCheckServiceImpl implements HealthCheckService {
                 QueryBuilders.availability().api(api).field(AvailabilityQuery.Field.valueOf(field)).build()
             );
 
-            return convert(executionContext, apiEntity, response.getEndpointAvailabilities(), field);
+            return response != null ? convert(executionContext, apiEntity, response.getEndpointAvailabilities(), field) : null;
         } catch (Exception ex) {
             logger.error("An unexpected error occurs while searching for health data.", ex);
             return null;
@@ -205,7 +206,7 @@ public class HealthCheckServiceImpl implements HealthCheckService {
                 QueryBuilders.responseTime().api(api).field(AverageResponseTimeQuery.Field.valueOf(field)).build()
             );
 
-            return convert(executionContext, apiEntity, response.getEndpointResponseTimes(), field);
+            return response != null ? convert(executionContext, apiEntity, response.getEndpointResponseTimes(), field) : null;
         } catch (Exception ex) {
             logger.error("An unexpected error occurs while searching for health data.", ex);
             return null;
@@ -230,7 +231,7 @@ public class HealthCheckServiceImpl implements HealthCheckService {
                     .build()
             );
 
-            return convert(executionContext, response);
+            return response != null ? convert(executionContext, response) : null;
         } catch (Exception ex) {
             logger.error("An unexpected error occurs while searching for health data.", ex);
             return null;
@@ -241,7 +242,7 @@ public class HealthCheckServiceImpl implements HealthCheckService {
     public Log findLog(String id) {
         try {
             ExtendedLog log = healthCheckRepository.findById(id);
-            return toLog(log);
+            return log != null ? toLog(log) : null;
         } catch (AnalyticsException ae) {
             logger.error("An unexpected error occurs while searching for health data.", ae);
             return null;
@@ -409,7 +410,6 @@ public class HealthCheckServiceImpl implements HealthCheckService {
 
     private Map<String, String> getEndpointMetadata(GenericApiEntity api, String endpointName) {
         Map<String, String> metadata = new HashMap<>();
-
         if (api.getDefinitionVersion() == DefinitionVersion.V4) {
             Optional<io.gravitee.definition.model.v4.endpointgroup.Endpoint> endpointOpt =
                 ((io.gravitee.rest.api.model.v4.api.ApiEntity) api).getEndpointGroups()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/LogsServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/LogsServiceImpl.java
@@ -30,7 +30,6 @@ import io.gravitee.repository.analytics.query.tabular.TabularResponse;
 import io.gravitee.repository.log.api.LogRepository;
 import io.gravitee.repository.log.model.ExtendedLog;
 import io.gravitee.repository.management.model.ApplicationStatus;
-import io.gravitee.rest.api.model.ApiKeyEntity;
 import io.gravitee.rest.api.model.ApplicationEntity;
 import io.gravitee.rest.api.model.InstanceEntity;
 import io.gravitee.rest.api.model.SubscriptionEntity;
@@ -151,6 +150,10 @@ public class LogsServiceImpl implements LogsService {
                     .build()
             );
 
+            if (response == null) {
+                return new SearchLogResponse<>(0);
+            }
+
             SearchLogResponse<ApiRequestItem> logResponse = new SearchLogResponse<>(response.getSize());
 
             // Transform repository logs
@@ -188,6 +191,10 @@ public class LogsServiceImpl implements LogsService {
     public ApiRequest findApiLog(final ExecutionContext executionContext, String id, Long timestamp) {
         try {
             final ExtendedLog log = logRepository.findById(id, timestamp);
+            if (log == null) {
+                return null;
+            }
+
             if (parameterService.findAsBoolean(executionContext, Key.LOGGING_AUDIT_ENABLED, ParameterReferenceType.ORGANIZATION)) {
                 auditService.createApiAuditLog(
                     executionContext,
@@ -225,6 +232,10 @@ public class LogsServiceImpl implements LogsService {
                     .root("application", application)
                     .build()
             );
+
+            if (response == null) {
+                return new SearchLogResponse<>(0);
+            }
 
             SearchLogResponse<ApplicationRequestItem> logResponse = new SearchLogResponse<>(response.getSize());
 
@@ -275,6 +286,10 @@ public class LogsServiceImpl implements LogsService {
                     .build()
             );
 
+            if (response == null) {
+                return new SearchLogResponse<>(0);
+            }
+
             SearchLogResponse<PlatformRequestItem> logResponse = new SearchLogResponse<>(response.getSize());
 
             // Transform repository logs
@@ -315,7 +330,12 @@ public class LogsServiceImpl implements LogsService {
     @Override
     public ApplicationRequest findApplicationLog(ExecutionContext executionContext, String id, Long timestamp) {
         try {
-            return toApplicationRequest(executionContext, logRepository.findById(id, timestamp));
+            ExtendedLog log = logRepository.findById(id, timestamp);
+            if (log == null) {
+                return null;
+            }
+
+            return toApplicationRequest(executionContext, log);
         } catch (AnalyticsException ae) {
             logger.error("Unable to retrieve log: " + id, ae);
             if (ae.getMessage().equals("Request [" + id + "] does not exist")) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MonitoringServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MonitoringServiceImpl.java
@@ -42,7 +42,7 @@ public class MonitoringServiceImpl implements MonitoringService {
     public MonitoringData findMonitoring(final String gatewayId) {
         LOGGER.debug("Running monitoring query for Gateway instance '{}'", gatewayId);
         final MonitoringResponse monitoringResponse = monitoringRepository.query(gatewayId);
-        return convert(monitoringResponse);
+        return monitoringResponse != null ? convert(monitoringResponse) : null;
     }
 
     private MonitoringData convert(final MonitoringResponse monitoringResponse) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AnalyticsServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AnalyticsServiceImplTest.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.repository.analytics.AnalyticsException;
+import io.gravitee.repository.analytics.api.AnalyticsRepository;
+import io.gravitee.repository.analytics.query.count.CountResponse;
+import io.gravitee.repository.analytics.query.groupby.GroupByResponse;
+import io.gravitee.repository.analytics.query.response.histogram.DateHistogramResponse;
+import io.gravitee.repository.analytics.query.stats.StatsResponse;
+import io.gravitee.rest.api.model.analytics.HistogramAnalytics;
+import io.gravitee.rest.api.model.analytics.HitsAnalytics;
+import io.gravitee.rest.api.model.analytics.TopHitsAnalytics;
+import io.gravitee.rest.api.model.analytics.query.*;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.AnalyticsCalculateException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AnalyticsServiceImplTest {
+
+    @InjectMocks
+    private AnalyticsServiceImpl cut;
+
+    @Mock
+    private AnalyticsRepository analyticsRepository;
+
+    private static final ExecutionContext EXECUTION_CONTEXT = GraviteeContext.getExecutionContext();
+
+    @Test(expected = AnalyticsCalculateException.class)
+    public void shouldThrowExceptionForStatusQuery() throws Exception {
+        when(analyticsRepository.query(any())).thenThrow(new AnalyticsException());
+
+        cut.execute(new StatsQuery());
+    }
+
+    @Test
+    public void shouldExecuteStatusQueryWithNoResponse() throws Exception {
+        when(analyticsRepository.query(any())).thenReturn(null);
+        StatsAnalytics execute = cut.execute(new StatsQuery());
+
+        assertNull(execute);
+        verify(analyticsRepository, times(1)).query(any());
+    }
+
+    @Test
+    public void shouldExecuteStatusQuery() throws Exception {
+        when(analyticsRepository.query(any())).thenReturn(new StatsResponse());
+        StatsAnalytics execute = cut.execute(new StatsQuery());
+
+        assertNotNull(execute);
+        verify(analyticsRepository, times(1)).query(any());
+    }
+
+    @Test(expected = AnalyticsCalculateException.class)
+    public void shouldThrowExceptionForCountQuery() throws Exception {
+        when(analyticsRepository.query(any())).thenThrow(new AnalyticsException());
+
+        cut.execute(new CountQuery());
+    }
+
+    @Test
+    public void shouldExecuteCountQueryWithNoResponse() throws Exception {
+        when(analyticsRepository.query(any())).thenReturn(null);
+        HitsAnalytics execute = cut.execute(new CountQuery());
+
+        assertNull(execute);
+        verify(analyticsRepository, times(1)).query(any());
+    }
+
+    @Test
+    public void shouldExecuteCountQuery() throws Exception {
+        when(analyticsRepository.query(any())).thenReturn(new CountResponse());
+        HitsAnalytics execute = cut.execute(new CountQuery());
+
+        assertNotNull(execute);
+        verify(analyticsRepository, times(1)).query(any());
+    }
+
+    @Test(expected = AnalyticsCalculateException.class)
+    public void shouldThrowExceptionForDateHistogramQuery() throws Exception {
+        when(analyticsRepository.query(any())).thenThrow(new AnalyticsException());
+
+        cut.execute(EXECUTION_CONTEXT, new DateHistogramQuery());
+    }
+
+    @Test
+    public void shouldExecuteDateHistogramQueryWithNoResponse() throws Exception {
+        when(analyticsRepository.query(any())).thenReturn(null);
+        HistogramAnalytics execute = cut.execute(EXECUTION_CONTEXT, new DateHistogramQuery());
+
+        assertNull(execute);
+        verify(analyticsRepository, times(1)).query(any());
+    }
+
+    @Test
+    public void shouldExecuteDateHistogramQuery() throws Exception {
+        when(analyticsRepository.query(any())).thenReturn(new DateHistogramResponse());
+        HistogramAnalytics execute = cut.execute(EXECUTION_CONTEXT, new DateHistogramQuery());
+
+        assertNotNull(execute);
+        verify(analyticsRepository, times(1)).query(any());
+    }
+
+    @Test(expected = AnalyticsCalculateException.class)
+    public void shouldThrowExceptionForGroupByQuery() throws Exception {
+        when(analyticsRepository.query(any())).thenThrow(new AnalyticsException());
+
+        cut.execute(EXECUTION_CONTEXT, new GroupByQuery());
+    }
+
+    @Test
+    public void shouldExecuteGroupByQueryWithNoResponse() throws Exception {
+        when(analyticsRepository.query(any())).thenReturn(null);
+        TopHitsAnalytics execute = cut.execute(EXECUTION_CONTEXT, new GroupByQuery());
+
+        assertNull(execute);
+        verify(analyticsRepository, times(1)).query(any());
+    }
+
+    @Test
+    public void shouldExecuteGroupByQuery() throws Exception {
+        when(analyticsRepository.query(any())).thenReturn(new GroupByResponse());
+        TopHitsAnalytics execute = cut.execute(EXECUTION_CONTEXT, new GroupByQuery());
+
+        assertNotNull(execute);
+        verify(analyticsRepository, times(1)).query(any());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/HealthCheckServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/HealthCheckServiceImplTest.java
@@ -16,26 +16,42 @@
 package io.gravitee.rest.api.service.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
+import io.gravitee.repository.analytics.AnalyticsException;
 import io.gravitee.repository.healthcheck.api.HealthCheckRepository;
 import io.gravitee.repository.healthcheck.query.FieldBucket;
 import io.gravitee.repository.healthcheck.query.availability.AvailabilityQuery;
 import io.gravitee.repository.healthcheck.query.availability.AvailabilityResponse;
+import io.gravitee.repository.healthcheck.query.log.ExtendedLog;
+import io.gravitee.repository.healthcheck.query.log.LogsResponse;
+import io.gravitee.repository.healthcheck.query.log.Step;
+import io.gravitee.repository.healthcheck.query.response.histogram.DateHistogramResponse;
+import io.gravitee.repository.healthcheck.query.responsetime.AverageResponseTimeResponse;
+import io.gravitee.rest.api.model.InstanceEntity;
+import io.gravitee.rest.api.model.analytics.Analytics;
+import io.gravitee.rest.api.model.analytics.query.DateHistogramQuery;
+import io.gravitee.rest.api.model.analytics.query.LogQuery;
 import io.gravitee.rest.api.model.healthcheck.ApiMetrics;
+import io.gravitee.rest.api.model.healthcheck.Log;
+import io.gravitee.rest.api.model.healthcheck.SearchLogResponse;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
-import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.service.InstanceService;
-import io.gravitee.rest.api.service.PermissionService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.AnalyticsCalculateException;
 import io.gravitee.rest.api.service.v4.ApiSearchService;
-import java.util.*;
-import junit.framework.TestCase;
+import io.reactivex.rxjava3.annotations.NonNull;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -54,8 +70,35 @@ public class HealthCheckServiceImplTest {
     @Mock
     private ApiSearchService apiSearchService;
 
+    @Mock
+    private InstanceService instanceService;
+
     @InjectMocks
-    private HealthCheckServiceImpl healthCheckServiceImpl;
+    private HealthCheckServiceImpl cut;
+
+    private static final ExecutionContext EXECUTION_CONTEXT = GraviteeContext.getExecutionContext();
+
+    @Test
+    public void should_throw_analytics_exception_for_getAvailability_metadata() throws Exception {
+        when(apiSearchService.findGenericById(any(ExecutionContext.class), anyString())).thenReturn(newApiEntity());
+        when(healthCheckRepository.query(any())).thenThrow(new AnalyticsException());
+        ApiMetrics result = cut.getAvailability(EXECUTION_CONTEXT, "test_api", AvailabilityQuery.Field.ENDPOINT.name());
+
+        assertNull(result);
+        verify(apiSearchService, times(1)).findGenericById(any(ExecutionContext.class), anyString());
+        verify(healthCheckRepository, times(1)).query(any());
+    }
+
+    @Test
+    public void should_get_noResponse_for_getAvailability_metadata() throws AnalyticsException {
+        when(apiSearchService.findGenericById(any(ExecutionContext.class), anyString())).thenReturn(new ApiEntity());
+        when(healthCheckRepository.query(any())).thenReturn(null);
+        ApiMetrics result = cut.getAvailability(EXECUTION_CONTEXT, "test_api", AvailabilityQuery.Field.ENDPOINT.name());
+
+        assertNull(result);
+        verify(apiSearchService, times(1)).findGenericById(any(ExecutionContext.class), anyString());
+        verify(healthCheckRepository, times(1)).query(any());
+    }
 
     @Test
     public void should_getAvailability_metadata() throws Exception {
@@ -70,21 +113,9 @@ public class HealthCheckServiceImplTest {
 
         when(healthCheckRepository.query(any())).thenReturn(availabilityResponse);
 
-        Endpoint endpoint = new Endpoint();
-        endpoint.setName("endpoint");
-        endpoint.setType("http");
+        when(apiSearchService.findGenericById(GraviteeContext.getExecutionContext(), "apiId")).thenReturn(newApiEntity());
 
-        EndpointGroup endpointGroup = new EndpointGroup();
-        endpointGroup.setEndpoints(List.of(endpoint));
-
-        ApiEntity api = new ApiEntity();
-        api.setId("apiId");
-        api.setDefinitionVersion(DefinitionVersion.V4);
-        api.setEndpointGroups(List.of(endpointGroup));
-
-        when(apiSearchService.findGenericById(GraviteeContext.getExecutionContext(), "apiId")).thenReturn(api);
-
-        ApiMetrics apiMetrics = healthCheckServiceImpl.getAvailability(
+        ApiMetrics apiMetrics = cut.getAvailability(
             GraviteeContext.getExecutionContext(),
             "apiId",
             AvailabilityQuery.Field.ENDPOINT.name()
@@ -92,5 +123,166 @@ public class HealthCheckServiceImplTest {
 
         assertEquals(Map.of("target", "http"), apiMetrics.getMetadata().get("endpoint"));
         assertEquals(Map.of("deleted", "true"), apiMetrics.getMetadata().get("deleted"));
+    }
+
+    @Test(expected = AnalyticsCalculateException.class)
+    public void shouldThrowExceptionForDateHistogramQuery() throws Exception {
+        when(healthCheckRepository.query(any())).thenThrow(new AnalyticsException());
+
+        cut.query(new DateHistogramQuery());
+    }
+
+    @Test
+    public void shouldFindNoAnalytics() throws AnalyticsException {
+        when(healthCheckRepository.query(any())).thenReturn(null);
+        Analytics execute = cut.query(new DateHistogramQuery());
+
+        assertNull(execute);
+        verify(healthCheckRepository, times(1)).query(any());
+    }
+
+    @Test
+    public void shouldFindAnalytics() throws AnalyticsException {
+        when(healthCheckRepository.query(any())).thenReturn(new DateHistogramResponse());
+        Analytics execute = cut.query(new DateHistogramQuery());
+
+        assertNotNull(execute);
+        verify(healthCheckRepository, times(1)).query(any());
+    }
+
+    @Test
+    public void shouldThrowExceptionForFindById() throws Exception {
+        when(healthCheckRepository.findById(anyString())).thenThrow(new AnalyticsException());
+        Log result = cut.findLog("test_log");
+
+        assertNull(result);
+        verify(healthCheckRepository, times(1)).findById(anyString());
+    }
+
+    @Test
+    public void shouldFindNoLogById() throws AnalyticsException {
+        when(healthCheckRepository.findById(anyString())).thenReturn(null);
+        Log result = cut.findLog("test_log");
+
+        assertNull(result);
+        verify(healthCheckRepository, times(1)).findById(anyString());
+    }
+
+    @Test
+    public void shouldFindLogById() throws AnalyticsException {
+        ExtendedLog log = newExtendedLog();
+
+        when(healthCheckRepository.findById(anyString())).thenReturn(log);
+        Log result = cut.findLog("test_log");
+
+        assertNotNull(result);
+        verify(healthCheckRepository, times(1)).findById(anyString());
+    }
+
+    @Test
+    public void shouldThrowExceptionForFindByApi() throws Exception {
+        when(healthCheckRepository.query(any())).thenThrow(new AnalyticsException());
+        SearchLogResponse result = cut.findByApi(EXECUTION_CONTEXT, "test_api", new LogQuery(), true);
+
+        assertNull(result);
+        verify(healthCheckRepository, times(1)).query(any());
+    }
+
+    @Test
+    public void shouldFindNoLogByApi() throws AnalyticsException {
+        when(healthCheckRepository.query(any())).thenReturn(null);
+        SearchLogResponse result = cut.findByApi(EXECUTION_CONTEXT, "test_api", new LogQuery(), true);
+
+        assertNull(result);
+        verify(healthCheckRepository, times(1)).query(any());
+    }
+
+    @Test
+    public void shouldFindLogByApi() throws AnalyticsException {
+        LogsResponse response = new LogsResponse(1L);
+        List<io.gravitee.repository.healthcheck.query.log.Log> logs = new ArrayList<>();
+        logs.add(new io.gravitee.repository.healthcheck.query.log.Log());
+        response.setLogs(logs);
+
+        when(healthCheckRepository.query(any())).thenReturn(response);
+        SearchLogResponse result = cut.findByApi(EXECUTION_CONTEXT, "test_api", new LogQuery(), true);
+
+        assertNotNull(result);
+        verify(healthCheckRepository, times(1)).query(any());
+    }
+
+    @Test
+    public void shouldThrowExceptionForGetResponseTime() throws Exception {
+        when(apiSearchService.findGenericById(any(ExecutionContext.class), anyString())).thenReturn(newApiEntity());
+        when(healthCheckRepository.query(any())).thenThrow(new AnalyticsException());
+        ApiMetrics result = cut.getResponseTime(EXECUTION_CONTEXT, "test_api", AvailabilityQuery.Field.ENDPOINT.name());
+
+        assertNull(result);
+        verify(apiSearchService, times(1)).findGenericById(any(ExecutionContext.class), anyString());
+        verify(healthCheckRepository, times(1)).query(any());
+    }
+
+    @Test
+    public void shouldFindNoResponseTime() throws AnalyticsException {
+        when(apiSearchService.findGenericById(any(ExecutionContext.class), anyString())).thenReturn(new ApiEntity());
+        when(healthCheckRepository.query(any())).thenReturn(null);
+        ApiMetrics result = cut.getResponseTime(EXECUTION_CONTEXT, "test_api", AvailabilityQuery.Field.ENDPOINT.name());
+
+        assertNull(result);
+        verify(apiSearchService, times(1)).findGenericById(any(ExecutionContext.class), anyString());
+        verify(healthCheckRepository, times(1)).query(any());
+    }
+
+    @Test
+    public void shouldFindGetResponseTime() throws AnalyticsException {
+        AverageResponseTimeResponse response = new AverageResponseTimeResponse();
+        List<FieldBucket<Long>> buckets = new ArrayList<>();
+        FieldBucket<Long> testBucket = new FieldBucket<>("test_bucket");
+        testBucket.setValues(new ArrayList<>());
+        buckets.add(testBucket);
+
+        response.setEndpointResponseTimes(buckets);
+
+        when(apiSearchService.findGenericById(any(ExecutionContext.class), anyString())).thenReturn(new ApiEntity());
+        when(healthCheckRepository.query(any())).thenReturn(response);
+        when(instanceService.findById(any(ExecutionContext.class), anyString())).thenReturn(new InstanceEntity());
+        ApiMetrics result = cut.getResponseTime(EXECUTION_CONTEXT, "test_api", AvailabilityQuery.Field.GATEWAY.name());
+
+        assertNotNull(result);
+        verify(apiSearchService, times(1)).findGenericById(any(ExecutionContext.class), anyString());
+        verify(healthCheckRepository, times(1)).query(any());
+        verify(instanceService, times(1)).findById(any(ExecutionContext.class), anyString());
+    }
+
+    @NonNull
+    private static ApiEntity newApiEntity() {
+        ApiEntity api = new ApiEntity();
+        api.setId("apiId");
+        api.setDefinitionVersion(DefinitionVersion.V4);
+        api.setEndpointGroups(List.of(newEndpointGroup()));
+        return api;
+    }
+
+    @NonNull
+    private static EndpointGroup newEndpointGroup() {
+        Endpoint endpoint = new Endpoint();
+        endpoint.setName("endpoint");
+        endpoint.setType("http");
+
+        EndpointGroup endpointGroup = new EndpointGroup();
+        endpointGroup.setEndpoints(List.of(endpoint));
+        return endpointGroup;
+    }
+
+    @NonNull
+    private static ExtendedLog newExtendedLog() {
+        ExtendedLog log = new ExtendedLog();
+        List<Step> steps = new ArrayList<>();
+        Step step = new Step();
+        step.setMessage("test_message");
+        steps.add(step);
+        log.setSteps(steps);
+
+        return log;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MonitoringServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/MonitoringServiceImplTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.repository.monitoring.MonitoringRepository;
+import io.gravitee.repository.monitoring.model.MonitoringResponse;
+import io.gravitee.rest.api.model.monitoring.MonitoringData;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author Kamiel Ahmadpour (kamiel.ahmadpour at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class MonitoringServiceImplTest {
+
+    @InjectMocks
+    private MonitoringServiceImpl cut;
+
+    @Mock
+    private MonitoringRepository monitoringRepository;
+
+    @Test
+    public void shouldFindNoMonitoring() {
+        when(monitoringRepository.query(anyString())).thenReturn(null);
+        MonitoringData result = cut.findMonitoring("a_gateway_id");
+
+        assertNull(result);
+        verify(monitoringRepository, times(1)).query(any());
+    }
+
+    @Test
+    public void shouldFindMonitoring() {
+        when(monitoringRepository.query(anyString())).thenReturn(new MonitoringResponse());
+        MonitoringData result = cut.findMonitoring("a_gateway_id");
+
+        assertNotNull(result);
+        verify(monitoringRepository, times(1)).query(any());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -227,9 +227,10 @@ services:
 
 
 # Analytics repository is used to store all reporting, metrics, health-checks stored by gateway instances
-# This is the default configuration using Elasticsearch
+# This is the default configuration using Elasticsearch. If you want to disable it completely, you can set
+# the type as "none"
 analytics:
-  type: elasticsearch
+  type: elasticsearch # or none
   elasticsearch:
     endpoints:
       - http://${ds.elastic.host}:${ds.elastic.port}

--- a/release/ci-steps/package-bundles.mjs
+++ b/release/ci-steps/package-bundles.mjs
@@ -210,6 +210,7 @@ const gatewayDependenciesExclusion = [
   // ArtifactIds to exclude
   'gravitee-apim-repository-elasticsearch',
   'gravitee-apim-repository-hazelcast',
+  'gravitee-apim-repository-noop',
   'gravitee-apim-repository-redis',
 ];
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1366

## Description

At the moment the end user always needs to provide an ES configuration for the Analytics even if they don't want to use it. The idea is to create a small dummy repository implementation so it can be used by the users if they want to disable analytics.

```
analytics:
  type: none
```
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rutzmlzhqx.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-noop-repository/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
