### PR TITLE
ci: fix sonar job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,7 +322,7 @@ jobs:
                 default: "gravitee-apim-rest-api"
                 type: string
         docker:
-            - image: sonarsource/sonar-scanner-cli
+            - image: sonarsource/sonar-scanner-cli:4.7
         resource_class: large
         steps:
             - run:


### PR DESCRIPTION
## Description

The latest sonarsource/sonar-scanner-cli image have its base image changed to debian-like distribution.

We can't upgrade yet because of https://github.com/SonarSource/sonar-scanner-cli-docker/issues/175
So I downgraded to 4.7 version util 4.8 is fixed

https://github.com/SonarSource/sonar-scanner-cli-docker/commit/a195c3c5c041dfb433381b444b0dc42eb27a0ab7

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xcvacrhvba.chromatic.com)
<!-- Storybook placeholder end -->
