### PR TITLE
fix: remove requirement on repository CACHE type

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-repository/src/main/java/io/gravitee/gateway/repository/plugins/RepositoryPluginHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-repository/src/main/java/io/gravitee/gateway/repository/plugins/RepositoryPluginHandler.java
@@ -62,8 +62,6 @@ public class RepositoryPluginHandler implements PluginHandler, InitializingBean 
         lookForRepositoryType(Scope.MANAGEMENT);
         // 2_ Rate limit
         lookForRepositoryType(Scope.RATE_LIMIT);
-        // 3_ Caching
-        lookForRepositoryType(Scope.CACHE);
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -152,9 +152,6 @@ ratelimit:
   mongodb:
     uri: mongodb://${ds.mongodb.host}:${ds.mongodb.port}/${ds.mongodb.dbname}
 
-cache:
-  type: ehcache
-
 # Reporters configuration (used to store reporting monitoring data, request metrics, healthchecks and others...
 # All reporters are enabled by default. To stop one of them, you have to add the property 'enabled: false'
 reporters:


### PR DESCRIPTION
## Description

Due to https://github.com/gravitee-io/helm-charts/pull/376, which removed the cache.type configuration, the gateway shouldn't depend on it.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mxoweuthyo.chromatic.com)
<!-- Storybook placeholder end -->
