### PR TITLE
Improve order of returned APIs when searching with a query

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/apis.controller.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis.controller.ts
@@ -82,6 +82,7 @@ export class ApisController {
       $timeout.cancel(this.timer);
       this.timer = $timeout(() => {
         if (query !== undefined && query !== previousQuery) {
+          this.order = null;
           this.searchWithQuery(query);
         }
       }, 300);

--- a/gravitee-apim-console-webui/src/services/api.service.ts
+++ b/gravitee-apim-console-webui/src/services/api.service.ts
@@ -164,7 +164,7 @@ export class ApiService {
     opts.params = {
       q: query ? query : '*',
       page: page,
-      order: order,
+      ...(order ? { order: order } : {}),
       size,
       ...(manageOnly ? {} : { manageOnly: false }),
     };

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
@@ -436,7 +436,7 @@ public class ApisResource extends AbstractResource {
                 implementation = String.class,
                 description = "By default, sort is ASC. If *field* starts with '-', the order sort is DESC. Currently, only **name** and **paths** are supported"
             )
-        ) @QueryParam("order") @DefaultValue("name") final ApisOrderParam apisOrderParam,
+        ) @QueryParam("order") final ApisOrderParam apisOrderParam,
         @Parameter(
             name = "manageOnly",
             description = "By default only APIs that the user can manage are returned. If set to false, all APIs that the user can view are returned."
@@ -459,7 +459,13 @@ public class ApisResource extends AbstractResource {
 
         final boolean isRatingServiceEnabled = ratingService.isEnabled(executionContext);
 
-        final Page<ApiEntity> apis = apiService.search(executionContext, query, filters, apisOrderParam.toSortable(), commonPageable);
+        final Page<ApiEntity> apis = apiService.search(
+            executionContext,
+            query,
+            filters,
+            apisOrderParam != null ? apisOrderParam.toSortable() : null,
+            commonPageable
+        );
 
         return new PagedResult<>(
             apis.getContent().stream().map(apiEntity -> this.convert(apiEntity, isRatingServiceEnabled)).collect(toList()),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApisResourceNotAdminTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApisResourceNotAdminTest.java
@@ -61,13 +61,36 @@ public class ApisResourceNotAdminTest extends AbstractResourceTest {
                 eq(GraviteeContext.getExecutionContext()),
                 eq("*"),
                 argThat(filters -> ((Set<String>) filters.get("api")).size() == 3),
-                isA(Sortable.class),
+                isNull(),
                 isA(Pageable.class)
             )
         )
             .thenReturn(apisPage);
 
         final Response response = envTarget().path("_search/_paged").queryParam("q", "*").request().post(null);
+
+        assertEquals(OK_200, response.getStatus());
+    }
+
+    @Test
+    public void get_should_search_apis_with_order() throws TechnicalException {
+        when(apiService.findIdsByUser(eq(GraviteeContext.getExecutionContext()), any(), isA(ApiQuery.class), eq(true)))
+            .thenReturn(Set.of("api1", "api2", "api15"));
+
+        List<ApiEntity> resultApis = List.of(mockApi("api1"), mockApi("api2"), mockApi("api15"));
+        Page<ApiEntity> apisPage = new Page<>(resultApis, 7, 3, 54);
+        when(
+            apiService.search(
+                eq(GraviteeContext.getExecutionContext()),
+                eq("*"),
+                argThat(filters -> ((Set<String>) filters.get("api")).size() == 3),
+                isA(Sortable.class),
+                isA(Pageable.class)
+            )
+        )
+            .thenReturn(apisPage);
+
+        final Response response = envTarget().path("_search/_paged").queryParam("q", "*").queryParam("order", "name").request().post(null);
 
         assertEquals(OK_200, response.getStatus());
     }
@@ -85,7 +108,7 @@ public class ApisResourceNotAdminTest extends AbstractResourceTest {
                 eq(GraviteeContext.getExecutionContext()),
                 eq("*"),
                 argThat(filters -> ((Set<String>) filters.get("api")).size() == 3),
-                isA(Sortable.class),
+                isNull(),
                 isA(Pageable.class)
             )
         )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcher.java
@@ -250,7 +250,8 @@ public class ApiDocumentSearcher extends AbstractDocumentSearcher {
         throws ParseException {
         QueryParser parser = new QueryParser("", new KeywordAnalyzer());
         parser.setAllowLeadingWildcard(true);
-        String escapedQuery = query;
+        // Escape [ and ] because they can be used in API names
+        String escapedQuery = query.replace("[", "\\[").replace("]", "\\]");
         if (escapedQuery.startsWith("/")) { // escape if we are looking for a path
             escapedQuery = QueryParserBase.escape(query);
         }
@@ -370,6 +371,13 @@ public class ApiDocumentSearcher extends AbstractDocumentSearcher {
         }
 
         String[] tokens = query.split(" ");
+
+        // Add boost on exact match on name
+        builder
+            .add(new BoostQuery(toWildcard(FIELD_NAME, query), 20.0f), BooleanClause.Occur.SHOULD)
+            .add(new BoostQuery(toWildcard(FIELD_NAME_LOWERCASE, query.toLowerCase()), 18.0f), BooleanClause.Occur.SHOULD);
+
+        // Add boost for partial match
         for (String token : tokens) {
             builder
                 .add(new BoostQuery(toWildcard(FIELD_NAME, token), 12.0f), BooleanClause.Occur.SHOULD)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcherTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/ApiDocumentSearcherTest.java
@@ -58,7 +58,7 @@ public class ApiDocumentSearcherTest {
         BooleanQuery.Builder builder = new BooleanQuery.Builder();
         assertEquals("", searcher.completeQueryWithFilters(query, builder));
         assertEquals(
-            "#(+(categories:\"sports\" categories:sports)) +(+((name:*Cycling*)^12.0 (name_lowercase:*cycling*)^10.0 (paths:*Cycling*)^8.0 description:*Cycling* description_lowercase:*cycling* hosts:*Cycling* labels:*Cycling* categories:*Cycling* tags:*Cycling* metadata:*Cycling*))",
+            "#(+(categories:\"sports\" categories:sports)) +(+((name:*Cycling*)^20.0 (name_lowercase:*cycling*)^18.0 (name:*Cycling*)^12.0 (name_lowercase:*cycling*)^10.0 (paths:*Cycling*)^8.0 description:*Cycling* description_lowercase:*cycling* hosts:*Cycling* labels:*Cycling* categories:*Cycling* tags:*Cycling* metadata:*Cycling*))",
             builder.build().toString()
         );
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1991
gravitee-io/issues#9095

## Description

Remove default sort on the name of an API in the search endpoint When doing a search we want to rely on Lucene indexes scores to have the most relevant APIs firsts in the list.

Also, add a boost on the API name to ensure search results are sorted in a more relevant way when typing an API name.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-yzyvwjggdr.chromatic.com)
<!-- Storybook placeholder end -->
