### PR TITLE
fix: execute security chain after CORSPreflight Processor in jupiter/v4

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactor.java
@@ -205,10 +205,10 @@ public class SyncApiReactor extends AbstractLifecycleComponent<ReactorHandler> i
         return executeProcessorChain(ctx, beforeHandleProcessors, REQUEST)
             // Execute platform flow chain
             .andThen(platformFlowChain.execute(ctx, REQUEST))
-            // Execute security chain.
-            .andThen(securityChain.execute(ctx))
             // Execute before flows processors
             .andThen(executeProcessorChain(ctx, beforeApiFlowsProcessors, REQUEST))
+            // Execute security chain.
+            .andThen(securityChain.execute(ctx))
             .andThen(executeFlowChain(ctx, apiPlanFlowChain, REQUEST))
             .andThen(executeFlowChain(ctx, apiFlowChain, REQUEST))
             // All request flows have been executed. Invokes backend.

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
@@ -239,10 +239,10 @@ public class DefaultApiReactor extends AbstractLifecycleComponent<ReactorHandler
         return new CompletableReactorChain(executeProcessorChain(ctx, beforeHandleProcessors, REQUEST))
             // Execute platform flow chain.
             .chainWith(platformFlowChain.execute(ctx, REQUEST))
-            // Execute security chain.
-            .chainWith(securityChain.execute(ctx))
             // Before flows processors.
             .chainWith(executeProcessorChain(ctx, beforeApiExecutionProcessors, REQUEST))
+            // Execute security chain.
+            .chainWith(securityChain.execute(ctx))
             // Resolve entrypoint and prepare request to be handled.
             .chainWith(handleEntrypointRequest(ctx))
             // Execute all flows for request phases.

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactorTest.java
@@ -22,7 +22,13 @@ import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.gravitee.common.component.Lifecycle;
 import io.gravitee.definition.model.Logging;
@@ -47,8 +53,6 @@ import io.gravitee.gateway.reactive.core.context.interruption.InterruptionExcept
 import io.gravitee.gateway.reactive.core.context.interruption.InterruptionFailureException;
 import io.gravitee.gateway.reactive.core.processor.ProcessorChain;
 import io.gravitee.gateway.reactive.core.tracing.TracingHook;
-import io.gravitee.gateway.reactive.core.v4.analytics.AnalyticsContext;
-import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
 import io.gravitee.gateway.reactive.handlers.api.adapter.invoker.ConnectionHandlerAdapter;
 import io.gravitee.gateway.reactive.handlers.api.adapter.invoker.InvokerAdapter;
 import io.gravitee.gateway.reactive.handlers.api.flow.FlowChain;
