### PR TITLE
fix: update api v2 mapper

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
@@ -107,11 +107,19 @@ public interface ApiMapper {
     UpdateApiEntity map(UpdateApiV4 updateApi, String apiId);
 
     @Mapping(target = "version", source = "apiVersion")
-    @Mapping(target = "graviteeDefinitionVersion", source = "definitionVersion")
+    @Mapping(target = "graviteeDefinitionVersion", source = "definitionVersion", qualifiedByName = "mapFromDefinitionVersion")
     io.gravitee.rest.api.model.api.UpdateApiEntity map(UpdateApiV2 updateApi);
 
     // DefinitionVersion
     io.gravitee.definition.model.DefinitionVersion mapDefinitionVersion(DefinitionVersion definitionVersion);
+
+    @Named("mapFromDefinitionVersion")
+    default String mapFromDefinitionVersion(DefinitionVersion definitionVersion) {
+        if (Objects.isNull(definitionVersion)) {
+            return null;
+        }
+        return io.gravitee.definition.model.DefinitionVersion.valueOf(definitionVersion.name()).getLabel();
+    }
 
     @Named("computeApiLinks")
     default ApiLinks computeApiLinks(GenericApiEntity api, UriInfo uriInfo) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapperTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import fixtures.ApiFixtures;
 import fixtures.CorsFixtures;
+import io.gravitee.definition.model.DefinitionVersion;
 import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
@@ -69,7 +70,7 @@ public class ApiMapperTest {
         assertThat(updateApiEntity.getCrossId()).isNull();
         assertThat(updateApiEntity.getName()).isEqualTo(updateApi.getName());
         assertThat(updateApiEntity.getVersion()).isEqualTo(updateApi.getApiVersion());
-        assertThat(updateApiEntity.getGraviteeDefinitionVersion()).isEqualTo(updateApi.getDefinitionVersion().name());
+        assertThat(updateApiEntity.getGraviteeDefinitionVersion()).isEqualTo(DefinitionVersion.V2.getLabel());
         assertThat(updateApiEntity.getDescription()).isEqualTo(updateApi.getDescription());
         assertThat(new ArrayList<>(updateApiEntity.getTags())).isEqualTo(updateApi.getTags());
         assertThat(updateApiEntity.getProxy()).isNotNull(); // To be tested in ProxyMapperTest ?

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiTest.java
@@ -22,11 +22,9 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import fixtures.ApiFixtures;
-import io.gravitee.rest.api.management.v2.rest.model.ApiV2;
-import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.rest.api.management.v2.rest.model.*;
 import io.gravitee.rest.api.management.v2.rest.model.Error;
-import io.gravitee.rest.api.management.v2.rest.model.UpdateApiV2;
-import io.gravitee.rest.api.management.v2.rest.model.UpdateApiV4;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
@@ -158,6 +156,7 @@ public class ApiResource_UpdateApiTest extends ApiResourceTest {
                 eq(API),
                 argThat(updateApiEntity -> {
                     assertEquals(updateApiV2.getName(), updateApiEntity.getName());
+                    assertEquals(updateApiEntity.getGraviteeDefinitionVersion(), DefinitionVersion.V2.getLabel());
                     return true;
                 }),
                 eq(false)


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1328

## Description

Fix UpdateApiV2 mapper to fix the match for definition version when updating V2 API 
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-oafhhksrex.chromatic.com)
<!-- Storybook placeholder end -->
