### PR TITLE
chore(perf): add tempo in the Async simulation to wait few sec before…

### DIFF
--- a/gravitee-apim-perf/scripts/run.sh
+++ b/gravitee-apim-perf/scripts/run.sh
@@ -139,6 +139,7 @@ then
     output_mode=$(jq -r '.k6.outputMode' "${CONFIG_DIR}/config.json")
 fi
 echo $K6_PROMETHEUS_RW_SERVER_URL
+
 ### Run K6
 k6 run --include-system-env-vars ${VERBOSE_OPTIONS} -o ${output_mode} -e K6_PROMETHEUS_RW_TREND_STATS="p(99),p(95),p(90),avg" "${file_path}"
 

--- a/gravitee-apim-perf/src/scenarios/message-kafka/http-post/keyless.test.ts
+++ b/gravitee-apim-perf/src/scenarios/message-kafka/http-post/keyless.test.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { check } from 'k6';
+import { check, sleep } from 'k6';
 import { Connection } from 'k6/x/kafka';
 import http from 'k6/http';
 import { ADMIN_USER, authorizationHeaderFor, k6Options } from '@env/environment';
@@ -192,9 +192,9 @@ export function teardown(data: GatewayTestData) {
     },
   });
 
-  // clear kafka topic
+  // wait to let the time to undeploy the Api (and close kafka client)
+  sleep((k6Options.apim.gatewaySyncInterval * 3) / 1000);
   if (__VU == 0) {
-    // Delete the topic
     connection.deleteTopic(kafkaTopic);
   }
 

--- a/gravitee-apim-perf/src/scenarios/message-kafka/webhook/subscription.test.ts
+++ b/gravitee-apim-perf/src/scenarios/message-kafka/webhook/subscription.test.ts
@@ -297,9 +297,9 @@ export function teardown(data: GatewayTestData) {
     },
   });
 
-  // clear kafka topic
+  // wait to let the time to undeploy the Api (and close kafka client)
+  sleep((k6Options.apim.gatewaySyncInterval * 3) / 1000);
   if (__VU == 0) {
-    // Delete the topic
     connection.deleteTopic(kafkaTopic);
   }
 


### PR DESCRIPTION
… deleting the topic at the end of the simulation

### description
To avoid already existing message in the kafka topic from on execution to another, we try to delete the topic at the end.
For safety we add a tempo before this action to let time the GW to close the kafka client
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zryrszfafs.chromatic.com)
<!-- Storybook placeholder end -->
