### PR TITLE
fix: more information for entrypoints using endpoints method and fix typo

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-2-entrypoints/step-2-entrypoints-1-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-2-entrypoints/step-2-entrypoints-1-list.component.ts
@@ -121,7 +121,7 @@ export class Step2Entrypoints1ListComponent implements OnInit, OnDestroy {
     event.stopPropagation();
 
     this.connectorPluginsV2Service
-      .getEndpointPluginMoreInformation(entrypoint.id)
+      .getEntrypointPluginMoreInformation(entrypoint.id)
       .pipe(
         takeUntil(this.unsubscribe$),
         catchError(() => of({})),

--- a/gravitee-apim-console-webui/src/services-ngx/connector-plugins-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/connector-plugins-v2.service.ts
@@ -69,6 +69,6 @@ export class ConnectorPluginsV2Service {
   }
 
   getEntrypointPluginMoreInformation(entrypointId: string): Observable<MoreInformation> {
-    return this.http.get<MoreInformation>(`${this.constants.v2BaseURL}/plugins/entrypoints/${entrypointId}/moreInformation`);
+    return this.http.get<MoreInformation>(`${this.constants.v2BaseURL}/plugins/entrypoints/${entrypointId}/more-information`);
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

The onMoreInfoClick for entrypoints page was using the endpoint method instead of the entrypoint one. The path was also having a typo ("moreInformation" instead of "more-information").
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-keqamhfenw.chromatic.com)
<!-- Storybook placeholder end -->
