### PR TITLE
fix(console): change api type to version number in apis list

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.html
@@ -153,7 +153,7 @@
 
     <!-- Display Version Column -->
     <ng-container matColumnDef="definitionVersion">
-      <th mat-header-cell *matHeaderCellDef id="definitionVersion">Mode</th>
+      <th mat-header-cell *matHeaderCellDef id="definitionVersion">Definition</th>
       <td mat-cell *matCellDef="let element">
         <span [matTooltip]="element.definitionVersion.label" class="gio-badge-neutral"
           ><mat-icon *ngIf="element.definitionVersion.icon" class="gio-left" [svgIcon]="element.definitionVersion.icon"></mat-icon

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.spec.ts
@@ -84,7 +84,7 @@ describe('ApisListComponent', () => {
         {
           actions: '',
           contextPath: 'Context Path',
-          definitionVersion: 'Mode',
+          definitionVersion: 'Definition',
           name: 'Name',
           owner: 'Owner',
           picture: '',
@@ -105,7 +105,7 @@ describe('ApisListComponent', () => {
         {
           actions: '',
           contextPath: 'Context Path',
-          definitionVersion: 'Mode',
+          definitionVersion: 'Definition',
           name: 'Name',
           owner: 'Owner',
           picture: '',
@@ -114,7 +114,7 @@ describe('ApisListComponent', () => {
           visibility: 'Visibility',
         },
       ]);
-      expect(rowCells).toEqual([['', '🪐 Planets (1.0)', '', '/planets', '', 'admin', 'Policy studio', 'public', 'edit']]);
+      expect(rowCells).toEqual([['', '🪐 Planets (1.0)', '', '/planets', '', 'admin', 'v2', 'public', 'edit']]);
       expect(await loader.getHarness(MatIconHarness.with({ selector: '.states__api-started' }))).toBeTruthy();
     }));
 
@@ -127,7 +127,7 @@ describe('ApisListComponent', () => {
         {
           actions: '',
           contextPath: 'Context Path',
-          definitionVersion: 'Mode',
+          definitionVersion: 'Definition',
           name: 'Name',
           owner: 'Owner',
           picture: '',
@@ -137,7 +137,7 @@ describe('ApisListComponent', () => {
         },
       ]);
       expect(rowCells).toEqual([
-        ['', '🪐 Planets (1.0)', '', 'No context path with this configuration', '', 'admin', 'Event native', 'public', 'edit'],
+        ['', '🪐 Planets (1.0)', '', 'No context path with this configuration', '', 'admin', 'v4', 'public', 'edit'],
       ]);
       expect(await loader.getHarness(MatIconHarness.with({ selector: '.states__api-started' }))).toBeTruthy();
     }));
@@ -168,7 +168,7 @@ describe('ApisListComponent', () => {
         {
           actions: '',
           contextPath: 'Context Path',
-          definitionVersion: 'Mode',
+          definitionVersion: 'Definition',
           name: 'Name',
           owner: 'Owner',
           picture: '',
@@ -177,7 +177,7 @@ describe('ApisListComponent', () => {
           visibility: 'Visibility',
         },
       ]);
-      expect(rowCells).toEqual([['', '🪐 Planets (1.0)', '', '/test/ws 2 more', '', 'admin', 'Event native', 'public', 'edit']]);
+      expect(rowCells).toEqual([['', '🪐 Planets (1.0)', '', '/test/ws 2 more', '', 'admin', 'v4', 'public', 'edit']]);
       expect(await loader.getHarness(MatIconHarness.with({ selector: '.states__api-started' }))).toBeTruthy();
     }));
 
@@ -286,7 +286,7 @@ describe('ApisListComponent', () => {
           visibility: { label: 'PUBLIC', icon: 'public' },
           origin: 'management' as OriginEnum,
           readonly: false,
-          definitionVersion: { label: 'Policy studio', icon: '' },
+          definitionVersion: { label: 'v2', icon: '' },
         };
 
         apiListComponent.onEditActionClicked(api);
@@ -338,7 +338,7 @@ describe('ApisListComponent', () => {
         {
           actions: '',
           contextPath: 'Context Path',
-          definitionVersion: 'Mode',
+          definitionVersion: 'Definition',
           name: 'Name',
           owner: 'Owner',
           picture: '',
@@ -348,7 +348,7 @@ describe('ApisListComponent', () => {
           visibility: 'Visibility',
         },
       ]);
-      expect(rowCells).toEqual([['', '🪐 Planets (1.0)', '', '/planets', '', '100%', 'admin', 'Policy studio', 'public', 'edit']]);
+      expect(rowCells).toEqual([['', '🪐 Planets (1.0)', '', '/planets', '', '100%', 'admin', 'v2', 'public', 'edit']]);
       expect(fixture.debugElement.query(By.css('.quality-score__good'))).toBeTruthy();
       expect(await loader.getHarness(MatIconHarness.with({ selector: '.states__api-started' }))).toBeTruthy();
     }));

--- a/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/list/api-list.component.ts
@@ -212,12 +212,11 @@ export class ApiListComponent implements OnInit, OnDestroy {
 
   private getDefinitionVersion(api: Api) {
     switch (api.definitionVersion) {
-      case 'V4':
-        return { label: 'Event native' };
       case 'V2':
-        return { label: 'Policy studio' };
+      case 'V4':
+        return { label: api.definitionVersion.toLowerCase() };
       default:
-        return { icon: 'gio:alert-circle', label: 'Path based' };
+        return { icon: 'gio:alert-circle', label: 'v1' };
     }
   }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1767

## Description

Rename API type to API version in the API List screen.

**NOTE**: For the moment, the gio-neutral-badge automatically capitalizes all words. Anthony is in discussion with UX to decide if this is still necessary and if we need to override it for the API List page + API Creation page for badges referencing API Definitions.

![Screen Shot 2023-06-08 at 15 32 25](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/c9ffe5e4-f27e-4cc1-afb4-4d36e28acafd)



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nvrxbqpxng.chromatic.com)
<!-- Storybook placeholder end -->
