### PR TITLE
fix: display logs of authorized resources only

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/AbstractResourceTest.java
@@ -22,10 +22,13 @@ import io.gravitee.common.event.EventManager;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.repository.management.api.GroupRepository;
 import io.gravitee.rest.api.management.rest.JerseySpringTest;
+import io.gravitee.rest.api.management.rest.security.Permission;
+import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.security.authentication.AuthenticationProvider;
 import io.gravitee.rest.api.security.cookies.CookieGenerator;
 import io.gravitee.rest.api.security.utils.AuthoritiesProvider;
 import io.gravitee.rest.api.service.*;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.configuration.application.ApplicationTypeService;
 import io.gravitee.rest.api.service.configuration.application.ClientRegistrationService;
 import io.gravitee.rest.api.service.configuration.dictionary.DictionaryService;
@@ -233,6 +236,9 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
 
     @Autowired
     protected MediaService mediaService;
+
+    @Autowired
+    protected LogsService logsService;
 
     @Configuration
     @PropertySource("classpath:/io/gravitee/rest/api/management/rest/resource/jwt.properties")
@@ -542,11 +548,17 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
         public AuditService auditService() {
             return mock(AuditService.class);
         }
+
+        @Bean
+        public LogsService logsService() {
+            return mock(LogsService.class);
+        }
     }
 
     @Before
     public void setUp() throws Exception {
-        when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(true);
+        when(permissionService.hasPermission(any(ExecutionContext.class), any(RolePermission.class), anyString(), anyVararg()))
+            .thenReturn(true);
     }
 
     @Priority(50)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformLogsResourceNotAdminTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformLogsResourceNotAdminTest.java
