### PR TITLE
fix: escaped search query when searching for a context path

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcher.java
@@ -54,7 +54,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.index.Term;


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/APIM-482 
see https://github.com/gravitee-io/issues/issues/8753

(cherry picked from commit 36b607804accb80dbb5467a9450e53541d6b9281)
