### PR TITLE
fix: execute security chain after CORSPreflight Processor in jupiter/v4

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactor.java
@@ -98,6 +98,7 @@ public class SyncApiReactor extends AbstractLifecycleComponent<ReactorHandler> i
     protected final FlowChain apiFlowChain;
     private final ProcessorChain beforeHandleProcessors;
     private final ProcessorChain afterHandleProcessors;
+    protected final ProcessorChain beforeSecurityChainProcessors;
     protected final ProcessorChain beforeApiFlowsProcessors;
     protected final ProcessorChain afterApiFlowsProcessors;
     protected final ProcessorChain onErrorProcessors;
@@ -136,6 +137,7 @@ public class SyncApiReactor extends AbstractLifecycleComponent<ReactorHandler> i
 
         this.beforeHandleProcessors = apiProcessorChainFactory.beforeHandle(api);
         this.afterHandleProcessors = apiProcessorChainFactory.afterHandle(api);
+        this.beforeSecurityChainProcessors = apiProcessorChainFactory.beforeSecurityChain(api);
         this.beforeApiFlowsProcessors = apiProcessorChainFactory.beforeApiExecution(api);
         this.afterApiFlowsProcessors = apiProcessorChainFactory.afterApiExecution(api);
         this.onErrorProcessors = apiProcessorChainFactory.onError(api);
@@ -205,6 +207,8 @@ public class SyncApiReactor extends AbstractLifecycleComponent<ReactorHandler> i
         return executeProcessorChain(ctx, beforeHandleProcessors, REQUEST)
             // Execute platform flow chain
             .andThen(platformFlowChain.execute(ctx, REQUEST))
+            // Before Security Chain.
+            .andThen(executeProcessorChain(ctx, beforeSecurityChainProcessors, REQUEST))
             // Execute security chain.
             .andThen(securityChain.execute(ctx))
             // Execute before flows processors

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/ApiProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/processor/ApiProcessorChainFactory.java
@@ -84,13 +84,29 @@ public class ApiProcessorChainFactory {
         return new ProcessorChain("processor-chain-before-api-handle", processors, processorHooks);
     }
 
