### PR TITLE
feat: add endpoint to list license features

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/GraviteeManagementV2Application.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/GraviteeManagementV2Application.java
@@ -28,6 +28,7 @@ import io.gravitee.rest.api.management.v2.rest.resource.connector.EndpointsResou
 import io.gravitee.rest.api.management.v2.rest.resource.connector.EntrypointsResource;
 import io.gravitee.rest.api.management.v2.rest.resource.group.GroupResource;
 import io.gravitee.rest.api.management.v2.rest.resource.installation.EnvironmentsResource;
+import io.gravitee.rest.api.management.v2.rest.resource.installation.GraviteeLicenseResource;
 import io.gravitee.rest.api.management.v2.rest.resource.installation.OrganizationResource;
 import jakarta.inject.Inject;
 import org.glassfish.jersey.jackson.JacksonFeature;
@@ -45,6 +46,7 @@ public class GraviteeManagementV2Application extends ResourceConfig {
     @Inject
     public GraviteeManagementV2Application() {
         //Main resource
+        register(GraviteeLicenseResource.class);
         register(OrganizationResource.class);
         register(EnvironmentsResource.class);
         register(ApisResource.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/GraviteeLicenseMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/GraviteeLicenseMapper.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.mapper;
+
+import io.gravitee.rest.api.management.v2.rest.model.GraviteeLicense;
+import io.gravitee.rest.api.model.v4.license.GraviteeLicenseEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Mapper
+public interface GraviteeLicenseMapper {
+    GraviteeLicenseMapper INSTANCE = Mappers.getMapper(GraviteeLicenseMapper.class);
+
+    GraviteeLicense convert(GraviteeLicenseEntity licenseEntity);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/GraviteeLicenseResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/installation/GraviteeLicenseResource.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.installation;
+
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.v2.rest.mapper.GraviteeLicenseMapper;
+import io.gravitee.rest.api.management.v2.rest.model.GraviteeLicense;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
+import io.gravitee.rest.api.service.v4.GraviteeLicenseService;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+
+/**
+ * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Path("/license")
+public class GraviteeLicenseResource extends AbstractResource {
+
+    @Inject
+    private GraviteeLicenseService licenseService;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    public GraviteeLicense get() {
+        return GraviteeLicenseMapper.INSTANCE.convert(licenseService.getLicense());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
@@ -31,6 +31,24 @@ servers:
     - url: /management/v2
       description: Gravitee.io APIM - Management API -v2
 paths:
+    /license:
+        get:
+            tags:
+                - Installation
+            summary: Get the license gravitee is running on.
+            description: |-
+                Returns the license information of the gravitee instance.
+            operationId: getLicense
+            responses:
+                "200":
+                    description: |-
+                        The license and its features. If there is no license, then the features will be empty.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/GraviteeLicense"
+                default:
+                    $ref: "#/components/responses/Error"
     /organizations/{orgId}:
         parameters:
             - $ref: "#/components/parameters/orgIdParam"
@@ -879,6 +897,29 @@ paths:
                     $ref: "#/components/responses/Error"
 components:
     schemas:
+        GraviteeLicense:
+            type: object
+            properties:
+                tier:
+                    type: string
+                    description:  The tier gravitee is running on.
+                    example: "tier-planet"
+                packs:
+                    type: array
+                    items:
+                        type: string
+                    description: The packs included in the tier gravitee is running on.
+                    example:
+                        - "pack-observability"
+                        - "pack-event-native"
+                features:
+                    type: array
+                    items:
+                        type: string
+                    description: The features included in the tier gravitee is running on.
+                    example:
+                        - feature-debug-mode
+                        - feature-datadog-reporter
         Analytics:
             type: object
             properties:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/GraviteeLicenseFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/GraviteeLicenseFixtures.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fixtures;
+
+import io.gravitee.rest.api.management.v2.rest.model.GraviteeLicense;
+import io.gravitee.rest.api.management.v2.rest.model.GraviteeLicense.GraviteeLicenseBuilder;
+import io.gravitee.rest.api.model.v4.license.GraviteeLicenseEntity;
+import io.gravitee.rest.api.model.v4.license.GraviteeLicenseEntity.GraviteeLicenseEntityBuilder;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@SuppressWarnings("rawtypes")
+public class GraviteeLicenseFixtures {
+
+    private static final GraviteeLicenseEntityBuilder BASE_GRAVITEE_LICENSE_ENTITY = GraviteeLicenseEntity
+        .builder()
+        .tier("tier-galaxy")
+        .features(Set.of("feature-datadog-reporter"))
+        .packs(Set.of("pack-observability"));
+
+    private static final GraviteeLicenseBuilder BASE_GRAVITEE_LICENSE = GraviteeLicense
+        .builder()
+        .tier("tier-galaxy")
+        .features(List.of("feature-datadog-reporter"))
+        .packs(List.of("pack-observability"));
+
+    public static GraviteeLicenseEntity aGraviteeLicenseEntity() {
+        return BASE_GRAVITEE_LICENSE_ENTITY.build();
+    }
+
+    public static GraviteeLicense aGraviteeLicense() {
+        return BASE_GRAVITEE_LICENSE.build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/GraviteeLicenseMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/GraviteeLicenseMapperTest.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.mapper;
+
+import static fixtures.GraviteeLicenseFixtures.*;
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class GraviteeLicenseMapperTest {
+
+    private final GraviteeLicenseMapper licenseMapper = Mappers.getMapper(GraviteeLicenseMapper.class);
+
+    @Test
+    void shouldConvertToLicense() {
+        var license = licenseMapper.convert(aGraviteeLicenseEntity());
+        assertThat(license).usingRecursiveComparison().isEqualTo(aGraviteeLicense());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/installation/GraviteeLicenseResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/installation/GraviteeLicenseResourceTest.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.installation;
+
+import static fixtures.GraviteeLicenseFixtures.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.doReturn;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.management.v2.rest.model.GraviteeLicense;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.service.v4.GraviteeLicenseService;
+import javax.inject.Inject;
+import org.junit.Test;
+
+/**
+ * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class GraviteeLicenseResourceTest extends AbstractResourceTest {
+
+    @Inject
+    GraviteeLicenseService licenseService;
+
+    @Override
+    protected String contextPath() {
+        return "/license";
+    }
+
+    @Test
+    public void shouldReturnLicenseWithFeatures() {
+        doReturn(aGraviteeLicenseEntity()).when(licenseService).getLicense();
+
+        var response = rootTarget().request().get();
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+
+        var license = response.readEntity(GraviteeLicense.class);
+        assertThat(license).isNotNull();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -22,6 +22,7 @@ import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.v4.ApiImportExportService;
 import io.gravitee.rest.api.service.v4.EndpointConnectorPluginService;
 import io.gravitee.rest.api.service.v4.EntrypointConnectorPluginService;
+import io.gravitee.rest.api.service.v4.GraviteeLicenseService;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import io.gravitee.rest.api.service.v4.PlanService;
 import org.springframework.context.annotation.Bean;
@@ -150,5 +151,10 @@ public class ResourceContextConfiguration {
     @Bean
     public WorkflowService workflowService() {
         return mock(WorkflowService.class);
+    }
+
+    @Bean
+    public GraviteeLicenseService licenseService() {
+        return mock(GraviteeLicenseService.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/license/GraviteeLicenseEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/license/GraviteeLicenseEntity.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.v4.license;
+
+import java.util.Set;
+import lombok.*;
+
+/**
+ * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Getter
+@Setter
+@ToString
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class GraviteeLicenseEntity {
+
+    private String tier;
+
+    @Builder.Default
+    private Set<String> packs = Set.of();
+
+    @Builder.Default
+    private Set<String> features = Set.of();
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/GraviteeLicenseService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/GraviteeLicenseService.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4;
+
+import io.gravitee.rest.api.model.v4.license.GraviteeLicenseEntity;
+
+public interface GraviteeLicenseService {
+    GraviteeLicenseEntity getLicense();
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/GraviteeLicenseServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/GraviteeLicenseServiceImpl.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.impl;
+
+import static java.util.stream.Collectors.*;
+
+import io.gravitee.node.api.Node;
+import io.gravitee.node.api.license.Feature;
+import io.gravitee.node.api.license.License;
+import io.gravitee.rest.api.model.v4.license.GraviteeLicenseEntity;
+import io.gravitee.rest.api.service.v4.GraviteeLicenseService;
+import jakarta.validation.constraints.NotNull;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Component
+public class GraviteeLicenseServiceImpl implements GraviteeLicenseService {
+
+    private static final String TIER_KEY = "tier";
+    private static final String PACKS_KEY = "packs";
+    private static final String FEATURE_VALUE = "included";
+    private static final String SEPARATOR = ",";
+
+    private final Node node;
+
+    public GraviteeLicenseServiceImpl(Node node) {
+        this.node = node;
+    }
+
+    @Override
+    public GraviteeLicenseEntity getLicense() {
+        var licenseEntity = new GraviteeLicenseEntity();
+        licenseEntity.setTier(readTier());
+        licenseEntity.setPacks(readPacks());
+        licenseEntity.setFeatures(readFeatures());
+        return licenseEntity;
+    }
+
+    private String readTier() {
+        return readString(TIER_KEY).orElse(null);
+    }
+
+    private Set<String> readPacks() {
+        return readString(PACKS_KEY).map(packs -> Set.of(packs.split(SEPARATOR))).orElse(Set.of());
+    }
+
+    private Set<String> readFeatures() {
+        return findLicense().map(this::extractFeatures).orElse(Set.of());
+    }
+
+    private Set<String> extractFeatures(@NotNull License license) {
+        return license
+            .features()
+            .entrySet()
+            .stream()
+            .filter(entry -> FEATURE_VALUE.equals(entry.getValue()))
+            .map(Map.Entry::getKey)
+            .collect(toSet());
+    }
+
+    private Optional<String> readString(String featureKey) {
+        return findLicense().flatMap(license -> license.feature(featureKey)).map(Feature::getString);
+    }
+
+    private Optional<License> findLicense() {
+        return Optional.ofNullable(node.license());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/GraviteeLicenseServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/GraviteeLicenseServiceTest.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.*;
+
+import io.gravitee.node.api.Node;
+import io.gravitee.node.api.license.Feature;
+import io.gravitee.node.api.license.License;
+import io.gravitee.rest.api.service.v4.GraviteeLicenseService;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class GraviteeLicenseServiceTest {
+
+    @Mock
+    private Node node;
+
+    @Mock
+    private License license;
+
+    @Mock
+    private Feature feature;
+
+    private GraviteeLicenseService licenseService;
+
+    @Before
+    public void setUp() throws Exception {
+        openMocks(this);
+        licenseService = new GraviteeLicenseServiceImpl(node);
+    }
+
+    @Test
+    public void shouldReturnNullTierWithNoLicense() {
+        assertThat(licenseService.getLicense().getTier()).isNull();
+    }
+
+    @Test
+    public void shouldReturnEmptyPacksWithNoLicense() {
+        assertThat(licenseService.getLicense().getPacks()).isEmpty();
+    }
+
+    @Test
+    public void shouldReturnEmptyFeaturesWithNoLicense() {
+        assertThat(licenseService.getLicense().getFeatures()).isEmpty();
+    }
+
+    @Test
+    public void shouldReturnTierFromLicense() {
+        when(feature.getString()).thenReturn("tier-planet");
+        when(license.feature("tier")).thenReturn(Optional.of(feature));
+        when(node.license()).thenReturn(license);
+        assertThat(licenseService.getLicense().getTier()).isEqualTo("tier-planet");
+    }
+
+    @Test
+    public void shouldReturnPacksFromLicense() {
+        when(feature.getString()).thenReturn("pack-observability,pack-event-native");
+        when(license.feature("packs")).thenReturn(Optional.of(feature));
+        when(node.license()).thenReturn(license);
+        assertThat(licenseService.getLicense().getPacks()).containsExactlyInAnyOrder("pack-observability", "pack-event-native");
+    }
+
+    @Test
+    public void shouldReturnFeaturesFromLicense() {
+        when(license.features()).thenReturn(Map.of("feature-debug-mode", "included", "feature-datadog-reporter", "included"));
+        when(node.license()).thenReturn(license);
+        assertThat(licenseService.getLicense().getFeatures()).containsExactlyInAnyOrder("feature-debug-mode", "feature-datadog-reporter");
+    }
+}


### PR DESCRIPTION
see https://gravitee.atlassian.net/browse/APIM-1687


Given
--
```bash
curl -u "admin:admin" localhost:8083/management/v2/license
```

Then
--
```json
{
  "tier": "tier-galaxy",
  "packs": [
    "pack-observability"
  ],
  "features": [
    "feature-datadog-reporter",
    "feature-tcp-reporter"
  ]
}
```

Note
--
Right now packs and tier are not included in the license file. This will result in the tier being null and the packs empty. If the license is not there, then the features will be empty as well.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-agubkpzfcl.chromatic.com)
<!-- Storybook placeholder end -->
