### PR TITLE
fix: wrong failure when execution interrupt while publishing a message

### DIFF
--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/fake/InterruptMessageRequestPhasePolicy.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/fake/InterruptMessageRequestPhasePolicy.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.fake;
+
+import io.gravitee.gateway.reactive.api.ExecutionFailure;
+import io.gravitee.gateway.reactive.api.context.MessageExecutionContext;
+import io.gravitee.gateway.reactive.api.policy.Policy;
+import io.reactivex.rxjava3.core.Completable;
+
+/**
+ * Policy that interrupts the publish phase.
+ */
+public class InterruptMessageRequestPhasePolicy implements Policy {
+
+    @Override
+    public String id() {
+        return "interrupt-message-request-phase";
+    }
+
+    @Override
+    public Completable onMessageRequest(MessageExecutionContext ctx) {
+        return ctx
+            .request()
+            .onMessage(message -> ctx.interruptMessageWith(new ExecutionFailure(412).key("FAKE_KEY").message("An error occurred")));
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/http-post-entrypoint-kafka-endpoint-failure.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/http-post-entrypoint-kafka-endpoint-failure.json
@@ -1,0 +1,77 @@
+{
+  "id": "http-post-entrypoint-kafka-endpoint-failure",
+  "name": "http-post-entrypoint-kafka-endpoint-failure",
+  "apiVersion": "1.0",
+  "definitionVersion": "4.0.0",
+  "type": "message",
+  "description": "Api v4 using HTTP POST entrypoint and Kafka endpoint with failure",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/http-post-entrypoint-kafka-endpoint-failure"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-post",
+          "configuration": {
+            "requestHeadersToMessage": true
+          }
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "kafka",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "kafka",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "bootstrapServers": "bootstrap-server"
+          },
+          "sharedConfigurationOverride": {
+            "producer": {
+              "enabled": true,
+              "topics": ["test-topic"]
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "flow-1",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "STARTS_WITH"
+        }
+      ],
+      "request": [],
+      "response": [],
+      "subscribe": [],
+      "publish": [
+        {
+          "name": "failure",
+          "description": "failure",
+          "enabled": true,
+          "policy": "interrupt-message-request-phase",
+          "configuration": {}
+        }
+      ]
+    }
+  ],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/logback-test.xml
+++ b/gravitee-apim-integration-tests/src/test/resources/logback-test.xml
@@ -26,13 +26,13 @@
         </encoder>
     </appender>
 
-    <logger name="io.gravitee" level="DEBUG" additivity="false">
+    <logger name="io.gravitee" level="ERROR" additivity="false">
         <appender-ref ref="STDOUT" />
     </logger>
 
     <!-- Strictly speaking, the level attribute is not necessary since -->
     <!-- the level of the root level is set to DEBUG by default.       -->
-    <root level="INFO">
+    <root level="ERROR">
         <appender-ref ref="STDOUT" />
     </root>
 

--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
         <gravitee-endpoint-mqtt5-advanced.version>1.2.0-alpha.1</gravitee-endpoint-mqtt5-advanced.version>
         <gravitee-resource-schema-registry-confluent.version>1.0.0-alpha.9
         </gravitee-resource-schema-registry-confluent.version>
-        <gravitee-reactor-message.version>1.0.0-alpha.1</gravitee-reactor-message.version>
+        <gravitee-reactor-message.version>1.0.0-alpha.2</gravitee-reactor-message.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1098

## Description

When a policy interrupts the execution in the onMessageRequest, the connector plugins may catch the exception and replace it with another one; it was the case of the Kafka plugin, where we catch errors to return an unknown error.

To prevent that, I've created another processor chain handling failure. This chain is executed before the endpoint and will catch any error to return the actual error in the response.
Errors thrown by the connectors are processed with the original chain after the API execution.

The fix can be found [here](https://github.com/gravitee-io/gravitee-reactor-message/pull/4) this PR only add an integration test

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tbzvrtqglq.chromatic.com)
<!-- Storybook placeholder end -->
