### PR TITLE
chore: APIM-2054 - Add RabbitMQ and Solace to list of exposed endpoints

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-2-entrypoints/step-2-entrypoints-0-architecture.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-2-entrypoints/step-2-entrypoints-0-architecture.component.html
@@ -75,6 +75,8 @@
                 Can expose
                 <span class="gio-badge-neutral gio-caption-2">Kafka</span>
                 <span class="gio-badge-neutral gio-caption-2">MQTT</span>
+                <span class="gio-badge-neutral gio-caption-2">RabbitMQ</span>
+                <span class="gio-badge-neutral gio-caption-2">Solace</span>
               </div>
             </gio-selection-list-option-layout-body>
           </gio-selection-list-option-layout>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2054

## Description

Adds RabbitMQ and Solace to the list of endpoints shown in the Can Expose section of the architecture selection screen. RabbitMQ is not in GA yet but will be there when we ship 4.0
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-oigsxeamaq.chromatic.com)
<!-- Storybook placeholder end -->
