### PR TITLE
Allow `summary` and `details` html tags in MD docs

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/PageContentUnsafeException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/PageContentUnsafeException.java
@@ -24,7 +24,7 @@ import java.util.Map;
  */
 public class PageContentUnsafeException extends AbstractManagementException {
 
-    private String rejectedMessage;
+    private final String rejectedMessage;
 
     public PageContentUnsafeException(String rejectedMessage) {
         this.rejectedMessage = rejectedMessage;
@@ -50,7 +50,7 @@ public class PageContentUnsafeException extends AbstractManagementException {
         String message = "The page content does not follow security policy";
 
         if (rejectedMessage != null) {
-            message = message + " : " + rejectedMessage;
+            message = message + ": " + rejectedMessage;
         }
 
         return message;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/sanitizer/HtmlSanitizer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/sanitizer/HtmlSanitizer.java
@@ -72,6 +72,12 @@ public final class HtmlSanitizer {
         .allowStyling(CssSchema.union(CssSchema.DEFAULT, CssSchema.withProperties(Collections.singleton("float"))))
         .toFactory();
 
+    /**
+     * Allow a set of HTML tags to support GitHub Flavoured Markdown.
+     * Spec is available at: <a href="https://github.github.com/gfm">https://github.github.com/gfm</a>
+     */
+    private static final PolicyFactory GITHUB_FLAVOURED_MARKDOWN = new HtmlPolicyBuilder().allowElements("summary", "details").toFactory();
+
     private static final PolicyFactory factory = Sanitizers.BLOCKS
         .and(Sanitizers.FORMATTING)
         .and(
@@ -86,7 +92,8 @@ public final class HtmlSanitizer {
         .and(Sanitizers.TABLES)
         .and(new HtmlPolicyBuilder().allowElements("pre", "hr").toFactory())
         .and(HTML_IMAGES_SANITIZER)
-        .and(new HtmlPolicyBuilder().allowElements("code").allowAttributes("class").globally().toFactory());
+        .and(new HtmlPolicyBuilder().allowElements("code").allowAttributes("class").globally().toFactory())
+        .and(GITHUB_FLAVOURED_MARKDOWN);
 
     private HtmlSanitizer() {}
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/sanitizer/HtmlSanitizerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/sanitizer/HtmlSanitizerTest.java
@@ -53,6 +53,9 @@ public class HtmlSanitizerTest {
     private static String DIV_TAG_WITH_STYLE_ATT_WITH_SINGLE_QUOTE = "<div style='margin:auto'></div>";
     private static String DIV_TAG_WITH_STYLE_ATT_WITH_TWO_SEMICOLON = "<div style=\"margin:auto;;\"></div>";
 
+    private static String SUMMARY_DETAILS =
+        "<details>\n" + "    <summary>Details</summary>\n" + "    Something small enough to escape casual notice.\n" + "</details>\n";
+
     @Test
     public void sanitize() {
         String html = getSafe();
@@ -173,5 +176,6 @@ public class HtmlSanitizerTest {
             HtmlSanitizer.isSafe(DIV_TAG_WITH_STYLE_ATT_WITH_TWO_SEMICOLON).isSafe(),
             is(true)
         );
+        collector.checkThat("SUMMARY_DETAILS", HtmlSanitizer.isSafe(SUMMARY_DETAILS).isSafe(), is(true));
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1966
https://github.com/gravitee-io/issues/issues/9090

## Description

Allow `summary` and `details` html tags in MD docs as they are part of GitHub Flavoured Markdown.
More improvments on that side will be done on the `master` branch

![image](https://github.com/gravitee-io/gravitee-api-management/assets/4112568/548858ce-31d9-4284-a8a6-f162892e9a62)

![image](https://github.com/gravitee-io/gravitee-api-management/assets/4112568/9b8264cc-d519-4f58-9d58-336dd25f04a3)


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dzyqtdkjsa.chromatic.com)
<!-- Storybook placeholder end -->
