### PR TITLE
refactor: move JSON validation in dedicated module

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
@@ -134,6 +134,11 @@
 			<scope>provided</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>io.gravitee.json</groupId>
+			<artifactId>gravitee-json-validation</artifactId>
+		</dependency>
+
 		<!-- Lucene -->
 		<dependency>
 			<groupId>org.apache.lucene</groupId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/spring/ServiceConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/spring/ServiceConfiguration.java
@@ -24,6 +24,8 @@ import io.gravitee.common.event.EventManager;
 import io.gravitee.common.event.impl.EventManagerImpl;
 import io.gravitee.common.util.DataEncryptor;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
+import io.gravitee.json.validation.JsonSchemaValidator;
+import io.gravitee.json.validation.JsonSchemaValidatorImpl;
 import io.gravitee.plugin.alert.spring.AlertPluginConfiguration;
 import io.gravitee.plugin.connector.spring.ConnectorPluginConfiguration;
 import io.gravitee.plugin.discovery.spring.ServiceDiscoveryPluginConfiguration;
@@ -126,6 +128,11 @@ public class ServiceConfiguration {
     @Bean
     public DataEncryptor apiPropertiesEncryptor() {
         return new DataEncryptor(environment, "api.properties.encryption.secret", "vvLJ4Q8Khvv9tm2tIPdkGEdmgKUruAL6");
+    }
+
+    @Bean
+    public JsonSchemaValidator jsonSchemaValidator() {
+        return new JsonSchemaValidatorImpl();
     }
 
     @Bean(name = "indexerThreadPoolTaskExecutor")

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
         <gravitee-resource-cache-provider-api.version>1.2.0</gravitee-resource-cache-provider-api.version>
         <gravitee-resource-oauth2-provider-api.version>1.3.0</gravitee-resource-oauth2-provider-api.version>
         <gravitee-service-discovery-api.version>1.1.1</gravitee-service-discovery-api.version>
+        <gravitee-json-validation.version>1.0.0</gravitee-json-validation.version>
         <!-- Other dependencies version -->
         <asm.version>9.2</asm.version>
         <batik-transcoder.version>1.15</batik-transcoder.version>
@@ -351,6 +352,12 @@
                 <groupId>io.gravitee.discovery</groupId>
                 <artifactId>gravitee-service-discovery-api</artifactId>
                 <version>${gravitee-service-discovery-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.gravitee.json</groupId>
+                <artifactId>gravitee-json-validation</artifactId>
+                <version>${gravitee-json-validation.version}</version>
             </dependency>
 
             <!-- Other dependencies -->


### PR DESCRIPTION
## Description

Move JSON validation in a dedicated module so it can be used in other modules (ie to test the policy's configuration directly in the policy's repository)

As there is no diff between `3.18.x` and `master` I will applying this change on all supported versions

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dbyswrqszg.chromatic.com)
<!-- Storybook placeholder end -->
