### PR TITLE
fix(console): keep existing api picture / background on rollback if e…

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/audit/history/apiHistory.controller.ts
@@ -13,17 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// eslint-disable-next-line @typescript-eslint/no-var-requires,import/order
-const copy = require('clipboard-copy');
-// eslint-disable-next-line @typescript-eslint/no-var-requires,import/order
-const JsDiff = require('diff/dist/diff.min.js');
-
 import '@gravitee/ui-components/wc/gv-policy-studio';
 import '@gravitee/ui-components/wc/gv-switch';
 import '@gravitee/ui-components/wc/gv-popover';
 import * as _ from 'lodash';
 import * as angular from 'angular';
 import { StateService } from '@uirouter/core';
+
+import { ApiService } from '../../../../services/api.service';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const copy = require('clipboard-copy');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const JsDiff = require('diff/dist/diff.min.js');
 
 const propertyProviders = [
   {
@@ -136,7 +138,7 @@ class ApiHistoryController {
     private $scope: any,
     private $rootScope: ng.IRootScopeService,
     private $state: StateService,
-    private ApiService,
+    private ApiService: ApiService,
     private NotificationService,
     private resolvedEvents,
     private PolicyService,
@@ -379,13 +381,21 @@ class ApiHistoryController {
     _apiDefinition.description = _apiPayload.description;
     _apiDefinition.visibility = _apiPayload.visibility;
 
-    this.ApiService.rollback(this.api.id, _apiDefinition).then(() => {
-      this.NotificationService.show('Api rollback !');
+    Promise.allSettled([this.ApiService.picture(this.api.id), this.ApiService.background(this.api.id)])
+      .then(([pictureResponse, backgroundResponse]) => {
+        _apiDefinition.picture = pictureResponse.status === 'fulfilled' ? pictureResponse?.value : null;
+        _apiDefinition.background = backgroundResponse.status === 'fulfilled' ? backgroundResponse?.value : null;
 
-      this.ApiService.get(this.api.id).then((response) => {
+        return this.ApiService.rollback(this.api.id, _apiDefinition);
+      })
+      .then(() => {
+        this.NotificationService.show('API successfully rollbacked!');
+
+        return this.ApiService.get(this.api.id);
+      })
+      .then((response) => {
         this.$rootScope.$broadcast('apiChangeSuccess', { api: response.data });
       });
-    });
   }
 
   showRollbackAPIConfirm(ev, api) {

--- a/gravitee-apim-console-webui/src/services/api.service.ts
+++ b/gravitee-apim-console-webui/src/services/api.service.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { IHttpPromise, IHttpService, IPromise, IRootScopeService } from 'angular';
+import { IHttpPromise, IHttpResponse, IHttpService, IPromise, IRootScopeService } from 'angular';
 import { clone } from 'lodash';
 
 import { ApplicationExcludeFilter } from './application.service';
@@ -766,6 +766,18 @@ export class ApiService {
     return this.$http.get(`${this.Constants.env.baseURL}/apis/schema`);
   }
 
+  picture(apiId: string): IPromise<string> {
+    return this.$http
+      .get(`${this.Constants.env.baseURL}/apis/${apiId}/picture`, { responseType: 'blob' })
+      .then((response: IHttpResponse<Blob>) => blobToBase64(response.data));
+  }
+
+  background(apiId: string): IPromise<string> {
+    return this.$http
+      .get(`${this.Constants.env.baseURL}/apis/${apiId}/background`, { responseType: 'blob' })
+      .then((response: IHttpResponse<Blob>) => blobToBase64(response.data));
+  }
+
   private async syncV2Api(api: { id: string }): Promise<boolean> {
     if (this.isV2(api)) {
       const updatedApi = await this.get(api.id);
@@ -803,3 +815,16 @@ export class ApiService {
     return api && api.gravitee === '2.0.0';
   }
 }
+
+const blobToBase64 = (blob: Blob): Promise<string> => {
+  return new Promise<string>((resolve, reject) => {
+    if (!blob || blob.size === 0) {
+      reject('Blob is empty');
+      return;
+    }
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(reader.result as string);
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+};


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-530
https://github.com/gravitee-io/issues/issues/8801


## Description

I don't add any test because it's not a migrated screens. I hope that we can improve this with the new rest-api v2 to have directly the image base64. or make the process is backend only.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mnktbeqalt.chromatic.com)
<!-- Storybook placeholder end -->
