### PR TITLE
fix: Remove Endpoint term from mqtt and mock plugin names

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mock/src/main/resources/plugin.properties
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mock/src/main/resources/plugin.properties
@@ -1,5 +1,5 @@
 id=mock
-name=Endpoint mock
+name=Mock
 version=${project.version}
 description=${project.description}
 class=io.gravitee.plugin.endpoint.mock.MockEndpointConnectorFactory

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mqtt5/src/main/resources/plugin.properties
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-mqtt5/src/main/resources/plugin.properties
@@ -1,5 +1,5 @@
 id=mqtt5
-name=Endpoint MQTT 5.x
+name=MQTT 5.x
 version=${project.version}
 description=${project.description}
 class=io.gravitee.plugin.endpoint.mqtt5.Mqtt5EndpointConnectorFactory


### PR DESCRIPTION
## Description

Removed "Endpoint" from the name of the Mock and MQTT5 plugins.

## Additional context

Goal is to have the UI not show the "Endpoint" term in front of these two endpoints.

