### PR TITLE
fix: remove requirement on repository CACHE scope

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-repository/src/main/java/io/gravitee/gateway/repository/plugins/GatewayRepositoryScopeProvider.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-repository/src/main/java/io/gravitee/gateway/repository/plugins/GatewayRepositoryScopeProvider.java
@@ -26,6 +26,6 @@ import org.springframework.stereotype.Component;
 public class GatewayRepositoryScopeProvider implements RepositoryScopeProvider {
 
     public Scope[] getHandledScopes() {
-        return new Scope[] { Scope.MANAGEMENT, Scope.RATE_LIMIT, Scope.CACHE };
+        return new Scope[] { Scope.MANAGEMENT, Scope.RATE_LIMIT };
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-repository/src/test/java/io/gravitee/gateway/repository/plugins/GatewayRepositoryScopeProviderTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-repository/src/test/java/io/gravitee/gateway/repository/plugins/GatewayRepositoryScopeProviderTest.java
@@ -28,6 +28,6 @@ public class GatewayRepositoryScopeProviderTest {
 
     @Test
     public void shouldReturnManagementAndAnalyticsScopes() {
-        Assert.assertArrayEquals(new Scope[] { Scope.MANAGEMENT, Scope.RATE_LIMIT, Scope.CACHE }, provider.getHandledScopes());
+        Assert.assertArrayEquals(new Scope[] { Scope.MANAGEMENT, Scope.RATE_LIMIT }, provider.getHandledScopes());
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -155,9 +155,6 @@ ratelimit:
     mongodb:
         uri: mongodb://${ds.mongodb.host}:${ds.mongodb.port}/${ds.mongodb.dbname}
 
-cache:
-    type: ehcache
-
 # Reporters configuration (used to store reporting monitoring data, request metrics, healthchecks and others...
 # All reporters are enabled by default. To stop one of them, you have to add the property 'enabled: false'
 reporters:


### PR DESCRIPTION
## Description

Due to https://github.com/gravitee-io/helm-charts/pull/376, which removed the cache.type configuration, the gateway shouldn't depend on it.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vbnjnukynp.chromatic.com)
<!-- Storybook placeholder end -->
