### PR TITLE
fix(rest-api-v2): add mapping for the apiId when updating an API

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
@@ -104,7 +104,8 @@ public interface ApiMapper {
 
     // UpdateApi
     @Mapping(target = "listeners", qualifiedByName = "toListeners")
-    UpdateApiEntity map(UpdateApiV4 updateApi);
+    @Mapping(target = "id", expression = "java(apiId)")
+    UpdateApiEntity map(UpdateApiV4 updateApi, String apiId);
 
     io.gravitee.rest.api.model.api.UpdateApiEntity map(UpdateApiV2 updateApi);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -144,7 +144,7 @@ public class ApiResource extends AbstractResource {
     }
 
     private GenericApiEntity updateApiV4(GenericApiEntity currentEntity, UpdateApiV4 updateApiV4) {
-        UpdateApiEntity apiToUpdate = ApiMapper.INSTANCE.map(updateApiV4);
+        UpdateApiEntity apiToUpdate = ApiMapper.INSTANCE.map(updateApiV4, currentEntity.getId());
         // Force listeners if user is not the primary_owner or an administrator
         if (
             !hasPermission(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/ApiFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/ApiFixtures.java
@@ -16,7 +16,6 @@
 package fixtures;
 
 import io.gravitee.common.component.Lifecycle;
-import io.gravitee.definition.model.ResponseTemplate;
 import io.gravitee.definition.model.Rule;
 import io.gravitee.definition.model.services.Services;
 import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
@@ -33,6 +32,7 @@ import io.gravitee.rest.api.management.v2.rest.model.ExecutionMode;
 import io.gravitee.rest.api.management.v2.rest.model.FlowMode;
 import io.gravitee.rest.api.management.v2.rest.model.Listener;
 import io.gravitee.rest.api.management.v2.rest.model.Proxy;
+import io.gravitee.rest.api.management.v2.rest.model.ResponseTemplate;
 import io.gravitee.rest.api.management.v2.rest.model.UpdateApiV2;
 import io.gravitee.rest.api.management.v2.rest.model.UpdateApiV4;
 import io.gravitee.rest.api.management.v2.rest.model.Visibility;
@@ -84,7 +84,7 @@ public class ApiFixtures {
             .properties(PropertyFixtures.aModelPropertiesV2())
             .services(new Services())
             .resources(List.of(ResourceFixtures.aResourceEntityV2()))
-            .responseTemplates(Map.of("template-id", Map.of("application/json", new ResponseTemplate())))
+            .responseTemplates(Map.of("template-id", Map.of("application/json", new io.gravitee.definition.model.ResponseTemplate())))
             .updatedAt(new Date())
             .flows(List.of(FlowFixtures.aModelFlowV2()));
 
@@ -114,7 +114,7 @@ public class ApiFixtures {
         .resources(List.of(ResourceFixtures.aResourceEntityV4()))
         .flowExecution(new FlowExecution())
         .flows(List.of(FlowFixtures.aModelFlowV4()))
-        .responseTemplates(Map.of("template-id", Map.of("application/json", new ResponseTemplate())))
+        .responseTemplates(Map.of("template-id", Map.of("application/json", new io.gravitee.definition.model.ResponseTemplate())))
         .services(new io.gravitee.definition.model.v4.service.ApiServices())
         .groups(Set.of("my-group1", "my-group2"))
         .visibility(io.gravitee.rest.api.model.Visibility.PUBLIC)
@@ -193,9 +193,20 @@ public class ApiFixtures {
         .name("api-name")
         .description("api-description")
         .visibility(Visibility.PUBLIC)
+        .tags(List.of("tag1", "tag2"))
+        .groups(List.of("group1", "group2"))
+        .labels(List.of("label1", "label2"))
+        .categories(List.of("category1", "category2"))
         .analytics(new Analytics())
         .listeners(List.of(new Listener(ListenerFixtures.aHttpListener())))
-        .endpointGroups(List.of(EndpointFixtures.anEndpointGroupV4()));
+        .endpointGroups(List.of(EndpointFixtures.anEndpointGroupV4()))
+        .resources(List.of(ResourceFixtures.aResource()))
+        .properties(List.of(PropertyFixtures.aProperty()))
+        .flows(List.of(FlowFixtures.aFlowV4()))
+        .services(new ApiServices())
+        .lifecycleState(ApiLifecycleState.ARCHIVED)
+        .disableMembershipNotifications(true)
+        .responseTemplates(Map.of("template-id", Map.of("application/json", new ResponseTemplate())));
 
     public static io.gravitee.rest.api.model.api.ApiEntity aModelApiV1() {
         return BASE_MODEL_API_V1.build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapperTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.mapper;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import fixtures.ApiFixtures;
+import fixtures.CorsFixtures;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+public class ApiMapperTest {
+
+    private final ApiMapper apiMapper = Mappers.getMapper(ApiMapper.class);
+
+    @Test
+    void shouldMapToUpdateApiEntityV4() {
+        var updateApi = ApiFixtures.anUpdateApiV4();
+
+        var updateApiEntity = apiMapper.map(updateApi, "api-id");
+        assertThat(updateApiEntity).isNotNull();
+        assertThat(updateApiEntity.getId()).isEqualTo("api-id");
+        assertThat(updateApiEntity.getCrossId()).isNull();
+        assertThat(updateApiEntity.getName()).isEqualTo(updateApi.getName());
+        assertThat(updateApiEntity.getApiVersion()).isEqualTo(updateApi.getApiVersion());
+        assertThat(updateApiEntity.getDefinitionVersion().name()).isEqualTo(updateApi.getDefinitionVersion().name());
+        assertThat(updateApiEntity.getType().name()).isEqualTo(updateApi.getType().name());
+        assertThat(updateApiEntity.getDescription()).isEqualTo(updateApi.getDescription());
+        assertThat(new ArrayList<>(updateApiEntity.getTags())).isEqualTo(updateApi.getTags());
+        assertThat(updateApiEntity.getListeners()).isNotNull(); // Tested in ListenerMapperTest
+        assertThat(updateApiEntity.getEndpointGroups()).isNotNull(); // Tested in EndpointMapperTest
+        assertThat(updateApiEntity.getAnalytics()).isNotNull();
+        assertThat(updateApiEntity.getProperties()).isNotNull(); // Tested in PropertiesMapperTest
+        assertThat(updateApiEntity.getResources()).isNotNull(); // Tested in ResourceMapperTest
+        assertThat(updateApiEntity.getPlans().size()).isEqualTo(0);
+        assertThat(updateApiEntity.getFlowExecution()).usingRecursiveAssertion().isEqualTo(updateApi.getFlowExecution());
+        assertThat(updateApiEntity.getFlows()).isNotNull(); // Tested in FlowMapperTest
+        assertThat(updateApiEntity.getResponseTemplates()).isNotNull();
+        assertThat(updateApiEntity.getServices()).isNotNull(); // Tested in ServiceMapperTest
+        assertThat(new ArrayList<>(updateApiEntity.getGroups())).isEqualTo(updateApi.getGroups());
+        assertThat(updateApiEntity.getVisibility().name()).isEqualTo(updateApi.getVisibility().name());
+        assertThat(new ArrayList<>(updateApiEntity.getCategories())).isEqualTo(updateApi.getCategories());
+        assertThat(updateApiEntity.getLabels()).isEqualTo(updateApi.getLabels());
+        assertThat(updateApiEntity.getMetadata()).isNull();
+        assertThat(updateApiEntity.getLifecycleState().name()).isEqualTo(updateApi.getLifecycleState().name());
+        assertThat(updateApiEntity.isDisableMembershipNotifications()).isEqualTo(updateApi.getDisableMembershipNotifications());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiTest.java
@@ -107,6 +107,7 @@ public class ApiResource_UpdateApiTest extends ApiResourceTest {
                 eq(API),
                 argThat(updateApiEntity -> {
                     assertEquals(updateApiV4.getName(), updateApiEntity.getName());
+                    assertEquals(API, updateApiEntity.getId());
                     return true;
                 }),
                 eq(false),


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1515

## Description

When updating a V4 API, the id is not in the payload but is expected in the service layer.
This PR adds the missing mapping + unit tests.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kgpsykzdjh.chromatic.com)
<!-- Storybook placeholder end -->
