### PR TITLE
Exclude tcpreporter from mapi distribution

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
@@ -165,6 +165,7 @@
                 <exclude>*:*:jar</exclude>
                 <exclude>io.gravitee.apim.repository.gateway.bridge.http:gravitee-apim-repository-gateway-bridge-http-client:zip</exclude>
                 <exclude>io.gravitee.policy:gravitee-gateway-services-ratelimit:zip</exclude>
+                <exclude>com.graviteesource.reporter:*:zip</exclude>
                 <exclude>io.gravitee.reporter:*:zip</exclude>
                 <exclude>io.gravitee.tracer:*:zip</exclude>
                 <exclude>com.graviteesource.reactor:*:zip</exclude>


### PR DESCRIPTION
## Issue

N/A

## Description

When TCP reporter became Enterprise and its groupdId changed to `com.graviteesource` the excluding rule in the assembly plugin descriptor stopped being efficient and the TCP reporter was not excluded any longer.

This PR adds the right rule
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-sgdknfjmhw.chromatic.com)
<!-- Storybook placeholder end -->
