### PR TITLE
Console 3.18.x -  Remove use of @gravitee/ui-policy-studio-angular

### DIFF
--- a/gravitee-apim-console-webui/package-lock.json
+++ b/gravitee-apim-console-webui/package-lock.json
@@ -24,7 +24,6 @@
         "@gravitee/ui-analytics": "3.5.0",
         "@gravitee/ui-components": "3.39.5",
         "@gravitee/ui-particles-angular": "3.4.0",
-        "@gravitee/ui-policy-studio-angular": "3.0.1",
         "@highcharts/map-collection": "1.1.4",
         "@toast-ui/editor": "3.2.2",
         "@toast-ui/editor-plugin-code-syntax-highlight": "3.1.0",
@@ -11283,30 +11282,6 @@
       }
     },
     "node_modules/@gravitee/ui-particles-angular/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-    },
-    "node_modules/@gravitee/ui-policy-studio-angular": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@gravitee/ui-policy-studio-angular/-/ui-policy-studio-angular-3.0.1.tgz",
-      "integrity": "sha512-PPugdRvpKh/0Dts0Qn8Pji0aiUiIJp+AW5ZCaZq18jrNtDY+PaQyHl62wMxtBJ4ZT/kF/8Gc4GRJ0w/xM2YLyQ==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@angular/animations": "^12.2.0",
-        "@angular/cdk": "^12.2.0",
-        "@angular/common": "^12.2.0",
-        "@angular/core": "^12.2.0",
-        "@angular/forms": "^12.2.0",
-        "@angular/material": "^12.2.0",
-        "@gravitee/ui-components": "^3.28.5",
-        "lodash": "^4.17.21",
-        "rxjs": "^6.0.0"
-      }
-    },
-    "node_modules/@gravitee/ui-policy-studio-angular/node_modules/tslib": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
@@ -56097,21 +56072,6 @@
         "@fontsource/golos-ui": "^4.5.1",
         "@fontsource/material-icons": "4.5.1",
         "tslib": "2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-        }
