### PR TITLE
Change plan security type

### DIFF
--- a/gravitee-apim-console-webui/src/entities/api/Api.ts
+++ b/gravitee-apim-console-webui/src/entities/api/Api.ts
@@ -96,7 +96,7 @@ export interface ApiPlan {
   id: string;
   name?: string;
   security?: string;
-  securityDefinition?: string;
+  securityDefinition?: unknown;
   paths?: Record<string, unknown[]>;
   api?: string;
   selectionRule?: string;

--- a/gravitee-apim-console-webui/src/entities/plan-v4/plan.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/plan-v4/plan.fixture.ts
@@ -21,7 +21,7 @@ export function fakeV4Plan(modifier?: Partial<Plan> | ((baseApi: Plan) => Plan))
   const base: Plan = {
     id: '45ff00ef-8256-3218-bf0d-b289735d84bb',
     name: 'Free Spaceshuttle',
-    security: { type: PlanSecurityType.KEY_LESS, configuration: undefined },
+    security: { type: PlanSecurityType.KEY_LESS, configuration: {} },
     paths: {},
     flows: [],
     status: 'published',

--- a/gravitee-apim-console-webui/src/entities/plan-v4/plan.ts
+++ b/gravitee-apim-console-webui/src/entities/plan-v4/plan.ts
@@ -37,7 +37,7 @@ export type PlanStatus = (typeof PLAN_STATUS)[number];
 
 export interface PlanSecurity {
   type: PlanSecurityType;
-  configuration: string;
+  configuration: unknown;
 }
 
 export interface NewPlan {

--- a/gravitee-apim-console-webui/src/entities/plan/plan.ts
+++ b/gravitee-apim-console-webui/src/entities/plan/plan.ts
@@ -40,7 +40,7 @@ export interface NewPlan {
   description?: string;
   validation?: PlanValidation;
   security: PlanSecurityType;
-  securityDefinition?: string;
+  securityDefinition?: unknown;
   type?: PlanType;
   status?: PlanStatus;
   api?: string;
@@ -61,7 +61,7 @@ export interface Plan {
   name: string;
   description?: string;
   security: PlanSecurityType;
-  securityDefinition?: string;
+  securityDefinition?: unknown;
   api?: string;
   characteristics?: Array<string>;
   closed_at?: Date;

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
@@ -217,7 +217,7 @@ describe('ApiPlanFormComponent', () => {
         excluded_groups: ['group-a'],
         general_conditions: 'doc-1',
         security: 'JWT',
-        securityDefinition: '{}',
+        securityDefinition: {},
         selection_rule: '{ #el ...}',
         tags: [TAG_1_ID],
         validation: 'AUTO',
@@ -293,7 +293,7 @@ describe('ApiPlanFormComponent', () => {
         general_conditions: '',
         tags: [],
         security: 'OAUTH2',
-        securityDefinition: '{}',
+        securityDefinition: {},
         selection_rule: null,
         validation: 'MANUAL',
         flows: [
@@ -391,7 +391,7 @@ describe('ApiPlanFormComponent', () => {
         general_conditions: '',
         tags: [],
         security: {
-          configuration: '{}',
+          configuration: {},
           type: 'JWT',
         },
         selection_rule: '{ #el ...}',
@@ -519,7 +519,7 @@ describe('ApiPlanFormComponent', () => {
         name: 'Old 🗺',
         description: 'Old Description',
         security: PlanSecurityType.API_KEY,
-        securityDefinition: JSON.stringify({ propagateApiKey: true }),
+        securityDefinition: { propagateApiKey: true },
         tags: [TAG_1_ID],
       });
       testComponent.planControl = new FormControl(planToUpdate);
@@ -704,7 +704,7 @@ describe('ApiPlanFormComponent', () => {
         comment_required: false,
         excluded_groups: ['group-a'],
         security: {
-          configuration: '{}',
+          configuration: {},
           type: 'KEY_LESS',
         },
         general_conditions: 'doc-1',
@@ -718,7 +718,7 @@ describe('ApiPlanFormComponent', () => {
         description: 'Old Description',
         security: {
           type: PlanSecurityType.API_KEY,
-          configuration: JSON.stringify({ propagateApiKey: true }),
+          configuration: { propagateApiKey: true },
         },
         tags: [TAG_1_ID],
       });

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
@@ -69,7 +69,7 @@ type InternalPlanFormValue = {
   };
   secure: {
     securityType: string;
-    securityConfig: string;
+    securityConfig: unknown;
     selectionRule: string;
   };
 
@@ -340,7 +340,7 @@ const planV3ToInternalFormValue = (plan: InternalPlanV3Value | undefined): Inter
     },
     secure: {
       securityType: plan.security,
-      securityConfig: plan.securityDefinition ? JSON.parse(plan.securityDefinition) : {},
+      securityConfig: plan.securityDefinition,
       selectionRule: plan.selection_rule,
     },
   };
@@ -365,7 +365,7 @@ const planV4ToInternalFormValue = (plan: InternalPlanV4Value | undefined): Inter
     },
     secure: {
       securityType: plan.security.type,
-      securityConfig: plan.security.configuration ? JSON.parse(plan.security.configuration) : {},
+      securityConfig: plan.security.configuration,
       selectionRule: plan.selection_rule,
     },
   };
@@ -433,7 +433,7 @@ const internalFormValueToPlanV3 = (value: InternalPlanFormValue, mode: 'create' 
 
     // Secure
     security: value.secure.securityType as PlanSecurityTypeV3,
-    securityDefinition: JSON.stringify(value.secure.securityConfig),
+    securityDefinition: value.secure.securityConfig,
     selection_rule: value.secure.selectionRule,
 
     // Restriction (only for create mode)
@@ -500,7 +500,7 @@ const internalFormValueToPlanV4 = (value: InternalPlanFormValue, mode: 'create' 
     // Secure
     security: {
       type: value.secure.securityType as PlanSecurityTypeV4,
-      configuration: JSON.stringify(value.secure.securityConfig),
+      configuration: value.secure.securityConfig,
     },
     selection_rule: value.secure.selectionRule,
 

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.spec.ts
@@ -875,7 +875,7 @@ describe('ApiCreationV4Component', () => {
             description: 'Default unsecured plan',
             security: {
               type: PlanSecurityType.KEY_LESS,
-              configuration: '',
+              configuration: {},
             },
             validation: 'manual',
           },
@@ -920,7 +920,7 @@ describe('ApiCreationV4Component', () => {
             description: 'Default unsecured plan',
             security: {
               type: PlanSecurityType.KEY_LESS,
-              configuration: '',
+              configuration: {},
             },
             validation: 'manual',
           },
@@ -946,7 +946,7 @@ describe('ApiCreationV4Component', () => {
             general_conditions: '',
             name: 'Secure by ApiKey',
             security: {
-              configuration: '{}',
+              configuration: {},
               type: 'API_KEY',
             },
             selection_rule: null,
@@ -969,7 +969,7 @@ describe('ApiCreationV4Component', () => {
             description: 'Default unsecured plan',
             security: {
               type: PlanSecurityType.KEY_LESS,
-              configuration: '{}',
+              configuration: {},
             },
             validation: 'manual',
             comment_required: false,

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans.component.ts
@@ -43,7 +43,7 @@ export class Step4Security1PlansComponent implements OnInit {
         description: 'Default unsecured plan',
         security: {
           type: PlanSecurityType.KEY_LESS,
-          configuration: '',
+          configuration: {},
         },
         validation: PlanValidation.MANUAL,
       });

--- a/gravitee-apim-console-webui/src/management/api/portal/plans/edit/api-portal-plan-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/plans/edit/api-portal-plan-edit.component.spec.ts
@@ -125,7 +125,7 @@ describe('ApiPortalPlanEditComponent', () => {
         excluded_groups: [],
         tags: [],
         security: 'KEY_LESS',
-        securityDefinition: '{}',
+        securityDefinition: {},
         selection_rule: null,
         flows: [
           {


### PR DESCRIPTION
fix: change security config type from `string` to `unknown` to avoid double serialization and issues when creating plans on the gateway

## Issue

https://gravitee.atlassian.net/browse/APIM-1526

## Description

When deploying a JWT plan on the gateway, we get the following error
```
12:04:44.626 [gio.sync-deployer-0] [2ef98f3d-88b1-4c46-b98f-3d88b1cc46a7] ERROR i.g.g.p.i.PolicyConfigurationFactoryImpl - Unable to instance Policy configuration for io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration
com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot construct instance of `io.gravitee.policy.jwt.configuration.JWTPolicyConfiguration` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('{"signature":"RSA_RS256","publicKeyResolver":"GIVEN_KEY","useSystemProxy":false,"extractClaims":false,"propagateAuthHeader":true,"userClaim":"sub"}')
 at [Source: (String)""{\"signature\":\"RSA_RS256\",\"publicKeyResolver\":\"GIVEN_KEY\",\"useSystemProxy\":false,\"extractClaims\":false,\"propagateAuthHeader\":true,\"userClaim\":\"sub\"}""; line: 1, column: 1]
```

If we look at the DB, the plan security is encoded twice
![Screenshot 2023-05-04 at 12 08 03 (2)](https://user-images.githubusercontent.com/1655950/236174928-85ec24fb-1d6b-407c-acae-28e3e550d9b1.png)

And this prevents the gateway from initializing the plan.

To fix this, we change the type for security configuration from `string` to `unknown` in order to save the object, and not its JSON representation.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qbvslblzuo.chromatic.com)
<!-- Storybook placeholder end -->
