### PR TITLE
fix: filter tasks when users does not have any membership

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TaskServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TaskServiceImpl.java
@@ -45,6 +45,7 @@ import java.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 /**
@@ -75,12 +76,15 @@ public class TaskServiceImpl extends AbstractService implements TaskService {
     @Autowired
     private PromotionTasksService promotionTasksService;
 
+    @Lazy
     @Autowired
     private ApplicationRepository applicationRepository;
 
+    @Lazy
     @Autowired
     private PlanRepository planRepository;
 
+    @Lazy
     @Autowired
     private ApiRepository apiRepository;
 
@@ -244,7 +248,9 @@ public class TaskServiceImpl extends AbstractService implements TaskService {
         // NOTE: Explicitly set the page size to MAX
         // If we want to improve performance, we need to change the way we retrieve tasks
         // ex: use a dedicated repository & collection to retrieve tasks
-        apiIds.addAll(apiRepository.searchIds(apiCriteriaList, convert(new PageableImpl(1, Integer.MAX_VALUE)), null).getContent());
+        if (!apiCriteriaList.isEmpty()) {
+            apiIds.addAll(apiRepository.searchIds(apiCriteriaList, convert(new PageableImpl(1, Integer.MAX_VALUE)), null).getContent());
+        }
 
         return apiIds;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/TaskServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/TaskServiceTest.java
@@ -162,8 +162,6 @@ public class TaskServiceTest {
         final Authentication authentication = mock(Authentication.class);
 
         SecurityContextHolder.setContext(new SecurityContextImpl(authentication));
-        when(apiRepository.searchIds(emptyList(), new PageableBuilder().pageNumber(0).pageSize(Integer.MAX_VALUE).build(), null))
-            .thenReturn(new Page<String>(emptyList(), 1, 0, 0));
 
         taskService.findAll(GraviteeContext.getExecutionContext(), "user");
 
@@ -171,6 +169,20 @@ public class TaskServiceTest {
             .search(eq(GraviteeContext.getExecutionContext()), argThat(subscriptionQuery -> subscriptionQuery.getApis().size() == 2));
         verify(promotionTasksService, times(1)).getPromotionTasks(GraviteeContext.getExecutionContext());
         verify(userService, times(0)).search(eq(GraviteeContext.getExecutionContext()), any(UserCriteria.class), any());
+    }
+
+    @Test
+    public void shouldNotFindAnythingWhenUserHasNoMembership() {
+        final Authentication authentication = mock(Authentication.class);
+        SecurityContextHolder.setContext(new SecurityContextImpl(authentication));
+        when(membershipService.getMembershipsByMemberAndReference(any(), any(), any())).thenReturn(Collections.emptySet());
+
+        taskService.findAll(GraviteeContext.getExecutionContext(), "user");
+
+        verify(userService, times(0)).search(eq(GraviteeContext.getExecutionContext()), any(UserCriteria.class), any());
+        verify(subscriptionService, times(0))
+            .search(eq(GraviteeContext.getExecutionContext()), argThat(subscriptionQuery -> subscriptionQuery.getApis().size() == 2));
+        verify(apiRepository, times(0)).searchIds(any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1478

## Description

Users without any membership and only the USER role should not have access to all APIs subscriptions tasks

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bvibdxwjkx.chromatic.com)
<!-- Storybook placeholder end -->