-      }
-    },
-    "@gravitee/ui-policy-studio-angular": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@gravitee/ui-policy-studio-angular/-/ui-policy-studio-angular-3.0.1.tgz",
-      "integrity": "sha512-PPugdRvpKh/0Dts0Qn8Pji0aiUiIJp+AW5ZCaZq18jrNtDY+PaQyHl62wMxtBJ4ZT/kF/8Gc4GRJ0w/xM2YLyQ==",
-      "requires": {
-        "tslib": "^2.3.0"
       },
       "dependencies": {
         "tslib": {

--- a/gravitee-apim-console-webui/package.json
+++ b/gravitee-apim-console-webui/package.json
@@ -18,7 +18,6 @@
     "@gravitee/ui-analytics": "3.5.0",
     "@gravitee/ui-components": "3.39.5",
     "@gravitee/ui-particles-angular": "3.4.0",
-    "@gravitee/ui-policy-studio-angular": "3.0.1",
     "@highcharts/map-collection": "1.1.4",
     "@toast-ui/editor": "3.2.2",
     "@toast-ui/editor-plugin-code-syntax-highlight": "3.1.0",

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/config/policy-studio-config.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/config/policy-studio-config.component.ts
@@ -17,7 +17,6 @@
 import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
 import { combineLatest, Subject } from 'rxjs';
 import { takeUntil, tap } from 'rxjs/operators';
-import { FlowConfigurationSchema } from '@gravitee/ui-policy-studio-angular';
 import { MatSlideToggleChange } from '@angular/material/slide-toggle';
 import '@gravitee/ui-components/wc/gv-icon';
 import '@gravitee/ui-components/wc/gv-schema-form';
@@ -28,6 +27,7 @@ import { ApiDefinition } from '../models/ApiDefinition';
 import { PolicyStudioService } from '../policy-studio.service';
 import { GvSchemaFormChangeEvent } from '../models/GvSchemaFormChangeEvent';
 import { Constants } from '../../../../entities/Constants';
+import { FlowConfigurationSchema } from '../../../../entities/flow/configurationSchema';
 
 @Component({
   selector: 'policy-studio-config',

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/gio-policy-studio-routing.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/gio-policy-studio-routing.module.ts
@@ -20,7 +20,6 @@ import { MatTabsModule } from '@angular/material/tabs';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { GioPolicyStudioModule } from '@gravitee/ui-policy-studio-angular';
 import { GioSaveBarModule } from '@gravitee/ui-particles-angular';
 
 import { PolicyStudioDebugComponent } from './debug/policy-studio-debug.component';
@@ -51,7 +50,6 @@ import { GioConfirmDialogModule } from '../../../shared/components/gio-confirm-d
     GioSaveBarModule,
     GioPermissionModule,
     GioConfirmDialogModule,
-    GioPolicyStudioModule,
 
     PolicyStudioDesignModule,
     PolicyStudioConfigModule,

--- a/gravitee-apim-console-webui/src/management/api/policy-studio/resources/policy-studio-resources.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio/resources/policy-studio-resources.component.ts
@@ -17,13 +17,13 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { combineLatest, Subject } from 'rxjs';
 import { takeUntil, tap } from 'rxjs/operators';
-import { ResourceListItem } from '@gravitee/ui-policy-studio-angular';
 import '@gravitee/ui-components/wc/gv-resources';
 
 import { PolicyStudioResourcesService } from './policy-studio-resources.service';
 
 import { ApiDefinition } from '../models/ApiDefinition';
 import { PolicyStudioService } from '../policy-studio.service';
+import { ResourceListItem } from '../../../../entities/resource/resourceListItem';
 
 @Component({
   selector: 'policy-studio-resources',

--- a/gravitee-apim-console-webui/src/management/management.module.ts
+++ b/gravitee-apim-console-webui/src/management/management.module.ts
@@ -17,7 +17,6 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { GioPolicyStudioModule } from '@gravitee/ui-policy-studio-angular';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 import { GioPolicyStudioRoutingModule } from './api/policy-studio/gio-policy-studio-routing.module';
@@ -35,7 +34,6 @@ import { GioPermissionModule } from '../shared/components/gio-permission/gio-per
     MatSnackBarModule,
     GioPermissionModule,
     GioConfirmDialogModule,
-    GioPolicyStudioModule,
     EnvAuditModule,
     ApiCreationModule,
     GioPolicyStudioRoutingModule.withRouting({ stateNamePrefix: 'management.apis.detail.design.flowsNg' }),

--- a/gravitee-apim-console-webui/src/organization/configuration/organization-settings.module.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/organization-settings.module.ts
@@ -42,6 +42,7 @@ import { MatSortModule } from '@angular/material/sort';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { GioBannerModule, GioFormTagsInputModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
 import { GioPolicyStudioModule } from '@gravitee/ui-policy-studio-angular';
+import { MatTabsModule } from '@angular/material/tabs';
 
 import { OrgSettingsGeneralComponent } from './console/org-settings-general.component';
 import { OrgSettingsUsersComponent } from './users/org-settings-users.component';
@@ -68,6 +69,7 @@ import { OrgSettingsRoleComponent } from './roles/role/org-settings-role.compone
 import { OrgSettingsUserDetailAddGroupDialogComponent } from './user/detail/org-settings-user-detail-add-group-dialog.component';
 import { OrgSettingsUserGenerateTokenComponent } from './user/detail/tokens/org-settings-user-generate-token.component';
 import { OrgSettingsAuditComponent } from './audit/org-settings-audit.component';
+import { OrgSettingsPlatformPoliciesStudioComponent } from './policies/studio/org-settings-platform-policies-studio.component';
 
 import { GioConfirmDialogModule } from '../../shared/components/gio-confirm-dialog/gio-confirm-dialog.module';
 import { GioAvatarModule } from '../../shared/components/gio-avatar/gio-avatar.module';
@@ -117,6 +119,7 @@ import { SpelService } from '../../services-ngx/spel.service';
     MatSortModule,
     MatDatepickerModule,
     MatNativeDateModule,
+    MatTabsModule,
 
     GioPermissionModule,
     GioConfirmDialogModule,
@@ -151,6 +154,7 @@ import { SpelService } from '../../services-ngx/spel.service';
     OrgSettingsNotificationTemplateComponent,
     OrgSettingsCockpitComponent,
     OrgSettingsPlatformPoliciesComponent,
+    OrgSettingsPlatformPoliciesStudioComponent,
     OrgSettingsTenantsComponent,
     OrgSettingAddTenantComponent,
     OrgSettingsRolesComponent,

--- a/gravitee-apim-console-webui/src/organization/configuration/organization-settings.module.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/organization-settings.module.ts
@@ -40,8 +40,7 @@ import { MatListModule } from '@angular/material/list';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatSortModule } from '@angular/material/sort';
 import { MatDatepickerModule } from '@angular/material/datepicker';
-import { GioBannerModule, GioFormJsonSchemaModule, GioFormTagsInputModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
-import { GioPolicyStudioModule } from '@gravitee/ui-policy-studio-angular';
+import { GioBannerModule, GioFormTagsInputModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
 import { MatTabsModule } from '@angular/material/tabs';
 
 import { OrgSettingsGeneralComponent } from './console/org-settings-general.component';
@@ -137,8 +136,6 @@ import { SpelService } from '../../services-ngx/spel.service';
     GioClipboardModule,
     GioTableWrapperModule,
     GioUsersSelectorModule,
-    GioPolicyStudioModule,
-    GioFormJsonSchemaModule,
   ],
   declarations: [
     OrgSettingsGeneralComponent,

--- a/gravitee-apim-console-webui/src/organization/configuration/organization-settings.module.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/organization-settings.module.ts
@@ -40,7 +40,7 @@ import { MatListModule } from '@angular/material/list';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatSortModule } from '@angular/material/sort';
 import { MatDatepickerModule } from '@angular/material/datepicker';
-import { GioBannerModule, GioFormTagsInputModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
+import { GioBannerModule, GioFormJsonSchemaModule, GioFormTagsInputModule, GioSaveBarModule } from '@gravitee/ui-particles-angular';
 import { GioPolicyStudioModule } from '@gravitee/ui-policy-studio-angular';
 import { MatTabsModule } from '@angular/material/tabs';
 
@@ -70,6 +70,7 @@ import { OrgSettingsUserDetailAddGroupDialogComponent } from './user/detail/org-
 import { OrgSettingsUserGenerateTokenComponent } from './user/detail/tokens/org-settings-user-generate-token.component';
 import { OrgSettingsAuditComponent } from './audit/org-settings-audit.component';
 import { OrgSettingsPlatformPoliciesStudioComponent } from './policies/studio/org-settings-platform-policies-studio.component';
+import { OrgSettingsPlatformPoliciesConfigComponent } from './policies/config/org-settings-platform-policies-config.component';
 
 import { GioConfirmDialogModule } from '../../shared/components/gio-confirm-dialog/gio-confirm-dialog.module';
 import { GioAvatarModule } from '../../shared/components/gio-avatar/gio-avatar.module';
@@ -137,6 +138,7 @@ import { SpelService } from '../../services-ngx/spel.service';
     GioTableWrapperModule,
     GioUsersSelectorModule,
     GioPolicyStudioModule,
+    GioFormJsonSchemaModule,
   ],
   declarations: [
     OrgSettingsGeneralComponent,
@@ -155,6 +157,7 @@ import { SpelService } from '../../services-ngx/spel.service';
     OrgSettingsCockpitComponent,
     OrgSettingsPlatformPoliciesComponent,
     OrgSettingsPlatformPoliciesStudioComponent,
+    OrgSettingsPlatformPoliciesConfigComponent,
     OrgSettingsTenantsComponent,
     OrgSettingAddTenantComponent,
     OrgSettingsRolesComponent,

--- a/gravitee-apim-console-webui/src/organization/configuration/policies/config/org-settings-platform-policies-config.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/config/org-settings-platform-policies-config.component.html
@@ -1,0 +1,37 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<mat-card>
+  <div *ngIf="!isLoading" class="policy-studio-api-config">
+    <gio-banner-info>
+      By default, the selection of a flow is based on the operator defined in the flow itself. This operator allows either to select a flow
+      when the path matches exactly, or when the start of the path matches. The "Best match" option allows you to select the flow from the
+      path that is closest.
+    </gio-banner-info>
+
+    <gv-schema-form
+      *ngIf="!isLoading"
+      class="policy-studio-api-config__schema-form"
+      [schema]="flowConfigurationSchema"
+      [values]="fromValue"
+      (:gv-schema-form:change)="onChange($event)"
+    >
+    </gv-schema-form>
+  </div>
+  <ng-container *ngIf="isLoading"> Loading... </ng-container>
+</mat-card>

--- a/gravitee-apim-console-webui/src/organization/configuration/policies/config/org-settings-platform-policies-config.component.scss
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/config/org-settings-platform-policies-config.component.scss
@@ -1,0 +1,8 @@
+@use '../../../../scss/gio-layout' as gio-layout;
+
+:host {
+  @include gio-layout.gio-responsive-margin-container;
+  display: block;
+
+  --gv-schema-form--bgc: transparent;
+}

--- a/gravitee-apim-console-webui/src/organization/configuration/policies/config/org-settings-platform-policies-config.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/config/org-settings-platform-policies-config.component.spec.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { InteractivityChecker } from '@angular/cdk/a11y';
+
+import { OrgSettingsPlatformPoliciesConfigComponent } from './org-settings-platform-policies-config.component';
+
+import { OrganizationSettingsModule } from '../../organization-settings.module';
+import { CONSTANTS_TESTING, GioHttpTestingModule } from '../../../../shared/testing';
+import { fakeOrganization } from '../../../../entities/organization/organization.fixture';
+import { fakeFlow } from '../../../../entities/flow/flow.fixture';
+import { fakeFlowConfigurationSchema } from '../../../../entities/flow/configurationSchema.fixture';
+
+describe('OrgSettingsPlatformPoliciesConfigComponent', () => {
+  let fixture: ComponentFixture<OrgSettingsPlatformPoliciesConfigComponent>;
+  let component: OrgSettingsPlatformPoliciesConfigComponent;
+  let httpTestingController: HttpTestingController;
+
+  const flowConfigurationSchema = fakeFlowConfigurationSchema();
+  const organization = fakeOrganization({
+    flows: [
+      fakeFlow({
+        condition: '',
+        enabled: true,
+        methods: [],
+        name: 'Flow',
+        'path-operator': { operator: 'STARTS_WITH', path: '' },
+        post: [],
+        pre: [],
+        consumers: [
+          { consumerId: 'Consumer 1', consumerType: 'TAG' },
+          { consumerId: 'Consumer 2', consumerType: 'TAG' },
+        ],
+      }),
+    ],
+    flowMode: 'BEST_MATCH',
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, GioHttpTestingModule, OrganizationSettingsModule],
+    })
+      .overrideProvider(InteractivityChecker, {
+        useValue: {
+          isFocusable: () => true, // This traps focus checks and so avoid warnings when dealing with
+        },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(OrgSettingsPlatformPoliciesConfigComponent);
+    component = fixture.componentInstance;
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+
+    httpTestingController
+      .expectOne(`${CONSTANTS_TESTING.org.baseURL}/configuration/flows/configuration-schema`)
+      .flush(flowConfigurationSchema);
+
+    httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}`).flush(organization);
+  });
+
+  describe('ngOnInit', () => {
+    it('should setup properties', async () => {
+      expect(component.flowConfigurationSchema).toStrictEqual(flowConfigurationSchema);
+      expect(component.fromValue).toStrictEqual({
+        flow_mode: 'BEST_MATCH',
+      });
+    });
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+});

--- a/gravitee-apim-console-webui/src/organization/configuration/policies/config/org-settings-platform-policies-config.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/config/org-settings-platform-policies-config.component.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, EventEmitter, OnDestroy, OnInit, Output } from '@angular/core';
+import { combineLatest, Subject } from 'rxjs';
+import { takeUntil, tap } from 'rxjs/operators';
+import { ComponentCustomEvent } from '@gravitee/ui-components/src/lib/events';
+
+import { OrganizationService } from '../../../../services-ngx/organization.service';
+import { OrgSettingsPlatformPoliciesService } from '../org-settings-platform-policies.service';
+import { DefinitionVM } from '../org-settings-platform-policies.component';
+import { FlowConfigurationSchema } from '../../../../entities/flow/configurationSchema';
+
+@Component({
+  selector: 'org-settings-platform-policies-config',
+  template: require('./org-settings-platform-policies-config.component.html'),
+  styles: [require('./org-settings-platform-policies-config.component.scss')],
+})
+export class OrgSettingsPlatformPoliciesConfigComponent implements OnInit, OnDestroy {
+  flowConfigurationSchema: FlowConfigurationSchema;
+
+  isLoading = true;
+
+  fromValue: {
+    flow_mode: DefinitionVM['flow_mode'];
+  };
+
+  @Output()
+  change = new EventEmitter<DefinitionVM['flow_mode']>();
+
+  private unsubscribe$ = new Subject<boolean>();
+
+  constructor(
+    private readonly organizationService: OrganizationService,
+    private readonly orgSettingsPlatformPoliciesService: OrgSettingsPlatformPoliciesService,
+  ) {}
+
+  ngOnInit(): void {
+    this.isLoading = true;
+
+    combineLatest([this.orgSettingsPlatformPoliciesService.getConfigurationSchemaForm(), this.organizationService.get()])
+      .pipe(
+        takeUntil(this.unsubscribe$),
+        tap(([flowSchema, organization]) => {
+          this.flowConfigurationSchema = flowSchema;
+
+          this.fromValue = {
+            flow_mode: organization.flowMode,
+          };
+
+          this.isLoading = false;
+        }),
+      )
+      .subscribe();
+  }
+
+  ngOnDestroy() {
+    this.unsubscribe$.next(true);
+    this.unsubscribe$.unsubscribe();
+  }
+
+  onChange(
+    $event: ComponentCustomEvent<{
+      values: {
+        flow_mode: DefinitionVM['flow_mode'];
+      };
+    }>,
+  ) {
+    this.change.emit($event.detail?.values?.flow_mode);
+  }
+}

--- a/gravitee-apim-console-webui/src/organization/configuration/policies/org-settings-platform-policies.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/org-settings-platform-policies.component.html
@@ -15,15 +15,33 @@
     limitations under the License.
 
 -->
-<gio-policy-studio
-  *ngIf="!isLoading"
-  flowsTitle="Platform flows"
-  [canAdd]="true"
-  [hasPolicyFilter]="true"
-  [hasConditionalSteps]="true"
-  [sortable]="true"
-  [flowSchema]="platformFlowSchema"
-  [policies]="policies"
-  [definition]="definition"
-  (save)="onSave($event)"
-></gio-policy-studio>
+<div class="header">
+  <nav mat-tab-nav-bar mat-align-tabs="end" class="header__nav">
+    <a mat-tab-link [active]="activeTab === 'design'" (click)="activeTab = 'design'"> Design </a>
+    <a mat-tab-link [active]="activeTab === 'config'" (click)="activeTab = 'config'"> Configuration </a>
+    <!-- save button -->
+    <button
+      class="header__nav__saveButton"
+      mat-flat-button
+      color="primary"
+      type="button"
+      [disabled]="isSaveButtonDisabled"
+      (click)="onSave()"
+    >
+      Save
+    </button>
+  </nav>
+</div>
+<div>
+  <div class="content">
+    <ng-container *ngIf="!isLoading && activeTab === 'design'">
+      <org-settings-platform-policies-studio (change)="onChangeStudio($event)"></org-settings-platform-policies-studio>
+    </ng-container>
+
+    <ng-container *ngIf="!isLoading && activeTab === 'config'">
+      WIP
+    </ng-container>
+
+    <ng-container *ngIf="isLoading"> Loading... </ng-container>
+  </div>
+</div>

--- a/gravitee-apim-console-webui/src/organization/configuration/policies/org-settings-platform-policies.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/org-settings-platform-policies.component.html
@@ -39,7 +39,7 @@
     </ng-container>
 
     <ng-container *ngIf="!isLoading && activeTab === 'config'">
-      WIP
+      <org-settings-platform-policies-config (change)="onConfigChange($event)"></org-settings-platform-policies-config>
     </ng-container>
 
     <ng-container *ngIf="isLoading"> Loading... </ng-container>

--- a/gravitee-apim-console-webui/src/organization/configuration/policies/org-settings-platform-policies.component.scss
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/org-settings-platform-policies.component.scss
@@ -2,5 +2,9 @@
 
 :host {
   @include gio-layout.gio-full-width-content-container;
-  --gv-policy-studio--h: 100vh - 75px;
+}
+
+.header__nav__saveButton {
+  margin: 0 24px;
+  align-self: center;
 }

--- a/gravitee-apim-console-webui/src/organization/configuration/policies/org-settings-platform-policies.service.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/org-settings-platform-policies.service.ts
@@ -16,7 +16,6 @@
 
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
-import { ListParams, PolicyListItem, PolicySchema, PolicyDocumentation, ResourceListItem } from '@gravitee/ui-policy-studio-angular';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -25,6 +24,9 @@ import { FlowSchema } from '../../../entities/flow/flowSchema';
 import { ApiService } from '../../../services-ngx/api.service';
 import { PlatformFlowSchema } from '../../../entities/flow/platformFlowSchema';
 import { FlowService } from '../../../services-ngx/flow.service';
+import { ListParams } from '../../../management/api/policy-studio/models/ListParams';
+import { PolicyDocumentation, PolicyListItem, PolicySchema } from '../../../entities/policy';
+import { ResourceListItem } from '../../../entities/resource/resourceListItem';
 
 @Injectable({
   providedIn: 'root',

--- a/gravitee-apim-console-webui/src/organization/configuration/policies/org-settings-platform-policies.service.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/org-settings-platform-policies.service.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Inject, Injectable } from '@angular/core';
+import { ListParams, PolicyListItem, PolicySchema, PolicyDocumentation, ResourceListItem } from '@gravitee/ui-policy-studio-angular';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import { Constants } from '../../../entities/Constants';
+import { FlowSchema } from '../../../entities/flow/flowSchema';
+import { ApiService } from '../../../services-ngx/api.service';
+import { PlatformFlowSchema } from '../../../entities/flow/platformFlowSchema';
+import { FlowService } from '../../../services-ngx/flow.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class OrgSettingsPlatformPoliciesService {
+  constructor(
+    readonly http: HttpClient,
+    readonly apiService: ApiService,
+    readonly flowService: FlowService,
+    @Inject('Constants') readonly constants: Constants,
+  ) {}
+
+  listPolicies(params: ListParams): Observable<PolicyListItem[]> {
+    let httpParams = new HttpParams();
+
+    if (params.expandSchema) {
+      httpParams = httpParams.append('expand', 'schema');
+    }
+    if (params.expandIcon) {
+      httpParams = httpParams.append('expand', 'icon');
+    }
+    if (params.withoutResource) {
+      httpParams = httpParams.set('withResource', false);
+    }
+
+    return this.http.get<PolicyListItem[]>(`${this.constants.env.baseURL}/policies`, {
+      params: httpParams,
+    });
+  }
+
+  listSwaggerPolicies(): Observable<PolicyListItem[]> {
+    return this.http.get<PolicyListItem[]>(`${this.constants.env.baseURL}/policies/swagger`);
+  }
+
+  getSchema(policyId: string): Observable<PolicySchema> {
+    return this.http.get<PolicySchema>(`${this.constants.env.baseURL}/policies/${policyId}/schema`);
+  }
+
+  getDocumentation(policyId: string): Observable<PolicyDocumentation> {
+    return this.http
+      .get(`${this.constants.env.baseURL}/policies/${policyId}/documentation`, {
+        responseType: 'text',
+      })
+      .pipe(map((buffer) => buffer.toString()));
+  }
+
+  getFlowSchemaForm(): Observable<FlowSchema> {
+    return this.apiService.getFlowSchemaForm();
+  }
+
+  getPlatformFlowSchemaForm(): Observable<PlatformFlowSchema> {
+    return this.flowService.getPlatformFlowSchemaForm();
+  }
+
+  getSpelGrammar(): Observable<any> {
+    return this.http.get(`${this.constants.env.baseURL}/configuration/spel/grammar`);
+  }
+
+  listResources(params: ListParams): Observable<ResourceListItem[]> {
+    let httpParams = new HttpParams();
+
+    if (params.expandSchema) {
+      httpParams = httpParams.append('expand', 'schema');
+    }
+    if (params.expandIcon) {
+      httpParams = httpParams.append('expand', 'icon');
+    }
+
+    return this.http.get<ResourceListItem[]>(`${this.constants.env.baseURL}/resources`, {
+      params: httpParams,
+    });
+  }
+
+  getConfigurationSchemaForm() {
+    return this.flowService.getConfigurationSchemaForm();
+  }
+}

--- a/gravitee-apim-console-webui/src/organization/configuration/policies/studio/org-settings-platform-policies-studio.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/studio/org-settings-platform-policies-studio.component.html
@@ -1,0 +1,39 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="policy-studio-design">
+  <gv-design
+    *ngIf="!isLoading"
+    #gvDesignComponent
+    flowsTitle="Platform flows"
+    can-add
+    has-policy-filter
+    has-conditional-steps
+    sortable
+    [flowSchema]="platformFlowSchema"
+    [policies]="policies"
+    [definition]="definition"
+    [resourceTypes]="resourceTypes"
+    [selectedFlowsId]="selectedFlowsIds"
+    [documentation]="policyDocumentation"
+    (:gv-design:change)="onChange($event)"
+    (:gv-design:fetch-documentation)="fetchPolicyDocumentation($any($event).detail)"
+    (:gv-design:select-flows)="onFlowSelectionChanged($any($event).detail)"
+    (:gv-expression-language:ready)="fetchSpelGrammar($any($event).detail)"
+  ></gv-design>
+</div>
+<ng-container *ngIf="isLoading"> Loading... </ng-container>

--- a/gravitee-apim-console-webui/src/organization/configuration/policies/studio/org-settings-platform-policies-studio.component.scss
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/studio/org-settings-platform-policies-studio.component.scss
@@ -1,0 +1,7 @@
+:host {
+  --gv-policy-studio--h: calc(100vh - 105px);
+}
+
+.policy-studio-design {
+  background-color: white; // to be coherent with --gv-policy-studio
+}

--- a/gravitee-apim-console-webui/src/organization/configuration/policies/studio/org-settings-platform-policies-studio.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/studio/org-settings-platform-policies-studio.component.spec.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { InteractivityChecker } from '@angular/cdk/a11y';
+
+import { OrgSettingsPlatformPoliciesStudioComponent } from './org-settings-platform-policies-studio.component';
+
+import { OrganizationSettingsModule } from '../../organization-settings.module';
+import { CONSTANTS_TESTING, GioHttpTestingModule } from '../../../../shared/testing';
+import { fakePolicyListItem } from '../../../../entities/policy';
+import { fakeOrganization } from '../../../../entities/organization/organization.fixture';
+import { fakePlatformFlowSchema } from '../../../../entities/flow/platformFlowSchema.fixture';
+import { fakeFlow } from '../../../../entities/flow/flow.fixture';
+
+describe('OrgSettingsPlatformPoliciesStudioComponent', () => {
+  let fixture: ComponentFixture<OrgSettingsPlatformPoliciesStudioComponent>;
+  let component: OrgSettingsPlatformPoliciesStudioComponent;
+  let httpTestingController: HttpTestingController;
+
+  const platformFlowSchema = fakePlatformFlowSchema();
+  const policies = [fakePolicyListItem()];
+  const organization = fakeOrganization({
+    flows: [
+      fakeFlow({
+        condition: '',
+        enabled: true,
+        methods: [],
+        name: 'Flow',
+        'path-operator': { operator: 'STARTS_WITH', path: '' },
+        post: [],
+        pre: [],
+        consumers: [
+          { consumerId: 'Consumer 1', consumerType: 'TAG' },
+          { consumerId: 'Consumer 2', consumerType: 'TAG' },
+        ],
+      }),
+    ],
+    flowMode: 'BEST_MATCH',
+  });
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, GioHttpTestingModule, OrganizationSettingsModule],
+    })
+      .overrideProvider(InteractivityChecker, {
+        useValue: {
+          isFocusable: () => true, // This traps focus checks and so avoid warnings when dealing with
+        },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(OrgSettingsPlatformPoliciesStudioComponent);
+    component = fixture.componentInstance;
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+
+    httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/configuration/flows/flow-schema`).flush(platformFlowSchema);
+
+    httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/policies?expand=schema&expand=icon`).flush(policies);
+
+    httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/resources?expand=schema&expand=icon`).flush(organization);
+
+    httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}`).flush(organization);
+  });
+
+  describe('ngOnInit', () => {
+    it('should setup properties', async () => {
+      expect(component.policies).toStrictEqual(policies);
+      expect(component.platformFlowSchema).toStrictEqual(platformFlowSchema);
+      expect(component.organization).toStrictEqual(organization);
+      expect(component.definition).toStrictEqual({
+        flows: [
+          {
+            condition: '',
+            consumers: ['Consumer 1', 'Consumer 2'],
+            enabled: true,
+            methods: [],
+            name: 'Flow',
+            'path-operator': { operator: 'STARTS_WITH', path: '' },
+            post: [],
+            pre: [],
+          },
+        ],
+      });
+    });
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+});

--- a/gravitee-apim-console-webui/src/organization/configuration/policies/studio/org-settings-platform-policies-studio.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/studio/org-settings-platform-policies-studio.component.ts
@@ -18,7 +18,6 @@ import { Component, EventEmitter, OnDestroy, OnInit, Output } from '@angular/cor
 import { combineLatest, Subject } from 'rxjs';
 import { takeUntil, tap } from 'rxjs/operators';
 import { ComponentCustomEvent } from '@gravitee/ui-components/src/lib/events';
-import { PlatformFlowSchema, PolicyListItem, ResourceListItem, Grammar } from '@gravitee/ui-policy-studio-angular';
 import { Location } from '@angular/common';
 
 import { UrlParams } from '../../../../management/api/policy-studio/design/policy-studio-design.component';
@@ -26,6 +25,10 @@ import { OrganizationService } from '../../../../services-ngx/organization.servi
 import { OrgSettingsPlatformPoliciesService } from '../org-settings-platform-policies.service';
 import { Organization } from '../../../../entities/organization/organization';
 import { DefinitionVM } from '../org-settings-platform-policies.component';
+import { PlatformFlowSchema } from '../../../../entities/flow/platformFlowSchema';
+import { PolicyListItem } from '../../../../entities/policy';
+import { ResourceListItem } from '../../../../entities/resource/resourceListItem';
+import { Grammar } from '../../../../entities/spel/grammar';
 
 @Component({
   selector: 'org-settings-platform-policies-studio',

--- a/gravitee-apim-console-webui/src/organization/configuration/policies/studio/org-settings-platform-policies-studio.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/policies/studio/org-settings-platform-policies-studio.component.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, EventEmitter, OnDestroy, OnInit, Output } from '@angular/core';
+import { combineLatest, Subject } from 'rxjs';
+import { takeUntil, tap } from 'rxjs/operators';
+import { ComponentCustomEvent } from '@gravitee/ui-components/src/lib/events';
+import { PlatformFlowSchema, PolicyListItem, ResourceListItem, Grammar } from '@gravitee/ui-policy-studio-angular';
+import { Location } from '@angular/common';
+
+import { UrlParams } from '../../../../management/api/policy-studio/design/policy-studio-design.component';
+import { OrganizationService } from '../../../../services-ngx/organization.service';
+import { OrgSettingsPlatformPoliciesService } from '../org-settings-platform-policies.service';
+import { Organization } from '../../../../entities/organization/organization';
+import { DefinitionVM } from '../org-settings-platform-policies.component';
+
+@Component({
+  selector: 'org-settings-platform-policies-studio',
+  template: require('./org-settings-platform-policies-studio.component.html'),
+  styles: [require('./org-settings-platform-policies-studio.component.scss')],
+})
+export class OrgSettingsPlatformPoliciesStudioComponent implements OnInit, OnDestroy {
+  get isLoading() {
+    return !this.definition;
+  }
+
+  organization: Organization;
+  definition: DefinitionVM;
+  platformFlowSchema: PlatformFlowSchema;
+  policies: PolicyListItem[];
+  resourceTypes: ResourceListItem[];
+  selectedFlowsIds: string[] = [];
+  policyDocumentation!: { id: string; image: string; content: string };
+
+  @Output()
+  change = new EventEmitter<DefinitionVM['flows']>();
+
+  private unsubscribe$ = new Subject<boolean>();
+
+  constructor(
+    private readonly location: Location,
+    private readonly organizationService: OrganizationService,
+    private readonly orgSettingsPlatformPoliciesService: OrgSettingsPlatformPoliciesService,
+  ) {}
+
+  ngOnInit(): void {
+    combineLatest([
+      this.orgSettingsPlatformPoliciesService.getPlatformFlowSchemaForm(),
+      this.orgSettingsPlatformPoliciesService.listPolicies({ expandSchema: true, expandIcon: true }),
+      this.organizationService.get(),
+      this.orgSettingsPlatformPoliciesService.listResources({ expandSchema: true, expandIcon: true }),
+    ])
+      .pipe(
+        takeUntil(this.unsubscribe$),
+        tap(([flowSchema, policies, organization, resourceTypes]) => {
+          this.platformFlowSchema = flowSchema;
+          this.policies = policies;
+          this.organization = organization;
+
+          this.definition = {
+            flows: (this.organization.flows ?? []).map((flow) => ({
+              ...flow,
+              consumers: flow.consumers.map((consumer) => consumer.consumerId),
+            })),
+          };
+
+          this.resourceTypes = resourceTypes;
+        }),
+      )
+      .subscribe();
+
+    const { flowsIds } = this.parseUrl();
+    this.selectedFlowsIds = [JSON.stringify(flowsIds)];
+  }
+
+  ngOnDestroy() {
+    this.unsubscribe$.next(true);
+    this.unsubscribe$.unsubscribe();
+  }
+
+  onFlowSelectionChanged({ flows }: { flows: string[] }): void {
+    this.updateUrl({ ...this.parseUrl(), flowsIds: flows });
+  }
+
+  fetchPolicyDocumentation({ policy }: { policy: { id: string; icon: string } }): void {
+    this.orgSettingsPlatformPoliciesService
+      .getDocumentation(policy.id)
+      .pipe(
+        tap(
+          (documentation) =>
+            (this.policyDocumentation = {
+              id: policy.id,
+              image: policy.icon,
+              content: documentation,
+            }),
+        ),
+      )
+      .subscribe();
+  }
+
+  fetchSpelGrammar({ currentTarget }: { currentTarget: { grammar: Grammar } }): void {
+    this.orgSettingsPlatformPoliciesService
+      .getSpelGrammar()
+      .pipe(tap((grammar) => (currentTarget.grammar = grammar)))
+      .subscribe();
+  }
+
+  onChange(
+    $event: ComponentCustomEvent<{
+      isDirty: boolean;
+      errors: number;
+      definition?: DefinitionVM;
+    }>,
+  ) {
+    const { isDirty, errors, definition } = $event.detail;
+    if (isDirty && errors === 0 && definition != null) {
+      this.change.emit(definition.flows);
+    }
+  }
+
+  private parseUrl(): UrlParams {
+    // TODO: Improve this with Angular Router
+    // Hack to add the tab as Fragment part of the URL
+    const [path] = this.location.path(true).split(/#(\w*)$/);
+
+    const [basePath, ...flowsIds] = path.split('flows');
+
+    const cleanedPath = basePath.replace('?', '');
+    const cleanedFlows = (flowsIds ?? []).map((flow) => flow.replace('=', ''));
+
+    return {
+      path: cleanedPath,
+      flowsIds: cleanedFlows,
+    };
+  }
+
+  private updateUrl({ path, flowsIds }: UrlParams): void {
+    // TODO: Improve this with Angular Router
+    // Hack to add the tab as Fragment part of the URL
+    const flowsQueryParams = (flowsIds ?? []).map((value) => `flows=${value}`).join('&');
+
+    const queryParams = flowsQueryParams.length > 0 ? `?${flowsQueryParams}` : '';
+
+    this.location.go(`${path}${queryParams}`);
+  }
+}

--- a/gravitee-apim-console-webui/src/services-ngx/flow.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/flow.service.ts
@@ -16,7 +16,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { FlowServiceAbstract } from '@gravitee/ui-policy-studio-angular';
 
 import { Constants } from '../entities/Constants';
 import { FlowConfigurationSchema } from '../entities/flow/configurationSchema';
@@ -26,7 +25,7 @@ import { OrganizationFlowConfiguration } from '../entities/flow/organizationFlow
 @Injectable({
   providedIn: 'root',
 })
-export class FlowService implements FlowServiceAbstract {
+export class FlowService {
   constructor(private readonly http: HttpClient, @Inject('Constants') private readonly constants: Constants) {}
 
   getConfigurationSchemaForm(): Observable<FlowConfigurationSchema> {

--- a/gravitee-apim-console-webui/src/services-ngx/policy.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/policy.service.ts
@@ -15,7 +15,6 @@
  */
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
-import { PolicyServiceAbstract } from '@gravitee/ui-policy-studio-angular';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -31,7 +30,7 @@ interface ListParams {
 @Injectable({
   providedIn: 'root',
 })
-export class PolicyService implements PolicyServiceAbstract {
+export class PolicyService {
   constructor(private readonly http: HttpClient, @Inject('Constants') private readonly constants: Constants) {}
 
   list(params: ListParams): Observable<PolicyListItem[]> {

--- a/gravitee-apim-console-webui/src/services-ngx/resource.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/resource.service.ts
@@ -15,7 +15,6 @@
  */
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
-import { ResourceServiceAbstract } from '@gravitee/ui-policy-studio-angular';
 import { Observable } from 'rxjs';
 
 import { Constants } from '../entities/Constants';
@@ -31,7 +30,7 @@ interface ListParams {
 @Injectable({
   providedIn: 'root',
 })
-export class ResourceService implements ResourceServiceAbstract {
+export class ResourceService {
   constructor(private readonly http: HttpClient, @Inject('Constants') private readonly constants: Constants) {}
 
   list(params: ListParams): Observable<ResourceListItem[]> {

--- a/gravitee-apim-console-webui/src/services-ngx/spel.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/spel.service.ts
@@ -15,7 +15,6 @@
  */
 import { HttpClient } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
-import { SpelServiceAbstract } from '@gravitee/ui-policy-studio-angular';
 import { Observable } from 'rxjs';
 
 import { Constants } from '../entities/Constants';
@@ -24,7 +23,7 @@ import { Grammar } from '../entities/spel/grammar';
 @Injectable({
   providedIn: 'root',
 })
-export class SpelService implements SpelServiceAbstract {
+export class SpelService {
   constructor(private readonly http: HttpClient, @Inject('Constants') private readonly constants: Constants) {}
 
   getGrammar(): Observable<Grammar> {


### PR DESCRIPTION
## Issue
n/a

## Description

Start to remove the use of `@gravitee/ui-policy-studio-angular`. I need to to it on all gravitee supported version. 

This version of the policy studio will never be migrated
this repository will be used for the future new version event native


## Additional context
Small Ui changes : 

<img width="1180" alt="image" src="https://github.com/gravitee-io/gravitee-api-management/assets/4974420/94422c71-4c96-4b3d-b27f-56ca5a2725ab">
<img width="1165" alt="image" src="https://github.com/gravitee-io/gravitee-api-management/assets/4974420/8ea07f68-e550-4618-84e8-a8f51e8b9ff0">


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xodyxzprgf.chromatic.com)
<!-- Storybook placeholder end -->
