### PR TITLE
fix: do not dispatch subscription if jupiter mode is disabled

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionService.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/services/SubscriptionService.java
@@ -47,7 +47,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-@Component
 public class SubscriptionService implements io.gravitee.gateway.api.service.SubscriptionService {
 
     public static final Logger LOGGER = LoggerFactory.getLogger(SubscriptionService.class);
@@ -68,6 +67,7 @@ public class SubscriptionService implements io.gravitee.gateway.api.service.Subs
     private final Node node;
 
     private ObjectMapper objectMapper;
+    private final boolean jupiterMode;
 
     public SubscriptionService(
         CacheManager cacheManager,
@@ -75,7 +75,8 @@ public class SubscriptionService implements io.gravitee.gateway.api.service.Subs
         SubscriptionDispatcher subscriptionDispatcher,
         CommandRepository commandRepository,
         Node node,
-        ObjectMapper objectMapper
+        ObjectMapper objectMapper,
+        boolean jupiterMode
     ) {
         cacheByApiClientId = cacheManager.getOrCreateCache(CACHE_NAME_BY_API_AND_CLIENT_ID);
         cacheBySubscriptionId = cacheManager.getOrCreateCache(CACHE_NAME_BY_SUBSCRIPTION_ID);
@@ -85,6 +86,7 @@ public class SubscriptionService implements io.gravitee.gateway.api.service.Subs
         this.commandRepository = commandRepository;
         this.node = node;
         this.objectMapper = objectMapper;
+        this.jupiterMode = jupiterMode;
     }
 
     @Override
@@ -112,7 +114,7 @@ public class SubscriptionService implements io.gravitee.gateway.api.service.Subs
     public void save(Subscription subscription) {
         if (Subscription.Type.STANDARD == subscription.getType()) {
             cacheStandardSubscription(subscription);
-        } else if (Subscription.Type.SUBSCRIPTION == subscription.getType()) {
+        } else if (Subscription.Type.SUBSCRIPTION == subscription.getType() && jupiterMode) {
             cacheDispatchableSubscription(subscription);
         }
     }
@@ -121,7 +123,7 @@ public class SubscriptionService implements io.gravitee.gateway.api.service.Subs
     public void saveOrDispatch(Subscription subscription) {
         if (Subscription.Type.STANDARD == subscription.getType()) {
             cacheStandardSubscription(subscription);
-        } else if (Subscription.Type.SUBSCRIPTION == subscription.getType()) {
+        } else if (Subscription.Type.SUBSCRIPTION == subscription.getType() && jupiterMode) {
             dispatch(subscription);
         }
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.gateway.handlers.api.spring;
 
+import static io.gravitee.gateway.env.GatewayConfiguration.JUPITER_MODE_ENABLED_BY_DEFAULT;
+import static io.gravitee.gateway.env.GatewayConfiguration.JUPITER_MODE_ENABLED_KEY;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.common.util.DataEncryptor;
 import io.gravitee.gateway.core.classloader.DefaultClassLoader;
@@ -62,6 +65,7 @@ import io.gravitee.plugin.entrypoint.EntrypointConnectorPluginManager;
 import io.gravitee.repository.management.api.CommandRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -208,9 +212,18 @@ public class ApiHandlerConfiguration {
         SubscriptionDispatcher subscriptionDispatcher,
         @Lazy CommandRepository commandRepository,
         Node node,
-        ObjectMapper objectMapper
+        ObjectMapper objectMapper,
+        @Value("${" + JUPITER_MODE_ENABLED_KEY + ":" + JUPITER_MODE_ENABLED_BY_DEFAULT + "}") boolean jupiterMode
     ) {
-        return new SubscriptionService(cacheManager, apiKeyService, subscriptionDispatcher, commandRepository, node, objectMapper);
+        return new SubscriptionService(
+            cacheManager,
+            apiKeyService,
+            subscriptionDispatcher,
+            commandRepository,
+            node,
+            objectMapper,
+            jupiterMode
+        );
     }
 
     @Bean


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1451

## Description

Do not dispatch subscription if jupiter mode is disabled

## Additional context

We can't apply this fix on the master branch because this part has changed with the improvement made on the Sychronization process. I will create another PR.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bcwcnxiang.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim1451/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
