### PR TITLE
chore: implement writePing method in VertxWebSocket

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/reactive/http/vertx/ws/VertxWebSocket.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/reactive/http/vertx/ws/VertxWebSocket.java
@@ -77,6 +77,14 @@ public class VertxWebSocket implements WebSocket {
         return Completable.complete();
     }
 
+    @Override
+    public Completable writePing() {
+        if (isValid()) {
+            return webSocket.writePing(io.vertx.rxjava3.core.buffer.Buffer.buffer("ping_pong"));
+        }
+        return Completable.complete();
+    }
+
     public Completable writeFrame(io.gravitee.gateway.api.ws.WebSocketFrame frame) {
         if (isValid()) {
             final WebSocketFrame webSocketFrame = convert(frame);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/reactive/http/vertx/ws/VertxWebSocketTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/test/java/io/gravitee/gateway/reactive/http/vertx/ws/VertxWebSocketTest.java
@@ -285,6 +285,29 @@ class VertxWebSocketTest {
     }
 
     @Nested
+    class WritePing {
+
+        @Test
+        void should_write_ping_frame() {
+            ReflectionTestUtils.setField(cut, "upgraded", true);
+            ReflectionTestUtils.setField(cut, "webSocket", webSocket);
+
+            when(webSocket.writePing(any(Buffer.class))).thenReturn(Completable.complete());
+
+            cut.writePing().test().assertComplete();
+            verify(webSocket).writePing(eq(Buffer.buffer("ping_pong")));
+        }
+
+        @Test
+        void should_not_write_ping_frame_if_not_upgraded() {
+            ReflectionTestUtils.setField(cut, "upgraded", false);
+
+            cut.writePing().test().assertComplete();
+            verifyNoInteractions(webSocket);
+        }
+    }
+
+    @Nested
     class Read {
 
         @Test

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <gravitee-connector-api.version>1.1.4</gravitee-connector-api.version>
         <gravitee-expression-language.version>2.2.1</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>3.0.0-alpha.3</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>3.0.0-alpha.4</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>3.1.0-alpha.9</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1700

## Description

Implement `writePing` method in VertxWebSocket so the WebSocket entrypoint can initialize a periodic task sending ping frame to keep the connection alive.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uqjtlmqazj.chromatic.com)
<!-- Storybook placeholder end -->
