### PR TITLE
test(sdk): introduce persistent mock endpoint connector

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/connector/fakes/MessageStorage.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/connector/fakes/MessageStorage.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.gateway.tests.sdk.connector.fakes;
+
+import io.gravitee.gateway.reactive.api.message.Message;
+import io.reactivex.rxjava3.subjects.ReplaySubject;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class MessageStorage {
+
+    private ReplaySubject<Message> subject;
+
+    public MessageStorage() {
+        subject = ReplaySubject.create();
+    }
+
+    public ReplaySubject<Message> subject() {
+        return subject;
+    }
+
+    public void reset() {
+        subject = ReplaySubject.create();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/connector/fakes/PersistentMockEndpointConnector.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/connector/fakes/PersistentMockEndpointConnector.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.gateway.tests.sdk.connector.fakes;
+
+import io.gravitee.gateway.reactive.api.context.ExecutionContext;
+import io.gravitee.plugin.endpoint.mock.MockEndpointConnector;
+import io.gravitee.plugin.endpoint.mock.configuration.MockEndpointConnectorConfiguration;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class PersistentMockEndpointConnector extends MockEndpointConnector {
+
+    public PersistentMockEndpointConnector(MockEndpointConnectorConfiguration configuration) {
+        super(configuration);
+    }
+
+    @Override
+    public Completable publish(ExecutionContext ctx) {
+        final MessageStorage messageStorage = ctx.getComponent(MessageStorage.class);
+        return Completable
+            .defer(() ->
+                ctx
+                    .request()
+                    .onMessage(message -> {
+                        messageStorage.subject().onNext(message);
+                        return Maybe.just(message);
+                    })
+            )
+            .andThen(super.publish(ctx));
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/connector/fakes/PersistentMockEndpointConnectorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/connector/fakes/PersistentMockEndpointConnectorFactory.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.gateway.tests.sdk.connector.fakes;
+
+import io.gravitee.gateway.reactive.api.ConnectorMode;
+import io.gravitee.gateway.reactive.api.connector.endpoint.async.EndpointAsyncConnectorFactory;
+import io.gravitee.gateway.reactive.api.context.DeploymentContext;
+import io.gravitee.gateway.reactive.api.exception.PluginConfigurationException;
+import io.gravitee.gateway.reactive.api.helper.PluginConfigurationHelper;
+import io.gravitee.gateway.reactive.api.qos.Qos;
+import io.gravitee.plugin.endpoint.mock.MockEndpointConnector;
+import io.gravitee.plugin.endpoint.mock.MockEndpointConnectorFactory;
+import io.gravitee.plugin.endpoint.mock.configuration.MockEndpointConnectorConfiguration;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class PersistentMockEndpointConnectorFactory implements EndpointAsyncConnectorFactory<PersistentMockEndpointConnector> {
+
+    private final PluginConfigurationHelper pluginConfigurationHelper;
+
+    public PersistentMockEndpointConnectorFactory(PluginConfigurationHelper pluginConfigurationHelper) {
+        this.pluginConfigurationHelper = pluginConfigurationHelper;
+    }
+
+    @Override
+    public Set<ConnectorMode> supportedModes() {
+        return Set.of(ConnectorMode.PUBLISH, ConnectorMode.SUBSCRIBE);
+    }
+
+    @Override
+    public Set<Qos> supportedQos() {
+        return Set.of(Qos.NONE, Qos.AUTO, Qos.AT_LEAST_ONCE, Qos.AT_MOST_ONCE);
+    }
+
+    @Override
+    public PersistentMockEndpointConnector createConnector(
+        DeploymentContext deploymentContext,
+        String configuration,
+        String sharedConfiguration
+    ) {
+        try {
+            return new PersistentMockEndpointConnector(
+                pluginConfigurationHelper.readConfiguration(MockEndpointConnectorConfiguration.class, configuration)
+            );
+        } catch (PluginConfigurationException e) {
+            return null;
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/container/GatewayTestContainer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/container/GatewayTestContainer.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.gateway.tests.sdk.container;
 
+import io.gravitee.apim.gateway.tests.sdk.connector.fakes.MessageStorage;
 import io.gravitee.apim.gateway.tests.sdk.reporter.FakeReporter;
 import io.gravitee.apim.gateway.tests.sdk.tracer.NoOpTracer;
 import io.gravitee.gateway.api.service.ApiKeyService;
@@ -121,6 +122,11 @@ public class GatewayTestContainer extends GatewayContainer {
         @Bean
         public SubscriptionService subscriptionService() {
             return Mockito.mock(SubscriptionService.class);
+        }
+
+        @Bean
+        public MessageStorage messageStorage() {
+            return new MessageStorage();
         }
     }
 }


### PR DESCRIPTION
## Description

- create PersistentMockEndpointConnector and PersistentMockEndpointConnectorFactory
- Instantiate a MessageStorage bean for the gateway test context (holds a ReplaySubject)
- PersistentMockEndpointConnector pushes messages to MessageStorage


<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gobfjjsnob.chromatic.com)
<!-- Storybook placeholder end -->
