### PR TITLE
feat(rest-api-v2): expand subscribedBy for getApiSubscription

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/UserMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/UserMapper.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.mapper;
+
+import io.gravitee.rest.api.management.v2.rest.model.BaseUser;
+import io.gravitee.rest.api.model.UserEntity;
+import java.util.Collection;
+import java.util.List;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface UserMapper {
+    UserMapper INSTANCE = Mappers.getMapper(UserMapper.class);
+
+    BaseUser map(UserEntity user);
+    List<BaseUser> mapToBaseUserList(Collection<UserEntity> users);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
@@ -871,6 +871,7 @@ paths:
                           enum:
                               - application
                               - plan
+                              - subscribedBy
                   explode: false
                 - $ref: "#/components/parameters/pageParam"
                 - $ref: "#/components/parameters/perPageParam"
@@ -1019,6 +1020,7 @@ paths:
                           enum:
                               - application
                               - plan
+                              - subscribedBy
             summary: Get one API's subscription
             description: |-
                 Get the API's subscription by its identifier.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/UserFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/fixtures/UserFixtures.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fixtures;
+
+import io.gravitee.rest.api.model.UserEntity;
+
+public class UserFixtures {
+
+    private static UserEntity.UserEntityBuilder USER_ENTITY = UserEntity
+        .builder()
+        .id("id")
+        .firstname("John")
+        .lastname("Doe")
+        .email("john@doe.com");
+
+    public static UserEntity aUserEntity() {
+        return USER_ENTITY.build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResourceTest.java
@@ -24,6 +24,7 @@ import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.service.ApiKeyService;
 import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.SubscriptionService;
+import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import java.util.Optional;
@@ -38,6 +39,7 @@ public abstract class ApiSubscriptionsResourceTest extends AbstractResourceTest 
     protected static final String PLAN = "my-plan";
     protected static final String APPLICATION = "my-application";
     protected static final String SUBSCRIPTION = "my-subscription";
+    protected static final String SUBSCRIBED_BY = "my-subscriber-id";
     protected static final String ENVIRONMENT = "my-env";
 
     @Autowired
@@ -51,6 +53,9 @@ public abstract class ApiSubscriptionsResourceTest extends AbstractResourceTest 
 
     @Autowired
     protected ApiKeyService apiKeyService;
+
+    @Autowired
+    protected UserService userService;
 
     @Before
     public void init() throws TechnicalException {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -178,4 +178,9 @@ public class ResourceContextConfiguration {
     public ApiKeyService apiKeyService() {
         return mock(ApiKeyService.class);
     }
+
+    @Bean
+    public UserService userService() {
+        return mock(UserService.class);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/UserEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/UserEntity.java
@@ -22,10 +22,7 @@ import java.util.Date;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -36,6 +33,9 @@ import lombok.ToString;
 @Setter
 @EqualsAndHashCode(of = "id")
 @ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(toBuilder = true)
 public class UserEntity implements Indexable {
 
     /**


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1405

## Description

The first of multiple PRs...

- Add "subscribedBy" to the api subscription query `expands`
- The subscriber info is needed in the frontend for the subscription detail page. 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-iomxmlgmkj.chromatic.com)
<!-- Storybook placeholder end -->
