### PR TITLE
[3.21.x] fix: do not deploy v4 api if jupiter mode is disabled

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/pom.xml
@@ -63,6 +63,13 @@
         </dependency>
 
         <dependency>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-env</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.gravitee.apim.gateway.handlers</groupId>
             <artifactId>gravitee-apim-gateway-handlers-api</artifactId>
             <version>${project.version}</version>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/spring/SyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/spring/SyncConfiguration.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.gateway.services.sync.spring;
 
+import static io.gravitee.gateway.env.GatewayConfiguration.JUPITER_MODE_ENABLED_BY_DEFAULT;
+import static io.gravitee.gateway.env.GatewayConfiguration.JUPITER_MODE_ENABLED_KEY;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.common.event.EventManager;
 import io.gravitee.gateway.api.service.SubscriptionService;
@@ -110,9 +113,10 @@ public class SyncConfiguration {
     public EventToReactableApiAdapter eventToReactableApiAdapter(
         ObjectMapper objectMapper,
         EnvironmentRepository environmentRepository,
-        OrganizationRepository organizationRepository
+        OrganizationRepository organizationRepository,
+        @Value("${" + JUPITER_MODE_ENABLED_KEY + ":" + JUPITER_MODE_ENABLED_BY_DEFAULT + "}") boolean jupiterMode
     ) {
-        return new EventToReactableApiAdapter(objectMapper, environmentRepository, organizationRepository);
+        return new EventToReactableApiAdapter(objectMapper, environmentRepository, organizationRepository, jupiterMode);
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/api/EventToReactableApiAdapter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/synchronizer/api/EventToReactableApiAdapter.java
@@ -36,6 +36,7 @@ public class EventToReactableApiAdapter {
     private final ObjectMapper objectMapper;
     private final EnvironmentRepository environmentRepository;
     private final OrganizationRepository organizationRepository;
+    private final boolean jupiterMode;
 
     private final Map<String, Environment> environmentMap = new ConcurrentHashMap<>();
     private final Map<String, io.gravitee.repository.management.model.Organization> organizationMap = new ConcurrentHashMap<>();
@@ -43,11 +44,13 @@ public class EventToReactableApiAdapter {
     public EventToReactableApiAdapter(
         ObjectMapper objectMapper,
         EnvironmentRepository environmentRepository,
-        OrganizationRepository organizationRepository
+        OrganizationRepository organizationRepository,
+        boolean jupiterMode
     ) {
         this.objectMapper = objectMapper;
         this.environmentRepository = environmentRepository;
         this.organizationRepository = organizationRepository;
+        this.jupiterMode = jupiterMode;
     }
 
     public Maybe<ReactableApi<?>> toReactableApi(Event apiEvent) {
@@ -74,6 +77,10 @@ public class EventToReactableApiAdapter {
                 // Update definition with required information for deployment phase
                 api = new io.gravitee.gateway.handlers.api.definition.Api(eventApiDefinition);
             } else {
+                if (!jupiterMode) {
+                    return Maybe.empty();
+                }
+
                 io.gravitee.definition.model.v4.Api eventApiDefinition = objectMapper.readValue(
                     eventPayload.getDefinition(),
                     io.gravitee.definition.model.v4.Api.class


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1451

## Description

Do not deploy v4 API if jupiter mode is disabled

## Additional context

We can't apply this fix on the master branch because this part has changed with the improvement made on the Sychronization process. I will create another PR.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-fbcyvrhqks.chromatic.com)
<!-- Storybook placeholder end -->
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim1451-3-21/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
