### PR TITLE
fix: bump gravitee node version to 3.1.0-alpha.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.0.0-alpha.1</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
-        <gravitee-node.version>3.1.0-alpha.5</gravitee-node.version>
+        <gravitee-node.version>3.1.0-alpha.6</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-plugin.version>1.27.0-alpha.2</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.2.1</gravitee-platform-repository-api.version>


### PR DESCRIPTION
see https://github.com/gravitee-io/gravitee-kubernetes/pull/54

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ekovooosbn.chromatic.com)
<!-- Storybook placeholder end -->
