### PR TITLE
Apim 1405 add pause + resume dialog

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.html
@@ -127,7 +127,7 @@
             <mat-icon svgIcon="gio:pause-circle"></mat-icon>
             Pause
           </button>
-          <button mat-stroked-button (click)="pauseSubscription()" *ngIf="subscription.status === 'PAUSED'">
+          <button mat-stroked-button (click)="resumeSubscription()" *ngIf="subscription.status === 'PAUSED'">
             <mat-icon svgIcon="gio:play-circle"></mat-icon>
             Resume
           </button>

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.ts
@@ -190,7 +190,33 @@ export class ApiPortalSubscriptionEditComponent implements OnInit {
   }
 
   resumeSubscription() {
-    // Do nothing for now
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
+        data: {
+          title: `Resume your subscription`,
+          content: 'The application will be able to consume your API.',
+          confirmButton: 'Resume',
+        },
+        role: 'alertdialog',
+        id: 'confirmResumeSubscriptionDialog',
+      })
+      .afterClosed()
+      .pipe(
+        switchMap((confirm) => {
+          if (confirm) {
+            return this.apiSubscriptionService.resume(this.subscription.id, this.apiId);
+          }
+          return EMPTY;
+        }),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe(
+        (_) => {
+          this.snackBarService.success(`Subscription resumed`);
+          this.ngOnInit();
+        },
+        (err) => this.snackBarService.error(err.message),
+      );
   }
 
   changeEndDate() {

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.harness.ts
@@ -104,12 +104,16 @@ export class ApiPortalSubscriptionEditHarness extends ComponentHarness {
     return this.getBtnByText('Transfer').then((btn) => btn.click());
   }
 
-  public async getTransferDialog(): Promise<MatDialogHarness> {
-    return this.getDialog('api-portal-subscription-transfer');
-  }
-
   public async pauseBtnIsVisible(): Promise<boolean> {
     return this.btnIsVisible('Pause');
+  }
+
+  public async openPauseDialog(): Promise<void> {
+    return this.getBtnByText('Pause').then((btn) => btn.click());
+  }
+
+  public async resumeBtnIsVisible(): Promise<boolean> {
+    return this.btnIsVisible('Resume');
   }
 
   public async changeEndDateBtnIsVisible(): Promise<boolean> {

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.harness.ts
@@ -116,6 +116,10 @@ export class ApiPortalSubscriptionEditHarness extends ComponentHarness {
     return this.btnIsVisible('Resume');
   }
 
+  public async openResumeDialog(): Promise<void> {
+    return this.getBtnByText('Resume').then((btn) => btn.click());
+  }
+
   public async changeEndDateBtnIsVisible(): Promise<boolean> {
     return this.btnIsVisible('Change end date');
   }

--- a/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.spec.ts
@@ -116,4 +116,42 @@ describe('ApiSubscriptionV2Service', () => {
       req.flush(subscription);
     });
   });
+
+  describe('pause', () => {
+    const SUBSCRIPTION_ID = 'my-subscription';
+    it('should call API', (done) => {
+      const subscription = fakeSubscription({ id: SUBSCRIPTION_ID });
+      apiSubscriptionV2Service.pause(SUBSCRIPTION_ID, API_ID).subscribe((response) => {
+        expect(response).toEqual(subscription);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/subscriptions/${SUBSCRIPTION_ID}/_pause`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual({});
+
+      req.flush(subscription);
+    });
+  });
+
+  describe('resume', () => {
+    const SUBSCRIPTION_ID = 'my-subscription';
+    it('should call API', (done) => {
+      const subscription = fakeSubscription({ id: SUBSCRIPTION_ID });
+      apiSubscriptionV2Service.resume(SUBSCRIPTION_ID, API_ID).subscribe((response) => {
+        expect(response).toEqual(subscription);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/subscriptions/${SUBSCRIPTION_ID}/_resume`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual({});
+
+      req.flush(subscription);
+    });
+  });
 });

--- a/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.ts
@@ -58,4 +58,12 @@ export class ApiSubscriptionV2Service {
       planId,
     });
   }
+
+  pause(subscriptionId: string, apiId: string): Observable<Subscription> {
+    return this.http.post<Subscription>(`${this.constants.env.v2BaseURL}/apis/${apiId}/subscriptions/${subscriptionId}/_pause`, {});
+  }
+
+  resume(subscriptionId: string, apiId: string): Observable<Subscription> {
+    return this.http.post<Subscription>(`${this.constants.env.v2BaseURL}/apis/${apiId}/subscriptions/${subscriptionId}/_resume`, {});
+  }
 }

--- a/gravitee-apim-console-webui/src/services-ngx/application.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/application.service.spec.ts
@@ -107,4 +107,22 @@ describe('ApplicationService', () => {
       req.flush(mockApplications);
     });
   });
+
+  describe('getById', () => {
+    it('should call the API', (done) => {
+      const mockApplication = fakeApplication({ id: 'my-app-id' });
+
+      applicationService.getById('my-app-id').subscribe((response) => {
+        expect(response).toMatchObject(mockApplication);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        method: 'GET',
+        url: `${CONSTANTS_TESTING.env.baseURL}/applications/my-app-id`,
+      });
+
+      req.flush(mockApplication);
+    });
+  });
 });

--- a/gravitee-apim-console-webui/src/services-ngx/application.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/application.service.ts
@@ -70,4 +70,8 @@ export class ApplicationService {
   restore(applicationId: string): Observable<Application> {
     return this.http.post<Application>(`${this.constants.env.baseURL}/applications/${applicationId}/_restore`, {});
   }
+
+  getById(applicationId: string): Observable<Application> {
+    return this.http.get<Application>(`${this.constants.env.baseURL}/applications/${applicationId}`);
+  }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1405

## Description

NOTE: We are using the old API for /applications/:apiId because it doesn't exist yet for rest-api-v2 

Add pause dialog

![Screen Shot 2023-06-22 at 16 56 45](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/1be26eeb-ed08-4ce9-ab7f-824651f0aad6)

Add resume dialog

![Screen Shot 2023-06-22 at 17 44 03](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/91464186-2fa6-47bb-87c9-81ab2ed51fa2)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zzdgclniie.chromatic.com)
<!-- Storybook placeholder end -->
