### PR TITLE
add or edit endpoints to group in an API V4

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/endpointV4.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/endpointV4.ts
@@ -34,6 +34,7 @@ export interface EndpointV4 {
    */
   inheritConfiguration?: boolean;
   configuration?: any;
+  sharedConfigurationOverride?: any;
   services?: EndpointServices;
   secondary?: boolean;
 }

--- a/gravitee-apim-console-webui/src/management/api/apis.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis.module.ts
@@ -34,9 +34,9 @@ import { ApisPortalModule } from './portal/apis-portal.module';
 import { ApiPortalSubscriptionEditComponent } from './portal/ng-subscriptions/edit/api-portal-subscription-edit.component';
 import { ApiEndpointsModule } from './endpoints-v4/api-endpoints.module';
 import { ApiBackendServicesComponent } from './endpoints-v4/backend-services/api-backend-services.component';
-import { ApiProxyGroupEndpointEditComponent } from './proxy/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component';
 import { ApiEntrypointsV4GeneralComponent } from './entrypoints-v4/api-entrypoints-v4-general.component';
 import { ApiEntrypointsV4Module } from './entrypoints-v4/api-entrypoints-v4.module';
+import { ApiEndpointComponent } from './endpoints-v4/backend-services/endpoint/api-endpoint.component';
 import { ApiEntrypointsV4EditComponent } from './entrypoints-v4/edit/api-entrypoints-v4-edit.component';
 
 import { GioPermissionService } from '../../shared/components/gio-permission/gio-permission.service';
@@ -253,9 +253,9 @@ const states: Ng2StateDeclaration[] = [
     },
   },
   {
-    name: 'management.apis.ng.endpoint',
-    url: '/groups/:groupName/endpoints/:endpointName',
-    component: ApiProxyGroupEndpointEditComponent,
+    name: 'management.apis.ng.endpoint-new',
+    url: '/groups/:groupName/endpoint/new',
+    component: ApiEndpointComponent,
     data: {
       useAngularMaterial: true,
       // TODO: Implement permissions

--- a/gravitee-apim-console-webui/src/management/api/apis.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis.module.ts
@@ -267,6 +267,21 @@ const states: Ng2StateDeclaration[] = [
       },
     },
   },
