### PR TITLE
Update Mergify config and reformat it with prettier

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,96 +1,96 @@
 pull_request_rules:
-  - name: Apply patches on `master`
-    conditions:
-      - label=apply-on-master
-    actions:
-      backport:
-        branches:
-          - master
-        assignees:
-          - "{{ author }}"
-        body: |
-          This is an automatic copy of pull request #{{number}} done by [Mergify](https://mergify.com).
-          
-          ----
-          
-          {{ body }}
-          
-          ----
-          {{ cherry_pick_error }}
-        title: "{{ title }} - master"
-  - name: Apply patches on `3.21.x`
-    conditions:
-      - label=apply-on-3-21-x
-    actions:
-      backport:
-        branches:
-          - 3.21.x
-        assignees:
-          - "{{ author }}"
-        body: |
-          This is an automatic copy of pull request #{{number}} done by [Mergify](https://mergify.com).
-          
-          ----
-          
-          {{ body }}
-          
-          ----
-          {{ cherry_pick_error }}
-        title: "{{ title }} - 3.21.x"
-  - name: Apply patches on `3.20.x`
-    conditions:
-      - label=apply-on-3-20-x
-    actions:
-      backport:
-        branches:
-          - 3.20.x
-        assignees:
-          - "{{ author }}"
-        body: |
-          This is an automatic copy of pull request #{{number}} done by [Mergify](https://mergify.com).
-          
-          ----
-          
-          {{ body }}
-          
-          ----
-          {{ cherry_pick_error }}
-        title: "{{ title }} - 3.20.x"
-  - name: Apply patches on `3.19.x`
-    conditions:
-      - label=apply-on-3-19-x
-    actions:
-      backport:
-        branches:
-          - 3.19.x
-        assignees:
-          - "{{ author }}"
-        body: |
-          This is an automatic copy of pull request #{{number}} done by [Mergify](https://mergify.com).
-          
-          ----
-          
-          {{ body }}
-          
-          ----
-          {{ cherry_pick_error }}
-        title: "{{ title }} - 3.19.x"          
-  - name: Apply patches on `3.18.x`
-    conditions:
-      - label=apply-on-3-18-x
-    actions:
-      backport:
-        branches:
-          - 3.18.x
-        assignees:
-          - "{{ author }}"          
-        body: |
-          This is an automatic copy of pull request #{{number}} done by [Mergify](https://mergify.com).
-          
-          ----
-          
-          {{ body }}
-          
-          ----
-          {{ cherry_pick_error }}
-        title: "{{ title }} - 3.18.x"
+    - name: Apply commits on `master`
+      conditions:
+          - label=apply-on-master
+      actions:
+          copy:
+              branches:
+                  - master
+              assignees:
+                  - "{{ author }}"
+              body: |
+                  This is an automatic copy of pull request #{{number}} done by [Mergify](https://mergify.com).
+
+                  ----
+
+                  {{ body }}
+
+                  ----
+                  {{ cherry_pick_error }}
+              title: "[master] {{ title }}"
+    - name: Apply commits on `3.21.x`
+      conditions:
+          - label=apply-on-3-21-x
+      actions:
+          copy:
+              branches:
+                  - 3.21.x
+              assignees:
+                  - "{{ author }}"
+              body: |
+                  This is an automatic copy of pull request #{{number}} done by [Mergify](https://mergify.com).
+
+                  ----
+
+                  {{ body }}
+
+                  ----
+                  {{ cherry_pick_error }}
+              title: "[3.21.x] {{ title }}"
+    - name: Apply commits on `3.20.x`
+      conditions:
+          - label=apply-on-3-20-x
+      actions:
+          copy:
+              branches:
+                  - 3.20.x
+              assignees:
+                  - "{{ author }}"
+              body: |
+                  This is an automatic copy of pull request #{{number}} done by [Mergify](https://mergify.com).
+
+                  ----
+
+                  {{ body }}
+
+                  ----
+                  {{ cherry_pick_error }}
+              title: "[3.20.x] {{ title }}"
+    - name: Apply commits on `3.19.x`
+      conditions:
+          - label=apply-on-3-19-x
+      actions:
+          copy:
+              branches:
+                  - 3.19.x
+              assignees:
+                  - "{{ author }}"
+              body: |
+                  This is an automatic copy of pull request #{{number}} done by [Mergify](https://mergify.com).
+
+                  ----
+
+                  {{ body }}
+
+                  ----
+                  {{ cherry_pick_error }}
+              title: "[3.19.x] {{ title }}"
+    - name: Apply commits on `3.18.x`
+      conditions:
+          - label=apply-on-3-18-x
+      actions:
+          copy:
+              branches:
+                  - 3.18.x
+              assignees:
+                  - "{{ author }}"
+              body: |
+                  This is an automatic copy of pull request #{{number}} done by [Mergify](https://mergify.com).
+
+                  ----
+
+                  {{ body }}
+
+                  ----
+                  {{ cherry_pick_error }}
+              title: "[3.18.x] {{ title }}"


### PR DESCRIPTION
## Issue

NA

## Description

Unify Mergify config between AM and APIM

- Use copy action instead of backport (it looks to be the same thing under the hood)
- Put the branch name as a prefix in the PR name

For AM: https://github.com/gravitee-io/gravitee-access-management/pull/2559
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vkthzqkaxj.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/update-mergify-config/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
