### PR TITLE
[console] allow user to add push plan to v4 apis

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/plan/planSecurityType.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/plan/planSecurityType.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
+// TODO remove this when the SUBSCRIPTION security type is renamed on the backend side
+export type PushSecurityType = 'PUSH' | 'SUBSCRIPTION';
+
 /**
  * Plan security type.
  */
-export type PlanSecurityType = 'KEY_LESS' | 'API_KEY' | 'OAUTH2' | 'JWT' | 'SUBSCRIPTION';
+export type PlanSecurityType = 'KEY_LESS' | 'API_KEY' | 'OAUTH2' | 'JWT' | PushSecurityType;

--- a/gravitee-apim-console-webui/src/management/api/component/plan/2-secure-step/plan-edit-secure-step.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/2-secure-step/plan-edit-secure-step.component.ts
@@ -63,7 +63,7 @@ export class PlanEditSecureStepComponent implements OnInit, OnDestroy {
       selectionRule: new FormControl(),
     });
 
-    if (this.securityType.id === 'KEY_LESS') {
+    if (['KEY_LESS', 'PUSH'].includes(this.securityType.id)) {
       return;
     }
 

--- a/gravitee-apim-console-webui/src/management/api/component/plan/2-secure-step/plan-edit-secure-step.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/2-secure-step/plan-edit-secure-step.component.ts
@@ -22,7 +22,7 @@ import '@gravitee/ui-components/wc/gv-schema-form-group';
 import { PlanResourceTypeService } from './plan-resource-type/plan-resource-type.service';
 
 import { Constants } from '../../../../../entities/Constants';
-import { PolicyService } from '../../../../../services-ngx/policy.service';
+import { PolicyV2Service } from '../../../../../services-ngx/policy-v2.service';
 import { ResourceService } from '../../../../../services-ngx/resource.service';
 import { ResourceListItem } from '../../../../../entities/resource/resourceListItem';
 import { ApiV2, ApiV4 } from '../../../../../entities/management-api-v2';
@@ -50,7 +50,7 @@ export class PlanEditSecureStepComponent implements OnInit, OnDestroy {
   securityType: PlanSecurityVM;
   constructor(
     @Inject('Constants') private readonly constants: Constants,
-    private readonly policyService: PolicyService,
+    private readonly policyService: PolicyV2Service,
     private readonly resourceService: ResourceService,
     private readonly snackBarService: SnackBarService,
     private readonly planOauth2ResourceTypeService: PlanResourceTypeService,

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.html
@@ -29,7 +29,7 @@
     ></plan-edit-general-step>
   </mat-step>
 
-  <mat-step *ngIf="securityType.id !== 'KEY_LESS'" state="secure" [stepControl]="planForm.get('secure')">
+  <mat-step *ngIf="!['KEY_LESS', 'PUSH'].includes(securityType.id)" state="secure" [stepControl]="planForm.get('secure')">
     <ng-template matStepperIcon="secure">
       <mat-icon svgIcon="gio:lock"></mat-icon>
     </ng-template>

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
@@ -24,6 +24,7 @@ import { set } from 'lodash';
 import { Component, ViewChild } from '@angular/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
+import { MatStepHarness } from '@angular/material/stepper/testing';
 
 import { ApiPlanFormModule } from './api-plan-form.module';
 import { ApiPlanFormHarness } from './api-plan-form.harness';
@@ -626,12 +627,10 @@ describe('ApiPlanFormComponent', () => {
   });
 
   describe('Create mode V4 without API', () => {
-    beforeEach(async () => {
+    it('should add new plan', async () => {
       configureTestingModule('create', 'JWT');
       fixture.detectChanges();
-    });
 
-    it('should add new plan', async () => {
       const planForm = await loader.getHarness(ApiPlanFormHarness);
 
       planForm.httpRequest(httpTestingController).expectGroupLisRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
@@ -741,6 +740,23 @@ describe('ApiPlanFormComponent', () => {
         ],
       } as CreatePlanV4);
     });
+  });
+  it('should not display secure step with push plans', async () => {
+    configureTestingModule('create', 'PUSH');
+    fixture.detectChanges();
+
+    const planForm = await loader.getHarness(ApiPlanFormHarness);
+
+    planForm.httpRequest(httpTestingController).expectGroupLisRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
+    fixture.detectChanges();
+
+    expect(testComponent.planControl.touched).toEqual(false);
+    expect(testComponent.planControl.dirty).toEqual(false);
+    expect(testComponent.planControl.valid).toEqual(false);
+
+    const stepsHarness = await loader.getAllHarnesses(MatStepHarness);
+    const steps = await Promise.all(stepsHarness.map((step) => step.getLabel()));
+    expect(steps).toEqual(['General', 'Restriction']);
   });
 
   describe('Edit mode V2', () => {

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
@@ -156,7 +156,7 @@ describe('ApiPlanFormComponent', () => {
         await nameInput.setValue('🗺');
 
         // 2- Secure Step
-        planForm.httpRequest(httpTestingController).expectPlanSchemaGetRequest('oauth2', {});
+        planForm.httpRequest(httpTestingController).expectPolicySchemaV2GetRequest('oauth2', {});
         planForm.httpRequest(httpTestingController).expectResourceGetRequest();
 
         // 3- Restriction Step
@@ -264,7 +264,7 @@ describe('ApiPlanFormComponent', () => {
         fixture.detectChanges();
 
         // 2- Secure Step
-        planForm.httpRequest(httpTestingController).expectPlanSchemaGetRequest('jwt', {});
+        planForm.httpRequest(httpTestingController).expectPolicySchemaV2GetRequest('jwt', {});
 
         const selectionRuleInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="selectionRule"]' }));
         await selectionRuleInput.setValue('{ #el ...}');
@@ -411,7 +411,7 @@ describe('ApiPlanFormComponent', () => {
         fixture.detectChanges();
 
         // 2- Secure Step
-        planForm.httpRequest(httpTestingController).expectPlanSchemaGetRequest('api-key', fakeApiKeySchema);
+        planForm.httpRequest(httpTestingController).expectPolicySchemaV2GetRequest('api-key', fakeApiKeySchema);
 
         const jsonSchemaPropagateApiKeyToggle = await loader.getHarness(
           MatSlideToggleHarness.with({ selector: '[id*="propagateApiKey"]' }),
@@ -669,7 +669,7 @@ describe('ApiPlanFormComponent', () => {
       await excludedGroupsInput.clickOptions({ text: 'Group A' });
 
       // 2- Secure Step
-      planForm.httpRequest(httpTestingController).expectPlanSchemaGetRequest('jwt', {});
+      planForm.httpRequest(httpTestingController).expectPolicySchemaV2GetRequest('jwt', {});
 
       const selectionRuleInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="selectionRule"]' }));
       await selectionRuleInput.setValue('{ #el ...}');
@@ -1008,7 +1008,7 @@ describe('ApiPlanFormComponent', () => {
         planForm.httpRequest(httpTestingController).expectGroupLisRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
         planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API.id, [{ id: 'doc-1', name: 'Doc 1' }]);
         planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
-        planForm.httpRequest(httpTestingController).expectPlanSchemaGetRequest('api-key', fakeApiKeySchema);
+        planForm.httpRequest(httpTestingController).expectPolicySchemaV2GetRequest('api-key', fakeApiKeySchema);
         fixture.detectChanges();
 
         expect(testComponent.planControl.touched).toEqual(false);

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
@@ -155,7 +155,7 @@ describe('ApiPlanFormComponent', () => {
         await nameInput.setValue('🗺');
 
         // 2- Secure Step
-        planForm.httpRequest(httpTestingController).expectPolicySchemaGetRequest('oauth2', {});
+        planForm.httpRequest(httpTestingController).expectPlanSchemaGetRequest('oauth2', {});
         planForm.httpRequest(httpTestingController).expectResourceGetRequest();
 
         // 3- Restriction Step
@@ -263,7 +263,7 @@ describe('ApiPlanFormComponent', () => {
         fixture.detectChanges();
 
         // 2- Secure Step
-        planForm.httpRequest(httpTestingController).expectPolicySchemaGetRequest('jwt', {});
+        planForm.httpRequest(httpTestingController).expectPlanSchemaGetRequest('jwt', {});
 
         const selectionRuleInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="selectionRule"]' }));
         await selectionRuleInput.setValue('{ #el ...}');
@@ -410,7 +410,7 @@ describe('ApiPlanFormComponent', () => {
         fixture.detectChanges();
 
         // 2- Secure Step
-        planForm.httpRequest(httpTestingController).expectPolicySchemaGetRequest('api-key', fakeApiKeySchema);
+        planForm.httpRequest(httpTestingController).expectPlanSchemaGetRequest('api-key', fakeApiKeySchema);
 
         const jsonSchemaPropagateApiKeyToggle = await loader.getHarness(
           MatSlideToggleHarness.with({ selector: '[id*="propagateApiKey"]' }),
@@ -670,7 +670,7 @@ describe('ApiPlanFormComponent', () => {
       await excludedGroupsInput.clickOptions({ text: 'Group A' });
 
       // 2- Secure Step
-      planForm.httpRequest(httpTestingController).expectPolicySchemaGetRequest('jwt', {});
+      planForm.httpRequest(httpTestingController).expectPlanSchemaGetRequest('jwt', {});
 
       const selectionRuleInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="selectionRule"]' }));
       await selectionRuleInput.setValue('{ #el ...}');
@@ -992,7 +992,7 @@ describe('ApiPlanFormComponent', () => {
         planForm.httpRequest(httpTestingController).expectGroupLisRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
         planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API.id, [{ id: 'doc-1', name: 'Doc 1' }]);
         planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
-        planForm.httpRequest(httpTestingController).expectPolicySchemaGetRequest('api-key', fakeApiKeySchema);
+        planForm.httpRequest(httpTestingController).expectPlanSchemaGetRequest('api-key', fakeApiKeySchema);
         fixture.detectChanges();
 
         expect(testComponent.planControl.touched).toEqual(false);

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.harness.ts
@@ -104,7 +104,7 @@ export class ApiPlanFormHarness extends ComponentHarness {
       httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/policies/${type}/schema`, method: 'GET' }).flush(schema);
     }
 
-    function expectPlanSchemaGetRequest(type: string, schema: unknown) {
+    function expectPolicySchemaV2GetRequest(type: string, schema: unknown) {
       httpTestingController
         .expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/policies/${type}/schema`, method: 'GET' })
         .flush(schema);
@@ -117,7 +117,7 @@ export class ApiPlanFormHarness extends ComponentHarness {
       expectCurrentUserTagsRequest,
       expectResourceGetRequest,
       expectPolicySchemaGetRequest,
-      expectPlanSchemaGetRequest,
+      expectPolicySchemaV2GetRequest,
     };
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.harness.ts
@@ -104,6 +104,12 @@ export class ApiPlanFormHarness extends ComponentHarness {
       httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.baseURL}/policies/${type}/schema`, method: 'GET' }).flush(schema);
     }
 
+    function expectPlanSchemaGetRequest(type: string, schema: unknown) {
+      httpTestingController
+        .expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/policies/${type}/schema`, method: 'GET' })
+        .flush(schema);
+    }
+
     return {
       expectTagsListRequest,
       expectGroupLisRequest,
@@ -111,6 +117,7 @@ export class ApiPlanFormHarness extends ComponentHarness {
       expectCurrentUserTagsRequest,
       expectResourceGetRequest,
       expectPolicySchemaGetRequest,
+      expectPlanSchemaGetRequest,
     };
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans-add.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans-add.component.ts
@@ -48,7 +48,11 @@ export class Step4Security1PlansAddComponent implements OnInit {
   }
 
   onAddPlan(): void {
-    this.planChanges.next(this.form.get('plan').value);
+    const planToSave: CreatePlanV4 = {
+      ...this.form.get('plan').value,
+      definitionVersion: 'V4',
+    };
+    this.planChanges.next(planToSave);
   }
 
   onExitPlanCreation(): void {

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans-list.component.ts
@@ -37,6 +37,9 @@ export class Step4Security1PlansListComponent implements OnInit {
   @Output()
   editPlanClicked = new EventEmitter<CreatePlanV4>();
 
+  @Output()
+  removePlanClicked = new EventEmitter<CreatePlanV4>();
+
   planSecurityOptions: PlanSecurityVM[];
 
   public form = new FormGroup({});
@@ -70,6 +73,6 @@ export class Step4Security1PlansListComponent implements OnInit {
   }
 
   removePlan(plan: CreatePlanV4) {
-    this.plans = this.plans.filter((listedPlan) => listedPlan !== plan);
+    this.removePlanClicked.emit(plan);
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans.component.html
@@ -27,6 +27,7 @@
       [plans]="plans"
       (addPlanClicked)="onAddPlanClicked($event)"
       (editPlanClicked)="onEditPlanClicked($event)"
+      (removePlanClicked)="onRemovePlanClicked($event)"
     ></step-4-security-1-plans-list>
   </ng-container>
 

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans.component.ts
@@ -83,5 +83,9 @@ export class Step4Security1PlansComponent implements OnInit {
     this.view = 'list';
   }
 
+  onRemovePlanClicked(plan: CreatePlanV4) {
+    this.plans = this.plans.filter((listedPlan) => listedPlan !== plan);
+  }
+
   protected readonly undefined = undefined;
 }

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans.component.ts
@@ -19,6 +19,7 @@ import { Component, OnInit } from '@angular/core';
 import { ApiCreationStepService } from '../../services/api-creation-step.service';
 import { CreatePlanV4 } from '../../../../../../entities/management-api-v2';
 import { PLAN_SECURITY_TYPES, PlanSecurityVM } from '../../../../../../services-ngx/constants.service';
+import { ApiCreationPayload } from '../../models/ApiCreationPayload';
 
 @Component({
   selector: 'step-4-security-1-plans',
@@ -41,6 +42,15 @@ export class Step4Security1PlansComponent implements OnInit {
 
     // For first pass-through of creation workflow
     if (!currentStepPayload.plans) {
+      this.computeDefaultApiPlans(currentStepPayload);
+    } else {
+      this.plans = currentStepPayload.plans;
+    }
+  }
+
+  private computeDefaultApiPlans(currentStepPayload: ApiCreationPayload) {
+    const entrypoint = currentStepPayload.selectedEntrypoints.find((e) => e.supportedListenerType !== 'SUBSCRIPTION');
+    if (entrypoint) {
       this.plans.push({
         definitionVersion: 'V4',
         name: 'Default Keyless (UNSECURED)',
@@ -51,8 +61,21 @@ export class Step4Security1PlansComponent implements OnInit {
         },
         validation: 'MANUAL',
       });
-    } else {
-      this.plans = currentStepPayload.plans;
+    }
+
+    const subscriptionEntrypoint = currentStepPayload.selectedEntrypoints.find((e) => e.supportedListenerType === 'SUBSCRIPTION');
+    if (subscriptionEntrypoint) {
+      // If yes, add a plan with a default security type
+      this.plans.push({
+        definitionVersion: 'V4',
+        name: 'Default PUSH plan',
+        description: 'Default push plan',
+        security: {
+          type: 'PUSH',
+          configuration: {},
+        },
+        validation: 'MANUAL',
+      });
     }
   }
 

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans.harness.ts
@@ -69,7 +69,7 @@ export class Step4Security1PlansHarness extends ComponentHarness {
   async addApiKeyPlan(planName: string, httpTestingController: HttpTestingController): Promise<void> {
     await this.getButtonBySelector('[aria-label="Add new plan"]').then((b) => b.click());
     const planSecurityDropdown = await this.locatorFor(MatMenuHarness)();
-    expect(await planSecurityDropdown.getItems().then((items) => items.length)).toEqual(4);
+    expect(await planSecurityDropdown.getItems().then((items) => items.length)).toEqual(5);
 
     await planSecurityDropdown.clickItem({ text: 'API Key' });
 
@@ -78,7 +78,7 @@ export class Step4Security1PlansHarness extends ComponentHarness {
     apiPlanFormHarness.httpRequest(httpTestingController).expectGroupLisRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
     await apiPlanFormHarness.getNameInput().then((i) => i.setValue(planName));
 
-    apiPlanFormHarness.httpRequest(httpTestingController).expectPolicySchemaGetRequest('api-key', {});
+    apiPlanFormHarness.httpRequest(httpTestingController).expectPlanSchemaGetRequest('api-key', {});
 
     await (await this.getButtonByText('Next')).click();
     await (await this.getButtonByText('Next')).click();

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans.harness.ts
@@ -78,7 +78,7 @@ export class Step4Security1PlansHarness extends ComponentHarness {
     apiPlanFormHarness.httpRequest(httpTestingController).expectGroupLisRequest([fakeGroup({ id: 'group-a', name: 'Group A' })]);
     await apiPlanFormHarness.getNameInput().then((i) => i.setValue(planName));
 
-    apiPlanFormHarness.httpRequest(httpTestingController).expectPlanSchemaGetRequest('api-key', {});
+    apiPlanFormHarness.httpRequest(httpTestingController).expectPolicySchemaV2GetRequest('api-key', {});
 
     await (await this.getButtonByText('Next')).click();
     await (await this.getButtonByText('Next')).click();

--- a/gravitee-apim-console-webui/src/management/api/portal/plans/edit/api-portal-plan-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/plans/edit/api-portal-plan-edit.component.spec.ts
@@ -112,7 +112,7 @@ describe('ApiPortalPlanEditComponent', () => {
           },
         ]);
         planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
-        planForm.httpRequest(httpTestingController).expectPlanSchemaGetRequest('jwt', {});
+        planForm.httpRequest(httpTestingController).expectPolicySchemaV2GetRequest('jwt', {});
 
         await planForm.getNameInput().then((i) => i.setValue('My new plan'));
 
@@ -414,7 +414,7 @@ describe('ApiPortalPlanEditComponent', () => {
         },
       ]);
       planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([TAG_1_ID]);
-      planForm.httpRequest(httpTestingController).expectPlanSchemaGetRequest('jwt', {});
+      planForm.httpRequest(httpTestingController).expectPolicySchemaV2GetRequest('jwt', {});
 
       await planForm.getNameInput().then((i) => i.setValue('My new plan'));
 

--- a/gravitee-apim-console-webui/src/management/api/portal/plans/edit/api-portal-plan-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/plans/edit/api-portal-plan-edit.component.ts
@@ -92,7 +92,12 @@ export class ApiPortalPlanEditComponent implements OnInit, OnDestroy {
       )
       .subscribe(() => {
         if (this.mode === 'edit') {
-          this.planSecurity = PLAN_SECURITY_TYPES.find((vm) => vm.id === this.planForm.value.plan.security.type);
+          // TODO remove this when the SUBSCRIPTION security type is renamed on the backend side
+          if (this.planForm.value.plan.security.type === 'SUBSCRIPTION') {
+            this.planSecurity = PLAN_SECURITY_TYPES.find((vm) => vm.id === 'PUSH');
+          } else {
+            this.planSecurity = PLAN_SECURITY_TYPES.find((vm) => vm.id === this.planForm.value.plan.security.type);
+          }
         } else {
           this.planSecurity = PLAN_SECURITY_TYPES.find((vm) => vm.id === this.ajsStateParams.securityType);
         }

--- a/gravitee-apim-console-webui/src/management/api/portal/plans/list/api-portal-plan-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/plans/list/api-portal-plan-list.component.spec.ts
@@ -91,6 +91,9 @@ describe('ApiPortalPlanListComponent', () => {
               sharedApiKey: {
                 enabled: true,
               },
+              push: {
+                enabled: true,
+              },
             });
             return constants;
           },
@@ -146,6 +149,16 @@ describe('ApiPortalPlanListComponent', () => {
         },
       ]);
       expect(rowCells).toEqual([['', 'Default plan', 'API_KEY', 'PUBLISHED', '🙅, 🔑', '']]);
+    }));
+
+    it('should not display PUSH plan option for V2 APIs', fakeAsync(async () => {
+      await initComponent([]);
+      await loader.getHarness(MatButtonHarness.with({ selector: '[aria-label="Add new plan"]' })).then((btn) => btn.click());
+
+      const planSecurityDropdown = await loader.getHarness(MatMenuHarness);
+      const items = await planSecurityDropdown.getItems();
+      const availablePlans = await Promise.all(items.map((item) => item.getText()));
+      expect(availablePlans).not.toContain('Push plan');
     }));
 
     it('should search closed plan on click', fakeAsync(async () => {

--- a/gravitee-apim-console-webui/src/management/api/portal/plans/list/api-portal-plan-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/plans/list/api-portal-plan-list.component.ts
@@ -88,6 +88,10 @@ export class ApiPortalPlanListComponent implements OnInit, OnDestroy {
           if (!this.isReadOnly && !this.displayedColumns.includes('drag-icon')) {
             this.displayedColumns.unshift('drag-icon');
           }
+
+          if (this.api && this.api.definitionVersion !== 'V4') {
+            this.planSecurityOptions = this.planSecurityOptions.filter((security) => security.id !== 'PUSH');
+          }
         }),
         tap(() => this.onInit(this.status, true)),
         catchError(({ error }) => {

--- a/gravitee-apim-console-webui/src/management/configuration/portal/portal.html
+++ b/gravitee-apim-console-webui/src/management/configuration/portal/portal.html
@@ -105,6 +105,17 @@
         </md-checkbox>
       </md-input-container>
 
+      <md-input-container class="gv-input-container-dense">
+        <md-checkbox
+          ng-model="$ctrl.settings.plan.security.push.enabled"
+          aria-label="push"
+          ng-disabled="$ctrl.isReadonlySetting('plan.security.push.enabled')"
+        >
+          Push plans ( only available for API V4 )
+          <md-tooltip ng-if="$ctrl.isReadonlySetting('plan.security.push.enabled')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
+        </md-checkbox>
+      </md-input-container>
+
       <h3>API labels dictionary</h3>
       <md-input-container class="md-block">
         <label>Labels <small>(Used by API Management to suggest labels for API's details)</small></label>

--- a/gravitee-apim-console-webui/src/services-ngx/api-plan-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-plan-v2.service.spec.ts
@@ -127,6 +127,29 @@ describe('ApiPlanV2Service', () => {
       expect(planReq.request.body).toEqual(plan);
       planReq.flush(plan);
     });
+
+    it('should create PUSH plans using SUBSCRIPTION type', (done) => {
+      const plan: CreatePlanV4 = {
+        description: '',
+        definitionVersion: 'V4',
+        flows: [],
+        validation: 'AUTO',
+        name: 'free',
+        security: { type: 'PUSH', configuration: '{}' },
+      };
+
+      apiPlanV2Service.create(API_ID, plan).subscribe((response) => {
+        expect(response).toMatchObject(plan);
+        done();
+      });
+
+      const planReq = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/plans`,
+      });
+      expect(planReq.request.body.security.type).toEqual('SUBSCRIPTION');
+      planReq.flush(plan);
+    });
   });
 
   describe('get', () => {

--- a/gravitee-apim-console-webui/src/services-ngx/api-plan-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-plan-v2.service.ts
@@ -37,6 +37,9 @@ export class ApiPlanV2Service {
   }
 
   public create(apiId: string, plan: CreatePlan): Observable<Plan> {
+    if (plan.security.type === 'PUSH') {
+      plan.security.type = 'SUBSCRIPTION';
+    }
     return this.http.post<Plan>(`${this.constants.env.v2BaseURL}/apis/${apiId}/plans`, plan);
   }
 

--- a/gravitee-apim-console-webui/src/services-ngx/constants.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/constants.service.spec.ts
@@ -60,6 +60,9 @@ describe('ConstantsService', () => {
         sharedApiKey: {
           enabled: true,
         },
+        push: {
+          enabled: true,
+        },
       });
       const expectedPlanSecurityTypes = PLAN_SECURITY_TYPES;
 

--- a/gravitee-apim-console-webui/src/services-ngx/constants.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/constants.service.ts
@@ -44,6 +44,10 @@ export const PLAN_SECURITY_TYPES: PlanSecurityVM[] = [
     id: 'KEY_LESS',
     name: 'Keyless (public)',
   },
+  {
+    id: 'PUSH',
+    name: 'Push plan',
+  },
 ];
 
 @Injectable({

--- a/gravitee-apim-console-webui/src/services-ngx/policy-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/policy-v2.service.spec.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { PolicyV2Service } from './policy-v2.service';
+
+import { CONSTANTS_TESTING, GioHttpTestingModule } from '../shared/testing';
+import { fakePolicySchema } from '../entities/policy';
+
+describe('PolicyService', () => {
+  let httpTestingController: HttpTestingController;
+  let policyService: PolicyV2Service;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [GioHttpTestingModule],
+    });
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+    policyService = TestBed.inject<PolicyV2Service>(PolicyV2Service);
+  });
+
+  describe('getSchema', () => {
+    it('should call the API', (done) => {
+      const policyId = 'policy#1';
+      const policySchema = fakePolicySchema();
+
+      policyService.getSchema(policyId).subscribe((response) => {
+        expect(response).toStrictEqual(policySchema);
+        done();
+      });
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.v2BaseURL}/plugins/policies/policy#1/schema`);
+      expect(req.request.method).toEqual('GET');
+
+      req.flush(policySchema);
+    });
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+});

--- a/gravitee-apim-console-webui/src/services-ngx/policy-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/policy-v2.service.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpClient } from '@angular/common/http';
+import { Inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { Constants } from '../entities/Constants';
+import { PolicySchema } from '../entities/policy';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PolicyV2Service {
+  constructor(private readonly http: HttpClient, @Inject('Constants') private readonly constants: Constants) {}
+
+  getSchema(policyId: string): Observable<PolicySchema> {
+    return this.http.get<PolicySchema>(`${this.constants.v2BaseURL}/plugins/policies/${policyId}/schema`);
+  }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -117,6 +117,7 @@ public enum Key {
         "true",
         new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))
     ),
+    PLAN_SECURITY_PUSH_ENABLED("plan.security.push.enabled", "false", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
 
     OPEN_API_DOC_TYPE_SWAGGER_ENABLED(
         "open.api.doc.type.swagger.enabled",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PlanSettings.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PlanSettings.java
@@ -60,6 +60,9 @@ public class PlanSettings {
         @ParameterKey(Key.PLAN_SECURITY_JWT_ENABLED)
         private Enabled jwt;
 
+        @ParameterKey(Key.PLAN_SECURITY_PUSH_ENABLED)
+        private Enabled push;
+
         public Enabled getApikey() {
             return apikey;
         }
@@ -106,6 +109,14 @@ public class PlanSettings {
 
         public void setSharedApiKey(Enabled sharedApiKey) {
             this.sharedApiKey = sharedApiKey;
+        }
+
+        public Enabled getPush() {
+            return push;
+        }
+
+        public void setPush(Enabled push) {
+            this.push = push;
         }
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1449

## Description

Allow users to add and edit push plan on async APIs.

## Screenshots

https://github.com/gravitee-io/gravitee-api-management/assets/25704259/57fc6961-b3e8-4a7b-89d5-6e514744bcbd

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-vosqlbrusr.chromatic.com)
<!-- Storybook placeholder end -->
