### PR TITLE
fix(rest-api): improve getUserMember performance

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
@@ -1285,10 +1285,10 @@ public class MembershipServiceImpl extends AbstractService implements Membership
             Set<String> entityGroups = new HashSet<>();
             switch (referenceType) {
                 case API:
-                    entityGroups = apiService.findById(executionContext, referenceId).getGroups();
+                    entityGroups = apiRepository.findById(referenceId).orElseThrow().getGroups();
                     break;
                 case APPLICATION:
-                    entityGroups = applicationService.findById(executionContext, referenceId).getGroups();
+                    entityGroups = applicationRepository.findById(referenceId).orElseThrow().getGroups();
                     break;
                 default:
                     break;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/MembershipService_TransferOwnershipTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/MembershipService_TransferOwnershipTest.java
@@ -21,7 +21,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.MembershipRepository;
+import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.Membership;
 import io.gravitee.repository.management.model.MembershipReferenceType;
 import io.gravitee.rest.api.model.MembershipMemberType;
@@ -83,8 +85,11 @@ public class MembershipService_TransferOwnershipTest {
     @Mock
     private ApiService apiService;
 
+    @Mock
+    private ApiRepository apiRepository;
+
     @Before
-    public void setUp() {
+    public void setUp() throws TechnicalException {
         newPrimaryOwnerRole.setId(USER_ROLE_ID);
         newPrimaryOwnerRole.setName(USER_ROLE_NAME);
         newPrimaryOwnerRole.setScope(RoleScope.API);
@@ -94,9 +99,9 @@ public class MembershipService_TransferOwnershipTest {
         when(userService.findByIds(EXECUTION_CONTEXT, Collections.singletonList(USER_ID), false)).thenReturn(Collections.singleton(user));
         when(userService.findById(EXECUTION_CONTEXT, USER_ID)).thenReturn(user);
 
-        ApiEntity apiEntity = new ApiEntity();
-        apiEntity.setId(API_ID);
-        when(apiService.findById(EXECUTION_CONTEXT, API_ID)).thenReturn(apiEntity);
+        Api api = new Api();
+        api.setId(API_ID);
+        when(apiRepository.findById(API_ID)).thenReturn(Optional.of(api));
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1604

## Description

Only groups are used to get the associated members. So, get from the repository directly without using apiService and its long to execute `convert` method allows to quickly obtain groupIds.

This should improve the overall performance if the change is ✅ 

Tested with : 

[Support-Tickets-Dev-v1 (1).json.txt](https://github.com/gravitee-io/gravitee-api-management/files/11442571/Support-Tickets-Dev-v1.1.json.txt)

when i make a simple call to my api with `{{management_host}}/management/organizations/DEFAULT/environments/DEFAULT/apis/fc6dad4f-fba5-3058-bb25-06b9ff6f3254/plans?status=staging,published,closed,deprecated`

my time feeling is
- before : ~4-5s
- now : ~1s 


## Additional context

I'm sure this will help. But here are some captures of the profiler :

Before with api1 user : 
![image](https://github.com/gravitee-io/gravitee-api-management/assets/4974420/c6a7e4a4-98b7-4656-87b9-6b628bc05b71)

Now with api1 user : 
![image](https://github.com/gravitee-io/gravitee-api-management/assets/4974420/36fb4a7b-5314-460a-a000-e8bc23ba1984)




With admin user : 
![image](https://github.com/gravitee-io/gravitee-api-management/assets/4974420/73a575fd-8bd3-43d2-90e3-4ce95b090b86)


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-atrtsikfzp.chromatic.com)
<!-- Storybook placeholder end -->
