### PR TITLE
Use environment reference id on dashboard permission check

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/DashboardsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/DashboardsResource.java
@@ -65,8 +65,18 @@ public class DashboardsResource extends AbstractResource {
     public List<DashboardEntity> getDashboards(final @QueryParam("reference_type") DashboardReferenceType referenceType) {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         if (
-            !hasPermission(executionContext, RolePermission.ENVIRONMENT_DASHBOARD, RolePermissionAction.READ) &&
-            !hasPermission(executionContext, RolePermission.ENVIRONMENT_API, RolePermissionAction.READ) &&
+            !hasPermission(
+                executionContext,
+                RolePermission.ENVIRONMENT_DASHBOARD,
+                executionContext.getEnvironmentId(),
+                RolePermissionAction.READ
+            ) &&
+            !hasPermission(
+                executionContext,
+                RolePermission.ENVIRONMENT_API,
+                executionContext.getEnvironmentId(),
+                RolePermissionAction.READ
+            ) &&
             !canReadAPIConfiguration() &&
             !DashboardReferenceType.HOME.equals(referenceType)
         ) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1784

## Description

As an environment admin user should be able to see the environment settings. Or today when an environment admin tries to access the environment settings the referenceId used in the permission check is null. It ends with a 403. Here is a quick fix to correct it

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nbasaexbhc.chromatic.com)
<!-- Storybook placeholder end -->