+  {
+    name: 'management.apis.ng.endpoint-edit',
+    url: '/groups/:groupIndex/endpoint/:endpointIndex/edit',
+    component: ApiEndpointComponent,
+    data: {
+      useAngularMaterial: true,
+      // TODO: Implement permissions
+      // perms: {
+      //   only: ['api-plan-r'],
+      // },
+      docs: {
+        page: 'management-api-proxy-endpoints',
+      },
+    },
+  },
 ];
 
 @NgModule({

--- a/gravitee-apim-console-webui/src/management/api/apis.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/apis.module.ts
@@ -254,7 +254,7 @@ const states: Ng2StateDeclaration[] = [
   },
   {
     name: 'management.apis.ng.endpoint-new',
-    url: '/groups/:groupName/endpoint/new',
+    url: '/groups/:groupIndex/endpoint/new',
     component: ApiEndpointComponent,
     data: {
       useAngularMaterial: true,

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.html
@@ -15,4 +15,34 @@
     limitations under the License.
 
 -->
-👍🏼
+<mat-card class="endpoint-card">
+  <div>
+    <div class="mat-h4">Configure your API endpoints access</div>
+    <p class="body-1">Choose the type of event-brokers/backend that will be exposed through the API</p>
+  </div>
+
+  <form *ngIf="formGroup; else loadingTpl" [formGroup]="formGroup">
+    <div>
+      <mat-form-field appearance="outline" class="endpoint-card__form__name">
+        <input id="name" type="text" matInput formControlName="name" required="true" />
+        <mat-label>Endpoint name</mat-label>
+        <mat-error *ngIf="formGroup.controls.name.errors?.required">Endpoint name is required</mat-error>
+      </mat-form-field>
+      <div class="endpoint-card__form__config">
+        <gio-form-json-schema formControlName="configuration" [jsonSchema]="endpointSchema.config"></gio-form-json-schema>
+      </div>
+      <div class="endpoint-card__form__shared-config">
+        <gio-form-json-schema formControlName="sharedConfiguration" [jsonSchema]="endpointSchema.sharedConfig"></gio-form-json-schema>
+      </div>
+    </div>
+
+    <div class="endpoint-card__actions">
+      <button mat-stroked-button type="button">Previous</button>
+      <button mat-flat-button aria-label="Validate my endpoints" color="primary" type="submit" [disabled]="formGroup.invalid">
+        Validate my endpoints
+      </button>
+    </div>
+  </form>
+</mat-card>
+
+<ng-template #loadingTpl><mat-progress-bar mode="indeterminate"></mat-progress-bar></ng-template>

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.html
@@ -16,12 +16,20 @@
 
 -->
 <mat-card class="endpoint-card">
-  <div>
+  <div class="endpoint-card__header">
+    <div class="endpoint-card__header__group-name">
+      <span class="mat-h2">{{ endpointGroup?.name }}</span>
+      <span class="gio-badge-primary">
+        <mat-icon *ngIf="connectorPlugin" [svgIcon]="connectorPlugin?.icon"></mat-icon>
+        {{ connectorPlugin?.name }}
+      </span>
+    </div>
+
     <div class="mat-h4">Configure your API endpoints access</div>
     <p class="body-1">Choose the type of event-brokers/backend that will be exposed through the API</p>
   </div>
 
-  <form *ngIf="formGroup; else loadingTpl" [formGroup]="formGroup">
+  <form *ngIf="formGroup && endpointSchema; else loadingTpl" [formGroup]="formGroup">
     <div>
       <mat-form-field appearance="outline" class="endpoint-card__form__name">
         <input id="name" type="text" matInput formControlName="name" required="true" />
@@ -29,10 +37,19 @@
         <mat-error *ngIf="formGroup.controls.name.errors?.required">Endpoint name is required</mat-error>
       </mat-form-field>
       <div class="endpoint-card__form__config">
-        <gio-form-json-schema formControlName="configuration" [jsonSchema]="endpointSchema.config"></gio-form-json-schema>
+        <gio-form-json-schema formControlName="configuration" [jsonSchema]="endpointSchema?.config"></gio-form-json-schema>
       </div>
+      <gio-form-slide-toggle class="endpoint-card__form__toggle" *ngIf="endpointSchema.sharedConfig">
+        <gio-form-label>Inherit configuration from the endpoint group</gio-form-label>
+        <mat-slide-toggle
+          gioFormSlideToggle
+          formControlName="inheritConfiguration"
+          aria-label="Inherit configuration from the endpoint group"
+          (change)="onInheritConfigurationChange()"
+        ></mat-slide-toggle>
+      </gio-form-slide-toggle>
       <div class="endpoint-card__form__shared-config">
-        <gio-form-json-schema formControlName="sharedConfiguration" [jsonSchema]="endpointSchema.sharedConfig"></gio-form-json-schema>
+        <gio-form-json-schema formControlName="sharedConfiguration" [jsonSchema]="endpointSchema?.sharedConfig"></gio-form-json-schema>
       </div>
     </div>
 
@@ -43,7 +60,7 @@
         aria-label="Validate my endpoints"
         color="primary"
         type="submit"
-        [disabled]="formGroup.invalid"
+        [disabled]="formGroup.invalid || !formGroup.dirty"
         (click)="onSave()"
       >
         Validate my endpoints

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.html
@@ -1,0 +1,18 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+👍🏼

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.html
@@ -38,7 +38,14 @@
 
     <div class="endpoint-card__actions">
       <a mat-stroked-button type="button" (click)="onPrevious()">Previous</a>
-      <button mat-flat-button aria-label="Validate my endpoints" color="primary" type="submit" [disabled]="formGroup.invalid">
+      <button
+        mat-flat-button
+        aria-label="Validate my endpoints"
+        color="primary"
+        type="submit"
+        [disabled]="formGroup.invalid"
+        (click)="onSave()"
+      >
         Validate my endpoints
       </button>
     </div>

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.html
@@ -37,7 +37,7 @@
     </div>
 
     <div class="endpoint-card__actions">
-      <button mat-stroked-button type="button">Previous</button>
+      <a mat-stroked-button type="button" (click)="onPrevious()">Previous</a>
       <button mat-flat-button aria-label="Validate my endpoints" color="primary" type="submit" [disabled]="formGroup.invalid">
         Validate my endpoints
       </button>

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.scss
@@ -1,0 +1,27 @@
+@use 'sass:map';
+@use '../../../../../scss/gio-layout' as gio-layout;
+
+:host {
+  @include gio-layout.gio-responsive-content-container;
+}
+
+.endpoint-card {
+  margin-bottom: 24px;
+
+  &__form {
+    &__name {
+      width: 100%;
+    }
+
+    &__config,
+    &__shared-config {
+      margin-bottom: 16px;
+    }
+  }
+
+  &__actions {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.scss
@@ -8,9 +8,32 @@
 .endpoint-card {
   margin-bottom: 24px;
 
+  &__header {
+    margin-bottom: 16px;
+
+    &__group-name {
+      display: flex;
+      flex-direction: row;
+      margin-bottom: 16px;
+
+      .gio-badge-primary {
+        margin: auto 8px;
+      }
+
+      .mat-h2 {
+        margin: auto 0;
+      }
+
+      mat-icon {
+        margin-right: 4px;
+      }
+    }
+  }
+
   &__form {
     &__name {
       width: 100%;
+      padding-bottom: 0;
     }
 
     &__config,

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.spec.ts
@@ -21,13 +21,14 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatInputHarness } from '@angular/material/input/testing';
 
 import { ApiEndpointComponent } from './api-endpoint.component';
 import { ApiEndpointModule } from './api-endpoint.module';
 import { ApiEndpointHarness } from './api-endpoint.harness';
 
 import { CONSTANTS_TESTING, GioHttpTestingModule } from '../../../../../shared/testing';
-import { ApiV4, fakeApiV4 } from '../../../../../entities/management-api-v2';
+import { ApiV4, fakeApiV4, fakeConnectorPlugin } from '../../../../../entities/management-api-v2';
 import { UIRouterState, UIRouterStateParams } from '../../../../../ajs-upgraded-providers';
 
 @Component({
@@ -52,13 +53,13 @@ describe('ApiEndpointComponent', () => {
   let loader: HarnessLoader;
   let componentHarness: ApiEndpointHarness;
 
-  const initComponent = async (api: ApiV4) => {
+  const initComponent = async (api: ApiV4, routerParams: unknown = { apiId: API_ID, groupIndex: 0 }) => {
     TestBed.configureTestingModule({
       declarations: [TestComponent],
       imports: [NoopAnimationsModule, GioHttpTestingModule, ApiEndpointModule, MatIconTestingModule],
       providers: [
         { provide: UIRouterState, useValue: fakeAjsState },
-        { provide: UIRouterStateParams, useValue: { apiId: API_ID, groupIndex: 0 } },
+        { provide: UIRouterStateParams, useValue: routerParams },
       ],
     });
 
@@ -70,6 +71,11 @@ describe('ApiEndpointComponent', () => {
     fixture.detectChanges();
 
     componentHarness = await loader.getHarness(ApiEndpointHarness);
+
+    expectApiGetRequest(api);
+    expectEndpointSchemaGetRequest(api.endpointGroups[0].type);
+    expectEndpointsSharedConfigurationSchemaGetRequest(api.endpointGroups[0].type);
+    expectEndpointPluginGetRequest(api.endpointGroups[0].type);
   };
 
   afterEach(() => {
@@ -80,18 +86,10 @@ describe('ApiEndpointComponent', () => {
   describe('add endpoints in a group', () => {
     it('should load kafka endpoint form dynamically', async () => {
       await initComponent(apiV4);
-
-      expectApiGetRequest(apiV4);
-      expectEndpointSchemaGetRequest(apiV4.endpointGroups[0].type);
-      expectEndpointsSharedConfigurationSchemaGetRequest(apiV4.endpointGroups[0].type);
     });
 
     it('should edit and save the endpoint', async () => {
       await initComponent(apiV4);
-
-      expectApiGetRequest(apiV4);
-      expectEndpointSchemaGetRequest(apiV4.endpointGroups[0].type);
-      expectEndpointsSharedConfigurationSchemaGetRequest(apiV4.endpointGroups[0].type);
 
       expect(await componentHarness.isSaveButtonDisabled()).toBeTruthy();
 
@@ -134,15 +132,95 @@ describe('ApiEndpointComponent', () => {
       expectApiPutRequest(updatedApi);
       expect(fakeAjsState.go).toHaveBeenCalledWith('management.apis.ng.endpoints');
     });
+
+    it('should edit and save an existing endpoint', async () => {
+      await initComponent(apiV4, { apiId: API_ID, groupIndex: 0, endpointIndex: 0 });
+
+      fixture.detectChanges();
+      expect(await componentHarness.getEndpointName()).toStrictEqual('default');
+
+      await componentHarness.fillInputName('endpoint-name updated');
+      fixture.detectChanges();
+
+      expect(await componentHarness.getEndpointName()).toStrictEqual('endpoint-name updated');
+
+      await componentHarness.clickSaveButton();
+
+      expectApiGetRequest(apiV4);
+
+      const updatedApi: ApiV4 = {
+        ...apiV4,
+        endpointGroups: [
+          {
+            name: 'default-group',
+            type: 'kafka',
+            loadBalancer: {
+              type: 'ROUND_ROBIN',
+            },
+            endpoints: [
+              {
+                name: 'default',
+                type: 'kafka',
+                weight: 1,
+                inheritConfiguration: false,
+                configuration: {
+                  bootstrapServers: 'localhost:9092',
+                },
+              },
+              {
+                name: 'endpoint-name updated',
+                type: 'kafka',
+              },
+            ],
+          },
+        ],
+      };
+      expectApiPutRequest(updatedApi);
+      expect(fakeAjsState.go).toHaveBeenCalledWith('management.apis.ng.endpoints');
+    });
+
+    it('should inherit configuration from parent', async () => {
+      const anApi = fakeApiV4({
+        id: API_ID,
+        endpointGroups: [
+          {
+            name: 'a group',
+            type: 'kafka',
+            loadBalancer: {
+              type: 'ROUND_ROBIN',
+            },
+            sharedConfiguration: {
+              test: 'test',
+            },
+            endpoints: [
+              {
+                name: 'a kafka endpoint',
+                type: 'kafka',
+                weight: 1,
+                inheritConfiguration: true,
+              },
+            ],
+          },
+        ],
+      });
+
+      await initComponent(anApi, { apiId: API_ID, groupIndex: 0, endpointIndex: 0 });
+
+      expect(await componentHarness.isConfigurationButtonToggled()).toBeTruthy();
+      fixture.detectChanges();
+
+      const inputHarness = await loader.getHarness(MatInputHarness.with({ selector: '[id*="test"]' }));
+      expect(await inputHarness.isDisabled()).toBeTruthy();
+      expect(await inputHarness.getValue()).toStrictEqual('test');
+
+      await componentHarness.toggleConfigurationButton();
+      fixture.detectChanges();
+    });
   });
 
   describe('onPreviousClick', () => {
     it('should go back to endpoints groups list page', async () => {
       await initComponent(apiV4);
-
-      expectApiGetRequest(apiV4);
-      expectEndpointSchemaGetRequest(apiV4.endpointGroups[0].type);
-      expectEndpointsSharedConfigurationSchemaGetRequest(apiV4.endpointGroups[0].type);
 
       await componentHarness.clickPreviousButton();
 
@@ -153,17 +231,21 @@ describe('ApiEndpointComponent', () => {
   function expectEndpointsSharedConfigurationSchemaGetRequest(id: string) {
     httpTestingController
       .expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints/${id}/shared-configuration-schema`, method: 'GET' })
-      .flush(
-        '{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","definitions":{"security":{"type":"object","title":"Security configuration","oneOf":[{"title":"Protocol PLAINTEXT","properties":{"protocol":{"const":"PLAINTEXT"}},"additionalProperties":false},{"title":"Protocol SASL_PLAINTEXT","properties":{"protocol":{"const":"SASL_PLAINTEXT"},"sasl":{"$ref":"#/definitions/securityProtocolSasl"}},"additionalProperties":false,"required":["sasl"]},{"title":"Protocol SASL_SSL","properties":{"protocol":{"const":"SASL_SSL"},"sasl":{"$ref":"#/definitions/securityProtocolSasl"},"ssl":{"$ref":"#/definitions/securityProtocolSsl"}},"additionalProperties":false,"required":["sasl","ssl"]},{"title":"Protocol SSL","properties":{"protocol":{"const":"SSL"},"ssl":{"$ref":"#/definitions/securityProtocolSsl"}},"additionalProperties":false,"required":["ssl"]}]}},"oneOf":[{"title":"Use Consumer","properties":{"security":{"$ref":"#/definitions/security"},"consumer":{"$ref":"#/definitions/consumer"}},"required":["consumer"],"additionalProperties":false},{"title":"Use Producer","properties":{"security":{"$ref":"#/definitions/security"},"producer":{"$ref":"#/definitions/producer"}},"required":["producer"],"additionalProperties":false},{"title":"Use Consumer and Producer","properties":{"security":{"$ref":"#/definitions/security"},"producer":{"$ref":"#/definitions/producer"},"consumer":{"$ref":"#/definitions/consumer"}},"required":["producer","consumer"],"additionalProperties":false}]}',
-      );
+      .flush({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        type: 'object',
+        properties: { test: { title: 'test', description: 'test', type: 'string' } },
+      });
   }
 
   function expectEndpointSchemaGetRequest(id: string) {
-    httpTestingController
-      .expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints/${id}/schema`, method: 'GET' })
-      .flush(
-        '{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","definitions":{"bootstrapServers":{"title":"Bootstrap servers (bootstrap.servers)","description":"This list should be in the form host1:port1,host2:port2,...","type":"string","gioConfig":{"banner":{"title":"Bootstrap servers","text":"A list of host/port pairs, separated by a comma, to use for establishing the initial connection to the Kafka cluster. The client will make use of all servers irrespective of which servers are specified here for bootstrapping—this list only impacts the initial hosts used to discover the full set of servers. "}}}},"properties":{"bootstrapServers":{"$ref":"#/definitions/bootstrapServers"}},"required":["bootstrapServers"],"additionalProperties":false}',
-      );
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints/${id}/schema`, method: 'GET' }).flush({
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      properties: {
+        bootstrapServers: { title: 'bootstrapServers', description: 'The list of kafka bootstrap servers.', type: 'string' },
+      },
+    });
     fixture.detectChanges();
   }
 
@@ -175,5 +257,11 @@ describe('ApiEndpointComponent', () => {
   function expectApiPutRequest(api: ApiV4) {
     httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}`, method: 'PUT' }).flush(api);
     fixture.detectChanges();
+  }
+
+  function expectEndpointPluginGetRequest(pluginId: string) {
+    httpTestingController
+      .expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints/${pluginId}`, method: 'GET' })
+      .flush([fakeConnectorPlugin({ id: pluginId, name: pluginId })]);
   }
 });

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.spec.ts
@@ -21,13 +21,17 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { GioHttpTestingModule } from '../../../../../shared/testing';
-import { ApiV4 } from '../../../../../entities/management-api-v2';
+
 import { ApiEndpointComponent } from './api-endpoint.component';
 import { ApiEndpointModule } from './api-endpoint.module';
+import { ApiEndpointHarness } from './api-endpoint.harness';
+
+import { CONSTANTS_TESTING, GioHttpTestingModule } from '../../../../../shared/testing';
+import { ApiV4, fakeApiV4 } from '../../../../../entities/management-api-v2';
+import { UIRouterState, UIRouterStateParams } from '../../../../../ajs-upgraded-providers';
 
 @Component({
-  template: `<api-endpoint #apiEndpoint [api]="api"></api-endpoint>`,
+  template: `<api-endpoint #apiEndpoint></api-endpoint>`,
 })
 class TestComponent {
   @ViewChild('apiEndpoint') apiEndpoint: ApiEndpointComponent;
@@ -35,14 +39,27 @@ class TestComponent {
 }
 
 describe('ApiEndpointComponent', () => {
+  const API_ID = 'apiId';
+  const apiV4 = fakeApiV4({
+    id: API_ID,
+  });
+  const fakeAjsState = {
+    go: jest.fn(),
+  };
+
   let fixture: ComponentFixture<TestComponent>;
   let httpTestingController: HttpTestingController;
   let loader: HarnessLoader;
+  let componentHarness: ApiEndpointHarness;
 
   const initComponent = async (api: ApiV4) => {
     TestBed.configureTestingModule({
       declarations: [TestComponent],
       imports: [NoopAnimationsModule, GioHttpTestingModule, ApiEndpointModule, MatIconTestingModule],
+      providers: [
+        { provide: UIRouterState, useValue: fakeAjsState },
+        { provide: UIRouterStateParams, useValue: { apiId: API_ID, groupName: 'default-group' } },
+      ],
     });
 
     fixture = TestBed.createComponent(TestComponent);
@@ -51,6 +68,8 @@ describe('ApiEndpointComponent', () => {
     loader = TestbedHarnessEnvironment.loader(fixture);
     httpTestingController = TestBed.inject(HttpTestingController);
     fixture.detectChanges();
+
+    componentHarness = await loader.getHarness(ApiEndpointHarness);
   };
 
   afterEach(() => {
@@ -58,5 +77,52 @@ describe('ApiEndpointComponent', () => {
     httpTestingController.verify();
   });
 
-  describe('add endpoints in a group', () => {});
+  describe('add endpoints in a group', () => {
+    it('should load kafka endpoint form dynamically', async () => {
+      await initComponent(apiV4);
+
+      expectApiGetRequest(apiV4);
+      expectEndpointSchemaGetRequest(apiV4.endpointGroups[0].type);
+      expectEndpointsSharedConfigurationSchemaGetRequest(apiV4.endpointGroups[0].type);
+    });
+
+    it('should edit and save the endpoint', async () => {
+      await initComponent(apiV4);
+
+      expectApiGetRequest(apiV4);
+      expectEndpointSchemaGetRequest(apiV4.endpointGroups[0].type);
+      expectEndpointsSharedConfigurationSchemaGetRequest(apiV4.endpointGroups[0].type);
+
+      expect(await componentHarness.isSaveButtonDisabled()).toBeTruthy();
+
+      await componentHarness.fillInputName('endpoint-name');
+      fixture.detectChanges();
+
+      expect(await componentHarness.isSaveButtonDisabled()).toBeFalsy();
+
+      // TODO implement save on button click
+    });
+  });
+
+  function expectEndpointsSharedConfigurationSchemaGetRequest(id: string) {
+    httpTestingController
+      .expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints/${id}/shared-configuration-schema`, method: 'GET' })
+      .flush(
+        '{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","definitions":{"security":{"type":"object","title":"Security configuration","oneOf":[{"title":"Protocol PLAINTEXT","properties":{"protocol":{"const":"PLAINTEXT"}},"additionalProperties":false},{"title":"Protocol SASL_PLAINTEXT","properties":{"protocol":{"const":"SASL_PLAINTEXT"},"sasl":{"$ref":"#/definitions/securityProtocolSasl"}},"additionalProperties":false,"required":["sasl"]},{"title":"Protocol SASL_SSL","properties":{"protocol":{"const":"SASL_SSL"},"sasl":{"$ref":"#/definitions/securityProtocolSasl"},"ssl":{"$ref":"#/definitions/securityProtocolSsl"}},"additionalProperties":false,"required":["sasl","ssl"]},{"title":"Protocol SSL","properties":{"protocol":{"const":"SSL"},"ssl":{"$ref":"#/definitions/securityProtocolSsl"}},"additionalProperties":false,"required":["ssl"]}]}},"oneOf":[{"title":"Use Consumer","properties":{"security":{"$ref":"#/definitions/security"},"consumer":{"$ref":"#/definitions/consumer"}},"required":["consumer"],"additionalProperties":false},{"title":"Use Producer","properties":{"security":{"$ref":"#/definitions/security"},"producer":{"$ref":"#/definitions/producer"}},"required":["producer"],"additionalProperties":false},{"title":"Use Consumer and Producer","properties":{"security":{"$ref":"#/definitions/security"},"producer":{"$ref":"#/definitions/producer"},"consumer":{"$ref":"#/definitions/consumer"}},"required":["producer","consumer"],"additionalProperties":false}]}',
+      );
+  }
+
+  function expectEndpointSchemaGetRequest(id: string) {
+    httpTestingController
+      .expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints/${id}/schema`, method: 'GET' })
+      .flush(
+        '{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","definitions":{"bootstrapServers":{"title":"Bootstrap servers (bootstrap.servers)","description":"This list should be in the form host1:port1,host2:port2,...","type":"string","gioConfig":{"banner":{"title":"Bootstrap servers","text":"A list of host/port pairs, separated by a comma, to use for establishing the initial connection to the Kafka cluster. The client will make use of all servers irrespective of which servers are specified here for bootstrapping—this list only impacts the initial hosts used to discover the full set of servers. "}}}},"properties":{"bootstrapServers":{"$ref":"#/definitions/bootstrapServers"}},"required":["bootstrapServers"],"additionalProperties":false}',
+      );
+    fixture.detectChanges();
+  }
+
+  function expectApiGetRequest(api: ApiV4) {
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}`, method: 'GET' }).flush(api);
+    fixture.detectChanges();
+  }
 });

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.spec.ts
@@ -104,6 +104,20 @@ describe('ApiEndpointComponent', () => {
     });
   });
 
+  describe('onPreviousClick', () => {
+    it('should go back to endpoints groups list page', async () => {
+      await initComponent(apiV4);
+
+      expectApiGetRequest(apiV4);
+      expectEndpointSchemaGetRequest(apiV4.endpointGroups[0].type);
+      expectEndpointsSharedConfigurationSchemaGetRequest(apiV4.endpointGroups[0].type);
+
+      await componentHarness.clickPreviousButton();
+
+      expect(fakeAjsState.go).toHaveBeenCalledWith('management.apis.ng.endpoints');
+    });
+  });
+
   function expectEndpointsSharedConfigurationSchemaGetRequest(id: string) {
     httpTestingController
       .expectOne({ url: `${CONSTANTS_TESTING.v2BaseURL}/plugins/endpoints/${id}/shared-configuration-schema`, method: 'GET' })

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.spec.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { GioHttpTestingModule } from '../../../../../shared/testing';
+import { ApiV4 } from '../../../../../entities/management-api-v2';
+import { ApiEndpointComponent } from './api-endpoint.component';
+import { ApiEndpointModule } from './api-endpoint.module';
+
+@Component({
+  template: `<api-endpoint #apiEndpoint [api]="api"></api-endpoint>`,
+})
+class TestComponent {
+  @ViewChild('apiEndpoint') apiEndpoint: ApiEndpointComponent;
+  api?: ApiV4;
+}
+
+describe('ApiEndpointComponent', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  let httpTestingController: HttpTestingController;
+  let loader: HarnessLoader;
+
+  const initComponent = async (api: ApiV4) => {
+    TestBed.configureTestingModule({
+      declarations: [TestComponent],
+      imports: [NoopAnimationsModule, GioHttpTestingModule, ApiEndpointModule, MatIconTestingModule],
+    });
+
+    fixture = TestBed.createComponent(TestComponent);
+    fixture.componentInstance.api = api;
+
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    httpTestingController.verify();
+  });
+
+  describe('add endpoints in a group', () => {});
+});

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.ts
@@ -76,4 +76,8 @@ export class ApiEndpointComponent implements OnInit, OnDestroy {
     this.unsubscribe$.next(true);
     this.unsubscribe$.unsubscribe();
   }
+
+  public onPrevious() {
+    this.ajsState.go('management.apis.ng.endpoints');
+  }
 }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.ts
@@ -13,11 +13,67 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component } from '@angular/core';
+import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import { StateService } from '@uirouter/core';
+import { switchMap, takeUntil, tap } from 'rxjs/operators';
+import { combineLatest, Subject } from 'rxjs';
+import { GioFormJsonSchemaComponent, GioJsonSchema } from '@gravitee/ui-particles-angular';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+
+import { UIRouterState, UIRouterStateParams } from '../../../../../ajs-upgraded-providers';
+import { ApiV2Service } from '../../../../../services-ngx/api-v2.service';
+import { ApiV4, EndpointGroupV4 } from '../../../../../entities/management-api-v2';
+import { ConnectorPluginsV2Service } from '../../../../../services-ngx/connector-plugins-v2.service';
 
 @Component({
   selector: 'api-endpoint',
   template: require('./api-endpoint.component.html'),
   styles: [require('./api-endpoint.component.scss')],
 })
-export class ApiEndpointComponent {}
+export class ApiEndpointComponent implements OnInit, OnDestroy {
+  private unsubscribe$: Subject<boolean> = new Subject<boolean>();
+  public endpointGroup: EndpointGroupV4;
+  public formGroup: FormGroup;
+  public endpointSchema: { config: GioJsonSchema; sharedConfig: GioJsonSchema };
+  public isLoading = false;
+
+  constructor(
+    @Inject(UIRouterState) private readonly ajsState: StateService,
+    @Inject(UIRouterStateParams) private readonly ajsStateParams,
+    private readonly apiService: ApiV2Service,
+    private readonly connectorPluginsV2Service: ConnectorPluginsV2Service,
+  ) {}
+
+  public ngOnInit(): void {
+    this.isLoading = true;
+    const apiId = this.ajsStateParams.apiId;
+    const groupName = this.ajsStateParams.groupName;
+
+    this.apiService
+      .get(apiId)
+      .pipe(
+        takeUntil(this.unsubscribe$),
+        switchMap((api: ApiV4) => {
+          this.endpointGroup = api.endpointGroups.find((group) => group.name === groupName);
+          return combineLatest([
+            this.connectorPluginsV2Service.getEndpointPluginSchema(this.endpointGroup.type),
+            this.connectorPluginsV2Service.getEndpointPluginSharedConfigurationSchema(this.endpointGroup.type),
+          ]);
+        }),
+        tap(([config, sharedConfig]) => {
+          this.endpointSchema = { config, sharedConfig };
+          this.formGroup = new FormGroup({
+            name: new FormControl(null, Validators.required),
+            configuration: new FormControl(GioFormJsonSchemaComponent.isDisplayable(config) ? config : {}),
+            sharedConfiguration: new FormControl(GioFormJsonSchemaComponent.isDisplayable(sharedConfig) ? sharedConfig : {}),
+          });
+        }),
+      )
+      .subscribe(() => (this.isLoading = false));
+  }
+
+  public ngOnDestroy() {
+    this.unsubscribe$.next(true);
+    this.unsubscribe$.unsubscribe();
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.component.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'api-endpoint',
+  template: require('./api-endpoint.component.html'),
+  styles: [require('./api-endpoint.component.scss')],
+})
+export class ApiEndpointComponent {}

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.harness.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+
+export class ApiEndpointHarness extends ComponentHarness {
+  static hostSelector = 'api-endpoint';
+
+  private getNameInput = this.locatorFor(MatInputHarness.with({ selector: '#name' }));
+  private getSaveButton = this.locatorFor(MatButtonHarness.with({ text: 'Validate my endpoints' }));
+
+  public async fillInputName(name: string) {
+    return this.getNameInput().then((input) => input.setValue(name));
+  }
+
+  public async isSaveButtonDisabled() {
+    return this.getSaveButton().then((button) => button.isDisabled());
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.harness.ts
@@ -16,6 +16,7 @@
 import { ComponentHarness } from '@angular/cdk/testing';
 import { MatInputHarness } from '@angular/material/input/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
 
 export class ApiEndpointHarness extends ComponentHarness {
   static hostSelector = 'api-endpoint';
@@ -23,9 +24,14 @@ export class ApiEndpointHarness extends ComponentHarness {
   private getNameInput = this.locatorFor(MatInputHarness.with({ selector: '#name' }));
   private getSaveButton = this.locatorFor(MatButtonHarness.with({ text: 'Validate my endpoints' }));
   private getPreviousButton = this.locatorFor(MatButtonHarness.with({ text: 'Previous' }));
+  private getConfigurationToggle = this.locatorFor(MatSlideToggleHarness);
 
   public async fillInputName(name: string) {
     return this.getNameInput().then((input) => input.setValue(name));
+  }
+
+  public async getEndpointName() {
+    return this.getNameInput().then((input) => input.getValue());
   }
 
   public async isSaveButtonDisabled() {
@@ -38,5 +44,17 @@ export class ApiEndpointHarness extends ComponentHarness {
 
   public async clickPreviousButton() {
     return this.getPreviousButton().then((button) => button.click());
+  }
+
+  public async isConfigurationButtonToggled() {
+    return this.getConfigurationToggle().then((toggle) => toggle.isChecked());
+  }
+
+  public async toggleConfigurationButton() {
+    return this.getConfigurationToggle().then((toggle) => toggle.toggle());
+  }
+
+  public async topicInputText(text: string) {
+    return this.locatorFor(MatInputHarness.with({ value: text }))();
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.harness.ts
@@ -22,6 +22,7 @@ export class ApiEndpointHarness extends ComponentHarness {
 
   private getNameInput = this.locatorFor(MatInputHarness.with({ selector: '#name' }));
   private getSaveButton = this.locatorFor(MatButtonHarness.with({ text: 'Validate my endpoints' }));
+  private getPreviousButton = this.locatorFor(MatButtonHarness.with({ text: 'Previous' }));
 
   public async fillInputName(name: string) {
     return this.getNameInput().then((input) => input.setValue(name));
@@ -29,5 +30,9 @@ export class ApiEndpointHarness extends ComponentHarness {
 
   public async isSaveButtonDisabled() {
     return this.getSaveButton().then((button) => button.isDisabled());
+  }
+
+  public async clickPreviousButton() {
+    return this.getPreviousButton().then((button) => button.click());
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.harness.ts
@@ -32,6 +32,10 @@ export class ApiEndpointHarness extends ComponentHarness {
     return this.getSaveButton().then((button) => button.isDisabled());
   }
 
+  public async clickSaveButton() {
+    return this.getSaveButton().then((button) => button.click());
+  }
+
   public async clickPreviousButton() {
     return this.getPreviousButton().then((button) => button.click());
   }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.module.ts
@@ -16,12 +16,28 @@
 
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { GioFormJsonSchemaModule } from '@gravitee/ui-particles-angular';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
 
 import { ApiEndpointComponent } from './api-endpoint.component';
 
 @NgModule({
   declarations: [ApiEndpointComponent],
   exports: [ApiEndpointComponent],
-  imports: [CommonModule],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatButtonModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    GioFormJsonSchemaModule,
+    MatProgressBarModule,
+  ],
 })
 export class ApiEndpointModule {}

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.module.ts
@@ -23,6 +23,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 import { ApiEndpointComponent } from './api-endpoint.component';
 
@@ -36,8 +37,9 @@ import { ApiEndpointComponent } from './api-endpoint.component';
     MatCardModule,
     MatFormFieldModule,
     MatInputModule,
-    GioFormJsonSchemaModule,
     MatProgressBarModule,
+    MatSnackBarModule,
+    GioFormJsonSchemaModule,
   ],
 })
 export class ApiEndpointModule {}

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.module.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { ApiEndpointComponent } from './api-endpoint.component';
+
+@NgModule({
+  declarations: [ApiEndpointComponent],
+  exports: [ApiEndpointComponent],
+  imports: [CommonModule],
+})
+export class ApiEndpointModule {}

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoint/api-endpoint.module.ts
@@ -16,7 +16,7 @@
 
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { GioFormJsonSchemaModule } from '@gravitee/ui-particles-angular';
+import { GioFormJsonSchemaModule, GioFormSlideToggleModule } from '@gravitee/ui-particles-angular';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { ReactiveFormsModule } from '@angular/forms';
@@ -24,6 +24,8 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 
 import { ApiEndpointComponent } from './api-endpoint.component';
 
@@ -33,13 +35,18 @@ import { ApiEndpointComponent } from './api-endpoint.component';
   imports: [
     CommonModule,
     ReactiveFormsModule,
+
     MatButtonModule,
     MatCardModule,
     MatFormFieldModule,
     MatInputModule,
     MatProgressBarModule,
     MatSnackBarModule,
+    MatIconModule,
+    MatSlideToggleModule,
+
     GioFormJsonSchemaModule,
+    GioFormSlideToggleModule,
   ],
 })
 export class ApiEndpointModule {}

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.html
@@ -102,7 +102,7 @@
             <td class="mat-cell" [attr.colspan]="endpointsDisplayedColumns.length">No Endpoints</td>
           </tr>
         </table>
-        <button mat-stroked-button aria-label="Add endpoint" class="add_endpoint">Add endpoint</button>
+        <a mat-stroked-button aria-label="Add endpoint" class="add_endpoint" (click)="addEndpoint(group.name)">Add endpoint</a>
       </mat-card-content>
     </ng-container>
   </mat-card>

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.html
@@ -77,11 +77,11 @@
           <!-- Actions Column -->
           <ng-container matColumnDef="actions">
             <th mat-header-cell *matHeaderCellDef id="actions">Actions</th>
-            <td mat-cell *matCellDef="let element">
+            <td mat-cell *matCellDef="let element; let j = index">
               <div class="endpoints-group-card__table__actions">
-                <button mat-icon-button aria-label="Edit endpoint" matTooltip="Edit endpoint">
+                <a mat-icon-button aria-label="Edit endpoint" matTooltip="Edit endpoint" (click)="editEndpoint(i, j)">
                   <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
-                </button>
+                </a>
                 <button
                   mat-icon-button
                   aria-label="Delete endpoint"

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.html
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.html
@@ -102,7 +102,7 @@
             <td class="mat-cell" [attr.colspan]="endpointsDisplayedColumns.length">No Endpoints</td>
           </tr>
         </table>
-        <a mat-stroked-button aria-label="Add endpoint" class="add_endpoint" (click)="addEndpoint(group.name)">Add endpoint</a>
+        <a mat-stroked-button aria-label="Add endpoint" class="add_endpoint" (click)="addEndpoint(i)">Add endpoint</a>
       </mat-card-content>
     </ng-container>
   </mat-card>

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.spec.ts
@@ -28,6 +28,7 @@ import { ApiEndpointsGroupsModule } from './api-endpoints-groups.module';
 
 import { ApiV4, fakeApiV4, fakeConnectorPlugin } from '../../../../../entities/management-api-v2';
 import { CONSTANTS_TESTING, GioHttpTestingModule } from '../../../../../shared/testing';
+import { UIRouterState } from '../../../../../ajs-upgraded-providers';
 
 @Component({
   template: ` <api-endpoints-groups #apiPortalEndpoints [api]="api"></api-endpoints-groups> `,
@@ -95,6 +96,7 @@ describe('ApiEndpointsGroupsComponent', () => {
       },
     ],
   });
+  const fakeUiRouter = { go: jest.fn() };
 
   let fixture: ComponentFixture<TestComponent>;
   let httpTestingController: HttpTestingController;
@@ -106,6 +108,7 @@ describe('ApiEndpointsGroupsComponent', () => {
     TestBed.configureTestingModule({
       declarations: [TestComponent],
       imports: [NoopAnimationsModule, GioHttpTestingModule, ApiEndpointsGroupsModule, MatIconTestingModule],
+      providers: [{ provide: UIRouterState, useValue: fakeUiRouter }],
     }).overrideProvider(InteractivityChecker, {
       useValue: {
         isFocusable: () => true,
@@ -210,6 +213,16 @@ describe('ApiEndpointsGroupsComponent', () => {
         ],
       });
       expectEndpointsGetRequest();
+    });
+  });
+
+  describe('addEndpoint', () => {
+    it('should navigate to endpoint creation page', async () => {
+      await initComponent(apiV4);
+
+      await componentHarness.clickAddEndpointGroup(0);
+
+      expect(fakeUiRouter.go).toHaveBeenCalledWith('management.apis.ng.endpoint-new', { groupName: expect.any(String) });
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.spec.ts
@@ -226,6 +226,16 @@ describe('ApiEndpointsGroupsComponent', () => {
     });
   });
 
+  describe('editEndpoint', () => {
+    it('should navigate to endpoint edition page', async () => {
+      await initComponent(apiV4);
+
+      await componentHarness.clickEditEndpoint(0);
+
+      expect(fakeUiRouter.go).toHaveBeenCalledWith('management.apis.ng.endpoint-edit', { groupIndex: 0, endpointIndex: 0 });
+    });
+  });
+
   function expectApiGetRequest(api: ApiV4) {
     httpTestingController
       .expectOne({

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.spec.ts
@@ -220,9 +220,9 @@ describe('ApiEndpointsGroupsComponent', () => {
     it('should navigate to endpoint creation page', async () => {
       await initComponent(apiV4);
 
-      await componentHarness.clickAddEndpointGroup(0);
+      await componentHarness.clickAddEndpoint(0);
 
-      expect(fakeUiRouter.go).toHaveBeenCalledWith('management.apis.ng.endpoint-new', { groupName: expect.any(String) });
+      expect(fakeUiRouter.go).toHaveBeenCalledWith('management.apis.ng.endpoint-new', { groupIndex: 0 });
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.ts
@@ -137,7 +137,7 @@ export class ApiEndpointsGroupsComponent implements OnInit, OnDestroy {
       .subscribe();
   }
 
-  public addEndpoint(groupName: string): void {
-    this.ajsState.go('management.apis.ng.endpoint-new', { groupName });
+  public addEndpoint(groupIndex: number): void {
+    this.ajsState.go('management.apis.ng.endpoint-new', { groupIndex });
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.ts
@@ -140,4 +140,8 @@ export class ApiEndpointsGroupsComponent implements OnInit, OnDestroy {
   public addEndpoint(groupIndex: number): void {
     this.ajsState.go('management.apis.ng.endpoint-new', { groupIndex });
   }
+
+  public editEndpoint(groupIndex: number, endpointIndex: number): void {
+    this.ajsState.go('management.apis.ng.endpoint-edit', { groupIndex, endpointIndex });
+  }
 }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.component.ts
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, Inject, Input, OnDestroy, OnInit } from '@angular/core';
 import { GioConfirmDialogComponent, GioConfirmDialogData } from '@gravitee/ui-particles-angular';
 import { catchError, filter, map, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { find, remove } from 'lodash';
 import { EMPTY, Subject } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
+import { StateService } from '@uirouter/angular';
 
 import { EndpointGroup, toEndpoints } from './api-endpoints-groups.adapter';
 
@@ -27,6 +28,7 @@ import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
 import { ApiV4, ConnectorPlugin, UpdateApi } from '../../../../../entities/management-api-v2';
 import { ConnectorPluginsV2Service } from '../../../../../services-ngx/connector-plugins-v2.service';
 import { IconService } from '../../../../../services-ngx/icon.service';
+import { UIRouterState } from '../../../../../ajs-upgraded-providers';
 
 @Component({
   selector: 'api-endpoints-groups',
@@ -41,6 +43,7 @@ export class ApiEndpointsGroupsComponent implements OnInit, OnDestroy {
   private unsubscribe$: Subject<boolean> = new Subject<boolean>();
 
   constructor(
+    @Inject(UIRouterState) private readonly ajsState: StateService,
     private readonly matDialog: MatDialog,
     private readonly apiService: ApiV2Service,
     private readonly snackBarService: SnackBarService,
@@ -132,5 +135,9 @@ export class ApiEndpointsGroupsComponent implements OnInit, OnDestroy {
         takeUntil(this.unsubscribe$),
       )
       .subscribe();
+  }
+
+  public addEndpoint(groupName: string): void {
+    this.ajsState.go('management.apis.ng.endpoint-new', { groupName });
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.harness.ts
@@ -24,6 +24,7 @@ export class ApiEndpointsGroupsHarness extends ComponentHarness {
   private getDeleteEndpointGroupButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Delete endpoints group"]' }));
   private getDeleteEndpointButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Delete endpoint"]' }));
   private getAddEndpointButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Add endpoint"]' }));
+  private getEditEndpointButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Edit endpoint"]' }));
 
   public async getTableRows(index: number) {
     const table = this.locatorFor(MatTableHarness.with({ selector: `#groupsTable-${index}` }));
@@ -50,6 +51,11 @@ export class ApiEndpointsGroupsHarness extends ComponentHarness {
 
   public async clickAddEndpoint(index: number) {
     const button = (await this.getAddEndpointButtons())[index];
+    return button.click();
+  }
+
+  public async clickEditEndpoint(index: number) {
+    const button = (await this.getEditEndpointButtons())[index];
     return button.click();
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.harness.ts
@@ -23,7 +23,7 @@ export class ApiEndpointsGroupsHarness extends ComponentHarness {
 
   private getDeleteEndpointGroupButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Delete endpoints group"]' }));
   private getDeleteEndpointButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Delete endpoint"]' }));
-  private getAddEndpointGroupButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Add endpoint"]' }));
+  private getAddEndpointButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Add endpoint"]' }));
 
   public async getTableRows(index: number) {
     const table = this.locatorFor(MatTableHarness.with({ selector: `#groupsTable-${index}` }));
@@ -48,8 +48,8 @@ export class ApiEndpointsGroupsHarness extends ComponentHarness {
       .then((element) => element.click());
   }
 
-  public async clickAddEndpointGroup(index: number) {
-    const button = (await this.getAddEndpointGroupButtons())[index];
+  public async clickAddEndpoint(index: number) {
+    const button = (await this.getAddEndpointButtons())[index];
     return button.click();
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.harness.ts
@@ -23,6 +23,7 @@ export class ApiEndpointsGroupsHarness extends ComponentHarness {
 
   private getDeleteEndpointGroupButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Delete endpoints group"]' }));
   private getDeleteEndpointButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Delete endpoint"]' }));
+  private getAddEndpointGroupButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[aria-label="Add endpoint"]' }));
 
   public async getTableRows(index: number) {
     const table = this.locatorFor(MatTableHarness.with({ selector: `#groupsTable-${index}` }));
@@ -45,5 +46,10 @@ export class ApiEndpointsGroupsHarness extends ComponentHarness {
       .getHarness(MatDialogHarness)
       .then((dialog) => dialog.getHarness(MatButtonHarness.with({ text: /Delete/ })))
       .then((element) => element.click());
+  }
+
+  public async clickAddEndpointGroup(index: number) {
+    const button = (await this.getAddEndpointGroupButtons())[index];
+    return button.click();
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.module.ts
@@ -25,6 +25,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 import { ApiEndpointsGroupsComponent } from './api-endpoints-groups.component';
+
 import { ApiEndpointModule } from '../endpoint/api-endpoint.module';
 
 @NgModule({

--- a/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints-v4/backend-services/endpoints-groups/api-endpoints-groups.module.ts
@@ -25,6 +25,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 import { ApiEndpointsGroupsComponent } from './api-endpoints-groups.component';
+import { ApiEndpointModule } from '../endpoint/api-endpoint.module';
 
 @NgModule({
   declarations: [ApiEndpointsGroupsComponent],
@@ -38,6 +39,8 @@ import { ApiEndpointsGroupsComponent } from './api-endpoints-groups.component';
     MatTooltipModule,
     MatSnackBarModule,
     GioIconsModule,
+
+    ApiEndpointModule,
   ],
 })
 export class ApiEndpointsGroupsModule {}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1416

## Description

1. Add endpoint to a group
2. Edit an endpoint in a group. The endpoint can inherit his configuration from the group. The form should be disabled ( we have some small bugs to fix on this part in ui-particles )
3. The failover and Health check are not a part of this pr
   
 

https://github.com/gravitee-io/gravitee-api-management/assets/25704259/97145102-7d48-4f89-9c77-b8e84ea12b75



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-jynzshudtp.chromatic.com)
<!-- Storybook placeholder end -->
