### PR TITLE
fix: change the path to the assets

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/OpenAPIResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/OpenAPIResource.java
@@ -31,12 +31,12 @@ public class OpenAPIResource {
     @Path("/openapi.yaml")
     @Produces("application/yaml")
     public Response getOpenApi() {
-        return Response.ok(this.getClass().getClassLoader().getResourceAsStream("management-openapi-v2.yaml")).build();
+        return Response.ok(this.getClass().getClassLoader().getResourceAsStream("openapi/management-openapi-v2.yaml")).build();
     }
 
     @GET
     @Produces("text/html")
     public Response getOpenApiDocumentation() {
-        return Response.ok(this.getClass().getClassLoader().getResourceAsStream("index.html")).build();
+        return Response.ok(this.getClass().getClassLoader().getResourceAsStream("openapi/index.html")).build();
     }
 }


### PR DESCRIPTION
## Issue

N/A

## Description
Fix https://github.com/gravitee-io/gravitee-api-management/pull/4095
Use the correct path to load assets
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ixtgssbhxj.chromatic.com)
<!-- Storybook placeholder end -->
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://4107.team-apim.gravitee.dev/console](https://4107.team-apim.gravitee.dev/console)
      Portal: [https://4107.team-apim.gravitee.dev/portal](https://4107.team-apim.gravitee.dev/portal)
      Management-api: [https://4107.team-apim.gravitee.dev/api/management](https://4107.team-apim.gravitee.dev/api/management)
      Gateway v4: [https://4107.team-apim.gravitee.dev](https://4107.team-apim.gravitee.dev)
      Gateway v3: [https://4107.gateway-v3.team-apim.gravitee.dev](https://4107.gateway-v3.team-apim.gravitee.dev)

<!-- Environment placeholder end -->
