### PR TITLE
MAPI V2 - map null collections into empty collectiond

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PropertiesMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PropertiesMapper.java
@@ -20,9 +20,10 @@ import io.gravitee.rest.api.model.PropertiesEntity;
 import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.NullValueMappingStrategy;
 import org.mapstruct.factory.Mappers;
 
-@Mapper
+@Mapper(nullValueIterableMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
 public interface PropertiesMapper {
     PropertiesMapper INSTANCE = Mappers.getMapper(PropertiesMapper.class);
 
@@ -46,7 +47,7 @@ public interface PropertiesMapper {
 
     default PropertiesEntity mapToPropertiesEntityV2(List<Property> propertyList) {
         if (propertyList == null) {
-            return null;
+            return new PropertiesEntity();
         }
         return new PropertiesEntity(this.mapToPropertyEntityV2List(propertyList));
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PropertiesMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PropertiesMapperTest.java
@@ -31,6 +31,14 @@ public class PropertiesMapperTest {
     private final PropertiesMapper propertiesMapper = Mappers.getMapper(PropertiesMapper.class);
 
     @Test
+    void shouldMapToEmptyPropertyEntityV4List() {
+        var propertyEntityV4List = propertiesMapper.mapToPropertyEntityV4List(null);
+
+        assertThat(propertyEntityV4List).isNotNull();
+        assertThat(propertyEntityV4List).asList().isEmpty();
+    }
+
+    @Test
     void shouldMapToPropertyEntityV4() {
         Property propertyToMap = PropertyFixtures.aProperty();
         var propertyEntityV4List = propertiesMapper.mapToPropertyEntityV4List(List.of(propertyToMap));
@@ -46,6 +54,24 @@ public class PropertiesMapperTest {
         assertThat(propertyEntityV4.isDynamic()).isEqualTo(propertyToMap.getDynamic());
         assertThat(propertyEntityV4.isEncryptable()).isFalse();
         assertThat(propertyEntityV4.isEncrypted()).isEqualTo(propertyToMap.getEncrypted());
+    }
+
+    @Test
+    void shouldMapToEmptyPropertyEntityV2List() {
+        var propertyEntityV2List = propertiesMapper.mapToPropertyEntityV2List(null);
+
+        assertThat(propertyEntityV2List).isNotNull();
+        assertThat(propertyEntityV2List).asList().isEmpty();
+    }
+
+    @Test
+    void shouldMapToEmptyPropertiesEntityV2() {
+        PropertiesEntity propertiesEntity = propertiesMapper.mapToPropertiesEntityV2(null);
+
+        assertThat(propertiesEntity).isNotNull();
+        List<PropertyEntity> properties = propertiesEntity.getProperties();
+        assertThat(properties).isNotNull();
+        assertThat(properties).asList().isEmpty();
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_getApiByIdTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_getApiByIdTest.java
@@ -215,7 +215,8 @@ public class ApiResource_getApiByIdTest extends ApiResourceTest {
         assertNotNull(responseApi.getLinks());
         assertNotNull(responseApi.getLinks().getPictureUrl());
         assertNotNull(responseApi.getLinks().getBackgroundUrl());
-        assertNull(responseApi.getProperties());
+        assertNotNull(responseApi.getProperties());
+        assertTrue(responseApi.getProperties().isEmpty());
         assertNull(responseApi.getServices());
         assertNull(responseApi.getResources());
         assertNotNull(responseApi.getResponseTemplates());


### PR DESCRIPTION
## Issue

N/A

## Description

When updating an API with no properties, MAPI V2 enables the client to send `null` in the `properties` field, but it can lead to NPE in the service layer because it's expected to have at least an empty list.

In this PR, we change the mapper strategy regarding null values, so null property collections are mapped to empty collections.

_Note: we should probably generalize this configuration to Map and to all the mappers but in a dedicated PR._
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wxqmltlfwe.chromatic.com)
<!-- Storybook placeholder end -->
