### PR TITLE
chore: bump gravitee-node version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-gateway-api.version>3.0.0-alpha.1</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
-        <gravitee-node.version>3.1.0-alpha.7</gravitee-node.version>
+        <gravitee-node.version>3.1.0-alpha.8</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-plugin.version>1.27.0-alpha.2</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.2.1</gravitee-platform-repository-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1566

## Description

Bump gravitee-node version to avoid NPE in monitoring on windows
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tmprfsqoxn.chromatic.com)
<!-- Storybook placeholder end -->
