### PR TITLE
Rewrite Dynamic Properties service to avoid blocking the event loop

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/pom.xml
@@ -40,6 +40,11 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-rx-java2</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <!-- Json transformer (jolt) -->
         <dependency>
             <groupId>com.bazaarvoice.jolt</groupId>
@@ -84,6 +89,12 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertiesService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertiesService.java
@@ -20,7 +20,6 @@ import io.gravitee.common.event.Event;
 import io.gravitee.common.event.EventListener;
 import io.gravitee.common.event.EventManager;
 import io.gravitee.common.service.AbstractService;
-import io.gravitee.definition.model.services.Services;
 import io.gravitee.definition.model.services.dynamicproperty.DynamicPropertyProvider;
 import io.gravitee.definition.model.services.dynamicproperty.DynamicPropertyService;
 import io.gravitee.node.api.Node;
@@ -143,6 +142,7 @@ public class DynamicPropertiesService extends AbstractService implements EventLi
                     HttpProvider provider = new HttpProvider(dynamicPropertyService);
                     provider.setHttpClientService(httpClientService);
                     provider.setNode(node);
+                    provider.setExecutor(executor);
 
                     updater.setProvider(provider);
                     updater.setApiService(apiService);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertyUpdater.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertyUpdater.java
@@ -31,9 +31,11 @@ import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.services.dynamicproperties.model.DynamicProperty;
 import io.gravitee.rest.api.services.dynamicproperties.provider.Provider;
