### PR TITLE
Use `Content-Disposition` header to force browser to download attachment

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/AbstractResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/AbstractResource.java
@@ -405,7 +405,14 @@ public abstract class AbstractResource<T, K> {
             return builder.cacheControl(cc).build();
         }
 
-        return Response.ok(media.getData()).cacheControl(cc).tag(etag).type(media.getType() + "/" + media.getSubType()).build();
+        return Response
+            .ok(media.getData())
+            // Add header to force download, so avoid browser to display the media and maybe render malicious attachments
+            .header("Content-Disposition", "attachment; filename=\"" + media.getFileName() + "\"")
+            .cacheControl(cc)
+            .tag(etag)
+            .type(media.getType() + "/" + media.getSubType())
+            .build();
     }
 
     protected class DataResponse {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1324

## Description

Use `Content-Disposition` header to force browser to download attachment instead of rendering it
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rrmixsxlnp.chromatic.com)
<!-- Storybook placeholder end -->
