### PR TITLE
feat: implement v2 reactivate subscription api key

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiSubscriptionsResource.java
@@ -542,9 +542,37 @@ public class ApiSubscriptionsResource extends AbstractResource {
             return Response.status(Response.Status.NOT_FOUND).entity(apiKeyNotFoundError(apiKeyId)).build();
         }
 
+        checkApplicationDoesntUseSharedApiKey(executionContext, apiKeyEntity.getApplication().getId());
         apiKeyService.revoke(executionContext, apiKeyEntity, true);
 
         return Response.ok(subscriptionMapper.mapToApiKey(apiKeyService.findById(executionContext, apiKeyId))).build();
+    }
+
+    @POST
+    @Path("/{subscriptionId}/api-keys/{apiKeyId}/_reactivate")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.API_SUBSCRIPTION, acls = RolePermissionAction.UPDATE) })
+    public Response reactivateApiSubscriptionApiKey(
+        @PathParam("subscriptionId") String subscriptionId,
+        @PathParam("apiKeyId") String apiKeyId
+    ) {
+        final SubscriptionEntity subscriptionEntity = subscriptionService.findById(subscriptionId);
+
+        if (!subscriptionEntity.getApi().equals(apiId)) {
+            return Response.status(Response.Status.NOT_FOUND).entity(subscriptionNotFoundError(subscriptionId)).build();
+        }
+
+        final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        ApiKeyEntity apiKeyEntity = apiKeyService.findById(executionContext, apiKeyId);
+
+        if (!apiKeyEntity.getSubscriptionIds().contains(subscriptionId)) {
+            return Response.status(Response.Status.NOT_FOUND).entity(apiKeyNotFoundError(apiKeyId)).build();
+        }
+
+        checkApplicationDoesntUseSharedApiKey(executionContext, apiKeyEntity.getApplication().getId());
+        apiKeyEntity = apiKeyService.reactivate(executionContext, apiKeyEntity);
+
+        return Response.ok(subscriptionMapper.mapToApiKey(apiKeyEntity)).build();
     }
 
     private Error subscriptionNotFoundError(String subscriptionId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
@@ -1293,10 +1293,13 @@ paths:
                 required: true
             responses:
                 "200":
-                    $ref: "#/components/responses/SubscriptionApiKey"
+                    description: The subscription api key.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ApiKey"
                 default:
                     $ref: "#/components/responses/Error"
-
 
     /environments/{envId}/apis/{apiId}/subscriptions/{subscriptionId}/api-keys/{apiKeyId}/_revoke:
         parameters:
@@ -1316,7 +1319,36 @@ paths:
             operationId: revokeApiSubscriptionApiKey
             responses:
                 "200":
-                    $ref: "#/components/responses/SubscriptionApiKey"
+                    description: The revoked subscription api key.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ApiKey"
+                default:
+                    $ref: "#/components/responses/Error"
+
+    /environments/{envId}/apis/{apiId}/subscriptions/{subscriptionId}/api-keys/{apiKeyId}/_reactivate:
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+            - $ref: "#/components/parameters/apiIdParam"
+            - $ref: "#/components/parameters/subscriptionIdParam"
+            - $ref: "#/components/parameters/apiKeyIdParam"
+        post:
+            tags:
+                - API Subscriptions
+            summary: Reactivate subscription api key
+            description: |-
+                Reactivate the revoked or expired subscription api key.
+                
+                User must have the API_SUBSCRIPTION[UPDATE] permission.
+            operationId: reactivateApiSubscriptionApiKey
+            responses:
+                "200":
+                    description: The reactivated subscription api key.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ApiKey"
                 default:
                     $ref: "#/components/responses/Error"
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1237

## Description

This PR implements the reactivate subscription api key feature.
Note: it also adds an extra check on the revoke feature to prevent revoking a share api key.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ytivpyzekx.chromatic.com)
<!-- Storybook placeholder end -->
