### PR TITLE
feat: add path parameter overlap validation

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/pathparameters/PathParametersExtractor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/pathparameters/PathParametersExtractor.java
@@ -73,7 +73,7 @@ public class PathParametersExtractor extends AbstractPathParametersExtractor<Api
             .flatMap(f -> f.selectorByType(SelectorType.HTTP).map(selector -> (HttpSelector) selector).stream())
             .flatMap(selector -> {
                 List<Map.Entry<PathParameterHttpMethod, PathParameters>> flowByMethod;
-                if (selector.getMethods().isEmpty()) {
+                if (selector.getMethods() == null || selector.getMethods().isEmpty()) {
                     flowByMethod =
                         List.of(
                             Map.entry(PathParameterHttpMethod.WILDCARD, new PathParameters(selector.getPath(), selector.getPathOperator()))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/GraviteeManagementV2Application.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/GraviteeManagementV2Application.java
@@ -70,6 +70,7 @@ public class GraviteeManagementV2Application extends ResourceConfig {
         register(NotAllowedExceptionMapper.class);
         register(BadRequestExceptionMapper.class);
         register(PreconditionFailedExceptionMapper.class);
+        register(ValidationExceptionMapper.class);
 
         register(CommaSeparatedQueryParamConverterProvider.class);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/ValidationExceptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/ValidationExceptionMapper.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.exceptionMapper;
+
+import io.gravitee.rest.api.management.v2.rest.model.Error;
+import io.gravitee.rest.api.management.v2.rest.model.ErrorDetailsInner;
+import io.gravitee.rest.api.service.exceptions.AbstractValidationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ValidationExceptionMapper extends AbstractExceptionMapper<AbstractValidationException> {
+
+    @Override
+    public Response toResponse(AbstractValidationException ve) {
+        return Response
+            .status(Response.Status.fromStatusCode(ve.getHttpStatusCode()))
+            .type(MediaType.APPLICATION_JSON_TYPE)
+            .entity(validationError(ve))
+            .build();
+    }
+
+    private Error validationError(AbstractValidationException ve) {
+        return Error.builder().httpStatus(ve.getHttpStatusCode()).message(ve.getMessage()).details(buildDetails(ve)).build();
+    }
+
+    private List<ErrorDetailsInner> buildDetails(AbstractValidationException exception) {
+        return exception
+            .getConstraints()
+            .entrySet()
+            .stream()
+            .map(entry ->
+                ErrorDetailsInner
+                    .builder()
+                    .message(exception.getDetailMessage())
+                    .invalidValue(entry.getKey())
+                    .location(entry.getValue())
+                    .build()
+            )
+            .collect(Collectors.toList());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/ValidationExceptionMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/exceptionMapper/ValidationExceptionMapperTest.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.exceptionMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.rest.api.management.v2.rest.model.Error;
+import io.gravitee.rest.api.management.v2.rest.model.ErrorDetailsInner;
+import io.gravitee.rest.api.service.exceptions.AbstractValidationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class ValidationExceptionMapperTest {
+
+    private ValidationExceptionMapper cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new ValidationExceptionMapper();
+    }
+
+    @Test
+    void shouldMapExceptionToResponse() {
+        final FakeValidationException exception = new FakeValidationException();
+        try (Response response = cut.toResponse(exception)) {
+            assertThat(response.getStatus()).isEqualTo(exception.getHttpStatusCode());
+            assertThat(response.getMediaType()).isEqualTo(MediaType.APPLICATION_JSON_TYPE);
+            assertThat(response.getEntity())
+                .isInstanceOf(Error.class)
+                .satisfies(errorObject -> {
+                    Error error = ((Error) errorObject);
+                    assertThat(error.getHttpStatus()).isEqualTo(exception.getHttpStatusCode());
+                    assertThat(error.getMessage()).isEqualTo(exception.getMessage());
+                    assertThat(error.getDetails())
+                        .hasSize(2)
+                        .satisfies(listErrorDetails -> {
+                            final ErrorDetailsInner firstDetail = listErrorDetails
+                                .stream()
+                                .filter(detail -> "key1".equals(detail.getInvalidValue()))
+                                .findFirst()
+                                .get();
+                            assertThat(firstDetail.getInvalidValue()).isEqualTo("key1");
+                            assertThat(firstDetail.getMessage()).isEqualTo("fake detail message");
+                            assertThat(firstDetail.getLocation()).isEqualTo("value1");
+
+                            final ErrorDetailsInner secondDetail = listErrorDetails
+                                .stream()
+                                .filter(detail -> "key2".equals(detail.getInvalidValue()))
+                                .findFirst()
+                                .get();
+                            assertThat(secondDetail.getInvalidValue()).isEqualTo("key2");
+                            assertThat(secondDetail.getMessage()).isEqualTo("fake detail message");
+                            assertThat(secondDetail.getLocation()).isEqualTo("value2");
+                        });
+                });
+        }
+    }
+
+    static class FakeValidationException extends AbstractValidationException {
+
+        @Override
+        public String getMessage() {
+            return "fake exception";
+        }
+
+        @Override
+        public String getDetailMessage() {
+            return "fake detail message";
+        }
+
+        @Override
+        public String getTechnicalCode() {
+            return null;
+        }
+
+        @Override
+        public Map<String, String> getParameters() {
+            return null;
+        }
+
+        @Override
+        public Map<String, String> getConstraints() {
+            return Map.of("key1", "value1", "key2", "value2");
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/AbstractValidationException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/AbstractValidationException.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.exceptions;
+
+import io.gravitee.common.http.HttpStatusCode;
+import java.util.Map;
+
+/**
+ * @author David BRASSELY (david.brassely at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public abstract class AbstractValidationException extends AbstractManagementException {
+
+    /**
+     * Constructor.
+     */
+    protected AbstractValidationException() {}
+
+    /**
+     * Constructor.
+     * @param cause the exception cause
+     */
+    protected AbstractValidationException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Constructor.
+     * @param message the exception message
+     */
+    protected AbstractValidationException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructor.
+     * @param message the exception message
+     * @param cause the exception cause
+     */
+    protected AbstractValidationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Validation error";
+    }
+
+    /**
+     * @return the message to display for detail.
+     */
+    public String getDetailMessage() {
+        return "Error occurs for:";
+    }
+
+    public abstract String getTechnicalCode();
+
+    public abstract Map<String, String> getParameters();
+
+    public abstract Map<String, String> getConstraints();
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PlanService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PlanService.java
@@ -39,8 +39,6 @@ public interface PlanService {
 
     PlanEntity update(final ExecutionContext executionContext, final UpdatePlanEntity plan);
 
-    PlanEntity update(final ExecutionContext executionContext, final UpdatePlanEntity plan, final boolean fromImport);
-
     PlanEntity close(final ExecutionContext executionContext, final String plan);
 
     void delete(final ExecutionContext executionContext, final String plan);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/exception/PathParameterOverlapValidationException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/exception/PathParameterOverlapValidationException.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.exception;
+
+import io.gravitee.rest.api.service.exceptions.AbstractValidationException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class PathParameterOverlapValidationException extends AbstractValidationException {
+
+    private final Map<String, String> overlaps;
+
+    public PathParameterOverlapValidationException(Map<String, String> overlaps) {
+        super();
+        this.overlaps = overlaps;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Some path parameters are used at different position across different flows.";
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "api.pathparams.overlap";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return new HashMap<>();
+    }
+
+    @Override
+    public String getDetailMessage() {
+        return "There is a path parameter overlap";
+    }
+
+    @Override
+    public Map<String, String> getConstraints() {
+        return overlaps;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
@@ -42,6 +42,7 @@ import io.gravitee.rest.api.service.v4.validation.EndpointGroupsValidationServic
 import io.gravitee.rest.api.service.v4.validation.FlowValidationService;
 import io.gravitee.rest.api.service.v4.validation.GroupValidationService;
 import io.gravitee.rest.api.service.v4.validation.ListenerValidationService;
+import io.gravitee.rest.api.service.v4.validation.PlanValidationService;
 import io.gravitee.rest.api.service.v4.validation.ResourcesValidationService;
 import io.gravitee.rest.api.service.v4.validation.TagsValidationService;
 import org.springframework.stereotype.Component;
@@ -61,6 +62,7 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
     private final ResourcesValidationService resourcesValidationService;
     private final AnalyticsValidationService analyticsValidationService;
     private final PlanService planService;
+    private final PlanValidationService planValidationService;
 
     public ApiValidationServiceImpl(
         final TagsValidationService tagsValidationService,
@@ -70,7 +72,8 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
         final FlowValidationService flowValidationService,
         final ResourcesValidationService resourcesValidationService,
         final AnalyticsValidationService loggingValidationService,
-        PlanService planService
+        PlanService planService,
+        final PlanValidationService planValidationService
     ) {
         this.tagsValidationService = tagsValidationService;
         this.groupValidationService = groupValidationService;
@@ -80,6 +83,7 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
         this.resourcesValidationService = resourcesValidationService;
         this.analyticsValidationService = loggingValidationService;
         this.planService = planService;
+        this.planValidationService = planValidationService;
     }
 
     @Override
@@ -160,6 +164,10 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
         );
         // Validate and clean flow
         updateApiEntity.setFlows(flowValidationService.validateAndSanitize(updateApiEntity.getType(), updateApiEntity.getFlows()));
+
+        // Validate and clean plans
+        updateApiEntity.setPlans(planValidationService.validateAndSanitize(updateApiEntity.getType(), updateApiEntity.getPlans()));
+
         // Validate and clean resources
         updateApiEntity.setResources(resourcesValidationService.validateAndSanitize(updateApiEntity.getResources()));
     }
@@ -192,6 +200,9 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
         );
         // Validate and clean flow
         apiEntity.setFlows(flowValidationService.validateAndSanitize(apiEntity.getType(), apiEntity.getFlows()));
+
+        // Validate and clean plans
+        apiEntity.setPlans(planValidationService.validateAndSanitize(apiEntity.getType(), apiEntity.getPlans()));
 
         // Validate and clean resources
         apiEntity.setResources(resourcesValidationService.validateAndSanitize(apiEntity.getResources()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/PathParametersValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/PathParametersValidationServiceImpl.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.impl.validation;
+
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.flow.selector.ChannelSelector;
+import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
+import io.gravitee.definition.model.v4.flow.selector.SelectorType;
+import io.gravitee.rest.api.service.v4.exception.PathParameterOverlapValidationException;
+import io.gravitee.rest.api.service.v4.validation.PathParametersValidationService;
+import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Component
+public class PathParametersValidationServiceImpl implements PathParametersValidationService {
+
+    private static final String PATH_PARAM_PREFIX = ":";
+    private static final String PATH_SEPARATOR = "/";
+    private static final Pattern SEPARATOR_SPLITTER = Pattern.compile(PATH_SEPARATOR);
+    private static final Pattern PARAM_PATTERN = Pattern.compile(":\\w*");
+
+    private static final Map<ApiType, Function<Flow, Optional<String>>> PATH_EXTRACTOR = Map.of(
+        ApiType.PROXY,
+        flow -> flow.selectorByType(SelectorType.HTTP).stream().map(selector -> ((HttpSelector) selector).getPath()).findFirst(),
+        ApiType.MESSAGE,
+        flow -> flow.selectorByType(SelectorType.CHANNEL).stream().map(selector -> ((ChannelSelector) selector).getChannel()).findFirst()
+    );
+
+    @Override
+    public void validate(ApiType apiType, Stream<Flow> apiFlows, Stream<Flow> planFlows) {
+        apiFlows = apiFlows == null ? Stream.empty() : apiFlows;
+        planFlows = planFlows == null ? Stream.empty() : planFlows;
+        // group all flows in one stream
+        final Stream<Flow> flowsWithPathParam = filterFlowsWithPathParam(apiType, apiFlows, planFlows);
+        // foreach flow, reprendre PathParameters.extractPathParamsAndPAttern
+        validatePathParamOverlapping(apiType, flowsWithPathParam);
+    }
+
+    private Stream<Flow> filterFlowsWithPathParam(ApiType apiType, Stream<Flow> apiFlows, Stream<Flow> planFlows) {
+        return Stream.concat(apiFlows, planFlows).filter(Flow::isEnabled).filter(flow -> containsPathParam(apiType, flow));
+    }
+
+    private void validatePathParamOverlapping(ApiType apiType, Stream<Flow> flows) {
+        Map<String, Integer> paramWithPosition = new HashMap<>();
+        Map<String, List<String>> pathsByParam = new HashMap<>();
+        final AtomicBoolean hasOverlap = new AtomicBoolean(false);
+
+        flows.forEach(flow -> {
+            final String path = extractPath(apiType, flow);
+            String[] branches = SEPARATOR_SPLITTER.split(path);
+            for (int i = 0; i < branches.length; i++) {
+                final String currentBranch = branches[i];
+                if (currentBranch.startsWith(PATH_PARAM_PREFIX)) {
+                    // Store every path for a path param in a map
+                    prepareOverlapsMap(pathsByParam, path, currentBranch);
+                    if (isOverlapping(paramWithPosition, currentBranch, i)) {
+                        // Exception is thrown later to be able to provide every overlapping case to the end user
+                        hasOverlap.set(true);
+                    } else {
+                        paramWithPosition.put(currentBranch, i);
+                    }
+                }
+            }
+        });
+
+        if (hasOverlap.get()) {
+            throw new PathParameterOverlapValidationException(
+                pathsByParam
+                    .entrySet()
+                    .stream()
+                    // Only keep params with overlap
+                    .filter(entry -> entry.getValue().size() > 1)
+                    .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().toString()))
+            );
+        }
+    }
+
+    private static void prepareOverlapsMap(Map<String, List<String>> pathsByParam, String path, String branches) {
+        pathsByParam.compute(
+            branches,
+            (key, value) -> {
+                if (value == null) {
+                    value = new ArrayList<>();
+                }
+                // Add the path only once to the error message
+                if (!value.contains(path)) {
+                    value.add(path);
+                }
+                return value;
+            }
+        );
+    }
+
+    private static boolean isOverlapping(Map<String, Integer> paramWithPosition, String param, Integer i) {
+        return paramWithPosition.containsKey(param) && !paramWithPosition.get(param).equals(i);
+    }
+
+    private static Boolean containsPathParam(ApiType apiType, Flow flow) {
+        final String path = extractPath(apiType, flow);
+        return PARAM_PATTERN.asPredicate().test(path);
+    }
+
+    private static String extractPath(ApiType apiType, Flow flow) {
+        return PATH_EXTRACTOR.get(apiType).apply(flow).orElse("");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/PlanValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/PlanValidationServiceImpl.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.impl.validation;
+
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.rest.api.model.v4.plan.PlanEntity;
+import io.gravitee.rest.api.service.v4.validation.FlowValidationService;
+import io.gravitee.rest.api.service.v4.validation.PlanValidationService;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Component
+@AllArgsConstructor
+public class PlanValidationServiceImpl implements PlanValidationService {
+
+    private final FlowValidationService flowValidationService;
+
+    @Override
+    public Set<PlanEntity> validateAndSanitize(ApiType apiType, Set<PlanEntity> plans) {
+        if (plans != null) {
+            plans.forEach(plan -> plan.setFlows(flowValidationService.validateAndSanitize(apiType, plan.getFlows())));
+        }
+        return plans;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/PathParametersValidationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/PathParametersValidationService.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.validation;
+
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.flow.Flow;
+import java.util.stream.Stream;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface PathParametersValidationService {
+    void validate(ApiType apiType, Stream<Flow> apiFlows, Stream<Flow> planFlows);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/PlanValidationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/PlanValidationService.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.validation;
+
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.rest.api.model.v4.plan.PlanEntity;
+import java.util.Set;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public interface PlanValidationService {
+    Set<PlanEntity> validateAndSanitize(final ApiType apiType, Set<PlanEntity> plans);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_CreateTest.java
@@ -41,8 +41,10 @@ import io.gravitee.rest.api.service.exceptions.TagNotAllowedException;
 import io.gravitee.rest.api.service.v4.FlowService;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import io.gravitee.rest.api.service.v4.mapper.PlanMapper;
+import io.gravitee.rest.api.service.v4.validation.FlowValidationService;
 import io.gravitee.rest.api.service.v4.validation.TagsValidationService;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.Before;
@@ -103,6 +105,9 @@ public class PlanService_CreateTest {
 
     @Mock
     private PolicyService policyService;
+
+    @Mock
+    private FlowValidationService flowValidationService;
 
     @Before
     public void setup() throws Exception {
@@ -179,6 +184,7 @@ public class PlanService_CreateTest {
         planService.create(GraviteeContext.getExecutionContext(), this.newPlanEntity);
 
         verify(flowService, times(1)).save(FlowReferenceType.PLAN, newPlanEntity.getId(), newPlanEntity.getFlows());
+        verify(flowValidationService, times(1)).validateAndSanitize(api.getType(), List.of());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_CreateTest.java
@@ -42,6 +42,7 @@ import io.gravitee.rest.api.service.v4.FlowService;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import io.gravitee.rest.api.service.v4.mapper.PlanMapper;
 import io.gravitee.rest.api.service.v4.validation.FlowValidationService;
+import io.gravitee.rest.api.service.v4.validation.PathParametersValidationService;
 import io.gravitee.rest.api.service.v4.validation.TagsValidationService;
 import java.util.ArrayList;
 import java.util.List;
@@ -109,6 +110,9 @@ public class PlanService_CreateTest {
     @Mock
     private FlowValidationService flowValidationService;
 
+    @Mock
+    private PathParametersValidationService pathParametersValidationService;
+
     @Before
     public void setup() throws Exception {
         when(newPlanEntity.getApiId()).thenReturn(API_ID);
@@ -175,6 +179,7 @@ public class PlanService_CreateTest {
         planService.create(GraviteeContext.getExecutionContext(), this.newPlanEntity);
 
         verify(planMapper, times(1)).toRepository(newPlanEntity);
+        verify(pathParametersValidationService, times(1)).validate(any(), any(), any());
     }
 
     @Test
@@ -185,6 +190,7 @@ public class PlanService_CreateTest {
 
         verify(flowService, times(1)).save(FlowReferenceType.PLAN, newPlanEntity.getId(), newPlanEntity.getFlows());
         verify(flowValidationService, times(1)).validateAndSanitize(api.getType(), List.of());
+        verify(pathParametersValidationService, times(1)).validate(any(), any(), any());
     }
 
     @Test
@@ -196,6 +202,7 @@ public class PlanService_CreateTest {
         verify(auditService, times(1))
             .createApiAuditLog(eq(GraviteeContext.getExecutionContext()), eq(API_ID), any(), eq(PLAN_CREATED), any(), isNull(), same(plan));
         verifyNoMoreInteractions(auditService);
+        verify(pathParametersValidationService, times(1)).validate(any(), any(), any());
     }
 
     // mock object mapper in order to deserialize api definition version

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_UpdateTest.java
@@ -19,11 +19,11 @@ import static io.gravitee.definition.model.DefinitionVersion.V1;
 import static io.gravitee.definition.model.DefinitionVersion.V2;
 import static io.gravitee.repository.management.model.Plan.Status.PUBLISHED;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -55,6 +55,7 @@ import io.gravitee.rest.api.service.v4.FlowService;
 import io.gravitee.rest.api.service.v4.PlanService;
 import io.gravitee.rest.api.service.v4.mapper.ApiMapper;
 import io.gravitee.rest.api.service.v4.mapper.PlanMapper;
+import io.gravitee.rest.api.service.v4.validation.FlowValidationService;
 import io.gravitee.rest.api.service.v4.validation.TagsValidationService;
 import io.reactivex.rxjava3.annotations.NonNull;
 import java.util.List;
@@ -130,6 +131,9 @@ public class PlanService_UpdateTest {
     @Mock
     private PolicyService policyService;
 
+    @Mock
+    private FlowValidationService flowValidationService;
+
     @Before
     public void setup() throws Exception {
         when(apiRepository.findById(API_ID)).thenReturn(Optional.of(api));
@@ -152,6 +156,7 @@ public class PlanService_UpdateTest {
 
         verify(planRepository).update(any());
         verify(parameterService).findAsBoolean(eq(GraviteeContext.getExecutionContext()), any(), eq(ParameterReferenceType.ENVIRONMENT));
+        verify(flowValidationService, times(1)).validateAndSanitize(any(), anyList());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PlanService_UpdateTest.java
@@ -56,6 +56,7 @@ import io.gravitee.rest.api.service.v4.PlanService;
 import io.gravitee.rest.api.service.v4.mapper.ApiMapper;
 import io.gravitee.rest.api.service.v4.mapper.PlanMapper;
 import io.gravitee.rest.api.service.v4.validation.FlowValidationService;
+import io.gravitee.rest.api.service.v4.validation.PathParametersValidationService;
 import io.gravitee.rest.api.service.v4.validation.TagsValidationService;
 import io.reactivex.rxjava3.annotations.NonNull;
 import java.util.List;
@@ -134,6 +135,9 @@ public class PlanService_UpdateTest {
     @Mock
     private FlowValidationService flowValidationService;
 
+    @Mock
+    private PathParametersValidationService pathParametersValidationService;
+
     @Before
     public void setup() throws Exception {
         when(apiRepository.findById(API_ID)).thenReturn(Optional.of(api));
@@ -157,6 +161,7 @@ public class PlanService_UpdateTest {
         verify(planRepository).update(any());
         verify(parameterService).findAsBoolean(eq(GraviteeContext.getExecutionContext()), any(), eq(ParameterReferenceType.ENVIRONMENT));
         verify(flowValidationService, times(1)).validateAndSanitize(any(), anyList());
+        verify(pathParametersValidationService, times(1)).validate(any(), any(), any());
     }
 
     @Test
@@ -176,6 +181,7 @@ public class PlanService_UpdateTest {
 
         verify(planRepository).update(any());
         verify(parameterService).findAsBoolean(eq(GraviteeContext.getExecutionContext()), any(), eq(ParameterReferenceType.ENVIRONMENT));
+        verify(pathParametersValidationService, times(1)).validate(any(), any(), any());
     }
 
     @Test
@@ -204,6 +210,7 @@ public class PlanService_UpdateTest {
 
         verify(planRepository).update(any());
         verify(parameterService).findAsBoolean(eq(GraviteeContext.getExecutionContext()), any(), eq(ParameterReferenceType.ENVIRONMENT));
+        verify(pathParametersValidationService, times(1)).validate(any(), any(), any());
     }
 
     @Test(expected = PlanGeneralConditionStatusException.class)
@@ -249,6 +256,7 @@ public class PlanService_UpdateTest {
         planService.update(GraviteeContext.getExecutionContext(), updatePlan);
 
         verify(planRepository, never()).update(any());
+        verify(pathParametersValidationService, times(1)).validate(any(), any(), any());
     }
 
     @Test
@@ -265,9 +273,10 @@ public class PlanService_UpdateTest {
 
         final UpdatePlanEntity updatePlan = initUpdatePlanEntity();
 
-        planService.update(GraviteeContext.getExecutionContext(), updatePlan, true);
+        planService.update(GraviteeContext.getExecutionContext(), updatePlan);
 
         verify(flowService, times(1)).save(FlowReferenceType.PLAN, updatePlan.getId(), updatePlan.getFlows());
+        verify(pathParametersValidationService, times(1)).validate(any(), any(), any());
     }
 
     @Test(expected = PlanFlowRequiredException.class)
@@ -288,6 +297,7 @@ public class PlanService_UpdateTest {
         unpublishedPage.setPublished(false);
 
         planService.update(GraviteeContext.getExecutionContext(), updatePlan);
+        verify(pathParametersValidationService, times(1)).validate(any(), any(), any());
     }
 
     @Test
@@ -311,9 +321,10 @@ public class PlanService_UpdateTest {
         unpublishedPage.setType("MARKDOWN");
         unpublishedPage.setPublished(false);
 
-        planService.update(GraviteeContext.getExecutionContext(), updatePlan, true);
+        planService.update(GraviteeContext.getExecutionContext(), updatePlan);
 
         verify(flowService, times(1)).save(FlowReferenceType.PLAN, updatePlan.getId(), updatePlan.getFlows());
+        verify(pathParametersValidationService, times(1)).validate(any(), any(), any());
     }
 
     @Test
@@ -336,6 +347,7 @@ public class PlanService_UpdateTest {
 
         verify(planRepository).update(any());
         verify(parameterService).findAsBoolean(eq(GraviteeContext.getExecutionContext()), any(), eq(ParameterReferenceType.ENVIRONMENT));
+        verify(pathParametersValidationService, times(1)).validate(any(), any(), any());
     }
 
     @Test(expected = TagNotAllowedException.class)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
@@ -55,6 +55,7 @@ import io.gravitee.rest.api.service.v4.validation.EndpointGroupsValidationServic
 import io.gravitee.rest.api.service.v4.validation.FlowValidationService;
 import io.gravitee.rest.api.service.v4.validation.GroupValidationService;
 import io.gravitee.rest.api.service.v4.validation.ListenerValidationService;
+import io.gravitee.rest.api.service.v4.validation.PlanValidationService;
 import io.gravitee.rest.api.service.v4.validation.ResourcesValidationService;
 import io.gravitee.rest.api.service.v4.validation.TagsValidationService;
 import java.util.List;
@@ -96,6 +97,9 @@ public class ApiValidationServiceImplTest {
     @Mock
     private PlanService planService;
 
+    @Mock
+    private PlanValidationService planValidationService;
+
     private ApiValidationService apiValidationService;
 
     @Before
@@ -109,7 +113,8 @@ public class ApiValidationServiceImplTest {
                 flowValidationService,
                 resourcesValidationService,
                 loggingValidationService,
-                planService
+                planService,
+                planValidationService
             );
     }
 
@@ -127,6 +132,7 @@ public class ApiValidationServiceImplTest {
         verify(loggingValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), newApiEntity.getType(), null);
         verify(flowValidationService, times(1)).validateAndSanitize(newApiEntity.getType(), null);
         verify(resourcesValidationService, never()).validateAndSanitize(any());
+        verify(planValidationService, never()).validateAndSanitize(any(), any());
     }
 
     @Test
@@ -147,6 +153,7 @@ public class ApiValidationServiceImplTest {
         verify(loggingValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), apiEntity.getType(), null);
         verify(flowValidationService, times(1)).validateAndSanitize(apiEntity.getType(), null);
         verify(resourcesValidationService, times(1)).validateAndSanitize(List.of());
+        verify(planValidationService, times(1)).validateAndSanitize(apiEntity.getType(), Set.of());
     }
 
     @Test(expected = InvalidDataException.class)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -55,11 +56,13 @@ import io.gravitee.rest.api.service.v4.validation.EndpointGroupsValidationServic
 import io.gravitee.rest.api.service.v4.validation.FlowValidationService;
 import io.gravitee.rest.api.service.v4.validation.GroupValidationService;
 import io.gravitee.rest.api.service.v4.validation.ListenerValidationService;
+import io.gravitee.rest.api.service.v4.validation.PathParametersValidationService;
 import io.gravitee.rest.api.service.v4.validation.PlanValidationService;
 import io.gravitee.rest.api.service.v4.validation.ResourcesValidationService;
 import io.gravitee.rest.api.service.v4.validation.TagsValidationService;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -100,6 +103,9 @@ public class ApiValidationServiceImplTest {
     @Mock
     private PlanValidationService planValidationService;
 
+    @Mock
+    private PathParametersValidationService pathParametersValidationService;
+
     private ApiValidationService apiValidationService;
 
     @Before
@@ -114,7 +120,8 @@ public class ApiValidationServiceImplTest {
                 resourcesValidationService,
                 loggingValidationService,
                 planService,
-                planValidationService
+                planValidationService,
+                pathParametersValidationService
             );
     }
 
@@ -133,6 +140,7 @@ public class ApiValidationServiceImplTest {
         verify(flowValidationService, times(1)).validateAndSanitize(newApiEntity.getType(), null);
         verify(resourcesValidationService, never()).validateAndSanitize(any());
         verify(planValidationService, never()).validateAndSanitize(any(), any());
+        verify(pathParametersValidationService, times(1)).validate(any(), any(), any());
     }
 
     @Test
@@ -154,6 +162,7 @@ public class ApiValidationServiceImplTest {
         verify(flowValidationService, times(1)).validateAndSanitize(apiEntity.getType(), null);
         verify(resourcesValidationService, times(1)).validateAndSanitize(List.of());
         verify(planValidationService, times(1)).validateAndSanitize(apiEntity.getType(), Set.of());
+        verify(pathParametersValidationService, times(1)).validate(eq(apiEntity.getType()), any(Stream.class), any(Stream.class));
     }
 
     @Test(expected = InvalidDataException.class)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/PathParametersValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/PathParametersValidationServiceImplTest.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.impl.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.rest.api.service.v4.exception.PathParameterOverlapValidationException;
+import io.gravitee.rest.api.service.v4.validation.PathParametersValidationService;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.assertj.core.api.Condition;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class PathParametersValidationServiceImplTest {
+
+    private PathParametersValidationService cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new PathParametersValidationServiceImpl();
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideParameters")
+    void should_test_overlaping_cases(String apiName, Map<String, List<String>> expectedOverlaps) throws IOException {
+        final Api api = readApi(apiName);
+
+        if (expectedOverlaps.isEmpty()) {
+            assertThatNoException().isThrownBy(() -> cut.validate(api.getType(), api.getFlows().stream(), getPlanFlows(api)));
+        } else {
+            assertThatThrownBy(() -> cut.validate(api.getType(), api.getFlows().stream(), getPlanFlows(api)))
+                .isInstanceOf(PathParameterOverlapValidationException.class)
+                .hasMessage("Some path parameters are used at different position across different flows.")
+                .is(
+                    new Condition<>(
+                        error -> {
+                            final PathParameterOverlapValidationException pathParamException =
+                                (PathParameterOverlapValidationException) error;
+                            assertThat(pathParamException.getDetailMessage()).isEqualTo("There is a path parameter overlap");
+                            assertThat(pathParamException.getConstraints()).containsOnlyKeys(expectedOverlaps.keySet());
+                            expectedOverlaps.forEach((key, value) -> {
+                                value.forEach(expectedPath -> {
+                                    assertThat(pathParamException.getConstraints().get(key)).contains(expectedPath);
+                                });
+                            });
+                            return true;
+                        },
+                        ""
+                    )
+                );
+        }
+    }
+
+    public static Stream<Arguments> provideParameters() {
+        return Stream.of(
+            Arguments.of("api-proxy-flows-overlap", Map.of(":productId", List.of("/products/:productId/items/:itemId", "/:productId"))),
+            Arguments.of("api-proxy-plans-overlap", Map.of(":productId", List.of("/products/:productId/items/:itemId", "/:productId"))),
+            Arguments.of(
+                "api-proxy-plans-and-flows-overlap",
+                Map.of(":productId", List.of("/products/:productId/items/:itemId", "/:productId"))
+            ),
+            Arguments.of("api-proxy-no-overlap", Map.of()),
+            Arguments.of("api-proxy-no-flows", Map.of()),
+            Arguments.of("api-message-flows-overlap", Map.of(":productId", List.of("/products/:productId/items/:itemId", "/:productId"))),
+            Arguments.of("api-message-plans-overlap", Map.of(":productId", List.of("/products/:productId/items/:itemId", "/:productId"))),
+            Arguments.of(
+                "api-message-plans-and-flows-overlap",
+                Map.of(":productId", List.of("/products/:productId/items/:itemId", "/:productId"))
+            ),
+            Arguments.of("api-message-no-overlap", Map.of()),
+            Arguments.of("api-message-no-flows", Map.of())
+        );
+    }
+
+    private static Api readApi(String name) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(
+            PathParametersValidationServiceImplTest.class.getClassLoader().getResourceAsStream("apis/v4/pathparams/" + name + ".json"),
+            Api.class
+        );
+    }
+
+    @NotNull
+    private static Stream<Flow> getPlanFlows(Api api) {
+        return api.getPlans().stream().flatMap(plan -> plan.getFlows() == null ? Stream.empty() : plan.getFlows().stream());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/PlanValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/PlanValidationServiceImplTest.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.impl.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.rest.api.model.v4.plan.PlanEntity;
+import io.gravitee.rest.api.service.v4.validation.FlowValidationService;
+import io.gravitee.rest.api.service.v4.validation.PlanValidationService;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@ExtendWith(MockitoExtension.class)
+class PlanValidationServiceImplTest {
+
+    @Mock
+    private FlowValidationService flowValidationService;
+
+    private PlanValidationService cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new PlanValidationServiceImpl(flowValidationService);
+    }
+
+    @Test
+    void shouldReturnNullWhenNoPlan() {
+        assertThat(cut.validateAndSanitize(ApiType.PROXY, null)).isNull();
+    }
+
+    @Test
+    void shouldReturnEmptyWhenEmptySetOfPlans() {
+        assertThat(cut.validateAndSanitize(ApiType.PROXY, Set.of())).isNotNull().isEmpty();
+    }
+
+    @Test
+    void shouldValidateAndSanitizePlans() {
+        PlanEntity plan1 = new PlanEntity();
+        plan1.setId("plan1");
+        PlanEntity plan2 = new PlanEntity();
+        plan2.setId("plan2");
+        Flow flowPlan2 = new Flow();
+        plan2.setFlows(List.of(flowPlan2));
+        PlanEntity plan3 = new PlanEntity();
+        plan3.setId("plan3");
+        Flow flow1Plan3 = new Flow();
+        Flow flow2Plan3 = new Flow();
+        plan3.setFlows(List.of(flow1Plan3, flow2Plan3));
+        when(flowValidationService.validateAndSanitize(any(), anyList())).thenAnswer(invocation -> invocation.getArguments()[1]);
+        final Set<PlanEntity> result = cut.validateAndSanitize(ApiType.PROXY, Set.of(plan1, plan2, plan3));
+        assertThat(result).isNotNull().hasSize(3);
+        assertThat(result.stream().filter(p -> p.getId().equals("plan1")).findFirst().get().getFlows()).isEmpty();
+        assertThat(result.stream().filter(p -> p.getId().equals("plan2")).findFirst().get().getFlows()).hasSize(1);
+        assertThat(result.stream().filter(p -> p.getId().equals("plan3")).findFirst().get().getFlows()).hasSize(2);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/apis/v4/pathparams/api-message-flows-overlap.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/apis/v4/pathparams/api-message-flows-overlap.json
@@ -1,0 +1,46 @@
+{
+  "type": "message",
+  "plans": [
+    {
+      "id": "keyless",
+      "name": "Keyless",
+      "security": {
+        "type": "key-less"
+      },
+      "flows": [
+
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "Item",
+      "selectors": [
+        {
+          "type": "channel",
+          "channel": "/products/:productId/items/:itemId",
+          "channelOperator": "STARTS_WITH",
+          "operations": []
+        }
+      ],
+      "request": [],
+      "response": [],
+      "enabled": true
+    },
+    {
+      "name": "Product",
+      "selectors": [
+        {
+          "type": "channel",
+          "channel": "/:productId",
+          "channelOperator": "STARTS_WITH",
+          "operations": []
+        }
+      ],
+      "request": [],
+      "response": [],
+      "enabled": true
+    }
+  ],
+  "resources": []
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/apis/v4/pathparams/api-message-no-flows.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/apis/v4/pathparams/api-message-no-flows.json
@@ -1,0 +1,10 @@
+{
+  "type": "message",
+  "plans": [
+
+  ],
+  "flows": [
+
+  ],
+  "resources": []
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/apis/v4/pathparams/api-message-no-overlap.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/apis/v4/pathparams/api-message-no-overlap.json
@@ -1,0 +1,184 @@
+{
+  "type": "message",
+  "plans": [
+    {
+      "id": "keyless",
+      "name": "Keyless",
+      "security": {
+        "type": "key-less"
+      },
+      "flows": [
+        {
+          "name": "Item",
+          "selectors": [
+            {
+              "type": "channel",
+              "channel": "/products/:productId/items/:itemId",
+              "channelOperator": "STARTS_WITH",
+              "operations": []
+            }
+          ],
+          "request": [],
+          "response": [],
+          "enabled": true
+        },
+        {
+          "name": "Products",
+          "selectors": [
+            {
+              "type": "channel",
+              "channel": "/products",
+              "channelOperator": "STARTS_WITH",
+              "operations": []
+            }
+          ],
+          "request": [],
+          "response": [],
+          "enabled": true
+        },
+        {
+          "name": "Products",
+          "selectors": [
+            {
+              "type": "channel",
+              "channel": "/products",
+              "channelOperator": "STARTS_WITH",
+              "operations": [
+              ]
+            }
+          ],
+          "request": [],
+          "response": [],
+          "enabled": true
+        },
+        {
+          "name": "Equals hello",
+          "selectors": [
+            {
+              "type": "channel",
+              "channel": "/products/:id/hello",
+              "channelOperator": "EQUALS",
+              "operations": [
+              ]
+            }
+          ],
+          "request": [],
+          "response": [],
+          "enabled": true
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "Accept all - And add path parameters to headers",
+      "selectors": [
+        {
+          "type": "channel",
+          "channel": "/",
+          "channelOperator": "STARTS_WITH",
+          "operations": []
+        }
+      ],
+      "request": [
+        {
+          "name": "Path Parameters to headers",
+          "description": "",
+          "enabled": true,
+          "policy": "path-param-to-header"
+        }
+      ],
+      "response": [],
+      "enabled": true
+    },
+    {
+      "name": "Product id",
+      "selectors": [
+        {
+          "type": "channel",
+          "channel": "/products/:productId",
+          "channelOperator": "STARTS_WITH",
+          "operations": [
+          ]
+        }
+      ],
+      "request": [],
+      "response": [],
+      "enabled": true
+    },
+    {
+      "name": "Products",
+      "selectors": [
+        {
+          "type": "channel",
+          "channel": "/products",
+          "channelOperator": "STARTS_WITH",
+          "operations": []
+        }
+      ],
+      "request": [],
+      "response": [],
+      "enabled": true
+    },
+    {
+      "name": "Products",
+      "selectors": [
+        {
+          "type": "channel",
+          "channel": "/products",
+          "channelOperator": "STARTS_WITH",
+          "operations": []
+        }
+      ],
+      "request": [],
+      "response": [],
+      "enabled": true
+    },
+    {
+      "name": "Product",
+      "selectors": [
+        {
+          "type": "channel",
+          "channel": "/products/:productId",
+          "channelOperator": "STARTS_WITH",
+          "operations": [
+          ]
+        }
+      ],
+      "request": [],
+      "response": [],
+      "enabled": true
+    },
+    {
+      "name": "Product",
+      "selectors": [
+        {
+          "type": "channel",
+          "channel": "/products-special-char/:product-id",
+          "channelOperator": "STARTS_WITH",
+          "operations": [
+          ]
+        }
+      ],
+      "request": [],
+      "response": [],
+      "enabled": true
+    },
+    {
+      "name": "Product",
+      "selectors": [
+        {
+          "type": "channel",
+          "channel": "/products-special-char/:product-id/items/:It€m_Id",
+          "channelOperator": "STARTS_WITH",
+          "operations": [
+          ]
+        }
+      ],
+      "request": [],
+      "response": [],
+      "enabled": true
+    }
+  ],
+  "resources": []
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/apis/v4/pathparams/api-message-plans-and-flows-overlap.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/apis/v4/pathparams/api-message-plans-and-flows-overlap.json
@@ -1,0 +1,87 @@
+{
+  "type": "message",
+  "plans": [
+    {
+      "id": "keyless",
+      "name": "Keyless",
+      "security": {
+        "type": "key-less"
+      },
+      "flows": [
+        {
+          "name": "Item",
+          "selectors": [
+            {
+              "type": "channel",
+              "channel": "/products/:productId/items/:itemId",
+              "channelOperator": "STARTS_WITH",
+              "operations": []
+            }
+          ],
+          "request": [],
+          "response": [],
+          "enabled": true
+        },
+        {
+          "name": "Product",
+          "selectors": [
+            {
+              "type": "channel",
+              "channel": "/:productId",
+              "channelOperator": "STARTS_WITH",
+              "operations": []
+            }
+          ],
+          "request": [],
+          "response": [],
+          "enabled": true
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "Item",
+      "selectors": [
+        {
+          "type": "channel",
+          "channel": "/products/:productId/items/:itemId",
+          "channelOperator": "STARTS_WITH",
+          "operations": []
+        }
+      ],
+      "request": [],
+      "response": [],
+      "enabled": true
+    },
+    {
+      "name": "Product",
+      "selectors": [
+        {
+          "type": "channel",
+          "channel": "/:productId",
+          "channelOperator": "STARTS_WITH",
+          "operations": []
+        }
+      ],
+      "request": [],
+      "response": [],
+      "enabled": true
+    },
+    {
+      "name": "Product from products",
+      "selectors": [
+        {
+          "type": "channel",
+          "channel": "/products/:productId",
+          "channelOperator": "STARTS_WITH",
+          "operations": []
+        }
+      ],
+      "request": [],
+      "response": [],
+      "enabled": true
+    }
+  ],
+  "resources": []
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/apis/v4/pathparams/api-message-plans-overlap.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/apis/v4/pathparams/api-message-plans-overlap.json
@@ -1,0 +1,44 @@
+{
+  "type": "message",
+  "plans": [
+    {
+      "id": "keyless",
+      "name": "Keyless",
+      "security": {
+        "type": "key-less"
+      },
+      "flows": [
+        {
+          "name": "Item",
+          "selectors": [
+            {
+              "type": "channel",
+              "channel": "/products/:productId/items/:itemId",
+              "channelOperator": "STARTS_WITH",
+              "operations": []
+            }
+          ],
+          "request": [],
+          "response": [],
+          "enabled": true
+        },
+        {
+          "name": "Product",
+          "selectors": [
+            {
+              "type": "channel",
+              "channel": "/:productId",
+              "channelOperator": "STARTS_WITH",
+              "operations": []
+            }
+          ],
+          "request": [],
+          "response": [],
+          "enabled": true
+        }
+      ]
+    }
+  ],
+  "flows": [],
+  "resources": []
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/apis/v4/pathparams/api-proxy-flows-overlap.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/apis/v4/pathparams/api-proxy-flows-overlap.json
@@ -1,0 +1,46 @@
+{
+  "type": "proxy",
+  "plans": [
+    {
+      "id": "keyless",
+      "name": "Keyless",
+      "security": {
+        "type": "key-less"
+      },
+      "flows": [
+
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "Item",
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/products/:productId/items/:itemId",
+          "pathOperator": "STARTS_WITH",
+          "methods": ["GET"]
+        }
+      ],
+      "request": [],
+      "response": [],
+      "enabled": true
+    },
+    {
+      "name": "Product",
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/:productId",
+          "pathOperator": "STARTS_WITH",
+          "methods": []
+        }
+      ],
+      "request": [],
+      "response": [],
+      "enabled": true
+    }
+  ],
+  "resources": []
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/apis/v4/pathparams/api-proxy-no-flows.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/apis/v4/pathparams/api-proxy-no-flows.json
@@ -1,0 +1,10 @@
+{
+  "type": "proxy",
+  "plans": [
+
+  ],
+  "flows": [
+
+  ],
+  "resources": []
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/apis/v4/pathparams/api-proxy-no-overlap.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/apis/v4/pathparams/api-proxy-no-overlap.json
@@ -1,0 +1,202 @@
+{
+  "type": "proxy",
+  "plans": [
+    {
+      "id": "keyless",
+      "name": "Keyless",
+      "security": {
+        "type": "key-less"
+      },
+      "flows": [
+        {
+          "name": "Item",
+          "selectors": [
+            {
+              "type": "http",
+              "path": "/products/:productId/items/:itemId",
+              "pathOperator": "STARTS_WITH",
+              "methods": []
+            }
+          ],
+          "request": [],
+          "response": [],
+          "enabled": true
+        },
+        {
+          "name": "Products",
+          "selectors": [
+            {
+              "type": "http",
+              "path": "/products",
+              "pathOperator": "STARTS_WITH",
+              "methods": []
+            }
+          ],
+          "request": [],
+          "response": [],
+          "enabled": true
+        },
+        {
+          "name": "Products",
+          "selectors": [
+            {
+              "type": "http",
+              "path": "/products",
+              "pathOperator": "STARTS_WITH",
+              "methods": [
+                "GET",
+                "PUT"
+              ]
+            }
+          ],
+          "request": [],
+          "response": [],
+          "enabled": true
+        },
+        {
+          "name": "Equals hello",
+          "selectors": [
+            {
+              "type": "http",
+              "path": "/products/:id/hello",
+              "pathOperator": "EQUALS",
+              "methods": [
+                "GET",
+                "PUT"
+              ]
+            }
+          ],
+          "request": [],
+          "response": [],
+          "enabled": true
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "Accept all - And add path parameters to headers",
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/",
+          "pathOperator": "STARTS_WITH",
+          "methods": []
+        }
+      ],
+      "request": [
+        {
+          "name": "Path Parameters to headers",
+          "description": "",
+          "enabled": true,
+          "policy": "path-param-to-header"
+        }
+      ],
+      "response": [],
+      "enabled": true
+    },
+    {
+      "name": "Product id",
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/products/:productId",
+          "pathOperator": "STARTS_WITH",
+          "methods": [
+            "CONNECT",
+            "DELETE",
+            "GET",
+            "HEAD",
+            "OPTIONS",
+            "PATCH",
+            "POST",
+            "TRACE"
+          ]
+        }
+      ],
+      "request": [],
+      "response": [],
+      "enabled": true
+    },
+    {
+      "name": "Products",
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/products",
+          "pathOperator": "STARTS_WITH",
+          "methods": []
+        }
+      ],
+      "request": [],
+      "response": [],
+      "enabled": true
+    },
+    {
+      "name": "Products",
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/products",
+          "pathOperator": "STARTS_WITH",
+          "methods": ["GET"]
+        }
+      ],
+      "request": [],
+      "response": [],
+      "enabled": true
+    },
+    {
+      "name": "Product",
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/products/:productId",
+          "pathOperator": "STARTS_WITH",
+          "methods": [
+            "DELETE",
+            "GET"
+          ]
+        }
+      ],
+      "request": [],
+      "response": [],
+      "enabled": true
+    },
+    {
+      "name": "Product",
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/products-special-char/:product-id",
+          "pathOperator": "STARTS_WITH",
+          "methods": [
+            "DELETE",
+            "GET"
+          ]
+        }
+      ],
+      "request": [],
+      "response": [],
+      "enabled": true
+    },
+    {
+      "name": "Product",
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/products-special-char/:product-id/items/:It€m_Id",
+          "pathOperator": "STARTS_WITH",
+          "methods": [
+            "DELETE",
+            "GET"
+          ]
+        }
+      ],
+      "request": [],
+      "response": [],
+      "enabled": true
+    }
+  ],
+  "resources": []
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/apis/v4/pathparams/api-proxy-plans-and-flows-overlap.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/apis/v4/pathparams/api-proxy-plans-and-flows-overlap.json
@@ -1,0 +1,87 @@
+{
+  "type": "proxy",
+  "plans": [
+    {
+      "id": "keyless",
+      "name": "Keyless",
+      "security": {
+        "type": "key-less"
+      },
+      "flows": [
+        {
+          "name": "Item",
+          "selectors": [
+            {
+              "type": "http",
+              "path": "/products/:productId/items/:itemId",
+              "pathOperator": "STARTS_WITH",
+              "methods": ["GET"]
+            }
+          ],
+          "request": [],
+          "response": [],
+          "enabled": true
+        },
+        {
+          "name": "Product",
+          "selectors": [
+            {
+              "type": "http",
+              "path": "/:productId",
+              "pathOperator": "STARTS_WITH",
+              "methods": []
+            }
+          ],
+          "request": [],
+          "response": [],
+          "enabled": true
+        }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "name": "Item",
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/products/:productId/items/:itemId",
+          "pathOperator": "STARTS_WITH",
+          "methods": ["GET"]
+        }
+      ],
+      "request": [],
+      "response": [],
+      "enabled": true
+    },
+    {
+      "name": "Product",
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/:productId",
+          "pathOperator": "STARTS_WITH",
+          "methods": []
+        }
+      ],
+      "request": [],
+      "response": [],
+      "enabled": true
+    },
+    {
+      "name": "Product from products",
+      "selectors": [
+        {
+          "type": "http",
+          "path": "/products/:productId",
+          "pathOperator": "STARTS_WITH",
+          "methods": []
+        }
+      ],
+      "request": [],
+      "response": [],
+      "enabled": true
+    }
+  ],
+  "resources": []
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/apis/v4/pathparams/api-proxy-plans-overlap.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/apis/v4/pathparams/api-proxy-plans-overlap.json
@@ -1,0 +1,44 @@
+{
+  "type": "proxy",
+  "plans": [
+    {
+      "id": "keyless",
+      "name": "Keyless",
+      "security": {
+        "type": "key-less"
+      },
+      "flows": [
+        {
+          "name": "Item",
+          "selectors": [
+            {
+              "type": "http",
+              "path": "/products/:productId/items/:itemId",
+              "pathOperator": "STARTS_WITH",
+              "methods": ["GET"]
+            }
+          ],
+          "request": [],
+          "response": [],
+          "enabled": true
+        },
+        {
+          "name": "Product",
+          "selectors": [
+            {
+              "type": "http",
+              "path": "/:productId",
+              "pathOperator": "STARTS_WITH",
+              "methods": []
+            }
+          ],
+          "request": [],
+          "response": [],
+          "enabled": true
+        }
+      ]
+    }
+  ],
+  "flows": [],
+  "resources": []
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1837

## Description

- Add validation for flows of plans
- Add Path parameter overlapping configuration: if the same path parameter is defined at two different positions across all flows of the api, then it's not valid (for example: `/:productId` (position 0) and `/products/:productId` (position 1))


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qngwtfjhfs.chromatic.com)
<!-- Storybook placeholder end -->