@@ -78,7 +82,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.*;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -208,12 +215,6 @@ class SyncApiReactorTest {
 
     @Spy
     Completable spyInterruptSecurityChain = Completable.error(new InterruptionFailureException(new ExecutionFailure(UNAUTHORIZED_401)));
-
-    @Mock
-    AnalyticsContext analyticsContext;
-
-    @Mock
-    LoggingContext loggingContext;
 
     SyncApiReactor cut;
 
@@ -401,14 +402,14 @@ class SyncApiReactorTest {
         when(securityChain.execute(any())).thenReturn(spySecurityChain);
         ReflectionTestUtils.setField(cut, "securityChain", securityChain);
 
-        TestObserver<Void> handleRequestObserver = cut.handle(ctx).test();
+        cut.handle(ctx).test().await().assertComplete();
 
         InOrder orderedChain = getInOrder();
 
         orderedChain.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         orderedChain.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        orderedChain.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         orderedChain.verify(spyBeforeApiFlowsProcessors).subscribe(any(CompletableObserver.class));
+        orderedChain.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         orderedChain.verify(spyRequestApiPlanFlowChain).subscribe(any(CompletableObserver.class));
         orderedChain.verify(spyRequestApiFlowChain).subscribe(any(CompletableObserver.class));
         orderedChain.verify(spyInvokerAdapterChain).subscribe(any(CompletableObserver.class));
@@ -438,14 +439,13 @@ class SyncApiReactorTest {
         when(securityChain.execute(any())).thenReturn(spySecurityChain);
         ReflectionTestUtils.setField(cut, "securityChain", securityChain);
 
-        TestObserver<Void> handleRequestObserver = cut.handle(ctx).test();
-
+        cut.handle(ctx).test().await().assertComplete();
         InOrder orderedChain = getInOrder();
 
         orderedChain.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         orderedChain.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        orderedChain.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         orderedChain.verify(spyBeforeApiFlowsProcessors).subscribe(any(CompletableObserver.class));
+        orderedChain.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         orderedChain.verify(spyRequestApiPlanFlowChain).subscribe(any(CompletableObserver.class));
         orderedChain.verify(spyRequestApiFlowChain).subscribe(any(CompletableObserver.class));
         orderedChain.verify(spyInvokerAdapterChain).subscribe(any(CompletableObserver.class));
@@ -483,10 +483,10 @@ class SyncApiReactorTest {
         when(securityChain.execute(any())).thenReturn(spySecurityChain);
         ReflectionTestUtils.setField(cut, "securityChain", securityChain);
 
-        TestObserver<Void> handleRequestObserver = cut.handle(ctx).test();
+        cut.handle(ctx).subscribe();
 
         verify(endpointInvoker).invoke(any(), any(), handlerArgumentCaptor.capture());
-        assertThat(handlerArgumentCaptor.getValue()).isNotNull().isInstanceOf(ConnectionHandlerAdapter.class);
+        assertThat(handlerArgumentCaptor.getValue()).isInstanceOf(ConnectionHandlerAdapter.class);
     }
 
     @Test
@@ -539,14 +539,13 @@ class SyncApiReactorTest {
         when(securityChain.execute(any())).thenReturn(spySecurityChain);
         ReflectionTestUtils.setField(cut, "securityChain", securityChain);
 
-        TestObserver<Void> handleRequestObserver = cut.handle(ctx).test();
-
+        cut.handle(ctx).test().await().assertComplete();
         InOrder orderedChain = getInOrder();
 
         orderedChain.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         orderedChain.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        orderedChain.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         orderedChain.verify(spyBeforeApiFlowsProcessors).subscribe(any(CompletableObserver.class));
+        orderedChain.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         orderedChain.verify(spyRequestApiPlanFlowChain).subscribe(any(CompletableObserver.class));
         orderedChain.verify(spyRequestApiFlowChain).subscribe(any(CompletableObserver.class));
         spyInvokerAdapterError.test().assertError(clazz);
@@ -574,15 +573,15 @@ class SyncApiReactorTest {
         when(securityChain.execute(any())).thenReturn(spySecurityChain);
         ReflectionTestUtils.setField(cut, "securityChain", securityChain);
 
-        TestObserver<Void> handleRequestObserver = cut.handle(ctx).test();
+        cut.handle(ctx).subscribe();
         testScheduler.advanceTimeBy(REQUEST_TIMEOUT + 30L, TimeUnit.MILLISECONDS);
 
         InOrder orderedChain = getInOrder();
 
         orderedChain.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         orderedChain.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        orderedChain.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         orderedChain.verify(spyBeforeApiFlowsProcessors).subscribe(any(CompletableObserver.class));
+        orderedChain.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         orderedChain.verify(spyRequestApiPlanFlowChain).subscribe(any(CompletableObserver.class));
         orderedChain.verify(spyRequestApiFlowChain).subscribe(any(CompletableObserver.class));
         spyTimeout.test().assertNotComplete();
@@ -612,15 +611,15 @@ class SyncApiReactorTest {
         when(securityChain.execute(any())).thenReturn(spySecurityChain);
         ReflectionTestUtils.setField(cut, "securityChain", securityChain);
 
-        TestObserver<Void> handleRequestObserver = cut.handle(ctx).test();
+        cut.handle(ctx).subscribe();
         testScheduler.advanceTimeBy(REQUEST_TIMEOUT + 30L, TimeUnit.MILLISECONDS);
 
         InOrder orderedChain = getInOrder();
 
         orderedChain.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         orderedChain.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        orderedChain.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         orderedChain.verify(spyBeforeApiFlowsProcessors).subscribe(any(CompletableObserver.class));
+        orderedChain.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         orderedChain.verify(spyRequestApiPlanFlowChain).subscribe(any(CompletableObserver.class));
         spyTimeout.test().assertNotComplete();
         orderedChain.verify(spyInvokerAdapterChain, never()).subscribe(any(CompletableObserver.class));
@@ -650,15 +649,15 @@ class SyncApiReactorTest {
         when(securityChain.execute(any())).thenReturn(spySecurityChain);
         ReflectionTestUtils.setField(cut, "securityChain", securityChain);
 
-        TestObserver<Void> handleRequestObserver = cut.handle(ctx).test();
+        cut.handle(ctx).subscribe();
         testScheduler.advanceTimeBy(REQUEST_TIMEOUT + 30L, TimeUnit.MILLISECONDS);
 
         InOrder orderedChain = getInOrder();
 
         orderedChain.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         orderedChain.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        orderedChain.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         orderedChain.verify(spyBeforeApiFlowsProcessors).subscribe(any(CompletableObserver.class));
+        orderedChain.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         orderedChain.verify(spyRequestApiPlanFlowChain).subscribe(any(CompletableObserver.class));
         spyTimeout.test().assertNotComplete();
         orderedChain.verify(spyInvokerAdapterChain, never()).subscribe(any(CompletableObserver.class));
@@ -683,8 +682,7 @@ class SyncApiReactorTest {
         when(securityChain.execute(any())).thenReturn(spyInterruptSecurityChain);
         ReflectionTestUtils.setField(cut, "securityChain", securityChain);
 
-        TestObserver<Void> handleRequestObserver = cut.handle(ctx).test();
-
+        cut.handle(ctx).test().await().assertComplete();
         InOrder orderedChain = getInOrder();
 
         orderedChain.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
@@ -703,7 +701,7 @@ class SyncApiReactorTest {
     }
 
     private InOrder getInOrder() {
-        InOrder orderedChain = inOrder(
+        return inOrder(
             spyBeforeHandleProcessors,
             spyAfterHandleProcessors,
             spyRequestPlatformFlowChain,
@@ -719,7 +717,6 @@ class SyncApiReactorTest {
             spyOnErrorProcessors,
             spyResponsePlatformFlowChain
         );
-        return orderedChain;
     }
 
     private void fillRequestExecutionContext() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorTest.java
@@ -17,8 +17,6 @@ package io.gravitee.gateway.reactive.handlers.api.v4;
 
 import static io.gravitee.common.component.Lifecycle.State.STOPPED;
 import static io.gravitee.common.http.HttpStatusCode.GATEWAY_TIMEOUT_504;
-import static io.gravitee.gateway.reactive.api.ExecutionPhase.MESSAGE_REQUEST;
-import static io.gravitee.gateway.reactive.api.ExecutionPhase.MESSAGE_RESPONSE;
 import static io.gravitee.gateway.reactive.api.ExecutionPhase.RESPONSE;
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_INVOKER;
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_INVOKER_SKIP;
@@ -110,8 +108,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 @ExtendWith(MockitoExtension.class)
 class DefaultApiReactorTest {
 
-    public static final Long REQUEST_TIMEOUT = 200L;
-    public static final Long REQUEST_TIMEOUT_GRACE_DELAY = 30L;
     public static final String CONTEXT_PATH = "context-path";
     public static final String API_ID = "api-id";
     public static final String ORGANIZATION_ID = "organization-id";
@@ -236,12 +232,6 @@ class DefaultApiReactorTest {
 
     @Mock
     private ProcessorChain onErrorProcessors;
-
-    @Mock
-    private ProcessorChain afterEntrypointRequestProcessors;
-
-    @Mock
-    private ProcessorChain beforeEntrypointResponseProcessors;
 
     @Mock
     private MutableExecutionContext ctx;
@@ -439,8 +429,8 @@ class DefaultApiReactorTest {
 
         inOrder.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
+        inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyEntrypointRequest).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlanFlowChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestApiFlowChain).subscribe(any(CompletableObserver.class));
@@ -469,8 +459,8 @@ class DefaultApiReactorTest {
 
         inOrder.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
+        inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyEntrypointRequest).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlanFlowChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestApiFlowChain).subscribe(any(CompletableObserver.class));
@@ -498,8 +488,8 @@ class DefaultApiReactorTest {
         InOrder inOrder = getInOrder();
         inOrder.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
+        inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyEntrypointRequest).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlanFlowChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestApiFlowChain).subscribe(any(CompletableObserver.class));
@@ -529,8 +519,8 @@ class DefaultApiReactorTest {
         InOrder inOrder = getInOrder();
         inOrder.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
+        inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyEntrypointRequest).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlanFlowChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestApiFlowChain).subscribe(any(CompletableObserver.class));
@@ -560,8 +550,8 @@ class DefaultApiReactorTest {
         InOrder inOrder = getInOrder();
         inOrder.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
+        inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyEntrypointRequest).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlanFlowChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestApiFlowChain).subscribe(any(CompletableObserver.class));
@@ -590,8 +580,8 @@ class DefaultApiReactorTest {
         InOrder inOrder = getInOrder();
         inOrder.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
+        inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyEntrypointRequest).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlanFlowChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestApiFlowChain).subscribe(any(CompletableObserver.class));
@@ -620,8 +610,8 @@ class DefaultApiReactorTest {
         InOrder inOrder = getInOrder();
         inOrder.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
+        inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyEntrypointRequest).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlanFlowChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestApiFlowChain).subscribe(any(CompletableObserver.class));
@@ -656,8 +646,8 @@ class DefaultApiReactorTest {
         InOrder inOrder = getInOrder();
         inOrder.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
+        inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyEntrypointRequest).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlanFlowChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestApiFlowChain).subscribe(any(CompletableObserver.class));
@@ -714,8 +704,8 @@ class DefaultApiReactorTest {
         InOrder inOrder = getInOrder();
         inOrder.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
+        inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyEntrypointRequest).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlanFlowChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestApiFlowChain).subscribe(any(CompletableObserver.class));
@@ -771,8 +761,8 @@ class DefaultApiReactorTest {
         InOrder inOrder = getInOrder();
         inOrder.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
+        inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyEntrypointRequest).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlanFlowChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestApiFlowChain).subscribe(any(CompletableObserver.class));
@@ -825,8 +815,8 @@ class DefaultApiReactorTest {
         InOrder inOrder = getInOrder();
         inOrder.verify(spyBeforeHandleProcessors).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlatformFlowChain).subscribe(any(CompletableObserver.class));
-        inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyBeforeApiExecutionProcessors).subscribe(any(CompletableObserver.class));
+        inOrder.verify(spySecurityChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyEntrypointRequest).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestPlanFlowChain).subscribe(any(CompletableObserver.class));
         inOrder.verify(spyRequestApiFlowChain).subscribe(any(CompletableObserver.class));
