### PR TITLE
fix: filter to have only subscribed apis in application logs

### DIFF
--- a/gravitee-apim-console-webui/src/components/logs/logs-filters.controller.ts
+++ b/gravitee-apim-console-webui/src/components/logs/logs-filters.controller.ts
@@ -344,6 +344,17 @@ class LogsFiltersController {
   }
 
   async searchApis(term) {
+    if (this.context === 'application') {
+      const searchResult = await this.ApplicationService.getSubscribedAPI(this.$state.params.applicationId);
+      let result = searchResult.data;
+      if (term) {
+        result = searchResult.data.filter((api) => {
+          return api.name.toLowerCase().includes(term.toLowerCase());
+        });
+      }
+      return result.slice(0, 10);
+    }
+
     const { data: searchResult } = await this.ApiService.searchApis(term, 1, null, null, 10);
     return searchResult.data;
   }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1872

## Description

Currently in application's logs the API filter always contains all apis even if you didn't subscribe to it. This quick fix allow the user to only filter on the subscribed apis in the application logs. 
During the angular migration we will have to change it and update the resource on the backend to have a real pagination and use the search engine.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

