### PR TITLE
Rest api V2 - add GET environments/{envId}/apis/_search

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
@@ -24,6 +24,7 @@ import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
+import io.gravitee.repository.jdbc.utils.FieldUtils;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldFilter;
@@ -439,11 +440,12 @@ public class JdbcApiRepository extends JdbcAbstractPageableRepository<Api> imple
 
     private void applySortable(Sortable sortable, StringBuilder query) {
         if (sortable != null && sortable.field() != null && sortable.field().length() > 0) {
+            String field = FieldUtils.toSnakeCase(sortable.field());
             query.append("order by ");
-            if ("created_at".equals(sortable.field()) || "updated_at".equals(sortable.field())) {
-                query.append("a.").append(sortable.field());
+            if ("created_at".equals(field) || "updated_at".equals(field)) {
+                query.append("a.").append(field);
             } else {
-                query.append(" lower(a.").append(sortable.field()).append(") ");
+                query.append(" lower(a.").append(field).append(") ");
             }
 
             query.append(sortable.order() == null || sortable.order().equals(Order.ASC) ? " asc " : " desc ");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
@@ -68,6 +68,9 @@ public interface ApiMapper {
     @Mapping(target = "selectors", qualifiedByName = "toSelectors")
     io.gravitee.definition.model.v4.flow.Flow map(FlowV4 flow);
 
+    // DefinitionVersion
+    io.gravitee.definition.model.DefinitionVersion map(DefinitionVersion definitionVersion);
+
     // DefinitionContext
     default DefinitionContext map(io.gravitee.definition.model.DefinitionContext definitionContext) {
         if (definitionContext == null) {
@@ -217,20 +220,6 @@ public interface ApiMapper {
             })
             .collect(Collectors.toList());
     }
-
-    // EndpointGroups
-    //    @Mapping(target = "sharedConfiguration", qualifiedByName = "toConfiguration")
-    //    EndpointGroup map(EndpointGroupV4 endpointGroup);
-    //
-    //
-    //    // Configuration
-    //    @Named("toConfiguration")
-    //    default String toConfiguration(Object value) {
-    //        if (Objects.isNull(value)) {
-    //            return null;
-    //        }
-    //        return value.toString();
-    //    }
 
     // DateTime
     default OffsetDateTime map(Date value) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -74,7 +74,6 @@ import javax.ws.rs.core.UriBuilder;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Path("/environments/{envId}/apis/{apiId}")
 public class ApiResource extends AbstractResource {
 
     @Context

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.rest.api.management.v2.rest.resource.api;
 
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_DEFINITION_VERSION;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_TYPE_VALUE;
+
 import com.google.common.base.Strings;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.common.http.MediaType;
@@ -27,8 +30,6 @@ import io.gravitee.rest.api.management.v2.rest.resource.param.ApiSortByParam;
 import io.gravitee.rest.api.management.v2.rest.resource.param.PaginationParam;
 import io.gravitee.rest.api.management.v2.rest.security.Permission;
 import io.gravitee.rest.api.management.v2.rest.security.Permissions;
-import io.gravitee.rest.api.model.common.Sortable;
-import io.gravitee.rest.api.model.common.SortableImpl;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
@@ -36,15 +37,14 @@ import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.model.v4.api.NewApiEntity;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.search.query.QueryBuilder;
-
-import javax.validation.*;
+import java.util.Objects;
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
 import javax.ws.rs.Path;
 import javax.ws.rs.container.ResourceContext;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
-import java.util.Objects;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
@@ -105,7 +105,11 @@ public class ApisResource extends AbstractResource {
         }
 
         if (Objects.nonNull(apiSearchQuery.getIds()) && !apiSearchQuery.getIds().isEmpty()) {
-            apiQueryBuilder.addFilter("api", apiSearchQuery.getIds());
+            apiQueryBuilder.addFilter(FIELD_TYPE_VALUE, apiSearchQuery.getIds());
+        }
+
+        if (Objects.nonNull(apiSearchQuery.getDefinitionVersion())) {
+            apiQueryBuilder.addFilter(FIELD_DEFINITION_VERSION, ApiMapper.INSTANCE.map(apiSearchQuery.getDefinitionVersion()).getLabel());
         }
 
         Page<GenericApiEntity> apis = apiSearchService.search(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/param/ApiSortByParam.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/param/ApiSortByParam.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.param;
+
+import io.gravitee.rest.api.model.common.Sortable;
+import io.gravitee.rest.api.model.common.SortableImpl;
+import java.util.Objects;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.QueryParam;
+
+public class ApiSortByParam {
+
+    public enum ApiSortByEnum {
+        NAME("name"),
+        _NAME("-name"),
+        CREATED_AT("createdAt"),
+        _CREATED_AT("-createdAt");
+
+        private String value;
+
+        ApiSortByEnum(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return this.value;
+        }
+
+        public static ApiSortByEnum getByValue(String value) {
+            for (ApiSortByEnum orderByEnum : ApiSortByEnum.values()) {
+                if (orderByEnum.getValue().equals(value)) {
+                    return orderByEnum;
+                }
+            }
+            return null;
+        }
+    }
+
+    @QueryParam("sortBy")
+    String sortBy;
+
+    public void validate() {
+        if (Objects.nonNull(this.sortBy) && Objects.isNull(ApiSortByEnum.getByValue(this.sortBy))) {
+            throw new BadRequestException("Invalid sortBy parameter: " + this.sortBy);
+        }
+    }
+
+    public Sortable toSortable() {
+        if (Objects.isNull(this.sortBy)) {
+            return null;
+        }
+        boolean isAsc = !this.sortBy.startsWith("-");
+        String field = this.sortBy.replace("-", "");
+
+        return new SortableImpl(field, isAsc);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/management-openapi-v2.yaml
@@ -132,7 +132,7 @@ paths:
             parameters:
                 - $ref: "#/components/parameters/pageParam"
                 - $ref: "#/components/parameters/perPageParam"
-                - $ref: "#/components/parameters/apiOrderByParam"
+                - $ref: "#/components/parameters/apiSortByParam"
             tags:
                 - APIs
             summary: Search APIs
@@ -153,7 +153,6 @@ paths:
                     $ref: "#/components/responses/Error"
     /environments/{envId}/apis/{apiId}:
         parameters:
-            - $ref: "#/components/parameters/envIdParam"
             - $ref: "#/components/parameters/apiIdParam"
         get:
             tags:
@@ -2815,6 +2814,21 @@ components:
         ###############################
         # Pagination Query Parameters #
         ###############################
+        apiSortByParam:
+            name: sortBy
+            in: query
+            required: false
+            description: |-
+                Possibility to sort APIs results by field.
+                Can be ASC (default) or DESC with minus '-' prefix.
+            schema:
+                type: string
+                example: name
+                enum:
+                    - name
+                    - -name
+                    - createdAt
+                    - -createdAt
         pageParam:
             name: page
             in: query
@@ -2832,22 +2846,6 @@ components:
             schema:
                 type: integer
                 default: 10
-        apiOrderByParam:
-            name: orderBy
-            in: query
-            required: false
-            description: |-
-               Possibility to sort results by field.
-               Can be ASC (default) or DESC with minus '-' prefix.
-            schema:
-                type: string
-                example: name
-                enum:
-                    - name
-                    - -name
-                    - createdAt
-                    - -createdAt
-
     responses:
         EnvironmentsResponse:
             description: Page of environments

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/management-openapi-v2.yaml
@@ -1094,6 +1094,8 @@ components:
                         type: string
                     description: List of ids to find
                     example: apiId-1, apiId-2
+                definitionVersion:
+                    $ref: "#/components/schemas/DefinitionVersion"
         ApiType:
             type: string
             description: API's type.
@@ -1278,7 +1280,6 @@ components:
             type: string
             description: API's gravitee definition version.
             example: V4
-            default: V4
             enum:
                 - V1
                 - V2

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/management-openapi-v2.yaml
@@ -125,6 +125,32 @@ paths:
                                 $ref: "#/components/schemas/Api"
                 default:
                     $ref: "#/components/responses/Error"
+    /environments/{envId}/apis/_search:
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+        post:
+            parameters:
+                - $ref: "#/components/parameters/pageParam"
+                - $ref: "#/components/parameters/perPageParam"
+                - $ref: "#/components/parameters/apiOrderByParam"
+            tags:
+                - APIs
+            summary: Search APIs
+            description: |-
+                Search APIs for a specific environment.
+                User must have the ENVIRONMENT_API[READ] permission.
+            operationId: searchApis
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ApiSearchQuery"
+                required: true
+            responses:
+                "200":
+                    $ref: "#/components/responses/ApisResponse"
+                default:
+                    $ref: "#/components/responses/Error"
     /environments/{envId}/apis/{apiId}:
         parameters:
             - $ref: "#/components/parameters/envIdParam"
@@ -1056,6 +1082,19 @@ components:
             properties:
                 dynamicProperty:
                     $ref: "#/components/schemas/ServiceV4"
+        ApiSearchQuery:
+            type: object
+            properties:
+                query:
+                    type: string
+                    description: The query to search for.
+                    example: my api
+                ids:
+                    type: array
+                    items:
+                        type: string
+                    description: List of ids to find
+                    example: apiId-1, apiId-2
         ApiType:
             type: string
             description: API's type.
@@ -2793,6 +2832,22 @@ components:
             schema:
                 type: integer
                 default: 10
+        apiOrderByParam:
+            name: orderBy
+            in: query
+            required: false
+            description: |-
+               Possibility to sort results by field.
+               Can be ASC (default) or DESC with minus '-' prefix.
+            schema:
+                type: string
+                example: name
+                enum:
+                    - name
+                    - -name
+                    - createdAt
+                    - -createdAt
+
     responses:
         EnvironmentsResponse:
             description: Page of environments

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_SearchApisTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_SearchApisTest.java
@@ -1,0 +1,225 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.common.component.Lifecycle;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.rest.api.management.v2.rest.model.ApiSearchQuery;
+import io.gravitee.rest.api.management.v2.rest.model.ApisResponse;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.model.v4.api.ApiEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.search.query.QueryBuilder;
+import java.util.List;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Response;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public class ApisResource_SearchApisTest extends AbstractResourceTest {
+
+    private static final String ENVIRONMENT = "fake-env";
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/apis/_search";
+    }
+
+    @Before
+    public void init() {
+        GraviteeContext.cleanContext();
+        GraviteeContext.setCurrentOrganization(ORGANIZATION);
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT);
+
+        EnvironmentEntity environment = new EnvironmentEntity();
+        environment.setId(ENVIRONMENT);
+        environment.setOrganizationId(ORGANIZATION);
+
+        doReturn(environment).when(environmentService).findById(ENVIRONMENT);
+        doReturn(environment).when(environmentService).findByOrgAndIdOrHrid(ORGANIZATION, ENVIRONMENT);
+    }
+
+    @Test
+    public void should_not_search_if_no_params() {
+        final Response response = rootTarget().request().post(null);
+        assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
+    }
+
+    @Test
+    public void should_search_with_empty_query() {
+        var apiSearchQuery = new ApiSearchQuery();
+        apiSearchQuery.setQuery("");
+
+        var apiEntity = new ApiEntity();
+        apiEntity.setId("api-id");
+        apiEntity.setState(Lifecycle.State.INITIALIZED);
+        apiEntity.setDefinitionVersion(DefinitionVersion.V4);
+
+        ArgumentCaptor<QueryBuilder<ApiEntity>> apiQueryBuilderCaptor = ArgumentCaptor.forClass(QueryBuilder.class);
+
+        when(
+            apiSearchServiceV4.search(
+                eq(GraviteeContext.getExecutionContext()),
+                eq("UnitTests"),
+                eq(true),
+                apiQueryBuilderCaptor.capture(),
+                eq(new PageableImpl(1, 10)),
+                isNull()
+            )
+        )
+            .thenReturn(new Page<>(List.of(apiEntity), 1, 1, 1));
+
+        final Response response = rootTarget().request().post(Entity.json(apiSearchQuery));
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+
+        var page = response.readEntity(ApisResponse.class);
+        var data = page.getData();
+        assertNotNull(data);
+        assertEquals(1, data.size());
+        assertEquals("api-id", data.get(0).getApiV4().getId());
+
+        var apiQueryBuilder = apiQueryBuilderCaptor.getValue();
+        var apiQuery = apiQueryBuilder.build();
+        assertNull(apiQuery.getQuery());
+    }
+
+    @Test
+    public void should_search_with_valid_query() {
+        var apiSearchQuery = new ApiSearchQuery();
+        apiSearchQuery.setQuery("api-name");
+
+        var apiEntity = new ApiEntity();
+        apiEntity.setId("api-id");
+        apiEntity.setState(Lifecycle.State.INITIALIZED);
+        apiEntity.setDefinitionVersion(DefinitionVersion.V4);
+
+        ArgumentCaptor<QueryBuilder<ApiEntity>> apiQueryBuilderCaptor = ArgumentCaptor.forClass(QueryBuilder.class);
+
+        when(
+            apiSearchServiceV4.search(
+                eq(GraviteeContext.getExecutionContext()),
+                eq("UnitTests"),
+                eq(true),
+                apiQueryBuilderCaptor.capture(),
+                eq(new PageableImpl(1, 10)),
+                isNull()
+            )
+        )
+            .thenReturn(new Page<>(List.of(apiEntity), 1, 1, 1));
+
+        final Response response = rootTarget().request().post(Entity.json(apiSearchQuery));
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+
+        var page = response.readEntity(ApisResponse.class);
+        var data = page.getData();
+        assertNotNull(data);
+        assertEquals(1, data.size());
+        assertEquals("api-id", data.get(0).getApiV4().getId());
+
+        var apiQueryBuilder = apiQueryBuilderCaptor.getValue();
+        var apiQuery = apiQueryBuilder.build();
+        assertEquals("api-name", apiQuery.getQuery());
+    }
+
+    @Test
+    public void should_not_search_with_empty_ids() {
+        var apiSearchQuery = new ApiSearchQuery();
+        apiSearchQuery.setIds(List.of());
+
+        var apiEntity = new ApiEntity();
+        apiEntity.setId("api-id");
+        apiEntity.setState(Lifecycle.State.INITIALIZED);
+        apiEntity.setDefinitionVersion(DefinitionVersion.V4);
+
+        ArgumentCaptor<QueryBuilder<ApiEntity>> apiQueryBuilderCaptor = ArgumentCaptor.forClass(QueryBuilder.class);
+
+        when(
+            apiSearchServiceV4.search(
+                eq(GraviteeContext.getExecutionContext()),
+                eq("UnitTests"),
+                eq(true),
+                apiQueryBuilderCaptor.capture(),
+                eq(new PageableImpl(1, 10)),
+                isNull()
+            )
+        )
+            .thenReturn(new Page<>(List.of(apiEntity), 1, 1, 1));
+
+        final Response response = rootTarget().request().post(Entity.json(apiSearchQuery));
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+
+        var page = response.readEntity(ApisResponse.class);
+        var data = page.getData();
+        assertNotNull(data);
+        assertEquals(1, data.size());
+        assertEquals("api-id", data.get(0).getApiV4().getId());
+
+        var apiQueryBuilder = apiQueryBuilderCaptor.getValue();
+        var apiQuery = apiQueryBuilder.build();
+        assertEquals(0, apiQuery.getFilters().size());
+    }
+
+    @Test
+    public void should_search_with_ids() {
+        var apiSearchQuery = new ApiSearchQuery();
+        apiSearchQuery.setIds(List.of("id-1", "id-2"));
+
+        var apiEntity = new ApiEntity();
+        apiEntity.setId("id-1");
+        apiEntity.setState(Lifecycle.State.INITIALIZED);
+        apiEntity.setDefinitionVersion(DefinitionVersion.V4);
+
+        ArgumentCaptor<QueryBuilder<ApiEntity>> apiQueryBuilderCaptor = ArgumentCaptor.forClass(QueryBuilder.class);
+
+        when(
+            apiSearchServiceV4.search(
+                eq(GraviteeContext.getExecutionContext()),
+                eq("UnitTests"),
+                eq(true),
+                apiQueryBuilderCaptor.capture(),
+                eq(new PageableImpl(1, 10)),
+                isNull()
+            )
+        )
+            .thenReturn(new Page<>(List.of(apiEntity), 1, 1, 1));
+
+        final Response response = rootTarget().request().post(Entity.json(apiSearchQuery));
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+
+        var page = response.readEntity(ApisResponse.class);
+        var data = page.getData();
+        assertNotNull(data);
+        assertEquals(1, data.size());
+        assertEquals("id-1", data.get(0).getApiV4().getId());
+
+        var apiQueryBuilder = apiQueryBuilderCaptor.getValue();
+        var apiQuery = apiQueryBuilder.build();
+        assertNotNull(apiQuery.getFilters());
+        assertNotNull(apiQuery.getFilters().get("api"));
+        List<String> ids = (List<String>) apiQuery.getFilters().get("api");
+        assertEquals(2, ids.size());
+        assertEquals("id-2", ids.get(1));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/AbstractDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/AbstractDocumentSearcher.java
@@ -133,7 +133,7 @@ public abstract class AbstractDocumentSearcher implements DocumentSearcher {
                         filterApisQuery.add(new TermQuery(new Term(apiReferenceField, (String) value)), BooleanClause.Occur.SHOULD)
                     );
                 if (valuesAsCollection.size() > 0) {
-                    filtersQuery.add(filterApisQuery.build(), BooleanClause.Occur.SHOULD);
+                    filtersQuery.add(filterApisQuery.build(), BooleanClause.Occur.MUST);
                 }
             }
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcher.java
@@ -115,6 +115,7 @@ public class ApiDocumentSearcher extends AbstractDocumentSearcher {
         FIELD_TAGS,
         FIELD_ORIGIN,
         FIELD_HAS_HEALTH_CHECK,
+        FIELD_DEFINITION_VERSION,
     };
 
     private BooleanQuery.Builder buildApiQuery(ExecutionContext executionContext, Optional<Query> filterQuery) {
@@ -371,7 +372,8 @@ public class ApiDocumentSearcher extends AbstractDocumentSearcher {
             !FIELD_PATHS.equals(term.field()) &&
             !FIELD_TAGS.equals(term.field()) &&
             !FIELD_ORIGIN.equals(term.field()) &&
-            !FIELD_HAS_HEALTH_CHECK.equals(term.field())
+            !FIELD_HAS_HEALTH_CHECK.equals(term.field()) &&
+            !FIELD_DEFINITION_VERSION.equals(term.field())
         ) {
             text = text.toLowerCase();
             field = field.concat("_lowercase");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/search/query/Query.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/search/query/Query.java
@@ -21,11 +21,15 @@ import io.gravitee.rest.api.model.search.Indexable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Getter
+@Setter
 public class Query<T extends Indexable> {
 
     private String query;
@@ -44,57 +48,5 @@ public class Query<T extends Indexable> {
 
     Query(final Class<T> root) {
         this.root = root;
-    }
-
-    public String getQuery() {
-        return query;
-    }
-
-    public void setQuery(String query) {
-        this.query = query;
-    }
-
-    public Map<String, Object> getFilters() {
-        return filters;
-    }
-
-    public void setFilters(Map<String, Object> filters) {
-        this.filters = filters;
-    }
-
-    public void setExcludedFilters(Map<String, Collection<String>> excludedFilters) {
-        this.excludedFilters = excludedFilters;
-    }
-
-    public Map<String, Collection<String>> getExcludedFilters() {
-        return excludedFilters;
-    }
-
-    public Class<T> getRoot() {
-        return root;
-    }
-
-    public Pageable getPage() {
-        return page;
-    }
-
-    public void setPage(Pageable page) {
-        this.page = page;
-    }
-
-    public Sortable getSort() {
-        return sort;
-    }
-
-    public void setSort(Sortable sort) {
-        this.sort = sort;
-    }
-
-    public void setIds(Collection<String> ids) {
-        this.ids = ids;
-    }
-
-    public Collection<String> getIds() {
-        return ids;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiSearchService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiSearchService.java
@@ -15,12 +15,15 @@
  */
 package io.gravitee.rest.api.service.v4;
 
+import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.rest.api.model.api.ApiQuery;
+import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.common.Sortable;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.search.query.QueryBuilder;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
@@ -48,6 +51,15 @@ public interface ApiSearchService {
     Collection<GenericApiEntity> search(final ExecutionContext executionContext, final ApiQuery query);
 
     Collection<GenericApiEntity> search(ExecutionContext executionContext, ApiQuery query, boolean excludeDefinitionV4);
+
+    Page<GenericApiEntity> search(
+        final ExecutionContext executionContext,
+        final String userId,
+        final boolean isAdmin,
+        final QueryBuilder<ApiEntity> queryBuilder,
+        final Pageable pageable,
+        final Sortable sortable
+    );
 
     Collection<String> searchIds(
         final ExecutionContext executionContext,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImplTest.java
@@ -68,10 +68,7 @@ import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.impl.search.SearchResult;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.search.query.Query;
-import io.gravitee.rest.api.service.v4.ApiSearchService;
-import io.gravitee.rest.api.service.v4.FlowService;
-import io.gravitee.rest.api.service.v4.PlanService;
-import io.gravitee.rest.api.service.v4.PrimaryOwnerService;
+import io.gravitee.rest.api.service.v4.*;
 import io.gravitee.rest.api.service.v4.mapper.ApiMapper;
 import io.gravitee.rest.api.service.v4.mapper.CategoryMapper;
 import io.gravitee.rest.api.service.v4.mapper.GenericApiMapper;
@@ -147,6 +144,9 @@ public class ApiSearchServiceImplTest {
     @Mock
     private PrimaryOwnerService primaryOwnerService;
 
+    @Mock
+    private ApiAuthorizationService apiAuthorizationService;
+
     private ApiSearchService apiSearchService;
     private Api api;
 
@@ -183,7 +183,8 @@ public class ApiSearchServiceImplTest {
                 new GenericApiMapper(apiMapper, apiConverter),
                 primaryOwnerService,
                 categoryService,
-                searchEngineService
+                searchEngineService,
+                apiAuthorizationService
             );
 
         reset(searchEngineService);
@@ -407,7 +408,18 @@ public class ApiSearchServiceImplTest {
         api2.setId("api2");
         api2.setName("api2");
 
-        when(apiRepository.search(eq(new ApiCriteria.Builder().environmentId("DEFAULT").build()), isNull(), eq(ApiFieldFilter.allFields())))
+        var definitionList = new ArrayList<DefinitionVersion>();
+        definitionList.add(null);
+        definitionList.add(DefinitionVersion.V1);
+        definitionList.add(DefinitionVersion.V2);
+
+        when(
+            apiRepository.search(
+                eq(new ApiCriteria.Builder().environmentId("DEFAULT").definitionVersion(definitionList).build()),
+                isNull(),
+                eq(ApiFieldFilter.allFields())
+            )
+        )
             .thenReturn(Stream.of(api1));
 
         UserEntity admin = new UserEntity();
@@ -437,6 +449,11 @@ public class ApiSearchServiceImplTest {
         api2.setId("api2");
         api2.setName("api2");
 
+        var definitionList = new ArrayList<DefinitionVersion>();
+        definitionList.add(null);
+        definitionList.add(DefinitionVersion.V1);
+        definitionList.add(DefinitionVersion.V2);
+
         when(
             apiRepository.search(
                 eq(
@@ -449,6 +466,7 @@ public class ApiSearchServiceImplTest {
                         .lifecycleStates(new ArrayList<>(List.of(ApiLifecycleState.CREATED)))
                         .ids(Set.of("api1"))
                         .crossId("api1")
+                        .definitionVersion(definitionList)
                         .build()
                 ),
                 isNull(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiSearchService_SearchTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiSearchService_SearchTest.java
@@ -1,0 +1,400 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.impl;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.api.search.ApiFieldFilter;
+import io.gravitee.repository.management.api.search.builder.PageableBuilder;
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.repository.management.model.LifecycleState;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.model.v4.api.ApiEntity;
+import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
+import io.gravitee.rest.api.service.*;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.converter.ApiConverter;
+import io.gravitee.rest.api.service.impl.search.SearchResult;
+import io.gravitee.rest.api.service.search.SearchEngineService;
+import io.gravitee.rest.api.service.search.query.QueryBuilder;
+import io.gravitee.rest.api.service.v4.*;
+import io.gravitee.rest.api.service.v4.PlanService;
+import io.gravitee.rest.api.service.v4.mapper.ApiMapper;
+import io.gravitee.rest.api.service.v4.mapper.CategoryMapper;
+import io.gravitee.rest.api.service.v4.mapper.GenericApiMapper;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ApiSearchService_SearchTest {
+
+    private final String USER_ID = "user-1";
+
+    @Mock
+    private ApiRepository apiRepository;
+
+    @Mock
+    private SearchEngineService searchEngineService;
+
+    @Mock
+    private CategoryService categoryService;
+
+    @Mock
+    private PrimaryOwnerService primaryOwnerService;
+
+    // ApiMapper injections
+    @Mock
+    private PlanService planService;
+
+    @Mock
+    private FlowService flowService;
+
+    @Mock
+    private ParameterService parameterService;
+
+    @Mock
+    private WorkflowService workflowService;
+
+    @Mock
+    private ApiAuthorizationService apiAuthorizationService;
+
+    private ApiSearchService apiSearchService;
+
+    @AfterClass
+    public static void cleanSecurityContextHolder() {
+        // reset authentication to avoid side effect during test executions.
+        SecurityContextHolder.setContext(
+            new SecurityContext() {
+                @Override
+                public Authentication getAuthentication() {
+                    return null;
+                }
+
+                @Override
+                public void setAuthentication(Authentication authentication) {}
+            }
+        );
+    }
+
+    @Before
+    public void setUp() {
+        ApiMapper apiMapper = new ApiMapper(
+            new ObjectMapper(),
+            planService,
+            flowService,
+            parameterService,
+            workflowService,
+            new CategoryMapper(categoryService)
+        );
+        apiSearchService =
+            new ApiSearchServiceImpl(
+                apiRepository,
+                apiMapper,
+                new GenericApiMapper(apiMapper, new ApiConverter()),
+                primaryOwnerService,
+                categoryService,
+                searchEngineService,
+                apiAuthorizationService
+            );
+    }
+
+    @Test
+    public void should_return_empty_page_if_no_results() {
+        QueryBuilder<ApiEntity> apiEntityQueryBuilder = QueryBuilder.create(ApiEntity.class);
+        apiEntityQueryBuilder.setQuery("*");
+
+        var ids = List.of("id-1", "id-2");
+
+        var filters = new HashMap<String, Object>();
+        filters.put("api", ids);
+
+        when(
+            searchEngineService.search(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(apiEntityQueryBuilder.setFilters(filters).build())
+            )
+        )
+            .thenReturn(new SearchResult(List.of()));
+
+        final Page<GenericApiEntity> apis = apiSearchService.search(
+            GraviteeContext.getExecutionContext(),
+            eq("UnitTests"),
+            eq(true),
+            apiEntityQueryBuilder.setFilters(filters),
+            new PageableImpl(1, 10),
+            null
+        );
+
+        assertThat(apis).isNotNull();
+        assertThat(apis.getContent().size()).isEqualTo(0);
+        assertThat(apis.getTotalElements()).isEqualTo(0);
+        assertThat(apis.getPageNumber()).isEqualTo(0);
+        assertThat(apis.getPageElements()).isEqualTo(0);
+
+        verify(apiAuthorizationService, never()).findApiIdsByUserId(any(), any(), any());
+        verify(apiRepository, never()).search(any(), any(), any(), any());
+    }
+
+    @Test
+    public void should_return_page_of_api_entity_if_no_ids_found() {
+        QueryBuilder<ApiEntity> apiEntityQueryBuilder = QueryBuilder.create(ApiEntity.class);
+        apiEntityQueryBuilder.setQuery("*");
+
+        var ids = List.of("id-1", "id-2");
+
+        var filters = new HashMap<String, Object>();
+        filters.put("api", ids);
+
+        when(
+            searchEngineService.search(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(apiEntityQueryBuilder.setFilters(filters).build())
+            )
+        )
+            .thenReturn(new SearchResult(ids));
+
+        var apiEntity1 = new Api();
+        apiEntity1.setId("id-1");
+        apiEntity1.setLifecycleState(LifecycleState.STARTED);
+
+        var apiEntity2 = new Api();
+        apiEntity2.setId("id-2");
+        apiEntity2.setLifecycleState(LifecycleState.STARTED);
+
+        when(
+            apiRepository.search(
+                eq(
+                    new ApiCriteria.Builder()
+                        .environmentId(GraviteeContext.getExecutionContext().getEnvironmentId())
+                        .ids(ids)
+                        .build()
+                ),
+                isNull(),
+                eq(new PageableBuilder().pageNumber(0).pageSize(10).build()),
+                eq(ApiFieldFilter.allFields())
+            )
+        )
+            .thenReturn(new Page<>(List.of(), 0, 0, 0));
+
+        final Page<GenericApiEntity> apis = apiSearchService.search(
+            GraviteeContext.getExecutionContext(),
+            USER_ID,
+            true,
+            apiEntityQueryBuilder.setFilters(filters),
+            new PageableImpl(1, 10),
+            null
+        );
+
+        assertThat(apis).isNotNull();
+        assertThat(apis.getContent().size()).isEqualTo(0);
+        assertThat(apis.getTotalElements()).isEqualTo(0);
+        assertThat(apis.getPageNumber()).isEqualTo(0);
+        assertThat(apis.getPageElements()).isEqualTo(0);
+
+        verify(apiAuthorizationService, never()).findApiIdsByUserId(any(), any(), any());
+        verify(apiRepository, times(1)).search(any(), any(), any(), any());
+    }
+
+    @Test
+    public void should_return_page_of_api_entity_if_ids_found() {
+        QueryBuilder<ApiEntity> apiEntityQueryBuilder = QueryBuilder.create(ApiEntity.class);
+        apiEntityQueryBuilder.setQuery("*");
+
+        var ids = List.of("id-1", "id-2");
+
+        var filters = new HashMap<String, Object>();
+        filters.put("api", ids);
+
+        when(
+            searchEngineService.search(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(apiEntityQueryBuilder.setFilters(filters).build())
+            )
+        )
+            .thenReturn(new SearchResult(ids));
+
+        var apiEntity1 = new Api();
+        apiEntity1.setId("id-1");
+        apiEntity1.setLifecycleState(LifecycleState.STARTED);
+
+        var apiEntity2 = new Api();
+        apiEntity2.setId("id-2");
+        apiEntity2.setLifecycleState(LifecycleState.STARTED);
+
+        when(
+            apiRepository.search(
+                eq(
+                    new ApiCriteria.Builder()
+                        .environmentId(GraviteeContext.getExecutionContext().getEnvironmentId())
+                        .ids(ids)
+                        .build()
+                ),
+                isNull(),
+                eq(new PageableBuilder().pageNumber(0).pageSize(10).build()),
+                eq(ApiFieldFilter.allFields())
+            )
+        )
+            .thenReturn(new Page<>(List.of(apiEntity1, apiEntity2), 1, 2, 2));
+
+        final Page<GenericApiEntity> apis = apiSearchService.search(
+            GraviteeContext.getExecutionContext(),
+            USER_ID,
+            true,
+            apiEntityQueryBuilder.setFilters(filters),
+            new PageableImpl(1, 10),
+            null
+        );
+
+        assertThat(apis).isNotNull();
+        assertThat(apis.getContent().size()).isEqualTo(2);
+        assertThat(apis.getTotalElements()).isEqualTo(2);
+        assertThat(apis.getPageNumber()).isEqualTo(1);
+        assertThat(apis.getPageElements()).isEqualTo(2);
+
+        verify(apiAuthorizationService, never()).findApiIdsByUserId(any(), any(), any());
+        verify(apiRepository, times(1)).search(any(), any(), any(), any());
+    }
+
+    @Test
+    public void should_get_user_api_ids_if_not_admin() {
+        QueryBuilder<ApiEntity> apiEntityQueryBuilder = QueryBuilder.create(ApiEntity.class);
+        apiEntityQueryBuilder.setQuery("*");
+
+        var ids = List.of("id-1", "id-2");
+
+        var filters = new HashMap<String, Object>();
+        filters.put("api", ids);
+
+        when(
+            searchEngineService.search(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(apiEntityQueryBuilder.setFilters(filters).build())
+            )
+        )
+            .thenReturn(new SearchResult(ids));
+
+        var apiEntity1 = new Api();
+        apiEntity1.setId("id-1");
+        apiEntity1.setLifecycleState(LifecycleState.STARTED);
+
+        var apiEntity2 = new Api();
+        apiEntity2.setId("id-2");
+        apiEntity2.setLifecycleState(LifecycleState.STARTED);
+
+        when(apiAuthorizationService.findApiIdsByUserId(eq(GraviteeContext.getExecutionContext()), eq(USER_ID), isNull()))
+            .thenReturn(Set.of("id-1"));
+
+        when(
+            apiRepository.search(
+                eq(
+                    new ApiCriteria.Builder()
+                        .environmentId(GraviteeContext.getExecutionContext().getEnvironmentId())
+                        .ids(Set.of("id-1"))
+                        .build()
+                ),
+                isNull(),
+                eq(new PageableBuilder().pageNumber(0).pageSize(10).build()),
+                eq(ApiFieldFilter.allFields())
+            )
+        )
+            .thenReturn(new Page<>(List.of(apiEntity1), 1, 1, 1));
+
+        final Page<GenericApiEntity> apis = apiSearchService.search(
+            GraviteeContext.getExecutionContext(),
+            USER_ID,
+            false,
+            apiEntityQueryBuilder.setFilters(filters),
+            new PageableImpl(1, 10),
+            null
+        );
+
+        assertThat(apis).isNotNull();
+        assertThat(apis.getContent().size()).isEqualTo(1);
+        assertThat(apis.getTotalElements()).isEqualTo(1);
+        assertThat(apis.getPageNumber()).isEqualTo(1);
+        assertThat(apis.getPageElements()).isEqualTo(1);
+
+        verify(apiAuthorizationService, times(1)).findApiIdsByUserId(any(), any(), any());
+        verify(apiRepository, times(1)).search(any(), any(), any(), any());
+    }
+
+    @Test
+    public void should_return_no_results_if_user_has_no_ids() {
+        QueryBuilder<ApiEntity> apiEntityQueryBuilder = QueryBuilder.create(ApiEntity.class);
+        apiEntityQueryBuilder.setQuery("*");
+
+        var ids = List.of("id-1", "id-2");
+
+        var filters = new HashMap<String, Object>();
+        filters.put("api", ids);
+
+        when(
+            searchEngineService.search(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(apiEntityQueryBuilder.setFilters(filters).build())
+            )
+        )
+            .thenReturn(new SearchResult(ids));
+
+        var apiEntity1 = new Api();
+        apiEntity1.setId("id-1");
+        apiEntity1.setLifecycleState(LifecycleState.STARTED);
+
+        var apiEntity2 = new Api();
+        apiEntity2.setId("id-2");
+        apiEntity2.setLifecycleState(LifecycleState.STARTED);
+
+        when(apiAuthorizationService.findApiIdsByUserId(eq(GraviteeContext.getExecutionContext()), eq(USER_ID), isNull()))
+            .thenReturn(Set.of());
+
+        final Page<GenericApiEntity> apis = apiSearchService.search(
+            GraviteeContext.getExecutionContext(),
+            USER_ID,
+            false,
+            apiEntityQueryBuilder.setFilters(filters),
+            new PageableImpl(1, 10),
+            null
+        );
+
+        assertThat(apis).isNotNull();
+        assertThat(apis.getContent().size()).isEqualTo(0);
+        assertThat(apis.getTotalElements()).isEqualTo(0);
+        assertThat(apis.getPageNumber()).isEqualTo(0);
+        assertThat(apis.getPageElements()).isEqualTo(0);
+
+        verify(apiAuthorizationService, times(1)).findApiIdsByUserId(any(), any(), any());
+        verify(apiRepository, never()).search(any(), any(), any(), any());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiSearchService_SearchTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiSearchService_SearchTest.java
@@ -223,6 +223,7 @@ public class ApiSearchService_SearchTest {
 
         var filters = new HashMap<String, Object>();
         filters.put("api", ids);
+        filters.put("definition_version", "4.0.0");
 
         when(searchEngineService.search(eq(GraviteeContext.getExecutionContext()), eq(apiEntityQueryBuilder.setFilters(filters).build())))
             .thenReturn(new SearchResult(ids));
@@ -237,7 +238,13 @@ public class ApiSearchService_SearchTest {
 
         when(
             apiRepository.search(
-                eq(new ApiCriteria.Builder().environmentId(GraviteeContext.getExecutionContext().getEnvironmentId()).ids(ids).build()),
+                eq(
+                    new ApiCriteria.Builder()
+                        .environmentId(GraviteeContext.getExecutionContext().getEnvironmentId())
+                        .ids(ids)
+                        .definitionVersion(List.of(DefinitionVersion.V4))
+                        .build()
+                ),
                 eq(new SortableBuilder().field("createdAt").setAsc(false).build()),
                 eq(new PageableBuilder().pageNumber(0).pageSize(10).build()),
                 eq(ApiFieldFilter.allFields())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiSearchService_SearchTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiSearchService_SearchTest.java
@@ -28,9 +28,11 @@ import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldFilter;
 import io.gravitee.repository.management.api.search.builder.PageableBuilder;
+import io.gravitee.repository.management.api.search.builder.SortableBuilder;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.LifecycleState;
 import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.model.common.SortableImpl;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.service.*;
@@ -140,12 +142,7 @@ public class ApiSearchService_SearchTest {
         var filters = new HashMap<String, Object>();
         filters.put("api", ids);
 
-        when(
-            searchEngineService.search(
-                eq(GraviteeContext.getExecutionContext()),
-                eq(apiEntityQueryBuilder.setFilters(filters).build())
-            )
-        )
+        when(searchEngineService.search(eq(GraviteeContext.getExecutionContext()), eq(apiEntityQueryBuilder.setFilters(filters).build())))
             .thenReturn(new SearchResult(List.of()));
 
         final Page<GenericApiEntity> apis = apiSearchService.search(
@@ -177,12 +174,7 @@ public class ApiSearchService_SearchTest {
         var filters = new HashMap<String, Object>();
         filters.put("api", ids);
 
-        when(
-            searchEngineService.search(
-                eq(GraviteeContext.getExecutionContext()),
-                eq(apiEntityQueryBuilder.setFilters(filters).build())
-            )
-        )
+        when(searchEngineService.search(eq(GraviteeContext.getExecutionContext()), eq(apiEntityQueryBuilder.setFilters(filters).build())))
             .thenReturn(new SearchResult(ids));
 
         var apiEntity1 = new Api();
@@ -195,12 +187,7 @@ public class ApiSearchService_SearchTest {
 
         when(
             apiRepository.search(
-                eq(
-                    new ApiCriteria.Builder()
-                        .environmentId(GraviteeContext.getExecutionContext().getEnvironmentId())
-                        .ids(ids)
-                        .build()
-                ),
+                eq(new ApiCriteria.Builder().environmentId(GraviteeContext.getExecutionContext().getEnvironmentId()).ids(ids).build()),
                 isNull(),
                 eq(new PageableBuilder().pageNumber(0).pageSize(10).build()),
                 eq(ApiFieldFilter.allFields())
@@ -237,12 +224,7 @@ public class ApiSearchService_SearchTest {
         var filters = new HashMap<String, Object>();
         filters.put("api", ids);
 
-        when(
-            searchEngineService.search(
-                eq(GraviteeContext.getExecutionContext()),
-                eq(apiEntityQueryBuilder.setFilters(filters).build())
-            )
-        )
+        when(searchEngineService.search(eq(GraviteeContext.getExecutionContext()), eq(apiEntityQueryBuilder.setFilters(filters).build())))
             .thenReturn(new SearchResult(ids));
 
         var apiEntity1 = new Api();
@@ -255,13 +237,8 @@ public class ApiSearchService_SearchTest {
 
         when(
             apiRepository.search(
-                eq(
-                    new ApiCriteria.Builder()
-                        .environmentId(GraviteeContext.getExecutionContext().getEnvironmentId())
-                        .ids(ids)
-                        .build()
-                ),
-                isNull(),
+                eq(new ApiCriteria.Builder().environmentId(GraviteeContext.getExecutionContext().getEnvironmentId()).ids(ids).build()),
+                eq(new SortableBuilder().field("createdAt").setAsc(false).build()),
                 eq(new PageableBuilder().pageNumber(0).pageSize(10).build()),
                 eq(ApiFieldFilter.allFields())
             )
@@ -274,7 +251,7 @@ public class ApiSearchService_SearchTest {
             true,
             apiEntityQueryBuilder.setFilters(filters),
             new PageableImpl(1, 10),
-            null
+            new SortableImpl("createdAt", false)
         );
 
         assertThat(apis).isNotNull();
@@ -297,12 +274,7 @@ public class ApiSearchService_SearchTest {
         var filters = new HashMap<String, Object>();
         filters.put("api", ids);
 
-        when(
-            searchEngineService.search(
-                eq(GraviteeContext.getExecutionContext()),
-                eq(apiEntityQueryBuilder.setFilters(filters).build())
-            )
-        )
+        when(searchEngineService.search(eq(GraviteeContext.getExecutionContext()), eq(apiEntityQueryBuilder.setFilters(filters).build())))
             .thenReturn(new SearchResult(ids));
 
         var apiEntity1 = new Api();
@@ -324,7 +296,7 @@ public class ApiSearchService_SearchTest {
                         .ids(Set.of("id-1"))
                         .build()
                 ),
-                isNull(),
+                eq(new SortableBuilder().field("name").setAsc(true).build()),
                 eq(new PageableBuilder().pageNumber(0).pageSize(10).build()),
                 eq(ApiFieldFilter.allFields())
             )
@@ -337,7 +309,7 @@ public class ApiSearchService_SearchTest {
             false,
             apiEntityQueryBuilder.setFilters(filters),
             new PageableImpl(1, 10),
-            null
+            new SortableImpl("name", true)
         );
 
         assertThat(apis).isNotNull();
@@ -360,12 +332,7 @@ public class ApiSearchService_SearchTest {
         var filters = new HashMap<String, Object>();
         filters.put("api", ids);
 
-        when(
-            searchEngineService.search(
-                eq(GraviteeContext.getExecutionContext()),
-                eq(apiEntityQueryBuilder.setFilters(filters).build())
-            )
-        )
+        when(searchEngineService.search(eq(GraviteeContext.getExecutionContext()), eq(apiEntityQueryBuilder.setFilters(filters).build())))
             .thenReturn(new SearchResult(ids));
 
         var apiEntity1 = new Api();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
@@ -323,7 +323,15 @@ public class ApiServiceImplTest {
                 apiAuthorizationService
             );
         apiSearchService =
-            new ApiSearchServiceImpl(apiRepository, apiMapper, genericApiMapper, primaryOwnerService, categoryService, searchEngineService);
+            new ApiSearchServiceImpl(
+                apiRepository,
+                apiMapper,
+                genericApiMapper,
+                primaryOwnerService,
+                categoryService,
+                searchEngineService,
+                apiAuthorizationService
+            );
         apiStateService =
             new ApiStateServiceImpl(
                 apiSearchService,


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1163

## Description


Search apis with lucene

Work of the search : 
Step 0 : build apiQueryBuilder with value of ApiSearchQuery

Step 1 : find apiIds from lucene indexer from 'query' parameter without any pagination and sorting
Step 2 :(not linked to result of 1st step) if user is not admin, get list of apiIds in their scope and join with Lucene results
Step 3: get APIs page from repository by ids(intersection or Step 1 & Step 2 )  and add pagination and sorting



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ustroqogql.chromatic.com)
<!-- Storybook placeholder end -->
