### PR TITLE
fix(rest-api): fix service circular dep using Lazy annotation

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TagServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TagServiceImpl.java
@@ -60,6 +60,7 @@ public class TagServiceImpl extends AbstractService implements TagService {
     private TagRepository tagRepository;
 
     @Autowired
+    @Lazy
     private ApiTagService apiTagService;
 
     @Autowired

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl.java
@@ -78,16 +78,16 @@ public class ApiStateServiceImpl implements ApiStateService {
     private final ApiMetadataService apiMetadataService;
 
     public ApiStateServiceImpl(
-        final ApiSearchService apiSearchService,
+        @Lazy final ApiSearchService apiSearchService,
         @Lazy final ApiRepository apiRepository,
         final ApiMapper apiMapper,
         final GenericApiMapper genericApiMapper,
-        final ApiNotificationService apiNotificationService,
-        final PrimaryOwnerService primaryOwnerService,
+        @Lazy final ApiNotificationService apiNotificationService,
+        @Lazy final PrimaryOwnerService primaryOwnerService,
         final AuditService auditService,
-        final EventService eventService,
+        @Lazy final EventService eventService,
         final ObjectMapper objectMapper,
-        final ApiMetadataService apiMetadataService
+        @Lazy final ApiMetadataService apiMetadataService
     ) {
         this.apiSearchService = apiSearchService;
         this.apiRepository = apiRepository;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiTemplateServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiTemplateServiceImpl.java
@@ -39,6 +39,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 /**
@@ -54,7 +55,7 @@ public class ApiTemplateServiceImpl implements ApiTemplateService {
     private final NotificationTemplateService notificationTemplateService;
 
     public ApiTemplateServiceImpl(
-        final ApiSearchService apiSearchService,
+        @Lazy final ApiSearchService apiSearchService,
         final ApiMetadataService apiMetadataService,
         final PrimaryOwnerService primaryOwnerService,
         final NotificationTemplateService notificationTemplateService


### PR DESCRIPTION
## Description

API REST service doesn't start due to circular dep in Service layer.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-xezvsppxsc.chromatic.com)
<!-- Storybook placeholder end -->
