### PR TITLE
fix(console): remove unnecessary api name

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/policy-studio/gio-policy-studio-layout.component.html
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/gio-policy-studio-layout.component.html
@@ -16,7 +16,6 @@
 
 -->
 <div class="gio-policy-studio-layout__header">
-  <h3 class="mat-h3 gio-policy-studio-layout__header__title">{{ apiDefinition?.name }}</h3>
   <nav mat-tab-nav-bar mat-align-tabs="end" class="gio-policy-studio-layout__header__nav">
     <a
       mat-tab-link

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/gio-policy-studio-layout.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/gio-policy-studio-layout.component.scss
@@ -14,14 +14,6 @@
       display: flex;
       background-color: mat.get-color-from-palette(gio.$mat-decorative-palette, 'surface');
 
-      &__title {
-        align-items: center;
-        color: mat.get-color-from-palette(gio.$mat-primary-palette, 'default');
-        display: flex;
-        padding: 14px;
-        position: absolute;
-      }
-
       &__nav {
         flex: 1;
       }


### PR DESCRIPTION

## Issue
https://gravitee.atlassian.net/browse/APIM-1363

## Description

 Remove unnecessary api name. the api name is already display in the left menu column




<img width="1330" alt="image" src="https://user-images.githubusercontent.com/4974420/231195598-9eb9d12b-849c-4c9b-87d2-fc613df2cadd.png">


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mcjgpwooew.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1363/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
