### PR TITLE
chore: APIM-2056 - Event-Native API entrypoints to API entrypoints

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-2-entrypoints/step-2-entrypoints-1-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/creation/v4/steps/step-2-entrypoints/step-2-entrypoints-1-list.component.html
@@ -18,7 +18,7 @@
 <mat-card class="api-creation-v4__step">
   <div class="api-creation-v4__step__header">
     <div class="api-creation-v4__step__header__step-number">Step 2</div>
-    <div class="api-creation-v4__step__header__subtitle">Select your Event-Native API entrypoints</div>
+    <div class="api-creation-v4__step__header__subtitle">Select your API entrypoints</div>
     <p class="api-creation-v4__step__header__paragraph-light">Choose how your users will consume your API</p>
   </div>
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2056

## Description

We want step 2 to say "API entrypoints" instead of "Event-Native API Entrypoints"
We'll keep "API entrypoints" since the other screens say that
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-qoiszjmggt.chromatic.com)
<!-- Storybook placeholder end -->
