### PR TITLE
Fix pagination in APIs search

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImpl.java
@@ -294,12 +294,11 @@ public class ApiSearchServiceImpl extends AbstractService implements ApiSearchSe
         Integer currentPage = pageable.getPageNumber();
 
         Integer startIndex = (currentPage - 1) * numberOfItemPerPage;
-        Integer lastIndex = Math.min(startIndex + numberOfItemPerPage, numberOfItems);
 
         if (startIndex >= numberOfItems || currentPage < 1) {
             throw new PaginationInvalidException();
         }
-        return ids.stream().skip(startIndex).limit(lastIndex).collect(toList());
+        return ids.stream().skip(startIndex).limit(numberOfItemPerPage).collect(toList());
     }
 
     /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiSearchService_SearchTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiSearchService_SearchTest.java
@@ -217,7 +217,7 @@ public class ApiSearchService_SearchTest {
         QueryBuilder<ApiEntity> apiEntityQueryBuilder = QueryBuilder.create(ApiEntity.class);
         apiEntityQueryBuilder.setQuery("*");
 
-        var ids = List.of("id-1", "id-2");
+        var ids = List.of("id-1", "id-2", "id-3", "id-4", "id-5", "id-6");
 
         var filters = new HashMap<String, Object>();
         filters.put("api", ids);
@@ -227,11 +227,11 @@ public class ApiSearchService_SearchTest {
             .thenReturn(new SearchResult(ids));
 
         var apiEntity1 = new Api();
-        apiEntity1.setId("id-1");
+        apiEntity1.setId("id-3");
         apiEntity1.setLifecycleState(LifecycleState.STARTED);
 
         var apiEntity2 = new Api();
-        apiEntity2.setId("id-2");
+        apiEntity2.setId("id-4");
         apiEntity2.setLifecycleState(LifecycleState.STARTED);
 
         when(
@@ -239,7 +239,7 @@ public class ApiSearchService_SearchTest {
                 eq(
                     new ApiCriteria.Builder()
                         .environmentId(GraviteeContext.getExecutionContext().getEnvironmentId())
-                        .ids(ids)
+                        .ids(List.of("id-3", "id-4"))
                         .definitionVersion(List.of(DefinitionVersion.V4))
                         .build()
                 ),
@@ -256,8 +256,8 @@ public class ApiSearchService_SearchTest {
             .thenReturn(
                 new HashMap<>() {
                     {
-                        put("id-1", primaryOwnerEntity);
-                        put("id-2", primaryOwnerEntity);
+                        put("id-3", primaryOwnerEntity);
+                        put("id-4", primaryOwnerEntity);
                     }
                 }
             );
@@ -267,14 +267,14 @@ public class ApiSearchService_SearchTest {
             USER_ID,
             true,
             apiEntityQueryBuilder.setFilters(filters),
-            new PageableImpl(1, 10)
+            new PageableImpl(2, 2)
         );
 
         assertThat(apis).isNotNull();
         assertThat(apis.getContent().size()).isEqualTo(2);
-        assertThat(apis.getContent().get(0).getId()).isEqualTo("id-1");
-        assertThat(apis.getTotalElements()).isEqualTo(2);
-        assertThat(apis.getPageNumber()).isEqualTo(1);
+        assertThat(apis.getContent().get(0).getId()).isEqualTo("id-3");
+        assertThat(apis.getTotalElements()).isEqualTo(6);
+        assertThat(apis.getPageNumber()).isEqualTo(2);
         assertThat(apis.getPageElements()).isEqualTo(2);
         assertThat(
             apis


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1749

## Description

When using streams to extract a sublist, `limit` is the max number of items to keep **after** items have been skipped with the `skip` method.
So we don't need to compute the limit from the `startIndex` parameter
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jhpubhfiym.chromatic.com)
<!-- Storybook placeholder end -->
