### PR TITLE
fix: update visibility of policy v3 adapter method for reusability

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/DefaultPolicyFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/DefaultPolicyFactory.java
@@ -37,7 +37,7 @@ public class DefaultPolicyFactory implements PolicyFactory {
     private final ConcurrentMap<String, Policy> policies = new ConcurrentHashMap<>();
     private final PolicyPluginFactory policyPluginFactory;
     private final io.gravitee.gateway.policy.PolicyFactory v3PolicyFactory;
-    private final ExpressionLanguageConditionFilter<ConditionalPolicy> filter;
+    protected final ExpressionLanguageConditionFilter<ConditionalPolicy> filter;
 
     public DefaultPolicyFactory(
         final PolicyPluginFactory policyPluginFactory,
@@ -95,6 +95,12 @@ public class DefaultPolicyFactory implements PolicyFactory {
             );
         }
 
+        policy = createConditionalPolicy(policyMetadata, policy);
+
+        return policy;
+    }
+
+    protected Policy createConditionalPolicy(PolicyMetadata policyMetadata, Policy policy) {
         if (policy != null) {
             final String condition = policyMetadata.getCondition();
 
@@ -103,7 +109,6 @@ public class DefaultPolicyFactory implements PolicyFactory {
                 policy = new ConditionalPolicy(policy, condition, filter);
             }
         }
-
         return policy;
     }
 
@@ -132,7 +137,7 @@ public class DefaultPolicyFactory implements PolicyFactory {
         );
     }
 
-    private boolean isNotBlank(String s) {
+    protected boolean isNotBlank(String s) {
         return s != null && !s.isBlank();
     }
 }


### PR DESCRIPTION
## Description

V3 Policies needs an adapter to work with v4 APIs.
The Message Reactor is not taking benefits of this, making a V4 API of type `message` not able to instantiate a v3 Policy.
Here, we just change the visibility so this class can easily be extended by the reactor
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-sgznuilnwg.chromatic.com)
<!-- Storybook placeholder end -->
