### PR TITLE
Allow to search api to all the one accessible for the application subscription - for no admin user

### DIFF
--- a/gravitee-apim-console-webui/src/management/application/details/subscribe/application-subscribe.controller.ts
+++ b/gravitee-apim-console-webui/src/management/application/details/subscribe/application-subscribe.controller.ts
@@ -68,7 +68,7 @@ class ApplicationSubscribeController {
   }
 
   searchApiByName(searchText): IHttpPromise<any> {
-    return this.ApiService.searchApis(searchText, 1, 'name').then((response) => response.data.data);
+    return this.ApiService.searchApis(searchText, 1, 'name', undefined, undefined, false).then((response) => response.data.data);
   }
 
   onSelectAPI(api) {

--- a/gravitee-apim-console-webui/src/services/api.service.ts
+++ b/gravitee-apim-console-webui/src/services/api.service.ts
@@ -152,7 +152,7 @@ export class ApiService {
     return this.$http.get(url, opts);
   }
 
-  searchApis(query?: string, page?: any, order?: string, opts?: any, size?: number): IHttpPromise<any> {
+  searchApis(query?: string, page?: any, order?: string, opts?: any, size?: number, manageOnly?: boolean): IHttpPromise<any> {
     let url = `${this.Constants.env.baseURL}/apis/_search/`;
 
     // Fallback to paginated search if a page parameter is provided.
@@ -166,6 +166,7 @@ export class ApiService {
       page: page,
       order: order,
       size,
+      ...(manageOnly ? {} : { manageOnly: false }),
     };
 
     return this.$http.post(url, {}, opts);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
@@ -412,7 +412,7 @@ public class ApisResource extends AbstractResource {
     @ApiResponse(responseCode = "500", description = "Internal server error")
     public Response searchApis(@Parameter(name = "q", required = true) @NotNull @QueryParam("q") String query) {
         try {
-            return Response.ok().entity(this.searchPagedApis(query, new ApisOrderParam("name"), null).getData()).build();
+            return Response.ok().entity(this.searchPagedApis(query, new ApisOrderParam("name"), true, null).getData()).build();
         } catch (TechnicalManagementException te) {
             return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(te).build();
         }
@@ -437,6 +437,10 @@ public class ApisResource extends AbstractResource {
                 description = "By default, sort is ASC. If *field* starts with '-', the order sort is DESC. Currently, only **name** and **paths** are supported"
             )
         ) @QueryParam("order") @DefaultValue("name") final ApisOrderParam apisOrderParam,
+        @Parameter(
+            name = "manageOnly",
+            description = "By default only APIs that the user can manage are returned. If set to false, all APIs that the user can view are returned."
+        ) @QueryParam("manageOnly") @DefaultValue("true") final boolean manageOnly,
         @Valid @BeanParam Pageable pageable
     ) {
         final ApiQuery apiQuery = new ApiQuery();
@@ -450,7 +454,7 @@ public class ApisResource extends AbstractResource {
 
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         if (!isAdmin()) {
-            filters.put("api", apiService.findIdsByUser(executionContext, getAuthenticatedUser(), apiQuery, true));
+            filters.put("api", apiService.findIdsByUser(executionContext, getAuthenticatedUser(), apiQuery, manageOnly));
         }
 
         final boolean isRatingServiceEnabled = ratingService.isEnabled(executionContext);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
@@ -185,7 +185,7 @@ public class ApisResource extends AbstractResource {
                         apiQuery,
                         sortable,
                         commonPageable,
-                        apisParam.isPortal()
+                        !apisParam.isPortal()
                     );
             } else {
                 apiQuery.setVisibility(PUBLIC);
@@ -450,7 +450,7 @@ public class ApisResource extends AbstractResource {
 
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         if (!isAdmin()) {
-            filters.put("api", apiService.findIdsByUser(executionContext, getAuthenticatedUser(), apiQuery, false));
+            filters.put("api", apiService.findIdsByUser(executionContext, getAuthenticatedUser(), apiQuery, true));
         }
 
         final boolean isRatingServiceEnabled = ratingService.isEnabled(executionContext);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentAnalyticsResource.java
@@ -37,9 +37,7 @@ import io.gravitee.rest.api.model.analytics.query.StatsQuery;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.api.ApiQuery;
 import io.gravitee.rest.api.model.application.ApplicationQuery;
-import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.common.PageableImpl;
-import io.gravitee.rest.api.model.common.SortableImpl;
 import io.gravitee.rest.api.service.AnalyticsService;
 import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.ApplicationService;
@@ -155,7 +153,7 @@ public class EnvironmentAnalyticsResource extends AbstractResource {
                             .getTotalElements()
                     );
                 } else {
-                    return buildCountStat(apiService.findIdsByUser(executionContext, getAuthenticatedUser(), new ApiQuery(), false).size());
+                    return buildCountStat(apiService.findIdsByUser(executionContext, getAuthenticatedUser(), new ApiQuery(), true).size());
                 }
             case APPLICATION_FIELD:
                 if (isAdmin()) {
@@ -255,7 +253,7 @@ public class EnvironmentAnalyticsResource extends AbstractResource {
             fieldName = API_FIELD;
             ids =
                 apiService
-                    .findIdsByUser(executionContext, getAuthenticatedUser(), null, false)
+                    .findIdsByUser(executionContext, getAuthenticatedUser(), null, true)
                     .stream()
                     .filter(apiId -> permissionService.hasPermission(executionContext, API_ANALYTICS, apiId, READ))
                     .collect(Collectors.toList());
@@ -318,7 +316,7 @@ public class EnvironmentAnalyticsResource extends AbstractResource {
     private TopHitsAnalytics getTopHitsAnalytics(final ExecutionContext executionContext, Function<ApiEntity, String> groupingByFunction) {
         Set<ApiEntity> apis = isAdmin()
             ? new HashSet<>(apiService.search(executionContext, new ApiQuery()))
-            : apiService.findByUser(executionContext, getAuthenticatedUser(), new ApiQuery(), false);
+            : apiService.findByUser(executionContext, getAuthenticatedUser(), new ApiQuery(), true);
         Map<String, Long> collect = apis.stream().collect(Collectors.groupingBy(groupingByFunction, Collectors.counting()));
         TopHitsAnalytics topHitsAnalytics = new TopHitsAnalytics();
         topHitsAnalytics.setValues(collect);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource.java
@@ -26,8 +26,6 @@ import io.gravitee.rest.api.management.rest.security.Permission;
 import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.model.analytics.Analytics;
 import io.gravitee.rest.api.model.analytics.query.*;
-import io.gravitee.rest.api.model.api.ApiEntity;
-import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.service.AnalyticsService;
 import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.ApplicationService;
@@ -105,7 +103,7 @@ public class PlatformAnalyticsResource extends AbstractResource {
                 fieldName = "api";
                 ids =
                     apiService
-                        .findIdsByUser(executionContext, getAuthenticatedUser(), null, false)
+                        .findIdsByUser(executionContext, getAuthenticatedUser(), null, true)
                         .stream()
                         .filter(appId -> permissionService.hasPermission(executionContext, API_ANALYTICS, appId, READ))
                         .collect(Collectors.toList());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformEventsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformEventsResource.java
@@ -85,7 +85,7 @@ public class PlatformEventsResource extends AbstractResource {
             properties.put(
                 Event.EventProperties.API_ID.getValue(),
                 apiService
-                    .findByUser(executionContext, getAuthenticatedUser(), null, false)
+                    .findByUser(executionContext, getAuthenticatedUser(), null, true)
                     .stream()
                     .filter(api -> permissionService.hasPermission(executionContext, API_ANALYTICS, api.getId(), READ))
                     .map(ApiEntity::getId)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformLogsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformLogsResource.java
@@ -111,7 +111,7 @@ public class PlatformLogsResource extends AbstractResource {
         String applicationsFilter = getExtraFilter("application", applicationIds);
 
         List<String> apiIds = apiService
-            .findIdsByUser(executionContext, getAuthenticatedUser(), null, false)
+            .findIdsByUser(executionContext, getAuthenticatedUser(), null, true)
             .stream()
             .filter(appId -> permissionService.hasPermission(executionContext, API_LOG, appId, READ))
             .collect(Collectors.toList());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/portal/PortalApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/portal/PortalApisResource.java
@@ -101,7 +101,7 @@ public class PortalApisResource extends AbstractResource {
             } else {
                 apiQuery.setLifecycleStates(singletonList(PUBLISHED));
                 if (isAuthenticated()) {
-                    apis = apiService.findByUser(executionContext, getAuthenticatedUser(), apiQuery, true);
+                    apis = apiService.findByUser(executionContext, getAuthenticatedUser(), apiQuery, false);
                 } else if (configService.portalLoginForced(executionContext)) {
                     // if portal requires login, this endpoint should hide the APIS even PUBLIC ones
                     return Response.ok().entity(emptyList()).build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApisResourceNotAdminTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApisResourceNotAdminTest.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.rest.resource;
+
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.definition.model.Proxy;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.model.api.ApiQuery;
+import io.gravitee.rest.api.model.common.Pageable;
+import io.gravitee.rest.api.model.common.Sortable;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.util.*;
+import javax.ws.rs.core.Response;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.Test;
+
+/**
+ * @author David BRASSELY (brasseld at gmail.com)
+ */
+public class ApisResourceNotAdminTest extends AbstractResourceTest {
+
+    @Override
+    protected String contextPath() {
+        return "apis";
+    }
+
+    @Override
+    protected void decorate(ResourceConfig resourceConfig) {
+        resourceConfig.register(NotAdminAuthenticationFilter.class);
+    }
+
+    @Test
+    public void get_should_search_apis() throws TechnicalException {
+        when(apiService.findIdsByUser(eq(GraviteeContext.getExecutionContext()), any(), isA(ApiQuery.class), eq(true)))
+            .thenReturn(Set.of("api1", "api2", "api15"));
+
+        List<ApiEntity> resultApis = List.of(mockApi("api1"), mockApi("api2"), mockApi("api15"));
+        Page<ApiEntity> apisPage = new Page<>(resultApis, 7, 3, 54);
+        when(
+            apiService.search(
+                eq(GraviteeContext.getExecutionContext()),
+                eq("*"),
+                argThat(filters -> ((Set<String>) filters.get("api")).size() == 3),
+                isA(Sortable.class),
+                isA(Pageable.class)
+            )
+        )
+            .thenReturn(apisPage);
+
+        final Response response = envTarget().path("_search/_paged").queryParam("q", "*").request().post(null);
+
+        assertEquals(OK_200, response.getStatus());
+    }
+
+    @Test
+    public void get_should_search_apis_with_manageOnly_to_false() throws TechnicalException {
+        when(apiService.findIdsByUser(eq(GraviteeContext.getExecutionContext()), any(), isA(ApiQuery.class), eq(false)))
+            .thenReturn(Set.of("api1", "api2", "api15"));
+
+        List<ApiEntity> resultApis = List.of(mockApi("api1"), mockApi("api2"), mockApi("api15"));
+        Page<ApiEntity> apisPage = new Page<>(resultApis, 7, 3, 54);
+
+        when(
+            apiService.search(
+                eq(GraviteeContext.getExecutionContext()),
+                eq("*"),
+                argThat(filters -> ((Set<String>) filters.get("api")).size() == 3),
+                isA(Sortable.class),
+                isA(Pageable.class)
+            )
+        )
+            .thenReturn(apisPage);
+        final Response response = envTarget()
+            .path("_search/_paged")
+            .queryParam("q", "*")
+            .queryParam("manageOnly", "false")
+            .request()
+            .post(null);
+
+        assertEquals(OK_200, response.getStatus());
+    }
+
+    private ApiEntity mockApi(String apiId) {
+        ApiEntity apiEntity = mock(ApiEntity.class);
+        when(apiEntity.getId()).thenReturn(apiId);
+        when(apiEntity.getUpdatedAt()).thenReturn(new Date());
+        when(apiEntity.getProxy()).thenReturn(new Proxy());
+        return apiEntity;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/EnvironmentAnalyticsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/EnvironmentAnalyticsResourceTest.java
@@ -135,7 +135,7 @@ public class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldGetEmptyHistoAnalyticsWhenNotAdminAndNoApi() {
-        when(apiService.findByUser(eq(GraviteeContext.getExecutionContext()), any(), eq(null), eq(false)))
+        when(apiService.findByUser(eq(GraviteeContext.getExecutionContext()), any(), eq(null), !eq(false)))
             .thenReturn(Collections.emptySet());
 
         Response response = envTarget()
@@ -155,7 +155,7 @@ public class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldGetEmptyTopHitsAnalyticsWhenNotAdminAndNoApi() {
-        when(apiService.findByUser(eq(GraviteeContext.getExecutionContext()), any(), eq(null), eq(false)))
+        when(apiService.findByUser(eq(GraviteeContext.getExecutionContext()), any(), eq(null), !eq(false)))
             .thenReturn(Collections.emptySet());
 
         Response response = envTarget()
@@ -175,7 +175,7 @@ public class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldGetEmptyCountAnalyticsWhenNotAdminAndNoApi() {
-        when(apiService.findByUser(eq(GraviteeContext.getExecutionContext()), any(), eq(null), eq(false)))
+        when(apiService.findByUser(eq(GraviteeContext.getExecutionContext()), any(), eq(null), !eq(false)))
             .thenReturn(Collections.emptySet());
 
         Response response = envTarget()
@@ -194,7 +194,7 @@ public class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldGetEmptyStatsAnalyticsWhenNotAdminAndNoApi() {
-        when(apiService.findByUser(eq(GraviteeContext.getExecutionContext()), any(), eq(null), eq(false)))
+        when(apiService.findByUser(eq(GraviteeContext.getExecutionContext()), any(), eq(null), !eq(false)))
             .thenReturn(Collections.emptySet());
 
         Response response = envTarget()
@@ -217,7 +217,7 @@ public class EnvironmentAnalyticsResourceTest extends AbstractResourceTest {
         ApiEntity api = new ApiEntity();
         api.setId("apiId");
 
-        when(apiService.findIdsByUser(eq(GraviteeContext.getExecutionContext()), any(), any(), eq(false)))
+        when(apiService.findIdsByUser(eq(GraviteeContext.getExecutionContext()), any(), any(), eq(true)))
             .thenReturn(Collections.singleton(api.getId()));
         when(permissionService.hasPermission(eq(GraviteeContext.getExecutionContext()), eq(API_ANALYTICS), eq(api.getId()), eq(READ)))
             .thenReturn(true);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformLogsResourceNotAdminTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformLogsResourceNotAdminTest.java
@@ -37,7 +37,6 @@ import java.util.Objects;
 import java.util.Set;
 import javax.ws.rs.core.Response;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -68,12 +67,12 @@ public class PlatformLogsResourceNotAdminTest extends AbstractResourceTest {
     public void shouldGetPlatformLogsAsNonAdmin() {
         when(logsService.findPlatform(any(ExecutionContext.class), any(LogQuery.class))).thenReturn(new SearchLogResponse<>(10));
         when(applicationService.findIdsByUser(any(ExecutionContext.class), anyString())).thenReturn(Set.of("app1"));
-        when(apiService.findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(false))).thenReturn(Set.of("api1"));
+        when(apiService.findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(true))).thenReturn(Set.of("api1"));
         Response logs = sendRequest();
         assertEquals(OK_200, logs.getStatus());
 
         verify(applicationService).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME));
-        verify(apiService).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(false));
+        verify(apiService).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(true));
         verify(logsService)
             .findPlatform(
                 any(ExecutionContext.class),
@@ -93,12 +92,12 @@ public class PlatformLogsResourceNotAdminTest extends AbstractResourceTest {
     public void shouldGetPlatformLogsAsNonAdminFilterOnlyApp() {
         when(logsService.findPlatform(any(ExecutionContext.class), any(LogQuery.class))).thenReturn(new SearchLogResponse<>(10));
         when(applicationService.findIdsByUser(any(ExecutionContext.class), anyString())).thenReturn(Set.of("app1"));
-        when(apiService.findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(false))).thenReturn(emptySet());
+        when(apiService.findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(true))).thenReturn(emptySet());
         Response logs = sendRequest();
         assertEquals(OK_200, logs.getStatus());
 
         verify(applicationService).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME));
-        verify(apiService).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(false));
+        verify(apiService).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(true));
         verify(logsService)
             .findPlatform(
                 any(ExecutionContext.class),
@@ -118,12 +117,12 @@ public class PlatformLogsResourceNotAdminTest extends AbstractResourceTest {
     public void shouldGetPlatformLogsAsNonAdminFilterOnlyAPI() {
         when(logsService.findPlatform(any(ExecutionContext.class), any(LogQuery.class))).thenReturn(new SearchLogResponse<>(10));
         when(applicationService.findIdsByUser(any(ExecutionContext.class), anyString())).thenReturn(emptySet());
-        when(apiService.findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(false))).thenReturn(Set.of("api1"));
+        when(apiService.findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(true))).thenReturn(Set.of("api1"));
         Response logs = sendRequest();
         assertEquals(OK_200, logs.getStatus());
 
         verify(applicationService).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME));
-        verify(apiService).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(false));
+        verify(apiService).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(true));
         verify(logsService)
             .findPlatform(
                 any(ExecutionContext.class),
@@ -142,7 +141,7 @@ public class PlatformLogsResourceNotAdminTest extends AbstractResourceTest {
     @Test
     public void shouldGetNoLogsAsNonAdminWithNoAPINoApp() {
         when(applicationService.findIdsByUser(any(ExecutionContext.class), eq(USER_NAME))).thenReturn(emptySet());
-        when(apiService.findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(false))).thenReturn(emptySet());
+        when(apiService.findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(true))).thenReturn(emptySet());
         Response logs = sendRequest();
         assertEquals(OK_200, logs.getStatus());
 
@@ -150,7 +149,7 @@ public class PlatformLogsResourceNotAdminTest extends AbstractResourceTest {
         assertEquals(0, jsonNode.get("total").intValue());
         assertNull(jsonNode.get("logs"));
         verify(applicationService).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME));
-        verify(apiService).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(false));
+        verify(apiService).findIdsByUser(any(ExecutionContext.class), eq(USER_NAME), isNull(), eq(true));
         verify(logsService, never()).findPlatform(any(ExecutionContext.class), any(LogQuery.class));
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformLogsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PlatformLogsResourceTest.java
@@ -50,7 +50,7 @@ public class PlatformLogsResourceTest extends AbstractResourceTest {
         Response logs = sendRequest();
         assertEquals(OK_200, logs.getStatus());
 
-        verify(applicationService, never()).findIdsByUser(any(ExecutionContext.class), anyString());
+        verify(applicationService, never()).findIdsByUser(any(ExecutionContext.class), any());
         verify(apiService, never()).findIdsByUser(any(ExecutionContext.class), anyString(), any(ApiQuery.class), anyBoolean());
         verify(logsService)
             .findPlatform(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiResource.java
@@ -150,7 +150,7 @@ public class ApiResource extends AbstractResource {
             GraviteeContext.getExecutionContext(),
             getAuthenticatedUserOrNull(),
             apiQuery,
-            true
+            false
         );
         if (userApis.stream().anyMatch(a -> a.getId().equals(apiId))) {
             InlinePictureEntity image = apiService.getPicture(GraviteeContext.getExecutionContext(), apiId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiResourceTest.java
@@ -66,7 +66,7 @@ public class ApiResourceTest extends AbstractResourceTest {
 
         Set<ApiEntity> mockApis = new HashSet<>(Arrays.asList(mockApi));
         doReturn(true).when(accessControlService).canAccessApiFromPortal(GraviteeContext.getExecutionContext(), API);
-        doReturn(mockApis).when(apiService).findByUser(eq(GraviteeContext.getExecutionContext()), any(), any(), eq(true));
+        doReturn(mockApis).when(apiService).findByUser(eq(GraviteeContext.getExecutionContext()), any(), any(), eq(false));
 
         Api api = new Api();
         api.setId(API);
@@ -192,7 +192,7 @@ public class ApiResourceTest extends AbstractResourceTest {
         ApiEntity userApi = new ApiEntity();
         userApi.setId("1");
         Set<ApiEntity> mockApis = new HashSet<>(Arrays.asList(userApi));
-        doReturn(mockApis).when(apiService).findByUser(eq(GraviteeContext.getExecutionContext()), any(), any(), eq(true));
+        doReturn(mockApis).when(apiService).findByUser(eq(GraviteeContext.getExecutionContext()), any(), any(), eq(false));
 
         // test
         final Response response = target(API).path("picture").request().get();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
@@ -48,10 +48,10 @@ public interface ApiService {
         ApiQuery apiQuery,
         Sortable sortable,
         Pageable pageable,
-        boolean portal
+        boolean manageOnly
     );
 
-    Set<ApiEntity> findByUser(ExecutionContext executionContext, String userId, ApiQuery apiQuery, boolean portal);
+    Set<ApiEntity> findByUser(ExecutionContext executionContext, String userId, ApiQuery apiQuery, boolean manageOnly);
 
     Page<ApiEntity> findPublishedByUser(
         ExecutionContext executionContext,
@@ -63,11 +63,11 @@ public interface ApiService {
 
     Set<ApiEntity> findPublishedByUser(ExecutionContext executionContext, String userId);
 
-    default Set<String> findIdsByUser(ExecutionContext executionContext, String userId, ApiQuery apiQuery, boolean portal) {
-        return findIdsByUser(executionContext, userId, apiQuery, null, portal);
+    default Set<String> findIdsByUser(ExecutionContext executionContext, String userId, ApiQuery apiQuery, boolean manageOnly) {
+        return findIdsByUser(executionContext, userId, apiQuery, null, manageOnly);
     }
 
-    Set<String> findIdsByUser(ExecutionContext executionContext, String userId, ApiQuery apiQuery, Sortable sortable, boolean portal);
+    Set<String> findIdsByUser(ExecutionContext executionContext, String userId, ApiQuery apiQuery, Sortable sortable, boolean manageOnly);
 
     Set<ApiEntity> findPublishedByUser(ExecutionContext executionContext, String userId, ApiQuery apiQuery);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_FindByUserTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_FindByUserTest.java
@@ -184,7 +184,7 @@ public class ApiService_FindByUserTest {
         final ApplicationListItem application = new ApplicationListItem();
         application.setId("appId");
 
-        final Set<ApiEntity> apiEntities = apiService.findByUser(GraviteeContext.getExecutionContext(), USER_NAME, null, false);
+        final Set<ApiEntity> apiEntities = apiService.findByUser(GraviteeContext.getExecutionContext(), USER_NAME, null, true);
 
         assertNotNull(apiEntities);
         assertEquals(1, apiEntities.size());
@@ -268,7 +268,7 @@ public class ApiService_FindByUserTest {
             null,
             new SortableImpl("name", false),
             new PageableImpl(2, 1),
-            false
+            true
         );
 
         assertNotNull(apiPage);
@@ -293,7 +293,7 @@ public class ApiService_FindByUserTest {
         when(membershipService.getMembershipsByMemberAndReference(MembershipMemberType.USER, USER_NAME, MembershipReferenceType.API))
             .thenReturn(Collections.emptySet());
 
-        final Set<ApiEntity> apiEntities = apiService.findByUser(GraviteeContext.getExecutionContext(), USER_NAME, null, false);
+        final Set<ApiEntity> apiEntities = apiService.findByUser(GraviteeContext.getExecutionContext(), USER_NAME, null, true);
 
         assertNotNull(apiEntities);
         assertTrue(apiEntities.isEmpty());
@@ -301,7 +301,7 @@ public class ApiService_FindByUserTest {
 
     @Test
     public void shouldFindPublicApisOnlyWithAnonymousUser() throws TechnicalException {
-        final Set<ApiEntity> apiEntities = apiService.findByUser(GraviteeContext.getExecutionContext(), null, null, false);
+        final Set<ApiEntity> apiEntities = apiService.findByUser(GraviteeContext.getExecutionContext(), null, null, true);
 
         assertNotNull(apiEntities);
         assertEquals(0, apiEntities.size());
@@ -334,7 +334,7 @@ public class ApiService_FindByUserTest {
 
         when(roleService.findByScope(RoleScope.API, GraviteeContext.getCurrentOrganization())).thenReturn(List.of(poRole, userRole));
 
-        final Set<ApiEntity> apiEntities = apiService.findByUser(GraviteeContext.getExecutionContext(), USER_NAME, null, false);
+        final Set<ApiEntity> apiEntities = apiService.findByUser(GraviteeContext.getExecutionContext(), USER_NAME, null, true);
 
         assertNotNull(apiEntities);
         assertEquals(0, apiEntities.size());


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1545
https://graviteesource.zendesk.com/agent/tickets/6375

## Description

Rename and invert the portal boolean to rename it to manageOnly.
This bool allow to have only the api you can manage or all apis even if you have a read only access 
Use this manageOnly to false to allow to see all accessible apis when user want to subscribe an application 


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ukbmsypamd.chromatic.com)
<!-- Storybook placeholder end -->
