### PR TITLE
chore: update gravitee-policy-cache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
         <gravitee-policy-apikey.version>3.2.1</gravitee-policy-apikey.version>
         <gravitee-policy-assign-attributes.version>1.5.1</gravitee-policy-assign-attributes.version>
         <gravitee-policy-assign-content.version>1.7.0</gravitee-policy-assign-content.version>
-        <gravitee-policy-cache.version>1.16.0</gravitee-policy-cache.version>
+        <gravitee-policy-cache.version>2.0.0-alpha.1</gravitee-policy-cache.version>
         <gravitee-policy-callout-http.version>2.0.1</gravitee-policy-callout-http.version>
         <gravitee-policy-dynamic-routing.version>1.11.1</gravitee-policy-dynamic-routing.version>
         <gravitee-policy-generate-http-signature.version>1.1.0</gravitee-policy-generate-http-signature.version>


### PR DESCRIPTION
related-to APIM-1625

## Description

import the cache policy compatible with V4 API
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ezfzvfjslm.chromatic.com)
<!-- Storybook placeholder end -->
