### PR TITLE
ci: rename required jobs to publish docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2530,14 +2530,14 @@ workflows:
                   requires:
                       - Build backend
             - job-webui-build:
-                  name: Build APIM Consoleand publish image
+                  name: Build APIM Console and publish image
                   context: cicd-orchestrator
                   apim-ui-project: gravitee-apim-console-webui
                   docker-image-name: apim-management-ui
                   requires:
                       - Setup
             - job-webui-build:
-                  name: Build APIM Portaland publish image
+                  name: Build APIM Portal and publish image
                   context: cicd-orchestrator
                   apim-ui-project: gravitee-apim-portal-webui
                   docker-image-name: apim-portal-ui
@@ -2547,6 +2547,6 @@ workflows:
                   name: Publish environment URLs in Github PR
                   context: cicd-orchestrator
                   requires:
-                      - Build and push rest api and gatewayimages
-                      - Build APIM Consoleand publish image
-                      - Build APIM Portaland publish image
+                      - Build and push rest api and gateway images
+                      - Build APIM Console and publish image
+                      - Build APIM Portal and publish image


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Some jobs has been renamed since 2 weeks, during the circle ci config rework, and the publish docker image job looks broken. This job is used in the ephemeral environment creation workflow

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-npzfckkufy.chromatic.com)
<!-- Storybook placeholder end -->
