### PR TITLE
fix(console): use the right param to set plan type

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/portal/apis.portal.route.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/apis.portal.route.ts
@@ -66,7 +66,7 @@ function apisPortalRouterConfig($stateProvider) {
       url: '/plan',
     })
     .state('management.apis.detail.portal.plan.new', {
-      url: '/new?securityType',
+      url: '/new?selectedPlanMenuItem',
       component: 'ngApiPortalPlanEdit',
       data: {
         useAngularMaterial: true,


### PR DESCRIPTION
## Issue

N/A

## Description

Use the right param to set plan type.
Related to https://gravitee.atlassian.net/browse/APIM-2025 and https://github.com/gravitee-io/gravitee-api-management/pull/4306
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jyxdfunswu.chromatic.com)
<!-- Storybook placeholder end -->
