### PR TITLE
Apim 1679 Part 1: integrate rest api v2 members

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/member/member.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/member/member.fixture.ts
@@ -13,11 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { isFunction } from 'lodash';
 
-export interface Role {
-  /**
-   * Role's name.
-   */
-  name?: string;
-  scope?: 'API' | 'APPLICATION' | 'GROUP' | 'ENVIRONMENT' | 'ORGANIZATION' | 'PLATFORM';
+import { Member } from './member';
+
+export function fakeMember(modifier?: Partial<Member>): Member {
+  const base: Member = {
+    id: '45ff00ef-8256-3218-bf0d-b289735d84bb',
+    roles: [
+      {
+        name: 'PRIMARY_OWNER',
+      },
+    ],
+    displayName: 'member-display-name',
+  };
+
+  if (isFunction(modifier)) {
+    return modifier(base);
+  }
+
+  return {
+    ...base,
+    ...modifier,
+  };
 }

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/member/membersResponse.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/member/membersResponse.ts
@@ -26,4 +26,5 @@ export interface MembersResponse {
   data?: Member[];
   pagination?: Pagination;
   links?: Links;
+  metadata?: Record<string, unknown>;
 }

--- a/gravitee-apim-console-webui/src/management/api/portal/user-group-access/members/api-portal-groups-members/api-portal-groups-members.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/user-group-access/members/api-portal-groups-members/api-portal-groups-members.harness.ts
@@ -13,11 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatTableHarness } from '@angular/material/table/testing';
 
-export interface Role {
-  /**
-   * Role's name.
-   */
-  name?: string;
-  scope?: 'API' | 'APPLICATION' | 'GROUP' | 'ENVIRONMENT' | 'ORGANIZATION' | 'PLATFORM';
+export class ApiPortalGroupsMembersHarness extends ComponentHarness {
+  static hostSelector = 'api-portal-groups-members';
+
+  protected getGroupTable = (groupName: string) =>
+    this.locatorFor(MatTableHarness.with({ selector: '[aria-label="Group ' + groupName + ' members table"]' }))();
+
+  public getGroupTableByGroupName(groupName: string): Promise<MatTableHarness> {
+    return this.getGroupTable(groupName);
+  }
 }

--- a/gravitee-apim-console-webui/src/management/api/portal/user-group-access/members/api-portal-members.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/user-group-access/members/api-portal-members.component.html
@@ -84,7 +84,7 @@
     </table>
   </mat-card>
 
-  <api-portal-groups-members></api-portal-groups-members>
+  <api-portal-groups-members [groupIds]="groupIds"></api-portal-groups-members>
 
   <gio-save-bar [form]="form" (resetClicked)="onReset()" (submitted)="onSubmit()"></gio-save-bar>
 </form>

--- a/gravitee-apim-console-webui/src/management/api/portal/user-group-access/members/api-portal-members.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/user-group-access/members/api-portal-members.component.ts
@@ -57,6 +57,7 @@ export class ApiPortalMembersComponent implements OnInit {
   defaultRole?: Role;
   members: ApiMember[];
   membersToAdd: (ApiMember & { _viewId: string })[] = [];
+  groupIds: string[];
   isReadOnly = false;
 
   dataSource: MemberDataSource[];
@@ -93,6 +94,7 @@ export class ApiPortalMembersComponent implements OnInit {
           this.members = members;
           this.roles = roles;
           this.defaultRole = roles.find((role) => role.default);
+          this.groupIds = api.groups;
           this.initDataSource(members);
           this.initForm(api, members);
         }),

--- a/gravitee-apim-console-webui/src/services-ngx/group-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/group-v2.service.spec.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { GroupV2Service } from './group-v2.service';
+
+import { CONSTANTS_TESTING, GioHttpTestingModule } from '../shared/testing';
+import { MembersResponse } from '../entities/management-api-v2';
+import { fakeMember } from '../entities/management-api-v2/member/member.fixture';
+
+describe('GroupV2Service', () => {
+  let httpTestingController: HttpTestingController;
+  let groupService: GroupV2Service;
+  const GROUP_ID = 'my-group';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [GioHttpTestingModule],
+    });
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+    groupService = TestBed.inject<GroupV2Service>(GroupV2Service);
+  });
+
+  describe('get members', () => {
+    it('should call the API', (done) => {
+      const fakeMembersResponse: MembersResponse = {
+        data: [fakeMember()],
+        metadata: {},
+        pagination: {
+          page: 1,
+          pageCount: 1,
+          pageItemsCount: 1,
+          perPage: 10,
+          totalCount: 1,
+        },
+      };
+
+      groupService.getMembers(GROUP_ID).subscribe((groups) => {
+        expect(groups).toMatchObject(fakeMembersResponse);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/groups/${GROUP_ID}/members?page=1&perPage=10`);
+      expect(req.request.method).toEqual('GET');
+
+      req.flush(fakeMembersResponse);
+    });
+
+    it('should allow custom pagination', (done) => {
+      const fakeMembersResponse: MembersResponse = {
+        data: [fakeMember()],
+        metadata: {
+          groupName: 'group-display-name',
+        },
+        pagination: {
+          page: 2,
+          pageCount: 1,
+          pageItemsCount: 1,
+          perPage: 1,
+          totalCount: 2,
+        },
+      };
+
+      groupService.getMembers(GROUP_ID, 2, 1).subscribe((groups) => {
+        expect(groups).toMatchObject(fakeMembersResponse);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/groups/${GROUP_ID}/members?page=2&perPage=1`);
+      expect(req.request.method).toEqual('GET');
+
+      req.flush(fakeMembersResponse);
+    });
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+});

--- a/gravitee-apim-console-webui/src/services-ngx/group-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/group-v2.service.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpClient } from '@angular/common/http';
+import { Inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { Constants } from '../entities/Constants';
+import { MembersResponse } from '../entities/management-api-v2';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class GroupV2Service {
+  constructor(private readonly http: HttpClient, @Inject('Constants') private readonly constants: Constants) {}
+
+  getMembers(groupId: string, page = 1, perPage = 10): Observable<MembersResponse> {
+    return this.http.get<MembersResponse>(`${this.constants.env.v2BaseURL}/groups/${groupId}/members`, {
+      params: {
+        page,
+        perPage,
+      },
+    });
+  }
+}

--- a/gravitee-apim-console-webui/src/shared/testing/gio-http.testing.module.ts
+++ b/gravitee-apim-console-webui/src/shared/testing/gio-http.testing.module.ts
@@ -43,6 +43,7 @@ export const CONSTANTS_TESTING: Constants = {
         enabled: false,
       },
     } as any,
+    v2BaseURL: 'https://url.test:3000/management/v2/environments/DEFAULT',
   },
   v2BaseURL: 'https://url.test:3000/management/v2',
 };


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1679

## Description

- Add v2 endpoint /environments/:envId/groups/:groupId/members to api-portal-groups-members component

Next PR: Integrate pagination into groups members

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jafaecdsqs.chromatic.com)
<!-- Storybook placeholder end -->