+import io.reactivex.Maybe;
+import io.reactivex.disposables.Disposable;
+import io.reactivex.schedulers.Schedulers;
 import io.vertx.core.Handler;
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -68,30 +70,30 @@ public class DynamicPropertyUpdater implements Handler<Long> {
 
     @Override
     public void handle(Long event) {
-        handle();
+        handle().subscribe();
     }
 
-    protected CompletableFuture<Collection<DynamicProperty>> handle() {
-        LOGGER.debug("Running dynamic-properties poller for {}", api);
+    protected Maybe<Collection<DynamicProperty>> handle() {
+        LOGGER.debug("[{}] Running dynamic properties poller", api.getId());
 
         return provider
             .get()
-            .whenCompleteAsync(
-                (dynamicProperties, throwable) -> {
-                    if (throwable != null) {
-                        LOGGER.error(
-                            "[{}] Unexpected error while getting dynamic properties from provider: {}",
-                            api.getId(),
-                            provider.name(),
-                            throwable
-                        );
-                    } else if (dynamicProperties != null) {
-                        authenticateAsAdmin();
-                        update(dynamicProperties);
-                    }
-                },
-                this.executor
-            );
+            .subscribeOn(Schedulers.from(executor))
+            .doOnSuccess(dynamicProperties -> {
+                LOGGER.debug("[{}] Got {} dynamic properties to update", api.getId(), dynamicProperties.size());
+                authenticateAsAdmin();
+                update(dynamicProperties);
+                LOGGER.debug("[{}] Dynamic properties updated", api.getId());
+            })
+            .doOnError(throwable ->
+                LOGGER.error(
+                    "[{}] Unexpected error while getting dynamic properties from provider: {}",
+                    api.getId(),
+                    provider.name(),
+                    throwable
+                )
+            )
+            .onErrorComplete();
     }
 
     private void update(Collection<DynamicProperty> dynamicProperties) {
@@ -140,7 +142,7 @@ public class DynamicPropertyUpdater implements Handler<Long> {
 
             // Update API
             try {
-                LOGGER.debug("Updating API [{}]", latestApi.getId());
+                LOGGER.debug("[{}] Updating API", latestApi.getId());
                 apiService.update(
                     GraviteeContext.getExecutionContext(),
                     latestApi.getId(),
@@ -148,27 +150,31 @@ public class DynamicPropertyUpdater implements Handler<Long> {
                     false,
                     false
                 );
-                LOGGER.debug("API [{}] has been updated", latestApi.getId());
-
-                // Do not deploy if there are manual changes to push
-                if (isSync) {
-                    // Publish API only in case of changes
-                    if (!updatedProperties.containsAll(properties) || !properties.containsAll(updatedProperties)) {
-                        LOGGER.debug("Property change detected, API [{}] is about to be deployed", api.getId());
-                        ApiDeploymentEntity deployEntity = new ApiDeploymentEntity();
-                        deployEntity.setDeploymentLabel("Dynamic properties sync");
-                        apiService.deploy(
-                            GraviteeContext.getExecutionContext(),
-                            latestApi.getId(),
-                            "dynamic-property-updater",
-                            EventType.PUBLISH_API,
-                            deployEntity
-                        );
-                        LOGGER.debug("API [{}] as been deployed", api.getId());
-                    }
-                }
+                LOGGER.debug("[{}] API has been updated", latestApi.getId());
             } catch (TechnicalManagementException e) {
-                LOGGER.error("An error occurred while updating synchronizing properties, the API has not been deployed", e);
+                LOGGER.error(
+                    "An error occurred while updating the API with new values of dynamic properties, deployment will be skipped.",
+                    e
+                );
+                throw e;
+            }
+
+            // Do not deploy if there are manual changes to push
+            if (isSync) {
+                // Publish API only in case of changes
+                if (!updatedProperties.containsAll(properties) || !properties.containsAll(updatedProperties)) {
+                    LOGGER.debug("[{}] Property change detected, API is about to be deployed", api.getId());
+                    ApiDeploymentEntity deployEntity = new ApiDeploymentEntity();
+                    deployEntity.setDeploymentLabel("Dynamic properties sync");
+                    apiService.deploy(
+                        GraviteeContext.getExecutionContext(),
+                        latestApi.getId(),
+                        "dynamic-property-updater",
+                        EventType.PUBLISH_API,
+                        deployEntity
+                    );
+                    LOGGER.debug("[{}] API as been deployed", api.getId());
+                }
             }
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/provider/Provider.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/provider/Provider.java
@@ -16,15 +16,15 @@
 package io.gravitee.rest.api.services.dynamicproperties.provider;
 
 import io.gravitee.rest.api.services.dynamicproperties.model.DynamicProperty;
+import io.reactivex.Maybe;
 import java.util.Collection;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface Provider {
-    CompletableFuture<Collection<DynamicProperty>> get();
+    Maybe<Collection<DynamicProperty>> get();
 
     String name();
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/provider/http/HttpProvider.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/provider/http/HttpProvider.java
@@ -122,7 +122,7 @@ public class HttpProvider implements Provider {
 
     @Override
     public String name() {
-        return "custom";
+        return "http-provider";
     }
 
     public void setHttpClientService(HttpClientService httpClientService) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/spring/DynamicPropertiesConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/spring/DynamicPropertiesConfiguration.java
@@ -28,9 +28,11 @@ public class DynamicPropertiesConfiguration {
 
     @Bean(name = "dynamicPropertiesExecutor")
     public Executor dynamicPropertiesExecutor() {
+        int maxPoolSize = Runtime.getRuntime().availableProcessors() * 2;
+
         final ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(
             0,
-            2, // maximumPoolSize
+            maxPoolSize, // maximumPoolSize
             5, // keepAliveTime
             TimeUnit.MINUTES,
             new LinkedBlockingQueue<>(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/resources/jolt/custom-response.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/resources/jolt/custom-response.json
@@ -1,14 +1,14 @@
 {
-  "content":
-    {
-      "name": "Elysee",
-      "country": "FRANCE",
-      "address": "Avenue des Champs-Élysées",
-      "city": "PARIS",
-      "stores_id": 1,
-      "zip_code": "75000",
-      "gps_x": "48.869729",
-      "gps_y": "2.307784",
-      "phone_number": "01 00 00 00 00",
-      "backend_url": "https://north-europe.company.com/"
-    }}
+    "content": {
+        "name": "Elysee",
+        "country": "FRANCE",
+        "address": "Avenue des Champs-Élysées",
+        "city": "PARIS",
+        "stores_id": 1,
+        "zip_code": "75000",
+        "gps_x": "48.869729",
+        "gps_y": "2.307784",
+        "phone_number": "01 00 00 00 00",
+        "backend_url": "https://north-europe.company.com/"
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/resources/mappings/request01.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/resources/mappings/request01.json
@@ -6,7 +6,18 @@
   "response": {
     "status": 200,
     "jsonBody": {
-      "key": "value"
+      "content": {
+        "name": "Elysee",
+        "country": "FRANCE",
+        "address": "Avenue des Champs-Élysées",
+        "city": "PARIS",
+        "stores_id": 1,
+        "zip_code": "75000",
+        "gps_x": "48.869729",
+        "gps_y": "2.307784",
+        "phone_number": "01 00 00 00 00",
+        "backend_url": "https://north-europe.company.com/"
+      }
     }
   }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/resources/mappings/request03.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/resources/mappings/request03.json
@@ -1,17 +1,36 @@
 {
   "request": {
-    "method": "GET",
+    "method": "POST",
     "url": "/success_post",
     "bodyPatterns": [
       {
-        "equalToJson" : "{}"
+        "equalToJson": "{}"
       }
-    ]
+    ],
+    "headers": {
+      "Content-Type": {
+        "equalTo": "application/json"
+      },
+      "X-Gravitee-Header" : {
+        "equalTo": "value"
+      }
+    }
   },
   "response": {
     "status": 200,
     "jsonBody": {
-      "key": "value"
+      "content": {
+        "name": "Elysee",
+        "country": "FRANCE",
+        "address": "Avenue des Champs-Élysées",
+        "city": "PARIS",
+        "stores_id": 1,
+        "zip_code": "75000",
+        "gps_x": "48.869729",
+        "gps_y": "2.307784",
+        "phone_number": "01 00 00 00 00",
+        "backend_url": "https://north-europe.company.com/"
+      }
     }
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1337
gravitee-io/issues#8969

## Description

With the implementation based on CompletableFuture the Vertx event loop.
was blocked as soon as the payload transformation (using Jolt) was long.
With the new implementation, all the long-running tasks are done by a dedicated executor.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-avsshdlioo.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1337-dont-block-the-event-loop/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
