### PR TITLE
[3.20.x] Bump policies and gravitee-node

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -85,7 +85,7 @@
         <gravitee-policy-rest-to-soap.version>1.13.0</gravitee-policy-rest-to-soap.version>
         <gravitee-policy-retry.version>2.1.0</gravitee-policy-retry.version>
         <gravitee-policy-role-based-access-control.version>1.1.0</gravitee-policy-role-based-access-control.version>
-        <gravitee-policy-ssl-enforcement.version>1.2.2</gravitee-policy-ssl-enforcement.version>
+        <gravitee-policy-ssl-enforcement.version>1.2.3</gravitee-policy-ssl-enforcement.version>
         <gravitee-policy-traffic-shadowing.version>2.0.0</gravitee-policy-traffic-shadowing.version>
         <gravitee-policy-transformheaders.version>1.10.0</gravitee-policy-transformheaders.version>
         <gravitee-policy-transformqueryparams.version>1.6.0</gravitee-policy-transformqueryparams.version>

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -80,7 +80,7 @@
         <gravitee-policy-ratelimit.version>2.0.0</gravitee-policy-ratelimit.version>
         <gravitee-policy-regex-threat-protection.version>1.3.3</gravitee-policy-regex-threat-protection.version>
         <gravitee-policy-request-content-limit.version>1.8.0</gravitee-policy-request-content-limit.version>
-        <gravitee-policy-request-validation.version>1.13.0</gravitee-policy-request-validation.version>
+        <gravitee-policy-request-validation.version>1.13.1</gravitee-policy-request-validation.version>
         <gravitee-policy-resource-filtering.version>1.8.0</gravitee-policy-resource-filtering.version>
         <gravitee-policy-rest-to-soap.version>1.13.0</gravitee-policy-rest-to-soap.version>
         <gravitee-policy-retry.version>2.1.0</gravitee-policy-retry.version>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>2.0.1</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
-        <gravitee-node.version>2.0.6</gravitee-node.version>
+        <gravitee-node.version>2.0.7</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-plugin.version>1.25.0</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.2.0</gravitee-platform-repository-api.version>


### PR DESCRIPTION
## Issue

Bump `gravitee-policy-request-validation` to `1.13.1`

https://gravitee.atlassian.net/browse/APIM-896
https://github.com/gravitee-io/issues/issues/8347

-------

Bump `gravitee-policy-ssl-enforcement` to `1.2.3`

https://gravitee.atlassian.net/browse/APIM-1497
https://github.com/gravitee-io/issues/issues/9029

-------

Bump `gravitee-node` to `2.0.7`

https://gravitee.atlassian.net/browse/APIM-1369
https://github.com/gravitee-io/issues/issues/8976
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kflbvpggmw.chromatic.com)
<!-- Storybook placeholder end -->
