### PR TITLE
fix: prevent V4 API update to clear images

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
@@ -485,21 +485,10 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 api.setCrossId(apiToUpdate.getCrossId());
             }
 
-            // If no new picture and the current picture url is not the default one, keep the current picture
-            if (
-                updateApiEntity.getPicture() == null &&
-                updateApiEntity.getPictureUrl() != null &&
-                updateApiEntity.getPictureUrl().indexOf("?hash") > 0
-            ) {
-                api.setPicture(apiToUpdate.getPicture());
-            }
-            if (
-                updateApiEntity.getBackground() == null &&
-                updateApiEntity.getBackgroundUrl() != null &&
-                updateApiEntity.getBackgroundUrl().indexOf("?hash") > 0
-            ) {
-                api.setBackground(apiToUpdate.getBackground());
-            }
+            // Keep existing picture as picture update has dedicated service
+            api.setPicture(apiToUpdate.getPicture());
+            api.setBackground(apiToUpdate.getBackground());
+
             if (updateApiEntity.getGroups() == null) {
                 api.setGroups(apiToUpdate.getGroups());
             }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1328

## Description

Images were not persisted when updating anything in the API. 


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zqwcnpqzej.chromatic.com)
<!-- Storybook placeholder end -->
