### PR TITLE
test: add flow execution phase integration test 

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/utils/HttpClientUtils.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/utils/HttpClientUtils.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.gateway.tests.sdk.utils;
+
+import io.vertx.rxjava3.core.http.HttpClientResponse;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Provides utility methods for {@link io.vertx.rxjava3.core.http.HttpClient}
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class HttpClientUtils {
+
+    private HttpClientUtils() {
+        // Utility class
+    }
+
+    /**
+     * Extracts headers from {@link HttpClientResponse} to a {@link Map <String, String>} to ease the assertions
+     * @param response on which extract the headers
+     * @return a {@link Map<String, String>} of the headers
+     */
+    public static Map<String, String> extractHeaders(HttpClientResponse response) {
+        return response.headers().entries().stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/io/gravitee/apim/gateway/tests/sdk/utils/HttpClientUtilsTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/test/java/io/gravitee/apim/gateway/tests/sdk/utils/HttpClientUtilsTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.gateway.tests.sdk.utils;
+
+import static org.mockito.Mockito.when;
+
+import io.vertx.rxjava3.core.MultiMap;
+import io.vertx.rxjava3.core.http.HttpClientResponse;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class HttpClientUtilsTest {
+
+    @Mock
+    private HttpClientResponse response;
+
+    @Test
+    void should_extract_headers() {
+        when(response.headers())
+            .thenReturn(MultiMap.caseInsensitiveMultiMap().set("X-Header-one", "value-one").set("X-Header-two", "value-two"));
+
+        Assertions
+            .assertThat(HttpClientUtils.extractHeaders(response))
+            .contains(Map.entry("X-Header-one", "value-one"), Map.entry("X-Header-two", "value-two"))
+            .doesNotContainKeys("random", "X-Header-three");
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/attributes/AbstractAttributesIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/attributes/AbstractAttributesIntegrationTest.java
@@ -87,10 +87,6 @@ public class AbstractAttributesIntegrationTest extends AbstractGatewayTest {
         }
     }
 
-    protected static Map<String, String> extractHeaders(HttpClientResponse response) {
-        return response.headers().entries().stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-    }
-
     protected ApiKey anApiKey(ReactableApi<?> api) {
         final ApiKey apiKey = new ApiKey();
         apiKey.setApi(api.getId());

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/attributes/AttributesIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/attributes/AttributesIntegrationTest.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.integration.tests.http.attributes;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static io.gravitee.apim.gateway.tests.sdk.utils.HttpClientUtils.extractHeaders;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/AbstractCorsIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/AbstractCorsIntegrationTest.java
@@ -52,8 +52,4 @@ public class AbstractCorsIntegrationTest extends AbstractGatewayTest {
             PolicyBuilder.build("api-key", ApiKeyPolicy.class, ApiKeyPolicyConfiguration.class, ApiKeyPolicyInitializer.class)
         );
     }
-
-    protected static Map<String, String> extractHeaders(HttpClientResponse response) {
-        return response.headers().entries().stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-    }
 }

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/CorsIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/CorsIntegrationTest.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.integration.tests.http.cors;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static io.gravitee.apim.gateway.tests.sdk.utils.HttpClientUtils.extractHeaders;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/CorsV3IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/cors/CorsV3IntegrationTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.integration.tests.http.cors;
 
+import static io.gravitee.apim.gateway.tests.sdk.utils.HttpClientUtils.extractHeaders;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/flows/FlowPhaseExecutionIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/flows/FlowPhaseExecutionIntegrationTest.java
@@ -1,0 +1,284 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.flows;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static io.gravitee.apim.gateway.tests.sdk.utils.HttpClientUtils.extractHeaders;
+import static io.gravitee.apim.integration.tests.http.flows.FlowPhaseExecutionParameterProviders.headerValue;
+import static io.gravitee.apim.integration.tests.http.flows.FlowPhaseExecutionParameterProviders.requestFlowHeader;
+import static io.gravitee.apim.integration.tests.http.flows.FlowPhaseExecutionParameterProviders.responseFlowHeader;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.flow.Operator;
+import io.gravitee.definition.model.flow.PathOperator;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.transformheaders.TransformHeadersPolicy;
+import io.gravitee.policy.transformheaders.configuration.TransformHeadersPolicyConfiguration;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class FlowPhaseExecutionIntegrationTest {
+
+    public static final String RESPONSE_FROM_BACKEND = "response from backend";
+    public static final String PARAMETERS_PROVIDERS_CLASS = "io.gravitee.apim.integration.tests.http.flows.FlowPhaseExecutionParameterProviders#";
+
+    /**
+     * Inherit from this class to have the required configuration to run each tests of this class
+     */
+    class TestPreparer extends AbstractGatewayTest {
+        @Override
+        public void configurePolicies(Map<String, PolicyPlugin> policies) {
+            policies.putIfAbsent(
+                   "transform-headers",
+                   PolicyBuilder.build("transform-headers", TransformHeadersPolicy.class, TransformHeadersPolicyConfiguration.class)
+            );
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/http/flows/api.json")
+    @DisplayName("Flows without condition and operator 'STARTS_WITH'")
+    class NoConditionOperatorStartsWith extends TestPreparer {
+
+        @ParameterizedTest
+        @MethodSource(PARAMETERS_PROVIDERS_CLASS + "parametersStartsWithOperatorCase")
+        void should_pass_through_correct_flows(
+            String path,
+            Map<String, String> expectedRequestHeaders,
+            Map<String, String> expectedResponseHeaders,
+            HttpClient client
+        ) {
+            wiremock.stubFor(get("/endpoint" + path).willReturn(ok(RESPONSE_FROM_BACKEND)));
+
+            client
+                .rxRequest(HttpMethod.GET, "/test" + path)
+                .flatMap(HttpClientRequest::rxSend)
+                .flatMap(response -> {
+                    assertThat(response.statusCode()).isEqualTo(200);
+                    expectedResponseHeaders.forEach((name, value) -> {
+                        assertThat(extractHeaders(response)).contains(Map.entry(name, value));
+                    });
+                    return response.body();
+                })
+                .test()
+                .awaitDone(2, TimeUnit.SECONDS)
+                .assertComplete()
+                .assertValue(response -> {
+                    assertThat(response).hasToString(RESPONSE_FROM_BACKEND);
+                    return true;
+                });
+
+            final RequestPatternBuilder requestedFor = getRequestedFor(urlPathEqualTo("/endpoint" + path));
+            expectedRequestHeaders.forEach((name, value) -> requestedFor.withHeader(name, equalTo(value)));
+            wiremock.verify(requestedFor);
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/http/flows/api.json")
+    @DisplayName("Flows without condition and operator 'EQUALS'")
+    class NoConditionOperatorEquals extends TestPreparer {
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            if (isLegacyApi(definitionClass)) {
+                final Api definition = (Api) api.getDefinition();
+                definition.getFlows().forEach(flow -> {
+                    flow.setPathOperator(new PathOperator(flow.getPath(), Operator.EQUALS));
+                });
+            }
+        }
+
+        @ParameterizedTest
+        @MethodSource(PARAMETERS_PROVIDERS_CLASS + "parametersEqualsOperatorCase")
+        void should_pass_through_correct_flows(
+               String path,
+               Map<String, String> expectedRequestHeaders,
+               Map<String, String> expectedResponseHeaders,
+               HttpClient client
+        ) {
+            wiremock.stubFor(get("/endpoint" + path).willReturn(ok(RESPONSE_FROM_BACKEND)));
+
+            client
+                   .rxRequest(HttpMethod.GET, "/test" + path)
+                   .flatMap(HttpClientRequest::rxSend)
+                   .flatMap(response -> {
+                       assertThat(response.statusCode()).isEqualTo(200);
+                       expectedResponseHeaders.forEach((name, value) -> {
+                           assertThat(extractHeaders(response)).contains(Map.entry(name, value));
+                       });
+                       return response.body();
+                   })
+                   .test()
+                   .awaitDone(2, TimeUnit.SECONDS)
+                   .assertComplete()
+                   .assertValue(response -> {
+                       assertThat(response).hasToString(RESPONSE_FROM_BACKEND);
+                       return true;
+                   });
+
+            final RequestPatternBuilder requestedFor = getRequestedFor(urlPathEqualTo("/endpoint" + path));
+            expectedRequestHeaders.forEach((name, value) -> requestedFor.withHeader(name, equalTo(value)));
+            wiremock.verify(requestedFor);
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/http/flows/api-flows-equals-and-starts-with.json")
+    @DisplayName("Flows without condition and mixed operators")
+    class NoConditionOperatorMixed extends TestPreparer {
+
+        @ParameterizedTest
+        @MethodSource(PARAMETERS_PROVIDERS_CLASS + "parametersMixedOperatorCase")
+        void should_pass_through_correct_flows(
+               String path,
+               Map<String, String> expectedRequestHeaders,
+               Map<String, String> expectedResponseHeaders,
+               HttpClient client
+        ) {
+            wiremock.stubFor(get("/endpoint" + path).willReturn(ok(RESPONSE_FROM_BACKEND)));
+
+            client
+                   .rxRequest(HttpMethod.GET, "/test" + path)
+                   .flatMap(HttpClientRequest::rxSend)
+                   .flatMap(response -> {
+                       assertThat(response.statusCode()).isEqualTo(200);
+                       expectedResponseHeaders.forEach((name, value) -> {
+                           assertThat(extractHeaders(response)).contains(Map.entry(name, value));
+                       });
+                       return response.body();
+                   })
+                   .test()
+                   .awaitDone(2, TimeUnit.SECONDS)
+                   .assertComplete()
+                   .assertValue(response -> {
+                       assertThat(response).hasToString(RESPONSE_FROM_BACKEND);
+                       return true;
+                   });
+
+            final RequestPatternBuilder requestedFor = getRequestedFor(urlPathEqualTo("/endpoint" + path));
+            expectedRequestHeaders.forEach((name, value) -> requestedFor.withHeader(name, equalTo(value)));
+            wiremock.verify(requestedFor);
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi({"/apis/http/flows/api-conditional-flows.json", "/apis/http/flows/api-conditional-flows-double-evaluation-case.json"})
+    @DisplayName("Flows with condition")
+    class ConditionalFlows extends TestPreparer {
+
+        @ParameterizedTest
+        @MethodSource(PARAMETERS_PROVIDERS_CLASS + "parametersConditionalFlowsCase")
+        void should_pass_through_correct_flows(
+               String path,
+               String conditionalHeader,
+               Map<String, String> expectedRequestHeaders,
+               Map<String, String> expectedResponseHeaders,
+               HttpClient client
+        ) {
+            wiremock.stubFor(get("/endpoint" + path).willReturn(ok(RESPONSE_FROM_BACKEND)));
+
+            client
+                   .rxRequest(HttpMethod.GET, "/test" + path)
+                   .flatMap(request ->
+                       request.putHeader("X-Condition-Flow-Selection", conditionalHeader).rxSend()
+                   )
+                   .flatMap(response -> {
+                       assertThat(response.statusCode()).isEqualTo(200);
+                       expectedResponseHeaders.forEach((name, value) -> {
+                           assertThat(extractHeaders(response)).contains(Map.entry(name, value));
+                       });
+                       return response.body();
+                   })
+                   .test()
+                   .awaitDone(2, TimeUnit.SECONDS)
+                   .assertComplete()
+                   .assertValue(response -> {
+                       assertThat(response).hasToString(RESPONSE_FROM_BACKEND);
+                       return true;
+                   });
+
+            final RequestPatternBuilder requestedFor = getRequestedFor(urlPathEqualTo("/endpoint" + path));
+            expectedRequestHeaders.forEach((name, value) -> requestedFor.withHeader(name, equalTo(value)));
+            wiremock.verify(requestedFor);
+        }
+
+        /**
+         * This test case remove the header used for evaluating the condition from the request.
+         * In V4 Emulation mode, it's not a problem.
+         * In V3, condition is evaluated before request and before response.
+         * If the header is removed, with the current condition it will end with a NullPointerException and so a 500 response.
+         */
+        @Test
+        void should_pass_through_correct_flow_condition_remove_header_on_request(
+               HttpClient client
+        ) {
+            wiremock.stubFor(get("/endpoint").willReturn(ok(RESPONSE_FROM_BACKEND)));
+
+            client
+                   .rxRequest(HttpMethod.GET, "/test-double-evaluation")
+                   .flatMap(request ->
+                          request.putHeader("X-Condition-Flow-Selection", "root-condition").rxSend()
+                   )
+                   .flatMap(response -> {
+                       assertThat(response.statusCode()).isEqualTo(200);
+                       assertThat(response.statusCode()).isEqualTo(200);
+                       assertThat(extractHeaders(response)).contains(Map.entry(responseFlowHeader(0), headerValue("/")));
+                       return response.body();
+                   })
+                   .test()
+                   .awaitDone(2, TimeUnit.SECONDS)
+                   .assertComplete()
+                   .assertValue(response -> {
+                       assertThat(response).hasToString(RESPONSE_FROM_BACKEND);
+                       return true;
+                   });
+
+            wiremock.verify(getRequestedFor(urlPathEqualTo("/endpoint")).withHeader(requestFlowHeader(0), equalTo(headerValue("/"))));
+        }
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/flows/FlowPhaseExecutionParameterProviders.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/flows/FlowPhaseExecutionParameterProviders.java
@@ -1,0 +1,187 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.flows;
+
+import org.junit.jupiter.params.provider.Arguments;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Provides:
+ * - path of the request
+ * - Expected headers on request
+ * - Expected headers on response
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class FlowPhaseExecutionParameterProviders {
+
+    public static String requestFlowHeader(int flowNumber) {
+        return "X-Request-Flow-" + flowNumber;
+    }
+
+    public static String responseFlowHeader(int flowNumber) {
+        return "X-Response-Flow-" + flowNumber;
+    }
+
+    public static String headerValue(String flowPath) {
+        return "Flow " + flowPath;
+    }
+
+    public static Stream<Arguments> parametersEqualsOperatorCase() {
+        return Stream.of(
+               Arguments.of(
+                      "/products",
+                      Map.of(requestFlowHeader(1), headerValue("/products")),
+                      Map.of(responseFlowHeader(1), headerValue("/products"))
+               ),
+               Arguments.of(
+                      "/",
+                      Map.of(requestFlowHeader(0), headerValue("/")),
+                      Map.of(responseFlowHeader(0), headerValue("/"))
+               ),
+               Arguments.of(
+                      "/products/id",
+                      Map.of(),
+                      Map.of()
+               ),
+               Arguments.of(
+                      "/random",
+                      Map.of(),
+                      Map.of()
+               )
+        );
+    }
+
+    public static Stream<Arguments> parametersStartsWithOperatorCase() {
+        return Stream.of(
+               Arguments.of(
+                      "/products",
+                      Map.of(requestFlowHeader(0), headerValue("/"), requestFlowHeader(1), headerValue("/products")),
+                      Map.of(responseFlowHeader(0), headerValue("/"), responseFlowHeader(1), headerValue("/products"))
+               ),
+               Arguments.of(
+                      "/",
+                      Map.of(requestFlowHeader(0), headerValue("/")),
+                      Map.of(responseFlowHeader(0), headerValue("/"))
+               ),
+               Arguments.of(
+                      "/products/id",
+                      Map.of(requestFlowHeader(0), headerValue("/"), requestFlowHeader(1), headerValue("/products")),
+                      Map.of(responseFlowHeader(0), headerValue("/"), responseFlowHeader(1), headerValue("/products"))
+               ),
+               Arguments.of(
+                      "/random",
+                      Map.of(requestFlowHeader(0), headerValue("/")),
+                      Map.of(responseFlowHeader(0), headerValue("/"))
+               )
+        );
+    }
+
+    public static Stream<Arguments> parametersMixedOperatorCase() {
+        return Stream.of(
+               Arguments.of(
+                      "/products",
+                      Map.of(requestFlowHeader(1), headerValue("/products")),
+                      Map.of(responseFlowHeader(1), headerValue("/products"))
+               ),
+               Arguments.of(
+                      "/",
+                      Map.of(requestFlowHeader(0), headerValue("/")),
+                      Map.of(responseFlowHeader(0), headerValue("/"))
+               ),
+               Arguments.of(
+                      "/products/id",
+                      Map.of(requestFlowHeader(1), headerValue("/products")),
+                      Map.of(responseFlowHeader(1), headerValue("/products"))
+               ),
+               Arguments.of(
+                      "/random",
+                      Map.of(),
+                      Map.of()
+               )
+        );
+    }
+
+    /**
+     * Provides:
+     * - path of the request
+     * - Header to send holding the value to satisfy condition
+     * - Expected headers on request
+     * - Expected headers on response
+     */
+    public static Stream<Arguments> parametersConditionalFlowsCase() {
+        return Stream.of(
+               // /products flow is executed
+               Arguments.of(
+                      "/products",
+                      "product-condition",
+                      Map.of(requestFlowHeader(1), headerValue("/products")),
+                      Map.of(responseFlowHeader(1), headerValue("/products"))
+               ),
+               // no flow is executed
+               Arguments.of(
+                      "/products",
+                      "root-condition",
+                      Map.of(),
+                      Map.of()
+               ),
+               // / flow is executed
+               Arguments.of(
+                      "/",
+                      "root-condition",
+                      Map.of(requestFlowHeader(0), headerValue("/")),
+                      Map.of(responseFlowHeader(0), headerValue("/"))
+               ),
+               // no flow is executed
+               Arguments.of(
+                      "/",
+                      "random-condition",
+                      Map.of(),
+                      Map.of()
+               ),
+               // /products flow is executed
+               Arguments.of(
+                      "/products/id",
+                      "product-condition",
+                      Map.of(requestFlowHeader(1), headerValue("/products")),
+                      Map.of(responseFlowHeader(1), headerValue("/products"))
+               ),
+               // / flow is executed because it starts with / and condition is fulfilled
+               Arguments.of(
+                      "/products/id",
+                      "root-condition",
+                      Map.of(requestFlowHeader(0), headerValue("/")),
+                      Map.of(responseFlowHeader(0), headerValue("/"))
+               ),
+               // no flow is executed
+               Arguments.of(
+                      "/random",
+                      "random-condition",
+                      Map.of(),
+                      Map.of()
+               ),
+               // no flow is executed
+               Arguments.of(
+                      "/random",
+                      "root-condition",
+                      Map.of(),
+                      Map.of()
+               )
+        );
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/flows/FlowPhaseExecutionV3CompatibilityIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/flows/FlowPhaseExecutionV3CompatibilityIntegrationTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.flows;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class FlowPhaseExecutionV3CompatibilityIntegrationTest extends FlowPhaseExecutionV3IntegrationTest {
+
+    @Nested
+    @GatewayTest(mode = GatewayMode.COMPATIBILITY)
+    @DisplayName("Flows without condition and operator 'STARTS_WITH'")
+    class NoConditionOperatorStartsWith extends FlowPhaseExecutionV3IntegrationTest.NoConditionOperatorStartsWith {}
+
+    @Nested
+    @GatewayTest(mode = GatewayMode.COMPATIBILITY)
+    @DisplayName("Flows without condition and operator 'EQUALS'")
+    class NoConditionOperatorEquals extends FlowPhaseExecutionV3IntegrationTest.NoConditionOperatorEquals {}
+
+    @Nested
+    @GatewayTest(mode = GatewayMode.COMPATIBILITY)
+    @DisplayName("Flows without condition and mixed operators")
+    class NoConditionOperatorMixed extends FlowPhaseExecutionV3IntegrationTest.NoConditionOperatorMixed {}
+
+    @Nested
+    @GatewayTest(mode = GatewayMode.COMPATIBILITY)
+    @DisplayName("Flows without condition and mixed operators")
+    class ConditionalFlows extends FlowPhaseExecutionV3IntegrationTest.ConditionalFlows {}
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/flows/FlowPhaseExecutionV3IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/flows/FlowPhaseExecutionV3IntegrationTest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.flows;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class FlowPhaseExecutionV3IntegrationTest extends FlowPhaseExecutionIntegrationTest {
+
+    @Nested
+    @GatewayTest(mode = GatewayMode.V3)
+    @DisplayName("Flows without condition and operator 'STARTS_WITH'")
+    class NoConditionOperatorStartsWith extends FlowPhaseExecutionIntegrationTest.NoConditionOperatorStartsWith {}
+
+    @Nested
+    @GatewayTest(mode = GatewayMode.V3)
+    @DisplayName("Flows without condition and operator 'EQUALS'")
+    class NoConditionOperatorEquals extends FlowPhaseExecutionIntegrationTest.NoConditionOperatorEquals {}
+
+    @Nested
+    @GatewayTest(mode = GatewayMode.V3)
+    @DisplayName("Flows without condition and mixed operators")
+    class NoConditionOperatorMixed extends FlowPhaseExecutionIntegrationTest.NoConditionOperatorMixed {}
+
+    @Nested
+    @GatewayTest(mode = GatewayMode.V3)
+    @DisplayName("Flows without condition and mixed operators")
+    class ConditionalFlows extends FlowPhaseExecutionIntegrationTest.ConditionalFlows {
+
+        /**
+         * This test case remove the header used for evaluating the condition from the request.
+         * In V4 Emulation mode, it's not a problem.
+         * In V3, condition is evaluated before request and before response.
+         * If the header is removed, with the current condition it will end with a NullPointerException and so a 500 response.
+         */
+        @Override
+        @Test
+        void should_pass_through_correct_flow_condition_remove_header_on_request(HttpClient client) {
+            wiremock.stubFor(get("/endpoint").willReturn(ok(RESPONSE_FROM_BACKEND)));
+
+            client
+                   .rxRequest(HttpMethod.GET, "/test-double-evaluation")
+                   .flatMap(request ->
+                          request.putHeader("X-Condition-Flow-Selection", "root-condition").rxSend()
+                   )
+                   .flatMap(response -> {
+                       assertThat(response.statusCode()).isEqualTo(500);
+                       return response.body();
+                   })
+                   .test()
+                   .awaitDone(2, TimeUnit.SECONDS)
+                   .assertComplete()
+                   .assertValue(response -> {
+                       assertThat(response).hasToString("The template evaluation returns an error. Expression:\n" +
+                              "{##request.headers['X-Condition-Flow-Selection'][0] == 'root-condition'} ");
+                       return true;
+                   });
+        }
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/flows/FlowPhaseExecutionV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/flows/FlowPhaseExecutionV4IntegrationTest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.flows;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.definition.model.flow.Operator;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
+import io.gravitee.definition.model.v4.flow.selector.SelectorType;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.http.HttpClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class FlowPhaseExecutionV4IntegrationTest extends FlowPhaseExecutionIntegrationTest {
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/v4/http/flows/api.json")
+    @DisplayName("Flows without condition and operator 'STARTS_WITH'")
+    class NoConditionOperatorStartsWith extends FlowPhaseExecutionIntegrationTest.NoConditionOperatorStartsWith {
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/v4/http/flows/api.json")
+    @DisplayName("Flows without condition and operator 'EQUALS'")
+    class NoConditionOperatorEquals extends FlowPhaseExecutionIntegrationTest.NoConditionOperatorEquals {
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            if (isV4Api(definitionClass)) {
+                final Api definition = (Api) api.getDefinition();
+                definition.getFlows().forEach(flow -> {
+                flow.selectorByType(SelectorType.HTTP)
+                       .ifPresent(selector ->
+                           ((HttpSelector) selector).setPathOperator(Operator.EQUALS)
+                       );
+                });
+            }
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/v4/http/flows/api-flows-equals-and-starts-with.json")
+    @DisplayName("Flows without condition and mixed operators")
+    class NoConditionOperatorMixed extends FlowPhaseExecutionIntegrationTest.NoConditionOperatorMixed {
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi({"/apis/v4/http/flows/api-conditional-flows.json", "/apis/v4/http/flows/api-conditional-flows-double-evaluation-case.json"})
+    @DisplayName("Flows without condition and mixed operators")
+    class ConditionalFlows extends FlowPhaseExecutionIntegrationTest.ConditionalFlows {
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        }
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/flows/FlowPhaseExecutionIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/flows/FlowPhaseExecutionIntegrationTest.java
@@ -1,0 +1,285 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.messages.flows;
+
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import com.graviteesource.entrypoint.http.get.HttpGetEntrypointConnectorFactory;
+import com.graviteesource.reactor.message.MessageApiReactorFactory;
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.apim.gateway.tests.sdk.reactor.ReactorBuilder;
+import io.gravitee.apim.plugin.reactor.ReactorPlugin;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.definition.model.flow.Operator;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.flow.selector.ChannelSelector;
+import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
+import io.gravitee.definition.model.v4.flow.selector.SelectorType;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.transformheaders.TransformHeadersPolicy;
+import io.gravitee.policy.transformheaders.configuration.TransformHeadersPolicyConfiguration;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static io.gravitee.apim.gateway.tests.sdk.utils.HttpClientUtils.extractHeaders;
+import static io.gravitee.apim.integration.tests.http.flows.FlowPhaseExecutionParameterProviders.headerValue;
+import static io.gravitee.apim.integration.tests.http.flows.FlowPhaseExecutionParameterProviders.responseFlowHeader;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class FlowPhaseExecutionIntegrationTest {
+
+    public static final String PARAMETERS_PROVIDERS_CLASS = "io.gravitee.apim.integration.tests.http.flows.FlowPhaseExecutionParameterProviders#";
+
+    /**
+     * Inherit from this class to have the required configuration to run each tests of this class
+     */
+    class TestPreparer extends AbstractGatewayTest {
+        @Override
+        public void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+            reactors.add(ReactorBuilder.build(MessageApiReactorFactory.class));
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            entrypoints.putIfAbsent("http-get", EntrypointBuilder.build("http-get", HttpGetEntrypointConnectorFactory.class));
+        }
+
+        @Override
+        public void configurePolicies(Map<String, PolicyPlugin> policies) {
+            policies.putIfAbsent(
+                   "transform-headers",
+                   PolicyBuilder.build("transform-headers", TransformHeadersPolicy.class, TransformHeadersPolicyConfiguration.class)
+            );
+        }
+    }
+
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/v4/messages/flows/api.json")
+    @DisplayName("Flows without condition and operator 'STARTS_WITH'")
+    class NoConditionOperatorStartsWith extends TestPreparer {
+        @ParameterizedTest
+        @MethodSource(PARAMETERS_PROVIDERS_CLASS + "parametersStartsWithOperatorCase")
+        void should_pass_through_correct_flows(
+               String path,
+               Map<String, String> expectedRequestHeaders,
+               Map<String, String> expectedResponseHeaders,
+               HttpClient client
+        ) {
+            client
+                   .rxRequest(HttpMethod.GET, "/test" + path)
+                   .flatMap(request -> request.putHeader(HttpHeaderNames.ACCEPT, MediaType.APPLICATION_JSON).rxSend())
+                   .flatMap(response -> {
+                       assertThat(response.statusCode()).isEqualTo(200);
+                       expectedResponseHeaders.forEach((name, value) -> {
+                           assertThat(extractHeaders(response)).contains(Map.entry(name, value));
+                       });
+                       return response.body();
+                   })
+                   .test()
+                   .awaitDone(2, TimeUnit.SECONDS)
+                   .assertComplete()
+                   .assertValue(response -> {
+                       final JsonObject jsonResponse = new JsonObject(response.toString());
+                       final JsonArray items = jsonResponse.getJsonArray("items");
+                       assertThat(items).hasSize(1);
+                       final JsonObject message = items.getJsonObject(0);
+                       assertThat(message.getString("content")).isEqualTo("Mock data");
+                       return true;
+                   });
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/v4/messages/flows/api.json")
+    @DisplayName("Flows without condition and operator 'EQUALS'")
+    class NoConditionOperatorEquals extends TestPreparer {
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            if (isV4Api(definitionClass)) {
+                final Api definition = (Api) api.getDefinition();
+                definition.getFlows().forEach(flow -> {
+                    flow.selectorByType(SelectorType.CHANNEL)
+                           .ifPresent(selector ->
+                                  ((ChannelSelector) selector).setChannelOperator(Operator.EQUALS)
+                           );
+                });
+            }
+        }
+
+        @ParameterizedTest
+        @MethodSource(PARAMETERS_PROVIDERS_CLASS + "parametersEqualsOperatorCase")
+        void should_pass_through_correct_flows(
+               String path,
+               Map<String, String> expectedRequestHeaders,
+               Map<String, String> expectedResponseHeaders,
+               HttpClient client
+        ) {
+            client
+                   .rxRequest(HttpMethod.GET, "/test" + path)
+                   .flatMap(request -> request.putHeader(HttpHeaderNames.ACCEPT, MediaType.APPLICATION_JSON).rxSend())
+                   .flatMap(response -> {
+                       assertThat(response.statusCode()).isEqualTo(200);
+                       expectedResponseHeaders.forEach((name, value) -> {
+                           assertThat(extractHeaders(response)).contains(Map.entry(name, value));
+                       });
+                       return response.body();
+                   })
+                   .test()
+                   .awaitDone(2, TimeUnit.SECONDS)
+                   .assertComplete()
+                   .assertValue(response -> {
+                       final JsonObject jsonResponse = new JsonObject(response.toString());
+                       final JsonArray items = jsonResponse.getJsonArray("items");
+                       assertThat(items).hasSize(1);
+                       final JsonObject message = items.getJsonObject(0);
+                       assertThat(message.getString("content")).isEqualTo("Mock data");
+                       return true;
+                   });
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/v4/messages/flows/api-flows-equals-and-starts-with.json")
+    @DisplayName("Flows without condition and mixed operators")
+    class NoConditionOperatorMixed extends TestPreparer {
+        @ParameterizedTest
+        @MethodSource(PARAMETERS_PROVIDERS_CLASS + "parametersMixedOperatorCase")
+        void should_pass_through_correct_flows(
+               String path,
+               Map<String, String> expectedRequestHeaders,
+               Map<String, String> expectedResponseHeaders,
+               HttpClient client
+        ) {
+            client
+                   .rxRequest(HttpMethod.GET, "/test" + path)
+                   .flatMap(request -> request.putHeader(HttpHeaderNames.ACCEPT, MediaType.APPLICATION_JSON).rxSend())
+                   .flatMap(response -> {
+                       assertThat(response.statusCode()).isEqualTo(200);
+                       expectedResponseHeaders.forEach((name, value) -> {
+                           assertThat(extractHeaders(response)).contains(Map.entry(name, value));
+                       });
+                       return response.body();
+                   })
+                   .test()
+                   .awaitDone(2, TimeUnit.SECONDS)
+                   .assertComplete()
+                   .assertValue(response -> {
+                       final JsonObject jsonResponse = new JsonObject(response.toString());
+                       final JsonArray items = jsonResponse.getJsonArray("items");
+                       assertThat(items).hasSize(1);
+                       final JsonObject message = items.getJsonObject(0);
+                       assertThat(message.getString("content")).isEqualTo("Mock data");
+                       return true;
+                   });
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi({"/apis/v4/messages/flows/api-conditional-flows.json", "/apis/v4/messages/flows/api-conditional-flows-double-evaluation-case.json"})
+    @DisplayName("Flows with condition")
+    class ConditionalFlows extends TestPreparer {
+        @ParameterizedTest
+        @MethodSource(PARAMETERS_PROVIDERS_CLASS + "parametersConditionalFlowsCase")
+        void should_pass_through_correct_flows(
+               String path,
+               String conditionalHeader,
+               Map<String, String> expectedRequestHeaders,
+               Map<String, String> expectedResponseHeaders,
+               HttpClient client
+        ) {
+            client
+                   .rxRequest(HttpMethod.GET, "/test" + path)
+                   .flatMap(request -> request.putHeader(HttpHeaderNames.ACCEPT, MediaType.APPLICATION_JSON)
+                          .putHeader("X-Condition-Flow-Selection", conditionalHeader)
+                          .rxSend())
+                   .flatMap(response -> {
+                       assertThat(response.statusCode()).isEqualTo(200);
+                       expectedResponseHeaders.forEach((name, value) -> {
+                           assertThat(extractHeaders(response)).contains(Map.entry(name, value));
+                       });
+                       return response.body();
+                   })
+                   .test()
+                   .awaitDone(2, TimeUnit.SECONDS)
+                   .assertComplete()
+                   .assertValue(response -> {
+                       final JsonObject jsonResponse = new JsonObject(response.toString());
+                       final JsonArray items = jsonResponse.getJsonArray("items");
+                       assertThat(items).hasSize(1);
+                       final JsonObject message = items.getJsonObject(0);
+                       assertThat(message.getString("content")).isEqualTo("Mock data");
+                       return true;
+                   });
+        }
+
+        @Test
+        void should_pass_through_correct_flow_condition_remove_header_on_request(HttpClient client) {
+            client
+                   .rxRequest(HttpMethod.GET, "/test-double-evaluation")
+                   .flatMap(request -> request.putHeader(HttpHeaderNames.ACCEPT, MediaType.APPLICATION_JSON)
+                          .putHeader("X-Condition-Flow-Selection", "root-condition")
+                          .rxSend())
+                   .flatMap(response -> {
+                       assertThat(response.statusCode()).isEqualTo(200);
+                       assertThat(extractHeaders(response)).contains(Map.entry(responseFlowHeader(0), headerValue("/")));
+                       return response.body();
+                   })
+                   .test()
+                   .awaitDone(2, TimeUnit.SECONDS)
+                   .assertComplete()
+                   .assertValue(response -> {
+                       final JsonObject jsonResponse = new JsonObject(response.toString());
+                       final JsonArray items = jsonResponse.getJsonArray("items");
+                       assertThat(items).hasSize(1);
+                       final JsonObject message = items.getJsonObject(0);
+                       assertThat(message.getString("content")).isEqualTo("Mock data");
+                       return true;
+                   });
+        }
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/http/flows/api-conditional-flows-double-evaluation-case.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/http/flows/api-conditional-flows-double-evaluation-case.json
@@ -1,0 +1,68 @@
+{
+  "id": "my-api-double-evaluation",
+  "name": "my-api-double-evaluation",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test-double-evaluation",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "Flow /",
+      "methods": [
+        "GET"
+      ],
+      "condition": "{#request.headers['X-Condition-Flow-Selection'][0] == 'root-condition'} ",
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "REQUEST",
+            "addHeaders": [
+              {
+                "name": "X-Request-Flow-0",
+                "value": "Flow /"
+              }
+            ],
+            "removeHeaders": ["X-Condition-Flow-Selection"]
+          }
+        }
+      ],
+      "post": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "RESPONSE",
+            "addHeaders": [
+              {
+                "name": "X-Response-Flow-0",
+                "value": "Flow /"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "resources": []
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/http/flows/api-conditional-flows.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/http/flows/api-conditional-flows.json
@@ -1,0 +1,113 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "Flow /",
+      "methods": [
+        "GET"
+      ],
+      "condition": "{#request.headers['X-Condition-Flow-Selection'][0] == 'root-condition'} ",
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "REQUEST",
+            "addHeaders": [
+              {
+                "name": "X-Request-Flow-0",
+                "value": "Flow /"
+              }
+            ]
+          }
+        }
+      ],
+      "post": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "RESPONSE",
+            "addHeaders": [
+              {
+                "name": "X-Response-Flow-0",
+                "value": "Flow /"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "Flow /products",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "condition": "{#request.headers['X-Condition-Flow-Selection'][0] == 'product-condition'} ",
+      "path-operator": {
+        "path": "/products",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "REQUEST",
+            "addHeaders": [
+              {
+                "name": "X-Request-Flow-1",
+                "value": "Flow /products"
+              }
+            ]
+          }
+        }
+      ],
+      "post": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "RESPONSE",
+            "addHeaders": [
+              {
+                "name": "X-Response-Flow-1",
+                "value": "Flow /products"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "resources": []
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/http/flows/api-flows-equals-and-starts-with.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/http/flows/api-flows-equals-and-starts-with.json
@@ -1,0 +1,111 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "Flow /",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "EQUALS"
+      },
+      "pre": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "REQUEST",
+            "addHeaders": [
+              {
+                "name": "X-Request-Flow-0",
+                "value": "Flow /"
+              }
+            ]
+          }
+        }
+      ],
+      "post": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "RESPONSE",
+            "addHeaders": [
+              {
+                "name": "X-Response-Flow-0",
+                "value": "Flow /"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "Flow /products",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/products",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "REQUEST",
+            "addHeaders": [
+              {
+                "name": "X-Request-Flow-1",
+                "value": "Flow /products"
+              }
+            ]
+          }
+        }
+      ],
+      "post": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "RESPONSE",
+            "addHeaders": [
+              {
+                "name": "X-Response-Flow-1",
+                "value": "Flow /products"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "resources": []
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/http/flows/api.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/http/flows/api.json
@@ -1,0 +1,111 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "Flow /",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "REQUEST",
+            "addHeaders": [
+              {
+                "name": "X-Request-Flow-0",
+                "value": "Flow /"
+              }
+            ]
+          }
+        }
+      ],
+      "post": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "RESPONSE",
+            "addHeaders": [
+              {
+                "name": "X-Response-Flow-0",
+                "value": "Flow /"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "Flow /products",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/products",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "REQUEST",
+            "addHeaders": [
+              {
+                "name": "X-Request-Flow-1",
+                "value": "Flow /products"
+              }
+            ]
+          }
+        }
+      ],
+      "post": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "RESPONSE",
+            "addHeaders": [
+              {
+                "name": "X-Response-Flow-1",
+                "value": "Flow /products"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "resources": []
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/flows/api-conditional-flows-double-evaluation-case.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/flows/api-conditional-flows-double-evaluation-case.json
@@ -1,0 +1,101 @@
+{
+  "id": "my-api-v4-double-evaluation",
+  "name": "my-api-v4-double-evaluation",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test-double-evaluation"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "Flow /",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "START_WITH",
+          "methods": []
+        },
+        {
+          "type": "condition",
+          "condition": "{#request.headers['X-Condition-Flow-Selection'][0] == 'root-condition'} "
+        }
+      ],
+      "request": [
+        {
+        "name": "Transform headers",
+        "description": "",
+        "enabled": true,
+        "policy": "transform-headers",
+        "configuration": {
+          "scope": "REQUEST",
+          "addHeaders": [
+            {
+              "name": "X-Request-Flow-0",
+              "value": "Flow /"
+            }
+          ],
+          "removeHeaders": ["X-Condition-Flow-Selection"]
+        }
+      }],
+      "response": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "RESPONSE",
+            "addHeaders": [
+              {
+                "name": "X-Response-Flow-0",
+                "value": "Flow /"
+              }
+            ]
+          }
+        }
+      ],
+      "subscribe": [],
+      "publish": []
+    }
+  ],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/flows/api-conditional-flows.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/flows/api-conditional-flows.json
@@ -1,0 +1,151 @@
+{
+  "id": "my-api-v4",
+  "name": "my-api-v4",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "Flow /",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "START_WITH",
+          "methods": []
+        },
+        {
+          "type": "condition",
+          "condition": "{#request.headers['X-Condition-Flow-Selection'][0] == 'root-condition'} "
+        }
+      ],
+      "request": [
+        {
+        "name": "Transform headers",
+        "description": "",
+        "enabled": true,
+        "policy": "transform-headers",
+        "configuration": {
+          "scope": "REQUEST",
+          "addHeaders": [
+            {
+              "name": "X-Request-Flow-0",
+              "value": "Flow /"
+            }
+          ]
+        }
+      }],
+      "response": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "RESPONSE",
+            "addHeaders": [
+              {
+                "name": "X-Response-Flow-0",
+                "value": "Flow /"
+              }
+            ]
+          }
+        }
+      ],
+      "subscribe": [],
+      "publish": []
+    },
+    {
+      "name": "Flow /products",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/products",
+          "pathOperator": "START_WITH",
+          "methods": []
+        },
+        {
+          "type": "condition",
+          "condition": "{#request.headers['X-Condition-Flow-Selection'][0] == 'product-condition'} "
+        }
+      ],
+      "request": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "REQUEST",
+            "addHeaders": [
+              {
+                "name": "X-Request-Flow-1",
+                "value": "Flow /products"
+              }
+            ]
+          }
+        }],
+      "response": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "RESPONSE",
+            "addHeaders": [
+              {
+                "name": "X-Response-Flow-1",
+                "value": "Flow /products"
+              }
+            ]
+          }
+        }
+      ],
+      "subscribe": [],
+      "publish": []
+    }
+  ],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/flows/api-flows-equals-and-starts-with.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/flows/api-flows-equals-and-starts-with.json
@@ -1,0 +1,143 @@
+{
+  "id": "my-api-v4",
+  "name": "my-api-v4",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "Flow /",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "EQUALS",
+          "methods": []
+        }
+      ],
+      "request": [
+        {
+        "name": "Transform headers",
+        "description": "",
+        "enabled": true,
+        "policy": "transform-headers",
+        "configuration": {
+          "scope": "REQUEST",
+          "addHeaders": [
+            {
+              "name": "X-Request-Flow-0",
+              "value": "Flow /"
+            }
+          ]
+        }
+      }],
+      "response": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "RESPONSE",
+            "addHeaders": [
+              {
+                "name": "X-Response-Flow-0",
+                "value": "Flow /"
+              }
+            ]
+          }
+        }
+      ],
+      "subscribe": [],
+      "publish": []
+    },
+    {
+      "name": "Flow /products",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/products",
+          "pathOperator": "START_WITH",
+          "methods": []
+        }
+      ],
+      "request": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "REQUEST",
+            "addHeaders": [
+              {
+                "name": "X-Request-Flow-1",
+                "value": "Flow /products"
+              }
+            ]
+          }
+        }],
+      "response": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "RESPONSE",
+            "addHeaders": [
+              {
+                "name": "X-Response-Flow-1",
+                "value": "Flow /products"
+              }
+            ]
+          }
+        }
+      ],
+      "subscribe": [],
+      "publish": []
+    }
+  ],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/flows/api.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/flows/api.json
@@ -1,0 +1,143 @@
+{
+  "id": "my-api-v4",
+  "name": "my-api-v4",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "Flow /",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "START_WITH",
+          "methods": []
+        }
+      ],
+      "request": [
+        {
+        "name": "Transform headers",
+        "description": "",
+        "enabled": true,
+        "policy": "transform-headers",
+        "configuration": {
+          "scope": "REQUEST",
+          "addHeaders": [
+            {
+              "name": "X-Request-Flow-0",
+              "value": "Flow /"
+            }
+          ]
+        }
+      }],
+      "response": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "RESPONSE",
+            "addHeaders": [
+              {
+                "name": "X-Response-Flow-0",
+                "value": "Flow /"
+              }
+            ]
+          }
+        }
+      ],
+      "subscribe": [],
+      "publish": []
+    },
+    {
+      "name": "Flow /products",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/products",
+          "pathOperator": "START_WITH",
+          "methods": []
+        }
+      ],
+      "request": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "REQUEST",
+            "addHeaders": [
+              {
+                "name": "X-Request-Flow-1",
+                "value": "Flow /products"
+              }
+            ]
+          }
+        }],
+      "response": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "RESPONSE",
+            "addHeaders": [
+              {
+                "name": "X-Response-Flow-1",
+                "value": "Flow /products"
+              }
+            ]
+          }
+        }
+      ],
+      "subscribe": [],
+      "publish": []
+    }
+  ],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/flows/api-conditional-flows-double-evaluation-case.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/flows/api-conditional-flows-double-evaluation-case.json
@@ -1,0 +1,103 @@
+{
+  "id": "my-api-v4-double-evaluation",
+  "name": "my-api-v4-double-evaluation",
+  "gravitee": "4.0.0",
+  "type": "message",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test-double-evaluation"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-get",
+          "configuration": {
+            "messagesLimitCount":  12,
+            "messagesLimitDurationMs": 500,
+            "headersInPayload":  true,
+            "metadataInPayload": true
+          }
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default",
+      "type": "mock",
+      "endpoints": [
+        {
+          "name": "default-endpoint",
+          "type": "mock",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "messageInterval": 1,
+            "messageContent": "Mock data",
+            "messageCount": 1
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "Flow /",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "channel",
+          "operation": [ "SUBSCRIBE" ],
+          "channel": "/",
+          "channel-operator": "STARTS_WITH"
+        },
+        {
+          "type": "condition",
+          "condition": "{#request.headers['X-Condition-Flow-Selection'][0] == 'root-condition'} "
+        }
+      ],
+      "request": [
+        {
+        "name": "Transform headers",
+        "description": "",
+        "enabled": true,
+        "policy": "transform-headers",
+        "configuration": {
+          "scope": "REQUEST",
+          "addHeaders": [
+            {
+              "name": "X-Request-Flow-0",
+              "value": "Flow /"
+            }
+          ],
+          "removeHeaders": ["X-Condition-Flow-Selection"]
+        }
+      }],
+      "response": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "RESPONSE",
+            "addHeaders": [
+              {
+                "name": "X-Response-Flow-0",
+                "value": "Flow /"
+              }
+            ]
+          }
+        }
+      ],
+      "subscribe": [],
+      "publish": []
+    }
+  ],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/flows/api-conditional-flows.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/flows/api-conditional-flows.json
@@ -1,0 +1,153 @@
+{
+  "id": "my-api-v4",
+  "name": "my-api-v4",
+  "gravitee": "4.0.0",
+  "type": "message",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-get",
+          "configuration": {
+            "messagesLimitCount":  12,
+            "messagesLimitDurationMs": 500,
+            "headersInPayload":  true,
+            "metadataInPayload": true
+          }
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default",
+      "type": "mock",
+      "endpoints": [
+        {
+          "name": "default-endpoint",
+          "type": "mock",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "messageInterval": 1,
+            "messageContent": "Mock data",
+            "messageCount": 1
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "Flow /",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "channel",
+          "operation": [ "SUBSCRIBE" ],
+          "channel": "/",
+          "channel-operator": "STARTS_WITH"
+        },
+        {
+          "type": "condition",
+          "condition": "{#request.headers['X-Condition-Flow-Selection'][0] == 'root-condition'} "
+        }
+      ],
+      "request": [
+        {
+        "name": "Transform headers",
+        "description": "",
+        "enabled": true,
+        "policy": "transform-headers",
+        "configuration": {
+          "scope": "REQUEST",
+          "addHeaders": [
+            {
+              "name": "X-Request-Flow-0",
+              "value": "Flow /"
+            }
+          ]
+        }
+      }],
+      "response": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "RESPONSE",
+            "addHeaders": [
+              {
+                "name": "X-Response-Flow-0",
+                "value": "Flow /"
+              }
+            ]
+          }
+        }
+      ],
+      "subscribe": [],
+      "publish": []
+    },
+    {
+      "name": "Flow /products",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "channel",
+          "operation": [ "SUBSCRIBE" ],
+          "channel": "/",
+          "channel-operator": "STARTS_WITH"
+        },
+        {
+          "type": "condition",
+          "condition": "{#request.headers['X-Condition-Flow-Selection'][0] == 'product-condition'} "
+        }
+      ],
+      "request": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "REQUEST",
+            "addHeaders": [
+              {
+                "name": "X-Request-Flow-1",
+                "value": "Flow /products"
+              }
+            ]
+          }
+        }],
+      "response": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "RESPONSE",
+            "addHeaders": [
+              {
+                "name": "X-Response-Flow-1",
+                "value": "Flow /products"
+              }
+            ]
+          }
+        }
+      ],
+      "subscribe": [],
+      "publish": []
+    }
+  ],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/flows/api-flows-equals-and-starts-with.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/flows/api-flows-equals-and-starts-with.json
@@ -1,0 +1,145 @@
+{
+  "id": "my-api-v4",
+  "name": "my-api-v4",
+  "gravitee": "4.0.0",
+  "type": "message",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-get",
+          "configuration": {
+            "messagesLimitCount":  12,
+            "messagesLimitDurationMs": 500,
+            "headersInPayload":  true,
+            "metadataInPayload": true
+          }
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default",
+      "type": "mock",
+      "endpoints": [
+        {
+          "name": "default-endpoint",
+          "type": "mock",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "messageInterval": 1,
+            "messageContent": "Mock data",
+            "messageCount": 1
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "Flow /",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "channel",
+          "operation": [ "SUBSCRIBE" ],
+          "channel": "/",
+          "channel-operator": "EQUALS"
+        }
+      ],
+      "request": [
+        {
+        "name": "Transform headers",
+        "description": "",
+        "enabled": true,
+        "policy": "transform-headers",
+        "configuration": {
+          "scope": "REQUEST",
+          "addHeaders": [
+            {
+              "name": "X-Request-Flow-0",
+              "value": "Flow /"
+            }
+          ]
+        }
+      }],
+      "response": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "RESPONSE",
+            "addHeaders": [
+              {
+                "name": "X-Response-Flow-0",
+                "value": "Flow /"
+              }
+            ]
+          }
+        }
+      ],
+      "subscribe": [],
+      "publish": []
+    },
+    {
+      "name": "Flow /products",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "channel",
+          "operation": [ "SUBSCRIBE" ],
+          "channel": "/",
+          "channel-operator": "STARTS_WITH"
+        }
+      ],
+      "request": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "REQUEST",
+            "addHeaders": [
+              {
+                "name": "X-Request-Flow-1",
+                "value": "Flow /products"
+              }
+            ]
+          }
+        }],
+      "response": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "RESPONSE",
+            "addHeaders": [
+              {
+                "name": "X-Response-Flow-1",
+                "value": "Flow /products"
+              }
+            ]
+          }
+        }
+      ],
+      "subscribe": [],
+      "publish": []
+    }
+  ],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/flows/api.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/flows/api.json
@@ -1,0 +1,145 @@
+{
+  "id": "my-api-v4",
+  "name": "my-api-v4",
+  "gravitee": "4.0.0",
+  "type": "message",
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-get",
+          "configuration": {
+            "messagesLimitCount":  12,
+            "messagesLimitDurationMs": 500,
+            "headersInPayload":  true,
+            "metadataInPayload": true
+          }
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default",
+      "type": "mock",
+      "endpoints": [
+        {
+          "name": "default-endpoint",
+          "type": "mock",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "messageInterval": 1,
+            "messageContent": "Mock data",
+            "messageCount": 1
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "Flow /",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "channel",
+          "operation": [ "SUBSCRIBE" ],
+          "channel": "/",
+          "channel-operator": "STARTS_WITH"
+        }
+      ],
+      "request": [
+        {
+        "name": "Transform headers",
+        "description": "",
+        "enabled": true,
+        "policy": "transform-headers",
+        "configuration": {
+          "scope": "REQUEST",
+          "addHeaders": [
+            {
+              "name": "X-Request-Flow-0",
+              "value": "Flow /"
+            }
+          ]
+        }
+      }],
+      "response": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "RESPONSE",
+            "addHeaders": [
+              {
+                "name": "X-Response-Flow-0",
+                "value": "Flow /"
+              }
+            ]
+          }
+        }
+      ],
+      "subscribe": [],
+      "publish": []
+    },
+    {
+      "name": "Flow /products",
+      "enabled": true,
+      "selectors": [
+        {
+          "type": "channel",
+          "operation": [ "SUBSCRIBE" ],
+          "channel": "/products",
+          "channel-operator": "STARTS_WITH"
+        }
+      ],
+      "request": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "REQUEST",
+            "addHeaders": [
+              {
+                "name": "X-Request-Flow-1",
+                "value": "Flow /products"
+              }
+            ]
+          }
+        }],
+      "response": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "RESPONSE",
+            "addHeaders": [
+              {
+                "name": "X-Response-Flow-1",
+                "value": "Flow /products"
+              }
+            ]
+          }
+        }
+      ],
+      "subscribe": [],
+      "publish": []
+    }
+  ],
+  "analytics": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1834

## Description

- HTTP
   - V3-V3 Compatibility-Emulation V4-V4 Http-proxy
        - Call the api and checks the flows are properly executed
        - Call an api with condition on flows
          - before v4 → condition is evaluated before request and response (use the remove header case to prove that)
          - v4 → condition is only evaluated before request
- Message: Test execution of flows on
  - Channel Selector
  - Conditional Selector

Tests should be decline using different path operators (starts_with / equals)

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-evlkibhopf.chromatic.com)
<!-- Storybook placeholder end -->
