### PR TITLE
fix(helm): Remove old and unused  from gateway config map

### DIFF
--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 4.0.0
+
+- Remove old and unused `cache.type` from gateway config map
+
 ### 3.20.12
 
 - Add support for managed Service Account for each product

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -22,3 +22,4 @@ annotations:
     - Change the versioning
     - Remove duplicate annotation in ui deployment
     - Add support for managed Service Account for each product
+    - Remove old and unused `cache.type` from gateway config map

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -204,10 +204,6 @@ data:
         {{- end }}
       {{- end }}
 
-    cache:
-      type: ehcache
-      enabled: true
-
     # Sharding tags configuration
     # Allows to define inclusion/exclusion sharding tags to only deploy a part of APIs. To exclude just prefix the tag with '!'.
     tags: {{ .Values.gateway.sharding_tags }}  


### PR DESCRIPTION
## Description

Since the introduction of the Cache plugin in gravitee-node, the cache.type defined in the gateway configmap template prevent the initialization of the standalone cache plugin. 

`{"timestamp":"2023-06-22T09:04:15.996Z","level":"WARN","thread":"graviteeio-node","logger":"io.gravitee.node.cache.plugin.CachePluginHandler","message":"Cache manager plugin 'cache-standalone' is not the type configured and won't be installed.","context":"default"}`

As a consequence, the "simple cache resource" can't be used with the cache policy
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-wswsiqvxlb.chromatic.com)
<!-- Storybook placeholder end -->
