### PR TITLE
test: add webhook kafka integration test

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/AbstractGatewayTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/AbstractGatewayTest.java
@@ -51,6 +51,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.platform.commons.PreconditionViolationException;
@@ -69,6 +71,7 @@ import org.springframework.util.StringUtils;
  */
 @Slf4j
 @ExtendWith(VertxExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public abstract class AbstractGatewayTest implements PluginRegister, ApiConfigurer, ApplicationContextAware {
 
     private static final ObjectMapper objectMapper = new GraviteeMapper();

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/webhook/WebhookEntrypoinSolaceEndpointIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/webhook/WebhookEntrypoinSolaceEndpointIntegrationTest.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.messages.webhook;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.graviteesource.entrypoint.webhook.WebhookEntrypointConnectorFactory;
+import com.graviteesource.entrypoint.webhook.configuration.HttpHeader;
+import com.solace.messaging.publisher.OutboundMessageBuilder;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.integration.tests.messages.AbstractSolaceEndpointIntegrationTest;
+import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.reactive.reactor.v4.subscription.SubscriptionDispatcher;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.reactivex.rxjava3.disposables.Disposable;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class WebhookEntrypoinSolaceEndpointIntegrationTest extends AbstractSolaceEndpointIntegrationTest {
+
+    private static final String WEBHOOK_URL_PATH = "/webhook";
+
+    private WebhookTestingActions webhookActions;
+    private OutboundMessageBuilder outboundMessageBuilder;
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("webhook", EntrypointBuilder.build("webhook", WebhookEntrypointConnectorFactory.class));
+    }
+
+    @BeforeEach
+    void setUp() {
+        webhookActions = new WebhookTestingActions(wiremock, getBean(SubscriptionDispatcher.class));
+        outboundMessageBuilder = messagingService.messageBuilder();
+    }
+
+    @Test
+    @DeployApi({ "/apis/v4/messages/webhook/webhook-entrypoint-solace-endpoint.json" })
+    void should_receive_all_messages_without_header() throws JsonProcessingException {
+        final String callbackPath = WEBHOOK_URL_PATH + "/without-header";
+
+        Subscription subscription = webhookActions.configureSubscriptionAndCallback("webhook-entrypoint-solace-endpoint", callbackPath);
+
+        final Disposable disposableSubscription = webhookActions.dispatchSubscription(subscription).subscribe();
+
+        // Publish several messages after a delay, to be sure the subscription has been fully dispatched and consumes message
+        publishToSolace(
+            topic,
+            List.of(
+                outboundMessageBuilder.build("message1".getBytes()),
+                outboundMessageBuilder.build("message2".getBytes()),
+                outboundMessageBuilder.build("message3".getBytes())
+            ),
+            5000
+        )
+            .blockingAwait();
+
+        // Wait for the webhook to have received 3 requests (message1, message2 and message3)
+        webhookActions.waitForRequestsOnCallback(3, callbackPath, disposableSubscription);
+
+        // verify requests received by wiremock
+        wiremock.verify(1, postRequestedFor(urlPathEqualTo(callbackPath)).withRequestBody(equalTo("message1")));
+        wiremock.verify(1, postRequestedFor(urlPathEqualTo(callbackPath)).withRequestBody(equalTo("message2")));
+        wiremock.verify(1, postRequestedFor(urlPathEqualTo(callbackPath)).withRequestBody(equalTo("message3")));
+
+        // close the subscription to avoid maintaining it between test methods
+        webhookActions.closeSubscription(subscription);
+    }
+
+    @Test
+    @DeployApi({ "/apis/v4/messages/webhook/webhook-entrypoint-solace-endpoint.json" })
+    void should_receive_all_messages_with_additional_headers() throws JsonProcessingException {
+        final String callbackPath = WEBHOOK_URL_PATH + "/without-header";
+
+        Subscription subscription = webhookActions.configureSubscriptionAndCallback(
+            "webhook-entrypoint-solace-endpoint",
+            callbackPath,
+            null,
+            List.of(new HttpHeader("Header1", "my-header-1-value"), new HttpHeader("Header2", "my-header-2-value"))
+        );
+
+        // Publish a first message that is retained before subscribing
+        final Disposable disposableSubscription = webhookActions.dispatchSubscription(subscription).subscribe();
+
+        // Publish several messages after a delay, to be sure the subscription has been fully dispatched and consumes message
+        publishToSolace(
+            topic,
+            List.of(
+                outboundMessageBuilder.build("message1".getBytes()),
+                outboundMessageBuilder.build("message2".getBytes()),
+                outboundMessageBuilder.build("message3".getBytes())
+            ),
+            5000
+        )
+            .blockingAwait();
+
+        // Wait for the webhook to have received 4 requests (message, message1, message2 and message3)
+        webhookActions.waitForRequestsOnCallback(3, callbackPath, disposableSubscription);
+
+        // verify requests received by wiremock
+        wiremock.verify(
+            1,
+            postRequestedFor(urlPathEqualTo(callbackPath))
+                .withRequestBody(equalTo("message1"))
+                .withHeader("Header1", equalTo("my-header-1-value"))
+                .withHeader("Header2", equalTo("my-header-2-value"))
+        );
+        wiremock.verify(
+            1,
+            postRequestedFor(urlPathEqualTo(callbackPath))
+                .withRequestBody(equalTo("message2"))
+                .withHeader("Header1", equalTo("my-header-1-value"))
+                .withHeader("Header2", equalTo("my-header-2-value"))
+        );
+        wiremock.verify(
+            1,
+            postRequestedFor(urlPathEqualTo(callbackPath))
+                .withRequestBody(equalTo("message3"))
+                .withHeader("Header1", equalTo("my-header-1-value"))
+                .withHeader("Header2", equalTo("my-header-2-value"))
+        );
+
+        // close the subscription to avoid maintaining it between test methods
+        webhookActions.closeSubscription(subscription);
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/webhook/WebhookEntrypointKafkaEndpointIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/webhook/WebhookEntrypointKafkaEndpointIntegrationTest.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.messages.webhook;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.graviteesource.entrypoint.webhook.WebhookEntrypointConnectorFactory;
+import com.graviteesource.entrypoint.webhook.configuration.HttpHeader;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.integration.tests.messages.AbstractKafkaEndpointIntegrationTest;
+import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.reactive.reactor.v4.subscription.SubscriptionDispatcher;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.rxjava3.core.Vertx;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+class WebhookEntrypointKafkaEndpointIntegrationTest extends AbstractKafkaEndpointIntegrationTest {
+
+    private static final String WEBHOOK_URL_PATH = "/webhook";
+
+    private WebhookTestingActions webhookActions;
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("webhook", EntrypointBuilder.build("webhook", WebhookEntrypointConnectorFactory.class));
+    }
+
+    @BeforeEach
+    public void prepare() {
+        webhookActions = new WebhookTestingActions(wiremock, getBean(SubscriptionDispatcher.class));
+    }
+
+    @Test
+    @DeployApi({ "/apis/v4/messages/webhook/webhook-entrypoint-kafka-endpoint.json" })
+    void should_receive_all_messages_without_header(Vertx vertx) throws JsonProcessingException {
+        final String callbackPath = WEBHOOK_URL_PATH + "/without-header";
+
+        // In order to simplify the test, Kafka endpoint's consumer is configured with "autoOffsetReset": "earliest"
+        // It allows us to publish the messages in the topic before opening the api connection.
+        Single
+            .fromCallable(() -> getKafkaProducer(vertx))
+            .flatMapCompletable(producer ->
+                publishToKafka(producer, "message1")
+                    .andThen(publishToKafka(producer, "message2"))
+                    .andThen(publishToKafka(producer, "message3"))
+                    .doFinally(producer::close)
+            )
+            .blockingAwait();
+
+        Subscription subscription = webhookActions.configureSubscriptionAndCallback("webhook-entrypoint-kafka-endpoint", callbackPath);
+
+        webhookActions.dispatchSubscriptionAndWaitForRequestsOnCallback(subscription, 3, callbackPath);
+
+        // verify requests received by wiremock
+        wiremock.verify(1, postRequestedFor(urlPathEqualTo(callbackPath)).withRequestBody(equalTo("message1")));
+        wiremock.verify(1, postRequestedFor(urlPathEqualTo(callbackPath)).withRequestBody(equalTo("message2")));
+        wiremock.verify(1, postRequestedFor(urlPathEqualTo(callbackPath)).withRequestBody(equalTo("message3")));
+
+        // close the subscription to avoid maintaining it between test methods
+        webhookActions.closeSubscription(subscription);
+    }
+
+    @Test
+    @DeployApi({ "/apis/v4/messages/webhook/webhook-entrypoint-kafka-endpoint.json" })
+    void should_receive_all_messages_with_additional_headers(Vertx vertx) throws JsonProcessingException {
+        final String callbackPath = WEBHOOK_URL_PATH + "/with-header";
+
+        // In order to simplify the test, Kafka endpoint's consumer is configured with "autoOffsetReset": "earliest"
+        // It allows us to publish the messages in the topic before opening the api connection.
+        Single
+            .fromCallable(() -> getKafkaProducer(vertx))
+            .flatMapCompletable(producer ->
+                publishToKafka(producer, "message1")
+                    .andThen(publishToKafka(producer, "message2"))
+                    .andThen(publishToKafka(producer, "message3"))
+                    .doFinally(producer::close)
+            )
+            .blockingAwait();
+
+        Subscription subscription = webhookActions.configureSubscriptionAndCallback(
+            "webhook-entrypoint-kafka-endpoint",
+            callbackPath,
+            null,
+            List.of(new HttpHeader("Header1", "my-header-1-value"), new HttpHeader("Header2", "my-header-2-value"))
+        );
+
+        webhookActions.dispatchSubscriptionAndWaitForRequestsOnCallback(subscription, 3, callbackPath);
+        // verify requests received by wiremock
+        wiremock.verify(
+            1,
+            postRequestedFor(urlPathEqualTo(callbackPath))
+                .withRequestBody(equalTo("message1"))
+                .withHeader("Header1", equalTo("my-header-1-value"))
+                .withHeader("Header2", equalTo("my-header-2-value"))
+        );
+        wiremock.verify(
+            1,
+            postRequestedFor(urlPathEqualTo(callbackPath))
+                .withRequestBody(equalTo("message2"))
+                .withHeader("Header1", equalTo("my-header-1-value"))
+                .withHeader("Header2", equalTo("my-header-2-value"))
+        );
+        wiremock.verify(
+            1,
+            postRequestedFor(urlPathEqualTo(callbackPath))
+                .withRequestBody(equalTo("message3"))
+                .withHeader("Header1", equalTo("my-header-1-value"))
+                .withHeader("Header2", equalTo("my-header-2-value"))
+        );
+
+        // close the subscription to avoid maintaining it between test methods
+        webhookActions.closeSubscription(subscription);
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/webhook/WebhookEntrypointMockEndpointIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/webhook/WebhookEntrypointMockEndpointIntegrationTest.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.messages.webhook;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static io.reactivex.rxjava3.core.Observable.interval;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.graviteesource.entrypoint.webhook.WebhookEntrypointConnectorFactory;
+import com.graviteesource.entrypoint.webhook.configuration.HttpHeader;
+import com.graviteesource.entrypoint.webhook.configuration.WebhookEntrypointConnectorSubscriptionConfiguration;
+import com.graviteesource.reactor.message.MessageApiReactorFactory;
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.reactor.ReactorBuilder;
+import io.gravitee.apim.plugin.reactor.ReactorPlugin;
+import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.api.service.SubscriptionConfiguration;
+import io.gravitee.gateway.reactive.reactor.v4.reactor.ReactorFactory;
+import io.gravitee.gateway.reactive.reactor.v4.subscription.SubscriptionDispatcher;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.reactivex.rxjava3.core.Completable;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+class WebhookEntrypointMockEndpointIntegrationTest extends AbstractGatewayTest {
+
+    private static final String API_ID = "my-api";
+    private static final String WEBHOOK_URL_PATH = "/webhook";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    public void configureReactors(Set<ReactorPlugin<? extends ReactorFactory<?>>> reactors) {
+        reactors.add(ReactorBuilder.build(MessageApiReactorFactory.class));
+    }
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("webhook", EntrypointBuilder.build("webhook", WebhookEntrypointConnectorFactory.class));
+    }
+
+    @Test
+    @DisplayName("Should send messages from mock endpoint to webhook entrypoint callback URL")
+    @DeployApi({ "/apis/v4/messages/webhook/api.json" })
+    void shouldSendMessagesFromMockEndpointToWebhookEntrypoint() throws JsonProcessingException {
+        WebhookEntrypointConnectorSubscriptionConfiguration configuration = new WebhookEntrypointConnectorSubscriptionConfiguration();
+        final String callbackPath = WEBHOOK_URL_PATH + "/without-header";
+        configuration.setCallbackUrl(String.format("http://localhost:%s%s", wiremock.port(), callbackPath));
+        wiremock.stubFor(post(callbackPath).willReturn(ok()));
+
+        Subscription subscription = buildTestSubscription(configuration);
+
+        dispatchSubscription(subscription)
+            .andThen(
+                interval(50, MILLISECONDS)
+                    .takeWhile(i -> wiremock.countRequestsMatching(anyRequestedFor(urlPathEqualTo(callbackPath)).build()).getCount() < 7)
+            )
+            .test()
+            .awaitDone(10, SECONDS)
+            .assertComplete();
+
+        // verify requests received by wiremock
+        wiremock.verify(7, postRequestedFor(urlPathEqualTo(callbackPath)).withRequestBody(equalTo("Mock data")));
+
+        // close the subscription to avoid maintaining it between test methods
+        subscription.setStatus("CLOSED");
+        dispatchSubscription(subscription).blockingAwait();
+    }
+
+    @Test
+    @DisplayName("Should send messages from mock endpoint to webhook entrypoint callback URL, with additional headers")
+    @DeployApi({ "/apis/v4/messages/webhook/api.json" })
+    void shouldSendMessagesFromMockEndpointToWebhookEntrypointWithHeaders() throws JsonProcessingException {
+        WebhookEntrypointConnectorSubscriptionConfiguration configuration = new WebhookEntrypointConnectorSubscriptionConfiguration();
+        final String callbackPath = WEBHOOK_URL_PATH + "/with-headers";
+        configuration.setCallbackUrl(String.format("http://localhost:%s%s", wiremock.port(), callbackPath));
+        configuration.setHeaders(List.of(new HttpHeader("Header1", "my-header-1-value"), new HttpHeader("Header2", "my-header-2-value")));
+        wiremock.stubFor(post(callbackPath).willReturn(ok()));
+
+        Subscription subscription = buildTestSubscription(configuration);
+        subscription.setApi(API_ID);
+
+        dispatchSubscription(subscription)
+            .andThen(
+                // wait for callback wiremock to receive 7 requests (timeouts after 1 sec)
+                interval(50, MILLISECONDS)
+                    .takeWhile(i -> wiremock.countRequestsMatching(anyRequestedFor(urlPathEqualTo(callbackPath)).build()).getCount() < 7)
+            )
+            .test()
+            .awaitDone(10, SECONDS)
+            .assertComplete();
+
+        // verify requests received by wiremock
+        wiremock.verify(
+            7,
+            postRequestedFor(urlPathEqualTo(callbackPath))
+                .withRequestBody(equalTo("Mock data"))
+                .withHeader("Header1", equalTo("my-header-1-value"))
+                .withHeader("Header2", equalTo("my-header-2-value"))
+        );
+
+        // close the subscription to avoid maintaining it between test methods
+        subscription.setStatus("CLOSED");
+        dispatchSubscription(subscription).blockingAwait();
+    }
+
+    private Completable dispatchSubscription(Subscription subscription) {
+        return getBean(SubscriptionDispatcher.class).dispatch(subscription);
+    }
+
+    private Subscription buildTestSubscription(WebhookEntrypointConnectorSubscriptionConfiguration configuration)
+        throws JsonProcessingException {
+        Subscription subscription = new Subscription();
+        subscription.setApi(API_ID);
+        subscription.setId(UUID.randomUUID().toString());
+        subscription.setStatus("ACCEPTED");
+        SubscriptionConfiguration subscriptionConfiguration = new SubscriptionConfiguration(
+            "subscribe",
+            "webhook",
+            MAPPER.writeValueAsString(configuration)
+        );
+        subscription.setConfiguration(subscriptionConfiguration);
+        return subscription;
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/webhook/WebhookEntrypointMqttEndpointIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/webhook/WebhookEntrypointMqttEndpointIntegrationTest.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.messages.webhook;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.graviteesource.entrypoint.webhook.WebhookEntrypointConnectorFactory;
+import com.graviteesource.entrypoint.webhook.configuration.HttpHeader;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.integration.tests.messages.AbstractMqtt5EndpointIntegrationTest;
+import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.reactive.reactor.v4.subscription.SubscriptionDispatcher;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.reactivex.rxjava3.disposables.Disposable;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class WebhookEntrypointMqttEndpointIntegrationTest extends AbstractMqtt5EndpointIntegrationTest {
+
+    private static final String WEBHOOK_URL_PATH = "/webhook";
+
+    private WebhookTestingActions webhookActions;
+
+    @Override
+    public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("webhook", EntrypointBuilder.build("webhook", WebhookEntrypointConnectorFactory.class));
+    }
+
+    @BeforeEach
+    void setUp() {
+        webhookActions = new WebhookTestingActions(wiremock, getBean(SubscriptionDispatcher.class));
+    }
+
+    @Test
+    @DeployApi({ "/apis/v4/messages/webhook/webhook-entrypoint-mqtt5-endpoint.json" })
+    void should_receive_all_messages_without_header() throws JsonProcessingException {
+        final String callbackPath = WEBHOOK_URL_PATH + "/without-header";
+
+        Subscription subscription = webhookActions.configureSubscriptionAndCallback("webhook-entrypoint-mqtt5-endpoint", callbackPath);
+
+        // Publish a first message that is retained before subscribing
+        blockingPublishToMqtt5(mqtt5RxClient, TEST_TOPIC, "message", true);
+        final Disposable disposableSubscription = webhookActions.dispatchSubscription(subscription).subscribe();
+        // Wait for the first request to be done on the webhook. It means the subscription is fully dispatched and we started to consume messages.
+        webhookActions.waitForRequestsOnCallback(1, callbackPath);
+
+        // Publish several messages
+        publishToMqtt5(mqtt5RxClient, TEST_TOPIC, "message1", false)
+            .flatMap(mapper -> publishToMqtt5(mqtt5RxClient, TEST_TOPIC, "message2", false))
+            .flatMap(mapper -> publishToMqtt5(mqtt5RxClient, TEST_TOPIC, "message3", false))
+            .ignoreElements()
+            .blockingAwait();
+
+        // Wait for the webhook to have received 4 requests (message, message1, message2 and message3)
+        webhookActions.waitForRequestsOnCallback(4, callbackPath, disposableSubscription);
+
+        // verify requests received by wiremock
+        wiremock.verify(1, postRequestedFor(urlPathEqualTo(callbackPath)).withRequestBody(equalTo("message")));
+        wiremock.verify(1, postRequestedFor(urlPathEqualTo(callbackPath)).withRequestBody(equalTo("message1")));
+        wiremock.verify(1, postRequestedFor(urlPathEqualTo(callbackPath)).withRequestBody(equalTo("message2")));
+        wiremock.verify(1, postRequestedFor(urlPathEqualTo(callbackPath)).withRequestBody(equalTo("message3")));
+
+        // close the subscription to avoid maintaining it between test methods
+        webhookActions.closeSubscription(subscription);
+    }
+
+    @Test
+    @DeployApi({ "/apis/v4/messages/webhook/webhook-entrypoint-mqtt5-endpoint.json" })
+    void should_receive_all_messages_with_additional_headers() throws JsonProcessingException {
+        final String callbackPath = WEBHOOK_URL_PATH + "/without-header";
+
+        Subscription subscription = webhookActions.configureSubscriptionAndCallback(
+            "webhook-entrypoint-mqtt5-endpoint",
+            callbackPath,
+            null,
+            List.of(new HttpHeader("Header1", "my-header-1-value"), new HttpHeader("Header2", "my-header-2-value"))
+        );
+
+        // Publish a first message that is retained before subscribing
+        blockingPublishToMqtt5(mqtt5RxClient, TEST_TOPIC, "message", true);
+        final Disposable disposableSubscription = webhookActions.dispatchSubscription(subscription).subscribe();
+        // Wait for the first request to be done on the webhook. It means the subscription is fully dispatched and we started to consume messages.
+        webhookActions.waitForRequestsOnCallback(1, callbackPath);
+
+        // Publish several messages
+        publishToMqtt5(mqtt5RxClient, TEST_TOPIC, "message1", false)
+            .flatMap(mapper -> publishToMqtt5(mqtt5RxClient, TEST_TOPIC, "message2", false))
+            .flatMap(mapper -> publishToMqtt5(mqtt5RxClient, TEST_TOPIC, "message3", false))
+            .ignoreElements()
+            .blockingAwait();
+
+        // Wait for the webhook to have received 4 requests (message, message1, message2 and message3)
+        webhookActions.waitForRequestsOnCallback(4, callbackPath, disposableSubscription);
+
+        // verify requests received by wiremock
+        wiremock.verify(
+            1,
+            postRequestedFor(urlPathEqualTo(callbackPath))
+                .withRequestBody(equalTo("message"))
+                .withHeader("Header1", equalTo("my-header-1-value"))
+                .withHeader("Header2", equalTo("my-header-2-value"))
+        );
+        wiremock.verify(
+            1,
+            postRequestedFor(urlPathEqualTo(callbackPath))
+                .withRequestBody(equalTo("message1"))
+                .withHeader("Header1", equalTo("my-header-1-value"))
+                .withHeader("Header2", equalTo("my-header-2-value"))
+        );
+        wiremock.verify(
+            1,
+            postRequestedFor(urlPathEqualTo(callbackPath))
+                .withRequestBody(equalTo("message2"))
+                .withHeader("Header1", equalTo("my-header-1-value"))
+                .withHeader("Header2", equalTo("my-header-2-value"))
+        );
+        wiremock.verify(
+            1,
+            postRequestedFor(urlPathEqualTo(callbackPath))
+                .withRequestBody(equalTo("message3"))
+                .withHeader("Header1", equalTo("my-header-1-value"))
+                .withHeader("Header2", equalTo("my-header-2-value"))
+        );
+
+        // close the subscription to avoid maintaining it between test methods
+        webhookActions.closeSubscription(subscription);
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/webhook/WebhookTestingActions.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/webhook/WebhookTestingActions.java
@@ -1,0 +1,180 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.messages.webhook;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static io.reactivex.rxjava3.core.Observable.interval;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.graviteesource.entrypoint.webhook.configuration.HttpHeader;
+import com.graviteesource.entrypoint.webhook.configuration.SecurityType;
+import com.graviteesource.entrypoint.webhook.configuration.WebhookEntrypointConnectorSubscriptionConfiguration;
+import com.graviteesource.entrypoint.webhook.configuration.WebhookSubscriptionAuthConfiguration;
+import io.gravitee.gateway.api.service.Subscription;
+import io.gravitee.gateway.api.service.SubscriptionConfiguration;
+import io.gravitee.gateway.reactive.reactor.v4.subscription.SubscriptionDispatcher;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.disposables.Disposable;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Useful methods to use for webhook related tests
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class WebhookTestingActions {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final WireMockServer wiremock;
+    private final SubscriptionDispatcher subscriptionDispatcher;
+
+    public WebhookTestingActions(WireMockServer wireMock, SubscriptionDispatcher subscriptionDispatcher) {
+        this.wiremock = wireMock;
+        this.subscriptionDispatcher = subscriptionDispatcher;
+    }
+
+    /**
+     * Dispatches a subscription
+     * @param subscription to dispatch
+     * @return a completable when subscription is dispatched
+     */
+    public Completable dispatchSubscription(Subscription subscription) {
+        return subscriptionDispatcher.dispatch(subscription);
+    }
+
+    /**
+     * Waits for the `callback` configured on wiremock to receive `requestCounts` requests
+     * @param requestCounts is the number of requests expected on the callback
+     * @param callback is the callback url
+     */
+    public void waitForRequestsOnCallback(int requestCounts, String callback) {
+        interval(50, MILLISECONDS)
+            .takeWhile(i -> wiremock.countRequestsMatching(anyRequestedFor(urlPathEqualTo(callback)).build()).getCount() < requestCounts)
+            .test()
+            .awaitDone(10, SECONDS)
+            .assertComplete();
+    }
+
+    /**
+     * Waits for the `callback` configured on wiremock to receive `requestCounts` requests
+     * @param requestCounts is the number of requests expected on the callback
+     * @param callback is the callback url
+     * @param dispatchSubscription is the Disposable returned by the dispatchSubscription call. When we received all the expected messages, we dispose it.
+     */
+    public void waitForRequestsOnCallback(int requestCounts, String callback, Disposable dispatchSubscription) {
+        interval(50, MILLISECONDS)
+            .takeWhile(i -> wiremock.countRequestsMatching(anyRequestedFor(urlPathEqualTo(callback)).build()).getCount() < requestCounts)
+            .doOnComplete(dispatchSubscription::dispose)
+            .test()
+            .awaitDone(10, SECONDS)
+            .assertComplete();
+    }
+
+    /**
+     * Concatenation of {@link this#dispatchSubscription(Subscription)} and {@link this#waitForRequestsOnCallback(int, String, Disposable)}
+     * It will dispatch the subscription, wait for the good number of requests on the defined callback and dispose the dispatchSubscription.
+     * @param subscription the subscription to dispatch
+     * @param requestCounts is the number of requests expected on the callback
+     * @param callback is the callback url
+     */
+    public void dispatchSubscriptionAndWaitForRequestsOnCallback(Subscription subscription, int requestCounts, String callback) {
+        final Disposable dispatch = dispatchSubscription(subscription).subscribe();
+        waitForRequestsOnCallback(requestCounts, callback, dispatch);
+    }
+
+    /**
+     * Closes the subscription
+     * @param subscription to close
+     */
+    public void closeSubscription(Subscription subscription) {
+        subscription.setStatus("CLOSED");
+        dispatchSubscription(subscription).blockingAwait();
+    }
+
+    /**
+     * Configures a {@link Subscription} object to be deployed and the wiremock target accordingly.
+     * 🔓 Default authentication chosen for subscription configuration and wiremock is Basic. Everything is already configured
+     * @param apiId is the id of the api to configure in the subscription. ⚠️ It must match the id used in the api you want to test.
+     * @param callbackPath is the path of callback to reach.
+     * @return the {@link Subscription} object.
+     * @throws JsonProcessingException
+     */
+    public Subscription configureSubscriptionAndCallback(String apiId, String callbackPath) throws JsonProcessingException {
+        return configureSubscriptionAndCallback(apiId, callbackPath, null, null);
+    }
+
+    /**
+     * Configures a {@link Subscription} object to be deployed and the wiremock target accordingly.
+     * @param apiId is the id of the api to configure in the subscription. ⚠️ It must match the id used in the api you want to test.
+     * @param callbackPath is the path of callback to reach.
+     * @param authConfiguration is the authentication configuration of the webhook subscription
+     * @param headers are the additional headers to send to callback
+     * @return the {@link Subscription} object.
+     * @throws JsonProcessingException
+     */
+    public Subscription configureSubscriptionAndCallback(
+        String apiId,
+        String callbackPath,
+        WebhookSubscriptionAuthConfiguration authConfiguration,
+        List<HttpHeader> headers
+    ) throws JsonProcessingException {
+        WebhookEntrypointConnectorSubscriptionConfiguration configuration = new WebhookEntrypointConnectorSubscriptionConfiguration();
+        configuration.setCallbackUrl(String.format("http://localhost:%s%s", wiremock.port(), callbackPath));
+        final WebhookSubscriptionAuthConfiguration auth = prepareWebhookAuth(authConfiguration);
+        configuration.setAuth(auth);
+        configuration.setHeaders(headers);
+        wiremock.stubFor(
+            post(callbackPath).withBasicAuth(auth.getBasic().getUsername(), auth.getBasic().getPassword()).willReturn(ok("callback body"))
+        );
+
+        return buildTestSubscription(apiId, configuration);
+    }
+
+    private WebhookSubscriptionAuthConfiguration prepareWebhookAuth(WebhookSubscriptionAuthConfiguration authConfiguration) {
+        return authConfiguration == null
+            ? new WebhookSubscriptionAuthConfiguration( // TODO: currently we have to default to basic auth, but would be better with no auth
+                SecurityType.BASIC,
+                WebhookSubscriptionAuthConfiguration.Basic.builder().username("toto").password("password").build(),
+                null,
+                null
+            )
+            : authConfiguration;
+    }
+
+    private Subscription buildTestSubscription(String apiId, WebhookEntrypointConnectorSubscriptionConfiguration configuration)
+        throws JsonProcessingException {
+        Subscription subscription = new Subscription();
+        subscription.setApi(apiId);
+        subscription.setId(UUID.randomUUID().toString());
+        subscription.setStatus("ACCEPTED");
+        SubscriptionConfiguration subscriptionConfiguration = new SubscriptionConfiguration(
+            "subscribe",
+            "webhook",
+            MAPPER.writeValueAsString(configuration)
+        );
+        subscription.setConfiguration(subscriptionConfiguration);
+        return subscription;
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/webhook/api.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/webhook/api.json
@@ -1,0 +1,43 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "apiVersion": "1.0",
+  "definitionVersion": "4.0.0",
+  "type": "message",
+  "description": "API v4 using webhook entrypoint",
+  "listeners": [
+    {
+      "type": "subscription",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "webhook"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default",
+      "type": "mock",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "mock",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "messageInterval": 5,
+            "messageContent": "Mock data",
+            "messageCount": 7
+          }
+        }
+      ]
+    }
+  ],
+  "flows": []
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/webhook/webhook-entrypoint-kafka-endpoint.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/webhook/webhook-entrypoint-kafka-endpoint.json
@@ -1,0 +1,51 @@
+{
+  "id": "webhook-entrypoint-kafka-endpoint",
+  "name": "my-api-auto",
+  "apiVersion": "1.0",
+  "definitionVersion": "4.0.0",
+  "type": "message",
+  "description": "api v4 using Webhook entrypoint",
+  "listeners": [
+    {
+      "type": "subscription",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "webhook"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "kafka",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "kafka",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "bootstrapServers": "bootstrap-server"
+          },
+          "sharedConfigurationOverride": {
+            "consumer": {
+              "enabled": true,
+              "topics": ["test-topic"],
+              "autoOffsetReset": "earliest"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/webhook/webhook-entrypoint-mqtt5-endpoint.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/webhook/webhook-entrypoint-mqtt5-endpoint.json
@@ -1,0 +1,51 @@
+{
+  "id": "webhook-entrypoint-mqtt5-endpoint",
+  "name": "my-api-auto",
+  "apiVersion": "1.0",
+  "definitionVersion": "4.0.0",
+  "type": "message",
+  "description": "api v4 using Webhook entrypoint",
+  "listeners": [
+    {
+      "type": "subscription",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "webhook"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "mqtt5",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "mqtt5",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "serverHost": "localhost",
+            "serverPort": "mqtt5-port"
+          },
+          "sharedConfigurationOverride": {
+            "consumer": {
+              "enabled": true,
+              "topic": "test-topic"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [],
+  "analytics": {
+    "enabled": false
+  }
+}

--- a/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/webhook/webhook-entrypoint-solace-endpoint.json
+++ b/gravitee-apim-integration-tests/src/test/resources/apis/v4/messages/webhook/webhook-entrypoint-solace-endpoint.json
@@ -1,0 +1,57 @@
+{
+  "id": "webhook-entrypoint-solace-endpoint",
+  "name": "my-api-auto",
+  "apiVersion": "1.0",
+  "definitionVersion": "4.0.0",
+  "type": "message",
+  "description": "api v4 using Webhook entrypoint",
+  "listeners": [
+    {
+      "type": "subscription",
+      "paths": [
+        {
+          "path": "/test"
+        }
+      ],
+      "entrypoints": [
+        {
+          "type": "webhook"
+        }
+      ]
+    }
+  ],
+  "endpointGroups": [
+    {
+      "name": "default-group",
+      "type": "solace",
+      "endpoints": [
+        {
+          "name": "default",
+          "type": "solace",
+          "weight": 1,
+          "inheritConfiguration": false,
+          "configuration": {
+            "url": "solace-url",
+            "vpnName": "default"
+          },
+          "sharedConfigurationOverride": {
+            "consumer": {
+              "enabled": true,
+              "topics": ["test-topic"]
+            },
+            "security": {
+              "auth" : {
+                "username" : "admin",
+                "password" : "admin"
+              }
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "flows": [],
+  "analytics": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1869

## Description

- **Kafka**: `autoOffsetReset` configured to `earliest` so that message can be published before the subscription starts to consume messages.
- **Mqtt5**: 
  - First, send a message that is retained
  - Dispatch the subscription and wait for webhook to receive the first message: the subscription is well dispatched 🚀 
  - Publish new messages and verify webhook receive them
- **Solace**: Dispatch the subscription and wait before publishing the message. No other way to chain that properly for now. 


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hmfraojljn.chromatic.com)
<!-- Storybook placeholder end -->
