### PR TITLE
Bump `gravitee-tracer-jaeger` to `1.2.1`

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -113,7 +113,7 @@
         <gravitee-reporter-tcp.version>1.4.4</gravitee-reporter-tcp.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->
         <!--    <gravitee-gateway-services-ratelimit.version>1.15.0</gravitee-gateway-services-ratelimit.version>    -->
-        <gravitee-tracer-jaeger.version>1.2.0</gravitee-tracer-jaeger.version>
+        <gravitee-tracer-jaeger.version>1.2.1</gravitee-tracer-jaeger.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1477
https://github.com/gravitee-io/issues/issues/9021

## Description

Bump `gravitee-tracer-jaeger` to `1.2.1`
