### PR TITLE
Fix: subscription/push plans

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/plan/plan.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/plan/plan.fixture.ts
@@ -116,6 +116,7 @@ export function fakePlanV4(modifier?: Partial<PlanV4> | ((base: PlanV4) => PlanV
         enabled: true,
       },
     ],
+    mode: 'STANDARD',
   };
 
   if (isFunction(modifier)) {

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/plan/planSecurityType.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/plan/planSecurityType.ts
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-// TODO remove this when the SUBSCRIPTION security type is renamed on the backend side
-export type PushSecurityType = 'PUSH' | 'SUBSCRIPTION';
-
 /**
  * Plan security type.
  */
-export type PlanSecurityType = 'KEY_LESS' | 'API_KEY' | 'OAUTH2' | 'JWT' | PushSecurityType;
+export type PlanSecurityType = 'KEY_LESS' | 'API_KEY' | 'OAUTH2' | 'JWT';

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/plan/v4/index.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/plan/v4/index.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export * from './planMode';
 export * from './planV4';
 export * from './createPlanV4';
 export * from './updatePlanV4';

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/plan/v4/planMode.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/plan/v4/planMode.ts
@@ -13,13 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { PlanMode } from './planMode';
 
-import { CreateBasePlan } from '../createBasePlan';
-import { FlowV4 } from '../../api/v4';
-
-export interface CreatePlanV4 extends CreateBasePlan {
-  definitionVersion: 'V4';
-  flows?: FlowV4[];
-  mode: PlanMode;
-}
+/**
+ * Plan mode.
+ */
+export const PLAN_MODE = ['STANDARD', 'PUSH'] as const;
+export type PlanMode = (typeof PLAN_MODE)[number];

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/plan/v4/planV4.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/plan/v4/planV4.fixture.ts
@@ -27,6 +27,7 @@ export function fakeV4Plan(modifier?: Partial<PlanV4> | ((baseApi: PlanV4) => Pl
     status: 'PUBLISHED',
     apiId: 'api#1',
     order: 0,
+    mode: 'STANDARD',
   };
 
   if (isFunction(modifier)) {

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/plan/v4/planV4.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/plan/v4/planV4.ts
@@ -13,10 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { PlanMode } from './planMode';
+
 import { FlowV4 } from '../../api/v4';
 import { BasePlan } from '../basePlan';
 
 export interface PlanV4 extends BasePlan {
   definitionVersion: 'V4';
   flows?: FlowV4[];
+  mode: PlanMode;
 }

--- a/gravitee-apim-console-webui/src/management/api/apis.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis.module.ts
@@ -118,14 +118,14 @@ const states: Ng2StateDeclaration[] = [
   },
   {
     name: 'management.apis.ng.plan.new',
-    url: '/new?{securityType:string}',
+    url: '/new?{selectedPlanMenuItem:string}',
     component: ApiPortalPlanEditComponent,
     data: {
       useAngularMaterial: true,
       docs: null,
     },
     params: {
-      securityType: {
+      selectedPlanMenuItem: {
         dynamic: true,
       },
     },

--- a/gravitee-apim-console-webui/src/management/api/component/plan/2-secure-step/plan-edit-secure-step.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/2-secure-step/plan-edit-secure-step.component.ts
@@ -27,7 +27,7 @@ import { ResourceService } from '../../../../../services-ngx/resource.service';
 import { ResourceListItem } from '../../../../../entities/resource/resourceListItem';
 import { ApiV2, ApiV4 } from '../../../../../entities/management-api-v2';
 import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
-import { PlanSecurityVM } from '../../../../../services-ngx/constants.service';
+import { PlanMenuItemVM } from '../../../../../services-ngx/constants.service';
 
 @Component({
   selector: 'plan-edit-secure-step',
@@ -47,7 +47,7 @@ export class PlanEditSecureStepComponent implements OnInit, OnDestroy {
   public api: ApiV2 | ApiV4;
 
   @Input()
-  securityType: PlanSecurityVM;
+  securityType: PlanMenuItemVM;
   constructor(
     @Inject('Constants') private readonly constants: Constants,
     private readonly policyService: PolicyV2Service,
@@ -63,7 +63,7 @@ export class PlanEditSecureStepComponent implements OnInit, OnDestroy {
       selectionRule: new FormControl(),
     });
 
-    if (['KEY_LESS', 'PUSH'].includes(this.securityType.id)) {
+    if (['KEY_LESS', 'PUSH'].includes(this.securityType.planFormType)) {
       return;
     }
 
@@ -82,7 +82,7 @@ export class PlanEditSecureStepComponent implements OnInit, OnDestroy {
       });
 
     // Load resources only if API has resources and when user select OAuth2 security type once
-    if (this.api?.resources && this.securityType.id === 'OAUTH2') {
+    if (this.api?.resources && this.securityType.planFormType === 'OAUTH2') {
       this.resourceService
         .list({ expandSchema: false, expandIcon: true })
         .pipe(

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.html
@@ -29,12 +29,12 @@
     ></plan-edit-general-step>
   </mat-step>
 
-  <mat-step *ngIf="!['KEY_LESS', 'PUSH'].includes(securityType.id)" state="secure" [stepControl]="planForm.get('secure')">
+  <mat-step *ngIf="!['KEY_LESS', 'PUSH'].includes(planMenuItem.planFormType)" state="secure" [stepControl]="planForm.get('secure')">
     <ng-template matStepperIcon="secure">
       <mat-icon svgIcon="gio:lock"></mat-icon>
     </ng-template>
-    <ng-template matStepLabel>{{ securityType.name }} authentication configuration</ng-template>
-    <plan-edit-secure-step matStepContent [api]="api" [securityType]="securityType"></plan-edit-secure-step>
+    <ng-template matStepLabel>{{ planMenuItem.name }} authentication configuration</ng-template>
+    <plan-edit-secure-step matStepContent [api]="api" [securityType]="planMenuItem"></plan-edit-secure-step>
   </mat-step>
 
   <mat-step *ngIf="mode === 'create'" state="restriction" [stepControl]="planForm.get('restriction')">

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
@@ -700,6 +700,7 @@ describe('ApiPlanFormComponent', () => {
         excludedGroups: ['group-a'],
         generalConditions: '',
         tags: [],
+        mode: 'STANDARD',
         security: {
           configuration: {},
           type: 'JWT',
@@ -973,6 +974,7 @@ describe('ApiPlanFormComponent', () => {
           commentMessage: 'comment message',
           commentRequired: false,
           excludedGroups: ['group-a'],
+          mode: 'STANDARD',
           security: {
             type: 'KEY_LESS',
             configuration: {},

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
@@ -46,19 +46,18 @@ import {
   Plan,
   PlanV2,
   PlanV4,
-  PlanSecurityType,
 } from '../../../../entities/management-api-v2';
-import { PLAN_SECURITY_TYPES, PlanSecurityVM } from '../../../../services-ngx/constants.service';
+import { AVAILABLE_PLANS_FOR_MENU, PlanFormType, PlanMenuItemVM } from '../../../../services-ngx/constants.service';
 
 @Component({
   template: `
-    <api-plan-form #apiPlanForm [formControl]="planControl" [mode]="mode" [api]="api" [securityType]="securityType"></api-plan-form>
+    <api-plan-form #apiPlanForm [formControl]="planControl" [mode]="mode" [api]="api" [planMenuItem]="planMenuItem"></api-plan-form>
   `,
 })
 class TestComponent {
   @ViewChild('apiPlanForm') apiPlanForm: ApiPlanFormComponent;
   mode: 'create' | 'edit' = 'create';
-  securityType: PlanSecurityVM;
+  planMenuItem: PlanMenuItemVM;
   planControl = new FormControl();
   api?: Api;
   plan?: Plan;
@@ -85,7 +84,7 @@ describe('ApiPlanFormComponent', () => {
   let loader: HarnessLoader;
   let httpTestingController: HttpTestingController;
 
-  const configureTestingModule = (mode: 'create' | 'edit', securityType: PlanSecurityType, api?: Api) => {
+  const configureTestingModule = (mode: 'create' | 'edit', planFormType: PlanFormType, api?: Api) => {
     TestBed.configureTestingModule({
       declarations: [TestComponent],
       imports: [ReactiveFormsModule, NoopAnimationsModule, GioHttpTestingModule, ApiPlanFormModule, MatIconTestingModule],
@@ -111,7 +110,7 @@ describe('ApiPlanFormComponent', () => {
     httpTestingController = TestBed.inject(HttpTestingController);
     testComponent = fixture.componentInstance;
     testComponent.mode = mode;
-    testComponent.securityType = PLAN_SECURITY_TYPES.find((vm) => vm.id === securityType);
+    testComponent.planMenuItem = AVAILABLE_PLANS_FOR_MENU.find((vm) => vm.planFormType === planFormType);
     testComponent.api = api;
   };
 

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
@@ -49,6 +49,7 @@ import {
   CreatePlan,
   Plan,
   UpdatePlan,
+  PlanMode,
 } from '../../../../entities/management-api-v2';
 import { isApiV2FromMAPIV2 } from '../../../../util';
 import { PlanSecurityVM } from '../../../../services-ngx/constants.service';
@@ -94,7 +95,7 @@ export type PlanFormValue = Pick<
   | 'security'
   | 'selectionRule'
   | 'flows'
->;
+> & { mode?: PlanMode };
 
 @Component({
   selector: 'api-plan-form',

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.spec.ts
@@ -983,10 +983,6 @@ describe('ApiCreationV4Component', () => {
               definitionVersion: 'V4',
               name: 'Default PUSH plan',
               description: 'Default push plan',
-              security: {
-                type: 'PUSH',
-                configuration: {},
-              },
               mode: 'PUSH',
               validation: 'MANUAL',
             },
@@ -1208,10 +1204,6 @@ describe('ApiCreationV4Component', () => {
             definitionVersion: 'V4',
             name: 'Default PUSH plan',
             description: 'Default push plan',
-            security: {
-              type: 'PUSH',
-              configuration: {},
-            },
             mode: 'PUSH',
             validation: 'MANUAL',
           },

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/api-creation-v4.component.spec.ts
@@ -963,7 +963,8 @@ describe('ApiCreationV4Component', () => {
 
           const pushPlan = await step4Security1PlansHarness.getColumnTextByRowIndex(1);
           expect(pushPlan.name).toEqual('Default PUSH plan');
-          expect(pushPlan.security).toEqual('PUSH');
+          expect(pushPlan.mode).toEqual('PUSH');
+          expect(pushPlan.security).toEqual('');
 
           await step4Security1PlansHarness.clickValidate();
           expect(component.currentStep.payload.plans).toEqual([
@@ -971,6 +972,7 @@ describe('ApiCreationV4Component', () => {
               definitionVersion: 'V4',
               name: 'Default Keyless (UNSECURED)',
               description: 'Default unsecured plan',
+              mode: 'STANDARD',
               security: {
                 type: 'KEY_LESS',
                 configuration: {},
@@ -985,6 +987,7 @@ describe('ApiCreationV4Component', () => {
                 type: 'PUSH',
                 configuration: {},
               },
+              mode: 'PUSH',
               validation: 'MANUAL',
             },
           ]);
@@ -1038,6 +1041,7 @@ describe('ApiCreationV4Component', () => {
             definitionVersion: 'V4',
             name: 'Default Keyless (UNSECURED)',
             description: 'Default unsecured plan',
+            mode: 'STANDARD',
             security: {
               type: 'KEY_LESS',
               configuration: {},
@@ -1067,6 +1071,7 @@ describe('ApiCreationV4Component', () => {
               definitionVersion: 'V4',
               name: 'Default Keyless (UNSECURED)',
               description: 'Default unsecured plan',
+              mode: 'STANDARD',
               security: {
                 type: 'KEY_LESS',
                 configuration: {},
@@ -1094,6 +1099,7 @@ describe('ApiCreationV4Component', () => {
               ],
               generalConditions: '',
               name: 'Secure by ApiKey',
+              mode: 'STANDARD',
               security: {
                 configuration: {},
                 type: 'API_KEY',
@@ -1117,6 +1123,7 @@ describe('ApiCreationV4Component', () => {
             {
               name: 'Update name',
               description: 'Default unsecured plan',
+              mode: 'STANDARD',
               security: {
                 type: 'KEY_LESS',
                 configuration: {},
@@ -1192,7 +1199,8 @@ describe('ApiCreationV4Component', () => {
 
         const pushPlan = await step4Security1PlansHarness.getColumnTextByRowIndex(0);
         expect(pushPlan.name).toEqual('Default PUSH plan');
-        expect(pushPlan.security).toEqual('PUSH');
+        expect(pushPlan.mode).toEqual('PUSH');
+        expect(pushPlan.security).toEqual('');
 
         await step4Security1PlansHarness.clickValidate();
         expect(component.currentStep.payload.plans).toEqual([
@@ -1204,6 +1212,7 @@ describe('ApiCreationV4Component', () => {
               type: 'PUSH',
               configuration: {},
             },
+            mode: 'PUSH',
             validation: 'MANUAL',
           },
         ]);

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-menu-item/step-4-menu-item.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-menu-item/step-4-menu-item.component.ts
@@ -17,11 +17,11 @@ import { Component, Inject, OnInit } from '@angular/core';
 
 import { MENU_ITEM_PAYLOAD } from '../../components/api-creation-stepper-menu/api-creation-stepper-menu.component';
 import { ApiCreationPayload } from '../../models/ApiCreationPayload';
-import { PlanSecurityType } from '../../../../../../entities/management-api-v2';
+import { PlanFormType } from '../../../../../../services-ngx/constants.service';
 
 interface MenuItemVM {
   name: string;
-  type: PlanSecurityType;
+  type: PlanFormType;
 }
 
 @Component({
@@ -37,7 +37,7 @@ export class Step4MenuItemComponent implements OnInit {
   ngOnInit(): void {
     this.menuItems = this.menuItemPayload?.plans?.map((plan) => ({
       name: plan.name,
-      type: plan.security.type,
+      type: plan.mode === 'PUSH' ? 'PUSH' : plan.security.type,
     }));
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans-add.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans-add.component.html
@@ -17,7 +17,7 @@
 -->
 
 <form [formGroup]="form" (ngSubmit)="onAddPlan()">
-  <api-plan-form #apiPlanForm formControlName="plan" mode="create" [securityType]="securityType"></api-plan-form>
+  <api-plan-form #apiPlanForm formControlName="plan" mode="create" [planMenuItem]="planMenuItem"></api-plan-form>
 
   <div class="api-creation-v4__step__footer">
     <button mat-stroked-button type="button" *ngIf="apiPlanForm.hasPreviousStep() === false" (click)="onExitPlanCreation()">

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans-add.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans-add.component.ts
@@ -17,7 +17,7 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 
-import { PlanSecurityVM } from '../../../../../../services-ngx/constants.service';
+import { PlanMenuItemVM } from '../../../../../../services-ngx/constants.service';
 import { CreatePlanV4 } from '../../../../../../entities/management-api-v2';
 
 @Component({
@@ -31,7 +31,7 @@ export class Step4Security1PlansAddComponent implements OnInit {
   plan?: CreatePlanV4;
 
   @Input()
-  securityType: PlanSecurityVM;
+  planMenuItem: PlanMenuItemVM;
 
   @Output()
   planChanges = new EventEmitter<CreatePlanV4>();

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans-list.component.html
@@ -22,7 +22,7 @@
     <mat-icon svgIcon="gio:plus"></mat-icon>Add plan
   </button>
   <mat-menu #menu="matMenu">
-    <button mat-menu-item *ngFor="let planSecurity of planSecurityOptions" (click)="addPlan(planSecurity)">{{ planSecurity.name }}</button>
+    <button mat-menu-item *ngFor="let planMenuItem of planMenuItems" (click)="addPlan(planMenuItem)">{{ planMenuItem.name }}</button>
   </mat-menu>
 </div>
 <form [formGroup]="form" (ngSubmit)="save()">
@@ -37,7 +37,7 @@
     </ng-container>
     <ng-container matColumnDef="security">
       <th mat-header-cell *matHeaderCellDef>Security</th>
-      <td mat-cell *matCellDef="let element">{{ element.security.type }}</td>
+      <td mat-cell *matCellDef="let element">{{ element.security?.type }}</td>
     </ng-container>
     <ng-container matColumnDef="actions">
       <th mat-header-cell *matHeaderCellDef></th>

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans-list.component.html
@@ -31,6 +31,10 @@
       <th mat-header-cell *matHeaderCellDef>Name</th>
       <td mat-cell *matCellDef="let element">{{ element.name }}</td>
     </ng-container>
+    <ng-container matColumnDef="mode">
+      <th mat-header-cell *matHeaderCellDef>Mode</th>
+      <td mat-cell *matCellDef="let element">{{ element.mode }}</td>
+    </ng-container>
     <ng-container matColumnDef="security">
       <th mat-header-cell *matHeaderCellDef>Security</th>
       <td mat-cell *matCellDef="let element">{{ element.security.type }}</td>

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans-list.component.ts
@@ -43,7 +43,7 @@ export class Step4Security1PlansListComponent implements OnInit {
   planSecurityOptions: PlanSecurityVM[];
 
   public form = new FormGroup({});
-  displayedColumns: string[] = ['name', 'security', 'actions'];
+  displayedColumns: string[] = ['name', 'mode', 'security', 'actions'];
 
   constructor(private readonly stepService: ApiCreationStepService, private readonly constantsService: ConstantsService) {}
 

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans-list.component.ts
@@ -19,7 +19,7 @@ import { FormGroup } from '@angular/forms';
 
 import { ApiCreationStepService } from '../../services/api-creation-step.service';
 import { Step5DocumentationComponent } from '../step-5-documentation/step-5-documentation.component';
-import { ConstantsService, PlanSecurityVM } from '../../../../../../services-ngx/constants.service';
+import { ConstantsService, PlanMenuItemVM } from '../../../../../../services-ngx/constants.service';
 import { CreatePlanV4 } from '../../../../../../entities/management-api-v2';
 
 @Component({
@@ -32,7 +32,7 @@ export class Step4Security1PlansListComponent implements OnInit {
   plans: CreatePlanV4[] = [];
 
   @Output()
-  addPlanClicked = new EventEmitter<PlanSecurityVM>();
+  addPlanClicked = new EventEmitter<PlanMenuItemVM>();
 
   @Output()
   editPlanClicked = new EventEmitter<CreatePlanV4>();
@@ -40,7 +40,7 @@ export class Step4Security1PlansListComponent implements OnInit {
   @Output()
   removePlanClicked = new EventEmitter<CreatePlanV4>();
 
-  planSecurityOptions: PlanSecurityVM[];
+  planMenuItems: PlanMenuItemVM[];
 
   public form = new FormGroup({});
   displayedColumns: string[] = ['name', 'mode', 'security', 'actions'];
@@ -48,13 +48,13 @@ export class Step4Security1PlansListComponent implements OnInit {
   constructor(private readonly stepService: ApiCreationStepService, private readonly constantsService: ConstantsService) {}
 
   ngOnInit(): void {
-    this.planSecurityOptions = this.constantsService.getEnabledPlanSecurityTypes();
+    this.planMenuItems = this.constantsService.getEnabledPlanMenuItems();
     if (this.stepService?.payload?.selectedEntrypoints.every((entrypoint) => entrypoint.supportedListenerType === 'SUBSCRIPTION')) {
-      this.planSecurityOptions = this.planSecurityOptions.filter((planSecurityType) => planSecurityType.id === 'PUSH');
+      this.planMenuItems = this.planMenuItems.filter((planMenuItem) => planMenuItem.planFormType === 'PUSH');
     }
 
     if (this.stepService?.payload?.selectedEntrypoints.every((entrypoint) => ['HTTP', 'TCP'].includes(entrypoint.supportedListenerType))) {
-      this.planSecurityOptions = this.planSecurityOptions.filter((planSecurityType) => planSecurityType.id !== 'PUSH');
+      this.planMenuItems = this.planMenuItems.filter((planMenuItem) => planMenuItem.planFormType !== 'PUSH');
     }
   }
 
@@ -71,8 +71,8 @@ export class Step4Security1PlansListComponent implements OnInit {
     this.stepService.goToPreviousStep();
   }
 
-  addPlan(securityType: PlanSecurityVM) {
-    this.addPlanClicked.emit(securityType);
+  addPlan(selectedPlanMenuItem: PlanMenuItemVM) {
+    this.addPlanClicked.emit(selectedPlanMenuItem);
   }
 
   editPlan(plan: CreatePlanV4) {

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans.component.html
@@ -33,7 +33,7 @@
 
   <ng-container *ngIf="view === 'add'">
     <step-4-security-1-plans-add
-      [securityType]="securityType"
+      [planMenuItem]="selectedPlanMenuItem"
       (planChanges)="addPlan($event)"
       (exitPlanCreation)="onExitPlanCreation()"
     ></step-4-security-1-plans-add>
@@ -42,7 +42,7 @@
   <ng-container *ngIf="view === 'edit'">
     <step-4-security-1-plans-add
       [plan]="planToEdit"
-      [securityType]="securityType"
+      [planMenuItem]="selectedPlanMenuItem"
       (planChanges)="editPlan($event)"
       (exitPlanCreation)="onExitPlanCreation()"
     ></step-4-security-1-plans-add>

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans.component.ts
@@ -55,6 +55,7 @@ export class Step4Security1PlansComponent implements OnInit {
         definitionVersion: 'V4',
         name: 'Default Keyless (UNSECURED)',
         description: 'Default unsecured plan',
+        mode: 'STANDARD',
         security: {
           type: 'KEY_LESS',
           configuration: {},
@@ -74,6 +75,7 @@ export class Step4Security1PlansComponent implements OnInit {
           type: 'PUSH',
           configuration: {},
         },
+        mode: 'PUSH',
         validation: 'MANUAL',
       });
     }

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans.component.ts
@@ -18,7 +18,7 @@ import { Component, OnInit } from '@angular/core';
 
 import { ApiCreationStepService } from '../../services/api-creation-step.service';
 import { CreatePlanV4 } from '../../../../../../entities/management-api-v2';
-import { PLAN_SECURITY_TYPES, PlanSecurityVM } from '../../../../../../services-ngx/constants.service';
+import { AVAILABLE_PLANS_FOR_MENU, PlanMenuItemVM } from '../../../../../../services-ngx/constants.service';
 import { ApiCreationPayload } from '../../models/ApiCreationPayload';
 
 @Component({
@@ -33,7 +33,7 @@ export class Step4Security1PlansComponent implements OnInit {
 
   public planToEdit: CreatePlanV4 | undefined = undefined;
 
-  securityType: PlanSecurityVM;
+  selectedPlanMenuItem: PlanMenuItemVM;
 
   constructor(private readonly stepService: ApiCreationStepService) {}
 
@@ -71,19 +71,15 @@ export class Step4Security1PlansComponent implements OnInit {
         definitionVersion: 'V4',
         name: 'Default PUSH plan',
         description: 'Default push plan',
-        security: {
-          type: 'PUSH',
-          configuration: {},
-        },
         mode: 'PUSH',
         validation: 'MANUAL',
       });
     }
   }
 
-  onAddPlanClicked(securityType: PlanSecurityVM) {
+  onAddPlanClicked(selectedPlanMenuItem: PlanMenuItemVM) {
     this.planToEdit = undefined;
-    this.securityType = securityType;
+    this.selectedPlanMenuItem = selectedPlanMenuItem;
     this.view = 'add';
   }
 
@@ -98,7 +94,8 @@ export class Step4Security1PlansComponent implements OnInit {
 
   onEditPlanClicked(plan: CreatePlanV4) {
     this.planToEdit = plan;
-    this.securityType = PLAN_SECURITY_TYPES.find((vm) => vm.id === plan.security.type);
+    const planFormType = plan.mode === 'PUSH' ? 'PUSH' : plan.security.type;
+    this.selectedPlanMenuItem = AVAILABLE_PLANS_FOR_MENU.find((vm) => vm.planFormType === planFormType);
     this.view = 'edit';
   }
 

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-4-security/step-4-security-1-plans.harness.ts
@@ -36,12 +36,12 @@ export class Step4Security1PlansHarness extends ComponentHarness {
       }),
     )();
 
-  async getColumnTextByRowIndex(index: number): Promise<{ name: string; security: string }> {
+  async getColumnTextByRowIndex(index: number): Promise<{ name: string; mode: string; security: string }> {
     return this.matTable()
       .then((x) => x.getRows())
       .then((rows) => rows[index])
       .then((row) => row.getCellTextByColumnName())
-      .then((cell) => ({ name: cell.name, security: cell.security }));
+      .then((cell) => ({ name: cell.name, mode: cell.mode, security: cell.security }));
   }
 
   async countNumberOfRows(): Promise<number> {

--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-6-summary/step-6-summary.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-6-summary/step-6-summary.component.html
@@ -111,7 +111,7 @@
             <div class="step-6-summary__step__info__security__content__card" *ngFor="let plan of currentStepPayload.plans">
               <div class="step-6-summary__step__info__security__content__card__title">
                 <span class="mat-body-strong">{{ plan.name }}</span
-                ><span class="gio-badge-neutral">{{ plan.security.type }}</span>
+                ><span class="gio-badge-neutral">{{ plan.security?.type || plan.mode }}</span>
               </div>
               <div class="step-6-summary__step__info__security__content__card__content">
                 <span>Entrypoints type: http</span>

--- a/gravitee-apim-console-webui/src/management/api/portal/plans/edit/api-portal-plan-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/plans/edit/api-portal-plan-edit.component.html
@@ -21,9 +21,9 @@
     Plan
   </span>
 </div>
-<form *ngIf="planForm && planSecurity" autocomplete="off" gioFormFocusInvalid [formGroup]="planForm" (ngSubmit)="onSubmit()">
+<form *ngIf="planForm && planMenuItem" autocomplete="off" gioFormFocusInvalid [formGroup]="planForm" (ngSubmit)="onSubmit()">
   <mat-card>
-    <api-plan-form #apiPlanForm formControlName="plan" [mode]="mode" [api]="api" [securityType]="planSecurity"></api-plan-form>
+    <api-plan-form #apiPlanForm formControlName="plan" [mode]="mode" [api]="api" [planMenuItem]="planMenuItem"></api-plan-form>
   </mat-card>
 
   <gio-save-bar

--- a/gravitee-apim-console-webui/src/management/api/portal/plans/edit/api-portal-plan-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/plans/edit/api-portal-plan-edit.component.spec.ts
@@ -52,7 +52,7 @@ describe('ApiPortalPlanEditComponent', () => {
       imports: [NoopAnimationsModule, GioHttpTestingModule, ApiPortalPlansModule, MatIconTestingModule],
       providers: [
         { provide: CurrentUserService, useValue: { currentUser } },
-        { provide: UIRouterStateParams, useValue: { apiId: API_ID, planId, securityType: 'JWT' } },
+        { provide: UIRouterStateParams, useValue: { apiId: API_ID, planId, selectedPlanMenuItem: 'JWT' } },
         { provide: UIRouterState, useValue: fakeUiRouter },
         {
           provide: 'Constants',
@@ -296,7 +296,7 @@ describe('ApiPortalPlanEditComponent', () => {
   describe('With a V4 API', () => {
     describe('Edit', () => {
       const TAG_1_ID = 'tag-1';
-      const PLAN = fakePlanV4({ apiId: API_ID, security: { type: 'SUBSCRIPTION' } });
+      const PLAN = fakePlanV4({ apiId: API_ID, mode: 'PUSH' });
 
       beforeEach(async () => {
         configureTestingModule(PLAN.id);

--- a/gravitee-apim-console-webui/src/management/api/portal/plans/list/api-portal-plan-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/plans/list/api-portal-plan-list.component.html
@@ -70,11 +70,11 @@
     </td>
   </ng-container>
 
-  <!-- Display Security Column -->
-  <ng-container matColumnDef="security">
-    <th mat-header-cell *matHeaderCellDef id="security">Security</th>
+  <!-- Display Type Column -->
+  <ng-container matColumnDef="type">
+    <th mat-header-cell *matHeaderCellDef id="type">Type</th>
     <td mat-cell *matCellDef="let element">
-      {{ element.security.type }}
+      {{ element.security?.type || element.mode }}
     </td>
   </ng-container>
 

--- a/gravitee-apim-console-webui/src/management/api/portal/plans/list/api-portal-plan-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/plans/list/api-portal-plan-list.component.html
@@ -28,8 +28,8 @@
       <mat-icon svgIcon="gio:plus"></mat-icon>Add new plan
     </button>
     <mat-menu #menu="matMenu">
-      <button mat-menu-item *ngFor="let planSecurity of planSecurityOptions" (click)="navigateToNewPlan(planSecurity.id)">
-        {{ planSecurity.name }}
+      <button mat-menu-item *ngFor="let planMenuItem of planMenuItems" (click)="navigateToNewPlan(planMenuItem.planFormType)">
+        {{ planMenuItem.name }}
       </button>
     </mat-menu>
   </div>

--- a/gravitee-apim-console-webui/src/management/api/portal/plans/list/api-portal-plan-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/plans/list/api-portal-plan-list.component.spec.ts
@@ -281,7 +281,7 @@ describe('ApiPortalPlanListComponent', () => {
         expect(await planSecurityDropdown.getItems().then((items) => items.length)).toEqual(4);
 
         await planSecurityDropdown.clickItem({ text: 'Keyless (public)' });
-        expect(fakeUiRouter.go).toBeCalledWith('management.apis.ng.plan.new', { securityType: 'KEY_LESS' });
+        expect(fakeUiRouter.go).toBeCalledWith('management.apis.ng.plan.new', { selectedPlanMenuItem: 'KEY_LESS' });
       });
       it('should navigate to edit when click on the name', async () => {
         await init(fakeAjsGlobals);
@@ -318,7 +318,7 @@ describe('ApiPortalPlanListComponent', () => {
       expect(await planSecurityDropdown.getItems().then((items) => items.length)).toEqual(4);
 
       await planSecurityDropdown.clickItem({ text: 'Keyless (public)' });
-      expect(fakeUiRouter.go).toBeCalledWith('management.apis.detail.portal.plan.new', { securityType: 'KEY_LESS' });
+      expect(fakeUiRouter.go).toBeCalledWith('management.apis.detail.portal.plan.new', { selectedPlanMenuItem: 'KEY_LESS' });
     });
 
     it('should navigate to edit when click on the name', async () => {

--- a/gravitee-apim-console-webui/src/management/api/portal/plans/list/api-portal-plan-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/plans/list/api-portal-plan-list.component.spec.ts
@@ -133,9 +133,9 @@ describe('ApiPortalPlanListComponent', () => {
         {
           'drag-icon': '',
           name: 'Name',
-          security: 'Security',
           status: 'Status',
           'deploy-on': 'Deploy on',
+          type: 'Type',
           actions: '',
         },
       ]);
@@ -151,9 +151,9 @@ describe('ApiPortalPlanListComponent', () => {
         {
           'drag-icon': '',
           name: 'Name',
-          security: 'Security',
           status: 'Status',
           'deploy-on': 'Deploy on',
+          type: 'Type',
           actions: '',
         },
       ]);
@@ -530,9 +530,9 @@ describe('ApiPortalPlanListComponent', () => {
       expect(headerCells).toEqual([
         {
           name: 'Name',
-          security: 'Security',
           status: 'Status',
           'deploy-on': 'Deploy on',
+          type: 'Type',
           actions: '',
         },
       ]);

--- a/gravitee-apim-console-webui/src/management/api/portal/plans/list/api-portal-plan-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/plans/list/api-portal-plan-list.component.ts
@@ -46,7 +46,7 @@ import { ApiPlanV2Service } from '../../../../../services-ngx/api-plan-v2.servic
 export class ApiPortalPlanListComponent implements OnInit, OnDestroy {
   private unsubscribe$: Subject<boolean> = new Subject<boolean>();
   private api: Api;
-  public displayedColumns = ['name', 'security', 'status', 'deploy-on', 'actions'];
+  public displayedColumns = ['name', 'type', 'status', 'deploy-on', 'actions'];
   public plansTableDS: Plan[] = [];
   public isLoadingData = true;
   public apiPlanStatus: { name: PlanStatus; number: number | null }[] = PLAN_STATUS.map((status) => ({ name: status, number: null }));

--- a/gravitee-apim-console-webui/src/management/api/portal/plans/list/api-portal-plan-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/plans/list/api-portal-plan-list.component.ts
@@ -33,7 +33,7 @@ import { PlanService } from '../../../../../services-ngx/plan.service';
 import { SubscriptionService } from '../../../../../services-ngx/subscription.service';
 import { GioPermissionService } from '../../../../../shared/components/gio-permission/gio-permission.service';
 import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
-import { ConstantsService, PlanSecurityVM } from '../../../../../services-ngx/constants.service';
+import { ConstantsService, PlanMenuItemVM } from '../../../../../services-ngx/constants.service';
 import { ApiV2Service } from '../../../../../services-ngx/api-v2.service';
 import { Api, PLAN_STATUS, Plan, PlanStatus, ApiV4 } from '../../../../../entities/management-api-v2';
 import { ApiPlanV2Service } from '../../../../../services-ngx/api-plan-v2.service';
@@ -53,7 +53,7 @@ export class ApiPortalPlanListComponent implements OnInit, OnDestroy {
   public status: PlanStatus;
   public isReadOnly = false;
   public isV2Api: boolean;
-  public planSecurityOptions: PlanSecurityVM[];
+  public planMenuItems: PlanMenuItemVM[];
   private routeBase: string;
 
   constructor(
@@ -136,8 +136,8 @@ export class ApiPortalPlanListComponent implements OnInit, OnDestroy {
     this.ajsState.go(`${this.routeBase}.plan.edit`, { planId });
   }
 
-  public navigateToNewPlan(securityType: string): void {
-    this.ajsState.go(`${this.routeBase}.plan.new`, { securityType });
+  public navigateToNewPlan(selectedPlanMenuItem: string): void {
+    this.ajsState.go(`${this.routeBase}.plan.new`, { selectedPlanMenuItem });
   }
 
   public designPlan(planId: string): void {
@@ -215,7 +215,7 @@ export class ApiPortalPlanListComponent implements OnInit, OnDestroy {
         takeUntil(this.unsubscribe$),
         switchMap((subscriptions) => {
           let content = '';
-          if (plan.security.type === 'KEY_LESS') {
+          if (plan.security?.type === 'KEY_LESS') {
             content = 'A keyless plan may have consumers. <br/>' + 'By closing this plan you will remove free access to this API.';
           } else {
             if (subscriptions.page.size === 0) {
@@ -225,7 +225,7 @@ export class ApiPortalPlanListComponent implements OnInit, OnDestroy {
             }
           }
           let confirmButton = 'Yes, close this plan.';
-          if (subscriptions.page.size === 0 && plan.security.type === 'API_KEY') {
+          if (subscriptions.page.size === 0 && plan.security?.type === 'API_KEY') {
             confirmButton = 'Yes, delete this plan';
           }
           return this.matDialog
@@ -301,17 +301,17 @@ export class ApiPortalPlanListComponent implements OnInit, OnDestroy {
   }
 
   private computePlanOptions(): void {
-    this.planSecurityOptions = this.constantsService.getEnabledPlanSecurityTypes();
+    this.planMenuItems = this.constantsService.getEnabledPlanMenuItems();
 
     if (this.api && this.api.definitionVersion !== 'V4') {
-      this.planSecurityOptions = this.planSecurityOptions.filter((security) => security.id !== 'PUSH');
+      this.planMenuItems = this.planMenuItems.filter((planMenuItem) => planMenuItem.planFormType !== 'PUSH');
     } else {
       if ((this.api as ApiV4)?.listeners?.every((entrypoint) => entrypoint.type === 'SUBSCRIPTION')) {
-        this.planSecurityOptions = this.planSecurityOptions.filter((planSecurityType) => planSecurityType.id === 'PUSH');
+        this.planMenuItems = this.planMenuItems.filter((planMenuItem) => planMenuItem.planFormType === 'PUSH');
       }
 
       if ((this.api as ApiV4)?.listeners?.every((entrypoint) => ['HTTP', 'TCP'].includes(entrypoint.type))) {
-        this.planSecurityOptions = this.planSecurityOptions.filter((planSecurityType) => planSecurityType.id !== 'PUSH');
+        this.planMenuItems = this.planMenuItems.filter((planMenuItem) => planMenuItem.planFormType !== 'PUSH');
       }
     }
   }

--- a/gravitee-apim-console-webui/src/services-ngx/api-plan-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-plan-v2.service.spec.ts
@@ -112,6 +112,7 @@ describe('ApiPlanV2Service', () => {
         flows: [],
         validation: 'AUTO',
         name: 'free',
+        mode: 'STANDARD',
         security: { type: 'API_KEY', configuration: '{}' },
       };
 
@@ -136,6 +137,7 @@ describe('ApiPlanV2Service', () => {
         validation: 'AUTO',
         name: 'free',
         security: { type: 'PUSH', configuration: '{}' },
+        mode: 'PUSH',
       };
 
       apiPlanV2Service.create(API_ID, plan).subscribe((response) => {
@@ -148,6 +150,7 @@ describe('ApiPlanV2Service', () => {
         url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/plans`,
       });
       expect(planReq.request.body.security.type).toEqual('SUBSCRIPTION');
+      expect(planReq.request.body.mode).toEqual('PUSH');
       planReq.flush(plan);
     });
   });

--- a/gravitee-apim-console-webui/src/services-ngx/api-plan-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-plan-v2.service.spec.ts
@@ -136,7 +136,6 @@ describe('ApiPlanV2Service', () => {
         flows: [],
         validation: 'AUTO',
         name: 'free',
-        security: { type: 'PUSH', configuration: '{}' },
         mode: 'PUSH',
       };
 
@@ -149,7 +148,7 @@ describe('ApiPlanV2Service', () => {
         method: 'POST',
         url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/plans`,
       });
-      expect(planReq.request.body.security.type).toEqual('SUBSCRIPTION');
+      expect(planReq.request.body.security).toBeUndefined();
       expect(planReq.request.body.mode).toEqual('PUSH');
       planReq.flush(plan);
     });

--- a/gravitee-apim-console-webui/src/services-ngx/api-plan-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-plan-v2.service.ts
@@ -37,9 +37,6 @@ export class ApiPlanV2Service {
   }
 
   public create(apiId: string, plan: CreatePlan): Observable<Plan> {
-    if (plan.security.type === 'PUSH') {
-      plan.security.type = 'SUBSCRIPTION';
-    }
     return this.http.post<Plan>(`${this.constants.env.v2BaseURL}/apis/${apiId}/plans`, plan);
   }
 

--- a/gravitee-apim-console-webui/src/services-ngx/constants.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/constants.service.spec.ts
@@ -16,7 +16,7 @@
 import { TestBed } from '@angular/core/testing';
 import { set } from 'lodash';
 
-import { ConstantsService, PLAN_SECURITY_TYPES, PlanSecurityVM } from './constants.service';
+import { ConstantsService, AVAILABLE_PLANS_FOR_MENU, PlanMenuItemVM } from './constants.service';
 
 import { CONSTANTS_TESTING, GioHttpTestingModule } from '../shared/testing';
 
@@ -64,9 +64,9 @@ describe('ConstantsService', () => {
           enabled: true,
         },
       });
-      const expectedPlanSecurityTypes = PLAN_SECURITY_TYPES;
+      const expectedPlanSecurityTypes = AVAILABLE_PLANS_FOR_MENU;
 
-      expect(constantsService.getEnabledPlanSecurityTypes()).toMatchObject(expectedPlanSecurityTypes);
+      expect(constantsService.getEnabledPlanMenuItems()).toMatchObject(expectedPlanSecurityTypes);
     });
     it('should return empty list when all disabled', async () => {
       await init({
@@ -89,16 +89,16 @@ describe('ConstantsService', () => {
           enabled: false,
         },
       });
-      const expectedPlanSecurityTypes: PlanSecurityVM[] = [];
+      const expectedPlanSecurityTypes: PlanMenuItemVM[] = [];
 
-      expect(constantsService.getEnabledPlanSecurityTypes()).toMatchObject(expectedPlanSecurityTypes);
+      expect(constantsService.getEnabledPlanMenuItems()).toMatchObject(expectedPlanSecurityTypes);
     });
 
     it('should return empty list if no plan settings', async () => {
       await init({});
-      const expectedPlanSecurityTypes: PlanSecurityVM[] = [];
+      const expectedPlanSecurityTypes: PlanMenuItemVM[] = [];
 
-      expect(constantsService.getEnabledPlanSecurityTypes()).toMatchObject(expectedPlanSecurityTypes);
+      expect(constantsService.getEnabledPlanMenuItems()).toMatchObject(expectedPlanSecurityTypes);
     });
   });
 });

--- a/gravitee-apim-console-webui/src/services-ngx/constants.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/constants.service.ts
@@ -19,33 +19,35 @@ import { camelCase } from 'lodash';
 import { Constants } from '../entities/Constants';
 import { PlanSecurityType } from '../entities/management-api-v2';
 
-export interface PlanSecurityVM {
-  id: PlanSecurityType;
+export type PlanFormType = PlanSecurityType | 'PUSH';
+
+export interface PlanMenuItemVM {
+  planFormType: PlanFormType;
   name: string;
   policy?: string;
 }
-export const PLAN_SECURITY_TYPES: PlanSecurityVM[] = [
+export const AVAILABLE_PLANS_FOR_MENU: PlanMenuItemVM[] = [
   {
-    id: 'OAUTH2',
+    planFormType: 'OAUTH2',
     name: 'OAuth2',
     policy: 'oauth2',
   },
   {
-    id: 'JWT',
+    planFormType: 'JWT',
     name: 'JWT',
     policy: 'jwt',
   },
   {
-    id: 'API_KEY',
+    planFormType: 'API_KEY',
     name: 'API Key',
     policy: 'api-key',
   },
   {
-    id: 'KEY_LESS',
+    planFormType: 'KEY_LESS',
     name: 'Keyless (public)',
   },
   {
-    id: 'PUSH',
+    planFormType: 'PUSH',
     name: 'Push plan',
   },
 ];
@@ -56,11 +58,11 @@ export const PLAN_SECURITY_TYPES: PlanSecurityVM[] = [
 export class ConstantsService {
   constructor(@Inject('Constants') private readonly constants: Constants) {}
 
-  getEnabledPlanSecurityTypes(): PlanSecurityVM[] {
+  getEnabledPlanMenuItems(): PlanMenuItemVM[] {
     const planSecuritySettings: [string, { enabled: boolean }][] = Object.entries(this.constants.env?.settings?.plan?.security ?? {});
 
-    return PLAN_SECURITY_TYPES.filter((securityType) => {
-      const cleanSecurityType = camelCase(securityType.id.replace('_', ''));
+    return AVAILABLE_PLANS_FOR_MENU.filter((planMenuItem) => {
+      const cleanSecurityType = camelCase(planMenuItem.planFormType.replace('_', ''));
 
       // One of the portal settings security types matches the security type from PLAN_SECURITY_TYPES
       const matchedSecurityType = planSecuritySettings

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PlanMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PlanMapper.java
@@ -25,9 +25,13 @@ import java.util.stream.Collectors;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
+import org.mapstruct.NullValueMappingStrategy;
 import org.mapstruct.factory.Mappers;
 
-@Mapper(uses = { ConfigurationSerializationMapper.class, DateMapper.class, FlowMapper.class, RuleMapper.class })
+@Mapper(
+    uses = { ConfigurationSerializationMapper.class, DateMapper.class, FlowMapper.class, RuleMapper.class },
+    nullValueIterableMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT
+)
 public interface PlanMapper {
     PlanMapper INSTANCE = Mappers.getMapper(PlanMapper.class);
 
@@ -63,6 +67,8 @@ public interface PlanMapper {
 
     @Mapping(target = "security.type", qualifiedByName = "mapFromSecurityType")
     @Mapping(target = "security.configuration", qualifiedByName = "serializeConfiguration")
+    @Mapping(target = "validation", defaultValue = "MANUAL")
+    @Mapping(target = "mode", defaultValue = "STANDARD")
     NewPlanEntity map(CreatePlanV4 plan);
 
     @Mapping(target = "security", source = "security.type")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
@@ -2893,7 +2893,6 @@ components:
                 - API_KEY
                 - OAUTH2
                 - JWT
-                - SUBSCRIPTION
         PlanStatus:
             type: string
             description: Plan status.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PlanMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/PlanMapperTest.java
@@ -17,12 +17,15 @@ package io.gravitee.rest.api.management.v2.rest.mapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fixtures.PlanFixtures;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.rest.api.model.v4.plan.PlanMode;
 import io.gravitee.rest.api.model.v4.plan.PlanSecurityType;
+import io.gravitee.rest.api.model.v4.plan.PlanValidationType;
 import java.util.HashSet;
 import org.junit.jupiter.api.AssertionFailureBuilder;
 import org.junit.jupiter.api.Assertions;
@@ -109,6 +112,18 @@ public class PlanMapperTest {
 
         assertSecurityV4Equals(newPlanEntity.getSecurity(), createPlanV4.getSecurity());
         assertEquals(newPlanEntity.getFlows().size(), createPlanV4.getFlows().size()); // Flow mapping is tested in FlowMapperTest
+    }
+
+    @Test
+    void should_map_CreatePlanV4_to_NewPlanEntity_with_default_values() {
+        final var createPlanV4 = PlanFixtures.aCreatePlanV4().toBuilder().validation(null).mode(null).flows(null).build();
+        final var newPlanEntity = planMapper.map(createPlanV4);
+
+        Assertions.assertNull(newPlanEntity.getId());
+        assertEquals(PlanValidationType.MANUAL, newPlanEntity.getValidation());
+        assertEquals(PlanMode.STANDARD, newPlanEntity.getMode());
+        assertNotNull(newPlanEntity.getFlows());
+        assertEquals(0, newPlanEntity.getFlows().size());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/PlanSecurityType.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/PlanSecurityType.java
@@ -42,9 +42,4 @@ public enum PlanSecurityType {
      * Plan which is using a JWT security authentication type for incoming HTTP requests.
      */
     JWT,
-
-    /**
-     * Plan which is use for the subscription type of APIs for which no particular authentication is required.
-     */
-    SUBSCRIPTION,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
@@ -791,11 +791,13 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
 
             SubscriptionEntity subscriptionEntity = convert(subscription);
             PlanSecurity planSecurity = genericPlanEntity.getPlanSecurity();
-            PlanSecurityType planSecurityType = PlanSecurityType.valueOfLabel(planSecurity.getType());
-            if (planSecurityType == PlanSecurityType.API_KEY && subscriptionEntity.getStatus() == SubscriptionStatus.ACCEPTED) {
+            if (
+                planSecurity != null &&
+                PlanSecurityType.API_KEY == PlanSecurityType.valueOfLabel(planSecurity.getType()) &&
+                subscriptionEntity.getStatus() == SubscriptionStatus.ACCEPTED
+            ) {
                 apiKeyService.generate(executionContext, application, subscriptionEntity, processSubscription.getCustomApiKey());
             }
-
             subscription = subscriptionRepository.update(subscription);
 
             final PrimaryOwnerEntity owner = application.getPrimaryOwner();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/PlanMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/PlanMapper.java
@@ -67,14 +67,12 @@ public class PlanMapper {
             entity.setStatus(PlanStatus.PUBLISHED);
         }
 
-        PlanSecurity security = new PlanSecurity();
-        if (plan.getSecurity() != null) {
+        if (plan.getMode() == Plan.PlanMode.STANDARD) {
+            PlanSecurity security = new PlanSecurity();
             security.setType(PlanSecurityType.valueOf(plan.getSecurity().name()).getLabel());
-        } else {
-            security.setType(PlanSecurityType.API_KEY.getLabel());
+            security.setConfiguration(plan.getSecurityDefinition());
+            entity.setSecurity(security);
         }
-        security.setConfiguration(plan.getSecurityDefinition());
-        entity.setSecurity(security);
 
         entity.setValidation(PlanValidationType.valueOf(plan.getValidation().name()));
         entity.setCharacteristics(plan.getCharacteristics());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/SubscriptionServiceTest.java
@@ -837,7 +837,7 @@ public class SubscriptionServiceTest {
         // Stub
         when(subscriptionRepository.findById(SUBSCRIPTION_ID)).thenReturn(Optional.of(subscription));
         when(subscriptionRepository.update(any())).thenAnswer(returnsFirstArg());
-        planEntity.setSecurity(PlanSecurityType.SUBSCRIPTION);
+        planEntity.setSecurity(PlanSecurityType.API_KEY);
         when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN_ID)).thenReturn(planEntity);
 
         // Run

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/PlanMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/PlanMapperTest.java
@@ -25,6 +25,7 @@ import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.repository.management.model.Plan;
 import io.gravitee.rest.api.model.v4.plan.NewPlanEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanEntity;
+import io.gravitee.rest.api.model.v4.plan.PlanMode;
 import io.gravitee.rest.api.model.v4.plan.PlanSecurityType;
 import io.gravitee.rest.api.model.v4.plan.PlanType;
 import io.gravitee.rest.api.model.v4.plan.PlanValidationType;
@@ -71,6 +72,35 @@ public class PlanMapperTest {
         assertEquals(plan.getApi(), planEntity.getApiId());
         assertEquals(plan.getGeneralConditions(), planEntity.getGeneralConditions());
         assertEquals(PlanSecurityType.KEY_LESS.getLabel(), planEntity.getSecurity().getType());
+        assertSame(flows, planEntity.getFlows());
+    }
+
+    @Test
+    public void shouldConvertPushPlanToPlanEntity() {
+        Plan plan = new Plan();
+        plan.setId("123123-1531-4563456166");
+        plan.setName("Push plan name");
+        plan.setDescription("Description for the new plan");
+        plan.setValidation(Plan.PlanValidationType.AUTO);
+        plan.setType(Plan.PlanType.API);
+        plan.setMode(Plan.PlanMode.PUSH);
+        plan.setStatus(Plan.Status.STAGING);
+        plan.setApi("api1");
+        plan.setGeneralConditions("general_conditions");
+
+        List<Flow> flows = new ArrayList<>();
+
+        PlanEntity planEntity = planMapper.toEntity(plan, flows);
+
+        assertEquals(plan.getId(), planEntity.getId());
+        assertEquals(plan.getName(), planEntity.getName());
+        assertEquals(plan.getDescription(), planEntity.getDescription());
+        assertEquals(plan.getValidation().name(), planEntity.getValidation().name());
+        assertEquals(plan.getStatus().name(), planEntity.getStatus().name());
+        assertEquals(plan.getApi(), planEntity.getApiId());
+        assertEquals(plan.getGeneralConditions(), planEntity.getGeneralConditions());
+        assertEquals(PlanMode.PUSH, planEntity.getMode());
+        assertNull(planEntity.getSecurity());
         assertSame(flows, planEntity.getFlows());
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2025
https://gravitee.atlassian.net/browse/APIM-719

## Description

 - A few modifications on the backend side to handle the fact that 'SUBSCRIPTION' is not a security type.
 - Introducing the "mode" (Standard vs. Push). In "Push" mode, there is no security configuration.
 - Adapt the plan edition form to handle this new mode
 - Replace the security column in tables by a "type" column which is a combination of "mode" and "securityType"
 - Fix minor bugs in plan mapping.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-nxboootkuo.chromatic.com)
<!-- Storybook placeholder end -->
