### PR TITLE
test: add best match integration test

### DIFF
--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/bestmatch/BestMatchIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/bestmatch/BestMatchIntegrationTest.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.bestmatch;
+
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.flow.Operator;
+import io.gravitee.definition.model.flow.PathOperator;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.transformheaders.TransformHeadersPolicy;
+import io.gravitee.policy.transformheaders.configuration.TransformHeadersPolicyConfiguration;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.rxjava3.core.buffer.Buffer;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class BestMatchIntegrationTest {
+
+    public static final String PLAN_FLOW_SELECTED = "X-Plan-Flow-Selected";
+    public static final String API_FLOW_SELECTED = "X-Api-Flow-Selected";
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/http/bestmatch/api.json")
+    class StartsWithOperator extends AbstractGatewayTest {
+
+        @Override
+        public void configurePolicies(Map<String, PolicyPlugin> policies) {
+            policies.putIfAbsent(
+                   "transform-headers",
+                   PolicyBuilder.build("transform-headers", TransformHeadersPolicy.class, TransformHeadersPolicyConfiguration.class)
+            );
+        }
+
+        /**
+         * @returns { path used for the request, expected plan flow, expected api flow }
+         */
+        Stream<Arguments> provideParameters() {
+            return Stream.of(
+              Arguments.of("/books", "/books", "/books"),
+              Arguments.of("/books", "/books", "/books"),
+              Arguments.of("/books/145/chapters/12", "/books/:bookId", "/books/:bookId/chapters/:chapterId"),
+              Arguments.of("/books/9999/chapters", "/books/:bookId", "/books/9999/chapters"),
+              Arguments.of("/books/9999/chapters/random", "/books/:bookId", "/books/9999/chapters"),
+              Arguments.of("/random", "/", null),
+              Arguments.of("/books/145", "/books/:bookId", null)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("provideParameters")
+        void should_use_best_matching_flow(String path, String planFlowSelected, String apiFlowSelected, HttpClient client) {
+
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            client.rxRequest(HttpMethod.GET, "/test" + path)
+                   .flatMap(HttpClientRequest::rxSend)
+                   .flatMap(response -> {
+                       assertThat(response.statusCode()).isEqualTo(200);
+                       return response.body();
+                   })
+                   .test()
+                   .awaitDone(10, TimeUnit.SECONDS)
+                   .assertValue(Buffer.buffer("response from backend"))
+                   .assertComplete();
+
+            final RequestPatternBuilder requestedFor = getRequestedFor(urlPathEqualTo("/endpoint" + path));
+            if (planFlowSelected != null) {
+                requestedFor.withHeader(PLAN_FLOW_SELECTED, equalTo(planFlowSelected));
+            }
+            if (apiFlowSelected != null) {
+                requestedFor.withHeader(API_FLOW_SELECTED, equalTo(apiFlowSelected));
+            }
+            wiremock.verify(requestedFor);
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/http/bestmatch/api.json")
+    class EqualsOperator extends AbstractGatewayTest {
+
+        @Override
+        public void configurePolicies(Map<String, PolicyPlugin> policies) {
+            policies.putIfAbsent(
+                   "transform-headers",
+                   PolicyBuilder.build("transform-headers", TransformHeadersPolicy.class, TransformHeadersPolicyConfiguration.class)
+            );
+        }
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            if (isLegacyApi(definitionClass)) {
+                final Api definition = (Api) api.getDefinition();
+                definition.getFlows().forEach(flow -> flow.setPathOperator(new PathOperator(flow.getPath(), Operator.EQUALS)));
+                definition.getPlans().stream().flatMap(plan -> plan.getFlows().stream()).forEach(flow -> flow.setPathOperator(new PathOperator(flow.getPath(), Operator.EQUALS)));
+            }
+        }
+
+        /**
+         * @returns { path used for the request, expected plan flow, expected api flow }
+         */
+        Stream<Arguments> provideParameters() {
+            return Stream.of(
+                   Arguments.of("/books", "/books", "/books"),
+                   Arguments.of("/books", "/books", "/books"),
+                   Arguments.of("/books/145/chapters/12", null, "/books/:bookId/chapters/:chapterId"),
+                   Arguments.of("/books/9999/chapters", null, "/books/9999/chapters"),
+                   Arguments.of("/books/9999/chapters/random", null, "/books/:bookId/chapters/:chapterId"),
+                   Arguments.of("/random", null, null),
+                   Arguments.of("/", "/", null),
+                   Arguments.of("/books/145", "/books/:bookId", null)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("provideParameters")
+        void should_use_best_matching_flow(String path, String planFlowSelected, String apiFlowSelected, HttpClient client) {
+
+            wiremock.stubFor(get(anyUrl()).willReturn(ok("response from backend")));
+
+            client.rxRequest(HttpMethod.GET, "/test" + path)
+                   .flatMap(HttpClientRequest::rxSend)
+                   .flatMap(response -> {
+                       assertThat(response.statusCode()).isEqualTo(200);
+                       return response.body();
+                   })
+                   .test()
+                   .awaitDone(10, TimeUnit.SECONDS)
+                   .assertValue(Buffer.buffer("response from backend"))
+                   .assertComplete();
+
+            final RequestPatternBuilder requestedFor = getRequestedFor(urlPathEqualTo("/endpoint" + path));
+            if (planFlowSelected != null) {
+                requestedFor.withHeader(PLAN_FLOW_SELECTED, equalTo(planFlowSelected));
+            }
+            if (apiFlowSelected != null) {
+                requestedFor.withHeader(API_FLOW_SELECTED, equalTo(apiFlowSelected));
+            }
+            wiremock.verify(requestedFor);
+        }
+    }
+
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/bestmatch/BestMatchV3CompatibilityIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/bestmatch/BestMatchV3CompatibilityIntegrationTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.bestmatch;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
+import org.junit.jupiter.api.Nested;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class BestMatchV3CompatibilityIntegrationTest extends BestMatchIntegrationTest {
+
+    @Nested
+    @GatewayTest(mode = GatewayMode.COMPATIBILITY)
+    @DeployApi("/apis/http/bestmatch/api.json")
+    class StartsWithOperator extends BestMatchIntegrationTest.StartsWithOperator {}
+
+    @Nested
+    @GatewayTest(mode = GatewayMode.COMPATIBILITY)
+    @DeployApi("/apis/http/bestmatch/api.json")
+    class EqualsOperator extends BestMatchIntegrationTest.EqualsOperator {}
+
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/bestmatch/BestMatchV3IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/bestmatch/BestMatchV3IntegrationTest.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.bestmatch;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayMode;
+import org.junit.jupiter.api.Nested;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class BestMatchV3IntegrationTest extends BestMatchIntegrationTest {
+
+    @Nested
+    @GatewayTest(mode = GatewayMode.V3)
+    @DeployApi("/apis/http/bestmatch/api.json")
+    class StartsWithOperator extends BestMatchIntegrationTest.StartsWithOperator {}
+
+    @Nested
+    @GatewayTest(mode = GatewayMode.V3)
+    @DeployApi("/apis/http/bestmatch/api.json")
+    class EqualsOperator extends BestMatchIntegrationTest.EqualsOperator {}
+
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/bestmatch/BestMatchV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/bestmatch/BestMatchV4IntegrationTest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http.bestmatch;
+
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.definition.model.flow.Operator;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
+import io.gravitee.definition.model.v4.flow.selector.SelectorType;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import org.junit.jupiter.api.Nested;
+
+import java.util.Map;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class BestMatchV4IntegrationTest extends BestMatchIntegrationTest {
+
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/v4/http/bestmatch/api.json")
+    class StartsWithOperator extends BestMatchIntegrationTest.StartsWithOperator {
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/v4/http/bestmatch/api.json")
+    class EqualsOperator extends BestMatchIntegrationTest.EqualsOperator {
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+        }
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            if (isV4Api(definitionClass)) {
+                final Api definition = (Api) api.getDefinition();
+                definition.getFlows().stream()
+                       .flatMap(flow -> flow.selectorByType(SelectorType.HTTP).stream())
+                       .forEach(selector -> {
+                    HttpSelector httpSelector = (HttpSelector) selector;
+                    httpSelector.setPathOperator(Operator.EQUALS);
+                });
+                definition
+                       .getPlans().stream().flatMap(plan -> plan.getFlows().stream())
+                       .flatMap(flow -> flow.selectorByType(SelectorType.HTTP).stream())
+                       .forEach(selector -> {
+                           HttpSelector httpSelector = (HttpSelector) selector;
+                           httpSelector.setPathOperator(Operator.EQUALS);
+                       });
+            }
+        }
+    }
+
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/bestmatch/BestMatchIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/bestmatch/BestMatchIntegrationTest.java
@@ -1,0 +1,211 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.messages.bestmatch;
+
+import com.graviteesource.entrypoint.http.get.HttpGetEntrypointConnectorFactory;
+import com.graviteesource.reactor.message.MessageApiReactorFactory;
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.policy.PolicyBuilder;
+import io.gravitee.apim.gateway.tests.sdk.reactor.ReactorBuilder;
+import io.gravitee.apim.plugin.reactor.ReactorPlugin;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.definition.model.flow.Operator;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.flow.selector.ChannelSelector;
+import io.gravitee.definition.model.v4.flow.selector.SelectorType;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.policy.transformheaders.TransformHeadersPolicy;
+import io.gravitee.policy.transformheaders.configuration.TransformHeadersPolicyConfiguration;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.rxjava3.core.http.HttpClient;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class BestMatchIntegrationTest {
+
+    public static final String PLAN_FLOW_SELECTED = "X-Plan-Flow-Selected";
+    public static final String API_FLOW_SELECTED = "X-Api-Flow-Selected";
+
+    /**
+     * Inherit from this class to have the required configuration to run each tests of this class
+     */
+    class TestPreparer extends AbstractGatewayTest {
+        @Override
+        public void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+            reactors.add(ReactorBuilder.build(MessageApiReactorFactory.class));
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            entrypoints.putIfAbsent("http-get", EntrypointBuilder.build("http-get", HttpGetEntrypointConnectorFactory.class));
+        }
+
+        @Override
+        public void configurePolicies(Map<String, PolicyPlugin> policies) {
+            policies.putIfAbsent(
+                   "transform-headers",
+                   PolicyBuilder.build("transform-headers", TransformHeadersPolicy.class, TransformHeadersPolicyConfiguration.class)
+            );
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/v4/messages/bestmatch/api.json")
+    class StartsWithOperator extends TestPreparer {
+
+        /**
+         * @returns { path used for the request, expected plan flow, expected api flow }
+         */
+        Stream<Arguments> provideParameters() {
+            return Stream.of(
+              Arguments.of("/books", "/books", "/books"),
+              Arguments.of("/books", "/books", "/books"),
+              Arguments.of("/books/145/chapters/12", "/books/:bookId", "/books/:bookId/chapters/:chapterId"),
+              Arguments.of("/books/9999/chapters", "/books/:bookId", "/books/9999/chapters"),
+              Arguments.of("/books/9999/chapters/random", "/books/:bookId", "/books/9999/chapters"),
+              Arguments.of("/random", "/", null),
+              Arguments.of("/books/145", "/books/:bookId", null)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("provideParameters")
+        void should_use_best_matching_flow(String path, String planFlowSelected, String apiFlowSelected, HttpClient client) {
+
+            client.rxRequest(HttpMethod.GET, "/test" + path)
+                   .flatMap(request -> request.putHeader(HttpHeaderNames.ACCEPT, MediaType.APPLICATION_JSON).rxSend())
+                   .flatMap(response -> {
+                       assertThat(response.statusCode()).isEqualTo(200);
+                       if (planFlowSelected != null) {
+                           assertThat(response.getHeader(PLAN_FLOW_SELECTED)).isEqualTo(planFlowSelected);
+                       }
+                       if (apiFlowSelected != null) {
+                           assertThat(response.getHeader(API_FLOW_SELECTED)).isEqualTo(apiFlowSelected);
+                       }
+                       return response.body();
+                   })
+                   .test()
+                   .awaitDone(10, TimeUnit.SECONDS)
+                   .assertValue(response -> {
+                       final JsonObject jsonResponse = new JsonObject(response.toString());
+                       final JsonArray items = jsonResponse.getJsonArray("items");
+                       assertThat(items).hasSize(1);
+                       final JsonObject message = items.getJsonObject(0);
+                       assertThat(message.getString("content")).isEqualTo("Mock data");
+                       return true;
+                   })
+                   .assertComplete();
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/v4/messages/bestmatch/api.json")
+    class EqualsOperator extends TestPreparer {
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            if (isV4Api(definitionClass)) {
+                final io.gravitee.definition.model.v4.Api definition = (Api) api.getDefinition();
+                definition.getFlows().stream()
+                       .flatMap(flow -> flow.selectorByType(SelectorType.CHANNEL).stream())
+                       .forEach(selector -> {
+                           ChannelSelector channelSelector = (ChannelSelector) selector;
+                           channelSelector.setChannelOperator(Operator.EQUALS);
+                       });
+                definition
+                       .getPlans().stream().flatMap(plan -> plan.getFlows().stream())
+                       .flatMap(flow -> flow.selectorByType(SelectorType.CHANNEL).stream())
+                       .forEach(selector -> {
+                           ChannelSelector channelSelector = (ChannelSelector) selector;
+                           channelSelector.setChannelOperator(Operator.EQUALS);
+                       });
+            }
+        }
+
+        /**
+         * @returns { path used for the request, expected plan flow, expected api flow }
+         */
+        Stream<Arguments> provideParameters() {
+            return Stream.of(
+                   Arguments.of("/books", "/books", "/books"),
+                   Arguments.of("/books", "/books", "/books"),
+                   Arguments.of("/books/145/chapters/12", null, "/books/:bookId/chapters/:chapterId"),
+                   Arguments.of("/books/9999/chapters", null, "/books/9999/chapters"),
+                   Arguments.of("/books/9999/chapters/random", null, "/books/:bookId/chapters/:chapterId"),
+                   Arguments.of("/random", null, null),
+                   Arguments.of("/", "/", null),
+                   Arguments.of("/books/145", "/books/:bookId", null)
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("provideParameters")
+        void should_use_best_matching_flow(String path, String planFlowSelected, String apiFlowSelected, HttpClient client) {
+
+            client.rxRequest(HttpMethod.GET, "/test" + path)
+                   .flatMap(request -> request.putHeader(HttpHeaderNames.ACCEPT, MediaType.APPLICATION_JSON).rxSend())
+                   .flatMap(response -> {
+                       assertThat(response.statusCode()).isEqualTo(200);
+                       if (planFlowSelected != null) {
+                           assertThat(response.getHeader(PLAN_FLOW_SELECTED)).isEqualTo(planFlowSelected);
+                       }
+                       if (apiFlowSelected != null) {
+                           assertThat(response.getHeader(API_FLOW_SELECTED)).isEqualTo(apiFlowSelected);
+                       }
+                       return response.body();
+                   })
+                   .test()
+                   .awaitDone(10, TimeUnit.SECONDS)
+                   .assertValue(response -> {
+                       final JsonObject jsonResponse = new JsonObject(response.toString());
+                       final JsonArray items = jsonResponse.getJsonArray("items");
+                       assertThat(items).hasSize(1);
+                       final JsonObject message = items.getJsonObject(0);
+                       assertThat(message.getString("content")).isEqualTo("Mock data");
+                       return true;
+                   })
+                   .assertComplete();
+        }
+    }
+
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/http/bestmatch/api.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/http/bestmatch/api.json
@@ -1,0 +1,228 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "flow_mode": "BEST_MATCH",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "plans": [
+    {
+      "name": "Keyless",
+      "description": "keyless",
+      "security": "KEY_LESS",
+      "flows": [
+        {
+          "name": "Everything",
+          "path-operator": {
+            "path": "/",
+            "operator": "STARTS_WITH"
+          },
+          "condition": "",
+          "methods": [],
+          "pre": [
+            {
+              "name": "Transform headers",
+              "description": "",
+              "enabled": true,
+              "policy": "transform-headers",
+              "configuration": {
+                "scope": "REQUEST",
+                "addHeaders": [
+                  {
+                    "name": "X-Plan-Flow-Selected",
+                    "value": "/"
+                  }
+                ]
+              }
+            }
+          ],
+          "post": [],
+          "enabled": true
+        },
+        {
+          "name": "All books",
+          "path-operator": {
+            "path": "/books",
+            "operator": "STARTS_WITH"
+          },
+          "condition": "",
+          "methods": [],
+          "pre": [
+            {
+              "name": "Transform headers",
+              "description": "",
+              "enabled": true,
+              "policy": "transform-headers",
+              "configuration": {
+                "scope": "REQUEST",
+                "addHeaders": [
+                  {
+                    "name": "X-Plan-Flow-Selected",
+                    "value": "/books"
+                  }
+                ]
+              }
+            }
+          ],
+          "post": [],
+          "enabled": true
+        },
+        {
+          "name": "A book",
+          "path-operator": {
+            "path": "/books/:bookId",
+            "operator": "STARTS_WITH"
+          },
+          "condition": "",
+          "methods": [],
+          "pre": [
+            {
+              "name": "Transform headers",
+              "description": "",
+              "enabled": true,
+              "policy": "transform-headers",
+              "configuration": {
+                "scope": "REQUEST",
+                "addHeaders": [
+                  {
+                    "name": "X-Plan-Flow-Selected",
+                    "value": "/books/:bookId"
+                  }
+                ]
+              }
+            }
+          ],
+          "post": [],
+          "enabled": true
+        }
+      ],
+      "comment_required": false
+    }
+  ],
+  "flows": [
+    {
+      "name": "All books",
+      "path-operator": {
+        "path": "/books",
+        "operator": "STARTS_WITH"
+      },
+      "condition": "",
+      "methods": [],
+      "pre": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "REQUEST",
+            "addHeaders": [
+              {
+                "name": "X-Api-Flow-Selected",
+                "value": "/books"
+              }
+            ]
+          }
+        }
+      ],
+      "post": [],
+      "enabled": true
+    },
+    {
+      "name": "A chapter of a book",
+      "path-operator": {
+        "path": "/books/:bookId/chapters/:chapterId",
+        "operator": "STARTS_WITH"
+      },
+      "condition": "",
+      "methods": [],
+      "pre": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "REQUEST",
+            "addHeaders": [
+              {
+                "name": "X-Api-Flow-Selected",
+                "value": "/books/:bookId/chapters/:chapterId"
+              }
+            ]
+          }
+        }
+      ],
+      "post": [],
+      "enabled": true
+    },
+    {
+      "name": "A page of a chapter of a book",
+      "path-operator": {
+        "path": "/books/:bookId/chapters/:chapterId/pages/:pageId",
+        "operator": "STARTS_WITH"
+      },
+      "condition": "",
+      "methods": [],
+      "pre": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "REQUEST",
+            "addHeaders": [
+              {
+                "name": "X-Api-Flow-Selected",
+                "value": "/books/:bookId/chapters/:chapterId/pages/:pageId"
+              }
+            ]
+          }
+        }
+      ],
+      "post": [],
+      "enabled": true
+    },
+    {
+      "name": "All chapters of book 9999",
+      "path-operator": {
+        "path": "/books/9999/chapters",
+        "operator": "STARTS_WITH"
+      },
+      "condition": "",
+      "methods": [],
+      "pre": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "REQUEST",
+            "addHeaders": [
+              {
+                "name": "X-Api-Flow-Selected",
+                "value": "/books/9999/chapters"
+              }
+            ]
+          }
+        }
+      ],
+      "post": [],
+      "enabled": true
+    }
+  ],
+  "resources": []
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/bestmatch/api.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/http/bestmatch/api.json
@@ -1,0 +1,287 @@
+{
+  "id": "my-api-v4",
+  "name": "my-api-v4",
+  "gravitee": "4.0.0",
+  "type": "proxy",
+  "flowExecution": {
+    "mode": "best-match"
+  },
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-proxy"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "http-proxy",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "http-proxy",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "target": "http://localhost:8080/endpoint"
+          },
+          "sharedConfigurationOverride": {
+            "http": {
+              "connectTimeout": 3000,
+              "readTimeout": 60000
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "plans": [
+    {
+      "id": "plan-id",
+      "name": "Keyless",
+      "description": "keyless",
+      "security": {
+        "type": "key-less"
+      },
+      "flows": [
+        {
+          "name": "Everything",
+          "selectors": [
+            {
+              "type": "http",
+              "path": "/",
+              "pathOperator": "START_WITH",
+              "methods": []
+            }
+          ],
+          "condition": "",
+          "methods": [],
+          "request": [
+            {
+              "name": "Transform headers",
+              "description": "",
+              "enabled": true,
+              "policy": "transform-headers",
+              "configuration": {
+                "scope": "REQUEST",
+                "addHeaders": [
+                  {
+                    "name": "X-Plan-Flow-Selected",
+                    "value": "/"
+                  }
+                ]
+              }
+            }
+          ],
+          "post": [],
+          "enabled": true
+        },
+        {
+          "name": "All books",
+          "selectors": [
+            {
+              "type": "http",
+              "path": "/books",
+              "pathOperator": "START_WITH",
+              "methods": []
+            }
+          ],
+          "condition": "",
+          "methods": [],
+          "request": [
+            {
+              "name": "Transform headers",
+              "description": "",
+              "enabled": true,
+              "policy": "transform-headers",
+              "configuration": {
+                "scope": "REQUEST",
+                "addHeaders": [
+                  {
+                    "name": "X-Plan-Flow-Selected",
+                    "value": "/books"
+                  }
+                ]
+              }
+            }
+          ],
+          "post": [],
+          "enabled": true
+        },
+        {
+          "name": "A book",
+          "selectors": [
+            {
+              "type": "http",
+              "path": "/books/:bookId",
+              "pathOperator": "START_WITH",
+              "methods": []
+            }
+          ],
+          "condition": "",
+          "methods": [],
+          "request": [
+            {
+              "name": "Transform headers",
+              "description": "",
+              "enabled": true,
+              "policy": "transform-headers",
+              "configuration": {
+                "scope": "REQUEST",
+                "addHeaders": [
+                  {
+                    "name": "X-Plan-Flow-Selected",
+                    "value": "/books/:bookId"
+                  }
+                ]
+              }
+            }
+          ],
+          "post": [],
+          "enabled": true
+        }
+      ],
+      "comment_required": false
+    }
+  ],
+  "flows": [
+    {
+      "name": "All books",
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/books",
+          "pathOperator": "START_WITH",
+          "methods": []
+        }
+      ],
+      "condition": "",
+      "methods": [],
+      "request": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "REQUEST",
+            "addHeaders": [
+              {
+                "name": "X-Api-Flow-Selected",
+                "value": "/books"
+              }
+            ]
+          }
+        }
+      ],
+      "post": [],
+      "enabled": true
+    },
+    {
+      "name": "A chapter of a book",
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/books/:bookId/chapters/:chapterId",
+          "pathOperator": "START_WITH",
+          "methods": []
+        }
+      ],
+      "condition": "",
+      "methods": [],
+      "request": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "REQUEST",
+            "addHeaders": [
+              {
+                "name": "X-Api-Flow-Selected",
+                "value": "/books/:bookId/chapters/:chapterId"
+              }
+            ]
+          }
+        }
+      ],
+      "post": [],
+      "enabled": true
+    },
+    {
+      "name": "A page of a chapter of a book",
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/books/:bookId/chapters/:chapterId/pages/:pageId",
+          "pathOperator": "START_WITH",
+          "methods": []
+        }
+      ],
+      "condition": "",
+      "methods": [],
+      "request": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "REQUEST",
+            "addHeaders": [
+              {
+                "name": "X-Api-Flow-Selected",
+                "value": "/books/:bookId/chapters/:chapterId/pages/:pageId"
+              }
+            ]
+          }
+        }
+      ],
+      "post": [],
+      "enabled": true
+    },
+    {
+      "name": "All chapters of book 9999",
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/books/9999/chapters",
+          "pathOperator": "START_WITH",
+          "methods": []
+        }
+      ],
+      "condition": "",
+      "methods": [],
+      "request": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "REQUEST",
+            "addHeaders": [
+              {
+                "name": "X-Api-Flow-Selected",
+                "value": "/books/9999/chapters"
+              }
+            ]
+          }
+        }
+      ],
+      "post": [],
+      "enabled": true
+    }
+  ],
+  "resources": []
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/bestmatch/api.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/bestmatch/api.json
@@ -1,0 +1,295 @@
+{
+  "id": "my-api-v4",
+  "name": "my-api-v4",
+  "gravitee": "4.0.0",
+  "type": "message",
+  "flowExecution": {
+    "mode": "best-match"
+  },
+  "listeners": [
+    {
+      "type": "http",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "http-get",
+          "configuration": {
+            "messagesLimitCount":  12,
+            "messagesLimitDurationMs": 500,
+            "headersInPayload":  true,
+            "metadataInPayload": true
+          }
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default",
+      "type": "mock",
+      "endpoints": [
+        {
+          "name": "default-endpoint",
+          "type": "mock",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "messageInterval": 1,
+            "messageContent": "Mock data",
+            "messageCount": 1
+          }
+        }
+      ]
+    }
+  ],
+  "plans": [
+    {
+      "id": "plan-id",
+      "name": "Keyless",
+      "description": "keyless",
+      "security": {
+        "type": "key-less"
+      },
+      "flows": [
+        {
+          "name": "Everything",
+          "selectors": [
+            {
+              "type": "channel",
+              "operation": ["SUBSCRIBE"],
+              "channel": "/",
+              "channel-operator": "STARTS_WITH"
+            }
+          ],
+          "condition": "",
+          "response": [
+            {
+              "name": "Transform headers",
+              "description": "",
+              "enabled": true,
+              "policy": "transform-headers",
+              "configuration": {
+                "scope": "RESPONSE",
+                "addHeaders": [
+                  {
+                    "name": "X-Plan-Flow-Selected",
+                    "value": "/"
+                  }
+                ]
+              }
+            }
+          ],
+          "request": [],
+          "subscribe": [],
+          "publish": [],
+          "enabled": true
+        },
+        {
+          "name": "All books",
+          "selectors": [
+            {
+              "type": "channel",
+              "operation": ["SUBSCRIBE"],
+              "channel": "/books",
+              "channel-operator": "STARTS_WITH"
+            }
+          ],
+          "condition": "",
+          "response": [
+            {
+              "name": "Transform headers",
+              "description": "",
+              "enabled": true,
+              "policy": "transform-headers",
+              "configuration": {
+                "scope": "RESPONSE",
+                "addHeaders": [
+                  {
+                    "name": "X-Plan-Flow-Selected",
+                    "value": "/books"
+                  }
+                ]
+              }
+            }
+          ],
+          "subscribe": [],
+          "publish": [],
+          "enabled": true
+        },
+        {
+          "name": "A book",
+          "selectors": [
+            {
+              "type": "channel",
+              "operation": ["SUBSCRIBE"],
+              "channel": "/books/:bookId",
+              "channel-operator": "STARTS_WITH"
+            }
+          ],
+          "condition": "",
+          "response": [
+            {
+              "name": "Transform headers",
+              "description": "",
+              "enabled": true,
+              "policy": "transform-headers",
+              "configuration": {
+                "scope": "RESPONSE",
+                "addHeaders": [
+                  {
+                    "name": "X-Plan-Flow-Selected",
+                    "value": "/books/:bookId"
+                  }
+                ]
+              }
+            }
+          ],
+          "request": [],
+          "subscribe": [],
+          "publish": [],
+          "enabled": true
+        }
+      ],
+      "comment_required": false
+    }
+  ],
+  "flows": [
+    {
+      "name": "All books",
+      "selectors": [
+        {
+          "type": "channel",
+          "operation": ["SUBSCRIBE"],
+          "channel": "/books",
+          "channel-operator": "STARTS_WITH"
+        }
+      ],
+      "condition": "",
+      "response": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "RESPONSE",
+            "addHeaders": [
+              {
+                "name": "X-Api-Flow-Selected",
+                "value": "/books"
+              }
+            ]
+          }
+        }
+      ],
+      "request": [],
+      "subscribe": [],
+      "publish": [],
+      "enabled": true
+    },
+    {
+      "name": "A chapter of a book",
+      "selectors": [
+        {
+          "type": "channel",
+          "operation": ["SUBSCRIBE"],
+          "channel": "/books/:bookId/chapters/:chapterId",
+          "channel-operator": "STARTS_WITH"
+        }
+      ],
+      "condition": "",
+      "response": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "RESPONSE",
+            "addHeaders": [
+              {
+                "name": "X-Api-Flow-Selected",
+                "value": "/books/:bookId/chapters/:chapterId"
+              }
+            ]
+          }
+        }
+      ],
+      "request": [],
+      "subscribe": [],
+      "publish": [],
+      "enabled": true
+    },
+    {
+      "name": "A page of a chapter of a book",
+      "selectors": [
+        {
+          "type": "channel",
+          "operation": ["SUBSCRIBE"],
+          "channel": "/books/:bookId/chapters/:chapterId/pages/:pageId",
+          "channel-operator": "STARTS_WITH"
+        }
+      ],
+      "condition": "",
+      "response": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "RESPONSE",
+            "addHeaders": [
+              {
+                "name": "X-Api-Flow-Selected",
+                "value": "/books/:bookId/chapters/:chapterId/pages/:pageId"
+              }
+            ]
+          }
+        }
+      ],
+      "request": [],
+      "subscribe": [],
+      "publish": [],
+      "enabled": true
+    },
+    {
+      "name": "All chapters of book 9999",
+      "selectors": [
+        {
+          "type": "channel",
+          "operation": ["SUBSCRIBE"],
+          "channel": "/books/9999/chapters",
+          "channel-operator": "STARTS_WITH"
+        }
+      ],
+      "condition": "",
+      "response": [
+        {
+          "name": "Transform headers",
+          "description": "",
+          "enabled": true,
+          "policy": "transform-headers",
+          "configuration": {
+            "scope": "RESPONSE",
+            "addHeaders": [
+              {
+                "name": "X-Api-Flow-Selected",
+                "value": "/books/9999/chapters"
+              }
+            ]
+          }
+        }
+      ],
+      "request": [],
+      "subscribe": [],
+      "publish": [],
+      "enabled": true
+    }
+  ],
+  "resources": []
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1859

## Description

**HTTP**

- V3-V3 Compatibility-Emulation V4-V4 Http-proxy

Call different flows with best match

**Message**: Test best match

Tests should be decline using different path operators (starts_with / equals)

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-tcnpqrutiu.chromatic.com)
<!-- Storybook placeholder end -->
