### PR TITLE
Allow an API Publisher to create subscription

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/subscription/createSubscription.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/subscription/createSubscription.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { SubscriptionConsumerConfiguration } from './subscriptionConsumerConfiguration';
+
+export interface CreateSubscription {
+  /**
+   * The id of the application subscribing.
+   */
+  applicationId: string;
+  /**
+   * The id plan the application is subscribing to.
+   */
+  planId: string;
+  /**
+   * Optional custom api key that can be given when the subscription is related to an api-key plan and custom api key support is enabled.
+   */
+  customApiKey?: string;
+  consumerConfiguration?: SubscriptionConsumerConfiguration;
+  /**
+   * A list of metadata associated to this subscription.
+   */
+  metadata?: { [key: string]: string };
+}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/subscription/index.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/subscription/index.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export * from './createSubscription';
 export * from './subscription';
 export * from './subscription.fixture';
 export * from './subscriptionConsumerConfiguration';

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/api-portal-subscriptions.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/api-portal-subscriptions.module.ts
@@ -16,53 +16,59 @@
 
 import { NgModule } from '@angular/core';
 import { CommonModule, DatePipe } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatOptionModule } from '@angular/material/core';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { MatButtonModule } from '@angular/material/button';
-import { DragDropModule } from '@angular/cdk/drag-drop';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { MatCardModule } from '@angular/material/card';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatOptionModule } from '@angular/material/core';
-import { MatSelectModule } from '@angular/material/select';
-import { MatInputModule } from '@angular/material/input';
 import { GioIconsModule, GioLoaderModule } from '@gravitee/ui-particles-angular';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
-import { MatDialogModule } from '@angular/material/dialog';
-import { MatRadioModule } from '@angular/material/radio';
 
-import { ApiPortalSubscriptionListComponent } from './list/api-portal-subscription-list.component';
-import { ApiPortalSubscriptionEditComponent } from './edit/api-portal-subscription-edit.component';
+import { ApiPortalSubscriptionCreationDialogComponent } from './components/creation-dialog/api-portal-subscription-creation-dialog.component';
 import { ApiPortalSubscriptionTransferDialogComponent } from './components/transfer-dialog/api-portal-subscription-transfer-dialog.component';
