### PR TITLE
fix: avoid NPE when flow methods is not set (null by default)

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/v4/policy/DefaultPolicyChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/v4/policy/DefaultPolicyChainFactory.java
@@ -135,7 +135,7 @@ public class DefaultPolicyChainFactory implements PolicyChainFactory {
                 .selectorByType(SelectorType.HTTP)
                 .map(HttpSelector.class::cast)
                 .ifPresent(httpSelector -> {
-                    if (httpSelector.getMethods().isEmpty()) {
+                    if (httpSelector.getMethods() == null || httpSelector.getMethods().isEmpty()) {
                         flowNameBuilder.append("ALL").append(ID_SEPARATOR);
                     } else {
                         httpSelector.getMethods().forEach(httpMethod -> flowNameBuilder.append(httpMethod).append("-"));

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/reactive/v4/policy/DefaultPolicyChainFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/reactive/v4/policy/DefaultPolicyChainFactoryTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.reactive.v4.policy;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -27,6 +28,8 @@ import static org.mockito.Mockito.when;
 
 import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
+import io.gravitee.definition.model.v4.flow.selector.SelectorType;
 import io.gravitee.definition.model.v4.flow.step.Step;
 import io.gravitee.gateway.policy.PolicyMetadata;
 import io.gravitee.gateway.reactive.api.ExecutionPhase;
@@ -35,6 +38,7 @@ import io.gravitee.gateway.reactive.policy.PolicyChain;
 import io.gravitee.gateway.reactive.policy.PolicyManager;
 import io.gravitee.node.container.spring.SpringEnvironmentConfiguration;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -254,5 +258,19 @@ class DefaultPolicyChainFactoryTest {
         verify(policyManager, times(2)).create(eq(ExecutionPhase.REQUEST), any(PolicyMetadata.class));
 
         verifyNoMoreInteractions(policyManager);
+    }
+
+    @Test
+    public void shouldNotFailIfFlowMethodsIsNull() {
+        final Flow flow = mock(Flow.class);
+        final HttpSelector selector = mock(HttpSelector.class);
+
+        when(flow.selectorByType(eq(SelectorType.HTTP))).thenReturn(Optional.of(selector));
+        when(selector.getMethods()).thenReturn(null);
+        when(selector.getPath()).thenReturn("path");
+
+        final PolicyChain policyChain = cut.create("flowchain-test", flow, ExecutionPhase.REQUEST);
+        assertNotNull(policyChain);
+        assertEquals("flowchain-test-all-path", policyChain.getId());
     }
 }


### PR DESCRIPTION
## Issue

Linked to https://gravitee.atlassian.net/browse/APIM-1526

## Description

While investigating issues with JWT plans for V4 APIs, I noticed the following issue in the logs

```
16:22:29.180 [vert.x-eventloop-thread-8] [] ERROR i.g.g.r.h.api.v4.DefaultApiReactor - Unexpected error while handling request
java.lang.NullPointerException: Cannot invoke "java.util.Set.isEmpty()" because the return value of "io.gravitee.definition.model.v4.flow.selector.HttpSelector.getMethods()" is null
	at io.gravitee.gateway.reactive.v4.policy.DefaultPolicyChainFactory.lambda$getFlowId$2(DefaultPolicyChainFactory.java:138)
	at java.base/java.util.Optional.ifPresent(Optional.java:178)
	at io.gravitee.gateway.reactive.v4.policy.DefaultPolicyChainFactory.getFlowId(DefaultPolicyChainFactory.java:137)
	at io.gravitee.gateway.reactive.v4.policy.DefaultPolicyChainFactory.create(DefaultPolicyChainFactory.java:94)
	at io.gravitee.gateway.reactive.handlers.api.v4.flow.FlowChain.executeFlow(FlowChain.java:176)
	at io.gravitee.gateway.reactive.handlers.api.v4.flow.FlowChain.lambda$execute$1(FlowChain.java:111)
```


## Additional context

This PR will not be enough to fix JWT plans with V4 APIs : there is still an issue with the way the security configuration is serialized, and we will also add empty `methods` in the plan creation payload to avoid using the default `null` value. But this fix can do no harm 😄 
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-unhnzzvtqx.chromatic.com)
<!-- Storybook placeholder end -->
