### PR TITLE
remove author picture from api promotion

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceImpl.java
@@ -157,7 +157,7 @@ public class PromotionServiceImpl extends AbstractService implements PromotionSe
 
         Promotion promotionToSave = convert(apiId, apiDefinition, currentEnvironmentEntity, promotionRequest, author);
         promotionToSave.setId(UuidString.generateRandom());
-        Promotion createdPromotion = null;
+        Promotion createdPromotion;
         try {
             createdPromotion = promotionRepository.create(promotionToSave);
 
@@ -322,7 +322,6 @@ public class PromotionServiceImpl extends AbstractService implements PromotionSe
         promotionAuthor.setUserId(author.getId());
         promotionAuthor.setDisplayName(author.getDisplayName());
         promotionAuthor.setEmail(author.getEmail());
-        promotionAuthor.setPicture(author.getPicture());
         promotionAuthor.setSource(author.getSource());
         promotionAuthor.setSourceId(author.getSourceId());
 
@@ -348,7 +347,6 @@ public class PromotionServiceImpl extends AbstractService implements PromotionSe
         promotionEntityAuthor.setUserId(promotion.getAuthor().getUserId());
         promotionEntityAuthor.setDisplayName(promotion.getAuthor().getDisplayName());
         promotionEntityAuthor.setEmail(promotion.getAuthor().getEmail());
-        promotionEntityAuthor.setPicture(promotion.getAuthor().getPicture());
         promotionEntityAuthor.setSource(promotion.getAuthor().getSource());
         promotionEntityAuthor.setSourceId(promotion.getAuthor().getSourceId());
 
@@ -375,7 +373,6 @@ public class PromotionServiceImpl extends AbstractService implements PromotionSe
         promotionAuthor.setUserId(promotionEntity.getAuthor().getUserId());
         promotionAuthor.setDisplayName(promotionEntity.getAuthor().getDisplayName());
         promotionAuthor.setEmail(promotionEntity.getAuthor().getEmail());
-        promotionAuthor.setPicture(promotionEntity.getAuthor().getPicture());
         promotionAuthor.setSource(promotionEntity.getAuthor().getSource());
         promotionAuthor.setSourceId(promotionEntity.getAuthor().getSourceId());
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1522

## Description

Remove author picture from api promotion. It can cause timeout or even worse if it's a large file because today the attribute is a nvarchar(64) in the database.
Here we quick fix it. Another PR is coming to remove the column using the new Upgrader framework

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-enzygnduhn.chromatic.com)
<!-- Storybook placeholder end -->
