### PR TITLE
fix: allow user to transfer subscription in the UI

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/portal/subscriptions/dialog/subscription.transfer.dialog.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/subscriptions/dialog/subscription.transfer.dialog.controller.ts
@@ -26,7 +26,7 @@ function DialogSubscriptionTransferController($scope, $mdDialog, plans) {
   };
 
   this.hasGeneralConditions = function (plan) {
-    return plan.general_conditions !== undefined && plan.general_conditions !== null;
+    return !!plan.general_conditions
   };
 
   this.atLeastOnePlanWithGeneralConditions = function () {


### PR DESCRIPTION
## Issue

N/a

## Description

The default value for general_conditions is an empty string but currently, the condition only checks for undefined or null. This results in APIM thinking all new plans have general conditions and API publisher's are unable to transfer subscriptions as shown in the screenshot below.
![Screenshot 2023-04-05 at 3 35 21 PM](https://github.com/gravitee-io/gravitee-api-management/assets/81941044/2c06ed1f-e04c-434e-ac4e-d694707e8c90)

