### PR TITLE
feat: implement v2 verify create api subscription

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
@@ -841,6 +841,35 @@ paths:
                 default:
                     $ref: "#/components/responses/Error"
 
+    /environments/{envId}/apis/{apiId}/subscriptions/_verify:
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+            - $ref: "#/components/parameters/apiIdParam"
+        post:
+            tags:
+                - API Subscriptions
+            summary: Check a subscription can be created
+            description: |-
+                Check a subscription can be created with given api key, and application.
+                
+                User must have the API_SUBSCRIPTION[CREATE] permission.
+            operationId: verifyCreateApiSubscription
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/VerifySubscription"
+                required: true
+            responses:
+                "200":
+                    description: Verification successfully performed.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/VerifySubscriptionResponse"
+                default:
+                    $ref: "#/components/responses/Error"
+
     # Plugins - Endpoints
     /plugins/endpoints:
         get:
@@ -2882,6 +2911,28 @@ components:
                     additionalProperties:
                         type: string
             required: [applicationId,planId]
+
+        VerifySubscription:
+            type: object
+            properties:
+                applicationId:
+                    type: string
+                    description: The id of the application subscribing.
+                apiKey:
+                    type: string
+                    description: 'The api key that needs to be verified. Should not contain: ^ # % @ \\ / ; = ? | ~ , (space)'
+                    pattern: '^[^#%@/;=?|^~, \\]*$'
+            required: [applicationId,apiKey]
+
+        VerifySubscriptionResponse:
+            type: object
+            properties:
+                ok:
+                    type: boolean
+                    description: Indicates whether the creation can be done or not.
+                reason:
+                    type: string
+                    description: An optional reason giving details about the result.
 
         BaseUser:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/SubscriptionFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/SubscriptionFixtures.java
@@ -17,6 +17,7 @@ package fixtures;
 
 import io.gravitee.rest.api.management.v2.rest.model.CreateSubscription;
 import io.gravitee.rest.api.management.v2.rest.model.SubscriptionConsumerConfiguration;
+import io.gravitee.rest.api.management.v2.rest.model.VerifySubscription;
 import io.gravitee.rest.api.model.SubscriptionConfigurationEntity;
 import io.gravitee.rest.api.model.SubscriptionConsumerStatus;
 import io.gravitee.rest.api.model.SubscriptionEntity;
