### PR TITLE
Migrate all the fields of the API plans

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/migration/APIV1toAPIV2Converter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/migration/APIV1toAPIV2Converter.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.service.migration;
 import static io.gravitee.common.http.HttpMethod.*;
 import static io.gravitee.rest.api.service.validator.JsonHelper.clearNullValues;
 import static java.util.Collections.reverseOrder;
+import static org.springframework.beans.BeanUtils.copyProperties;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.jackson.JsonLoader;
@@ -38,6 +39,7 @@ import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
 
@@ -101,20 +103,8 @@ public class APIV1toAPIV2Converter {
             .filter(planEntity -> !PlanStatus.CLOSED.equals(planEntity.getStatus()))
             .map(planEntity -> {
                 final PlanEntity plan = new PlanEntity();
-                plan.setId(planEntity.getId());
-                plan.setApi(planEntity.getApi());
-                plan.setName(planEntity.getName());
-                plan.setSecurity(planEntity.getSecurity());
-                plan.setSecurityDefinition(planEntity.getSecurityDefinition());
-                plan.setValidation(planEntity.getValidation());
-                plan.setDescription(planEntity.getDescription());
-                plan.setType(planEntity.getType());
-                plan.setStatus(planEntity.getStatus());
-                plan.setOrder(planEntity.getOrder());
+                copyProperties(planEntity, plan, "paths");
                 plan.setFlows(migratePathsToFlows(planEntity.getPaths(), policies));
-                if (planEntity.getTags() != null) {
-                    plan.setTags(new HashSet<>(planEntity.getTags()));
-                }
                 return plan;
             })
             .collect(Collectors.toSet());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/service/migration/api-withOnlyPlans-migrated.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/service/migration/api-withOnlyPlans-migrated.json
@@ -49,7 +49,9 @@
     } ],
     "status" : "PUBLISHED",
     "tags" : [ "first-tag", "second-tag" ],
-    "api" : "api-id"
+    "api" : "api-id",
+    "comment_required" : false,
+    "selection_rule" : "true"
   } ],
   "gravitee" : "2.0.0",
   "properties" : [ ],

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/service/migration/api-withPathsAndPlans-migrated.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/service/migration/api-withPathsAndPlans-migrated.json
@@ -204,7 +204,9 @@
             ],
             "status": "PUBLISHED",
             "tags": ["first-tag", "second-tag"],
-            "api": "api-id"
+            "api": "api-id",
+            "comment_required" : false,
+            "selection_rule" : "true"
         }
     ],
     "gravitee": "2.0.0",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/service/migration/plans.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/rest/api/service/migration/plans.json
@@ -32,7 +32,8 @@
     } ]
   },
   "flows" : [ ],
-  "comment_required" : false
+  "comment_required" : false,
+  "selection_rule" : "true"
 },
   {
     "id" : "closed-plan-id",


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1521
https://github.com/gravitee-io/issues/issues/9032

## Description

Some fields of an API plan were not correctly mapped while migrating the policy studio to v2.

## Additional context

Steps to reproduce:
1.  Import the [echo12-migrate-to-v2.txt](https://github.com/gravitee-io/gravitee-api-management/files/11487486/echo12-migrate-to-v2.txt) API at http://localhost:3000/#!/environments/DEFAULT/apis/new/import/1.0.0 (version 1.0.0 is important).
2. Migrate to v2 policy studio.
3. And check that the plan has a null selection_rule field.

To avoid any other mistakes/oversights in the future, I used a helper which uses a bit of reflection to copy the whole object, which should not cause performance issues as it is an action performed only once on an API.



<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mdzvbbyahq.chromatic.com)
<!-- Storybook placeholder end -->
