### PR TITLE
fix: be consistent on plan security types values

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionResource.java
@@ -28,6 +28,7 @@ import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import io.gravitee.rest.api.model.v4.plan.PlanSecurityType;
 import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
@@ -218,7 +219,7 @@ public class ApplicationSubscriptionResource extends AbstractResource {
         GenericPlanEntity plan = planSearchService.findById(executionContext, subscriptionEntity.getPlan());
         subscription.setPlan(new Subscription.Plan(plan.getId(), plan.getName()));
         if (plan.getPlanSecurity() != null) {
-            subscription.getPlan().setSecurity(plan.getPlanSecurity().getType());
+            subscription.getPlan().setSecurity(PlanSecurityType.valueOfLabel(plan.getPlanSecurity().getType()).name());
         }
 
         GenericApiEntity genericApiEntity = apiSearchService.findGenericById(executionContext, subscriptionEntity.getApi());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscriptionResourceTest.java
@@ -72,17 +72,17 @@ public class ApplicationSubscriptionResourceTest extends AbstractResourceTest {
     }
 
     @Test
-    public void shouldGetApplicationSubscription_onPlanV3() {
+    public void shouldGetApplicationSubscription_onPlanV2() {
         when(subscriptionService.findById(SUBSCRIPTION_ID)).thenReturn(fakeSubscriptionEntity);
         when(userService.findById(eq(GraviteeContext.getExecutionContext()), any(), anyBoolean())).thenReturn(mock(UserEntity.class));
 
-        ApiEntity apiV3 = new ApiEntity();
-        apiV3.setPrimaryOwner(new PrimaryOwnerEntity());
-        when(apiSearchServiceV4.findGenericById(eq(GraviteeContext.getExecutionContext()), eq(API_ID))).thenReturn(apiV3);
+        ApiEntity apiV2 = new ApiEntity();
+        apiV2.setPrimaryOwner(new PrimaryOwnerEntity());
+        when(apiSearchServiceV4.findGenericById(eq(GraviteeContext.getExecutionContext()), eq(API_ID))).thenReturn(apiV2);
 
-        PlanEntity planV3 = new PlanEntity();
-        planV3.setSecurity(PlanSecurityType.OAUTH2);
-        when(planSearchService.findById(eq(GraviteeContext.getExecutionContext()), eq(PLAN_ID))).thenReturn(planV3);
+        PlanEntity planV2 = new PlanEntity();
+        planV2.setSecurity(PlanSecurityType.OAUTH2);
+        when(planSearchService.findById(eq(GraviteeContext.getExecutionContext()), eq(PLAN_ID))).thenReturn(planV2);
 
         Response response = envTarget(SUBSCRIPTION_ID).request().get();
 
@@ -110,7 +110,7 @@ public class ApplicationSubscriptionResourceTest extends AbstractResourceTest {
 
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
         JsonNode responseBody = response.readEntity(JsonNode.class);
-        assertEquals("oauth2", responseBody.get("plan").get("security").asText());
+        assertEquals(PlanSecurityType.OAUTH2.name(), responseBody.get("plan").get("security").asText());
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2047

## Description

When listing v4 plans, security type should be in same case as for v2 plans.
Otherwise the client will have to handle different cases for the same value. For instance oauth2 vs OAUTH2, or api-key vs API_KEY.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-zgnjbjixxm.chromatic.com)
<!-- Storybook placeholder end -->
