### PR TITLE
fix: check that executionContext exists before saving settings

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalSettingsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalSettingsResource.java
@@ -23,6 +23,7 @@ import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.settings.PortalSettingsEntity;
 import io.gravitee.rest.api.service.ConfigService;
+import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -51,6 +52,9 @@ public class PortalSettingsResource {
 
     @Inject
     private ConfigService configService;
+
+    @Inject
+    private EnvironmentService environmentService;
 
     @Context
     private ResourceContext resourceContext;
@@ -81,6 +85,9 @@ public class PortalSettingsResource {
     @ApiResponse(responseCode = "500", description = "Internal server error")
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_SETTINGS, acls = { CREATE, UPDATE, DELETE }) })
     public Response savePortalSettings(@Parameter(name = "config", required = true) @NotNull PortalSettingsEntity portalSettingsEntity) {
+        // check that environment exists
+        environmentService.findById(GraviteeContext.getCurrentEnvironment());
+
         configService.save(GraviteeContext.getExecutionContext(), portalSettingsEntity);
         return Response.ok().entity(portalSettingsEntity).build();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/ConsoleSettingsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/ConsoleSettingsResource.java
@@ -25,6 +25,7 @@ import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.settings.ConsoleSettingsEntity;
 import io.gravitee.rest.api.service.ConfigService;
+import io.gravitee.rest.api.service.OrganizationService;
 import io.gravitee.rest.api.service.ParameterService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.MaintenanceModeException;
@@ -55,6 +56,9 @@ public class ConsoleSettingsResource {
 
     @Inject
     private ConfigService configService;
+
+    @Inject
+    private OrganizationService organizationService;
 
     @Inject
     private ParameterService parameterService;
@@ -90,6 +94,9 @@ public class ConsoleSettingsResource {
     public Response saveConsoleSettings(@Parameter(name = "config", required = true) @NotNull ConsoleSettingsEntity consoleSettingsEntity) {
         // reject settings update if maintenanceMode isn't disabled into the payload
         checkMaintenanceMode(consoleSettingsEntity);
+
+        // check that organization exists
+        organizationService.findById(GraviteeContext.getCurrentOrganization());
 
         configService.save(GraviteeContext.getExecutionContext(), consoleSettingsEntity);
         return Response.ok().entity(consoleSettingsEntity).build();


### PR DESCRIPTION
## Issue

N/A

## Description

Add organization and environment checks when saving Settings for Console or Portal.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dceyyqaqdn.chromatic.com)
<!-- Storybook placeholder end -->