@@ -82,5 +83,9 @@ public class SubscriptionFixtures {
 
     public static CreateSubscription aCreateSubscription() {
         return BASE_CREATE_SUBSCRIPTION.build();
+    }
+
+    public static VerifySubscription aVerifySubscription() {
+        return VerifySubscription.builder().applicationId("my-application").apiKey("custom").build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResourceTest.java
@@ -17,12 +17,10 @@ package io.gravitee.rest.api.management.v2.rest.resource.api;
 
 import static org.mockito.Mockito.doReturn;
 
-import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
 import io.gravitee.rest.api.model.EnvironmentEntity;
-import io.gravitee.rest.api.model.v4.api.ApiEntity;
 import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.common.GraviteeContext;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource_VerifyCreateApiSubscriptionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource_VerifyCreateApiSubscriptionTest.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api;
+
+import static io.gravitee.common.http.HttpStatusCode.*;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import fixtures.SubscriptionFixtures;
+import io.gravitee.rest.api.management.v2.rest.model.Error;
+import io.gravitee.rest.api.management.v2.rest.model.VerifySubscription;
+import io.gravitee.rest.api.management.v2.rest.model.VerifySubscriptionResponse;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.ApiKeyService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ApiSubscriptionsResource_VerifyCreateApiSubscriptionTest extends ApiSubscriptionsResourceTest {
+
+    @Autowired
+    private ApiKeyService apiKeyService;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/apis/" + API + "/subscriptions/_verify";
+    }
+
+    @Before
+    public void before() {
+        reset(apiKeyService);
+    }
+
+    @Test
+    public void should_return_403_if_incorrect_permissions() {
+        when(
+            permissionService.hasPermission(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(RolePermission.API_SUBSCRIPTION),
+                eq(API),
+                eq(RolePermissionAction.CREATE)
+            )
+        )
+            .thenReturn(false);
+
+        final Response response = rootTarget().request().post(Entity.json(SubscriptionFixtures.aVerifySubscription()));
+        assertEquals(FORBIDDEN_403, response.getStatus());
+
+        var error = response.readEntity(Error.class);
+        assertEquals(FORBIDDEN_403, (int) error.getHttpStatus());
+        assertEquals("You do not have sufficient rights to access this resource", error.getMessage());
+    }
+
+    @Test
+    public void should_return_400_when_invalid_api_key_pattern() {
+        final Response response = rootTarget()
+            .request()
+            .post(Entity.json(SubscriptionFixtures.aVerifySubscription().toBuilder().apiKey("###").build()));
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+
+        var error = response.readEntity(Error.class);
+        assertEquals(BAD_REQUEST_400, (int) error.getHttpStatus());
+        assertEquals("Validation error", error.getMessage());
+    }
+
+    @Test
+    public void should_return_400_when_missing_api_key() {
+        final Response response = rootTarget()
+            .request()
+            .post(Entity.json(SubscriptionFixtures.aVerifySubscription().toBuilder().apiKey(null).build()));
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+
+        var error = response.readEntity(Error.class);
+        assertEquals(BAD_REQUEST_400, (int) error.getHttpStatus());
+        assertEquals("Validation error", error.getMessage());
+    }
+
+    @Test
+    public void should_return_400_when_missing_application() {
+        final Response response = rootTarget()
+            .request()
+            .post(Entity.json(SubscriptionFixtures.aVerifySubscription().toBuilder().applicationId(null).build()));
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+
+        var error = response.readEntity(Error.class);
+        assertEquals(BAD_REQUEST_400, (int) error.getHttpStatus());
+        assertEquals("Validation error", error.getMessage());
+    }
+
+    @Test
+    public void should_verify_subscription() {
+        when(apiKeyService.canCreate(GraviteeContext.getExecutionContext(), "apiKey", API, APPLICATION)).thenReturn(true);
+
+        final VerifySubscription verifySubscription = SubscriptionFixtures
+            .aVerifySubscription()
+            .toBuilder()
+            .applicationId(APPLICATION)
+            .apiKey("apiKey")
+            .build();
+        final Response response = rootTarget().request().post(Entity.json(verifySubscription));
+        assertEquals(OK_200, response.getStatus());
+
+        final VerifySubscriptionResponse verifyResponse = response.readEntity(VerifySubscriptionResponse.class);
+        assertTrue(verifyResponse.getOk());
+    }
+
+    @Test
+    public void should_verify_subscription_false_response() {
+        when(apiKeyService.canCreate(GraviteeContext.getExecutionContext(), "apiKey", API, APPLICATION)).thenReturn(false);
+
+        final VerifySubscription verifySubscription = SubscriptionFixtures
+            .aVerifySubscription()
+            .toBuilder()
+            .applicationId(APPLICATION)
+            .apiKey("apiKey")
+            .build();
+        final Response response = rootTarget().request().post(Entity.json(verifySubscription));
+        assertEquals(OK_200, response.getStatus());
+
+        final VerifySubscriptionResponse verifyResponse = response.readEntity(VerifySubscriptionResponse.class);
+        assertFalse(verifyResponse.getOk());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -173,4 +173,9 @@ public class ResourceContextConfiguration {
     public ApplicationService applicationService() {
         return mock(ApplicationService.class);
     }
+
+    @Bean
+    public ApiKeyService apiKeyService() {
+        return mock(ApiKeyService.class);
+    }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1229

## Description

This PR adds support for verifying api subscription for creation by checking the api key is not already used.

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-pyuezztjdb.chromatic.com)
<!-- Storybook placeholder end -->
