### PR TITLE
Increase client creation timeout for test purpose

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/RedisTestRepositoryInitializer.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/RedisTestRepositoryInitializer.java
@@ -42,7 +42,7 @@ public class RedisTestRepositoryInitializer implements TestRepositoryInitializer
         // Wait for all RedisApi to be ready
         redisClients.forEach(redisClient -> {
             try {
-                redisClient.redisApi().toCompletionStage().toCompletableFuture().get(500, TimeUnit.MILLISECONDS);
+                redisClient.redisApi().toCompletionStage().toCompletableFuture().get(1500, TimeUnit.MILLISECONDS);
             } catch (Exception e) {
                 LOGGER.error("Error while waiting for RedisApi to be ready", e);
                 Thread.currentThread().interrupt();


### PR DESCRIPTION
## Issue

N/A

## Description

Try to fix Redis flaky tests by increasing a client creation timeout.
The goal is to avoid this =>
![image](https://github.com/gravitee-io/gravitee-api-management/assets/13161768/b01c31d7-c42d-432b-97dc-3e2493be8320)
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-bsdiqddmwd.chromatic.com)
<!-- Storybook placeholder end -->
