### PR TITLE
fix: find api accross all environments in dynamic properties updater

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertyUpdater.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertyUpdater.java
@@ -26,6 +26,7 @@ import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.service.ApiService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
@@ -98,7 +99,9 @@ public class DynamicPropertyUpdater implements Handler<Long> {
 
     private void update(Collection<DynamicProperty> dynamicProperties) {
         // Get latest changes
-        ApiEntity latestApi = apiService.findById(GraviteeContext.getExecutionContext(), api.getId());
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        ExecutionContext lookupContext = new ExecutionContext(executionContext.getOrganizationId(), null);
+        ApiEntity latestApi = apiService.findById(lookupContext, api.getId());
 
         List<Property> properties = (latestApi.getProperties() != null)
             ? latestApi.getProperties().getProperties()
@@ -138,18 +141,12 @@ public class DynamicPropertyUpdater implements Handler<Long> {
             }
             latestApi.setProperties(apiProperties);
 
-            boolean isSync = apiService.isSynchronized(GraviteeContext.getExecutionContext(), api.getId());
+            boolean isSync = apiService.isSynchronized(executionContext, api.getId());
 
             // Update API
             try {
                 LOGGER.debug("[{}] Updating API", latestApi.getId());
-                apiService.update(
-                    GraviteeContext.getExecutionContext(),
-                    latestApi.getId(),
-                    apiConverter.toUpdateApiEntity(latestApi),
-                    false,
-                    false
-                );
+                apiService.update(executionContext, latestApi.getId(), apiConverter.toUpdateApiEntity(latestApi), false, false);
                 LOGGER.debug("[{}] API has been updated", latestApi.getId());
             } catch (TechnicalManagementException e) {
                 LOGGER.error(
@@ -166,13 +163,7 @@ public class DynamicPropertyUpdater implements Handler<Long> {
                     LOGGER.debug("[{}] Property change detected, API is about to be deployed", api.getId());
                     ApiDeploymentEntity deployEntity = new ApiDeploymentEntity();
                     deployEntity.setDeploymentLabel("Dynamic properties sync");
-                    apiService.deploy(
-                        GraviteeContext.getExecutionContext(),
-                        latestApi.getId(),
-                        "dynamic-property-updater",
-                        EventType.PUBLISH_API,
-                        deployEntity
-                    );
+                    apiService.deploy(executionContext, latestApi.getId(), "dynamic-property-updater", EventType.PUBLISH_API, deployEntity);
                     LOGGER.debug("[{}] API as been deployed", api.getId());
                 }
             }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1472
https://github.com/gravitee-io/issues/issues/9018


<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-dynamic-properties-multi-env/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fkwshhwmyv.chromatic.com)
<!-- Storybook placeholder end -->
