### PR TITLE
fix: exclude v4 apis when fetching apis

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiQuery.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiQuery.java
@@ -19,11 +19,17 @@ import io.gravitee.rest.api.model.Visibility;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class ApiQuery {
 
     private Collection<String> ids;
@@ -194,7 +200,7 @@ public class ApiQuery {
             '\'' +
             ", lifecycleStates=" +
             lifecycleStates +
-            +'\'' +
+            '\'' +
             ", crossId=" +
             crossId +
             '}'


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1968
https://github.com/gravitee-io/issues/issues/9091

## Description

We apply the same principle used in ApiService by setting a list of allowed definition to exclude v4 apis from the search.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- UI placeholder -->
🚀 CI was able to deploy the build of this PR, so you can now try it directly [here](https://apimnightlywebui24386.z6.web.core.windows.net/apim1968-3-19-x/index.html)
_Notes_: The deployed app is linked to the management API of APIM master. (Same login and password as APIM master)
<!-- UI placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mrscwfeqqu.chromatic.com)
<!-- Storybook placeholder end -->
