### PR TITLE
fix(console): serialize/deserialize securityConfig for rest-api-v1

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
@@ -217,7 +217,7 @@ describe('ApiPlanFormComponent', () => {
         excluded_groups: ['group-a'],
         general_conditions: 'doc-1',
         security: 'JWT',
-        securityDefinition: {},
+        securityDefinition: '{}',
         selection_rule: '{ #el ...}',
         tags: [TAG_1_ID],
         validation: 'AUTO',
@@ -293,7 +293,7 @@ describe('ApiPlanFormComponent', () => {
         general_conditions: '',
         tags: [],
         security: 'OAUTH2',
-        securityDefinition: {},
+        securityDefinition: '{}',
         selection_rule: null,
         validation: 'MANUAL',
         flows: [

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
@@ -260,6 +260,10 @@ export class ApiPlanFormComponent implements OnInit, AfterViewInit, OnDestroy, C
     });
 
     if (value) {
+      // TODO: Delete if-check once rest-api-v2 is implemented
+      if (typeof value.secure?.securityConfig === 'string') {
+        value.secure.securityConfig = JSON.parse(<string>value.secure.securityConfig);
+      }
       this.planForm.patchValue(value);
       this.planForm.updateValueAndValidity();
     }
@@ -433,7 +437,7 @@ const internalFormValueToPlanV3 = (value: InternalPlanFormValue, mode: 'create' 
 
     // Secure
     security: value.secure.securityType as PlanSecurityTypeV3,
-    securityDefinition: value.secure.securityConfig,
+    securityDefinition: JSON.stringify(value.secure.securityConfig), // TODO: remove stringify when rest-api-v2 implemented
     selection_rule: value.secure.selectionRule,
 
     // Restriction (only for create mode)

--- a/gravitee-apim-console-webui/src/management/api/portal/plans/edit/api-portal-plan-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/plans/edit/api-portal-plan-edit.component.spec.ts
@@ -125,7 +125,7 @@ describe('ApiPortalPlanEditComponent', () => {
         excluded_groups: [],
         tags: [],
         security: 'KEY_LESS',
-        securityDefinition: {},
+        securityDefinition: '{}',
         selection_rule: null,
         flows: [
           {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1671

## Description

The problem is that when creating a plan, the form sets the value for `securityDefinition` as an object. The backend (for now) only accepts String for `securityDefinition`, so it refuses the request.
However, when updating a plan, the console accepts the stringified config sent from the back, which it then sends to the back without touching it.

The solution allows for:
- the object config sent to the back to be stringified for rest-api-v1 APIs V1-V3.
- the stringified `securityDefinition` sent from the back to be transformed into an object.

This will change once rest-api-v2 is implemented:
- all config objects sent from the back will be in object form (no more long config strings)
- all endpoints in the back will be able to accept either an object or string for any configuration attribute
... both of which will allow console to simply accept the backend object and resend it to the back, no transformations.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mmhbtaiewl.chromatic.com)
<!-- Storybook placeholder end -->