+import { ApiPortalSubscriptionEditComponent } from './edit/api-portal-subscription-edit.component';
+import { ApiPortalSubscriptionListComponent } from './list/api-portal-subscription-list.component';
 
 import { GioTableWrapperModule } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
 import { GioPermissionModule } from '../../../../shared/components/gio-permission/gio-permission.module';
 
 @NgModule({
-  declarations: [ApiPortalSubscriptionListComponent, ApiPortalSubscriptionEditComponent, ApiPortalSubscriptionTransferDialogComponent],
-  exports: [ApiPortalSubscriptionListComponent, ApiPortalSubscriptionEditComponent],
+  declarations: [
+    ApiPortalSubscriptionEditComponent,
+    ApiPortalSubscriptionListComponent,
+    ApiPortalSubscriptionCreationDialogComponent,
+    ApiPortalSubscriptionTransferDialogComponent,
+  ],
+  exports: [ApiPortalSubscriptionEditComponent, ApiPortalSubscriptionListComponent],
   imports: [
     CommonModule,
-    DragDropModule,
+    FormsModule,
     ReactiveFormsModule,
 
-    CommonModule,
+    MatAutocompleteModule,
     MatButtonModule,
-    MatTableModule,
-    MatTooltipModule,
-    GioTableWrapperModule,
-    GioPermissionModule,
     MatCardModule,
+    MatDialogModule,
     MatFormFieldModule,
+    MatInputModule,
     MatOptionModule,
     MatSelectModule,
-    MatInputModule,
     MatSnackBarModule,
+    MatRadioModule,
+    MatTableModule,
+    MatTooltipModule,
+
     GioIconsModule,
     GioLoaderModule,
-    MatDialogModule,
-    MatRadioModule,
-    FormsModule,
+    GioPermissionModule,
+    GioTableWrapperModule,
   ],
   providers: [DatePipe],
 })

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.component.html
@@ -1,0 +1,82 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<form [formGroup]="form" *ngIf="form">
+  <h2 mat-dialog-title class="title">Create a subscription</h2>
+
+  <mat-dialog-content class="subscription-creation__content">
+    <ng-container *ngIf="plans?.length > 0; else noPlansForCreation">
+      <mat-form-field class="subscription-creation__content__applications" #searchField>
+        <mat-icon matPrefix>search</mat-icon>
+        <mat-label>Search an application by name</mat-label>
+        <!--Using focus workaround to avoid label overlapping border https://github.com/angular/components/issues/15027#issuecomment-1335147036-->
+        <input
+          matInput
+          type="search"
+          [matAutocomplete]="auto"
+          formControlName="selectedApplication"
+          (focus)="searchField.updateOutlineGap()"
+        />
+
+        <mat-autocomplete #auto="matAutocomplete" [displayWith]="displayApplication">
+          <mat-option *ngFor="let application of applications$ | async" [value]="application">
+            {{ application.name }}
+          </mat-option>
+          <mat-option *ngIf="(applications$ | async)?.length === 0" disabled>No application matching</mat-option>
+        </mat-autocomplete>
+        <mat-error *ngIf="form.get('selectedApplication').hasError('selectionRequired')"
+          >Please select an application from the list</mat-error
+        >
+      </mat-form-field>
+
+      <label id="radio-group-label">Select a plan to subscribe</label>
+      <mat-radio-group
+        aria-labelledby="radio-group-label"
+        formControlName="selectedPlan"
+        arial-label="Select an plan"
+        class="subscription-creation__content__plans"
+      >
+        <mat-radio-button *ngFor="let plan of plans" [value]="plan" [disabled]="!!plan.generalConditions || plan.mode === 'PUSH'">
+          {{ plan.name }}
+        </mat-radio-button>
+      </mat-radio-group>
+
+      <mat-form-field class="subscription-creation__content__custom-apikey" *ngIf="shouldDisplayCustomApiKey()">
+        <mat-label>Custom API-Key</mat-label>
+        <input matInput type="text" formControlName="customApiKey" />
+        <mat-hint>You can provide a custom API key if you already have one. Leave it blank to get a generated apikey</mat-hint>
+      </mat-form-field>
+    </ng-container>
+    <ng-template #noPlansForCreation>
+      <div>No plans available to subscribe</div>
+    </ng-template>
+  </mat-dialog-content>
+
+  <mat-dialog-actions class="actions">
+    <button class="actions__cancelBtn" mat-flat-button [mat-dialog-close]="false">Cancel</button>
+    <button
+      class="actions__saveBtn"
+      color="primary"
+      mat-stroked-button
+      role="dialog"
+      (click)="onSave()"
+      [disabled]="this.form.invalid || this.form.pristine"
+    >
+      Create
+    </button>
+  </mat-dialog-actions>
+</form>

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.component.scss
@@ -1,0 +1,16 @@
+.subscription-creation {
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    width: 600px;
+
+    &__plans {
+      display: flex;
+      flex-direction: column;
+      margin-bottom: 12px;
+      align-items: flex-start;
+      gap: 8px;
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.component.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Observable, of, Subject } from 'rxjs';
+import { FormControl, FormGroup, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
+import { debounceTime, distinctUntilChanged, map, share, switchMap, takeUntil } from 'rxjs/operators';
+
+import { CreateSubscription, Plan } from '../../../../../../entities/management-api-v2';
+import { UIRouterStateParams } from '../../../../../../ajs-upgraded-providers';
+import { ApplicationService } from '../../../../../../services-ngx/application.service';
+import { Application } from '../../../../../../entities/application/application';
+import { PagedResult } from '../../../../../../entities/pagedResult';
+import { Constants } from '../../../../../../entities/Constants';
+
+export type ApiPortalSubscriptionCreationDialogData = {
+  plans: Plan[];
+};
+
+export type ApiPortalSubscriptionCreationDialogResult = {
+  subscriptionToCreate: CreateSubscription;
+};
+
+@Component({
+  selector: 'api-portal-subscription-creation-dialog',
+  template: require('./api-portal-subscription-creation-dialog.component.html'),
+  styles: [require('./api-portal-subscription-creation-dialog.component.scss')],
+})
+export class ApiPortalSubscriptionCreationDialogComponent implements OnInit, OnDestroy {
+  public plans: Plan[];
+  public applications$: Observable<Application[]> = new Observable<Application[]>();
+  public showGeneralConditionsMsg: boolean;
+  public canUseCustomApikey: boolean;
+  public form: FormGroup = new FormGroup({
+    selectedPlan: new FormControl(undefined, [Validators.required]),
+    selectedApplication: new FormControl(undefined, [applicationSelectionRequiredValidator]),
+  });
+
+  private unsubscribe$: Subject<boolean> = new Subject<boolean>();
+
+  constructor(
+    private readonly dialogRef: MatDialogRef<ApiPortalSubscriptionCreationDialogComponent, ApiPortalSubscriptionCreationDialogResult>,
+    @Inject(MAT_DIALOG_DATA) dialogData: ApiPortalSubscriptionCreationDialogData,
+    @Inject(UIRouterStateParams) private readonly ajsStateParams,
+    @Inject('Constants') private readonly constants: Constants,
+    private readonly applicationService: ApplicationService,
+  ) {
+    this.plans = dialogData.plans.filter((plan) => plan.security?.type !== 'KEY_LESS');
+    this.canUseCustomApikey = this.constants.env?.settings?.plan?.security?.customApiKey?.enabled;
+    if (this.canUseCustomApikey) {
+      this.form.addControl('customApiKey', new FormControl('', []));
+    }
+  }
+
+  ngOnInit(): void {
+    this.showGeneralConditionsMsg = this.plans.some((plan) => plan.generalConditions);
+
+    this.applications$ = this.form.get('selectedApplication').valueChanges.pipe(
+      distinctUntilChanged(),
+      debounceTime(100),
+      switchMap((term) =>
+        term.length > 0 ? this.applicationService.list('ACTIVE', term, 'name', 1, 20) : of(new PagedResult<Application>()),
+      ),
+      map((applicationsPage) => applicationsPage.data),
+      share(),
+      takeUntil(this.unsubscribe$),
+    );
+  }
+
+  onSave() {
+    this.dialogRef.close({
+      subscriptionToCreate: {
+        planId: this.form.getRawValue().selectedPlan.id,
+        applicationId: this.form.getRawValue().selectedApplication.id,
+        customApiKey:
+          this.shouldDisplayCustomApiKey() && this.form.getRawValue().customApiKey ? this.form.getRawValue().customApiKey : undefined,
+      },
+    });
+  }
+
+  ngOnDestroy() {
+    this.unsubscribe$.next(true);
+    this.unsubscribe$.unsubscribe();
+  }
+
+  displayApplication(application: Application): string {
+    return application?.name;
+  }
+
+  shouldDisplayCustomApiKey(): boolean {
+    return this.canUseCustomApikey && this.form.get('selectedPlan').value?.security?.type === 'API_KEY';
+  }
+}
+
+const applicationSelectionRequiredValidator: ValidatorFn = (control): ValidationErrors | null => {
+  const value = control?.value;
+  if (value && typeof value !== 'string' && 'id' in value && 'name' in value) {
+    return null;
+  }
+  return { selectionRequired: true };
+};

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/transfer-dialog/api-portal-subscription-transfer-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/transfer-dialog/api-portal-subscription-transfer-dialog.component.ts
@@ -28,6 +28,11 @@ export interface SubscriptionTransferData {
   securityType: PlanSecurityType;
   mode: PlanMode;
 }
+
+export interface SubscriptionTransferResult {
+  selectedPlanId: string;
+}
+
 interface PlanVM {
   id: string;
   name: string;
@@ -46,7 +51,7 @@ export class ApiPortalSubscriptionTransferDialogComponent implements OnInit {
   private data: SubscriptionTransferData;
 
   constructor(
-    private readonly dialogRef: MatDialogRef<string>,
+    private readonly dialogRef: MatDialogRef<ApiPortalSubscriptionTransferDialogComponent, SubscriptionTransferResult>,
     @Inject(MAT_DIALOG_DATA) dialogData: SubscriptionTransferData,
     private readonly apiPlanService: ApiPlanV2Service,
   ) {
@@ -70,6 +75,8 @@ export class ApiPortalSubscriptionTransferDialogComponent implements OnInit {
   }
 
   onClose() {
-    this.dialogRef.close(this.form.getRawValue().selectedPlanId);
+    this.dialogRef.close({
+      selectedPlanId: this.form.getRawValue().selectedPlanId,
+    });
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.ts
@@ -27,6 +27,7 @@ import { UIRouterState, UIRouterStateParams } from '../../../../../ajs-upgraded-
 import {
   ApiPortalSubscriptionTransferDialogComponent,
   SubscriptionTransferData,
+  SubscriptionTransferResult,
 } from '../components/transfer-dialog/api-portal-subscription-transfer-dialog.component';
 import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
 import { ApplicationService } from '../../../../../services-ngx/application.service';
@@ -130,20 +131,25 @@ export class ApiPortalSubscriptionEditComponent implements OnInit {
 
   transferSubscription() {
     this.matDialog
-      .open<ApiPortalSubscriptionTransferDialogComponent, SubscriptionTransferData, string>(ApiPortalSubscriptionTransferDialogComponent, {
-        width: '500px',
-        data: {
-          apiId: this.apiId,
-          securityType: this.subscription.plan.securityType,
-          currentPlanId: this.subscription.plan.id,
-          mode: this.subscription.plan.mode,
+      .open<ApiPortalSubscriptionTransferDialogComponent, SubscriptionTransferData, SubscriptionTransferResult>(
+        ApiPortalSubscriptionTransferDialogComponent,
+        {
+          width: '500px',
+          data: {
+            apiId: this.apiId,
+            securityType: this.subscription.plan.securityType,
+            currentPlanId: this.subscription.plan.id,
+            mode: this.subscription.plan.mode,
+          },
+          role: 'alertdialog',
+          id: 'transferSubscriptionDialog',
         },
-        role: 'alertdialog',
-        id: 'transferSubscriptionDialog',
-      })
+      )
       .afterClosed()
       .pipe(
-        switchMap((planId) => (planId ? this.apiSubscriptionService.transfer(this.apiId, this.subscription.id, planId) : EMPTY)),
+        switchMap((result) =>
+          result ? this.apiSubscriptionService.transfer(this.apiId, this.subscription.id, result.selectedPlanId) : EMPTY,
+        ),
         takeUntil(this.unsubscribe$),
       )
       .subscribe(

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.component.html
@@ -29,9 +29,8 @@
       mat-raised-button
       type="button"
       color="primary"
-      disabled="true"
       aria-label="Create a subscription"
-      (click)="navigateToNewSubscription()"
+      (click)="createSubscription()"
     >
       <mat-icon svgIcon="gio:plus"></mat-icon>Create a subscription
     </button>
@@ -43,7 +42,7 @@
     <mat-form-field class="subscriptions__filters__field">
       <mat-label>Plan</mat-label>
       <mat-select formControlName="planIds" [multiple]="true">
-        <mat-option *ngFor="let plan of plans$ | async" [value]="plan.id">{{ plan.name }}</mat-option>
+        <mat-option *ngFor="let plan of plans" [value]="plan.id">{{ plan.name }}</mat-option>
       </mat-select>
     </mat-form-field>
 

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.harness.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatSelectHarness } from '@angular/material/select/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+
+export class ApiPortalSubscriptionListHarness extends ComponentHarness {
+  static hostSelector = 'api-portal-subscription-list';
+
+  public getPlanSelectInput = this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="planIds"]' }));
+  public getApplicationSelectInput = this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="applicationIds"]' }));
+  public getStatusSelectInput = this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="statuses"]' }));
+  public getApiKeyInput = this.locatorFor(MatInputHarness.with({ selector: '[formControlName="apikey"]' }));
+  public getCreateSubscriptionButton = this.locatorFor(MatButtonHarness.with({ selector: '[aria-label="Create a subscription"]' }));
+  public getResetFilterButton = this.locatorFor(MatButtonHarness.with({ selector: '[aria-label="Reset filters"]' }));
+
+  public async openCreationDialog(): Promise<void> {
+    return this.getCreateSubscriptionButton().then((btn) => btn.click());
+  }
+}

--- a/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.spec.ts
@@ -19,12 +19,14 @@ import { TestBed } from '@angular/core/testing';
 import { ApiSubscriptionV2Service } from './api-subscription-v2.service';
 
 import { CONSTANTS_TESTING, GioHttpTestingModule } from '../shared/testing';
-import { ApiSubscriptionsResponse, fakeSubscription } from '../entities/management-api-v2';
+import { ApiSubscriptionsResponse, CreateSubscription, fakeSubscription } from '../entities/management-api-v2';
 
 describe('ApiSubscriptionV2Service', () => {
   let httpTestingController: HttpTestingController;
   let apiSubscriptionV2Service: ApiSubscriptionV2Service;
   const API_ID = 'api-id';
+  const PLAN_ID = 'plan-id';
+  const APPLICATION_ID = 'application-id';
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -152,6 +154,31 @@ describe('ApiSubscriptionV2Service', () => {
       expect(req.request.body).toEqual({});
 
       req.flush(subscription);
+    });
+  });
+
+  describe('creation', () => {
+    it('should call the API', (done) => {
+      const createSubscription: CreateSubscription = {
+        applicationId: APPLICATION_ID,
+        planId: PLAN_ID,
+        customApiKey: 'my-custom-api-key',
+        metadata: {
+          key: 'value',
+        },
+      };
+
+      apiSubscriptionV2Service.create(API_ID, createSubscription).subscribe((subscription) => {
+        expect(subscription).toEqual(fakeSubscription());
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/subscriptions`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual(createSubscription);
+      req.flush(fakeSubscription());
     });
   });
 });

--- a/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.ts
@@ -18,7 +18,7 @@ import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { Constants } from '../entities/Constants';
-import { ApiSubscriptionsResponse, Subscription } from '../entities/management-api-v2';
+import { ApiSubscriptionsResponse, CreateSubscription, Subscription } from '../entities/management-api-v2';
 
 @Injectable({
   providedIn: 'root',
@@ -65,5 +65,9 @@ export class ApiSubscriptionV2Service {
 
   resume(subscriptionId: string, apiId: string): Observable<Subscription> {
     return this.http.post<Subscription>(`${this.constants.env.v2BaseURL}/apis/${apiId}/subscriptions/${subscriptionId}/_resume`, {});
+  }
+
+  create(apiId: string, createSubscription: CreateSubscription): Observable<Subscription> {
+    return this.http.post<Subscription>(`${this.constants.env.v2BaseURL}/apis/${apiId}/subscriptions`, createSubscription);
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2023

## Description

This PR adds a dialog accessible from the subscriptions list screen that allow to create a subscription for Standard plans.

Another PR is needed to handle Push plans.

+

Little refactoring in the edit component.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-topnovngad.chromatic.com)
<!-- Storybook placeholder end -->