@@ -843,7 +833,7 @@ class DefaultApiReactorTest {
         inOrder.verify(spyResponseEnd).subscribe(any(CompletableObserver.class));
 
         verify(endpointInvoker).invoke(any(), any(), handlerArgumentCaptor.capture());
-        assertThat(handlerArgumentCaptor.getValue()).isNotNull().isInstanceOf(ConnectionHandlerAdapter.class);
+        assertThat(handlerArgumentCaptor.getValue()).isInstanceOf(ConnectionHandlerAdapter.class);
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/plugin/PluginManifestLoader.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/plugin/PluginManifestLoader.java
@@ -45,7 +45,10 @@ public class PluginManifestLoader {
         try {
             final Path resources = Path.of("src/main/resources");
             final PluginManifestVisitor visitor = new PluginManifestVisitor();
-            Files.walkFileTree(resources, visitor);
+
+            if (resources.toFile().exists()) {
+                Files.walkFileTree(resources, visitor);
+            }
 
             Path pluginManifestPath = visitor.getPluginManifest();
             if (pluginManifestPath != null) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/policy/PolicyBuilder.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/policy/PolicyBuilder.java
@@ -33,10 +33,19 @@ public class PolicyBuilder {
     }
 
     public static PolicyPlugin<?> build(String id, Class<?> policy) {
-        return build(id, policy, null);
+        return build(id, policy, null, null);
     }
 
     public static PolicyPlugin<?> build(String id, Class<?> policy, Class<? extends PolicyConfiguration> policyConfiguration) {
+        return build(id, policy, policyConfiguration, null);
+    }
+
+    public static PolicyPlugin<?> build(
+        String id,
+        Class<?> policy,
+        Class<? extends PolicyConfiguration> policyConfiguration,
+        Class<? extends PolicyContext> policyContext
+    ) {
         return new PolicyPlugin<>() {
             @Override
             public Class<?> policy() {
@@ -50,7 +59,7 @@ public class PolicyBuilder {
 
             @Override
             public Class<? extends PolicyContext> context() {
-                return null;
+                return policyContext;
             }
 
             @Override

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/AbstractCorsIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/AbstractCorsIntegrationTest.java
@@ -25,6 +25,9 @@ import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
 import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
 import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.apikey.ApiKeyPolicy;
+import io.gravitee.policy.apikey.ApiKeyPolicyInitializer;
+import io.gravitee.policy.apikey.configuration.ApiKeyPolicyConfiguration;
 import io.vertx.rxjava3.core.http.HttpClientResponse;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -44,6 +47,10 @@ public class AbstractCorsIntegrationTest extends AbstractGatewayTest {
     @Override
     public void configurePolicies(Map<String, PolicyPlugin> policies) {
         policies.put("add-header", PolicyBuilder.build("add-header", AddHeaderPolicy.class));
+        policies.put(
+            "api-key",
+            PolicyBuilder.build("api-key", ApiKeyPolicy.class, ApiKeyPolicyConfiguration.class, ApiKeyPolicyInitializer.class)
+        );
     }
 
     protected static Map<String, String> extractHeaders(HttpClientResponse response) {

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/CorsIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/CorsIntegrationTest.java
@@ -15,14 +15,21 @@
  */
 package io.gravitee.apim.integration.tests.http.cors;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
 import io.gravitee.apim.integration.tests.fake.AddHeaderPolicy;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.Plan;
+import io.gravitee.gateway.api.service.ApiKey;
+import io.gravitee.gateway.reactor.ReactableApi;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.rxjava3.core.http.HttpClient;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -219,6 +226,103 @@ public class CorsIntegrationTest {
                 .await()
                 .assertComplete()
                 .assertNoErrors();
+        }
+    }
+
+    @Nested
+    @GatewayTest(mode = GatewayMode.JUPITER)
+    @DeployApi({ "/apis/http/cors-running-policies.json" })
+    class CheckingSecurityChainSkip extends AbstractCorsIntegrationTest {
+
+        protected ApiKey apiKey;
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            super.configureApi(api, definitionClass);
+
+            apiKey = anApiKey(api);
+            if (api.getDefinition() instanceof Api) {
+                ((Api) api.getDefinition()).setPlans(
+                        List.of(
+                            Plan
+                                .builder()
+                                .id("plan-id")
+                                .api(api.getId())
+                                .security("API_KEY")
+                                .status("PUBLISHED")
+                                .securityDefinition("{\"propagateApiKey\":true}")
+                                .build()
+                        )
+                    );
+            }
+        }
+
+        @Override
+        public void configureApi(Api api) {
+            super.configureApi(api);
+        }
+
+        @Test
+        void should_skip_security_on_preflight_request_when_valid(HttpClient httpClient) throws InterruptedException {
+            httpClient
+                .rxRequest(HttpMethod.OPTIONS, "/api-cors-running-policies")
+                .flatMap(httpClientRequest ->
+                    httpClientRequest.putHeader("Origin", "https://mydomain.com").putHeader("Access-Control-Request-Method", "GET").rxSend()
+                )
+                .flatMapPublisher(response -> {
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    return response.toFlowable();
+                })
+                .test()
+                .await()
+                .assertComplete()
+                .assertNoErrors();
+        }
+
+        @Test
+        void should_skip_security_on_preflight_request_when_invalid(HttpClient httpClient) throws InterruptedException {
+            httpClient
+                .rxRequest(HttpMethod.OPTIONS, "/api-cors-running-policies")
+                .flatMap(httpClientRequest ->
+                    httpClientRequest.putHeader("Origin", "https://unknown.com").putHeader("Access-Control-Request-Method", "GET").rxSend()
+                )
+                .flatMapPublisher(response -> {
+                    assertThat(response.statusCode()).isNotEqualTo(401);
+                    return response.toFlowable();
+                })
+                .test()
+                .await()
+                .assertComplete()
+                .assertNoErrors();
+        }
+
+        @Test
+        void should_apply_security_chain_on_regular_request(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get("/endpoint").willReturn(ok()));
+
+            httpClient
+                .rxRequest(HttpMethod.GET, "/api-cors-running-policies")
+                .flatMap(httpClientRequest ->
+                    httpClientRequest.putHeader("Origin", "https://mydomain.com").putHeader("Access-Control-Request-Method", "GET").rxSend()
+                )
+                .flatMapPublisher(response -> {
+                    assertThat(response.statusCode()).isEqualTo(401);
+                    return response.toFlowable();
+                })
+                .test()
+                .await()
+                .assertComplete()
+                .assertNoErrors();
+        }
+
+        private ApiKey anApiKey(ReactableApi<?> api) {
+            final ApiKey apiKey = new ApiKey();
+            apiKey.setApi(api.getId());
+            apiKey.setApplication("application-id");
+            apiKey.setSubscription("subscription-id");
+            apiKey.setPlan("plan-id");
+            apiKey.setKey("apiKeyValue");
+            return apiKey;
         }
     }
 }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/CorsV3CompatibilityIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/CorsV3CompatibilityIntegrationTest.java
@@ -36,4 +36,9 @@ public class CorsV3CompatibilityIntegrationTest extends CorsV3IntegrationTest {
     @GatewayTest(mode = GatewayMode.COMPATIBILITY)
     @DeployApi({ "/apis/http/cors-running-policies.json", "/apis/http/cors-not-running-policies.json" })
     class CheckingRejection extends CorsV3IntegrationTest.CheckingRejection {}
+
+    @Nested
+    @GatewayTest(mode = GatewayMode.COMPATIBILITY)
+    @DeployApi({ "/apis/http/cors-running-policies.json" })
+    class CheckingSecurityChainSkip extends CorsV3IntegrationTest.CheckingSecurityChainSkip {}
 }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/CorsV3IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/CorsV3IntegrationTest.java
@@ -136,4 +136,9 @@ public class CorsV3IntegrationTest extends CorsIntegrationTest {
     @GatewayTest(mode = GatewayMode.V3)
     @DeployApi({ "/apis/http/cors-running-policies.json", "/apis/http/cors-not-running-policies.json" })
     class CheckingRejection extends CorsIntegrationTest.CheckingRejection {}
+
+    @Nested
+    @GatewayTest(mode = GatewayMode.V3)
+    @DeployApi({ "/apis/http/cors-running-policies.json" })
+    class CheckingSecurityChainSkip extends CorsIntegrationTest.CheckingSecurityChainSkip {}
 }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/CorsV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/CorsV4IntegrationTest.java
@@ -18,6 +18,12 @@ package io.gravitee.apim.integration.tests.http.cors;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.plan.Plan;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.gateway.reactor.ReactableApi;
+import java.util.List;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
@@ -45,4 +51,23 @@ public class CorsV4IntegrationTest extends CorsIntegrationTest {
     @GatewayTest(mode = GatewayMode.JUPITER)
     @DeployApi({ "/apis/v4/http/cors-running-policies.json", "/apis/v4/http/cors-not-running-policies.json" })
     class CheckingRejection extends CorsIntegrationTest.CheckingRejection {}
+
+    @Nested
+    @GatewayTest(mode = GatewayMode.JUPITER)
+    @DeployApi({ "/apis/v4/http/cors-running-policies.json" })
+    class CheckingSecurityChainSkip extends CorsIntegrationTest.CheckingSecurityChainSkip {
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            super.configureApi(api, definitionClass);
+
+            if (api.getDefinition() instanceof Api) {
+                var security = new PlanSecurity();
+                security.setType("api-key");
+
+                var plan = Plan.builder().id("plan-id").security(security).status(PlanStatus.PUBLISHED).build();
+                ((Api) api.getDefinition()).setPlans(List.of(plan));
+            }
+        }
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
         <gravitee-endpoint-mqtt5-advanced.version>1.2.0-alpha.1</gravitee-endpoint-mqtt5-advanced.version>
         <gravitee-resource-schema-registry-confluent.version>1.0.0-alpha.9
         </gravitee-resource-schema-registry-confluent.version>
-        <gravitee-reactor-message.version>1.0.0-alpha.2</gravitee-reactor-message.version>
+        <gravitee-reactor-message.version>1.0.0-alpha.3</gravitee-reactor-message.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1150

## Description

Execute security chain after CORSPreflight Processor in jupiter/v4

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-lihdziftdg.chromatic.com)
<!-- Storybook placeholder end -->
