### PR TITLE
fix: remove slash from path param regex 3.20.x

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/main/java/io/gravitee/gateway/flow/condition/evaluation/PathPatterns.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/main/java/io/gravitee/gateway/flow/condition/evaluation/PathPatterns.java
@@ -30,7 +30,7 @@ public class PathPatterns {
     private static final char OPTIONAL_TRAILING_SEPARATOR = '?';
     private static final String PATH_SEPARATOR = "/";
     private static final String PATH_PARAM_PREFIX = ":";
-    private static final String PATH_PARAM_REGEX = "[a-zA-Z0-9\\-._~%!$&'()* +,;=:@/]+";
+    private static final String PATH_PARAM_REGEX = "[a-zA-Z0-9\\-._~%!$&'()* +,;=:@]+";
     private static final Pattern SEPARATOR_SPLITTER = Pattern.compile(PATH_SEPARATOR);
 
     private final Map<String, Pattern> cache = new ConcurrentHashMap<>();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/flow/PathBasedConditionEvaluatorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/flow/PathBasedConditionEvaluatorTest.java
@@ -152,4 +152,13 @@ public class PathBasedConditionEvaluatorTest {
 
         assertTrue(evaluator.evaluate(context, flow));
     }
+
+    @Test
+    public void shouldNotEvaluate_pathParamEquals() {
+        when(request.pathInfo()).thenReturn("/my/path/subpath");
+        when(flow.getOperator()).thenReturn(Operator.EQUALS);
+        when(flow.getPath()).thenReturn("/my/:param");
+
+        assertFalse(evaluator.evaluate(context, flow));
+    }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/jupiter/flow/BestMatchFlowBaseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/test/java/io/gravitee/gateway/jupiter/flow/BestMatchFlowBaseTest.java
@@ -154,12 +154,7 @@ public abstract class BestMatchFlowBaseTest {
                     "/path/:id/:id2",
                     "/path/5555/5559/5553",
                 },
-                {
-                    List.of("/path/:id", "/path/staticId", "/path/:id/secondId", "/path/:id/:id2"),
-                    Operator.EQUALS,
-                    "/path/:id/:id2",
-                    "/path/5555/5559/5553",
-                },
+                { List.of("/path/:id", "/path/:id/secondId"), Operator.EQUALS, "/path/:id/secondId", "/path/5555/secondId" },
                 {
                     List.of("/path/:id", "/path/staticId", "/path/:id/secondId", "/path/:id/:id2", "/path/:id/subResource/:id2"),
                     Operator.STARTS_WITH,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1100

## Description

Path parameters should not contain `/`

## Additional context

Had to fix a unit test, but the expected result was incorrect : 
With the following paths
`/path/:id`, `/path/staticId`, `/path/:id/secondId`, `/path/:id/:id2`
and operator `EQUALS`,
The URL `/path/5555/5559/5553` does not match `/path/:id/:id2` pattern. 

It matches with operator `STARTS_WITH` (test case just above) but not `EQUALS`.
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1100-path-param-match-320/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dhpkvmeuuk.chromatic.com)
<!-- Storybook placeholder end -->
