### PR TITLE
Fix search method when user can't access the found APIs

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImpl.java
@@ -239,6 +239,9 @@ public class ApiSearchServiceImpl extends AbstractService implements ApiSearchSe
             }
 
             apiIds.retainAll(userApiIds);
+            if (apiIds.isEmpty()) {
+                return new Page<>(List.of(), 0, 0, 0);
+            }
         }
 
         // Step 3: add filters to ApiCriteria to be used by the repository search


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1577

## Description

When searching APIs, we first look into Lucene to fetch matching APIs.
Then we retain only the APIs the current user can access.

In case the user can't access any of the found APIs, the search in the database was done with an empty list of ids, which leads to a search for all APIs.

This PR force the return of an empty page if no ids match.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ygniaqbacd.chromatic.com)
<!-- Storybook placeholder end -->
