### PR TITLE
Enable use of API's metadata as email recipient

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -2112,6 +2112,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         try {
             LOGGER.debug("Start API {}", apiId);
             ApiEntity apiEntity = updateLifecycle(executionContext, apiId, LifecycleState.STARTED, userId);
+            fetchMetadataForApi(executionContext, apiEntity);
             notifierService.trigger(
                 executionContext,
                 ApiHook.API_STARTED,
@@ -2130,6 +2131,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         try {
             LOGGER.debug("Stop API {}", apiId);
             ApiEntity apiEntity = updateLifecycle(executionContext, apiId, LifecycleState.STOPPED, userId);
+            fetchMetadataForApi(executionContext, apiEntity);
             notifierService.trigger(
                 executionContext,
                 ApiHook.API_STOPPED,
@@ -2293,6 +2295,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         final ApiEntity deployed = convert(executionContext, singletonList(api)).iterator().next();
 
         if (!getAuthenticatedUser().isSystem()) {
+            fetchMetadataForApi(executionContext, deployed);
             notifierService.trigger(
                 executionContext,
                 ApiHook.API_DEPLOYED,
@@ -2972,6 +2975,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         apiEntity.setWorkflowState(workflowState);
 
         final UserEntity user = userService.findById(executionContext, userId);
+        fetchMetadataForApi(executionContext, apiEntity);
         notifierService.trigger(executionContext, hook, apiId, new NotificationParamsBuilder().api(apiEntity).user(user).build());
 
         // Find all reviewers of the API and send them a notification email
@@ -3626,8 +3630,8 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
     private void triggerNotification(ExecutionContext executionContext, String apiId, ApiHook hook, ApiEntity apiEntity) {
         String userId = getAuthenticatedUsername();
-
         if (userId != null && !getAuthenticatedUser().isSystem()) {
+            fetchMetadataForApi(executionContext, apiEntity);
             notifierService.trigger(
                 executionContext,
                 hook,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_StartTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_StartTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.service.impl;
 
 import static io.gravitee.rest.api.model.EventType.PUBLISH_API;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -41,6 +42,8 @@ import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.jackson.filter.ApiPermissionFilter;
 import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.NotificationTemplateService;
+import java.io.StringReader;
 import java.util.*;
 import org.junit.Before;
 import org.junit.Test;
@@ -100,6 +103,12 @@ public class ApiService_StartTest {
     @Mock
     private FlowService flowService;
 
+    @Mock
+    private ApiMetadataService apiMetadataService;
+
+    @Mock
+    private NotificationTemplateService notificationTemplateService;
+
     @Spy
     private ApiConverter apiConverter;
 
@@ -134,6 +143,9 @@ public class ApiService_StartTest {
         query.setApi(API_ID);
         query.setTypes(singleton(PUBLISH_API));
         when(eventService.search(GraviteeContext.getExecutionContext(), query)).thenReturn(singleton(event));
+        when(apiMetadataService.findAllByApi(anyString())).thenReturn(List.of());
+        when(notificationTemplateService.resolveInlineTemplateWithParam(anyString(), anyString(), any(StringReader.class), anyMap()))
+            .thenReturn("content");
 
         apiService.start(GraviteeContext.getExecutionContext(), API_ID, USER_NAME);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_StopTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_StopTest.java
@@ -41,6 +41,8 @@ import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.jackson.filter.ApiPermissionFilter;
 import io.gravitee.rest.api.service.notification.ApiHook;
+import io.gravitee.rest.api.service.notification.NotificationTemplateService;
+import java.io.StringReader;
 import java.util.*;
 import org.junit.Before;
 import org.junit.Test;
@@ -100,6 +102,12 @@ public class ApiService_StopTest {
     @Mock
     private FlowService flowService;
 
+    @Mock
+    private ApiMetadataService apiMetadataService;
+
+    @Mock
+    private NotificationTemplateService notificationTemplateService;
+
     @Spy
     private ApiConverter apiConverter;
 
@@ -134,6 +142,9 @@ public class ApiService_StopTest {
         query.setApi(API_ID);
         query.setTypes(singleton(PUBLISH_API));
         when(eventService.search(GraviteeContext.getExecutionContext(), query)).thenReturn(singleton(event));
+        when(apiMetadataService.findAllByApi(anyString())).thenReturn(List.of());
+        when(notificationTemplateService.resolveInlineTemplateWithParam(anyString(), anyString(), any(StringReader.class), anyMap()))
+            .thenReturn("content");
 
         apiService.stop(GraviteeContext.getExecutionContext(), API_ID, USER_NAME);
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1513
https://github.com/gravitee-io/issues/issues/9030

## Description

Enable use of API's metadata as email recipient by fetching them before evaluating the freemarker template
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jmotjlmhlv.chromatic.com)
<!-- Storybook placeholder end -->
