### PR TITLE
feat(console): remove Organization Theme settings

### DIFF
--- a/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.html
@@ -136,46 +136,6 @@
       </mat-card-content>
     </mat-card>
 
-    <mat-card class="settings-general__form__card" formGroupName="theme">
-      <h2 gioTableOfContents>Theme</h2>
-      <mat-card-content>
-        <mat-form-field
-          [matTooltip]="providedConfigurationMessage"
-          [matTooltipDisabled]="!isReadonlySetting('theme.name')"
-          appearance="fill"
-          class="settings-general__form__card__form-field"
-        >
-          <mat-icon *ngIf="isReadonlySetting('theme.name')" class="settings-general__form__card__form-field__icon" matPrefix>lock</mat-icon>
-          <mat-label>Name</mat-label>
-          <input matInput formControlName="name" />
-        </mat-form-field>
-
-        <mat-form-field
-          [matTooltip]="providedConfigurationMessage"
-          [matTooltipDisabled]="!isReadonlySetting('theme.logo')"
-          appearance="fill"
-          class="settings-general__form__card__form-field"
-        >
-          <mat-icon *ngIf="isReadonlySetting('theme.logo')" class="settings-general__form__card__form-field__icon" matPrefix>lock</mat-icon>
-          <mat-label>Logo</mat-label>
-          <input matInput formControlName="logo" />
-        </mat-form-field>
-
-        <mat-form-field
-          [matTooltip]="providedConfigurationMessage"
-          [matTooltipDisabled]="!isReadonlySetting('theme.loader')"
-          appearance="fill"
-          class="settings-general__form__card__form-field"
-        >
-          <mat-icon *ngIf="isReadonlySetting('theme.loader')" class="settings-general__form__card__form-field__icon" matPrefix
-            >lock</mat-icon
-          >
-          <mat-label>Loader</mat-label>
-          <input matInput formControlName="loader" />
-        </mat-form-field>
-      </mat-card-content>
-    </mat-card>
-
     <mat-card class="settings-general__form__card" formGroupName="scheduler">
       <h2 gioTableOfContents>Schedulers</h2>
       <mat-card-content>

--- a/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.spec.ts
@@ -172,62 +172,6 @@ describe('ConsoleSettingsComponent', () => {
     });
   });
 
-  describe('theme', () => {
-    it('should disable field when setting is readonly', async () => {
-      expectConsoleSettingsGetRequest({
-        theme: {
-          name: undefined,
-          logo: 'The logo',
-          loader: '',
-        },
-        metadata: {
-          readonly: ['theme.name', 'theme.logo', 'theme.loader'],
-        },
-      });
-
-      const nameFormField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'Name' }));
-      expect(await nameFormField.isDisabled()).toEqual(true);
-
-      const logoFormField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'Logo' }));
-      expect(await logoFormField.isDisabled()).toEqual(true);
-
-      const loaderFormField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'Loader' }));
-      expect(await loaderFormField.isDisabled()).toEqual(true);
-    });
-
-    it('should save theme settings', async () => {
-      expectConsoleSettingsGetRequest({
-        theme: {
-          name: undefined,
-          logo: 'The logo',
-          loader: '',
-          css: 'red style',
-        },
-      });
-
-      const nameFormField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'Name' }));
-      await (await nameFormField.getControl(MatInputHarness)).setValue('New name');
-
-      const logoFormField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'Logo' }));
-      await (await logoFormField.getControl(MatInputHarness)).setValue('');
-
-      const loaderFormField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'Loader' }));
-      await (await loaderFormField.getControl(MatInputHarness)).setValue('New loader');
-
-      const saveButton = await loader.getHarness(GioSaveBarHarness);
-      await saveButton.clickSubmit();
-
-      expectConsoleSettingsSendRequest({
-        theme: {
-          name: 'New name',
-          logo: '',
-          loader: 'New loader',
-          css: 'red style',
-        },
-      });
-    });
-  });
-
   describe('scheduler', () => {
     it('should disable field when setting is readonly', async () => {
       expectConsoleSettingsGetRequest({

--- a/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/console/org-settings-general.component.ts
@@ -79,11 +79,6 @@ export class OrgSettingsGeneralComponent implements OnInit, OnDestroy {
             userCreation: this.fb.group({ enabled: [toFormState(this.settings, 'management.userCreation.enabled')] }),
             automaticValidation: this.fb.group({ enabled: [toFormState(this.settings, 'management.automaticValidation.enabled')] }),
           }),
-          theme: this.fb.group({
-            name: [toFormState(this.settings, 'theme.name')],
-            logo: [toFormState(this.settings, 'theme.logo')],
-            loader: [toFormState(this.settings, 'theme.loader')],
-          }),
           scheduler: this.fb.group({
             tasks: [toFormState(this.settings, 'scheduler.tasks')],
             notifications: [toFormState(this.settings, 'scheduler.notifications')],


### PR DESCRIPTION
## Issue


https://gravitee.atlassian.net/browse/APIM-834
https://github.com/gravitee-io/issues/issues/8882

## Description

Following the gravitee  new desig it was decided to keep the gravitee brand in the console and do not allow to personalise the theme anymore. Only the portal is intended to be customized by another brand. This PR only removes the theme settings in the console. A more complete removal will be done in next major



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dgbvsunwzy.chromatic.com)
<!-- Storybook placeholder end -->
