### PR TITLE
Archi 249 add execution context get attribute as list method

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractExecutionContext.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractExecutionContext.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.reactive.core.context;
 
+import com.google.common.base.Splitter;
 import io.gravitee.el.TemplateContext;
 import io.gravitee.el.TemplateEngine;
 import io.gravitee.el.TemplateVariableProvider;
@@ -34,12 +35,18 @@ import io.gravitee.reporter.api.v4.metric.Metrics;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.Maybe;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import java.lang.reflect.Array;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public abstract class AbstractExecutionContext<RQ extends MutableRequest, RS extends MutableResponse> implements ExecutionContext {
+
+    public static final Splitter SPLIT_BY_COMMA = Splitter.on(',');
 
     protected RQ request;
     protected RS response;
@@ -151,6 +158,52 @@ public abstract class AbstractExecutionContext<RQ extends MutableRequest, RS ext
     @Override
     public <T> T getAttribute(String name) {
         return (T) attributes.get(name);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> List<T> getAttributeAsList(String name) {
+        Object o = attributes.get(name);
+        if (o == null) {
+            return null;
+        }
+
+        if (o instanceof String) {
+            String s = ((String) o);
+            if (isJSONArray(s)) {
+                JsonArray jsonArray = (JsonArray) Json.decodeValue(s);
+                return (List<T>) jsonArray.getList().stream().map(Objects::toString).collect(Collectors.toUnmodifiableList());
+            } else {
+                // split by ','
+                List<String> list = SPLIT_BY_COMMA.splitToList(s);
+                if (list.size() == 1) {
+                    // no split, just wrap it
+                    return (List<T>) list;
+                } else {
+                    // else trim values
+                    return (List<T>) list.stream().map(String::trim).collect(Collectors.toUnmodifiableList());
+                }
+            }
+        }
+
+        if (o instanceof Collection) {
+            // copy to immutable list
+            return List.copyOf((Collection<? extends T>) o);
+        }
+
+        if (o.getClass().isArray()) {
+            List<T> list = new ArrayList<>(Array.getLength(o));
+            for (int i = 0; i < Array.getLength(o); i++) {
+                list.add((T) Array.get(o, i));
+            }
+            return List.copyOf(list);
+        }
+
+        return List.of((T) o);
+    }
+
+    private boolean isJSONArray(String jsonCandidate) {
+        return jsonCandidate.startsWith("[") && jsonCandidate.endsWith("]");
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <gravitee-connector-api.version>1.1.4</gravitee-connector-api.version>
         <gravitee-expression-language.version>2.2.1</gravitee-expression-language.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <gravitee-gateway-api.version>3.0.0-alpha.4</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>3.0.0-alpha.5</gravitee-gateway-api.version>
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>3.1.0-alpha.9</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-249

## Description

Implementation of ExecutionContext's getAttributeAsList

## Additional context

Check the tests to make the behaviour is as excepted, take a look at https://github.com/gravitee-io/gravitee-gateway-api/pull/202

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-yqoionhobq.chromatic.com)
<!-- Storybook placeholder end -->
