### PR TITLE
MAPI V2 - add resources to change the status of a subscription

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource.java
@@ -271,7 +271,7 @@ public class ApiSubscriptionsResource extends AbstractResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Permissions({ @Permission(value = RolePermission.API_SUBSCRIPTION, acls = { RolePermissionAction.UPDATE }) })
-    public Response updateApiPlan(
+    public Response updateApiSubscription(
         @PathParam("subscriptionId") String subscriptionId,
         @Valid @NotNull UpdateSubscription updateSubscription
     ) {
@@ -287,6 +287,51 @@ public class ApiSubscriptionsResource extends AbstractResource {
             .status(Response.Status.OK)
             .entity(subscriptionMapper.map(subscriptionService.update(executionContext, updateSubscriptionEntity)))
             .build();
+    }
+
+    @POST
+    @Path("/{subscriptionId}/_close")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.API_SUBSCRIPTION, acls = { RolePermissionAction.UPDATE }) })
+    public Response closeApiSubscription(@PathParam("subscriptionId") String subscriptionId) {
+        final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        SubscriptionEntity subscriptionEntity = subscriptionService.findById(subscriptionId);
+
+        if (!subscriptionEntity.getApi().equals(apiId)) {
+            return Response.status(Response.Status.NOT_FOUND).entity(subscriptionNotFoundError(subscriptionId)).build();
+        }
+
+        return Response.ok(subscriptionMapper.map(subscriptionService.close(executionContext, subscriptionId))).build();
+    }
+
+    @POST
+    @Path("/{subscriptionId}/_pause")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.API_SUBSCRIPTION, acls = { RolePermissionAction.UPDATE }) })
+    public Response pauseApiSubscription(@PathParam("subscriptionId") String subscriptionId) {
+        final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        SubscriptionEntity subscriptionEntity = subscriptionService.findById(subscriptionId);
+
+        if (!subscriptionEntity.getApi().equals(apiId)) {
+            return Response.status(Response.Status.NOT_FOUND).entity(subscriptionNotFoundError(subscriptionId)).build();
+        }
+
+        return Response.ok(subscriptionMapper.map(subscriptionService.pause(executionContext, subscriptionId))).build();
+    }
+
+    @POST
+    @Path("/{subscriptionId}/_resume")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.API_SUBSCRIPTION, acls = { RolePermissionAction.UPDATE }) })
+    public Response resumeApiSubscription(@PathParam("subscriptionId") String subscriptionId) {
+        final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        SubscriptionEntity subscriptionEntity = subscriptionService.findById(subscriptionId);
+
+        if (!subscriptionEntity.getApi().equals(apiId)) {
+            return Response.status(Response.Status.NOT_FOUND).entity(subscriptionNotFoundError(subscriptionId)).build();
+        }
+
+        return Response.ok(subscriptionMapper.map(subscriptionService.resume(executionContext, subscriptionId))).build();
     }
 
     private void expandData(Subscription subscription, Set<String> expands) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
@@ -1055,6 +1055,75 @@ paths:
                                 $ref: "#/components/schemas/Subscription"
                 default:
                     $ref: "#/components/responses/Error"
+    /environments/{envId}/apis/{apiId}/subscriptions/{subscriptionId}/_close:
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+            - $ref: "#/components/parameters/apiIdParam"
+            - $ref: "#/components/parameters/subscriptionIdParam"
+        post:
+            tags:
+                - API Subscriptions
+            summary: Close one API's subscription
+            description: |-
+                Close the API's subscription.
+
+                User must have the API_SUBSCRIPTION[UPDATE] permission.
+            operationId: closeApiSubscription
+            responses:
+                "200":
+                    description: API's subscription successfully closed
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Subscription"
+                default:
+                    $ref: "#/components/responses/Error"
+    /environments/{envId}/apis/{apiId}/subscriptions/{subscriptionId}/_pause:
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+            - $ref: "#/components/parameters/apiIdParam"
+            - $ref: "#/components/parameters/subscriptionIdParam"
+        post:
+            tags:
+                - API Subscriptions
+            summary: Pause one API's subscription
+            description: |-
+                Pause the API's subscription.
+
+                User must have the API_SUBSCRIPTION[UPDATE] permission.
+            operationId: pauseApiSubscription
+            responses:
+                "200":
+                    description: API's subscription successfully paused
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Subscription"
+                default:
+                    $ref: "#/components/responses/Error"
+    /environments/{envId}/apis/{apiId}/subscriptions/{subscriptionId}/_resume:
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+            - $ref: "#/components/parameters/apiIdParam"
+            - $ref: "#/components/parameters/subscriptionIdParam"
+        post:
+            tags:
+                - API Subscriptions
+            summary: Resume a paused API's subscription
+            description: |-
+                Resume a previously paused subscription.
+
+                User must have the API_SUBSCRIPTION[UPDATE] permission.
+            operationId: resumeApiSubscription
+            responses:
+                "200":
+                    description: API's subscription successfully resumed
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Subscription"
+                default:
+                    $ref: "#/components/responses/Error"
 
     # Plugins - Endpoints
     /plugins/endpoints:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource_CloseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource_CloseTest.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api;
