### PR TITLE
fix: prevent adding an API PO in a group in user mode

### DIFF
--- a/gravitee-apim-console-webui/src/management/configuration/groups/group/group.component.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/groups/group/group.component.ts
@@ -23,6 +23,7 @@ import { Member, MembershipState, MemberState, RoleName, RoleScope } from './mem
 import GroupService from '../../../../services/group.service';
 import NotificationService from '../../../../services/notification.service';
 import UserService from '../../../../services/user.service';
+import ApiPrimaryOwnerModeService from '../../../../services/apiPrimaryOwnerMode.service';
 
 interface IGroupDetailComponentScope extends ng.IScope {
   groupApis: any[];
@@ -50,6 +51,7 @@ const GroupComponent: ng.IComponentOptions = {
   controller: function (
     GroupService: GroupService,
     NotificationService: NotificationService,
+    ApiPrimaryOwnerModeService: ApiPrimaryOwnerModeService,
     $mdDialog: angular.material.IDialogService,
     $state: StateService,
     $scope: IGroupDetailComponentScope,
@@ -465,7 +467,12 @@ const GroupComponent: ng.IComponentOptions = {
       return hasGroupAdmin;
     };
 
-    this.isApiRoleDisabled = (role) => role.system && role.name !== 'PRIMARY_OWNER';
+    this.isApiRoleDisabled = (role) => {
+      if (ApiPrimaryOwnerModeService.isUserOnly()) {
+        return role.name === 'PRIMARY_OWNER';
+      }
+      return role.system && role.name !== 'PRIMARY_OWNER';
+    };
   },
 };
 


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/APIM-1467
https://gravitee.atlassian.net/browse/APIM-1476
<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/fix-group-api-po-run-e2e/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wlucosfllf.chromatic.com)
<!-- Storybook placeholder end -->
