### PR TITLE
add missing definitionVersion to an edited or a newly created plan

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.spec.ts
@@ -1119,7 +1119,7 @@ describe('ApiCreationV4Component', () => {
       expect(step3Summary).toContain('Mock');
 
       const step4Summary = await step6Harness.getStepSummaryTextContent(4);
-      expect(step4Summary).toContain('Default Keyless (UNSECURED)' + 'KEY_LESS');
+      expect(step4Summary).toContain('Update name' + 'KEY_LESS');
     });
 
     it('should go back to step 1 after clicking Change button', async () => {
@@ -1210,7 +1210,7 @@ describe('ApiCreationV4Component', () => {
       let step6Harness = await harnessLoader.getHarness(Step6SummaryHarness);
 
       let step4Summary = await step6Harness.getStepSummaryTextContent(4);
-      expect(step4Summary).toContain('Default Keyless (UNSECURED)' + 'KEY_LESS');
+      expect(step4Summary).toContain('Update name' + 'KEY_LESS');
 
       await step6Harness.clickChangeButton(4);
 
@@ -1362,7 +1362,10 @@ describe('ApiCreationV4Component', () => {
 
   async function fillAndValidateStep4Security1PlansList() {
     const step4 = await harnessLoader.getHarness(Step4Security1PlansHarness);
-    await step4.fillAndValidate();
+
+    await step4.editDefaultKeylessPlanName('Update name', httpTestingController);
+    await step4.addRateLimitToPlan(httpTestingController);
+    await step4.clickValidate();
   }
 
   async function fillAndValidateStep5Documentation() {
@@ -1395,6 +1398,7 @@ describe('ApiCreationV4Component', () => {
     // TODO: complete with all the expected fields
     expect(createApiRequest.request.body).toEqual(
       expect.objectContaining({
+        definitionVersion: 'V4',
         name: 'API name',
       }),
     );
@@ -1406,7 +1410,8 @@ describe('ApiCreationV4Component', () => {
     });
     expect(createPlansRequest.request.body).toEqual(
       expect.objectContaining({
-        name: 'Default Keyless (UNSECURED)',
+        definitionVersion: 'V4',
+        name: 'Update name',
       }),
     );
     createPlansRequest.flush(fakePlanV4({ apiId: apiId, id: planId }));

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.ts
@@ -242,7 +242,9 @@ export class ApiCreationV4Component implements OnInit, OnDestroy {
 
   private createPlans$(apiCreationStatus: Result): Observable<Result> {
     const api = apiCreationStatus.result.api;
-    return forkJoin(apiCreationStatus.apiCreationPayload.plans.map((plan) => this.apiPlanV2Service.create(api.id, plan))).pipe(
+    return forkJoin(
+      apiCreationStatus.apiCreationPayload.plans.map((plan) => this.apiPlanV2Service.create(api.id, { ...plan, definitionVersion: 'V4' })),
+    ).pipe(
       map((plans: PlanV4[]) => ({ ...apiCreationStatus, result: { ...apiCreationStatus.result, plans }, status: 'success' as const })),
       catchError((err) => {
         return of({


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1952

## Description

In the API creation workflow, when you edit the default keyless plan or add a new plan, the plan returned by the dialog doesn't contain the definition version. It's up to the parent component (here the creation workflow) to set this definitionVersion.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-uwqlgaatto.chromatic.com)
<!-- Storybook placeholder end -->
