### PR TITLE
Update `gravitee-bom` to 3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.3</version>
+        <version>21.0.0</version>
     </parent>
 
     <groupId>io.gravitee.apim</groupId>
@@ -64,7 +64,7 @@
         <!-- Vert.X version is mandatory for vertx-grpc-protoc-plugin in gravitee-apim-gateway-standalone-container -->
         <vertx.version>4.2.7</vertx.version>
         <!-- Gravitee dependencies version -->
-        <gravitee-bom.version>2.8</gravitee-bom.version>
+        <gravitee-bom.version>3.0.8</gravitee-bom.version>
         <gravitee-alert-api.version>1.9.1</gravitee-alert-api.version>
         <gravitee-cockpit-api.version>1.12.0</gravitee-cockpit-api.version>
         <gravitee-common.version>1.27.0</gravitee-common.version>


### PR DESCRIPTION
## Issue

NA

## Description

Goal of this PR is to start the alignment of `gravitee-bom` major version between APIM 3.18, 3.19 and 3.20
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-enoneaaxao.chromatic.com)
<!-- Storybook placeholder end -->
