### PR TITLE
Fix API images management

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/portal/details/api-portal-details.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/details/api-portal-details.component.ts
@@ -265,14 +265,20 @@ export class ApiPortalDetailsComponent implements OnInit, OnDestroy {
         switchMap((api: Api) => {
           if (this.apiImagesForm.controls['picture'].dirty) {
             const picture = getBase64(apiImagesFormValue.picture[0]);
-            return this.apiService.updatePicture(this.apiId, picture).pipe(switchMap(() => of(api)));
+            if (picture) {
+              return this.apiService.updatePicture(this.apiId, picture).pipe(switchMap(() => of(api)));
+            }
+            return this.apiService.deletePicture(this.apiId).pipe(switchMap(() => of(api)));
           }
           return of(api);
         }),
         switchMap((api: Api) => {
           if (this.apiImagesForm.controls['background'].dirty) {
             const background = getBase64(apiImagesFormValue.background[0]);
-            return this.apiService.updateBackground(this.apiId, background).pipe(switchMap(() => of(api)));
+            if (background) {
+              return this.apiService.updateBackground(this.apiId, background).pipe(switchMap(() => of(api)));
+            }
+            return this.apiService.deleteBackground(this.apiId).pipe(switchMap(() => of(api)));
           }
           return of(api);
         }),

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.spec.ts
@@ -198,7 +198,7 @@ describe('ApiV2Service', () => {
   });
 
   describe('picture', () => {
-    it('should call the API', (done) => {
+    it('should update', (done) => {
       const apiId = 'apiId';
 
       apiV2Service.updatePicture(apiId, 'newPicture').subscribe(() => {
@@ -213,10 +213,25 @@ describe('ApiV2Service', () => {
       expect(req.request.body).toEqual('newPicture');
       req.flush(null);
     });
+
+    it('should delete', (done) => {
+      const apiId = 'apiId';
+
+      apiV2Service.deletePicture(apiId).subscribe(() => {
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/picture`,
+        method: 'DELETE',
+      });
+
+      req.flush(null);
+    });
   });
 
   describe('background', () => {
-    it('should call the API', (done) => {
+    it('should update', (done) => {
       const apiId = 'apiId';
 
       apiV2Service.updateBackground(apiId, 'newBackground').subscribe(() => {
@@ -229,6 +244,21 @@ describe('ApiV2Service', () => {
       });
 
       expect(req.request.body).toEqual('newBackground');
+      req.flush(null);
+    });
+
+    it('should delete', (done) => {
+      const apiId = 'apiId';
+
+      apiV2Service.deleteBackground(apiId).subscribe(() => {
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/background`,
+        method: 'DELETE',
+      });
+
       req.flush(null);
     });
   });

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
@@ -82,6 +82,14 @@ export class ApiV2Service {
     return this.http.put<void>(`${this.constants.env.v2BaseURL}/apis/${apiId}/background`, newImage);
   }
 
+  deletePicture(apiId: string): Observable<void> {
+    return this.http.delete<void>(`${this.constants.env.v2BaseURL}/apis/${apiId}/picture`);
+  }
+
+  deleteBackground(apiId: string): Observable<void> {
+    return this.http.delete<void>(`${this.constants.env.v2BaseURL}/apis/${apiId}/background`);
+  }
+
   getSubscribers(apiId: string, name?: string, page = 1, perPage = 10): Observable<ApiSubscribersResponse> {
     return this.http.get<ApiSubscribersResponse>(`${this.constants.env.v2BaseURL}/apis/${apiId}/subscribers`, {
       params: {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -323,6 +323,14 @@ public class ApiResource extends AbstractResource {
         }
     }
 
+    @DELETE
+    @Path("picture")
+    @Permissions({ @Permission(value = RolePermission.API_DEFINITION, acls = RolePermissionAction.UPDATE) })
+    public Response deleteApiPicture(@PathParam("apiId") String apiId) {
+        apiImagesService.updateApiPicture(GraviteeContext.getExecutionContext(), apiId, null);
+        return Response.noContent().build();
+    }
+
     @GET
     @Path("background")
     @Permissions({ @Permission(value = RolePermission.API_DEFINITION, acls = RolePermissionAction.READ) })
@@ -342,6 +350,14 @@ public class ApiResource extends AbstractResource {
             log.warn("Error while parsing background image for api {}", apiId, e);
             throw new BadRequestException("Invalid image format");
         }
+    }
+
+    @DELETE
+    @Path("background")
+    @Permissions({ @Permission(value = RolePermission.API_DEFINITION, acls = RolePermissionAction.UPDATE) })
+    public Response deleteApiBackground(@PathParam("apiId") String apiId) {
+        apiImagesService.updateApiBackground(GraviteeContext.getExecutionContext(), apiId, null);
+        return Response.noContent().build();
     }
 
     @GET

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -314,8 +314,8 @@ public class ApiResource extends AbstractResource {
     @Permissions({ @Permission(value = RolePermission.API_DEFINITION, acls = RolePermissionAction.UPDATE) })
     public Response updateApiPicture(@PathParam("apiId") String apiId, String pictureContent) {
         try {
-            ImageUtils.Image picture = ImageUtils.verifyAndRescale(pictureContent);
-            apiImagesService.updateApiPicture(GraviteeContext.getExecutionContext(), apiId, picture.toBase64());
+            ImageUtils.verify(pictureContent);
+            apiImagesService.updateApiPicture(GraviteeContext.getExecutionContext(), apiId, pictureContent);
             return Response.noContent().build();
         } catch (InvalidImageException e) {
             log.warn("Error while parsing picture for api {}", apiId, e);
@@ -333,10 +333,10 @@ public class ApiResource extends AbstractResource {
     @PUT
     @Path("background")
     @Permissions({ @Permission(value = RolePermission.API_DEFINITION, acls = RolePermissionAction.UPDATE) })
-    public Response updateApiBackground(@PathParam("apiId") String apiId, String pictureContent) {
+    public Response updateApiBackground(@PathParam("apiId") String apiId, String backgroundContent) {
         try {
-            ImageUtils.Image picture = ImageUtils.verifyAndRescale(pictureContent);
-            apiImagesService.updateApiBackground(GraviteeContext.getExecutionContext(), apiId, picture.toBase64());
+            ImageUtils.verifyAndRescale(backgroundContent);
+            apiImagesService.updateApiBackground(GraviteeContext.getExecutionContext(), apiId, backgroundContent);
             return Response.noContent().build();
         } catch (InvalidImageException e) {
             log.warn("Error while parsing background image for api {}", apiId, e);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
@@ -250,6 +250,21 @@ paths:
                     description: API background successfully updated
                 default:
                     $ref: "#/components/responses/Error"
+        delete:
+            tags:
+                - APIs
+            summary: Delete an API's background
+            description: |-
+                Delete the API's background.
+
+                User must have the API_DEFINITION[UPDATE] permission.
+            operationId: deleteApiBackground
+            responses:
+                "204":
+                    description: API background successfully deleted.
+                default:
+                    $ref: "#/components/responses/Error"
+
     /environments/{envId}/apis/{apiId}/deployments:
         parameters:
             - $ref: "#/components/parameters/envIdParam"
@@ -310,6 +325,20 @@ paths:
             responses:
                 "204":
                     description: API picture successfully updated
+                default:
+                    $ref: "#/components/responses/Error"
+        delete:
+            tags:
+                - APIs
+            summary: Delete an API's picture
+            description: |-
+                Delete the API's picture.
+
+                User must have the API_DEFINITION[UPDATE] permission.
+            operationId: deleteApiPicture
+            responses:
+                "204":
+                    description: API picture successfully deleted.
                 default:
                     $ref: "#/components/responses/Error"
     /environments/{envId}/apis/{apiId}/_export/definition:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_ImagesTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_ImagesTest.java
@@ -106,6 +106,14 @@ public class ApiResource_ImagesTest extends ApiResourceTest {
     }
 
     @Test
+    public void should_delete_api_picture() {
+        final Response response = rootTarget("picture").request().delete();
+        assertEquals(HttpStatusCode.NO_CONTENT_204, response.getStatus());
+
+        verify(apiImagesService, times(1)).updateApiPicture(GraviteeContext.getExecutionContext(), API, null);
+    }
+
+    @Test
     public void should_get_invalid_format_picture() {
         final Response response = rootTarget("picture").request().put(Entity.text(""));
         assertEquals(HttpStatusCode.BAD_REQUEST_400, response.getStatus());
@@ -171,6 +179,14 @@ public class ApiResource_ImagesTest extends ApiResourceTest {
         assertEquals(HttpStatusCode.NO_CONTENT_204, response.getStatus());
 
         verify(apiImagesService, times(1)).updateApiBackground(GraviteeContext.getExecutionContext(), API, PICTURE);
+    }
+
+    @Test
+    public void should_delete_api_background() {
+        final Response response = rootTarget("background").request().delete();
+        assertEquals(HttpStatusCode.NO_CONTENT_204, response.getStatus());
+
+        verify(apiImagesService, times(1)).updateApiBackground(GraviteeContext.getExecutionContext(), API, null);
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1970
https://gravitee.atlassian.net/browse/APIM-1971

## Description

- Do not resize the image => resizing implies loosing the animation of an animated gif
- Add a DELETE /picture and DELETE /background to easily remove an API picture or background.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-rlzkgtxmrb.chromatic.com)
<!-- Storybook placeholder end -->