+
+import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
+import static io.gravitee.common.http.HttpStatusCode.NOT_FOUND_404;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import fixtures.PlanFixtures;
+import fixtures.SubscriptionFixtures;
+import io.gravitee.rest.api.management.v2.rest.model.Error;
+import io.gravitee.rest.api.management.v2.rest.model.PlanV2;
+import io.gravitee.rest.api.management.v2.rest.model.PlanV4;
+import io.gravitee.rest.api.management.v2.rest.model.Subscription;
+import io.gravitee.rest.api.model.SubscriptionEntity;
+import io.gravitee.rest.api.model.SubscriptionStatus;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.model.v4.plan.PlanEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.PlanNotFoundException;
+import io.gravitee.rest.api.service.exceptions.SubscriptionNotFoundException;
+import io.gravitee.rest.api.service.v4.PlanSearchService;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ApiSubscriptionsResource_CloseTest extends ApiSubscriptionsResourceTest {
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/apis/" + API + "/subscriptions" + "/" + SUBSCRIPTION + "/_close";
+    }
+
+    @Test
+    public void should_return_404_if_not_found() {
+        when(subscriptionService.findById(SUBSCRIPTION)).thenThrow(new SubscriptionNotFoundException(SUBSCRIPTION));
+
+        final Response response = rootTarget().request().post(Entity.json(null));
+        assertEquals(NOT_FOUND_404, response.getStatus());
+
+        var error = response.readEntity(Error.class);
+        assertEquals(NOT_FOUND_404, (int) error.getHttpStatus());
+        assertEquals("Subscription [" + SUBSCRIPTION + "] cannot be found.", error.getMessage());
+
+        verify(subscriptionService, never()).close(any(), any());
+    }
+
+    @Test
+    public void should_return_404_if_plan_associated_to_another_api() {
+        final SubscriptionEntity subscriptionEntity = SubscriptionFixtures
+            .aSubscriptionEntity()
+            .toBuilder()
+            .id(SUBSCRIPTION)
+            .api("ANOTHER-API")
+            .build();
+
+        when(subscriptionService.findById(SUBSCRIPTION)).thenReturn(subscriptionEntity);
+
+        final Response response = rootTarget().request().post(Entity.json(null));
+        assertEquals(NOT_FOUND_404, response.getStatus());
+
+        var error = response.readEntity(Error.class);
+        assertEquals(NOT_FOUND_404, (int) error.getHttpStatus());
+        assertEquals("Subscription [" + SUBSCRIPTION + "] cannot be found.", error.getMessage());
+
+        verify(subscriptionService, never()).close(any(), any());
+    }
+
+    @Test
+    public void should_return_403_if_incorrect_permissions() {
+        when(
+            permissionService.hasPermission(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(RolePermission.API_SUBSCRIPTION),
+                eq(API),
+                eq(RolePermissionAction.UPDATE)
+            )
+        )
+            .thenReturn(false);
+
+        final Response response = rootTarget().request().post(Entity.json(null));
+        assertEquals(FORBIDDEN_403, response.getStatus());
+
+        var error = response.readEntity(Error.class);
+        assertEquals(FORBIDDEN_403, (int) error.getHttpStatus());
+        assertEquals("You do not have sufficient rights to access this resource", error.getMessage());
+
+        verify(subscriptionService, never()).close(any(), any());
+    }
+
+    @Test
+    public void should_return_subscription_when_subscription_closed() {
+        final SubscriptionEntity subscriptionEntity = SubscriptionFixtures
+            .aSubscriptionEntity()
+            .toBuilder()
+            .id(SUBSCRIPTION)
+            .api(API)
+            .build();
+        when(subscriptionService.findById(SUBSCRIPTION)).thenReturn(subscriptionEntity);
+
+        when(subscriptionService.close(GraviteeContext.getExecutionContext(), SUBSCRIPTION))
+            .thenReturn(subscriptionEntity.toBuilder().status(SubscriptionStatus.CLOSED).build());
+
+        final Response response = rootTarget().request().post(Entity.json(null));
+        assertEquals(OK_200, response.getStatus());
+
+        var subscription = response.readEntity(Subscription.class);
+        assertEquals(subscriptionEntity.getId(), subscription.getId());
+
+        verify(subscriptionService, times(1)).close(GraviteeContext.getExecutionContext(), SUBSCRIPTION);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource_PauseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource_PauseTest.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api;
+
+import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
+import static io.gravitee.common.http.HttpStatusCode.NOT_FOUND_404;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import fixtures.SubscriptionFixtures;
+import io.gravitee.rest.api.management.v2.rest.model.Error;
+import io.gravitee.rest.api.management.v2.rest.model.Subscription;
+import io.gravitee.rest.api.model.SubscriptionEntity;
+import io.gravitee.rest.api.model.SubscriptionStatus;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.SubscriptionNotFoundException;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
+import org.junit.Test;
+
+public class ApiSubscriptionsResource_PauseTest extends ApiSubscriptionsResourceTest {
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/apis/" + API + "/subscriptions" + "/" + SUBSCRIPTION + "/_pause";
+    }
+
+    @Test
+    public void should_return_404_if_not_found() {
+        when(subscriptionService.findById(SUBSCRIPTION)).thenThrow(new SubscriptionNotFoundException(SUBSCRIPTION));
+
+        final Response response = rootTarget().request().post(Entity.json(null));
+        assertEquals(NOT_FOUND_404, response.getStatus());
+
+        var error = response.readEntity(Error.class);
+        assertEquals(NOT_FOUND_404, (int) error.getHttpStatus());
+        assertEquals("Subscription [" + SUBSCRIPTION + "] cannot be found.", error.getMessage());
+
+        verify(subscriptionService, never()).pause(any(), any());
+    }
+
+    @Test
+    public void should_return_404_if_plan_associated_to_another_api() {
+        final SubscriptionEntity subscriptionEntity = SubscriptionFixtures
+            .aSubscriptionEntity()
+            .toBuilder()
+            .id(SUBSCRIPTION)
+            .api("ANOTHER-API")
+            .build();
+
+        when(subscriptionService.findById(SUBSCRIPTION)).thenReturn(subscriptionEntity);
+
+        final Response response = rootTarget().request().post(Entity.json(null));
+        assertEquals(NOT_FOUND_404, response.getStatus());
+
+        var error = response.readEntity(Error.class);
+        assertEquals(NOT_FOUND_404, (int) error.getHttpStatus());
+        assertEquals("Subscription [" + SUBSCRIPTION + "] cannot be found.", error.getMessage());
+
+        verify(subscriptionService, never()).pause(any(), any());
+    }
+
+    @Test
+    public void should_return_403_if_incorrect_permissions() {
+        when(
+            permissionService.hasPermission(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(RolePermission.API_SUBSCRIPTION),
+                eq(API),
+                eq(RolePermissionAction.UPDATE)
+            )
+        )
+            .thenReturn(false);
+
+        final Response response = rootTarget().request().post(Entity.json(null));
+        assertEquals(FORBIDDEN_403, response.getStatus());
+
+        var error = response.readEntity(Error.class);
+        assertEquals(FORBIDDEN_403, (int) error.getHttpStatus());
+        assertEquals("You do not have sufficient rights to access this resource", error.getMessage());
+
+        verify(subscriptionService, never()).pause(any(), any());
+    }
+
+    @Test
+    public void should_return_subscription_when_subscription_paused() {
+        final SubscriptionEntity subscriptionEntity = SubscriptionFixtures
+            .aSubscriptionEntity()
+            .toBuilder()
+            .id(SUBSCRIPTION)
+            .api(API)
+            .build();
+        when(subscriptionService.findById(SUBSCRIPTION)).thenReturn(subscriptionEntity);
+
+        when(subscriptionService.pause(GraviteeContext.getExecutionContext(), SUBSCRIPTION))
+            .thenReturn(subscriptionEntity.toBuilder().status(SubscriptionStatus.PAUSED).build());
+
+        final Response response = rootTarget().request().post(Entity.json(null));
+        assertEquals(OK_200, response.getStatus());
+
+        var subscription = response.readEntity(Subscription.class);
+        assertEquals(subscriptionEntity.getId(), subscription.getId());
+
+        verify(subscriptionService, times(1)).pause(GraviteeContext.getExecutionContext(), SUBSCRIPTION);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource_ResumeTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource_ResumeTest.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api;
+
+import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
+import static io.gravitee.common.http.HttpStatusCode.NOT_FOUND_404;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import fixtures.SubscriptionFixtures;
+import io.gravitee.rest.api.management.v2.rest.model.Error;
+import io.gravitee.rest.api.management.v2.rest.model.Subscription;
+import io.gravitee.rest.api.model.SubscriptionEntity;
+import io.gravitee.rest.api.model.SubscriptionStatus;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.SubscriptionNotFoundException;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
+import org.junit.Test;
+
+public class ApiSubscriptionsResource_ResumeTest extends ApiSubscriptionsResourceTest {
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/apis/" + API + "/subscriptions" + "/" + SUBSCRIPTION + "/_resume";
+    }
+
+    @Test
+    public void should_return_404_if_not_found() {
+        when(subscriptionService.findById(SUBSCRIPTION)).thenThrow(new SubscriptionNotFoundException(SUBSCRIPTION));
+
+        final Response response = rootTarget().request().post(Entity.json(null));
+        assertEquals(NOT_FOUND_404, response.getStatus());
+
+        var error = response.readEntity(Error.class);
+        assertEquals(NOT_FOUND_404, (int) error.getHttpStatus());
+        assertEquals("Subscription [" + SUBSCRIPTION + "] cannot be found.", error.getMessage());
+
+        verify(subscriptionService, never()).resume(any(), any());
+    }
+
+    @Test
+    public void should_return_404_if_plan_associated_to_another_api() {
+        final SubscriptionEntity subscriptionEntity = SubscriptionFixtures
+            .aSubscriptionEntity()
+            .toBuilder()
+            .id(SUBSCRIPTION)
+            .api("ANOTHER-API")
+            .build();
+
+        when(subscriptionService.findById(SUBSCRIPTION)).thenReturn(subscriptionEntity);
+
+        final Response response = rootTarget().request().post(Entity.json(null));
+        assertEquals(NOT_FOUND_404, response.getStatus());
+
+        var error = response.readEntity(Error.class);
+        assertEquals(NOT_FOUND_404, (int) error.getHttpStatus());
+        assertEquals("Subscription [" + SUBSCRIPTION + "] cannot be found.", error.getMessage());
+
+        verify(subscriptionService, never()).resume(any(), any());
+    }
+
+    @Test
+    public void should_return_403_if_incorrect_permissions() {
+        when(
+            permissionService.hasPermission(
+                eq(GraviteeContext.getExecutionContext()),
+                eq(RolePermission.API_SUBSCRIPTION),
+                eq(API),
+                eq(RolePermissionAction.UPDATE)
+            )
+        )
+            .thenReturn(false);
+
+        final Response response = rootTarget().request().post(Entity.json(null));
+        assertEquals(FORBIDDEN_403, response.getStatus());
+
+        var error = response.readEntity(Error.class);
+        assertEquals(FORBIDDEN_403, (int) error.getHttpStatus());
+        assertEquals("You do not have sufficient rights to access this resource", error.getMessage());
+
+        verify(subscriptionService, never()).resume(any(), any());
+    }
+
+    @Test
+    public void should_return_subscription_when_subscription_resumed() {
+        final SubscriptionEntity subscriptionEntity = SubscriptionFixtures
+            .aSubscriptionEntity()
+            .toBuilder()
+            .id(SUBSCRIPTION)
+            .api(API)
+            .build();
+        when(subscriptionService.findById(SUBSCRIPTION)).thenReturn(subscriptionEntity);
+
+        when(subscriptionService.resume(GraviteeContext.getExecutionContext(), SUBSCRIPTION))
+            .thenReturn(subscriptionEntity.toBuilder().status(SubscriptionStatus.RESUMED).build());
+
+        final Response response = rootTarget().request().post(Entity.json(null));
+        assertEquals(OK_200, response.getStatus());
+
+        var subscription = response.readEntity(Subscription.class);
+        assertEquals(subscriptionEntity.getId(), subscription.getId());
+
+        verify(subscriptionService, times(1)).resume(GraviteeContext.getExecutionContext(), SUBSCRIPTION);
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2006

## Description

You can now close, pause, and resume a subscription with MAPI v2 by calling these resources:
 - POST /apis/{apiId}/subscriptions/{subscriptionId}/_close
 - POST /apis/{apiId}/subscriptions/{subscriptionId}/_pause
 - POST /apis/{apiId}/subscriptions/{subscriptionId}/_resume
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-prtvtcwral.chromatic.com)
<!-- Storybook placeholder end -->
