### PR TITLE
fix(console): use right env var to get settings.documentation url

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation/steps/api-creation-step5.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/steps/api-creation-step5.component.ts
@@ -20,8 +20,8 @@ const ApiCreationStep5Component: ng.IComponentOptions = {
   template: require('./api-creation-step5.html'),
   controller: function (Constants) {
     'ngInject';
-    if (Constants.org.settings.documentation && Constants.org.settings.documentation.url) {
-      this.url = Constants.org.settings.documentation.url;
+    if (Constants.env.settings.documentation && Constants.env.settings.documentation.url) {
+      this.url = Constants.env.settings.documentation.url;
     } else {
       this.url = 'https://docs.gravitee.io';
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-873
https://github.com/gravitee-io/issues/issues/7242

## Description

Use right env var to get settings.documentation url

Note : We must add url with http or https otherwise :
<img width="201" alt="image" src="https://user-images.githubusercontent.com/4974420/237050148-a8d05dc2-878f-4f1d-96a8-0ce823a88797.png">
same behavior for the other url like the `portal` one

## Additional context
<img width="1015" alt="image" src="https://user-images.githubusercontent.com/4974420/237049827-494c3db7-eecc-4543-8984-b415d1100efc.png">

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

