### PR TITLE
test: fix for Cypress unwanted page reloads

### DIFF
--- a/gravitee-apim-e2e/cypress.config.ts
+++ b/gravitee-apim-e2e/cypress.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from 'cypress';
 
 export default defineConfig({
+  env: {
+    managementApi: 'http://localhost:8083',
+  },
   e2e: {
     baseUrl: 'http://localhost:8083',
     watchForFileChanges: false,

--- a/gravitee-apim-e2e/docker/ui-tests/conf/cypress-ui-config.ts
+++ b/gravitee-apim-e2e/docker/ui-tests/conf/cypress-ui-config.ts
@@ -11,9 +11,9 @@ export default defineConfig({
         low_permission_user_password: "password",
         admin_user_login: "admin",
         admin_user_password: "admin",
-        managementOrganizationApi: "/management/organizations/DEFAULT",
-        managementApi: "/management/organizations/DEFAULT/environments/DEFAULT",
-        managementUI: "http://nginx/console",
+        defaultOrg: "/management/organizations/DEFAULT",
+        defaultOrgEnv: "/management/organizations/DEFAULT/environments/DEFAULT",
+        managementApi: 'http://nginx',
         gatewayServer: "http://nginx/gateway",
         portalApi: "/portal/environments/DEFAULT",
     },
@@ -28,7 +28,7 @@ export default defineConfig({
         videosFolder: "./ui-test/videos",
         video: false,
         screenshotOnRunFailure: false,
-        baseUrl: "http://nginx",
+        baseUrl: "http://nginx/console",
         setupNodeEvents(on, config) {
             // implement node event listeners here
         },

--- a/gravitee-apim-e2e/ui-test/commands/gravitee.commands.ts
+++ b/gravitee-apim-e2e/ui-test/commands/gravitee.commands.ts
@@ -22,7 +22,7 @@ class GraviteeCommands {
   static management(auth?: BasicAuthentication): ManagementCommands {
     const requestInfo: RequestInfo = {
       auth,
-      baseUrl: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}`,
+      baseUrl: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}`,
     };
     return new ManagementCommands(requestInfo);
   }
@@ -30,7 +30,7 @@ class GraviteeCommands {
   static portal(auth?: BasicAuthentication): PortalCommands {
     const requestInfo: RequestInfo = {
       auth,
-      baseUrl: `${Cypress.config().baseUrl}${Cypress.env('portalApi')}`,
+      baseUrl: `${Cypress.env('managementApi')}${Cypress.env('portalApi')}`,
     };
     return new PortalCommands(requestInfo);
   }

--- a/gravitee-apim-e2e/ui-test/commands/management/api-management-commands.ts
+++ b/gravitee-apim-e2e/ui-test/commands/management/api-management-commands.ts
@@ -27,7 +27,7 @@ import { requestGateway } from 'ui-test/support/common/http.commands';
 export function createApi(auth: BasicAuthentication, body: Api, failOnStatusCode = false) {
   return cy.request({
     method: 'POST',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis`,
     body,
     auth,
     failOnStatusCode,
@@ -47,7 +47,7 @@ export function publishApi(auth: BasicAuthentication, createdApi: Api, failOnSta
   delete apiToPublish.contextPath;
   return cy.request({
     method: 'PUT',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${createdApi.id}`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/${createdApi.id}`,
     body: apiToPublish,
     auth,
     failOnStatusCode,
@@ -57,7 +57,7 @@ export function publishApi(auth: BasicAuthentication, createdApi: Api, failOnSta
 export function deleteApi(auth: BasicAuthentication, apiId: string, failOnStatusCode = false) {
   return cy.request({
     method: 'DELETE',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/${apiId}`,
     auth,
     failOnStatusCode,
   });
@@ -66,7 +66,7 @@ export function deleteApi(auth: BasicAuthentication, apiId: string, failOnStatus
 export function deployApi(auth: BasicAuthentication, apiId: string, failOnStatusCode = false) {
   return cy.request({
     method: 'POST',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}/deploy`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/${apiId}/deploy`,
     auth,
     failOnStatusCode,
   });
@@ -75,7 +75,7 @@ export function deployApi(auth: BasicAuthentication, apiId: string, failOnStatus
 export function startApi(auth: BasicAuthentication, apiId: string, failOnStatusCode = false) {
   return cy.request({
     method: 'POST',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}?action=START`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/${apiId}?action=START`,
     auth,
     failOnStatusCode,
   });
@@ -84,7 +84,7 @@ export function startApi(auth: BasicAuthentication, apiId: string, failOnStatusC
 export function stopApi(auth: BasicAuthentication, apiId: string, failOnStatusCode = false) {
   return cy.request({
     method: 'POST',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}?action=STOP`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/${apiId}?action=STOP`,
     auth,
     failOnStatusCode,
   });
@@ -93,7 +93,7 @@ export function stopApi(auth: BasicAuthentication, apiId: string, failOnStatusCo
 export function importCreateApi(auth: BasicAuthentication, body: ApiImport) {
   return cy.request({
     method: 'POST',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/import`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/import`,
     body,
     auth,
     failOnStatusCode: false,
@@ -103,7 +103,7 @@ export function importCreateApi(auth: BasicAuthentication, body: ApiImport) {
 export function importSwaggerApi(auth: BasicAuthentication, swaggerImport: string, attributes?: Partial<ImportSwaggerDescriptorEntity>) {
   return cy.request({
     method: 'POST',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/import/swagger`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/import/swagger`,
     qs: { definitionVersion: '2.0.0' },
     body: {
       payload: swaggerImport,
@@ -117,7 +117,7 @@ export function importSwaggerApi(auth: BasicAuthentication, swaggerImport: strin
 export function importUpdateApi(auth: BasicAuthentication, apiId: string, body: ApiImport) {
   return cy.request({
     method: 'PUT',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}/import`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/${apiId}/import`,
     body,
     auth,
     failOnStatusCode: false,
@@ -127,7 +127,7 @@ export function importUpdateApi(auth: BasicAuthentication, apiId: string, body: 
 export function exportApi(auth: BasicAuthentication, apiId: string) {
   return cy.request({
     method: 'GET',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}/export`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/${apiId}/export`,
     auth,
     failOnStatusCode: false,
   });
@@ -136,7 +136,7 @@ export function exportApi(auth: BasicAuthentication, apiId: string) {
 export function getApiById(auth: BasicAuthentication, apiId: string) {
   return cy.request({
     method: 'GET',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/${apiId}`,
     auth,
     failOnStatusCode: false,
   });
@@ -145,7 +145,7 @@ export function getApiById(auth: BasicAuthentication, apiId: string) {
 export function getApiMetadata(auth: BasicAuthentication, apiId: string) {
   return cy.request({
     method: 'GET',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}/metadata`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/${apiId}/metadata`,
     auth,
     failOnStatusCode: false,
   });
@@ -154,7 +154,7 @@ export function getApiMetadata(auth: BasicAuthentication, apiId: string) {
 export function addMemberToApi(auth: BasicAuthentication, apiId: string, body: ApiMember) {
   return cy.request({
     method: 'POST',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}/members`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/${apiId}/members`,
     body,
     auth,
     failOnStatusCode: false,
@@ -164,7 +164,7 @@ export function addMemberToApi(auth: BasicAuthentication, apiId: string, body: A
 export function getApiMembers(auth: BasicAuthentication, apiId: string) {
   return cy.request({
     method: 'GET',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}/members`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/${apiId}/members`,
     auth,
     failOnStatusCode: false,
   });
@@ -173,7 +173,7 @@ export function getApiMembers(auth: BasicAuthentication, apiId: string) {
 export function updateApi(auth: BasicAuthentication, apiId: string, apiUpdate: UpdateApiEntity, failOnStatusCode = false) {
   return cy.request({
     method: 'PUT',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/${apiId}`,
     auth,
     body: apiUpdate,
     failOnStatusCode,
@@ -188,7 +188,7 @@ export function updateApiSubscription(
 ) {
   return cy.request({
     method: 'POST',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}/subscriptions/${subscriptionId}/_process`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/${apiId}/subscriptions/${subscriptionId}/_process`,
     auth,
     body: subscription,
     failOnStatusCode: false,
@@ -198,7 +198,7 @@ export function updateApiSubscription(
 export function getApiKeys(auth: BasicAuthentication, apiId: string, subscriptionId: string) {
   return cy.request({
     method: 'GET',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}/subscriptions/${subscriptionId}/apikeys`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/${apiId}/subscriptions/${subscriptionId}/apikeys`,
     auth,
     failOnStatusCode: false,
   });
@@ -207,7 +207,7 @@ export function getApiKeys(auth: BasicAuthentication, apiId: string, subscriptio
 export function getApiAnalytics(auth: BasicAuthentication, apiId: string, field = 'mapped-path') {
   return requestGateway(
     {
-      url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}/analytics`,
+      url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/${apiId}/analytics`,
       auth,
       headers: {
         'Cache-Control': 'no-cache, no-store',

--- a/gravitee-apim-e2e/ui-test/commands/management/api-pages-management-commands.ts
+++ b/gravitee-apim-e2e/ui-test/commands/management/api-pages-management-commands.ts
@@ -25,7 +25,7 @@ class ApiPagesQueryParams {
 export function getPages(auth: BasicAuthentication, apiId: string, params = new ApiPagesQueryParams()) {
   return cy.request({
     method: 'GET',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}/pages`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/${apiId}/pages`,
     auth,
     failOnStatusCode: false,
     qs: params,
@@ -35,7 +35,7 @@ export function getPages(auth: BasicAuthentication, apiId: string, params = new 
 export function getPage(auth: BasicAuthentication, apiId: string, pageId: string) {
   return cy.request({
     method: 'GET',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}/pages/${pageId}`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/${apiId}/pages/${pageId}`,
     auth,
     failOnStatusCode: false,
   });
@@ -44,7 +44,7 @@ export function getPage(auth: BasicAuthentication, apiId: string, pageId: string
 export function deletePage(auth: BasicAuthentication, apiId: string, pageId: string) {
   return cy.request({
     method: 'DELETE',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}/pages/${pageId}`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/${apiId}/pages/${pageId}`,
     auth,
     failOnStatusCode: false,
   });

--- a/gravitee-apim-e2e/ui-test/commands/management/api-plan-management-commands.ts
+++ b/gravitee-apim-e2e/ui-test/commands/management/api-plan-management-commands.ts
@@ -19,7 +19,7 @@ import { BasicAuthentication } from '@model/users';
 export function createPlan(auth: BasicAuthentication, apiId: string, body: Partial<NewPlanEntity>, failOnStatusCode = false) {
   return cy.request({
     method: 'POST',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}/plans`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/${apiId}/plans`,
     auth,
     body,
     failOnStatusCode,
@@ -29,7 +29,7 @@ export function createPlan(auth: BasicAuthentication, apiId: string, body: Parti
 export function deletePlan(auth: BasicAuthentication, apiId: string, planId: string, failOnStatusCode = false) {
   return cy.request({
     method: 'DELETE',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}/plans/${planId}`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/${apiId}/plans/${planId}`,
     auth,
     failOnStatusCode,
   });
@@ -38,7 +38,7 @@ export function deletePlan(auth: BasicAuthentication, apiId: string, planId: str
 export function closePlan(auth: BasicAuthentication, apiId: string, planId: string) {
   return cy.request({
     method: 'POST',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}/plans/${planId}/_close`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/${apiId}/plans/${planId}/_close`,
     auth,
     failOnStatusCode: false,
   });
@@ -47,7 +47,7 @@ export function closePlan(auth: BasicAuthentication, apiId: string, planId: stri
 export function publishPlan(auth: BasicAuthentication, apiId: string, planId: string, failOnStatusCode = false) {
   return cy.request({
     method: 'POST',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}/plans/${planId}/_publish`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/${apiId}/plans/${planId}/_publish`,
     auth,
     failOnStatusCode,
   });

--- a/gravitee-apim-e2e/ui-test/commands/management/api-plans-management-commands.ts
+++ b/gravitee-apim-e2e/ui-test/commands/management/api-plans-management-commands.ts
@@ -19,7 +19,7 @@ import { PlanStatus } from '@model/plan';
 export function getPlans(auth: BasicAuthentication, apiId: string, status: PlanStatus) {
   return cy.request({
     method: 'GET',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}/plans`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/${apiId}/plans`,
     auth,
     failOnStatusCode: false,
     qs: {
@@ -31,7 +31,7 @@ export function getPlans(auth: BasicAuthentication, apiId: string, status: PlanS
 export function getPlan(auth: BasicAuthentication, apiId: string, planId: string) {
   return cy.request({
     method: 'GET',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/apis/${apiId}/plans/${planId}`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/${apiId}/plans/${planId}`,
     auth,
     failOnStatusCode: false,
   });

--- a/gravitee-apim-e2e/ui-test/commands/management/application-management-commands.ts
+++ b/gravitee-apim-e2e/ui-test/commands/management/application-management-commands.ts
@@ -19,7 +19,7 @@ import { BasicAuthentication } from '@model/users';
 export function createApplication(auth: BasicAuthentication, body: Application) {
   return cy.request({
     method: 'POST',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/applications`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/applications`,
     body,
     auth,
     failOnStatusCode: false,
@@ -29,7 +29,7 @@ export function createApplication(auth: BasicAuthentication, body: Application) 
 export function deleteApplication(auth: BasicAuthentication, applicationId: string) {
   return cy.request({
     method: 'DELETE',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/applications/${applicationId}`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/applications/${applicationId}`,
     auth,
     failOnStatusCode: false,
   });
@@ -38,7 +38,7 @@ export function deleteApplication(auth: BasicAuthentication, applicationId: stri
 export function subscribeApplication(auth: BasicAuthentication, applicationId: string, planId: string) {
   return cy.request({
     method: 'POST',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/applications/${applicationId}/subscriptions`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/applications/${applicationId}/subscriptions`,
     auth,
     qs: {
       plan: `${planId}`,
@@ -50,7 +50,7 @@ export function subscribeApplication(auth: BasicAuthentication, applicationId: s
 export function closeApplicationSubscription(auth: BasicAuthentication, applicationId: string, subscriptionId: string) {
   return cy.request({
     method: 'DELETE',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/applications/${applicationId}/subscriptions/${subscriptionId}`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/applications/${applicationId}/subscriptions/${subscriptionId}`,
     auth,
     failOnStatusCode: false,
   });

--- a/gravitee-apim-e2e/ui-test/commands/management/environment-management-commands.ts
+++ b/gravitee-apim-e2e/ui-test/commands/management/environment-management-commands.ts
@@ -19,7 +19,7 @@ import { Group } from '@model/groups';
 export function createGroup(auth: BasicAuthentication, body: Group) {
   return cy.request({
     method: 'POST',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/configuration/groups`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/configuration/groups`,
     auth,
     failOnStatusCode: false,
     body,
@@ -29,7 +29,7 @@ export function createGroup(auth: BasicAuthentication, body: Group) {
 export function getGroup(auth: BasicAuthentication, groupId: string) {
   return cy.request({
     method: 'GET',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/configuration/groups/${groupId}`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/configuration/groups/${groupId}`,
     auth,
     failOnStatusCode: false,
   });
@@ -38,7 +38,7 @@ export function getGroup(auth: BasicAuthentication, groupId: string) {
 export function deleteGroup(auth: BasicAuthentication, groupId: string) {
   return cy.request({
     method: 'DELETE',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/configuration/groups/${groupId}`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/configuration/groups/${groupId}`,
     auth,
     failOnStatusCode: false,
   });

--- a/gravitee-apim-e2e/ui-test/commands/management/organization-configuration-management-commands.ts
+++ b/gravitee-apim-e2e/ui-test/commands/management/organization-configuration-management-commands.ts
@@ -19,7 +19,7 @@ import { Role } from '@model/roles';
 export function createRole(auth: BasicAuthentication, body: Role) {
   return cy.request({
     method: 'POST',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementOrganizationApi')}/configuration/rolescopes/API/roles`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrg')}/configuration/rolescopes/API/roles`,
     body,
     auth,
     failOnStatusCode: false,
@@ -29,7 +29,7 @@ export function createRole(auth: BasicAuthentication, body: Role) {
 export function deleteRole(auth: BasicAuthentication, roleId: string) {
   return cy.request({
     method: 'DELETE',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementOrganizationApi')}/configuration/rolescopes/API/roles/${roleId}`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrg')}/configuration/rolescopes/API/roles/${roleId}`,
     auth,
     failOnStatusCode: false,
   });

--- a/gravitee-apim-e2e/ui-test/commands/management/user-management-commands.ts
+++ b/gravitee-apim-e2e/ui-test/commands/management/user-management-commands.ts
@@ -18,7 +18,7 @@ import { BasicAuthentication, ApiUser } from '@model/users';
 export function getCurrentUser(auth: BasicAuthentication) {
   return cy.request({
     method: 'GET',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/user`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/user`,
     auth,
     failOnStatusCode: false,
   });
@@ -27,7 +27,7 @@ export function getCurrentUser(auth: BasicAuthentication) {
 export function createUser(auth: BasicAuthentication, body: ApiUser) {
   return cy.request({
     method: 'POST',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/users`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/users`,
     body,
     auth,
     failOnStatusCode: false,
@@ -37,7 +37,7 @@ export function createUser(auth: BasicAuthentication, body: ApiUser) {
 export function deleteUser(auth: BasicAuthentication, userId: string) {
   return cy.request({
     method: 'DELETE',
-    url: `${Cypress.config().baseUrl}${Cypress.env('managementApi')}/users/${userId}`,
+    url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/users/${userId}`,
     auth,
     failOnStatusCode: false,
   });

--- a/gravitee-apim-e2e/ui-test/integration/apim/cypress-apim-config.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/cypress-apim-config.ts
@@ -19,7 +19,6 @@ import cypressConfig from '../cypress-integration-config';
 export default defineConfig({
   env: {
     ...cypressConfig.env,
-    managementUI: 'http://localhost:8084',
     gatewayServer: 'http://localhost:8082',
     portalApi: '/portal/environments/DEFAULT',
   },

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-list.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-list.spec.ts
@@ -24,12 +24,12 @@ describe('API List feature', () => {
   });
 
   it(`Visit Home board`, () => {
-    cy.visit(Cypress.env('managementUI'), { timeout: 10000 });
+    cy.visit('/');
     cy.wait(1000);
     cy.contains('Home board').should('be.visible');
   });
 
   it(`Visit Search Apis`, () => {
-    cy.visit(`${Cypress.env('managementUI')}/#!/environments/DEFAULT/apis/`, { timeout: 10000 });
+    cy.visit('/#!/environments/DEFAULT/apis/');
   });
 });

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-metadata.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/apis/ui-api-metadata.spec.ts
@@ -29,7 +29,7 @@ describe('API metadata screen', () => {
   before(() => {
     cy.request({
       method: 'POST',
-      url: `${Cypress.config().baseUrl}/management/organizations/${orgId}/environments/${envId}/apis/import`,
+      url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/import`,
       auth: { username: API_PUBLISHER_USER.username, password: API_PUBLISHER_USER.password },
       body: ApisFaker.apiImport({
         plans: [PlansFaker.plan({ status: PlanStatus.PUBLISHED })],
@@ -42,8 +42,8 @@ describe('API metadata screen', () => {
 
   beforeEach(function () {
     cy.loginInAPIM(API_PUBLISHER_USER.username, API_PUBLISHER_USER.password);
-    cy.visit(`${Cypress.env('managementUI')}/#!/environments/${envId}/apis/${api.id}/metadata`, { timeout: 30000 });
-    cy.get('h2', { timeout: 30000 }).contains('API metadata').should('be.visible');
+    cy.visit(`/#!/environments/${envId}/apis/${api.id}/metadata`);
+    cy.get('h2', { timeout: 40000 }).contains('API metadata').should('be.visible');
   });
 
   after(function () {
@@ -51,16 +51,14 @@ describe('API metadata screen', () => {
     // delete (close) Plan
     cy.request({
       method: 'POST',
-      url: `${Cypress.config().baseUrl}/management/organizations/${orgId}/environments/${envId}/apis/${api.id}/plans/${
-        api.plans[0].id
-      }/_close`,
+      url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/${api.id}/plans/${api.plans[0].id}/_close`,
       auth: { username: API_PUBLISHER_USER.username, password: API_PUBLISHER_USER.password },
     });
 
     // delete API
     cy.request({
       method: 'DELETE',
-      url: `${Cypress.config().baseUrl}/management/organizations/${orgId}/environments/${envId}/apis/${api.id}`,
+      url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/apis/${api.id}`,
       auth: { username: API_PUBLISHER_USER.username, password: API_PUBLISHER_USER.password },
     });
   });
@@ -220,7 +218,7 @@ describe('API metadata screen', () => {
     before(() => {
       cy.request({
         method: 'POST',
-        url: `${Cypress.config().baseUrl}/management/organizations/${orgId}/environments/${envId}/configuration/metadata`,
+        url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/configuration/metadata`,
         auth: { username: ADMIN_USER.username, password: ADMIN_USER.password },
         body: {
           format: 'STRING',
@@ -263,7 +261,7 @@ describe('API metadata screen', () => {
       const key = globalMetadataName.toLowerCase();
       cy.request({
         method: 'DELETE',
-        url: `${Cypress.config().baseUrl}/management/organizations/${orgId}/environments/${envId}/configuration/metadata/${key}`,
+        url: `${Cypress.env('managementApi')}${Cypress.env('defaultOrgEnv')}/configuration/metadata/${key}`,
         auth: { username: ADMIN_USER.username, password: ADMIN_USER.password },
       });
     });

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/gateways/ui-gateway-information.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/gateways/ui-gateway-information.spec.ts
@@ -18,7 +18,7 @@ import { ADMIN_USER, API_PUBLISHER_USER } from '@fakers/users/users';
 describe('Get Gateway instance information as admin', () => {
   beforeEach(() => {
     cy.loginInAPIM(ADMIN_USER.username, ADMIN_USER.password);
-    cy.visit(`${Cypress.env('managementUI')}/#!/environments/DEFAULT/instances/`);
+    cy.visit('/#!/environments/DEFAULT/instances/');
     cy.url().should('contain', 'instances');
   });
 
@@ -90,7 +90,7 @@ describe('Get Gateway instance information as non-admin', () => {
   });
 
   it('should not be able to call gateway instances', function () {
-    cy.visit(`${Cypress.env('managementUI')}/#!/environments/DEFAULT/instances/`);
+    cy.visit('/#!/environments/DEFAULT/instances/');
     cy.wait(1000);
     cy.url().should('not.contain', 'instances');
   });

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/login/ui-login.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/login/ui-login.spec.ts
@@ -20,7 +20,7 @@ describe('Login Feature', () => {
   // otherwise we are sometimes redirected or face XRCF issues
   beforeEach(() => {
     cy.clearCookie('Auth-Graviteeio-APIM');
-    cy.visit(`${Cypress.env('managementUI')}/#!/login`);
+    cy.visit('/');
   });
 
   it(`should launch the login page`, () => {

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/organization-settings/ui-tenants.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/organization-settings/ui-tenants.spec.ts
@@ -23,7 +23,7 @@ describe('Tenants', () => {
 
   beforeEach(() => {
     cy.loginInAPIM(ADMIN_USER.username, ADMIN_USER.password);
-    cy.visit(`${Cypress.env('managementUI')}/#!/organization/settings/tenants`);
+    cy.visit('/#!/organization/settings/tenants');
   });
 
   it('should create a tenant', () => {

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/organization-settings/ui-users.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/organization-settings/ui-users.spec.ts
@@ -19,7 +19,7 @@ import faker from '@faker-js/faker';
 describe('Users', () => {
   beforeEach(() => {
     cy.loginInAPIM(ADMIN_USER.username, ADMIN_USER.password);
-    cy.visit(`${Cypress.env('managementUI')}/#!/organization/settings/users`);
+    cy.visit('/#!/organization/settings/users');
   });
 
   it('should create a new user', () => {

--- a/gravitee-apim-e2e/ui-test/integration/apim/ui/user-tasks/task.spec.ts
+++ b/gravitee-apim-e2e/ui-test/integration/apim/ui/user-tasks/task.spec.ts
@@ -36,7 +36,7 @@ describe('Task screen', () => {
   describe('Go to tasks by clicking on profile picture', () => {
     it('should open Task page with no tasks to be done', () => {
       cy.loginInAPIM(API_PUBLISHER_USER.username, API_PUBLISHER_USER.password);
-      cy.visit(`${Cypress.env('managementUI')}`);
+      cy.visit('/');
       cy.getByDataTestId('top-nav-user-menu-button').click();
       cy.getByDataTestId('user-menu-task-button').click();
       cy.url().should('include', 'tasks');
@@ -48,7 +48,7 @@ describe('Task screen', () => {
   describe('Check appearance for different kind of tasks', () => {
     beforeEach(() => {
       cy.loginInAPIM(ADMIN_USER.username, ADMIN_USER.password);
-      cy.visit(`${Cypress.env('managementUI')}/#!/environments/${envId}/tasks`);
+      cy.visit(`/#!/environments/${envId}/tasks`);
       cy.url().should('include', 'tasks');
     });
 
@@ -59,7 +59,7 @@ describe('Task screen', () => {
         // create API
         cy.request({
           method: 'POST',
-          url: `/management/organizations/${orgId}/environments/${envId}/apis/import`,
+          url: `${Cypress.env('managementApi')}/management/organizations/${orgId}/environments/${envId}/apis/import`,
           auth: { username: API_PUBLISHER_USER.username, password: API_PUBLISHER_USER.password },
           body: ApisFaker.apiImport({
             plans: [PlansFaker.plan({ status: PlanStatus.PUBLISHED })],
@@ -71,7 +71,7 @@ describe('Task screen', () => {
           // change API review state to 'ASK'
           cy.request({
             method: 'POST',
-            url: `/management/organizations/${orgId}/environments/${envId}/apis/${api.id}/reviews`,
+            url: `${Cypress.env('managementApi')}/management/organizations/${orgId}/environments/${envId}/apis/${api.id}/reviews`,
             auth: { username: API_PUBLISHER_USER.username, password: API_PUBLISHER_USER.password },
             body: { message: 'my test message' },
             qs: { action: ReviewAction.ASK },
@@ -105,7 +105,7 @@ describe('Task screen', () => {
         // create API with key plan and manual validation
         cy.request({
           method: 'POST',
-          url: `/management/organizations/${orgId}/environments/${envId}/apis/import`,
+          url: `${Cypress.env('managementApi')}/management/organizations/${orgId}/environments/${envId}/apis/import`,
           auth: { username: API_PUBLISHER_USER.username, password: API_PUBLISHER_USER.password },
           body: ApisFaker.apiImport({
             plans: [
@@ -119,7 +119,7 @@ describe('Task screen', () => {
           // create an application to subscribe to the API key plan
           cy.request({
             method: 'POST',
-            url: `/management/organizations/${orgId}/environments/${envId}/applications`,
+            url: `${Cypress.env('managementApi')}/management/organizations/${orgId}/environments/${envId}/applications`,
             auth: { username: API_PUBLISHER_USER.username, password: API_PUBLISHER_USER.password },
             body: ApplicationsFaker.newApplication(),
           }).then((response) => {
@@ -129,7 +129,9 @@ describe('Task screen', () => {
             // subscribe application to plan
             cy.request({
               method: 'POST',
-              url: `/management/organizations/${orgId}/environments/${envId}/applications/${application.id}/subscriptions`,
+              url: `${Cypress.env('managementApi')}/management/organizations/${orgId}/environments/${envId}/applications/${
+                application.id
+              }/subscriptions`,
               auth: { username: API_PUBLISHER_USER.username, password: API_PUBLISHER_USER.password },
               qs: {
                 plan: api.plans[0].id,
@@ -169,7 +171,7 @@ describe('Task screen', () => {
       before(() => {
         cy.request({
           method: 'POST',
-          url: `/management/organizations/${orgId}/settings`,
+          url: `${Cypress.env('managementApi')}/management/organizations/${orgId}/settings`,
           auth: { username: ADMIN_USER.username, password: ADMIN_USER.password },
           body: {
             management: {
@@ -181,7 +183,7 @@ describe('Task screen', () => {
 
           cy.request({
             method: 'POST',
-            url: `/management/organizations/${orgId}/users/registration`,
+            url: `${Cypress.env('managementApi')}/management/organizations/${orgId}/users/registration`,
             body: { email, firstname, lastname },
           }).then((response) => {
             expect(response.status).to.eq(200);
@@ -205,7 +207,7 @@ describe('Task screen', () => {
         cy.request({
           method: 'DELETE',
           auth: { username: ADMIN_USER.username, password: ADMIN_USER.password },
-          url: `/management/organizations/${orgId}/users/${userId}`,
+          url: `${Cypress.env('managementApi')}/management/organizations/${orgId}/users/${userId}`,
         });
       });
     });

--- a/gravitee-apim-e2e/ui-test/integration/cypress-integration-config.ts
+++ b/gravitee-apim-e2e/ui-test/integration/cypress-integration-config.ts
@@ -18,6 +18,7 @@ import cypressConfig from '../../cypress.config';
 
 export default defineConfig({
   env: {
+    ...cypressConfig.env,
     failOnStatusCode: false,
     api_publisher_user_login: 'api1',
     api_publisher_user_password: 'api1',
@@ -29,8 +30,8 @@ export default defineConfig({
     admin_user_password: 'admin',
     am_admin_user_login: 'admin',
     am_admin_user_password: 'adminadmin',
-    managementOrganizationApi: '/management/organizations/DEFAULT',
-    managementApi: '/management/organizations/DEFAULT/environments/DEFAULT',
+    defaultOrg: '/management/organizations/DEFAULT',
+    defaultOrgEnv: '/management/organizations/DEFAULT/environments/DEFAULT',
     managementUI: 'https://apim.gravitee.io/console',
     gatewayServer: 'https://apim.gravitee.io',
     am_gatewayServer: 'https://am.gravitee.io',

--- a/gravitee-apim-e2e/ui-test/support/common/ui.commands.ts
+++ b/gravitee-apim-e2e/ui-test/support/common/ui.commands.ts
@@ -51,7 +51,7 @@ Cypress.Commands.add('loginInAPIM', (username: string, password: string) => {
   cy.clearCookie('Auth-Graviteeio-APIM');
   cy.request({
     method: 'POST',
-    url: `${Cypress.config().baseUrl}/management/organizations/DEFAULT/user/login`,
+    url: `${Cypress.env('managementApi')}/management/organizations/DEFAULT/user/login`,
     auth: { username, password },
   });
 });


### PR DESCRIPTION
APIM-1811

## Description
To avoid unwanted page reloads by Cypress it was necessary to change the baseUrl in the Cypress config, it now points to the management console instead of the API server. That change however required a whole cascade of changes in test, config and helper files.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ttuimlpgbo.chromatic.com)
<!-- Storybook placeholder end -->