-    public ProcessorChain beforeApiExecution(final Api api) {
+    /**
+     * Return the chain of processors to execute before executing security chain.
+     *
+     * @param api the api to create the processor chain for.
+     *
+     * @return the chain of processors.
+     */
+    public ProcessorChain beforeSecurityChain(final Api api) {
         List<Processor> preProcessorList = new ArrayList<>();
 
         Cors cors = api.getDefinition().getProxy().getCors();
         if (cors != null && cors.isEnabled()) {
             preProcessorList.add(CorsPreflightRequestProcessor.instance());
         }
+
+        ProcessorChain processorChain = new ProcessorChain("processor-chain-before-security-chain", preProcessorList);
+        processorChain.addHooks(processorHooks);
+        return processorChain;
+    }
+
+    public ProcessorChain beforeApiExecution(final Api api) {
+        List<Processor> preProcessorList = new ArrayList<>();
+
         if (overrideXForwardedPrefix) {
             preProcessorList.add(XForwardedPrefixProcessor.instance());
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
@@ -119,6 +119,7 @@ public class DefaultApiReactor extends AbstractLifecycleComponent<ReactorHandler
     private final ResourceLifecycleManager resourceLifecycleManager;
     protected final ProcessorChain beforeHandleProcessors;
     protected final ProcessorChain afterHandleProcessors;
+    protected final ProcessorChain beforeSecurityChainProcessors;
     protected final ProcessorChain beforeApiExecutionProcessors;
     protected final ProcessorChain afterApiExecutionProcessors;
     protected final ProcessorChain onErrorProcessors;
@@ -172,6 +173,7 @@ public class DefaultApiReactor extends AbstractLifecycleComponent<ReactorHandler
 
         this.beforeHandleProcessors = apiProcessorChainFactory.beforeHandle(api);
         this.afterHandleProcessors = apiProcessorChainFactory.afterHandle(api);
+        this.beforeSecurityChainProcessors = apiProcessorChainFactory.beforeSecurityChain(api);
         this.beforeApiExecutionProcessors = apiProcessorChainFactory.beforeApiExecution(api);
         this.afterApiExecutionProcessors = apiProcessorChainFactory.afterApiExecution(api);
 
@@ -239,6 +241,8 @@ public class DefaultApiReactor extends AbstractLifecycleComponent<ReactorHandler
         return new CompletableReactorChain(executeProcessorChain(ctx, beforeHandleProcessors, REQUEST))
             // Execute platform flow chain.
             .chainWith(platformFlowChain.execute(ctx, REQUEST))
+            // Before Security Chain.
+            .chainWith(executeProcessorChain(ctx, beforeSecurityChainProcessors, REQUEST))
             // Execute security chain.
             .chainWith(securityChain.execute(ctx))
             // Before flows processors.

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactory.java
@@ -18,7 +18,6 @@ package io.gravitee.gateway.reactive.handlers.api.v4.processor;
 import static io.gravitee.gateway.reactive.handlers.api.processor.subscription.SubscriptionProcessor.DEFAULT_CLIENT_IDENTIFIER_HEADER;
 
 import io.gravitee.definition.model.Cors;
-import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
@@ -96,13 +95,13 @@ public class ApiProcessorChainFactory {
     }
 
     /**
-     * Return the chain of processors to execute before executing all the apis flows.
+     * Return the chain of processors to execute before executing security chain.
      *
      * @param api the api to create the processor chain for.
      *
      * @return the chain of processors.
      */
-    public ProcessorChain beforeApiExecution(final Api api) {
+    public ProcessorChain beforeSecurityChain(final Api api) {
         final List<Processor> processors = new ArrayList<>();
         if (api.getDefinition().getListeners() != null) {
             getHttpListener(api)
@@ -112,11 +111,25 @@ public class ApiProcessorChainFactory {
                     if (cors != null && cors.isEnabled()) {
                         processors.add(CorsPreflightRequestProcessor.instance());
                     }
-
-                    if (overrideXForwardedPrefix) {
-                        processors.add(XForwardedPrefixProcessor.instance());
-                    }
                 });
+        }
+
+        return new ProcessorChain("processor-chain-before-security-chain", processors, processorHooks);
+    }
+
+    /**
+     * Return the chain of processors to execute before executing all the apis flows.
+     *
+     * @param api the api to create the processor chain for.
+     *
+     * @return the chain of processors.
+     */
+    public ProcessorChain beforeApiExecution(final Api api) {
+        final List<Processor> processors = new ArrayList<>();
+        if (api.getDefinition().getListeners() != null) {
+            if (overrideXForwardedPrefix) {
+                processors.add(XForwardedPrefixProcessor.instance());
+            }
 
             processors.add(SubscriptionProcessor.instance(clientIdentifierHeader));
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/ApiProcessorChainFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/processor/ApiProcessorChainFactoryTest.java
@@ -127,7 +127,7 @@ class ApiProcessorChainFactoryTest {
     }
 
     @Test
-    void shouldReturnCorsBeforeApiExecutionChainWithCors() {
+    void shouldReturnCorsBeforeSecurityChainWithCors() {
         io.gravitee.definition.model.Api apiModel = new io.gravitee.definition.model.Api();
         final Proxy proxy = new Proxy();
         Cors cors = new Cors();
@@ -135,34 +135,18 @@ class ApiProcessorChainFactoryTest {
         proxy.setCors(cors);
         apiModel.setProxy(proxy);
         Api api = new Api(apiModel);
-        ProcessorChain processorChain = apiProcessorChainFactory.beforeApiExecution(api);
-        assertThat(processorChain.getId()).isEqualTo("processor-chain-before-api-execution");
+        ProcessorChain processorChain = apiProcessorChainFactory.beforeSecurityChain(api);
+        assertThat(processorChain.getId()).isEqualTo("processor-chain-before-security-chain");
         Flowable<Processor> processors = extractProcessorChain(processorChain);
         processors
             .test()
             .assertComplete()
-            .assertValueCount(2)
-            .assertValueAt(0, processor -> processor instanceof CorsPreflightRequestProcessor)
-            .assertValueAt(1, processor -> processor instanceof SubscriptionProcessor);
+            .assertValueCount(1)
+            .assertValueAt(0, processor -> processor instanceof CorsPreflightRequestProcessor);
     }
 
     @Test
-    void shouldReturnBeforeApiExecutionChain() {
-        io.gravitee.definition.model.Api apiModel = new io.gravitee.definition.model.Api();
-        final Logging logging = new Logging();
-        logging.setMode(LoggingMode.CLIENT);
-        final Proxy proxy = new Proxy();
-        proxy.setLogging(logging);
-        apiModel.setProxy(proxy);
-        Api api = new Api(apiModel);
-        ProcessorChain processorChain = apiProcessorChainFactory.beforeApiExecution(api);
-        assertThat(processorChain.getId()).isEqualTo("processor-chain-before-api-execution");
-        Flowable<Processor> processors = extractProcessorChain(processorChain);
-        processors.test().assertComplete().assertValueCount(1).assertValueAt(0, processor -> processor instanceof SubscriptionProcessor);
-    }
-
-    @Test
-    void shouldReturnXForwardedBeforeApiExecutionChainWithOverrideXForwarded() {
+    void shouldReturnXForwardedBeforeApiExecutionWithOverrideXForwarded() {
         when(configuration.getProperty("handlers.request.headers.x-forwarded-prefix", Boolean.class, false)).thenReturn(true);
         apiProcessorChainFactory = new ApiProcessorChainFactory(configuration, node);
 
@@ -180,6 +164,21 @@ class ApiProcessorChainFactoryTest {
             .assertValueCount(2)
             .assertValueAt(0, processor -> processor instanceof XForwardedPrefixProcessor)
             .assertValueAt(1, processor -> processor instanceof SubscriptionProcessor);
+    }
+
+    @Test
+    void shouldReturnBeforeApiExecutionChain() {
+        io.gravitee.definition.model.Api apiModel = new io.gravitee.definition.model.Api();
+        final Logging logging = new Logging();
+        logging.setMode(LoggingMode.CLIENT);
+        final Proxy proxy = new Proxy();
+        proxy.setLogging(logging);
+        apiModel.setProxy(proxy);
+        Api api = new Api(apiModel);
+        ProcessorChain processorChain = apiProcessorChainFactory.beforeApiExecution(api);
+        assertThat(processorChain.getId()).isEqualTo("processor-chain-before-api-execution");
+        Flowable<Processor> processors = extractProcessorChain(processorChain);
+        processors.test().assertComplete().assertValueCount(1).assertValueAt(0, processor -> processor instanceof SubscriptionProcessor);
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactoryTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.definition.model.Cors;
-import io.gravitee.definition.model.ResponseTemplate;
 import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.analytics.logging.Logging;
 import io.gravitee.definition.model.v4.analytics.logging.LoggingMode;
@@ -143,7 +142,7 @@ class ApiProcessorChainFactoryTest {
     }
 
     @Test
-    void shouldReturnCorsBeforeApiExecutionChainWithHttpListenerAndCors() {
+    void shouldReturnCorsBeforeSecurityChainWithHttpListenerAndCors() {
         io.gravitee.definition.model.v4.Api apiModel = new io.gravitee.definition.model.v4.Api();
         HttpListener httpListener = new HttpListener();
         Cors cors = new Cors();
@@ -151,27 +150,14 @@ class ApiProcessorChainFactoryTest {
         httpListener.setCors(cors);
         apiModel.setListeners(List.of(httpListener));
         Api api = new Api(apiModel);
-        ProcessorChain processorChain = apiProcessorChainFactory.beforeApiExecution(api);
-        assertThat(processorChain.getId()).isEqualTo("processor-chain-before-api-execution");
+        ProcessorChain processorChain = apiProcessorChainFactory.beforeSecurityChain(api);
+        assertThat(processorChain.getId()).isEqualTo("processor-chain-before-security-chain");
         Flowable<Processor> processors = extractProcessorChain(processorChain);
         processors
             .test()
             .assertComplete()
-            .assertValueCount(2)
-            .assertValueAt(0, processor -> processor instanceof CorsPreflightRequestProcessor)
-            .assertValueAt(1, processor -> processor instanceof SubscriptionProcessor);
-    }
-
-    @Test
-    void shouldReturnBeforeApiExecutionChainWithHttpListener() {
-        io.gravitee.definition.model.v4.Api apiModel = new io.gravitee.definition.model.v4.Api();
-        HttpListener httpListener = new HttpListener();
-        apiModel.setListeners(List.of(httpListener));
-        Api api = new Api(apiModel);
-        ProcessorChain processorChain = apiProcessorChainFactory.beforeApiExecution(api);
-        assertThat(processorChain.getId()).isEqualTo("processor-chain-before-api-execution");
-        Flowable<Processor> processors = extractProcessorChain(processorChain);
-        processors.test().assertComplete().assertValueCount(1).assertValueAt(0, processor -> processor instanceof SubscriptionProcessor);
+            .assertValueCount(1)
+            .assertValueAt(0, processor -> processor instanceof CorsPreflightRequestProcessor);
     }
 
     @Test
@@ -192,6 +178,18 @@ class ApiProcessorChainFactoryTest {
             .assertValueCount(2)
             .assertValueAt(0, processor -> processor instanceof XForwardedPrefixProcessor)
             .assertValueAt(1, processor -> processor instanceof SubscriptionProcessor);
+    }
+
+    @Test
+    void shouldReturnBeforeApiExecutionChainWithHttpListener() {
+        io.gravitee.definition.model.v4.Api apiModel = new io.gravitee.definition.model.v4.Api();
+        HttpListener httpListener = new HttpListener();
+        apiModel.setListeners(List.of(httpListener));
+        Api api = new Api(apiModel);
+        ProcessorChain processorChain = apiProcessorChainFactory.beforeApiExecution(api);
+        assertThat(processorChain.getId()).isEqualTo("processor-chain-before-api-execution");
+        Flowable<Processor> processors = extractProcessorChain(processorChain);
+        processors.test().assertComplete().assertValueCount(1).assertValueAt(0, processor -> processor instanceof SubscriptionProcessor);
     }
 
     @Test

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/fake/AttributesToHeaderPolicy.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/fake/AttributesToHeaderPolicy.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.fake;
+
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.Request;
+import io.gravitee.gateway.api.Response;
+import io.gravitee.gateway.reactive.api.context.HttpExecutionContext;
+import io.gravitee.gateway.reactive.api.policy.Policy;
+import io.gravitee.policy.api.PolicyChain;
+import io.gravitee.policy.api.annotations.OnResponse;
+import io.reactivex.rxjava3.core.Completable;
+import java.util.Optional;
+
+public class AttributesToHeaderPolicy implements Policy {
+
+    @OnResponse
+    public void onResponse(final Request request, final Response response, ExecutionContext ctx, final PolicyChain policyChain) {
+        ctx
+            .getAttributeNames()
+            .asIterator()
+            .forEachRemaining(attribute ->
+                response.headers().add(attribute, Optional.ofNullable(ctx.getAttribute(attribute)).map(Object::toString).orElse("null"))
+            );
+        policyChain.doNext(request, response);
+    }
+
+    @Override
+    public String id() {
+        return "attributes-to-header";
+    }
+
+    @Override
+    public Completable onResponse(HttpExecutionContext ctx) {
+        return Completable.fromRunnable(() ->
+            ctx
+                .getAttributeNames()
+                .forEach(attribute ->
+                    ctx
+                        .response()
+                        .headers()
+                        .add(attribute, Optional.ofNullable(ctx.getAttribute(attribute)).map(Object::toString).orElse("null"))
+                )
+        );
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/attributes/AbstractAttributesIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/attributes/AbstractAttributesIntegrationTest.java
@@ -13,13 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.integration.tests.http.cors;
+package io.gravitee.apim.integration.tests.http.attributes;
 
 import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
 import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
 import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
-import io.gravitee.apim.integration.tests.fake.AddHeaderPolicy;
+import io.gravitee.apim.integration.tests.fake.AttributesToHeaderPolicy;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.Plan;
+import io.gravitee.gateway.api.service.ApiKey;
+import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.reactor.ReactableApi;
 import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
 import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
@@ -29,10 +34,13 @@ import io.gravitee.policy.apikey.ApiKeyPolicy;
 import io.gravitee.policy.apikey.ApiKeyPolicyInitializer;
 import io.gravitee.policy.apikey.configuration.ApiKeyPolicyConfiguration;
 import io.vertx.rxjava3.core.http.HttpClientResponse;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public class AbstractCorsIntegrationTest extends AbstractGatewayTest {
+public class AbstractAttributesIntegrationTest extends AbstractGatewayTest {
+
+    protected ApiKey apiKey;
 
     @Override
     public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
@@ -46,14 +54,58 @@ public class AbstractCorsIntegrationTest extends AbstractGatewayTest {
 
     @Override
     public void configurePolicies(Map<String, PolicyPlugin> policies) {
-        policies.put("add-header", PolicyBuilder.build("add-header", AddHeaderPolicy.class));
+        policies.put("attributes-to-header", PolicyBuilder.build("attributes-to-header", AttributesToHeaderPolicy.class));
         policies.put(
             "api-key",
             PolicyBuilder.build("api-key", ApiKeyPolicy.class, ApiKeyPolicyConfiguration.class, ApiKeyPolicyInitializer.class)
         );
     }
 
+    protected void addApiKeyPlan(ReactableApi<?> api) {
+        apiKey = anApiKey(api);
+        if (api.getDefinition() instanceof Api) {
+            ((Api) api.getDefinition()).setPlans(
+                    List.of(
+                        Plan
+                            .builder()
+                            .id("default_plan")
+                            .api(api.getId())
+                            .security("key_less")
+                            .status("PUBLISHED")
+                            .securityDefinition("{\"propagateApiKey\":true}")
+                            .build(),
+                        Plan
+                            .builder()
+                            .id("plan-id")
+                            .api(api.getId())
+                            .security("API_KEY")
+                            .status("PUBLISHED")
+                            .securityDefinition("{\"propagateApiKey\":true}")
+                            .build()
+                    )
+                );
+        }
+    }
+
     protected static Map<String, String> extractHeaders(HttpClientResponse response) {
         return response.headers().entries().stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    protected ApiKey anApiKey(ReactableApi<?> api) {
+        final ApiKey apiKey = new ApiKey();
+        apiKey.setApi(api.getId());
+        apiKey.setApplication("application-id");
+        apiKey.setSubscription("subscription-id");
+        apiKey.setPlan("plan-id");
+        apiKey.setKey("apiKeyValue");
+        return apiKey;
+    }
+
+    protected Subscription aSubscription() {
+        final Subscription subscription = new Subscription();
+        subscription.setApplication("application-id");
+        subscription.setId("subscription-id");
+        subscription.setPlan("plan-id");
+        return subscription;
     }
 }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/attributes/AttributesIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/attributes/AttributesIntegrationTest.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.attributes;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
+import io.gravitee.gateway.api.ExecutionContext;
+import io.gravitee.gateway.api.service.ApiKeyService;
+import io.gravitee.gateway.api.service.SubscriptionService;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class AttributesIntegrationTest {
+
+    private static final Pattern UUID_PATTERN = Pattern.compile("([a-f0-9]{8}(-[a-f0-9]{4}){4}[a-f0-9]{8})");
+
+    @Nested
+    @GatewayTest(mode = GatewayMode.JUPITER)
+    @DeployApi({ "/apis/http/attributes-to-headers.json" })
+    class CheckingAttributes extends AbstractAttributesIntegrationTest {
+
+        @Test
+        void should_set_attributes(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get("/endpoint").willReturn(ok()));
+
+            httpClient
+                .rxRequest(HttpMethod.GET, "/attributes-to-headers")
+                .flatMap(HttpClientRequest::rxSend)
+                .flatMapPublisher(response -> {
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    assertThat(extractHeaders(response))
+                        .contains(
+                            Map.entry(ExecutionContext.ATTR_APPLICATION, "1"),
+                            Map.entry(ExecutionContext.ATTR_API, "attributes-to-headers"),
+                            Map.entry(ExecutionContext.ATTR_CONTEXT_PATH, "/attributes-to-headers/"),
+                            Map.entry(ExecutionContext.ATTR_PLAN, "default_plan"),
+                            Map.entry(ExecutionContext.ATTR_SUBSCRIPTION_ID, "127.0.0.1")
+                        );
+
+                    return response.toFlowable();
+                })
+                .test()
+                .await()
+                .assertComplete()
+                .assertNoErrors();
+        }
+    }
+
+    @Nested
+    @GatewayTest(mode = GatewayMode.JUPITER)
+    @DeployApi({ "/apis/http/attributes-to-headers.json" })
+    class CheckingClientIdAttribute extends AbstractAttributesIntegrationTest {
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            addApiKeyPlan(api);
+        }
+
+        @Test
+        void should_generate_client_id_attribute_by_hashing_subscription_id_attribute_when_equals_to_remote_address(HttpClient httpClient)
+            throws InterruptedException {
+            wiremock.stubFor(get("/endpoint").willReturn(ok()));
+
+            httpClient
+                .rxRequest(HttpMethod.GET, "/attributes-to-headers")
+                .flatMap(HttpClientRequest::rxSend)
+                .flatMapPublisher(response -> {
+                    assertThat(response.statusCode()).isEqualTo(200);
+
+                    assertThat(extractHeaders(response).get(ExecutionContext.ATTR_CLIENT_IDENTIFIER)).doesNotMatch(UUID_PATTERN);
+                    return response.toFlowable();
+                })
+                .test()
+                .await()
+                .assertComplete()
+                .assertNoErrors();
+        }
+
+        @Test
+        void should_use_subscription_id_for_client_id_when_not_equal_to_remote_address(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get("/endpoint").willReturn(ok()));
+
+            when(getBean(ApiKeyService.class).getByApiAndKey(any(), any())).thenReturn(Optional.of(apiKey));
+            when(getBean(SubscriptionService.class).getByApiAndSecurityToken(eq(apiKey.getApi()), any(), eq(apiKey.getPlan())))
+                .thenReturn(Optional.of(aSubscription()));
+
+            httpClient
+                .rxRequest(HttpMethod.GET, "/attributes-to-headers")
+                .flatMap(httpClientRequest -> httpClientRequest.putHeader("X-Gravitee-Api-Key", apiKey.getKey()).rxSend())
+                .flatMapPublisher(response -> {
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    assertThat(extractHeaders(response)).contains(Map.entry(ExecutionContext.ATTR_CLIENT_IDENTIFIER, "subscription-id"));
+                    return response.toFlowable();
+                })
+                .test()
+                .await()
+                .assertComplete()
+                .assertNoErrors();
+        }
+
+        @Test
+        void should_generate_client_id_from_value_provided(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get("/endpoint").willReturn(ok()));
+
+            httpClient
+                .rxRequest(HttpMethod.GET, "/attributes-to-headers")
+                .flatMap(httpClientRequest -> httpClientRequest.putHeader("X-Gravitee-Client-Identifier", "my-client-id").rxSend())
+                .flatMapPublisher(response -> {
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    assertThat(extractHeaders(response).get(ExecutionContext.ATTR_CLIENT_IDENTIFIER)).startsWith("my-client-id-");
+                    return response.toFlowable();
+                })
+                .test()
+                .await()
+                .assertComplete()
+                .assertNoErrors();
+        }
+
+        @Test
+        void should_use_client_id_provided(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get("/endpoint").willReturn(ok()));
+
+            httpClient
+                .rxRequest(HttpMethod.GET, "/attributes-to-headers")
+                .flatMap(httpClientRequest ->
+                    httpClientRequest
+                        .putHeader("X-Gravitee-Transaction-Id", "1234")
+                        .putHeader("X-Gravitee-Client-Identifier", "my-client-id-1234")
+                        .rxSend()
+                )
+                .flatMapPublisher(response -> {
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    assertThat(extractHeaders(response)).contains(Map.entry(ExecutionContext.ATTR_CLIENT_IDENTIFIER, "my-client-id-1234"));
+                    return response.toFlowable();
+                })
+                .test()
+                .await()
+                .assertComplete()
+                .assertNoErrors();
+        }
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/CorsIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/CorsIntegrationTest.java
@@ -15,14 +15,21 @@
  */
 package io.gravitee.apim.integration.tests.http.cors;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
 import io.gravitee.apim.integration.tests.fake.AddHeaderPolicy;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.Plan;
+import io.gravitee.gateway.api.service.ApiKey;
+import io.gravitee.gateway.reactor.ReactableApi;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.rxjava3.core.http.HttpClient;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -219,6 +226,103 @@ public class CorsIntegrationTest {
                 .await()
                 .assertComplete()
                 .assertNoErrors();
+        }
+    }
+
+    @Nested
+    @GatewayTest(mode = GatewayMode.JUPITER)
+    @DeployApi({ "/apis/http/cors-running-policies.json" })
+    class CheckingSecurityChainSkip extends AbstractCorsIntegrationTest {
+
+        protected ApiKey apiKey;
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            super.configureApi(api, definitionClass);
+
+            apiKey = anApiKey(api);
+            if (api.getDefinition() instanceof Api) {
+                ((Api) api.getDefinition()).setPlans(
+                        List.of(
+                            Plan
+                                .builder()
+                                .id("plan-id")
+                                .api(api.getId())
+                                .security("API_KEY")
+                                .status("PUBLISHED")
+                                .securityDefinition("{\"propagateApiKey\":true}")
+                                .build()
+                        )
+                    );
+            }
+        }
+
+        @Override
+        public void configureApi(Api api) {
+            super.configureApi(api);
+        }
+
+        @Test
+        void should_skip_security_on_preflight_request_when_valid(HttpClient httpClient) throws InterruptedException {
+            httpClient
+                .rxRequest(HttpMethod.OPTIONS, "/api-cors-running-policies")
+                .flatMap(httpClientRequest ->
+                    httpClientRequest.putHeader("Origin", "https://mydomain.com").putHeader("Access-Control-Request-Method", "GET").rxSend()
+                )
+                .flatMapPublisher(response -> {
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    return response.toFlowable();
+                })
+                .test()
+                .await()
+                .assertComplete()
+                .assertNoErrors();
+        }
+
+        @Test
+        void should_skip_security_on_preflight_request_when_invalid(HttpClient httpClient) throws InterruptedException {
+            httpClient
+                .rxRequest(HttpMethod.OPTIONS, "/api-cors-running-policies")
+                .flatMap(httpClientRequest ->
+                    httpClientRequest.putHeader("Origin", "https://unknown.com").putHeader("Access-Control-Request-Method", "GET").rxSend()
+                )
+                .flatMapPublisher(response -> {
+                    assertThat(response.statusCode()).isNotEqualTo(401);
+                    return response.toFlowable();
+                })
+                .test()
+                .await()
+                .assertComplete()
+                .assertNoErrors();
+        }
+
+        @Test
+        void should_apply_security_chain_on_regular_request(HttpClient httpClient) throws InterruptedException {
+            wiremock.stubFor(get("/endpoint").willReturn(ok()));
+
+            httpClient
+                .rxRequest(HttpMethod.GET, "/api-cors-running-policies")
+                .flatMap(httpClientRequest ->
+                    httpClientRequest.putHeader("Origin", "https://mydomain.com").putHeader("Access-Control-Request-Method", "GET").rxSend()
+                )
+                .flatMapPublisher(response -> {
+                    assertThat(response.statusCode()).isEqualTo(401);
+                    return response.toFlowable();
+                })
+                .test()
+                .await()
+                .assertComplete()
+                .assertNoErrors();
+        }
+
+        private ApiKey anApiKey(ReactableApi<?> api) {
+            final ApiKey apiKey = new ApiKey();
+            apiKey.setApi(api.getId());
+            apiKey.setApplication("application-id");
+            apiKey.setSubscription("subscription-id");
+            apiKey.setPlan("plan-id");
+            apiKey.setKey("apiKeyValue");
+            return apiKey;
         }
     }
 }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/CorsV3CompatibilityIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/CorsV3CompatibilityIntegrationTest.java
@@ -36,4 +36,9 @@ public class CorsV3CompatibilityIntegrationTest extends CorsV3IntegrationTest {
     @GatewayTest(mode = GatewayMode.COMPATIBILITY)
     @DeployApi({ "/apis/http/cors-running-policies.json", "/apis/http/cors-not-running-policies.json" })
     class CheckingRejection extends CorsV3IntegrationTest.CheckingRejection {}
+
+    @Nested
+    @GatewayTest(mode = GatewayMode.COMPATIBILITY)
+    @DeployApi({ "/apis/http/cors-running-policies.json" })
+    class CheckingSecurityChainSkip extends CorsV3IntegrationTest.CheckingSecurityChainSkip {}
 }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/CorsV3IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/CorsV3IntegrationTest.java
@@ -136,4 +136,9 @@ public class CorsV3IntegrationTest extends CorsIntegrationTest {
     @GatewayTest(mode = GatewayMode.V3)
     @DeployApi({ "/apis/http/cors-running-policies.json", "/apis/http/cors-not-running-policies.json" })
     class CheckingRejection extends CorsIntegrationTest.CheckingRejection {}
+
+    @Nested
+    @GatewayTest(mode = GatewayMode.V3)
+    @DeployApi({ "/apis/http/cors-running-policies.json" })
+    class CheckingSecurityChainSkip extends CorsIntegrationTest.CheckingSecurityChainSkip {}
 }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/CorsV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/CorsV4IntegrationTest.java
@@ -18,6 +18,12 @@ package io.gravitee.apim.integration.tests.http.cors;
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
 import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
 import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.plan.Plan;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.gateway.reactor.ReactableApi;
+import java.util.List;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
@@ -45,4 +51,23 @@ public class CorsV4IntegrationTest extends CorsIntegrationTest {
     @GatewayTest(mode = GatewayMode.JUPITER)
     @DeployApi({ "/apis/v4/http/cors-running-policies.json", "/apis/v4/http/cors-not-running-policies.json" })
     class CheckingRejection extends CorsIntegrationTest.CheckingRejection {}
+
+    @Nested
+    @GatewayTest(mode = GatewayMode.JUPITER)
+    @DeployApi({ "/apis/v4/http/cors-running-policies.json" })
+    class CheckingSecurityChainSkip extends CorsIntegrationTest.CheckingSecurityChainSkip {
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            super.configureApi(api, definitionClass);
+
+            if (api.getDefinition() instanceof Api) {
+                var security = new PlanSecurity();
+                security.setType("api-key");
+
+                var plan = Plan.builder().id("plan-id").security(security).status(PlanStatus.PUBLISHED).build();
+                ((Api) api.getDefinition()).setPlans(List.of(plan));
+            }
+        }
+    }
 }

--- a/gravitee-apim-integration-tests/src/test/resources/apis/http/attributes-to-headers.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/http/attributes-to-headers.json
@@ -1,0 +1,42 @@
+{
+  "id": "attributes-to-headers",
+  "name": "attributes-to-headers",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/attributes-to-headers",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [],
+      "post": [
+        {
+          "name": "Attributes to Headers",
+          "description": "",
+          "enabled": true,
+          "policy": "attributes-to-header",
+          "configuration": {}
+        }
+      ]
+    }
+  ],
+  "resources": []
+}

--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
         <gravitee-endpoint-mqtt5-advanced.version>1.2.0-alpha.1</gravitee-endpoint-mqtt5-advanced.version>
         <gravitee-resource-schema-registry-confluent.version>1.0.0-alpha.9
         </gravitee-resource-schema-registry-confluent.version>
-        <gravitee-reactor-message.version>1.0.0-alpha.2</gravitee-reactor-message.version>
+        <gravitee-reactor-message.version>1.0.0-alpha.3</gravitee-reactor-message.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1150

## Description

Execute security chain after CORSPreflight Processor in jupiter/v4. A new Processor chain has been introduced, `processor-chain-before-security-chain` containing the Cors and Xforwared processors. 
The existing chain `processor-chain-before-api-execution` has been updated to contain the Subscription processor only.

New integration tests have been created to ensure some attributes are correctly defined. Checking that the Subscription processor runs correctly to set expected attributes (the feature that was broken in the previous attempt)
This processor is not used for proxy API, but it contains metrics-related stuff that requires some refactoring.

Also, I couldn't create a webhook integration test because I need to merge this PR to update the artifactory to be able to create a PR in https://github.com/gravitee-io/gravitee-reactor-message


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-yewutzvahj.chromatic.com)
<!-- Storybook placeholder end -->
