### PR TITLE
test: add entrypoint not found integration test

### DIFF
--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/errors/EntrypointNotFoundIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/errors/EntrypointNotFoundIntegrationTest.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.messages.errors;
+
+import com.graviteesource.entrypoint.http.post.HttpPostEntrypointConnectorFactory;
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonObject;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class EntrypointNotFoundIntegrationTest {
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/v4/messages/http-get-entrypoint-mock-endpoint.json")
+    class NoErrorMessageOverride extends AbstractGatewayTest {
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            entrypoints.putIfAbsent("http-post", EntrypointBuilder.build("http-post", HttpPostEntrypointConnectorFactory.class));
+        }
+
+        @Test
+        void should_receive_not_found_when_entrypoint_not_installed(HttpClient client) {
+            client.rxRequest(HttpMethod.GET, "/test")
+                   .flatMap(HttpClientRequest::rxSend)
+                   .flatMap(response -> {
+                       assertThat(response.statusCode()).isEqualTo(404);
+                       assertThat(response.getHeader(HttpHeaders.CONTENT_TYPE)).isEqualTo(MediaType.TEXT_PLAIN);
+                       return response.body();
+                   })
+                   .test()
+                   .awaitDone(2, TimeUnit.SECONDS)
+                   .assertComplete()
+                   .assertValue(response -> {
+                       assertThat(response).hasToString("No context-path matches the request URI.");
+                       return true;
+                   });
+        }
+
+        @Test
+        void should_receive_not_found_when_entrypoint_not_configured_for_api(HttpClient client) {
+            client.rxRequest(HttpMethod.POST, "/test")
+                   .flatMap(HttpClientRequest::rxSend)
+                   .flatMap(response -> {
+                       assertThat(response.statusCode()).isEqualTo(404);
+                       assertThat(response.getHeader(HttpHeaders.CONTENT_TYPE)).isEqualTo(MediaType.TEXT_PLAIN);
+                       return response.body();
+                   })
+                   .test()
+                   .awaitDone(2, TimeUnit.SECONDS)
+                   .assertComplete()
+                   .assertValue(response -> {
+                       assertThat(response).hasToString("No context-path matches the request URI.");
+                       return true;
+                   });
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    class ErrorMessageOverride extends AbstractGatewayTest {
+
+        private JsonObject errorMessage;
+
+        @Override
+        protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
+            errorMessage = new JsonObject();
+            errorMessage.put("error", "This is the new not found message");
+
+            gatewayConfigurationBuilder.set("http.errors[404].message", errorMessage)
+                   .set("http.errors[404].contentType", MediaType.APPLICATION_JSON);
+        }
+
+        @Test
+        void should_receive_not_found_when_entrypoint_not_installed(HttpClient client) {
+            client.rxRequest(HttpMethod.GET, "/test")
+                   .flatMap(HttpClientRequest::rxSend)
+                   .flatMap(response -> {
+                       assertThat(response.statusCode()).isEqualTo(404);
+                       assertThat(response.getHeader(HttpHeaders.CONTENT_TYPE)).isEqualTo(MediaType.APPLICATION_JSON);
+                       assertThat(response.getHeader(HttpHeaders.CONTENT_LENGTH)).isEqualTo(Integer.toString(errorMessage.toBuffer().length()));
+                       return response.body();
+                   })
+                   .test()
+                   .awaitDone(2, TimeUnit.SECONDS)
+                   .assertComplete()
+                   .assertValue(response -> {
+                       assertThat(response).hasToString(errorMessage.toString());
+                       return true;
+                   });
+        }
+
+        @Test
+        void should_receive_not_found_when_entrypoint_not_configured_for_api(HttpClient client) {
+            client.rxRequest(HttpMethod.POST, "/test")
+                   .flatMap(HttpClientRequest::rxSend)
+                   .flatMap(response -> {
+                       assertThat(response.statusCode()).isEqualTo(404);
+                       assertThat(response.getHeader(HttpHeaders.CONTENT_TYPE)).isEqualTo(MediaType.APPLICATION_JSON);
+                       assertThat(response.getHeader(HttpHeaders.CONTENT_LENGTH)).isEqualTo(Integer.toString(errorMessage.toBuffer().length()));
+                       return response.body();
+                   })
+                   .test()
+                   .awaitDone(2, TimeUnit.SECONDS)
+                   .assertComplete()
+                   .assertValue(response -> {
+                       assertThat(response).hasToString(errorMessage.toString());
+                       return true;
+                   });
+        }
+    }
+
+
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1823

## Description

- **Entrypoint not installed**: We should have a 404 when the entrypoint for which api is configured is not installed
- **Entrypoint not configured**: We should have a 404 when trying to call the api with an entrypoint not configured for the api. Let’s say an API exposing HTTP-GET and trying to call it with POST.

Both of these scenarios should be tested with error message override
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zgfeckvneh.chromatic.com)
<!-- Storybook placeholder end -->
