### PR TITLE
fix: pagination data in applications

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/PagedResult.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/PagedResult.java
@@ -25,9 +25,9 @@ import java.util.Map;
  */
 public class PagedResult<T> {
 
-    private final Collection<T> data;
+    private Collection<T> data;
     private Map<String, Map<String, Object>> metadata;
-    private final Page page;
+    private Page page;
 
     public PagedResult(Collection<T> data, int pageNumber, int perPage, int totalElements) {
         this.data = data;
@@ -41,6 +41,8 @@ public class PagedResult<T> {
     public PagedResult(io.gravitee.common.data.domain.Page<T> page, int perPage) {
         this(page.getContent(), page.getPageNumber(), perPage, (int) page.getTotalElements());
     }
+
+    public PagedResult() {}
 
     public Collection<T> getData() {
         return data;
@@ -58,35 +60,37 @@ public class PagedResult<T> {
         return page;
     }
 
-    public class Page {
+    public static class Page {
 
         /**
          * the current page number. Start to 1
          */
-        private final int current;
+        private int current;
 
         /**
          * the requested number of elements per page
          */
         @JsonProperty("per_page")
-        private final int perPage;
+        private int perPage;
 
         /**
          * the size of the result
          */
-        private final int size;
+        private int size;
 
         /**
          * the maximum page number
          */
         @JsonProperty("total_pages")
-        private final int totalPages;
+        private int totalPages;
 
         /**
          * the count of all elements
          */
         @JsonProperty("total_elements")
-        private final int totalElements;
+        private int totalElements;
+
+        public Page() {}
 
         public Page(int current, int perPage, int size, int totalElements) {
             this.current = current;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/wrapper/ApplicationListItemPagedResult.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/wrapper/ApplicationListItemPagedResult.java
@@ -16,11 +16,14 @@
 package io.gravitee.rest.api.management.rest.model.wrapper;
 
 import io.gravitee.rest.api.management.rest.model.PagedResult;
-import io.gravitee.rest.api.model.api.ApiListItem;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
 import java.util.Collection;
 
 public class ApplicationListItemPagedResult extends PagedResult<ApplicationListItem> {
+
+    public ApplicationListItemPagedResult() {
+        super();
+    }
 
     public ApplicationListItemPagedResult(Collection<ApplicationListItem> data, int pageNumber, int perPage, int totalElements) {
         super(data, pageNumber, perPage, totalElements);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationsResource.java
@@ -168,7 +168,10 @@ public class ApplicationsResource extends AbstractResource {
             applications.getContent().forEach(this::addPictureUrl);
         }
 
-        return new ApplicationListItemPagedResult(applications, (int) applications.getPageElements());
+        return new ApplicationListItemPagedResult(
+            applications,
+            pageable != null ? pageable.getSize() : (int) applications.getPageElements()
+        );
     }
 
     private void addPictureUrl(ApplicationListItem application) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1613

## Description

Pagination last page metadata was broken 

## Additional context

NB: Needed to add empty constructors and make page inner class static for Jakarta to be able to deserialize response content.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mwhaleqjqr.chromatic.com)
<!-- Storybook placeholder end -->
