### PR TITLE
[console] filter plan according to API definition version and entrypoints types 

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.spec.ts
@@ -936,6 +936,7 @@ describe('ApiCreationV4Component', () => {
       describe('step4 - plans list', () => {
         it('should add default keyless and push plans to payload', async () => {
           const step4Security1PlansHarness = await harnessLoader.getHarness(Step4Security1PlansHarness);
+          expect(await step4Security1PlansHarness.getPlanNames()).toEqual(['OAuth2', 'JWT', 'API Key', 'Keyless (public)', 'Push plan']);
 
           const keylessPlan = await step4Security1PlansHarness.getColumnTextByRowIndex(0);
           expect(keylessPlan.name).toEqual('Default Keyless (UNSECURED)');
@@ -1006,6 +1007,7 @@ describe('ApiCreationV4Component', () => {
 
       it('should add default keyless plan only', async () => {
         const step4Security1PlansHarness = await harnessLoader.getHarness(Step4Security1PlansHarness);
+        expect(await step4Security1PlansHarness.getPlanNames()).toEqual(['OAuth2', 'JWT', 'API Key', 'Keyless (public)']);
 
         const keylessPlan = await step4Security1PlansHarness.getColumnTextByRowIndex(0);
         expect(keylessPlan.name).toEqual('Default Keyless (UNSECURED)');
@@ -1167,6 +1169,7 @@ describe('ApiCreationV4Component', () => {
 
       it('should add default push plan only', async () => {
         const step4Security1PlansHarness = await harnessLoader.getHarness(Step4Security1PlansHarness);
+        expect(await step4Security1PlansHarness.getPlanNames()).toEqual(['Push plan']);
 
         const pushPlan = await step4Security1PlansHarness.getColumnTextByRowIndex(0);
         expect(pushPlan.name).toEqual('Default PUSH plan');

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans-list.component.ts
@@ -49,6 +49,13 @@ export class Step4Security1PlansListComponent implements OnInit {
 
   ngOnInit(): void {
     this.planSecurityOptions = this.constantsService.getEnabledPlanSecurityTypes();
+    if (this.stepService?.payload?.selectedEntrypoints.every((entrypoint) => entrypoint.supportedListenerType === 'SUBSCRIPTION')) {
+      this.planSecurityOptions = this.planSecurityOptions.filter((planSecurityType) => planSecurityType.id === 'PUSH');
+    }
+
+    if (this.stepService?.payload?.selectedEntrypoints.every((entrypoint) => ['HTTP', 'TCP'].includes(entrypoint.supportedListenerType))) {
+      this.planSecurityOptions = this.planSecurityOptions.filter((planSecurityType) => planSecurityType.id !== 'PUSH');
+    }
   }
 
   save(): void {

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans.harness.ts
@@ -69,7 +69,7 @@ export class Step4Security1PlansHarness extends ComponentHarness {
   async addApiKeyPlan(planName: string, httpTestingController: HttpTestingController): Promise<void> {
     await this.getButtonBySelector('[aria-label="Add new plan"]').then((b) => b.click());
     const planSecurityDropdown = await this.locatorFor(MatMenuHarness)();
-    expect(await planSecurityDropdown.getItems().then((items) => items.length)).toEqual(5);
+    expect(await planSecurityDropdown.getItems().then((items) => items.length)).toEqual(4);
 
     await planSecurityDropdown.clickItem({ text: 'API Key' });
 
@@ -128,5 +128,12 @@ export class Step4Security1PlansHarness extends ComponentHarness {
     apiPlanFormHarness.httpRequest(httpTestingController).expectPolicySchemaGetRequest('rate-limit', {});
 
     await (await this.getButtonByText('Save changes')).click();
+  }
+
+  async getPlanNames(): Promise<string[]> {
+    await this.getButtonBySelector('[aria-label="Add new plan"]').then((b) => b.click());
+    const planSecurityDropdown = await this.locatorFor(MatMenuHarness)();
+    const items = await planSecurityDropdown.getItems();
+    return Promise.all(items.map((item) => item.getText()));
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1449

## Description

In this PR we filter the V4 APIs plans available in the wizard and plan edition page.

- If the API only has SUBSCRIPTION entrypoints only push is displayed.
-  If the API only has HTTP or TCP entrypoints all plans except push are displayed.
-  If the API only has HTTP or TCP and SUBSCRIPTION entrypoints all plans are displayed.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hrbzdvlkkn.chromatic.com)
<!-- Storybook placeholder end -->
