### PR TITLE
Reload API info and doc after an API search 

### DIFF
--- a/gravitee-apim-portal-webui/src/app/pages/api/api-general/api-general.component.html
+++ b/gravitee-apim-portal-webui/src/app/pages/api/api-general/api-general.component.html
@@ -17,15 +17,17 @@
 -->
 <div *ngIf="currentApi" class="page__content page__content-with-aside">
   <div class="main">
-    <gv-button
-      link
-      icon="navigation:angle-left"
-      class="page__content-back-button"
-      *ngIf="this.backButton.label !== null"
-      (:gv-button:click)="goBack()"
-    >
-      {{ backButton.label }}
-    </gv-button>
+    <div *ngIf="this.backButton.url">
+      <gv-button
+        link
+        icon="navigation:angle-left"
+        class="page__content-back-button"
+        *ngIf="this.backButton.label !== null"
+        (:gv-button:click)="goBack()"
+      >
+        {{ backButton.label }}
+      </gv-button>
+    </div>
     <div *ngIf="description && !apiHomepage" class="page__box">
       <div class="page__box-title">
         <h3 class="title">{{ 'apiGeneral.description' | translate }}</h3>

--- a/gravitee-apim-portal-webui/src/app/pages/api/api-general/api-general.component.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/api/api-general/api-general.component.ts
@@ -114,9 +114,7 @@ export class ApiGeneralComponent implements OnInit {
 
   ngOnInit() {
     const apiId = this.route.snapshot.params.apiId;
-    this.permissions = this.route.snapshot.data.permissions;
-    this.apiHomepage = this.route.snapshot.data.apiHomepage;
-    this.apiInformations = this.route.snapshot.data.apiInformations;
+
     if (this.apiHomepage == null) {
       this.apiHomepageLoaded = true;
     }
@@ -177,6 +175,9 @@ export class ApiGeneralComponent implements OnInit {
             .catch(() => []);
         }
 
+        this.apiHomepage = this.route.snapshot.data.apiHomepage;
+        this.permissions = this.route.snapshot.data.permissions;
+        this.apiInformations = this.route.snapshot.data.apiInformations;
         this.description = this.currentApi.description;
         this.computeBackButton();
         return this.currentApi;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-887
https://github.com/gravitee-io/issues/issues/8145

## Description

- Display back button in API page only if needed
- Reload API info and doc after an API search 

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim-887-fix-doc-as-homepage/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ibkedtphmx.chromatic.com)
<!-- Storybook placeholder end -->
