### PR TITLE
fix: check correct permission to get dictionary

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/configuration/dictionary/DictionaryResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/configuration/dictionary/DictionaryResource.java
@@ -69,6 +69,7 @@ public class DictionaryResource extends AbstractResource {
         boolean notReadOnly = hasPermission(
             GraviteeContext.getExecutionContext(),
             RolePermission.ENVIRONMENT_DICTIONARY,
+            GraviteeContext.getCurrentEnvironment(),
             RolePermissionAction.CREATE,
             RolePermissionAction.UPDATE,
             RolePermissionAction.DELETE


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1565

## Description

When getting a dictionary, the permission check was not done on current environment, meaning no membership were retrieved if user was not a system admin
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ivtritizzf.chromatic.com)
<!-- Storybook placeholder end -->
