### PR TITLE
feat(console): application search can be done by application id

### DIFF
--- a/gravitee-apim-console-webui/src/services-ngx/application.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/application.service.spec.ts
@@ -72,4 +72,39 @@ describe('ApplicationService', () => {
       req.flush(mockApplications);
     });
   });
+
+  describe('search', () => {
+    it('should search application', (done) => {
+      const mockApplications = [fakeApplication()];
+
+      applicationService.list().subscribe((response) => {
+        expect(response).toMatchObject(mockApplications);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        method: 'GET',
+        url: `${CONSTANTS_TESTING.env.baseURL}/applications/_paged?page=1&size=10`,
+      });
+
+      req.flush(mockApplications);
+    });
+
+    it('should search application with application id', (done) => {
+      const mockApplications = [fakeApplication()];
+      const query = '0d93fd04-e834-447f-93fd-04e834047f9d';
+
+      applicationService.list(undefined, query).subscribe((response) => {
+        expect(response).toMatchObject(mockApplications);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        method: 'GET',
+        url: `${CONSTANTS_TESTING.env.baseURL}/applications/_paged?page=1&size=10&ids=0d93fd04-e834-447f-93fd-04e834047f9d`,
+      });
+
+      req.flush(mockApplications);
+    });
+  });
 });

--- a/gravitee-apim-console-webui/src/services-ngx/application.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/application.service.ts
@@ -46,13 +46,22 @@ export class ApplicationService {
     });
   }
 
-  list(status?: string, query?: string, order?: string, page = 1, size = 10): Observable<PagedResult<Application>> {
+  list(status?: string, _query?: string, order?: string, page = 1, size = 10): Observable<PagedResult<Application>> {
+    let query = _query;
+    let applicationIds = undefined;
+    // Search by application id when query is a valid id
+    if (_query && _query.match(/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/)) {
+      query = undefined;
+      applicationIds = [_query];
+    }
+
     return this.http.get<PagedResult<Application>>(`${this.constants.env.baseURL}/applications/_paged`, {
       params: {
         page,
         size,
         ...(status ? { status } : {}),
         ...(query ? { query } : {}),
+        ...(applicationIds ? { ids: applicationIds } : {}),
         ...(order ? { order } : {}),
       },
     });


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-1399

## Description

Following several discussions we have retained the solution with the least code as it is a support topic. If a need to add a more advanced search it will be possible to implement a solution similar to api or user

I didn't add a prefix `id: ` because on the api search side it doesn't work. this solution allows to keep a little consistency between the 2 pages 🤷‍♂️ 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ukbogzaavl.chromatic.com)
<!-- Storybook placeholder end -->
