### PR TITLE
Console - Init separate layout for api V4 🧙 

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/analytics/apis.analytics.route.ts
+++ b/gravitee-apim-console-webui/src/management/api/analytics/apis.analytics.route.ts
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { StateParams } from '@uirouter/core';
+import { StateParams, StateService } from '@uirouter/core';
 
 import { Scope } from '../../../entities/alert';
 import AlertService from '../../../services/alert.service';
 import { ApiService } from '../../../services/api.service';
 import DashboardService from '../../../services/dashboard.service';
 import TenantService from '../../../services/tenant.service';
+import EnvironmentService from '../../../services/environment.service';
 
 export default apisAnalyticsRouterConfig;
 
@@ -36,6 +37,19 @@ function apisAnalyticsRouterConfig($stateProvider) {
       controllerAs: 'analyticsCtrl',
       resolve: {
         dashboards: (DashboardService: DashboardService) => DashboardService.list('API').then((response) => response.data),
+        resolvedApi: function (
+          $stateParams: StateParams,
+          ApiService: ApiService,
+          $state: StateService,
+          Constants: any,
+          EnvironmentService: EnvironmentService,
+        ) {
+          return ApiService.get($stateParams.apiId).catch((err) => {
+            if (err && err.interceptorFuture) {
+              $state.go('management.apis.list', { environmentId: EnvironmentService.getFirstHridOrElseId(Constants.org.currentEnv.id) });
+            }
+          });
+        },
       },
       data: {
         perms: {
@@ -108,6 +122,19 @@ function apisAnalyticsRouterConfig($stateProvider) {
         applications: ($stateParams: StateParams, ApiService: ApiService) =>
           ApiService.getSubscribers($stateParams.apiId, null, null, null, ['owner']),
         tenants: (TenantService: TenantService) => TenantService.list(),
+        resolvedApi: function (
+          $stateParams: StateParams,
+          ApiService: ApiService,
+          $state: StateService,
+          Constants: any,
+          EnvironmentService: EnvironmentService,
+        ) {
+          return ApiService.get($stateParams.apiId).catch((err) => {
+            if (err && err.interceptorFuture) {
+              $state.go('management.apis.list', { environmentId: EnvironmentService.getFirstHridOrElseId(Constants.org.currentEnv.id) });
+            }
+          });
+        },
       },
     })
     .state('management.apis.detail.analytics.logs.configuration', {

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation-tabs/api-ng-navigation-tabs.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation-tabs/api-ng-navigation-tabs.component.html
@@ -1,0 +1,27 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<nav mat-tab-nav-bar class="api-navigation-tabs">
+  <a
+    mat-tab-link
+    *ngFor="let menuItem of this.tabMenuItems"
+    (click)="navigateTo(menuItem.targetRoute)"
+    [active]="isActive(menuItem.baseRoute)"
+    class="api-navigation-tabs__link"
+    >{{ menuItem.displayName }}</a
+  >
+</nav>

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation-tabs/api-ng-navigation-tabs.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation-tabs/api-ng-navigation-tabs.component.scss
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+.api-navigation-tabs {
+  display: flex;
+  align-items: center;
+  width: 100%;
+}

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation-tabs/api-ng-navigation-tabs.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation-tabs/api-ng-navigation-tabs.component.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, Inject, Input } from '@angular/core';
+import { StateService } from '@uirouter/core';
+import { castArray } from 'lodash';
+
+import { MenuItem } from '../api-ng-navigation.component';
+import { UIRouterState } from '../../../../ajs-upgraded-providers';
+
+@Component({
+  selector: 'api-ng-navigation-tabs',
+  template: require('./api-ng-navigation-tabs.component.html'),
+  styles: [require('./api-ng-navigation-tabs.component.scss')],
+})
+export class ApiNgNavigationTabsComponent {
+  @Input()
+  public tabMenuItems: MenuItem[] = [];
+
+  constructor(@Inject(UIRouterState) private readonly ajsState: StateService) {}
+
+  navigateTo(route: string) {
+    this.ajsState.go(route);
+  }
+
+  isActive(baseRoute: MenuItem['baseRoute']): boolean {
+    return castArray(baseRoute).some((baseRoute) => this.ajsState.includes(baseRoute));
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation-title/api-ng-navigation-title.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation-title/api-ng-navigation-title.component.html
@@ -1,0 +1,64 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="api-navigation-title">
+  <span class="api-navigation-title__icons" [class.api-navigation-title__icons-pipe]="separator === 'pipe'">
+    <mat-icon
+      *ngIf="apiState === 'STARTED'"
+      matTooltip="Started"
+      class="api-navigation-title__icons__icon api-navigation-title__icons__icon__play"
+      svgIcon="gio:play-circle"
+    ></mat-icon>
+    <mat-icon
+      *ngIf="apiState !== 'STARTED'"
+      matTooltip="Stopped"
+      class="api-navigation-title__icons__icon api-navigation-title__icons__icon__stop"
+      svgIcon="gio:stop-circle"
+    ></mat-icon>
+    <mat-icon
+      *ngIf="!apiIsSync"
+      matTooltip="API out of sync"
+      class="api-navigation-title__icons__icon api-navigation-title__icons__icon__refresh"
+      svgIcon="gio:refresh-cw"
+    ></mat-icon>
+    <mat-icon
+      *ngIf="apiLifecycleState === 'PUBLISHED'"
+      matTooltip="Published"
+      class="api-navigation-title__icons__icon"
+      svgIcon="gio:cloud-published"
+    ></mat-icon>
+    <mat-icon
+      *ngIf="apiLifecycleState !== 'PUBLISHED'"
+      matTooltip="Unpublished"
+      class="api-navigation-title__icons__icon"
+      svgIcon="gio:cloud-unpublished"
+    ></mat-icon>
+    <mat-icon
+      *ngIf="apiOrigin === 'kubernetes'"
+      matTooltip="Kubernetes Origin"
+      class="api-navigation-title__icons__icon"
+      svgIcon="gio:kubernetes"
+    ></mat-icon>
+  </span>
+  <div
+    class="api-navigation-title__name"
+    [class.api-navigation-title__name-pipe]="separator === 'pipe'"
+    [matTooltip]="apiName + ' ( ' + apiVersion + ' )'"
+  >
+    {{ apiName }} ({{ apiVersion }})
+  </div>
+</div>

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation-title/api-ng-navigation-title.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation-title/api-ng-navigation-title.component.scss
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+$textColor: map.get(gio.$mat-dove-palette, default);
+$borderColor: mat.get-color-from-palette(gio.$mat-space-palette, 'lighter80');
+
+:host {
+  width: 100%;
+}
+
+.api-navigation-title {
+  display: flex;
+  align-items: center;
+
+  &__icons {
+    display: flex;
+    align-items: center;
+    margin: 0 4px;
+    border: 1px solid $borderColor;
+    border-radius: 4px;
+
+    &__icon {
+      margin: 4px;
+      width: 15px;
+      height: 15px;
+      flex-shrink: 0;
+
+      &__play {
+        color: map.get(gio.$mat-success-palette, default);
+      }
+
+      &__stop {
+        color: map.get(gio.$mat-error-palette, default);
+      }
+
+      &__refresh {
+        color: map.get(gio.$mat-warning-palette, default);
+      }
+    }
+  }
+
+  &__icons-pipe {
+    border: 0;
+  }
+
+  &__name {
+    padding-left: 4px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &__name-pipe {
+    border-left: 1px solid $textColor;
+    padding-left: 8px;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation-title/api-ng-navigation-title.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation-title/api-ng-navigation-title.component.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, Input } from '@angular/core';
+
+import { Api } from '../../../../entities/management-api-v2';
+
+@Component({
+  selector: 'api-ng-navigation-title',
+  template: require('./api-ng-navigation-title.component.html'),
+  styles: [require('./api-ng-navigation-title.component.scss')],
+})
+export class ApiNgNavigationTitleComponent {
+  @Input()
+  public apiName: string;
+  @Input()
+  public apiVersion: string;
+  @Input()
+  public apiState: Api['state'];
+  @Input()
+  public apiIsSync: boolean;
+  @Input()
+  public apiLifecycleState: Api['lifecycleState'];
+  @Input()
+  public apiOrigin: string;
+  @Input()
+  public separator: 'pipe' | 'border' = 'border';
+}

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation.component.html
@@ -1,0 +1,100 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="api-navigation">
+  <div class="api-navigation__menu">
+    <gio-submenu class="api-navigation__submenu">
+      <api-ng-navigation-title
+        gioSubmenuTitle
+        class="api-navigation__submenu__title"
+        [apiName]="currentApi.name"
+        [apiVersion]="currentApi.apiVersion"
+        [apiState]="currentApi.state"
+        [apiLifecycleState]="currentApi.lifecycleState"
+        [apiIsSync]="currentApiIsSync"
+        [apiOrigin]="currentApi.definitionContext.origin"
+        separator="pipe"
+      ></api-ng-navigation-title>
+      <ng-container *ngFor="let menuItem of this.subMenuItems">
+        <gio-submenu-item
+          *ngIf="!menuItem?.targetRoute && menuItem?.tabs?.length > 0"
+          tabIndex="1"
+          (click)="navigateTo(menuItem?.tabs[0]?.targetRoute)"
+          [active]="isTabActive(menuItem?.tabs)"
+          >{{ menuItem?.displayName }}</gio-submenu-item
+        >
+        <gio-submenu-item
+          *ngIf="menuItem?.targetRoute"
+          tabIndex="1"
+          (click)="navigateTo(menuItem?.targetRoute)"
+          [active]="isActive(menuItem?.baseRoute)"
+          >{{ menuItem?.displayName }}</gio-submenu-item
+        >
+      </ng-container>
+      <ng-container *ngFor="let group of this.groupItems">
+        <gio-submenu-group [title]="group.title" *ngIf="group.title">
+          <ng-container *ngFor="let subItem of group.items">
+            <gio-submenu-item
+              *ngIf="!subItem?.targetRoute && subItem?.tabs?.length > 0"
+              tabIndex="1"
+              (click)="navigateTo(subItem?.tabs[0]?.targetRoute)"
+              [active]="isTabActive(subItem?.tabs)"
+              >{{ subItem?.displayName }}</gio-submenu-item
+            >
+            <gio-submenu-item
+              *ngIf="subItem?.targetRoute"
+              tabIndex="1"
+              (click)="navigateTo(subItem?.targetRoute)"
+              [active]="isActive(subItem?.baseRoute)"
+              >{{ subItem?.displayName }}</gio-submenu-item
+            >
+          </ng-container>
+        </gio-submenu-group>
+      </ng-container>
+    </gio-submenu>
+  </div>
+  <div class="api-navigation__content">
+    <ng-content select="#banner"></ng-content>
+    <div class="api-navigation__content__view">
+      <gio-breadcrumb *ngIf="hasBreadcrumb" class="api-navigation__breadcrumb">
+        <span *gioBreadcrumbItem class="api-navigation__breadcrumb__item">APIs</span>
+        <api-ng-navigation-title
+          gioSubmenuTitle
+          class="api-navigation__submenu__title api-navigation__breadcrumb__item"
+          [apiName]="currentApi.name"
+          [apiVersion]="currentApi.apiVersion"
+          [apiState]="currentApi.state"
+          [apiLifecycleState]="currentApi.lifecycleState"
+          [apiIsSync]="currentApiIsSync"
+          [apiOrigin]="currentApi.definitionContext.origin"
+          *gioBreadcrumbItem
+        ></api-ng-navigation-title>
+        <ng-template ngFor let-item [ngForOf]="this.computeBreadcrumbItems()">
+          <span *gioBreadcrumbItem class="api-navigation__breadcrumb__item">{{ item }}</span>
+        </ng-template>
+      </gio-breadcrumb>
+
+      <api-ng-navigation-tabs
+        *ngIf="selectedItemWithTabs"
+        class="api-navigation__content__tabs"
+        [tabMenuItems]="this.selectedItemWithTabs.tabs"
+      ></api-ng-navigation-tabs>
+
+      <ui-view></ui-view>
+    </div>
+  </div>
+</div>

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation.component.scss
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use 'sass:map';
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+$textColor: map.get(gio.$mat-dove-palette, default);
+
+:host {
+  height: 100%;
+}
+
+.api-navigation {
+  display: flex;
+  justify-content: flex-start;
+  height: 100%;
+
+  &__menu {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__submenu {
+    z-index: 70;
+    height: 100%;
+    color: $textColor;
+
+    &__title {
+      padding: 2px;
+    }
+  }
+
+  &__breadcrumb {
+    padding: 24px 32px 0 32px;
+
+    &__item {
+      display: contents;
+    }
+  }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+
+    &__view {
+      display: flex;
+      flex-direction: column;
+      flex: 1 1 auto;
+      height: 100%;
+    }
+
+    &__tabs {
+      padding: 24px 32px;
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation.component.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, Inject, Input, OnInit } from '@angular/core';
+import { StateService } from '@uirouter/core';
+import { IScope } from 'angular';
+import { castArray, flatMap } from 'lodash';
+import { takeUntil } from 'rxjs/operators';
+import { GioMenuService } from '@gravitee/ui-particles-angular';
+import { Subject } from 'rxjs';
+
+import { AjsRootScope, CurrentUserService, UIRouterState } from '../../../ajs-upgraded-providers';
+import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
+import UserService from '../../../services/user.service';
+import { Constants } from '../../../entities/Constants';
+import { Api } from '../../../entities/management-api-v2';
+
+export interface MenuItem {
+  targetRoute?: string;
+  baseRoute?: string | string[];
+  displayName: string;
+  tabs?: MenuItem[];
+}
+
+interface GroupItem {
+  title: string;
+  items: MenuItem[];
+}
+
+@Component({
+  selector: 'api-ng-navigation',
+  template: require('./api-ng-navigation.component.html'),
+  styles: [require('./api-ng-navigation.component.scss')],
+})
+export class ApiNgNavigationComponent implements OnInit {
+  @Input()
+  public currentApi: Api;
+
+  @Input()
+  public currentApiIsSync: boolean;
+
+  public subMenuItems: MenuItem[] = [];
+  public groupItems: GroupItem[] = [];
+  public selectedItemWithTabs: MenuItem = undefined;
+  public bannerState: string;
+  public hasBreadcrumb = false;
+  private unsubscribe$ = new Subject();
+  public breadcrumbItems: string[] = [];
+
+  constructor(
+    @Inject(UIRouterState) private readonly ajsState: StateService,
+    private readonly permissionService: GioPermissionService,
+    @Inject(CurrentUserService) private readonly currentUserService: UserService,
+    @Inject('Constants') private readonly constants: Constants,
+    @Inject(AjsRootScope) private readonly ajsRootScope: IScope,
+    private readonly gioMenuService: GioMenuService,
+  ) {}
+
+  ngOnInit() {
+    this.gioMenuService.reduce.pipe(takeUntil(this.unsubscribe$)).subscribe((reduced) => {
+      this.hasBreadcrumb = reduced;
+    });
+
+    this.bannerState = localStorage.getItem('gv-api-navigation-banner');
+
+    this.appendDesign();
+    this.appendPortalGroup();
+
+    this.selectedItemWithTabs = this.findMenuItemWithTabs();
+    this.breadcrumbItems = this.computeBreadcrumbItems();
+  }
+
+  private appendDesign() {
+    this.subMenuItems.push({
+      displayName: 'Design',
+      targetRoute: 'management.apis.ng.design',
+      baseRoute: 'management.apis.ng.design',
+      tabs: undefined,
+    });
+  }
+
+  private appendPortalGroup() {
+    const portalGroup: GroupItem = {
+      title: 'Portal',
+      items: [
+        {
+          displayName: 'General',
+          targetRoute: 'management.apis.ng.general',
+          baseRoute: 'management.apis.ng.general',
+        },
+      ],
+    };
+    this.groupItems.push(portalGroup);
+  }
+
+  private findMenuItemWithTabs(): MenuItem {
+    let item: MenuItem = this.findActiveMenuItem(this.subMenuItems);
+    if (item) {
+      return item;
+    }
+
+    for (const groupItem of this.groupItems) {
+      item = this.findActiveMenuItem(groupItem.items);
+      if (item) {
+        return item;
+      }
+    }
+  }
+
+  private findActiveMenuItem(items: MenuItem[]) {
+    return items.filter((item) => item.tabs).find((item) => this.isTabActive(item.tabs));
+  }
+
+  navigateTo(route: string) {
+    this.ajsState.go(route);
+  }
+
+  isActive(baseRoute: MenuItem['baseRoute']): boolean {
+    return castArray(baseRoute).some((baseRoute) => this.ajsState.includes(baseRoute));
+  }
+
+  isTabActive(tabs: MenuItem[]): boolean {
+    return flatMap(tabs, (tab) => tab.baseRoute).some((baseRoute) => this.ajsState.includes(baseRoute));
+  }
+
+  public computeBreadcrumbItems(): string[] {
+    const breadcrumbItems: string[] = [];
+
+    this.groupItems.forEach((groupItem) => {
+      groupItem.items.forEach((item) => {
+        if (this.isActive(item.baseRoute)) {
+          breadcrumbItems.push(groupItem.title);
+          breadcrumbItems.push(item.displayName);
+        } else if (item.tabs && this.isTabActive(item.tabs)) {
+          breadcrumbItems.push(groupItem.title);
+          breadcrumbItems.push(item.displayName);
+        }
+      });
+    });
+
+    return breadcrumbItems;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-ng-navigation/api-ng-navigation.module.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { GioBreadcrumbModule, GioIconsModule, GioSubmenuModule } from '@gravitee/ui-particles-angular';
+import { MatButtonModule } from '@angular/material/button';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatTabsModule } from '@angular/material/tabs';
+import { UIRouterModule } from '@uirouter/angular';
+
+import { ApiNgNavigationComponent } from './api-ng-navigation.component';
+import { ApiNgNavigationTitleComponent } from './api-ng-navigation-title/api-ng-navigation-title.component';
+import { ApiNgNavigationTabsComponent } from './api-ng-navigation-tabs/api-ng-navigation-tabs.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    GioSubmenuModule,
+    GioIconsModule,
+    MatButtonModule,
+    MatTooltipModule,
+    MatTabsModule,
+    GioBreadcrumbModule,
+    UIRouterModule,
+  ],
+  declarations: [ApiNgNavigationComponent, ApiNgNavigationTitleComponent, ApiNgNavigationTabsComponent],
+  exports: [ApiNgNavigationComponent],
+})
+export class ApiNgNavigationModule {}

--- a/gravitee-apim-console-webui/src/management/api/apiAdmin.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/apiAdmin.controller.ts
@@ -31,7 +31,7 @@ class ApiAdminController {
 
   /* @ngInject */
   constructor(
-    private resolvedApi: any,
+    private resolvedApiV1V2: any,
     private $state: StateService,
     private $scope: IScope,
     private $rootScope: IScope,
@@ -51,8 +51,8 @@ class ApiAdminController {
 
     this.hasPlatformPolicies = false;
 
-    this.api = resolvedApi.data;
-    this.ngIfMatchEtagInterceptor.updateLastEtag('api', resolvedApi.headers('etag'));
+    this.api = resolvedApiV1V2.data;
+    this.ngIfMatchEtagInterceptor.updateLastEtag('api', resolvedApiV1V2.headers('etag'));
 
     this.ApiService = ApiService;
     this.NotificationService = NotificationService;

--- a/gravitee-apim-console-webui/src/management/api/apis.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis.module.ts
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import { NgModule } from '@angular/core';
+import { Ng2StateDeclaration, UIRouterModule } from '@uirouter/angular';
+import { Transition } from '@uirouter/angularjs';
 
 import { ApiPortalDetailsModule } from './portal/details/api-portal-details.module';
 import { ApiListModule } from './list/api-list.module';
@@ -23,17 +26,77 @@ import { ApiPortalPlansModule } from './portal/plans/api-portal-plans.module';
 import { ApiAnalyticsModule } from './analytics/api-analytics.module';
 import { ApiPortalUserGroupModule } from './portal/user-group-access/api-portal-user-group.module';
 import { ApiPortalDocumentationModule } from './portal/documentation/api-portal-documentation.module';
+import { ApiPortalDetailsComponent } from './portal/details/api-portal-details.component';
+import { ApiNgNavigationComponent } from './api-ng-navigation/api-ng-navigation.component';
+import { ApiNgNavigationModule } from './api-ng-navigation/api-ng-navigation.module';
+import { ApiV4PolicyStudioModule } from './policy-studio-v4/api-v4-policy-studio.module';
+import { ApiV4PolicyStudioDesignComponent } from './policy-studio-v4/design/api-v4-policy-studio-design.component';
+
+import { GioPermissionService } from '../../shared/components/gio-permission/gio-permission.service';
+import { ApiV2Service } from '../../services-ngx/api-v2.service';
+
+// New Angular routing
+const states: Ng2StateDeclaration[] = [
+  {
+    name: 'management.apis.ng',
+    url: '/ng/:apiId',
+    abstract: true,
+    component: ApiNgNavigationComponent,
+
+    resolve: [
+      {
+        token: 'currentApi',
+        deps: [ApiV2Service, Transition],
+        resolveFn: (apiV2Service: ApiV2Service, transition: Transition) => apiV2Service.get(transition.params().apiId).toPromise(),
+      },
+      {
+        token: 'currentApiIsSync',
+        // TODO: Implement api sync check
+        resolveFn: () => false,
+      },
+      // Load current API permissions for current user into permissionService
+      {
+        token: 'guard',
+        deps: [GioPermissionService, Transition],
+        resolveFn: (permissionService: GioPermissionService, transition: Transition) =>
+          permissionService.loadApiPermissions(transition.params().apiId).toPromise(),
+      },
+    ],
+  },
+  {
+    name: 'management.apis.ng.design',
+    url: '/design',
+    data: {
+      useAngularMaterial: true,
+      docs: null,
+    },
+    component: ApiV4PolicyStudioDesignComponent,
+  },
+  {
+    name: 'management.apis.ng.general',
+    url: '/general',
+    data: {
+      useAngularMaterial: true,
+      docs: null,
+    },
+    component: ApiPortalDetailsComponent,
+  },
+];
 
 @NgModule({
   imports: [
     ApiAnalyticsModule,
     ApiListModule,
     ApiNavigationModule,
+    ApiNgNavigationModule,
+    ApiV4PolicyStudioModule,
     ApiPortalDetailsModule,
     ApiPortalDocumentationModule,
     ApiPortalPlansModule,
     ApiProxyModule,
     ApiPortalUserGroupModule,
+
+    UIRouterModule.forChild({ states }),
   ],
 })
 export class ApisModule {}

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
@@ -55,7 +55,7 @@ import {
   FlowStep,
 } from '../../../../entities/plan-v4';
 import { Flow, Step } from '../../../../entities/flow/flow';
-import { isApiV3 } from '../../../../util';
+import { isApiV1V2FromMAPIV1 } from '../../../../util';
 
 type InternalPlanFormValue = {
   general: {
@@ -138,7 +138,7 @@ export class ApiPlanFormComponent implements OnInit, AfterViewInit, OnDestroy, C
     if (!this.api) {
       return false;
     }
-    return isApiV3(this.api);
+    return isApiV1V2FromMAPIV1(this.api);
   }
   constructor(private readonly changeDetectorRef: ChangeDetectorRef, @Host() @Optional() public readonly ngControl?: NgControl) {
     if (ngControl) {

--- a/gravitee-apim-console-webui/src/management/api/design/apis.design.route.ts
+++ b/gravitee-apim-console-webui/src/management/api/design/apis.design.route.ts
@@ -13,8 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { StateParams, StateService } from '@uirouter/core';
+
 import ResourceService from '../../../services/resource.service';
 import TenantService from '../../../services/tenant.service';
+import { ApiService } from '../../../services/api.service';
+import EnvironmentService from '../../../services/environment.service';
 
 export default apisDesignRouterConfig;
 
@@ -66,6 +70,21 @@ function apisDesignRouterConfig($stateProvider) {
       controller: 'ApiPropertiesController',
       controllerAs: 'apiPropertiesCtrl',
       apiDefinition: { version: '1.0.0', redirect: 'management.apis.detail.design.flowsNg' },
+      resolve: {
+        resolvedApi: function (
+          $stateParams: StateParams,
+          ApiService: ApiService,
+          $state: StateService,
+          Constants: any,
+          EnvironmentService: EnvironmentService,
+        ) {
+          return ApiService.get($stateParams.apiId).catch((err) => {
+            if (err && err.interceptorFuture) {
+              $state.go('management.apis.list', { environmentId: EnvironmentService.getFirstHridOrElseId(Constants.org.currentEnv.id) });
+            }
+          });
+        },
+      },
       data: {
         perms: {
           only: ['api-definition-r'],

--- a/gravitee-apim-console-webui/src/management/api/notifications/apis.notifications.settings.route.ts
+++ b/gravitee-apim-console-webui/src/management/api/notifications/apis.notifications.settings.route.ts
@@ -13,9 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { StateParams, StateService } from '@uirouter/core';
+
 import { Scope } from '../../../entities/scope';
 import AlertService from '../../../services/alert.service';
 import { ApiService } from '../../../services/api.service';
+import EnvironmentService from '../../../services/environment.service';
 import NotificationSettingsService from '../../../services/notificationSettings.service';
 import NotifierService from '../../../services/notifier.service';
 import { Scope as AlertScope } from '../../../entities/alert';
@@ -102,6 +105,19 @@ function apisNotificationsRouterConfig($stateProvider) {
           AlertService.getStatus(AlertScope.API, $stateParams.apiId).then((response) => response.data),
         notifiers: (NotifierService: NotifierService) => NotifierService.list().then((response) => response.data),
         mode: () => 'create',
+        resolvedApi: function (
+          $stateParams: StateParams,
+          ApiService: ApiService,
+          $state: StateService,
+          Constants: any,
+          EnvironmentService: EnvironmentService,
+        ) {
+          return ApiService.get($stateParams.apiId).catch((err) => {
+            if (err && err.interceptorFuture) {
+              $state.go('management.apis.list', { environmentId: EnvironmentService.getFirstHridOrElseId(Constants.org.currentEnv.id) });
+            }
+          });
+        },
       },
     })
     .state('management.apis.detail.alerts.alert', {
@@ -122,6 +138,19 @@ function apisNotificationsRouterConfig($stateProvider) {
           AlertService.getStatus(AlertScope.API, $stateParams.apiId).then((response) => response.data),
         notifiers: (NotifierService: NotifierService) => NotifierService.list().then((response) => response.data),
         mode: () => 'detail',
+        resolvedApi: function (
+          $stateParams: StateParams,
+          ApiService: ApiService,
+          $state: StateService,
+          Constants: any,
+          EnvironmentService: EnvironmentService,
+        ) {
+          return ApiService.get($stateParams.apiId).catch((err) => {
+            if (err && err.interceptorFuture) {
+              $state.go('management.apis.list', { environmentId: EnvironmentService.getFirstHridOrElseId(Constants.org.currentEnv.id) });
+            }
+          });
+        },
       },
     });
 }

--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v4/api-v4-policy-studio.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v4/api-v4-policy-studio.module.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+
+import { ApiV4PolicyStudioDesignComponent } from './design/api-v4-policy-studio-design.component';
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [ApiV4PolicyStudioDesignComponent],
+})
+export class ApiV4PolicyStudioModule {}

--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.html
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.html
@@ -1,0 +1,18 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+🚧 Coming soon...

--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.scss
@@ -1,0 +1,5 @@
+@use 'src/scss/gio-layout' as gio-layout;
+
+:host {
+  @include gio-layout.gio-responsive-margin-container;
+}

--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.spec.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { InteractivityChecker } from '@angular/cdk/a11y';
+
+import { ApiV4PolicyStudioDesignComponent } from './api-v4-policy-studio-design.component';
+
+import { GioHttpTestingModule } from '../../../../shared/testing';
+import { ApiV4PolicyStudioModule } from '../api-v4-policy-studio.module';
+
+describe('ApiV4PolicyStudioDesignComponent', () => {
+  let fixture: ComponentFixture<ApiV4PolicyStudioDesignComponent>;
+  let component: ApiV4PolicyStudioDesignComponent;
+  let httpTestingController: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, GioHttpTestingModule, ApiV4PolicyStudioModule],
+      providers: [],
+    })
+      .overrideProvider(InteractivityChecker, {
+        useValue: {
+          isFocusable: () => true, // This traps focus checks and so avoid warnings when dealing with
+        },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(ApiV4PolicyStudioDesignComponent);
+    component = fixture.componentInstance;
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+  });
+
+  describe('ngOnInit', () => {
+    it('should work', async () => {
+      expect(component).toBeTruthy();
+    });
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Subject } from 'rxjs';
+
+@Component({
+  selector: 'api-v4-policy-studio-design',
+  template: require('./api-v4-policy-studio-design.component.html'),
+  styles: [require('./api-v4-policy-studio-design.component.scss')],
+})
+export class ApiV4PolicyStudioDesignComponent implements OnInit, OnDestroy {
+  private unsubscribe$ = new Subject<boolean>();
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  constructor() {}
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  ngOnInit(): void {}
+
+  ngOnDestroy() {
+    this.unsubscribe$.next(true);
+    this.unsubscribe$.unsubscribe();
+  }
+}

--- a/gravitee-apim-console-webui/src/management/management.module.ajs.ts
+++ b/gravitee-apim-console-webui/src/management/management.module.ajs.ts
@@ -530,6 +530,7 @@ import AlertTabsController from '../components/alerts/alertTabs/alert-tabs-compo
 import AlertsActivityController from '../components/alerts/activity/alerts-activity.controller';
 import { ApiPortalPlanEditComponent } from './api/portal/plans/edit/api-portal-plan-edit.component';
 import { ApiPortalDocumentationMetadataComponent } from './api/portal/documentation/metadata/api-portal-documentation-metadata.component';
+import { ApiV2Service } from '../services-ngx/api-v2.service';
 
 (<any>window).moment = moment;
 require('angular-moment-picker');
@@ -803,6 +804,7 @@ graviteeManagementModule.service('InstallationService', InstallationService);
 graviteeManagementModule.service('FlowService', FlowService);
 graviteeManagementModule.service('SpelService', SpelService);
 graviteeManagementModule.service('ConnectorService', ConnectorService);
+graviteeManagementModule.factory('ngApiV2Service', downgradeInjectable(ApiV2Service));
 graviteeManagementModule.controller('DialogGenerateTokenController', DialogGenerateTokenController);
 
 graviteeManagementModule.directive('filecontent', () => FileContentDirective);

--- a/gravitee-apim-console-webui/src/management/messages/messages.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/messages/messages.component.spec.ts
@@ -30,6 +30,7 @@ import { fakeRole } from '../../entities/role/role.fixture';
 import { MessageService } from '../../services-ngx/message.service';
 import { User } from '../../entities/user';
 import { HttpMessagePayload, TextMessagePayload } from '../../entities/message/messagePayload';
+import { GioHttpTestingModule } from '../../shared/testing';
 
 describe('MigratedMessagesComponent', () => {
   let fixture: ComponentFixture<MessagesComponent>;
@@ -41,7 +42,7 @@ describe('MigratedMessagesComponent', () => {
   const init = async (apiId?: string) => {
     await TestBed.configureTestingModule({
       declarations: [MessagesComponent],
-      imports: [NoopAnimationsModule, MessagesModule, MatIconTestingModule],
+      imports: [NoopAnimationsModule, GioHttpTestingModule, MessagesModule, MatIconTestingModule],
       providers: [
         {
           provide: UIRouterStateParams,

--- a/gravitee-apim-console-webui/src/scss/material-layout-compatibility.scss
+++ b/gravitee-apim-console-webui/src/scss/material-layout-compatibility.scss
@@ -122,3 +122,7 @@
   display: flex;
   flex-direction: column;
 }
+
+ui-view-ng-upgrade {
+  height: 100%;
+}

--- a/gravitee-apim-console-webui/src/services-ngx/api.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api.service.ts
@@ -340,4 +340,8 @@ export class ApiService {
   deleteMetadata(apiId: string, metadataKey: string): Observable<void> {
     return this.http.delete<void>(`${this.constants.env.baseURL}/apis/${apiId}/metadata/${metadataKey}`);
   }
+
+  getPermissions(apiId: string): Observable<Record<string, ('C' | 'R' | 'U' | 'D')[]>> {
+    return this.http.get<Record<string, ('C' | 'R' | 'U' | 'D')[]>>(`${this.constants.env.baseURL}/apis/${apiId}/members/permissions`);
+  }
 }

--- a/gravitee-apim-console-webui/src/shared/components/gio-permission/gio-permission.directive.spec.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-permission/gio-permission.directive.spec.ts
@@ -21,6 +21,7 @@ import { GioPermissionCheckOptions } from './gio-permission.directive';
 
 import { CurrentUserService } from '../../../ajs-upgraded-providers';
 import { User } from '../../../entities/user';
+import { GioHttpTestingModule } from '../../testing';
 
 @Component({ template: `<div *gioPermission="permissions">A Content</div>` })
 class TestPermissionComponent {
@@ -39,7 +40,7 @@ describe('GioPermissionDirective', () => {
   function prepareTestPermissionComponent(permission: GioPermissionCheckOptions) {
     fixture = TestBed.configureTestingModule({
       declarations: [TestPermissionComponent],
-      imports: [GioPermissionModule],
+      imports: [GioHttpTestingModule, GioPermissionModule],
       providers: [{ provide: CurrentUserService, useValue: { currentUser } }],
     }).createComponent(TestPermissionComponent);
 

--- a/gravitee-apim-console-webui/src/util/index.ts
+++ b/gravitee-apim-console-webui/src/util/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 export { Json } from './json';
-export * from './isApiV3orV4';
+export * from './isApiV1V2orV4';

--- a/gravitee-apim-console-webui/src/util/isApiV1V2orV4.ts
+++ b/gravitee-apim-console-webui/src/util/isApiV1V2orV4.ts
@@ -15,13 +15,17 @@
  */
 import { get, has } from 'lodash';
 
-import { Api as ApiV3 } from '../entities/api';
-import { ApiV4 } from '../entities/management-api-v2';
+import { Api as ApiV1V2FromMAPIV1 } from '../entities/api';
+import { ApiV4, ApiV2 as ApiV2FromMAPIV2 } from '../entities/management-api-v2';
 
-export const isApiV3 = (api: ApiV3 | ApiV4): api is ApiV3 => {
+export const isApiV1V2FromMAPIV1 = (api: ApiV1V2FromMAPIV1 | ApiV4): api is ApiV1V2FromMAPIV1 => {
   return !isApiV4(api);
 };
 
-export const isApiV4 = (api: ApiV3 | ApiV4): api is ApiV4 => {
+export const isApiV2FromMAPIV2 = (api: ApiV2FromMAPIV2 | ApiV4): api is ApiV2FromMAPIV2 => {
+  return !isApiV4(api);
+};
+
+export const isApiV4 = (api: ApiV1V2FromMAPIV1 | ApiV4): api is ApiV4 => {
   return has(api, 'definitionVersion') && get(api as ApiV4, 'definitionVersion') === 'V4';
 };


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1328

## Description


🧙 Make some 🪄 with the 🧟 hybrid console

Init new routing with angular & ui-router for apis/... pages. 
This routing manage the menu and the banners of sync / review / ... For the moment only for V4.
but once completed and finished that we remove the current one

📝 General page not working yet. Goal of next PR


## Additional context
<img width="1121" alt="image" src="https://github.com/gravitee-io/gravitee-api-management/assets/4974420/7c6072de-deb7-4f91-812d-e17728d6c82e">



<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ejovzaofbx.chromatic.com)
<!-- Storybook placeholder end -->
