### PR TITLE
chore(deps): upgrade json-smart to 2.4.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <jsonassert.version>1.5.0</jsonassert.version>
         <json-patch.version>1.13</json-patch.version>
         <json-path.version>2.6.0</json-path.version>
-        <json-smart.version>2.4.9</json-smart.version>
+        <json-smart.version>2.4.11</json-smart.version>
         <jsoup.version>1.14.3</jsoup.version>
         <lucene.version>7.7.3</lucene.version>
         <netty-tcnative-boringssl-static.version>2.0.48.Final</netty-tcnative-boringssl-static.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2049

## Description

This brings a fix https://github.com/netplex/json-smart-v2/pull/133


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qmohebzmap.chromatic.com)
<!-- Storybook placeholder end -->
