### PR TITLE
Handle path parameters containing special character

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParameter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParameter.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.processor.pathparameters;
+
+public class PathParameter {
+
+    private final String id;
+    private final String name;
+
+    public PathParameter(String name, Integer position) {
+        this.name = name;
+        // We use a prefix to ensure id is a valid group name based on the Java Pattern documentation
+        this.id = "group" + position;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParameters.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParameters.java
@@ -25,7 +25,7 @@ import java.util.regex.Pattern;
  * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class PathParameter {
+public class PathParameters {
 
     private static final String PATH_SEPARATOR = "/";
     private static final Pattern SEPARATOR_SPLITTER = Pattern.compile(PATH_SEPARATOR);
@@ -37,7 +37,7 @@ public class PathParameter {
     private Pattern pathPattern;
     private final List<String> parameters = new ArrayList<>();
 
-    public PathParameter(String originalPath, Operator operator) {
+    public PathParameters(String originalPath, Operator operator) {
         this.originalPath = originalPath;
         this.operator = operator;
         extractPathParamsAndPattern();
@@ -82,7 +82,7 @@ public class PathParameter {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        PathParameter that = (PathParameter) o;
+        PathParameters that = (PathParameters) o;
         return Objects.equals(originalPath, that.originalPath) && Objects.equals(operator, that.operator);
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParameters.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParameters.java
@@ -35,7 +35,7 @@ public class PathParameters {
     private final String originalPath;
     private final Operator operator;
     private Pattern pathPattern;
-    private final List<String> parameters = new ArrayList<>();
+    private final List<PathParameter> parameters = new ArrayList<PathParameter>();
 
     public PathParameters(String originalPath, Operator operator) {
         this.originalPath = originalPath;
@@ -51,8 +51,9 @@ public class PathParameters {
             if (!branches[i].isEmpty()) {
                 if (branches[i].startsWith(PATH_PARAM_PREFIX)) {
                     String paramWithoutColon = branches[i].substring(1);
-                    parameters.add(paramWithoutColon);
-                    patternizedPath.append("(?<" + paramWithoutColon + ">" + PATH_PARAM_REGEX + ")");
+                    PathParameter pathParameter = new PathParameter(paramWithoutColon, parameters.size());
+                    parameters.add(pathParameter);
+                    patternizedPath.append("(?<" + pathParameter.getId() + ">" + PATH_PARAM_REGEX + ")");
                 } else {
                     patternizedPath.append(branches[i]);
                 }
@@ -74,7 +75,7 @@ public class PathParameters {
         return pathPattern;
     }
 
-    public List<String> getParameters() {
+    public List<PathParameter> getParameters() {
         return parameters;
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParametersExtractor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParametersExtractor.java
@@ -54,7 +54,7 @@ public class PathParametersExtractor {
             .stream()
             .flatMap(Collection::stream)
             .flatMap(p -> p.getParameters().stream())
-            .anyMatch(parameters -> parameters.length() > 0);
+            .anyMatch(parameters -> !parameters.getName().isEmpty());
     }
 
     /**
@@ -113,7 +113,8 @@ public class PathParametersExtractor {
                         f
                             .getMethods()
                             .stream()
-                            .map(m -> Map.entry(PathParameterHttpMethod.valueOf(m.name()), new PathParameters(f.getPath(), f.getOperator())))
+                            .map(m -> Map.entry(PathParameterHttpMethod.valueOf(m.name()), new PathParameters(f.getPath(), f.getOperator()))
+                            )
                             .collect(Collectors.toList());
                 }
                 return flowByMethod.stream();
@@ -157,7 +158,7 @@ public class PathParametersExtractor {
 
                 final Matcher matcher = pattern.getPathPattern().matcher(path);
                 if (matcher.find()) {
-                    pattern.getParameters().forEach(p -> pathParameters.put(p, matcher.group(p)));
+                    pattern.getParameters().forEach(p -> pathParameters.put(p.getName(), matcher.group(p.getId())));
                 }
             });
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParametersExtractor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParametersExtractor.java
@@ -37,7 +37,7 @@ import java.util.stream.Stream;
 public class PathParametersExtractor {
 
     private static final Pattern PARAM_PATTERN = Pattern.compile(":\\w*");
-    private final Map<PathParameterHttpMethod, Set<PathParameter>> patternsByHttpMethod;
+    private final Map<PathParameterHttpMethod, Set<PathParameters>> patternsByHttpMethod;
 
     public PathParametersExtractor(Api api) {
         Objects.requireNonNull(api, "Api is mandatory");
@@ -62,9 +62,9 @@ public class PathParametersExtractor {
      * If a flow is defined for all methods (empty set), then it will be assigned to WILDCARD key.
      *
      * @param api
-     * @return a map of {@link PathParameter}, containing patterns and parameters name grouped by {@link PathParameterHttpMethod}
+     * @return a map of {@link PathParameters}, containing patterns and parameters name grouped by {@link PathParameterHttpMethod}
      */
-    private static Map<PathParameterHttpMethod, Set<PathParameter>> compilePatternsByHttpMethod(final Api api) {
+    private static Map<PathParameterHttpMethod, Set<PathParameters>> compilePatternsByHttpMethod(final Api api) {
         final Stream<Flow> flowsWithParam = filterFlowsWithPathParam(api);
         // group pattern by HTTP Method <> List<Pattern>
         return groupPatternsByMethod(flowsWithParam);
@@ -102,18 +102,18 @@ public class PathParametersExtractor {
      * @param flows
      * @return
      */
-    private static Map<PathParameterHttpMethod, Set<PathParameter>> groupPatternsByMethod(final Stream<Flow> flows) {
-        final Map<PathParameterHttpMethod, Set<PathParameter>> patternsByMethod = flows
+    private static Map<PathParameterHttpMethod, Set<PathParameters>> groupPatternsByMethod(final Stream<Flow> flows) {
+        final Map<PathParameterHttpMethod, Set<PathParameters>> patternsByMethod = flows
             .flatMap(f -> {
-                List<Map.Entry<PathParameterHttpMethod, PathParameter>> flowByMethod;
+                List<Map.Entry<PathParameterHttpMethod, PathParameters>> flowByMethod;
                 if (f.getMethods().isEmpty()) {
-                    flowByMethod = List.of(Map.entry(PathParameterHttpMethod.WILDCARD, new PathParameter(f.getPath(), f.getOperator())));
+                    flowByMethod = List.of(Map.entry(PathParameterHttpMethod.WILDCARD, new PathParameters(f.getPath(), f.getOperator())));
                 } else {
                     flowByMethod =
                         f
                             .getMethods()
                             .stream()
-                            .map(m -> Map.entry(PathParameterHttpMethod.valueOf(m.name()), new PathParameter(f.getPath(), f.getOperator())))
+                            .map(m -> Map.entry(PathParameterHttpMethod.valueOf(m.name()), new PathParameters(f.getPath(), f.getOperator())))
                             .collect(Collectors.toList());
                 }
                 return flowByMethod.stream();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParametersExtractorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParametersExtractorTest.java
@@ -97,6 +97,7 @@ class PathParametersExtractorTest {
             Arguments.of(readApi("simple-api"), "GET", "/products", Map.of(), Set.of()),
             Arguments.of(readApi("simple-api"), "TRACE", "/products", Map.of(), Set.of()),
             Arguments.of(readApi("simple-api"), "GET", "/products/my-product", Map.of("productId", "my-product"), Set.of()),
+            Arguments.of(readApi("simple-api"), "GET", "/products-special-char/my-product", Map.of("product-id", "my-product"), Set.of()),
             Arguments.of(
                 readApi("simple-api"),
                 "GET",
@@ -118,6 +119,13 @@ class PathParametersExtractorTest {
                 "GET",
                 "/products/my-product/items/my-item",
                 Map.of("productId", "my-product", "itemId", "my-item"),
+                Set.of()
+            ),
+            Arguments.of(
+                readApi("simple-api"),
+                "GET",
+                "/products-special-char/my-product/items/my-item",
+                Map.of("product-id", "my-product", "It€m_Id", "my-item"),
                 Set.of()
             ),
             Arguments.of(readApi("api-flows-equals-operator"), "GET", "/products", Map.of(), Set.of()),

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParametersTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParametersTest.java
@@ -51,12 +51,12 @@ class PathParametersTest {
     @Test
     void should_have_parameters_starts_with_operator() {
         final PathParameters cut = new PathParameters("/product/:productId/item/:itemId", Operator.STARTS_WITH);
-        assertThat(cut.getParameters()).hasSize(2).contains("productId", "itemId");
+        assertThat(cut.getParameters()).hasSize(2).extracting(PathParameter::getName).contains("productId", "itemId");
         assertThat(cut.getPathPattern())
             .hasToString(
                 Pattern
                     .compile(
-                        "^/product/(?<productId>[a-zA-Z0-9\\-._~%!$&'()* +,;=:@]+)/item/(?<itemId>[a-zA-Z0-9\\-._~%!$&'()* +,;=:@]+)(?:/.*)?$"
+                        "^/product/(?<group0>[a-zA-Z0-9\\-._~%!$&'()* +,;=:@]+)/item/(?<group1>[a-zA-Z0-9\\-._~%!$&'()* +,;=:@]+)(?:/.*)?$"
                     )
                     .toString()
             );
@@ -65,12 +65,24 @@ class PathParametersTest {
     @Test
     void should_have_parameters_equals_operator() {
         final PathParameters cut = new PathParameters("/product/:productId/item/:itemId", Operator.EQUALS);
-        assertThat(cut.getParameters()).hasSize(2).contains("productId", "itemId");
+        assertThat(cut.getParameters()).hasSize(2).extracting(PathParameter::getName).contains("productId", "itemId");
+        assertThat(cut.getPathPattern())
+            .hasToString(
+                Pattern
+                    .compile("^/product/(?<group0>[a-zA-Z0-9\\-._~%!$&'()* +,;=:@]+)/item/(?<group1>[a-zA-Z0-9\\-._~%!$&'()* +,;=:@]+)/?$")
+                    .toString()
+            );
+    }
+
+    @Test
+    void should_have_parameters_with_special_character() {
+        final PathParameters cut = new PathParameters("/product/:product-id/item/:It€m_Id", Operator.STARTS_WITH);
+        assertThat(cut.getParameters()).hasSize(2).extracting(PathParameter::getName).contains("product-id", "It€m_Id");
         assertThat(cut.getPathPattern())
             .hasToString(
                 Pattern
                     .compile(
-                        "^/product/(?<productId>[a-zA-Z0-9\\-._~%!$&'()* +,;=:@]+)/item/(?<itemId>[a-zA-Z0-9\\-._~%!$&'()* +,;=:@]+)/?$"
+                        "^/product/(?<group0>[a-zA-Z0-9\\-._~%!$&'()* +,;=:@]+)/item/(?<group1>[a-zA-Z0-9\\-._~%!$&'()* +,;=:@]+)(?:/.*)?$"
                     )
                     .toString()
             );

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParametersTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/processor/pathparameters/PathParametersTest.java
@@ -32,25 +32,25 @@ import org.junit.jupiter.params.provider.MethodSource;
  * @author GraviteeSource Team
  */
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-class PathParameterTest {
+class PathParametersTest {
 
     @Test
     void should_not_have_parameters_starts_with_operator() {
-        final PathParameter cut = new PathParameter("/product/apim/item/portal", Operator.STARTS_WITH);
+        final PathParameters cut = new PathParameters("/product/apim/item/portal", Operator.STARTS_WITH);
         assertThat(cut.getParameters()).isEmpty();
         assertThat(cut.getPathPattern()).hasToString(Pattern.compile("^/product/apim/item/portal(?:/.*)?$").toString());
     }
 
     @Test
     void should_not_have_parameters_equals_operator() {
-        final PathParameter cut = new PathParameter("/product/apim/item/portal", Operator.EQUALS);
+        final PathParameters cut = new PathParameters("/product/apim/item/portal", Operator.EQUALS);
         assertThat(cut.getParameters()).isEmpty();
         assertThat(cut.getPathPattern()).hasToString(Pattern.compile("^/product/apim/item/portal/?$").toString());
     }
 
     @Test
     void should_have_parameters_starts_with_operator() {
-        final PathParameter cut = new PathParameter("/product/:productId/item/:itemId", Operator.STARTS_WITH);
+        final PathParameters cut = new PathParameters("/product/:productId/item/:itemId", Operator.STARTS_WITH);
         assertThat(cut.getParameters()).hasSize(2).contains("productId", "itemId");
         assertThat(cut.getPathPattern())
             .hasToString(
@@ -64,7 +64,7 @@ class PathParameterTest {
 
     @Test
     void should_have_parameters_equals_operator() {
-        final PathParameter cut = new PathParameter("/product/:productId/item/:itemId", Operator.EQUALS);
+        final PathParameters cut = new PathParameters("/product/:productId/item/:itemId", Operator.EQUALS);
         assertThat(cut.getParameters()).hasSize(2).contains("productId", "itemId");
         assertThat(cut.getPathPattern())
             .hasToString(
@@ -78,24 +78,24 @@ class PathParameterTest {
 
     @ParameterizedTest
     @MethodSource("provideParameters")
-    void should_check_equality(final PathParameter first, final PathParameter second, boolean expectedResult) {
+    void should_check_equality(final PathParameters first, final PathParameters second, boolean expectedResult) {
         assertThat(first.equals(second)).isEqualTo(expectedResult);
     }
 
     public static Stream<Arguments> provideParameters() {
         return Stream.of(
             Arguments.of(
-                new PathParameter("/products/", Operator.STARTS_WITH),
-                new PathParameter("/products/", Operator.STARTS_WITH),
+                new PathParameters("/products/", Operator.STARTS_WITH),
+                new PathParameters("/products/", Operator.STARTS_WITH),
                 true
             ),
             Arguments.of(
-                new PathParameter("/products/", Operator.STARTS_WITH),
-                new PathParameter("/products/second", Operator.STARTS_WITH),
+                new PathParameters("/products/", Operator.STARTS_WITH),
+                new PathParameters("/products/second", Operator.STARTS_WITH),
                 false
             ),
-            Arguments.of(new PathParameter("/products/", Operator.STARTS_WITH), null, false),
-            Arguments.of(new PathParameter("/products/", Operator.EQUALS), new PathParameter("/products/", Operator.STARTS_WITH), false)
+            Arguments.of(new PathParameters("/products/", Operator.STARTS_WITH), null, false),
+            Arguments.of(new PathParameters("/products/", Operator.EQUALS), new PathParameters("/products/", Operator.STARTS_WITH), false)
         );
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/resources/apis/pathparams/simple-api.json
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/resources/apis/pathparams/simple-api.json
@@ -143,6 +143,36 @@
       "pre": [],
       "post": [],
       "enabled": true
+    },
+    {
+      "name": "Product",
+      "path-operator": {
+        "path": "/products-special-char/:product-id",
+        "operator": "STARTS_WITH"
+      },
+      "condition": "",
+      "methods": [
+        "DELETE",
+        "GET"
+      ],
+      "pre": [],
+      "post": [],
+      "enabled": true
+    },
+    {
+      "name": "Product",
+      "path-operator": {
+        "path": "/products-special-char/:product-id/items/:It€m_Id",
+        "operator": "STARTS_WITH"
+      },
+      "condition": "",
+      "methods": [
+        "DELETE",
+        "GET"
+      ],
+      "pre": [],
+      "post": [],
+      "enabled": true
     }
   ],
   "resources": []

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/flow/PathParametersFlowTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/flow/PathParametersFlowTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
  * @author GraviteeSource Team
  */
 @ApiDescriptor("/io/gravitee/gateway/standalone/flow/path-parameter-flow.json")
-public class PathParameterFlowTest extends AbstractWiremockGatewayTest {
+public class PathParametersFlowTest extends AbstractWiremockGatewayTest {
 
     @Test
     public void shouldRunFlows_withPathParameters() throws Exception {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1879
https://github.com/gravitee-io/issues/issues/9081

## Description

Handle path parameters containing special characters.
To do so, the `PathParameter` is introduced; it contains the path parameter name and an id. 
This id defines the named groups in the Java Pattern used to extract params from the request path.

The named group concept has been kept as it's easier to understand than just playing with indexes.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-czkvpfowzm.chromatic.com)
<!-- Storybook placeholder end -->
