### PR TITLE
fix: don't rely on args to determine location

### DIFF
--- a/gravitee-apim-portal-webui/docker/config/templates/default.conf.tmpl
+++ b/gravitee-apim-portal-webui/docker/config/templates/default.conf.tmpl
@@ -24,7 +24,7 @@ server {
     gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/javascript;
 
     location / {
-        try_files $uri$args $uri$args/ $uri $uri/ /index.html =404;
+        try_files $uri $uri/ /index.html =404;
         root /usr/share/nginx/html;
         sub_filter '<base href="/"' '<base href="{{ getenv "PORTAL_BASE_HREF" "/" }}"';
         sub_filter_once on;


### PR DESCRIPTION
## Issue

N/A

## Description

don't rely on args to determine location
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-potal-default-nginx-config/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