@@ -1,0 +1,169 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource;
+
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static java.util.Collections.emptySet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.rest.api.model.analytics.query.LogQuery;
+import io.gravitee.rest.api.model.log.SearchLogResponse;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.Objects;
+import java.util.Set;
+import javax.ws.rs.core.Response;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Florent CHAMFROY (florent.chamfroy at gravitee.io
+ * @author GraviteeSource Team
+ */
+public class PlatformLogsResourceNotAdminTest extends AbstractResourceTest {
+
+    @Override
+    protected String contextPath() {
+        return "platform/logs/";
+    }
+
+    @Override
+    protected void decorate(ResourceConfig resourceConfig) {
+        resourceConfig.register(NotAdminAuthenticationFilter.class);
+    }
+
+    @Before
+    public void init() {
+        reset(apiService);
+        reset(applicationService);
+        reset(logsService);
+    }
+
+    @Test
+    public void shouldGetPlatformLogsAsNonAdmin() {
+        when(logsService.findPlatform(any(ExecutionContext.class), any(LogQuery.class))).thenReturn(new SearchLogResponse<>(10));
+        when(applicationService.findIdsByUser(any(ExecutionContext.class), anyString())).thenReturn(Set.of("app1"));
+        when(apiService.findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(false))).thenReturn(Set.of("api1"));
+        Response logs = sendRequest();
+        assertEquals(OK_200, logs.getStatus());
+
+        verify(applicationService).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME));
+        verify(apiService).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(false));
+        verify(logsService)
+            .findPlatform(
+                any(ExecutionContext.class),
+                argThat(query ->
+                    Objects.equals(query.getQuery(), "(foo:bar) AND (application:(app1) OR api:(api1))") &&
+                    query.getPage() == 1 &&
+                    query.getSize() == 10 &&
+                    query.getFrom() == 0 &&
+                    query.getTo() == 1 &&
+                    Objects.equals(query.getField(), "@timestamp") &&
+                    query.isOrder()
+                )
+            );
+    }
+
+    @Test
+    public void shouldGetPlatformLogsAsNonAdminFilterOnlyApp() {
+        when(logsService.findPlatform(any(ExecutionContext.class), any(LogQuery.class))).thenReturn(new SearchLogResponse<>(10));
+        when(applicationService.findIdsByUser(any(ExecutionContext.class), anyString())).thenReturn(Set.of("app1"));
+        when(apiService.findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(false))).thenReturn(emptySet());
+        Response logs = sendRequest();
+        assertEquals(OK_200, logs.getStatus());
+
+        verify(applicationService).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME));
+        verify(apiService).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(false));
+        verify(logsService)
+            .findPlatform(
+                any(ExecutionContext.class),
+                argThat(query ->
+                    Objects.equals(query.getQuery(), "(foo:bar) AND (application:(app1))") &&
+                    query.getPage() == 1 &&
+                    query.getSize() == 10 &&
+                    query.getFrom() == 0 &&
+                    query.getTo() == 1 &&
+                    Objects.equals(query.getField(), "@timestamp") &&
+                    query.isOrder()
+                )
+            );
+    }
+
+    @Test
+    public void shouldGetPlatformLogsAsNonAdminFilterOnlyAPI() {
+        when(logsService.findPlatform(any(ExecutionContext.class), any(LogQuery.class))).thenReturn(new SearchLogResponse<>(10));
+        when(applicationService.findIdsByUser(any(ExecutionContext.class), anyString())).thenReturn(emptySet());
+        when(apiService.findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(false))).thenReturn(Set.of("api1"));
+        Response logs = sendRequest();
+        assertEquals(OK_200, logs.getStatus());
+
+        verify(applicationService).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME));
+        verify(apiService).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(false));
+        verify(logsService)
+            .findPlatform(
+                any(ExecutionContext.class),
+                argThat(query ->
+                    Objects.equals(query.getQuery(), "(foo:bar) AND (api:(api1))") &&
+                    query.getPage() == 1 &&
+                    query.getSize() == 10 &&
+                    query.getFrom() == 0 &&
+                    query.getTo() == 1 &&
+                    Objects.equals(query.getField(), "@timestamp") &&
+                    query.isOrder()
+                )
+            );
+    }
+
+    @Test
+    public void shouldGetNoLogsAsNonAdminWithNoAPINoApp() {
+        when(applicationService.findIdsByUser(any(ExecutionContext.class), eq(USER_NAME))).thenReturn(emptySet());
+        when(apiService.findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(false))).thenReturn(emptySet());
+        Response logs = sendRequest();
+        assertEquals(OK_200, logs.getStatus());
+
+        JsonNode jsonNode = logs.readEntity(JsonNode.class);
+        assertEquals(0, jsonNode.get("total").intValue());
+        assertNull(jsonNode.get("logs"));
+        verify(applicationService).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME));
+        verify(apiService).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(false));
+        verify(logsService, never()).findPlatform(any(ExecutionContext.class), any(LogQuery.class));
+    }
+
+    private Response sendRequest() {
+        return envTarget()
+            .queryParam("query", "foo:bar")
+            .queryParam("page", 1)
+            .queryParam("size", 10)
+            .queryParam("from", 0)
+            .queryParam("to", 1)
+            .queryParam("field", "@timestamp")
+            .queryParam("order", true)
+            .request()
+            .get();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformLogsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformLogsResourceTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource;
+
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.rest.api.model.analytics.query.LogQuery;
+import io.gravitee.rest.api.model.api.ApiQuery;
+import io.gravitee.rest.api.model.log.SearchLogResponse;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.Objects;
+import javax.ws.rs.core.Response;
+import org.junit.Test;
+
+/**
+ * @author Florent CHAMFROY (florent.chamfroy at gravitee.io
+ * @author GraviteeSource Team
+ */
+public class PlatformLogsResourceTest extends AbstractResourceTest {
+
+    @Override
+    protected String contextPath() {
+        return "platform/logs/";
+    }
+
+    @Test
+    public void shouldGetPlatformLogsAsAdmin() {
+        when(logsService.findPlatform(any(ExecutionContext.class), any(LogQuery.class))).thenReturn(new SearchLogResponse<>(10));
+        Response logs = sendRequest();
+        assertEquals(OK_200, logs.getStatus());
+
+        verify(applicationService, never()).findIdsByUser(any(ExecutionContext.class), anyString());
+        verify(apiService, never()).findIdsByUser(any(ExecutionContext.class), anyString(), any(ApiQuery.class), anyBoolean());
+        verify(logsService)
+            .findPlatform(
+                any(ExecutionContext.class),
+                argThat(query ->
+                    Objects.equals(query.getQuery(), "foo:bar") &&
+                    query.getPage() == 1 &&
+                    query.getSize() == 10 &&
+                    query.getFrom() == 0 &&
+                    query.getTo() == 1 &&
+                    Objects.equals(query.getField(), "@timestamp") &&
+                    query.isOrder()
+                )
+            );
+    }
+
+    private Response sendRequest() {
+        return envTarget()
+            .queryParam("query", "foo:bar")
+            .queryParam("page", 1)
+            .queryParam("size", 10)
+            .queryParam("from", 0)
+            .queryParam("to", 1)
+            .queryParam("field", "@timestamp")
+            .queryParam("order", true)
+            .request()
+            .get();
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1336
https://github.com/gravitee-io/issues/issues/8968

## Description

Display logs of authorized resources only.
Based on the same mechanism as for the analytics to display only logs that are linked to APIs and applications the current user is allowed to see.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1336-display-logs-for-authorized-resources-only/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mzkldhuyfi.chromatic.com)
<!-- Storybook placeholder end -->
