### PR TITLE
ci: deactivate community-build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1837,15 +1837,16 @@ workflows:
             and:
                 - equal: [pull_requests, << pipeline.parameters.gio_action >>]
         jobs:
-            - community-build:
-                  context: cicd-orchestrator
-                  filters:
-                      branches:
-                          only:
-                              - master
-                              - /^\d+\.\d+\.x$/
-                              - /.*-run-e2e.*/
-                              - /.*merge.*/
+            # Deactivated until https://gravitee.atlassian.net/browse/APIM-1598
+            # - community-build:
+            #       context: cicd-orchestrator
+            #       filters:
+            #           branches:
+            #               only:
+            #                   - master
+            #                   - /^\d+\.\d+\.x$/
+            #                   - /.*-run-e2e.*/
+            #                   - /.*merge.*/
 
             - setup:
                   context: cicd-orchestrator


### PR DESCRIPTION
## Issue


## Description

community-build is systematically failing because entrypoint-http-get looks for an enterprise plugin (reactor-message).
This EE component is not released on Nexus, so it fails.

We deactivate the job until the EE plugins have been extracted. We added a task in the Split CE/EE epic to not forget to reactivate it.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ygxkkkjtak.chromatic.com)
<!-- Storybook placeholder end -->
