### PR TITLE
fix: add path parameters resolution for v2 api [3.21]

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/RequestProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/RequestProcessorChainFactory.java
@@ -43,7 +43,9 @@ import io.gravitee.gateway.handlers.api.policy.plan.PlanPolicyResolver;
 import io.gravitee.gateway.handlers.api.processor.cors.CorsPreflightRequestProcessor;
 import io.gravitee.gateway.handlers.api.processor.forward.XForwardedPrefixProcessor;
 import io.gravitee.gateway.handlers.api.processor.logging.ApiLoggableRequestProcessor;
+import io.gravitee.gateway.handlers.api.processor.pathparameters.PathParametersExtractor;
 import io.gravitee.gateway.handlers.api.processor.pathparameters.PathParametersIndexProcessor;
+import io.gravitee.gateway.handlers.api.processor.pathparameters.PathParametersProcessor;
 import io.gravitee.gateway.policy.PolicyChainOrder;
 import io.gravitee.gateway.policy.PolicyChainProviderLoader;
 import io.gravitee.gateway.policy.PolicyManager;
@@ -133,6 +135,12 @@ public class RequestProcessorChainFactory extends ApiProcessorChainFactory {
             add(new PlanPolicyChainProvider(StreamType.ON_REQUEST, new PlanPolicyResolver(api), policyChainFactory));
             add(new ApiPolicyChainProvider(StreamType.ON_REQUEST, new ApiPolicyResolver(), policyChainFactory));
         } else if (api.getDefinitionVersion() == DefinitionVersion.V2) {
+            final PathParametersExtractor extractor = new PathParametersExtractor(api);
+            if (extractor.canExtractPathParams()) {
+                final PathParametersProcessor pathParametersProcessor = new PathParametersProcessor(extractor);
+                add(() -> pathParametersProcessor);
+            }
+
             if (api.getDefinition().getFlowMode() == null || api.getDefinition().getFlowMode() == FlowMode.DEFAULT) {
                 add(
                     new PlanFlowPolicyChainProvider(

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParameter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParameter.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.processor.pathparameters;
+
+import io.gravitee.definition.model.flow.Operator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class PathParameter {
+
+    private static final String PATH_SEPARATOR = "/";
+    private static final Pattern SEPARATOR_SPLITTER = Pattern.compile(PATH_SEPARATOR);
+    private static final String PATH_PARAM_PREFIX = ":";
+    private static final String PATH_PARAM_REGEX = "[a-zA-Z0-9\\-._~%!$&'()* +,;=:@]+";
+
+    private final String originalPath;
+    private final Operator operator;
+    private Pattern pathPattern;
+    private final List<String> parameters = new ArrayList<>();
+
+    public PathParameter(String originalPath, Operator operator) {
+        this.originalPath = originalPath;
+        this.operator = operator;
+        extractPathParamsAndPattern();
+    }
+
+    private void extractPathParamsAndPattern() {
+        String[] branches = SEPARATOR_SPLITTER.split(originalPath);
+        StringBuilder patternizedPath = new StringBuilder(PATH_SEPARATOR);
+
+        for (int i = 0; i < branches.length; i++) {
+            if (!branches[i].isEmpty()) {
+                if (branches[i].startsWith(PATH_PARAM_PREFIX)) {
+                    String paramWithoutColon = branches[i].substring(1);
+                    parameters.add(paramWithoutColon);
+                    patternizedPath.append("(?<" + paramWithoutColon + ">" + PATH_PARAM_REGEX + ")");
+                } else {
+                    patternizedPath.append(branches[i]);
+                }
+
+                // Do not add a trailing slash for last branch
+                if (i < branches.length - 1) {
+                    patternizedPath.append(PATH_SEPARATOR);
+                }
+            }
+        }
+
+        pathPattern =
+            operator.equals(Operator.STARTS_WITH)
+                ? Pattern.compile("^" + patternizedPath + "(?:/.*)?$")
+                : Pattern.compile("^" + patternizedPath + "/?$");
+    }
+
+    public Pattern getPathPattern() {
+        return pathPattern;
+    }
+
+    public List<String> getParameters() {
+        return parameters;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PathParameter that = (PathParameter) o;
+        return Objects.equals(originalPath, that.originalPath) && Objects.equals(operator, that.operator);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(originalPath, operator);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParameterHttpMethod.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParameterHttpMethod.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.processor.pathparameters;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+enum PathParameterHttpMethod {
+    WILDCARD,
+    CONNECT,
+    DELETE,
+    GET,
+    HEAD,
+    OPTIONS,
+    PATCH,
+    POST,
+    PUT,
+    TRACE,
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParametersExtractor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParametersExtractor.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.processor.pathparameters;
+
+import io.gravitee.definition.model.flow.Flow;
+import io.gravitee.gateway.handlers.api.definition.Api;
+import io.netty.handler.codec.http.QueryStringDecoder;
+import java.nio.charset.Charset;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class PathParametersExtractor {
+
+    private static final Pattern PARAM_PATTERN = Pattern.compile(":\\w*");
+    private final Map<PathParameterHttpMethod, Set<PathParameter>> patternsByHttpMethod;
+
+    public PathParametersExtractor(Api api) {
+        Objects.requireNonNull(api, "Api is mandatory");
+        patternsByHttpMethod = compilePatternsByHttpMethod(api);
+    }
+
+    /**
+     * Check if path parameters can be extracted for the api.
+     * @return true if at least one flow is configured with a path parameter.
+     */
+    public boolean canExtractPathParams() {
+        return patternsByHttpMethod
+            .values()
+            .stream()
+            .flatMap(Collection::stream)
+            .flatMap(p -> p.getParameters().stream())
+            .anyMatch(parameters -> parameters.length() > 0);
+    }
+
+    /**
+     * Group flow path containing path parameters by Http Method.
+     * If a flow is defined for all methods (empty set), then it will be assigned to WILDCARD key.
+     *
+     * @param api
+     * @return a map of {@link PathParameter}, containing patterns and parameters name grouped by {@link PathParameterHttpMethod}
+     */
+    private static Map<PathParameterHttpMethod, Set<PathParameter>> compilePatternsByHttpMethod(final Api api) {
+        final Stream<Flow> flowsWithParam = filterFlowsWithPathParam(api);
+        // group pattern by HTTP Method <> List<Pattern>
+        return groupPatternsByMethod(flowsWithParam);
+    }
+
+    /**
+     * Filter flows that contains a path parameter (for example ':productId')
+     * @param api
+     * @return a stream of flows containing a path parameter
+     */
+    private static Stream<Flow> filterFlowsWithPathParam(final Api api) {
+        Stream<Flow> flowsWithParam;
+        flowsWithParam = Stream.empty();
+
+        if (api.getDefinition().getFlows() != null) {
+            flowsWithParam =
+                Stream.concat(
+                    flowsWithParam,
+                    api.getDefinition().getFlows().stream().filter(flow -> PARAM_PATTERN.asPredicate().test(flow.getPath()))
+                );
+        }
+        if (api.getDefinition().getPlans() != null) {
+            flowsWithParam =
+                Stream.concat(
+                    flowsWithParam,
+                    api
+                        .getDefinition()
+                        .getPlans()
+                        .stream()
+                        .flatMap(plan -> plan.getFlows() == null ? Stream.empty() : plan.getFlows().stream())
+                        .filter(flow -> PARAM_PATTERN.asPredicate().test(flow.getPath()))
+                );
+        }
+        return flowsWithParam;
+    }
+
+    /**
+     * Group pattern by HTTP Method. If flow is configured with an empty list of method, then pattern is assigned to WILDCARD key.
+     * @param flows
+     * @return
+     */
+    private static Map<PathParameterHttpMethod, Set<PathParameter>> groupPatternsByMethod(final Stream<Flow> flows) {
+        final Map<PathParameterHttpMethod, Set<PathParameter>> patternsByMethod = flows
+            .flatMap(f -> {
+                List<Map.Entry<PathParameterHttpMethod, PathParameter>> flowByMethod;
+                if (f.getMethods().isEmpty()) {
+                    flowByMethod = List.of(Map.entry(PathParameterHttpMethod.WILDCARD, new PathParameter(f.getPath(), f.getOperator())));
+                } else {
+                    flowByMethod =
+                        f
+                            .getMethods()
+                            .stream()
+                            .map(m -> Map.entry(PathParameterHttpMethod.valueOf(m.name()), new PathParameter(f.getPath(), f.getOperator())))
+                            .collect(Collectors.toList());
+                }
+                return flowByMethod.stream();
+            })
+            .collect(Collectors.groupingBy(Map.Entry::getKey, Collectors.mapping(Map.Entry::getValue, Collectors.toSet())));
+
+        // Use an empty map for method without path param.
+        for (PathParameterHttpMethod method : PathParameterHttpMethod.values()) {
+            patternsByMethod.computeIfAbsent(method, param -> Set.of());
+        }
+        return patternsByMethod;
+    }
+
+    /**
+     * Extracts path parameters value regarding current request method and pathInfo.
+     * @param requestMethod is the HTTP Method for the current request
+     * @param requestPathInfo is the pathInfo for the current request
+     * @return a map of path parameters value by path parameter name
+     */
+    public Map<String, String> extract(final String requestMethod, final String requestPathInfo) {
+        Map<String, String> pathParameters = new HashMap<>();
+        computePathParam(PathParameterHttpMethod.WILDCARD, requestPathInfo, pathParameters);
+        computePathParam(requestMethod, requestPathInfo, pathParameters);
+        return pathParameters;
+    }
+
+    private void computePathParam(final String requestMethod, final String requestPathInfo, Map<String, String> pathParameters) {
+        computePathParam(PathParameterHttpMethod.valueOf(requestMethod), requestPathInfo, pathParameters);
+    }
+
+    private void computePathParam(final PathParameterHttpMethod method, final String requestPathInfo, Map<String, String> pathParameters) {
+        patternsByHttpMethod
+            .get(method)
+            .forEach(pattern -> {
+                String path = requestPathInfo;
+                try {
+                    path = QueryStringDecoder.decodeComponent(path, Charset.defaultCharset());
+                } catch (IllegalArgumentException ignored) {
+                    // Keep path as it is in case of exception
+                }
+
+                final Matcher matcher = pattern.getPathPattern().matcher(path);
+                if (matcher.find()) {
+                    pattern.getParameters().forEach(p -> pathParameters.put(p, matcher.group(p)));
+                }
+            });
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParametersProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParametersProcessor.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.processor.pathparameters;
+
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.core.processor.AbstractProcessor;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class PathParametersProcessor extends AbstractProcessor<ExecutionContext> {
+
+    private final PathParametersExtractor extractor;
+
+    public PathParametersProcessor(PathParametersExtractor extractor) {
+        this.extractor = extractor;
+    }
+
+    @Override
+    public void handle(ExecutionContext executionContext) {
+        final Request request = executionContext.request();
+        extractor.extract(request.method().name(), request.pathInfo()).forEach((key, value) -> request.pathParameters().set(key, value));
+        next.handle(executionContext);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/processor/pathparameters/PathParametersProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/jupiter/handlers/api/processor/pathparameters/PathParametersProcessor.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.handlers.api.processor.pathparameters;
+
+import io.gravitee.gateway.handlers.api.processor.pathparameters.PathParametersExtractor;
+import io.gravitee.gateway.reactive.core.context.MutableExecutionContext;
+import io.gravitee.gateway.reactive.core.processor.Processor;
+import io.reactivex.rxjava3.core.Completable;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class PathParametersProcessor implements Processor {
+
+    public static final String ID = "processor-path-parameters";
+
+    private final PathParametersExtractor extractor;
+
+    public PathParametersProcessor(PathParametersExtractor extractor) {
+        this.extractor = extractor;
+    }
+
+    @Override
+    public String getId() {
+        return ID;
+    }
+
+    @Override
+    public Completable execute(MutableExecutionContext ctx) {
+        return Completable.fromRunnable(() ->
+            extractor
+                .extract(ctx.request().method().name(), ctx.request().pathInfo())
+                .forEach((key, value) -> ctx.request().pathParameters().set(key, value))
+        );
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/ApiProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/ApiProcessorChainFactory.java
@@ -21,6 +21,8 @@ import static io.gravitee.gateway.reactive.handlers.api.processor.subscription.S
 import io.gravitee.definition.model.Cors;
 import io.gravitee.gateway.core.logging.utils.LoggingUtils;
 import io.gravitee.gateway.handlers.api.definition.Api;
+import io.gravitee.gateway.handlers.api.processor.pathparameters.PathParametersExtractor;
+import io.gravitee.gateway.jupiter.handlers.api.processor.pathparameters.PathParametersProcessor;
 import io.gravitee.gateway.reactive.api.hook.ProcessorHook;
 import io.gravitee.gateway.reactive.core.processor.Processor;
 import io.gravitee.gateway.reactive.core.processor.ProcessorChain;
@@ -91,6 +93,11 @@ public class ApiProcessorChainFactory {
         }
         if (overrideXForwardedPrefix) {
             preProcessorList.add(XForwardedPrefixProcessor.instance());
+        }
+
+        final PathParametersExtractor extractor = new PathParametersExtractor(api);
+        if (extractor.canExtractPathParams()) {
+            preProcessorList.add(new PathParametersProcessor(extractor));
         }
 
         preProcessorList.add(SubscriptionProcessor.instance(clientIdentifierHeader));

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParameterTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParameterTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.processor.pathparameters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.definition.model.flow.Operator;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PathParameterTest {
+
+    @Test
+    void should_not_have_parameters_starts_with_operator() {
+        final PathParameter cut = new PathParameter("/product/apim/item/portal", Operator.STARTS_WITH);
+        assertThat(cut.getParameters()).isEmpty();
+        assertThat(cut.getPathPattern()).hasToString(Pattern.compile("^/product/apim/item/portal(?:/.*)?$").toString());
+    }
+
+    @Test
+    void should_not_have_parameters_equals_operator() {
+        final PathParameter cut = new PathParameter("/product/apim/item/portal", Operator.EQUALS);
+        assertThat(cut.getParameters()).isEmpty();
+        assertThat(cut.getPathPattern()).hasToString(Pattern.compile("^/product/apim/item/portal/?$").toString());
+    }
+
+    @Test
+    void should_have_parameters_starts_with_operator() {
+        final PathParameter cut = new PathParameter("/product/:productId/item/:itemId", Operator.STARTS_WITH);
+        assertThat(cut.getParameters()).hasSize(2).contains("productId", "itemId");
+        assertThat(cut.getPathPattern())
+            .hasToString(
+                Pattern
+                    .compile(
+                        "^/product/(?<productId>[a-zA-Z0-9\\-._~%!$&'()* +,;=:@]+)/item/(?<itemId>[a-zA-Z0-9\\-._~%!$&'()* +,;=:@]+)(?:/.*)?$"
+                    )
+                    .toString()
+            );
+    }
+
+    @Test
+    void should_have_parameters_equals_operator() {
+        final PathParameter cut = new PathParameter("/product/:productId/item/:itemId", Operator.EQUALS);
+        assertThat(cut.getParameters()).hasSize(2).contains("productId", "itemId");
+        assertThat(cut.getPathPattern())
+            .hasToString(
+                Pattern
+                    .compile(
+                        "^/product/(?<productId>[a-zA-Z0-9\\-._~%!$&'()* +,;=:@]+)/item/(?<itemId>[a-zA-Z0-9\\-._~%!$&'()* +,;=:@]+)/?$"
+                    )
+                    .toString()
+            );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideParameters")
+    void should_check_equality(final PathParameter first, final PathParameter second, boolean expectedResult) {
+        assertThat(first.equals(second)).isEqualTo(expectedResult);
+    }
+
+    public static Stream<Arguments> provideParameters() {
+        return Stream.of(
+            Arguments.of(
+                new PathParameter("/products/", Operator.STARTS_WITH),
+                new PathParameter("/products/", Operator.STARTS_WITH),
+                true
+            ),
+            Arguments.of(
+                new PathParameter("/products/", Operator.STARTS_WITH),
+                new PathParameter("/products/second", Operator.STARTS_WITH),
+                false
+            ),
+            Arguments.of(new PathParameter("/products/", Operator.STARTS_WITH), null, false),
+            Arguments.of(new PathParameter("/products/", Operator.EQUALS), new PathParameter("/products/", Operator.STARTS_WITH), false)
+        );
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParametersExtractorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParametersExtractorTest.java
@@ -1,0 +1,196 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.processor.pathparameters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.definition.model.flow.Flow;
+import io.gravitee.definition.model.flow.Operator;
+import io.gravitee.definition.model.flow.PathOperator;
+import io.gravitee.gateway.handlers.api.definition.Api;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PathParametersExtractorTest {
+
+    @Test
+    void can_not_extract_param_null_api() {
+        assertThatThrownBy(() -> new PathParametersExtractor(null)).isInstanceOf(NullPointerException.class).hasMessage("Api is mandatory");
+    }
+
+    @Test
+    void can_not_extract_param_no_flow() {
+        assertThat(new PathParametersExtractor(new Api(new io.gravitee.definition.model.Api())).canExtractPathParams()).isFalse();
+    }
+
+    @Test
+    void can_not_extract_param_no_flow_with_path_param() {
+        final Api api = new Api(new io.gravitee.definition.model.Api());
+        final Flow flow = new Flow();
+        final PathOperator pathOperator = new PathOperator();
+        pathOperator.setOperator(Operator.STARTS_WITH);
+        pathOperator.setPath("/products");
+        flow.setPathOperator(pathOperator);
+        api.getDefinition().setFlows(List.of(flow));
+        assertThat(new PathParametersExtractor(api).canExtractPathParams()).isFalse();
+    }
+
+    @Test
+    void can_extract_param_flow_with_path_param() {
+        final Api api = new Api(new io.gravitee.definition.model.Api());
+        final Flow flow = new Flow();
+        final PathOperator pathOperator = new PathOperator();
+        pathOperator.setOperator(Operator.STARTS_WITH);
+        pathOperator.setPath("/products/:productId");
+        flow.setPathOperator(pathOperator);
+        api.getDefinition().setFlows(List.of(flow));
+        assertThat(new PathParametersExtractor(api).canExtractPathParams()).isTrue();
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideParameters")
+    void can_extract_flow_and_extract_param_on_request(
+        Api api,
+        String method,
+        String path,
+        Map<String, String> expectedPathParam,
+        Set<String> excludedPathParam
+    ) {
+        final PathParametersExtractor cut = new PathParametersExtractor(api);
+        final Map<String, String> pathParams = cut.extract(method, path);
+        assertThat(pathParams).isEqualTo(expectedPathParam).doesNotContainKeys(excludedPathParam.toArray(new String[0]));
+    }
+
+    public static Stream<Arguments> provideParameters() throws IOException {
+        return Stream.of(
+            Arguments.of(readApi("simple-api"), "GET", "/products", Map.of(), Set.of()),
+            Arguments.of(readApi("simple-api"), "TRACE", "/products", Map.of(), Set.of()),
+            Arguments.of(readApi("simple-api"), "GET", "/products/my-product", Map.of("productId", "my-product"), Set.of()),
+            Arguments.of(
+                readApi("simple-api"),
+                "GET",
+                "/products/my-product/hello",
+                Map.of("productId", "my-product", "id", "my-product"),
+                Set.of()
+            ),
+            Arguments.of(readApi("simple-api"), "DELETE", "/products/my-product/hello", Map.of("productId", "my-product"), Set.of("id")),
+            Arguments.of(readApi("simple-api"), "PUT", "/products/my-product/hello", Map.of("id", "my-product"), Set.of("productId")),
+            Arguments.of(
+                readApi("simple-api"),
+                "GET",
+                "/products/my-product/hello/something",
+                Map.of("productId", "my-product"),
+                Set.of("id")
+            ),
+            Arguments.of(
+                readApi("simple-api"),
+                "GET",
+                "/products/my-product/items/my-item",
+                Map.of("productId", "my-product", "itemId", "my-item"),
+                Set.of()
+            ),
+            Arguments.of(readApi("api-flows-equals-operator"), "GET", "/products", Map.of(), Set.of()),
+            Arguments.of(readApi("api-flows-equals-operator"), "TRACE", "/products", Map.of(), Set.of()),
+            Arguments.of(readApi("api-flows-equals-operator"), "GET", "/products/my-product", Map.of("productId", "my-product"), Set.of()),
+            Arguments.of(
+                readApi("api-flows-equals-operator"),
+                "GET",
+                "/products/my-product/hello",
+                Map.of("id", "my-product"),
+                Set.of("productId")
+            ),
+            Arguments.of(readApi("api-flows-equals-operator"), "DELETE", "/products/my-product/hello", Map.of(), Set.of("productId", "id")),
+            Arguments.of(
+                readApi("api-flows-equals-operator"),
+                "DELETE",
+                "/products/my-product",
+                Map.of("productId", "my-product"),
+                Set.of("id")
+            ),
+            Arguments.of(
+                readApi("api-flows-equals-operator"),
+                "PUT",
+                "/products/my-product/hello",
+                Map.of("id", "my-product"),
+                Set.of("productId")
+            ),
+            Arguments.of(
+                readApi("api-flows-equals-operator"),
+                "GET",
+                "/products/my-product/hello/something",
+                Map.of(),
+                Set.of("productId", "id")
+            ),
+            Arguments.of(
+                readApi("api-flows-equals-operator"),
+                "GET",
+                "/products/my-product/items/my-item",
+                Map.of("productId", "my-product", "itemId", "my-item"),
+                Set.of()
+            ),
+            // This test is a particular overlapping case:
+            // - GET starts with /products/:productId/item/:itemId
+            // - *   starts with /:productId
+            // As wildcard flows are evaluated first, 'productId' will have the value overridden from GET flow.
+            Arguments.of(
+                readApi("api-overlap"),
+                "GET",
+                "/products/my-product/items/my-item",
+                Map.of("productId", "my-product", "itemId", "my-item"),
+                Set.of()
+            ),
+            // This test is a particular overlapping case:
+            // - *   starts with /products/:productId/item/:itemId
+            // - GET starts with /:productId
+            // As wildcard flows are evaluated first, 'productId' will have the value overridden from * (wildcard) flow.
+            Arguments.of(
+                readApi("api-overlap-reverse-wildcard"),
+                "GET",
+                "/products/my-product/items/my-item",
+                Map.of("productId", "products", "itemId", "my-item"),
+                Set.of()
+            )
+        );
+    }
+
+    private static Api readApi(String name) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        return new Api(
+            mapper.readValue(
+                PathParametersExtractorTest.class.getClassLoader().getResourceAsStream("apis/pathparams/" + name + ".json"),
+                io.gravitee.definition.model.Api.class
+            )
+        );
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParametersProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParametersProcessorTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.processor.pathparameters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.common.util.LinkedMultiValueMap;
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.Request;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class PathParametersProcessorTest {
+
+    @Mock
+    private PathParametersExtractor pathParametersExtractor;
+
+    @Mock
+    private ExecutionContext ctx;
+
+    @Mock
+    private Request request;
+
+    private PathParametersProcessor cut;
+
+    @BeforeEach
+    void setUp() {
+        when(ctx.request()).thenReturn(request);
+        when(request.method()).thenReturn(HttpMethod.GET);
+        cut = new PathParametersProcessor(pathParametersExtractor);
+    }
+
+    @Test
+    void should_assign_path_params_to_request_and_call_next() {
+        final AtomicBoolean nextCalled = new AtomicBoolean(false);
+        cut.handler(ctx -> {
+            nextCalled.set(true);
+        });
+        final LinkedMultiValueMap<String, String> pathParameters = new LinkedMultiValueMap<>();
+        when(request.pathParameters()).thenReturn(pathParameters);
+        when(pathParametersExtractor.extract(any(), any())).thenReturn(Map.of("key", "value", "anotherKey", "anotherValue"));
+
+        cut.handle(ctx);
+
+        assertThat(pathParameters).hasSize(2).containsEntry("key", List.of("value")).containsEntry("anotherKey", List.of("anotherValue"));
+        assertThat(nextCalled.get()).isTrue();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/processor/pathparameters/PathParametersProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/jupiter/handlers/api/processor/pathparameters/PathParametersProcessorTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.jupiter.handlers.api.processor.pathparameters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.common.util.LinkedMultiValueMap;
+import io.gravitee.gateway.handlers.api.processor.pathparameters.PathParametersExtractor;
+import io.gravitee.gateway.reactive.core.context.MutableExecutionContext;
+import io.gravitee.gateway.reactive.core.context.MutableRequest;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class PathParametersProcessorTest {
+
+    @Mock
+    private PathParametersExtractor pathParametersExtractor;
+
+    @Mock
+    private MutableExecutionContext ctx;
+
+    @Mock
+    private MutableRequest request;
+
+    private PathParametersProcessor cut;
+
+    @BeforeEach
+    void setUp() {
+        when(ctx.request()).thenReturn(request);
+        when(request.method()).thenReturn(HttpMethod.GET);
+        cut = new PathParametersProcessor(pathParametersExtractor);
+    }
+
+    @Test
+    void should_assign_path_params_to_request_and_complete() {
+        final LinkedMultiValueMap<String, String> pathParameters = new LinkedMultiValueMap<>();
+        when(request.pathParameters()).thenReturn(pathParameters);
+        when(pathParametersExtractor.extract(any(), any())).thenReturn(Map.of("key", "value", "anotherKey", "anotherValue"));
+
+        cut.execute(ctx).test().assertComplete();
+
+        assertThat(pathParameters).hasSize(2).containsEntry("key", List.of("value")).containsEntry("anotherKey", List.of("anotherValue"));
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/resources/apis/pathparams/api-flows-equals-operator.json
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/resources/apis/pathparams/api-flows-equals-operator.json
@@ -1,0 +1,149 @@
+{
+  "plans": [
+    {
+      "id": "keyless",
+      "name": "Keyless",
+      "security": "KEY_LESS",
+      "flows": [
+        {
+          "name": "Item",
+          "path-operator": {
+            "path": "/products/:productId/items/:itemId",
+            "operator": "EQUALS"
+          },
+          "condition": "",
+          "methods": [],
+          "pre": [],
+          "post": [],
+          "enabled": true
+        },
+        {
+          "name": "Products",
+          "path-operator": {
+            "path": "/products",
+            "operator": "EQUALS"
+          },
+          "condition": "",
+          "methods": [],
+          "pre": [],
+          "post": [],
+          "enabled": true
+        },
+        {
+          "name": "Products",
+          "path-operator": {
+            "path": "/products",
+            "operator": "EQUALS"
+          },
+          "condition": "",
+          "methods": [
+            "GET",
+            "PUT"
+          ],
+          "pre": [],
+          "post": [],
+          "enabled": true
+        },
+        {
+          "name": "Equals hello",
+          "path-operator": {
+            "path": "/products/:id/hello",
+            "operator": "EQUALS"
+          },
+          "condition": "",
+          "methods": [
+            "GET",
+            "PUT"
+          ],
+          "pre": [],
+          "post": [],
+          "enabled": true
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "Accept all - And add path parameters to headers",
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "condition": "",
+      "methods": [],
+      "pre": [
+        {
+          "name": "Path Parameters to headers",
+          "description": "",
+          "enabled": true,
+          "policy": "path-param-to-header"
+        }
+      ],
+      "post": [],
+      "enabled": true
+    },
+    {
+      "name": "Product id",
+      "path-operator": {
+        "path": "/products/:productId",
+        "operator": "EQUALS"
+      },
+      "condition": "",
+      "methods": [
+        "CONNECT",
+        "DELETE",
+        "GET",
+        "HEAD",
+        "OPTIONS",
+        "PATCH",
+        "POST",
+        "TRACE"
+      ],
+      "pre": [],
+      "post": [],
+      "enabled": true
+    },
+    {
+      "name": "Products",
+      "path-operator": {
+        "path": "/products",
+        "operator": "EQUALS"
+      },
+      "condition": "",
+      "methods": [],
+      "pre": [],
+      "post": [],
+      "enabled": true
+    },
+    {
+      "name": "",
+      "path-operator": {
+        "path": "/products",
+        "operator": "EQUALS"
+      },
+      "condition": "",
+      "methods": [
+        "GET"
+      ],
+      "pre": [],
+      "post": [],
+      "enabled": true
+    },
+    {
+      "name": "Product",
+      "path-operator": {
+        "path": "/products/:productId",
+        "operator": "EQUALS"
+      },
+      "condition": "",
+      "methods": [
+        "DELETE",
+        "GET"
+      ],
+      "pre": [],
+      "post": [],
+      "enabled": true
+    }
+  ],
+  "resources": []
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/resources/apis/pathparams/api-overlap-reverse-wildcard.json
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/resources/apis/pathparams/api-overlap-reverse-wildcard.json
@@ -1,0 +1,37 @@
+{
+  "plans": [
+    {
+      "id": "keyless",
+      "name": "Keyless",
+      "security": "KEY_LESS",
+      "flows": [
+        {
+          "name": "Item",
+          "path-operator": {
+            "path": "/products/:productId/items/:itemId",
+            "operator": "STARTS_WITH"
+          },
+          "condition": "",
+          "methods": [],
+          "pre": [],
+          "post": [],
+          "enabled": true
+        },
+        {
+          "name": "Product",
+          "path-operator": {
+            "path": "/:productId",
+            "operator": "STARTS_WITH"
+          },
+          "condition": "",
+          "methods": ["GET"],
+          "pre": [],
+          "post": [],
+          "enabled": true
+        }
+      ]
+    }
+  ],
+  "flows": [],
+  "resources": []
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/resources/apis/pathparams/api-overlap.json
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/resources/apis/pathparams/api-overlap.json
@@ -1,0 +1,37 @@
+{
+  "plans": [
+    {
+      "id": "keyless",
+      "name": "Keyless",
+      "security": "KEY_LESS",
+      "flows": [
+        {
+          "name": "Item",
+          "path-operator": {
+            "path": "/products/:productId/items/:itemId",
+            "operator": "STARTS_WITH"
+          },
+          "condition": "",
+          "methods": ["GET"],
+          "pre": [],
+          "post": [],
+          "enabled": true
+        },
+        {
+          "name": "Product",
+          "path-operator": {
+            "path": "/:productId",
+            "operator": "STARTS_WITH"
+          },
+          "condition": "",
+          "methods": [],
+          "pre": [],
+          "post": [],
+          "enabled": true
+        }
+      ]
+    }
+  ],
+  "flows": [],
+  "resources": []
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/resources/apis/pathparams/simple-api.json
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/resources/apis/pathparams/simple-api.json
@@ -1,0 +1,149 @@
+{
+  "plans": [
+    {
+      "id": "keyless",
+      "name": "Keyless",
+      "security": "KEY_LESS",
+      "flows": [
+        {
+          "name": "Item",
+          "path-operator": {
+            "path": "/products/:productId/items/:itemId",
+            "operator": "STARTS_WITH"
+          },
+          "condition": "",
+          "methods": [],
+          "pre": [],
+          "post": [],
+          "enabled": true
+        },
+        {
+          "name": "Products",
+          "path-operator": {
+            "path": "/products",
+            "operator": "STARTS_WITH"
+          },
+          "condition": "",
+          "methods": [],
+          "pre": [],
+          "post": [],
+          "enabled": true
+        },
+        {
+          "name": "Products",
+          "path-operator": {
+            "path": "/products",
+            "operator": "STARTS_WITH"
+          },
+          "condition": "",
+          "methods": [
+            "GET",
+            "PUT"
+          ],
+          "pre": [],
+          "post": [],
+          "enabled": true
+        },
+        {
+          "name": "Equals hello",
+          "path-operator": {
+            "path": "/products/:id/hello",
+            "operator": "EQUALS"
+          },
+          "condition": "",
+          "methods": [
+            "GET",
+            "PUT"
+          ],
+          "pre": [],
+          "post": [],
+          "enabled": true
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "Accept all - And add path parameters to headers",
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "condition": "",
+      "methods": [],
+      "pre": [
+        {
+          "name": "Path Parameters to headers",
+          "description": "",
+          "enabled": true,
+          "policy": "path-param-to-header"
+        }
+      ],
+      "post": [],
+      "enabled": true
+    },
+    {
+      "name": "Product id",
+      "path-operator": {
+        "path": "/products/:productId",
+        "operator": "STARTS_WITH"
+      },
+      "condition": "",
+      "methods": [
+        "CONNECT",
+        "DELETE",
+        "GET",
+        "HEAD",
+        "OPTIONS",
+        "PATCH",
+        "POST",
+        "TRACE"
+      ],
+      "pre": [],
+      "post": [],
+      "enabled": true
+    },
+    {
+      "name": "Products",
+      "path-operator": {
+        "path": "/products",
+        "operator": "STARTS_WITH"
+      },
+      "condition": "",
+      "methods": [],
+      "pre": [],
+      "post": [],
+      "enabled": true
+    },
+    {
+      "name": "",
+      "path-operator": {
+        "path": "/products",
+        "operator": "STARTS_WITH"
+      },
+      "condition": "",
+      "methods": [
+        "GET"
+      ],
+      "pre": [],
+      "post": [],
+      "enabled": true
+    },
+    {
+      "name": "Product",
+      "path-operator": {
+        "path": "/products/:productId",
+        "operator": "STARTS_WITH"
+      },
+      "condition": "",
+      "methods": [
+        "DELETE",
+        "GET"
+      ],
+      "pre": [],
+      "post": [],
+      "enabled": true
+    }
+  ],
+  "resources": []
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/fakes/policies/PathParamToHeaderPolicy.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/fakes/policies/PathParamToHeaderPolicy.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.tests.fakes.policies;
+
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.policy.Policy;
+import io.gravitee.policy.api.PolicyChain;
+import io.gravitee.policy.api.annotations.OnRequest;
+import io.gravitee.policy.api.annotations.OnResponse;
+import io.reactivex.rxjava3.core.Completable;
+
+/**
+ * Policy that add a header for each Path Parameter:
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class PathParamToHeaderPolicy implements Policy {
+
+    public static final String X_PATH_PARAM = "X-PathParam-";
+
+    @OnRequest
+    public void onRequest(final Request request, final Response response, final PolicyChain policyChain) {
+        if (request.pathParameters() != null) {
+            request.pathParameters().forEach((key, value) -> request.headers().add(X_PATH_PARAM + key, value.get(0)));
+        }
+        policyChain.doNext(request, response);
+    }
+
+    @OnResponse
+    public void onResponse(final Request request, final Response response, final PolicyChain policyChain) {
+        if (request.pathParameters() != null) {
+            request.pathParameters().forEach((key, value) -> response.headers().add(X_PATH_PARAM + key, value.get(0)));
+        }
+        policyChain.doNext(request, response);
+    }
+
+    @Override
+    public String id() {
+        return "path-param-to-header";
+    }
+
+    @Override
+    public Completable onRequest(HttpExecutionContext ctx) {
+        return Completable.fromRunnable(() -> {
+            if (ctx.request().pathParameters() != null) {
+                ctx.request().pathParameters().forEach((key, value) -> ctx.request().headers().add(X_PATH_PARAM + key, value.get(0)));
+            }
+        });
+    }
+
+    @Override
+    public Completable onResponse(HttpExecutionContext ctx) {
+        return Completable.fromRunnable(() -> {
+            if (ctx.request().pathParameters() != null) {
+                ctx.request().pathParameters().forEach((key, value) -> ctx.response().headers().add(X_PATH_PARAM + key, value.get(0)));
+            }
+        });
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/http/PathParametersIntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/http/PathParametersIntegrationTest.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.tests.http;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.request;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import com.github.tomakehurst.wiremock.matching.UrlPattern;
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.ExecutionMode;
+import io.gravitee.gateway.tests.fakes.policies.PathParamToHeaderPolicy;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PathParametersIntegrationTest extends AbstractGatewayTest {
+
+    @Override
+    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
+        super.configureGateway(gatewayConfigurationBuilder);
+        gatewayConfigurationBuilder.set("api.jupiterMode.enabled", "true");
+    }
+
+    @Override
+    public void configureApi(Api api) {
+        api.setExecutionMode(ExecutionMode.JUPITER);
+    }
+
+    @Override
+    public void configurePolicies(Map<String, PolicyPlugin> policies) {
+        policies.put("path-param-to-header", PolicyBuilder.build("path-param-to-header", PathParamToHeaderPolicy.class));
+    }
+
+    @Test
+    @DeployApi("/apis/http/pathparam/api-no-path-param.json")
+    void should_not_add_path_param_to_headers_when_no_param(HttpClient httpClient) throws InterruptedException {
+        wiremock.stubFor(get("/endpoint").willReturn(ok("response from backend")));
+
+        httpClient
+            .rxRequest(HttpMethod.GET, "/test")
+            .flatMap(HttpClientRequest::rxSend)
+            .flatMap(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.body();
+            })
+            .test()
+            .await()
+            .assertComplete()
+            .assertNoErrors()
+            .assertValue(body -> {
+                assertThat(body).hasToString("response from backend");
+                return true;
+            });
+
+        wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint")));
+    }
+
+    @ParameterizedTest
+    @DeployApi("/apis/http/pathparam/api-path-param.json")
+    @MethodSource("provideParameters")
+    void should_add_path_param_to_headers_when_no_param(
+        String method,
+        String path,
+        Map<String, String> expectedHeaders,
+        Set<String> excludedHeaders,
+        HttpClient httpClient
+    ) throws InterruptedException {
+        wiremock.stubFor(request(method, urlEqualTo("/endpoint" + path)).willReturn(ok("response from backend")));
+
+        httpClient
+            .rxRequest(HttpMethod.valueOf(method), "/test" + path)
+            .flatMap(HttpClientRequest::rxSend)
+            .flatMap(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.body();
+            })
+            .test()
+            .await()
+            .assertComplete()
+            .assertNoErrors()
+            .assertValue(body -> {
+                assertThat(body).hasToString("response from backend");
+                return true;
+            });
+
+        final RequestPatternBuilder requestedFor = requestedFor(method, urlPathEqualTo("/endpoint" + path));
+        expectedHeaders.forEach((key, value) -> requestedFor.withHeader(PathParamToHeaderPolicy.X_PATH_PARAM + key, equalTo(value)));
+        excludedHeaders.forEach(key -> requestedFor.withoutHeader(PathParamToHeaderPolicy.X_PATH_PARAM + key));
+
+        wiremock.verify(1, requestedFor);
+    }
+
+    private RequestPatternBuilder requestedFor(String method, UrlPattern urlPattern) {
+        return new RequestPatternBuilder(RequestMethod.fromString(method), urlPattern);
+    }
+
+    public Stream<Arguments> provideParameters() {
+        return Stream.of(
+            Arguments.of("GET", "/products", Map.of(), Set.of()),
+            Arguments.of("TRACE", "/products", Map.of(), Set.of()),
+            Arguments.of("GET", "/products/my-product", Map.of("productId", "my-product"), Set.of()),
+            Arguments.of("GET", "/products/my-product/hello", Map.of("productId", "my-product", "id", "my-product"), Set.of()),
+            Arguments.of("DELETE", "/products/my-product/hello", Map.of("productId", "my-product"), Set.of("id")),
+            Arguments.of("PUT", "/products/my-product/hello", Map.of("id", "my-product"), Set.of("productId")),
+            Arguments.of("GET", "/products/my-product/hello/something", Map.of("productId", "my-product"), Set.of("id")),
+            Arguments.of("GET", "/products/my-product/items/my-item", Map.of("productId", "my-product", "itemId", "my-item"), Set.of())
+        );
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/http/PathParametersV3CompatibilityIntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/http/PathParametersV3CompatibilityIntegrationTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.tests.http;
+
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.ExecutionMode;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class PathParametersV3CompatibilityIntegrationTest extends PathParametersIntegrationTest {
+
+    @Override
+    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
+        super.configureGateway(gatewayConfigurationBuilder);
+        gatewayConfigurationBuilder.set("api.jupiterMode.enabled", "true");
+    }
+
+    @Override
+    public void configureApi(Api api) {
+        super.configureApi(api);
+        api.setExecutionMode(ExecutionMode.V3);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/http/PathParametersV3IntegrationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/java/io/gravitee/gateway/tests/http/PathParametersV3IntegrationTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.tests.http;
+
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.ExecutionMode;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class PathParametersV3IntegrationTest extends PathParametersIntegrationTest {
+
+    @Override
+    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
+        super.configureGateway(gatewayConfigurationBuilder);
+        gatewayConfigurationBuilder.set("api.jupiterMode.enabled", "false");
+    }
+
+    @Override
+    public void configureApi(Api api) {
+        super.configureApi(api);
+        api.setExecutionMode(ExecutionMode.V3);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/resources/apis/http/pathparam/api-no-path-param.json
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/resources/apis/http/pathparam/api-no-path-param.json
@@ -1,0 +1,42 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Path Parameters to headers",
+          "description": "",
+          "enabled": true,
+          "policy": "path-param-to-header",
+          "configuration": {}
+        }
+      ],
+      "post": []
+    }
+  ],
+  "resources": []
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/resources/apis/http/pathparam/api-path-param.json
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-integration/src/test/resources/apis/http/pathparam/api-path-param.json
@@ -1,0 +1,167 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "plans": [
+    {
+      "name": "Keyless",
+      "description": "keyless",
+      "security": "KEY_LESS",
+      "flows": [
+        {
+          "name": "Item",
+          "path-operator": {
+            "path": "/products/:productId/items/:itemId",
+            "operator": "STARTS_WITH"
+          },
+          "condition": "",
+          "methods": [],
+          "pre": [],
+          "post": [],
+          "enabled": true
+        },
+        {
+          "name": "Products",
+          "path-operator": {
+            "path": "/products",
+            "operator": "STARTS_WITH"
+          },
+          "condition": "",
+          "methods": [],
+          "pre": [],
+          "post": [],
+          "enabled": true
+        },
+        {
+          "name": "Products",
+          "path-operator": {
+            "path": "/products",
+            "operator": "STARTS_WITH"
+          },
+          "condition": "",
+          "methods": [
+            "GET",
+            "PUT"
+          ],
+          "pre": [],
+          "post": [],
+          "enabled": true
+        },
+        {
+          "name": "Equals hello",
+          "path-operator": {
+            "path": "/products/:id/hello",
+            "operator": "EQUALS"
+          },
+          "condition": "",
+          "methods": [
+            "GET",
+            "PUT"
+          ],
+          "pre": [],
+          "post": [],
+          "enabled": true
+        }
+      ],
+      "comment_required": false
+    }
+  ],
+  "flows": [
+    {
+      "name": "Accept all - And add path parameters to headers",
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "condition": "",
+      "methods": [],
+      "pre": [
+        {
+          "name": "Path Parameters to headers",
+          "description": "",
+          "enabled": true,
+          "policy": "path-param-to-header",
+          "configuration": {}
+        }
+      ],
+      "post": [],
+      "enabled": true
+    },
+    {
+      "name": "Product id",
+      "path-operator": {
+        "path": "/products/:productId",
+        "operator": "STARTS_WITH"
+      },
+      "condition": "",
+      "methods": [
+        "CONNECT",
+        "DELETE",
+        "GET",
+        "HEAD",
+        "OPTIONS",
+        "PATCH",
+        "POST",
+        "TRACE"
+      ],
+      "pre": [],
+      "post": [],
+      "enabled": true
+    },
+    {
+      "name": "Products",
+      "path-operator": {
+        "path": "/products",
+        "operator": "STARTS_WITH"
+      },
+      "condition": "",
+      "methods": [],
+      "pre": [],
+      "post": [],
+      "enabled": true
+    },
+    {
+      "name": "",
+      "path-operator": {
+        "path": "/products",
+        "operator": "STARTS_WITH"
+      },
+      "condition": "",
+      "methods": [
+        "GET"
+      ],
+      "pre": [],
+      "post": [],
+      "enabled": true
+    },
+    {
+      "name": "Product",
+      "path-operator": {
+        "path": "/products/:productId",
+        "operator": "STARTS_WITH"
+      },
+      "condition": "",
+      "methods": [
+        "DELETE",
+        "GET"
+      ],
+      "pre": [],
+      "post": [],
+      "enabled": true
+    }
+  ],
+  "resources": []
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/plugin/PluginManifestLoader.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/plugin/PluginManifestLoader.java
@@ -57,7 +57,7 @@ public class PluginManifestLoader {
                 }
             }
         } catch (IOException e) {
-            LOGGER.warn("Unable to find a 'plugin.properties' file in src/main/resources folder", e);
+            LOGGER.warn("Unable to find a 'plugin.properties' file in src/main/resources folder");
         }
 
         return null;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-446

## Description

Implement path parameter resolution for v2 apis.
Done for v3 engine and jupiter one.

- It prepare a collection of patterns at processor chain creation, and instantiate the processor only if path params are detected
- It extracts path parameters for a request based on the prepared collection of patterns

For a request method, patterns for flows configured for all methods (wildcard) are evaluated first, then we evaluate patterns for the current http method. 


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bqjagystgu.chromatic.com)
<!-- Storybook placeholder end -->
