### PR TITLE
fix: use DEFAULT org cors configuration to unblock dev environment

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-security/src/main/java/io/gravitee/rest/api/management/v2/security/config/GraviteeUrlBasedCorsConfigurationSource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-security/src/main/java/io/gravitee/rest/api/management/v2/security/config/GraviteeUrlBasedCorsConfigurationSource.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.management.v2.security.config;
 
 import io.gravitee.common.event.EventManager;
 import io.gravitee.rest.api.service.ParameterService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.HashMap;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
@@ -29,10 +30,10 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
  */
 public class GraviteeUrlBasedCorsConfigurationSource extends UrlBasedCorsConfigurationSource {
 
-    private Map<String, GraviteeCorsConfiguration> corsConfigurationByOrganization = new HashMap<>();
+    private final Map<String, GraviteeCorsConfiguration> corsConfigurationByOrganization = new HashMap<>();
 
-    private ParameterService parameterService;
-    private EventManager eventManager;
+    private final ParameterService parameterService;
+    private final EventManager eventManager;
 
     public GraviteeUrlBasedCorsConfigurationSource(ParameterService parameterService, EventManager eventManager) {
         this.parameterService = parameterService;
@@ -40,19 +41,8 @@ public class GraviteeUrlBasedCorsConfigurationSource extends UrlBasedCorsConfigu
     }
 
     private String computeOrganizationId(HttpServletRequest request) {
-        String path = request.getPathInfo();
-        final String organizationsResourcePath = "/organizations/";
-        final int organizationPathIndex = path.indexOf(organizationsResourcePath);
-
-        if (organizationPathIndex > -1) {
-            int orgIdStartIndex = organizationPathIndex + organizationsResourcePath.length();
-            int endIndex = path.indexOf('/', orgIdStartIndex);
-            if (endIndex > -1) {
-                return path.substring(orgIdStartIndex, endIndex);
-            }
-            return path.substring(orgIdStartIndex);
-        }
-        return null;
+        // FIXME: should return null if no organization found.
+        return GraviteeContext.getDefaultOrganization();
     }
 
     @Override


### PR DESCRIPTION
## Issue

N/A

## Description

With Management API v2, we do not rely on the path anymore to determine the Organization, but on the authenticated user.
However, when the cors mechanism is activated, the authentication process has not been executed, so we can't rely on the security context to find the current organization.

We could partially fix the issue by looking into the bearer token to find the orgId. But what could we do for BasicAuth?
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-knzxgwzonq.chromatic.com)
<!-- Storybook placeholder end -->
