### PR TITLE
Fix: return v4 APIs with portal API

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiQuery.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/api/ApiQuery.java
@@ -15,13 +15,16 @@
  */
 package io.gravitee.rest.api.model.api;
 
+import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.rest.api.model.Visibility;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
@@ -30,6 +33,9 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@Getter
+@Setter
+@EqualsAndHashCode
 public class ApiQuery {
 
     private Collection<String> ids;
@@ -44,166 +50,5 @@ public class ApiQuery {
     private String tag;
     private String crossId;
     private List<ApiLifecycleState> lifecycleStates;
-
-    public Collection<String> getIds() {
-        return ids;
-    }
-
-    public void setIds(Collection<String> ids) {
-        this.ids = ids;
-    }
-
-    public String getCategory() {
-        return category;
-    }
-
-    public void setCategory(String category) {
-        this.category = category;
-    }
-
-    public List<String> getGroups() {
-        return groups;
-    }
-
-    public void setGroups(List<String> groups) {
-        this.groups = groups;
-    }
-
-    public String getContextPath() {
-        return contextPath;
-    }
-
-    public void setContextPath(String contextPath) {
-        this.contextPath = contextPath;
-    }
-
-    public String getLabel() {
-        return label;
-    }
-
-    public void setLabel(String label) {
-        this.label = label;
-    }
-
-    public String getState() {
-        return state;
-    }
-
-    public void setState(String state) {
-        this.state = state;
-    }
-
-    public Visibility getVisibility() {
-        return visibility;
-    }
-
-    public void setVisibility(Visibility visibility) {
-        this.visibility = visibility;
-    }
-
-    public String getVersion() {
-        return version;
-    }
-
-    public void setVersion(String version) {
-        this.version = version;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getTag() {
-        return tag;
-    }
-
-    public void setTag(String tag) {
-        this.tag = tag;
-    }
-
-    public List<ApiLifecycleState> getLifecycleStates() {
-        return lifecycleStates;
-    }
-
-    public void setLifecycleStates(List<ApiLifecycleState> lifecycleStates) {
-        this.lifecycleStates = lifecycleStates;
-    }
-
-    public String getCrossId() {
-        return crossId;
-    }
-
-    public void setCrossId(String crossId) {
-        this.crossId = crossId;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        ApiQuery apiQuery = (ApiQuery) o;
-        return (
-            Objects.equals(ids, apiQuery.ids) &&
-            Objects.equals(category, apiQuery.category) &&
-            Objects.equals(groups, apiQuery.groups) &&
-            Objects.equals(contextPath, apiQuery.contextPath) &&
-            Objects.equals(label, apiQuery.label) &&
-            Objects.equals(state, apiQuery.state) &&
-            visibility == apiQuery.visibility &&
-            Objects.equals(version, apiQuery.version) &&
-            Objects.equals(name, apiQuery.name) &&
-            Objects.equals(tag, apiQuery.tag) &&
-            Objects.equals(lifecycleStates, apiQuery.lifecycleStates) &&
-            Objects.equals(crossId, apiQuery.crossId)
-        );
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(ids, category, groups, contextPath, label, state, visibility, version, name, tag, lifecycleStates, crossId);
-    }
-
-    @Override
-    public String toString() {
-        return (
-            "ApiQuery{" +
-            "ids=" +
-            ids +
-            ", category='" +
-            category +
-            '\'' +
-            ", groups=" +
-            groups +
-            ", contextPath='" +
-            contextPath +
-            '\'' +
-            ", label='" +
-            label +
-            '\'' +
-            ", state='" +
-            state +
-            '\'' +
-            ", visibility=" +
-            visibility +
-            ", version='" +
-            version +
-            '\'' +
-            ", name='" +
-            name +
-            '\'' +
-            ", tag='" +
-            tag +
-            '\'' +
-            ", lifecycleStates=" +
-            lifecycleStates +
-            '\'' +
-            ", crossId=" +
-            crossId +
-            '}'
-        );
-    }
+    private List<DefinitionVersion> definitionVersions;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -96,7 +96,12 @@ import io.gravitee.rest.api.service.processor.SynchronizationService;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.search.query.Query;
 import io.gravitee.rest.api.service.search.query.QueryBuilder;
-import io.gravitee.rest.api.service.v4.*;
+import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
+import io.gravitee.rest.api.service.v4.ApiEntrypointService;
+import io.gravitee.rest.api.service.v4.ApiNotificationService;
+import io.gravitee.rest.api.service.v4.ApiSearchService;
+import io.gravitee.rest.api.service.v4.ApiTemplateService;
+import io.gravitee.rest.api.service.v4.PrimaryOwnerService;
 import io.gravitee.rest.api.service.v4.validation.AnalyticsValidationService;
 import io.gravitee.rest.api.service.v4.validation.CorsValidationService;
 import io.gravitee.rest.api.service.v4.validation.TagsValidationService;
@@ -775,6 +780,13 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     ) {
         try {
             LOGGER.debug("Find APIs page by user {}", userId);
+            if (apiQuery == null) {
+                apiQuery = new ApiQuery();
+            }
+
+            // By default, in this service, we do not care for V4 APIs.
+            apiQuery.setDefinitionVersions(getAllowedDefinitionVersion());
+
             Set<String> apiIds = apiAuthorizationService.findIdsByUser(executionContext, userId, apiQuery, sortable, manageOnly);
             return loadPage(executionContext, apiIds, pageable);
         } catch (TechnicalException ex) {
@@ -2526,13 +2538,17 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
     @NotNull
     private ApiCriteria.Builder getDefaultApiCriteriaBuilder() {
-        // By default in this service, we do not care for V4 APIs.
+        // By default, in this service, we do not care for V4 APIs.
+        return new ApiCriteria.Builder().definitionVersion(getAllowedDefinitionVersion());
+    }
+
+    @NotNull
+    private static List<DefinitionVersion> getAllowedDefinitionVersion() {
         List<DefinitionVersion> allowedDefinitionVersion = new ArrayList<>();
         allowedDefinitionVersion.add(null);
         allowedDefinitionVersion.add(DefinitionVersion.V1);
         allowedDefinitionVersion.add(DefinitionVersion.V2);
-
-        return new ApiCriteria.Builder().definitionVersion(allowedDefinitionVersion);
+        return allowedDefinitionVersion;
     }
 
     private Query<ApiEntity> addDefaultExcludedFilters(Query<ApiEntity> searchEngineQuery) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImpl.java
@@ -16,14 +16,12 @@
 package io.gravitee.rest.api.service.v4.impl;
 
 import static io.gravitee.repository.management.model.Visibility.PUBLIC;
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_DEFINITION_VERSION;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
-import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldFilter;
@@ -37,6 +35,7 @@ import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.RoleEntity;
 import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.model.api.ApiQuery;
+import io.gravitee.rest.api.model.application.ApplicationListItem;
 import io.gravitee.rest.api.model.application.ApplicationQuery;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.common.PageableImpl;
@@ -74,7 +73,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
@@ -184,8 +182,8 @@ public class ApiAuthorizationServiceImpl extends AbstractService implements ApiA
     /**
      * This method use ApiQuery to search in indexer for fields in api definition
      *
-     * @param executionContext The execution context
-     * @param apiQuery The api query
+     * @param executionContext
+     * @param apiQuery
      * @return Optional<List < String>> an optional list of api ids and Optional.empty()
      * if ApiQuery doesn't contain fields stores in the api definition.
      */
@@ -197,7 +195,7 @@ public class ApiAuthorizationServiceImpl extends AbstractService implements ApiA
         if (isBlank(searchEngineQuery.getQuery())) {
             return Optional.empty();
         }
-        SearchResult matchApis = searchEngineService.search(executionContext, addDefaultExcludedFilters(searchEngineQuery));
+        SearchResult matchApis = searchEngineService.search(executionContext, searchEngineQuery);
         return Optional.of(matchApis.getDocuments());
     }
 
@@ -486,7 +484,7 @@ public class ApiAuthorizationServiceImpl extends AbstractService implements ApiA
     }
 
     private ApiCriteria.Builder queryToCriteria(ExecutionContext executionContext, ApiQuery query) {
-        final ApiCriteria.Builder builder = getDefaultApiCriteriaBuilder().environmentId(executionContext.getEnvironmentId());
+        final ApiCriteria.Builder builder = new ApiCriteria.Builder().environmentId(executionContext.getEnvironmentId());
         if (query == null) {
             return builder;
         }
@@ -521,22 +519,5 @@ public class ApiAuthorizationServiceImpl extends AbstractService implements ApiA
         }
 
         return builder;
-    }
-
-    @NotNull
-    private ApiCriteria.Builder getDefaultApiCriteriaBuilder() {
-        // By default, in this service, we do not care for V4 APIs.
-        List<DefinitionVersion> allowedDefinitionVersion = new ArrayList<>();
-        allowedDefinitionVersion.add(null);
-        allowedDefinitionVersion.add(DefinitionVersion.V1);
-        allowedDefinitionVersion.add(DefinitionVersion.V2);
-
-        return new ApiCriteria.Builder().definitionVersion(allowedDefinitionVersion);
-    }
-
-    private Query<GenericApiEntity> addDefaultExcludedFilters(Query<GenericApiEntity> searchEngineQuery) {
-        // By default, in this service, we do not care for V4 APIs.
-        searchEngineQuery.getExcludedFilters().put(FIELD_DEFINITION_VERSION, singletonList(DefinitionVersion.V4.getLabel()));
-        return searchEngineQuery;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiAuthorizationServiceImplTest.java
@@ -15,9 +15,7 @@
  */
 package io.gravitee.rest.api.service.v4.impl;
 
-import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_DEFINITION_VERSION;
 import static java.util.Collections.emptySet;
-import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -29,7 +27,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import io.gravitee.common.data.domain.Page;
-import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.model.Api;
@@ -50,13 +48,11 @@ import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.impl.search.SearchResult;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.search.query.Query;
 import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
 import io.gravitee.rest.api.service.v4.PrimaryOwnerService;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -148,13 +144,7 @@ public class ApiAuthorizationServiceImplTest {
         when(roleService.findById(userRoleId)).thenReturn(userRole);
         when(api.getId()).thenReturn("api-1");
         List<ApiCriteria> apiCriteriaList = new ArrayList<>();
-        apiCriteriaList.add(
-            new ApiCriteria.Builder()
-                .environmentId("DEFAULT")
-                .ids("api-1")
-                .definitionVersion(Arrays.asList(null, DefinitionVersion.V1, DefinitionVersion.V2))
-                .build()
-        );
+        apiCriteriaList.add(new ApiCriteria.Builder().environmentId("DEFAULT").ids("api-1").build());
 
         when(apiRepository.searchIds(eq(apiCriteriaList), any(), any())).thenReturn(new Page<>(List.of("api-1"), 0, 1, 1));
 
@@ -258,16 +248,10 @@ public class ApiAuthorizationServiceImplTest {
                 .environmentId("DEFAULT")
                 .lifecycleStates(List.of(ApiLifecycleState.PUBLISHED))
                 .visibility(Visibility.PUBLIC)
-                .definitionVersion(Arrays.asList(null, DefinitionVersion.V1, DefinitionVersion.V2))
                 .build()
         );
         apiCriteriaList.add(
-            new ApiCriteria.Builder()
-                .environmentId("DEFAULT")
-                .lifecycleStates(List.of(ApiLifecycleState.PUBLISHED))
-                .ids("api-1")
-                .definitionVersion(Arrays.asList(null, DefinitionVersion.V1, DefinitionVersion.V2))
-                .build()
+            new ApiCriteria.Builder().environmentId("DEFAULT").lifecycleStates(List.of(ApiLifecycleState.PUBLISHED)).ids("api-1").build()
         );
         when(apiRepository.searchIds(eq(apiCriteriaList), any(), any())).thenReturn(new Page<>(List.of("api-1"), 0, 1, 1));
 
@@ -313,16 +297,10 @@ public class ApiAuthorizationServiceImplTest {
                 .environmentId("DEFAULT")
                 .lifecycleStates(List.of(ApiLifecycleState.PUBLISHED))
                 .visibility(Visibility.PUBLIC)
-                .definitionVersion(Arrays.asList(null, DefinitionVersion.V1, DefinitionVersion.V2))
                 .build()
         );
         apiCriteriaList.add(
-            new ApiCriteria.Builder()
-                .environmentId("DEFAULT")
-                .lifecycleStates(List.of(ApiLifecycleState.PUBLISHED))
-                .ids("api-1")
-                .definitionVersion(Arrays.asList(null, DefinitionVersion.V1, DefinitionVersion.V2))
-                .build()
+            new ApiCriteria.Builder().environmentId("DEFAULT").lifecycleStates(List.of(ApiLifecycleState.PUBLISHED)).ids("api-1").build()
         );
         when(apiRepository.searchIds(eq(apiCriteriaList), any(), any())).thenReturn(new Page<>(List.of("api-1"), 0, 1, 1));
 
@@ -373,16 +351,10 @@ public class ApiAuthorizationServiceImplTest {
                 .lifecycleStates(List.of(ApiLifecycleState.PUBLISHED))
                 .ids("api-1")
                 .visibility(Visibility.PUBLIC)
-                .definitionVersion(Arrays.asList(null, DefinitionVersion.V1, DefinitionVersion.V2))
                 .build()
         );
         apiCriteriaList.add(
-            new ApiCriteria.Builder()
-                .environmentId("DEFAULT")
-                .lifecycleStates(List.of(ApiLifecycleState.PUBLISHED))
-                .ids("api-1")
-                .definitionVersion(Arrays.asList(null, DefinitionVersion.V1, DefinitionVersion.V2))
-                .build()
+            new ApiCriteria.Builder().environmentId("DEFAULT").lifecycleStates(List.of(ApiLifecycleState.PUBLISHED)).ids("api-1").build()
         );
         when(apiRepository.searchIds(eq(apiCriteriaList), any(), any())).thenReturn(new Page<>(List.of("api-1"), 0, 1, 1));
 
@@ -419,14 +391,7 @@ public class ApiAuthorizationServiceImplTest {
         when(searchEngineService.search(any(), any())).thenReturn(new SearchResult(List.of("api-2")));
 
         List<ApiCriteria> apiCriteriaList = new ArrayList<>();
-        apiCriteriaList.add(
-            new ApiCriteria.Builder()
-                .environmentId("DEFAULT")
-                .ids(List.of("api-2"))
-                .visibility(Visibility.PUBLIC)
-                .definitionVersion(Arrays.asList(null, DefinitionVersion.V1, DefinitionVersion.V2))
-                .build()
-        );
+        apiCriteriaList.add(new ApiCriteria.Builder().environmentId("DEFAULT").ids(List.of("api-2")).visibility(Visibility.PUBLIC).build());
         when(apiRepository.searchIds(eq(apiCriteriaList), any(), any())).thenReturn(new Page<>(List.of("api-2"), 0, 1, 1));
 
         final Set<String> apisId = apiAuthorizationService.findIdsByUser(
@@ -442,9 +407,7 @@ public class ApiAuthorizationServiceImplTest {
         SoftAssertions.assertSoftly(soft -> {
             var query = searchEngineQueryCaptor.getValue();
             soft.assertThat(query.getQuery()).isEqualTo("tag:a\\-tag");
-            soft
-                .assertThat(query.getExcludedFilters())
-                .containsEntry(FIELD_DEFINITION_VERSION, singletonList(DefinitionVersion.V4.getLabel()));
+            soft.assertThat(query.getExcludedFilters()).isEmpty();
         });
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2027

## Description

`ApiAuthorizationService` is shared by Portal API, MAPI v1 & MAPI v2.
Filtering APIs by definitionVersion should be done only in MAPI V1 components & services, since V4 APIs should be returned by Portal API and MAPI v2.

This also reverts commit 8984f08.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-npszkugpwb.chromatic.com)
<!-- Storybook placeholder end -->
