### PR TITLE
Fix typo in enum values of `ssl.clientAuth` config

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -26,7 +26,7 @@
 #  secured: false
 #  alpn: false
 #  ssl:
-#    clientAuth: none # Supports none, request, requires
+#    clientAuth: none # Supports none, request, required
 #    tlsProtocols: TLSv1.2, TLSv1.3
 #    tlsCiphers: TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
 #    keystore:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1715
https://github.com/gravitee-io/issues/issues/9061

## Description

It's mapped to this enum under the hood: 
![image](https://github.com/gravitee-io/gravitee-api-management/assets/4112568/c58db615-9b64-4796-a748-f2e715a3bfe2)


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gcmimjlpmk.chromatic.com)
<!-- Storybook placeholder end -->
