### PR TITLE
Rewrite Dynamic Properties service to avoid blocking the event loop

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/pom.xml
@@ -40,6 +40,11 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-rx-java3</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <!-- Json transformer (jolt) -->
         <dependency>
             <groupId>com.bazaarvoice.jolt</groupId>
@@ -84,6 +89,12 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertiesService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertiesService.java
@@ -148,6 +148,7 @@ public class DynamicPropertiesService extends AbstractService implements EventLi
                     HttpProvider provider = new HttpProvider(dynamicPropertyService);
                     provider.setHttpClientService(httpClientService);
                     provider.setNode(node);
+                    provider.setExecutor(executor);
 
                     updater.setProvider(provider);
                     updater.setApiService(apiService);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/provider/Provider.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/provider/Provider.java
@@ -16,15 +16,15 @@
 package io.gravitee.rest.api.services.dynamicproperties.provider;
 
 import io.gravitee.rest.api.services.dynamicproperties.model.DynamicProperty;
+import io.reactivex.rxjava3.core.Maybe;
 import java.util.Collection;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
 public interface Provider {
-    CompletableFuture<Collection<DynamicProperty>> get();
+    Maybe<Collection<DynamicProperty>> get();
 
     String name();
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/provider/http/HttpProvider.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/provider/http/HttpProvider.java
@@ -122,7 +122,7 @@ public class HttpProvider implements Provider {
 
     @Override
     public String name() {
-        return "custom";
+        return "http-provider";
     }
 
     public void setHttpClientService(HttpClientService httpClientService) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/provider/http/HttpProvider.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/provider/http/HttpProvider.java
@@ -15,7 +15,8 @@
  */
 package io.gravitee.rest.api.services.dynamicproperties.provider.http;
 
-import io.gravitee.common.http.HttpHeaders;
+import static io.gravitee.gateway.api.http.HttpHeaderNames.USER_AGENT;
+
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.definition.model.services.dynamicproperty.DynamicPropertyService;
 import io.gravitee.definition.model.services.dynamicproperty.http.HttpDynamicPropertyProviderConfiguration;
@@ -26,16 +27,15 @@ import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.services.dynamicproperties.model.DynamicProperty;
 import io.gravitee.rest.api.services.dynamicproperties.provider.Provider;
 import io.gravitee.rest.api.services.dynamicproperties.provider.http.mapper.JoltMapper;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
-import io.vertx.core.Promise;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.*;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.RequestOptions;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collection;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Function;
+import java.util.concurrent.Executor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
@@ -46,6 +46,8 @@ import org.springframework.util.StringUtils;
  */
 public class HttpProvider implements Provider {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpProvider.class);
+
     private static final String HTTPS_SCHEME = "https";
 
     private final HttpDynamicPropertyProviderConfiguration dpConfiguration;
@@ -55,6 +57,7 @@ public class HttpProvider implements Provider {
     private HttpClientService httpClientService;
 
     private Node node;
+    private Executor executor;
 
     public HttpProvider(final DynamicPropertyService dpService) {
         Objects.requireNonNull(dpService, "Service must not be null");
@@ -64,129 +67,62 @@ public class HttpProvider implements Provider {
     }
 
     @Override
-    public CompletableFuture<Collection<DynamicProperty>> get() {
-        Promise<Buffer> promise = Promise.promise();
-
+    public Maybe<Collection<DynamicProperty>> get() {
+        URL requestUrl = null;
         try {
-            URL requestUrl = new URL(dpConfiguration.getUrl());
-
-            final HttpClient httpClient = httpClientService.createHttpClient(requestUrl.getProtocol(), dpConfiguration.isUseSystemProxy());
-
-            final int port = requestUrl.getPort() != -1 ? requestUrl.getPort() : (HTTPS_SCHEME.equals(requestUrl.getProtocol()) ? 443 : 80);
-
-            String relativeUri = (requestUrl.getQuery() == null)
-                ? requestUrl.getPath()
-                : requestUrl.getPath() + '?' + requestUrl.getQuery();
-
-            RequestOptions options = new RequestOptions()
-                .setMethod(HttpMethod.valueOf(dpConfiguration.getMethod().name()))
-                .setHost(requestUrl.getHost())
-                .setPort(port)
-                .setURI(relativeUri);
-
-            //headers
-            options.putHeader(HttpHeaders.USER_AGENT, NodeUtils.userAgent(node));
-            options.putHeader("X-Gravitee-Request-Id", UuidString.generateRandom());
-
-            if (dpConfiguration.getHeaders() != null) {
-                dpConfiguration.getHeaders().forEach(httpHeader -> options.putHeader(httpHeader.getName(), httpHeader.getValue()));
-            }
-
-            httpClient
-                .request(options)
-                .onFailure(
-                    new Handler<Throwable>() {
-                        @Override
-                        public void handle(Throwable event) {
-                            promise.fail(event);
-
-                            // Close client
-                            httpClient.close();
-                        }
-                    }
-                )
-                .onSuccess(
-                    new Handler<HttpClientRequest>() {
-                        @Override
-                        public void handle(HttpClientRequest request) {
-                            request
-                                .response(
-                                    new Handler<AsyncResult<HttpClientResponse>>() {
-                                        @Override
-                                        public void handle(AsyncResult<HttpClientResponse> asyncResponse) {
-                                            if (asyncResponse.failed()) {
-                                                promise.fail(asyncResponse.cause());
-
-                                                // Close client
-                                                httpClient.close();
-                                            } else {
-                                                final HttpClientResponse response = asyncResponse.result();
-
-                                                if (response.statusCode() == HttpStatusCode.OK_200) {
-                                                    response.bodyHandler(buffer -> {
-                                                        promise.complete(buffer);
-
-                                                        // Close client
-                                                        httpClient.close();
-                                                    });
-                                                } else {
-                                                    promise.complete(null);
-
-                                                    // Close client
-                                                    httpClient.close();
-                                                }
-                                            }
-                                        }
-                                    }
-                                )
-                                .exceptionHandler(
-                                    new Handler<Throwable>() {
-                                        @Override
-                                        public void handle(Throwable throwable) {
-                                            promise.fail(throwable);
-
-                                            // Close client
-                                            httpClient.close();
-                                        }
-                                    }
-                                );
-
-                            if (!StringUtils.isEmpty(dpConfiguration.getBody())) {
-                                request.end(dpConfiguration.getBody());
-                            } else {
-                                request.end();
-                            }
-                        }
-                    }
-                );
-        } catch (Exception e) {
-            promise.fail(e);
+            requestUrl = new URL(dpConfiguration.getUrl());
+        } catch (MalformedURLException ex) {
+            LOGGER.error("Unable to parse URL: {}", dpConfiguration.getUrl(), ex);
+            return Maybe.empty();
         }
 
-        return promise
-            .future()
-            .map(
-                new Function<Buffer, Collection<DynamicProperty>>() {
-                    @Override
-                    public Collection<DynamicProperty> apply(Buffer buffer) {
-                        if (buffer == null) {
-                            return null;
-                        }
-                        return mapper.map(buffer.toString());
-                    }
+        final io.vertx.rxjava3.core.http.HttpClient httpClient = new io.vertx.rxjava3.core.http.HttpClient(
+            httpClientService.createHttpClient(requestUrl.getProtocol(), dpConfiguration.isUseSystemProxy())
+        );
+
+        final int port = requestUrl.getPort() != -1 ? requestUrl.getPort() : (HTTPS_SCHEME.equals(requestUrl.getProtocol()) ? 443 : 80);
+
+        String relativeUri = (requestUrl.getQuery() == null) ? requestUrl.getPath() : requestUrl.getPath() + '?' + requestUrl.getQuery();
+
+        RequestOptions options = new RequestOptions()
+            .setMethod(HttpMethod.valueOf(dpConfiguration.getMethod().name()))
+            .setHost(requestUrl.getHost())
+            .setPort(port)
+            .setURI(relativeUri);
+
+        //headers
+        options.putHeader(USER_AGENT, NodeUtils.userAgent(node));
+        options.putHeader("X-Gravitee-Request-Id", UuidString.generateRandom());
+
+        if (dpConfiguration.getHeaders() != null) {
+            dpConfiguration.getHeaders().forEach(httpHeader -> options.putHeader(httpHeader.getName(), httpHeader.getValue()));
+        }
+
+        return httpClient
+            .rxRequest(options)
+            .flatMap(request -> {
+                LOGGER.debug(
+                    "Dynamic properties will be fetched with the following request: {} {}",
+                    request.getMethod(),
+                    request.absoluteURI()
+                );
+                if (StringUtils.hasText(dpConfiguration.getBody())) {
+                    return request.rxSend(dpConfiguration.getBody());
+                } else {
+                    return request.rxSend();
                 }
-            )
-            .toCompletionStage()
-            .toCompletableFuture();
+            })
+            .filter(response -> response.statusCode() == HttpStatusCode.OK_200)
+            .flatMap(response -> response.rxBody().toMaybe())
+            .doFinally(httpClient::close)
+            // Move to a specific executor to avoid blocking the event loop as the Jolt transformation can be long
+            .observeOn(Schedulers.from(executor))
+            .map(buffer -> mapper.map(buffer.toString()));
     }
 
     @Override
     public String name() {
         return "custom";
-    }
-
-    public void setMapper(JoltMapper mapper) {
-        this.mapper = mapper;
     }
 
     public void setHttpClientService(HttpClientService httpClientService) {
@@ -195,5 +131,9 @@ public class HttpProvider implements Provider {
 
     public void setNode(Node node) {
         this.node = node;
+    }
+
+    public void setExecutor(Executor executor) {
+        this.executor = executor;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/spring/DynamicPropertiesConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/spring/DynamicPropertiesConfiguration.java
@@ -28,9 +28,11 @@ public class DynamicPropertiesConfiguration {
 
     @Bean(name = "dynamicPropertiesExecutor")
     public Executor dynamicPropertiesExecutor() {
+        int maxPoolSize = Runtime.getRuntime().availableProcessors() * 2;
+
         final ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(
             0,
-            2, // maximumPoolSize
+            maxPoolSize, // maximumPoolSize
             5, // keepAliveTime
             TimeUnit.MINUTES,
             new LinkedBlockingQueue<>(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertyUpdaterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertyUpdaterTest.java
@@ -18,34 +18,37 @@ package io.gravitee.rest.api.services.dynamicproperties;
 import static org.mockito.Mockito.*;
 
 import io.gravitee.definition.model.Properties;
+import io.gravitee.definition.model.Property;
+import io.gravitee.rest.api.model.EventType;
 import io.gravitee.rest.api.model.api.ApiEntity;
-import io.gravitee.rest.api.model.api.UpdateApiEntity;
 import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.services.dynamicproperties.model.DynamicProperty;
 import io.gravitee.rest.api.services.dynamicproperties.provider.Provider;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.concurrent.*;
+import io.reactivex.rxjava3.core.Maybe;
+import java.util.List;
+import java.util.concurrent.Executors;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@RunWith(MockitoJUnitRunner.class)
 public class DynamicPropertyUpdaterTest {
 
-    private static final DynamicProperty property = new DynamicProperty("my-key", "my-value");
+    private DynamicPropertyUpdater dynamicPropertyUpdater;
+    private final List<DynamicProperty> dynamicProperties = List.of(new DynamicProperty("my-key", "my-value"));
+    private final List<Property> propertiesList = List.of(new Property("my-key", "my-value"));
+    private final Properties properties = new Properties();
 
-    private DynamicPropertyUpdater poller;
-
-    @Mock
-    private ApiEntity apiEntity;
+    private ApiEntity existingApi;
 
     @Mock
     private Provider provider;
@@ -58,65 +61,75 @@ public class DynamicPropertyUpdaterTest {
 
     @Before
     public void setUp() {
-        MockitoAnnotations.openMocks(this);
-        poller = new DynamicPropertyUpdater(apiEntity, Executors.newSingleThreadExecutor());
+        properties.setProperties(propertiesList);
+
+        existingApi = new ApiEntity();
+        existingApi.setId("api-id");
+        Properties apiProperties = new Properties();
+        apiProperties.setProperties(List.of());
+        existingApi.setProperties(apiProperties);
+
+        dynamicPropertyUpdater = new DynamicPropertyUpdater(existingApi, Executors.newSingleThreadExecutor());
         when(provider.name()).thenReturn("mock");
-        reset(provider, apiService, apiConverter);
-        poller.setProvider(provider);
-        poller.setApiService(apiService);
-        poller.setApiConverter(apiConverter);
+        dynamicPropertyUpdater.setProvider(provider);
+        dynamicPropertyUpdater.setApiService(apiService);
+        dynamicPropertyUpdater.setApiConverter(apiConverter);
     }
 
     @Test
     public void shouldNotUpdatePropertiesBecauseOfProviderException() {
-        when(provider.get())
-            .thenReturn(
-                CompletableFuture
-                    .completedFuture((Collection<DynamicProperty>) Collections.<DynamicProperty>emptyList())
-                    .whenCompleteAsync((dynamicProperties, throwable) -> {
-                        throw new IllegalStateException();
-                    })
-            );
+        when(provider.get()).thenReturn(Maybe.error(new IllegalStateException()));
 
-        poller.handle(1L);
+        dynamicPropertyUpdater.handle().blockingGet();
         verifyNoInteractions(apiService);
     }
 
     @Test
-    public void shouldUpdateProperties() throws ExecutionException, InterruptedException {
-        when(provider.get()).thenReturn(CompletableFuture.completedFuture(Collections.singletonList(property)));
+    public void shouldUpdatePropertiesWithoutDeploymentIfManualChange() {
+        when(apiService.findById(any(), any())).thenReturn(existingApi);
+        // Simulate a manual change
+        when(apiService.isSynchronized(any(), any())).thenReturn(false);
 
-        ApiEntity api = new ApiEntity();
-        apiEntity.setId("api-id");
-        apiEntity.setProperties(new Properties());
+        when(provider.get()).thenReturn(Maybe.just(dynamicProperties));
+        dynamicPropertyUpdater.handle().blockingGet();
 
-        when(apiService.findById(any(), any())).thenReturn(api);
-        when(apiService.isSynchronized(any(), any())).thenReturn(true);
-        when(apiService.update(eq(GraviteeContext.getExecutionContext()), eq("api-id"), any(UpdateApiEntity.class))).thenReturn(api);
-
-        poller.handle().get();
-
-        verify(apiService, times(1)).update(any(), any(), any(), eq(false), eq(false));
-        verify(apiService, times(1)).deploy(any(), any(), eq("dynamic-property-updater"), any(), any());
+        verify(apiService, times(1))
+            .update(eq(GraviteeContext.getExecutionContext()), eq(existingApi.getId()), any(), eq(false), eq(false));
+        verify(apiService, never()).deploy(any(), any(), any(), any(), any());
     }
 
     @Test
-    public void shouldNotUpdatePropertyOnUpdateError() throws ExecutionException, InterruptedException {
-        DynamicProperty property = new DynamicProperty("my-key", "my-value");
-        when(provider.get()).thenReturn(CompletableFuture.completedFuture(Collections.singletonList(property)));
+    public void shouldUpdatePropertiesAndDeployApi() {
+        when(apiService.findById(any(), any())).thenReturn(existingApi);
+        when(apiService.isSynchronized(any(), any())).thenReturn(true);
 
-        ApiEntity api = new ApiEntity();
-        apiEntity.setId("api-id");
-        apiEntity.setProperties(new Properties());
+        when(provider.get()).thenReturn(Maybe.just(dynamicProperties));
+        dynamicPropertyUpdater.handle().blockingGet();
 
-        when(apiService.findById(any(), any())).thenReturn(api);
-        when(apiService.isSynchronized(GraviteeContext.getExecutionContext(), "api-id")).thenReturn(true);
-        when(apiService.update(eq(GraviteeContext.getExecutionContext()), eq("api-id"), any()))
-            .thenThrow(new TechnicalManagementException());
+        verify(apiService, times(1))
+            .update(eq(GraviteeContext.getExecutionContext()), eq(existingApi.getId()), any(), eq(false), eq(false));
+        verify(apiService, times(1))
+            .deploy(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(existingApi.getId()),
+                eq("dynamic-property-updater"),
+                eq(EventType.PUBLISH_API),
+                any()
+            );
+    }
 
-        poller.handle().get();
+    @Test
+    public void shouldNotDeployAPIOnUpdateError() {
+        when(apiService.findById(any(), any())).thenReturn(existingApi);
+        when(apiService.isSynchronized(any(), any())).thenReturn(true);
+
+        when(apiService.update(eq(GraviteeContext.getExecutionContext()), eq(existingApi.getId()), any(), eq(false), eq(false)))
+            .thenThrow(new TechnicalManagementException("Unable to update the API"));
+
+        when(provider.get()).thenReturn(Maybe.just(dynamicProperties));
+        dynamicPropertyUpdater.handle().blockingGet();
 
         verify(apiService, times(1)).update(any(), any(), any(), eq(false), eq(false));
-        verify(apiService, never()).deploy(eq(GraviteeContext.getExecutionContext()), eq("api-id"), eq(null), any(), any());
+        verify(apiService, never()).deploy(any(), any(), any(), any(), any());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/resources/jolt/custom-response.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/resources/jolt/custom-response.json
@@ -1,14 +1,14 @@
 {
-  "content":
-    {
-      "name": "Elysee",
-      "country": "FRANCE",
-      "address": "Avenue des Champs-Élysées",
-      "city": "PARIS",
-      "stores_id": 1,
-      "zip_code": "75000",
-      "gps_x": "48.869729",
-      "gps_y": "2.307784",
-      "phone_number": "01 00 00 00 00",
-      "backend_url": "https://north-europe.company.com/"
-    }}
+    "content": {
+        "name": "Elysee",
+        "country": "FRANCE",
+        "address": "Avenue des Champs-Élysées",
+        "city": "PARIS",
+        "stores_id": 1,
+        "zip_code": "75000",
+        "gps_x": "48.869729",
+        "gps_y": "2.307784",
+        "phone_number": "01 00 00 00 00",
+        "backend_url": "https://north-europe.company.com/"
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/resources/mappings/request01.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/resources/mappings/request01.json
@@ -6,7 +6,18 @@
   "response": {
     "status": 200,
     "jsonBody": {
-      "key": "value"
+      "content": {
+        "name": "Elysee",
+        "country": "FRANCE",
+        "address": "Avenue des Champs-Élysées",
+        "city": "PARIS",
+        "stores_id": 1,
+        "zip_code": "75000",
+        "gps_x": "48.869729",
+        "gps_y": "2.307784",
+        "phone_number": "01 00 00 00 00",
+        "backend_url": "https://north-europe.company.com/"
+      }
     }
   }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/resources/mappings/request03.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/resources/mappings/request03.json
@@ -1,17 +1,36 @@
 {
   "request": {
-    "method": "GET",
+    "method": "POST",
     "url": "/success_post",
     "bodyPatterns": [
       {
-        "equalToJson" : "{}"
+        "equalToJson": "{}"
       }
-    ]
+    ],
+    "headers": {
+      "Content-Type": {
+        "equalTo": "application/json"
+      },
+      "X-Gravitee-Header" : {
+        "equalTo": "value"
+      }
+    }
   },
   "response": {
     "status": 200,
     "jsonBody": {
-      "key": "value"
+      "content": {
+        "name": "Elysee",
+        "country": "FRANCE",
+        "address": "Avenue des Champs-Élysées",
+        "city": "PARIS",
+        "stores_id": 1,
+        "zip_code": "75000",
+        "gps_x": "48.869729",
+        "gps_y": "2.307784",
+        "phone_number": "01 00 00 00 00",
+        "backend_url": "https://north-europe.company.com/"
+      }
     }
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1337
gravitee-io/issues#8969

## Description

Apply https://github.com/gravitee-io/gravitee-api-management/pull/3593 on 3.20.x and use RxJava 3 instead of RxJava 2
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lathwedgko.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-1337-dont-block-the-event-loop-3-20-x/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
