### PR TITLE
Apim 1405 add change end date close dialogs

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/subscription/updateSubscription.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/subscription/updateSubscription.ts
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './createSubscription';
-export * from './subscription';
-export * from './subscription.fixture';
-export * from './subscriptionConsumerConfiguration';
-export * from './subscriptionConsumerStatus';
-export * from './subscriptionStatus';
-export * from './updateSubscription';
+import { SubscriptionConsumerConfiguration } from './subscriptionConsumerConfiguration';
+
+export interface UpdateSubscription {
+  consumerConfiguration?: SubscriptionConsumerConfiguration;
+  metadata?: { [key: string]: string };
+  startingAt?: Date;
+  endingAt?: Date;
+}

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/api-portal-subscriptions.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/api-portal-subscriptions.module.ts
@@ -30,11 +30,14 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { GioIconsModule, GioLoaderModule } from '@gravitee/ui-particles-angular';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MAT_MOMENT_DATE_ADAPTER_OPTIONS, MatMomentDateModule } from '@angular/material-moment-adapter';
 
 import { ApiPortalSubscriptionCreationDialogComponent } from './components/creation-dialog/api-portal-subscription-creation-dialog.component';
 import { ApiPortalSubscriptionTransferDialogComponent } from './components/transfer-dialog/api-portal-subscription-transfer-dialog.component';
 import { ApiPortalSubscriptionEditComponent } from './edit/api-portal-subscription-edit.component';
 import { ApiPortalSubscriptionListComponent } from './list/api-portal-subscription-list.component';
+import { ApiPortalSubscriptionChangeEndDateDialogComponent } from './components/change-end-date-dialog/api-portal-subscription-change-end-date-dialog.component';
 
 import { GioTableWrapperModule } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
 import { GioPermissionModule } from '../../../../shared/components/gio-permission/gio-permission.module';
@@ -43,6 +46,7 @@ import { GioPermissionModule } from '../../../../shared/components/gio-permissio
   declarations: [
     ApiPortalSubscriptionEditComponent,
     ApiPortalSubscriptionListComponent,
+    ApiPortalSubscriptionChangeEndDateDialogComponent,
     ApiPortalSubscriptionCreationDialogComponent,
     ApiPortalSubscriptionTransferDialogComponent,
   ],
@@ -55,9 +59,11 @@ import { GioPermissionModule } from '../../../../shared/components/gio-permissio
     MatAutocompleteModule,
     MatButtonModule,
     MatCardModule,
+    MatDatepickerModule,
     MatDialogModule,
     MatFormFieldModule,
     MatInputModule,
+    MatMomentDateModule,
     MatOptionModule,
     MatSelectModule,
     MatSnackBarModule,
@@ -70,6 +76,6 @@ import { GioPermissionModule } from '../../../../shared/components/gio-permissio
     GioPermissionModule,
     GioTableWrapperModule,
   ],
-  providers: [DatePipe],
+  providers: [DatePipe, { provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS, useValue: { useUtc: true } }],
 })
 export class ApiPortalSubscriptionsModule {}

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/change-end-date-dialog/api-portal-subscription-change-end-date-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/change-end-date-dialog/api-portal-subscription-change-end-date-dialog.component.html
@@ -1,0 +1,52 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<form [formGroup]="form" *ngIf="form">
+  <h2 mat-dialog-title class="title">Change the subscription end date</h2>
+
+  <mat-dialog-content class="change-end-date__dialog-content">
+    <div class="change-end-date__content">
+      <!--      TODO: Check styling for txt -->
+      <div class="change-end-date__warning">
+        Be careful, by changing the end date, {{ data.applicationName }} may no longer have access to this API.
+      </div>
+      <div *ngIf="data.securityType === 'API_KEY'">All API keys after the new end date will be revoked.</div>
+      <mat-form-field appearance="outline">
+        <mat-label>Choose a date</mat-label>
+        <div class="change-end-date__datepicker">
+          <input matInput [min]="minDate" [matDatepicker]="picker" formControlName="endDate" />
+          <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
+          <mat-datepicker #picker></mat-datepicker>
+        </div>
+        <mat-hint>MM/DD/YYYY</mat-hint>
+      </mat-form-field>
+    </div>
+  </mat-dialog-content>
+  <mat-dialog-actions class="actions">
+    <button mat-flat-button [mat-dialog-close]="undefined">Cancel</button>
+    <button
+      color="primary"
+      type="submit"
+      mat-raised-button
+      aria-label="Change end date of subscription"
+      (click)="onClose()"
+      [disabled]="form.invalid || form.pristine"
+    >
+      Change end date
+    </button>
+  </mat-dialog-actions>
+</form>

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/change-end-date-dialog/api-portal-subscription-change-end-date-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/change-end-date-dialog/api-portal-subscription-change-end-date-dialog.component.scss
@@ -1,0 +1,18 @@
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+
+.change-end-date {
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  &__datepicker {
+    display: flex;
+  }
+
+  &__warning {
+    color: mat.get-color-from-palette(gio.$mat-error-palette, 'default');
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/change-end-date-dialog/api-portal-subscription-change-end-date-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/change-end-date-dialog/api-portal-subscription-change-end-date-dialog.component.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, Inject, OnInit } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+import { PlanSecurityType } from '../../../../../../entities/management-api-v2';
+
+export interface ApiPortalSubscriptionChangeEndDateDialogData {
+  applicationName: string;
+  securityType: PlanSecurityType;
+  currentEndDate: Date;
+}
+export interface ApiPortalSubscriptionChangeEndDateDialogResult {
+  endDate: Date;
+}
+@Component({
+  selector: 'api-portal-subscription-change-end-date-dialog',
+  template: require('./api-portal-subscription-change-end-date-dialog.component.html'),
+  styles: [require('./api-portal-subscription-change-end-date-dialog.component.scss')],
+})
+export class ApiPortalSubscriptionChangeEndDateDialogComponent implements OnInit {
+  form: FormGroup;
+  data: ApiPortalSubscriptionChangeEndDateDialogData;
+  minDate: Date = new Date();
+
+  constructor(
+    private readonly dialogRef: MatDialogRef<
+      ApiPortalSubscriptionChangeEndDateDialogComponent,
+      ApiPortalSubscriptionChangeEndDateDialogResult
+    >,
+    @Inject(MAT_DIALOG_DATA) dialogData: ApiPortalSubscriptionChangeEndDateDialogData,
+  ) {
+    this.data = dialogData;
+  }
+
+  ngOnInit(): void {
+    this.form = new FormGroup({
+      endDate: new FormControl(this.data.currentEndDate, [Validators.required]),
+    });
+  }
+
+  onClose() {
+    this.dialogRef.close({ endDate: this.form.getRawValue().endDate });
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/transfer-dialog/api-portal-subscription-transfer-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/transfer-dialog/api-portal-subscription-transfer-dialog.component.ts
@@ -22,14 +22,14 @@ import { Subject } from 'rxjs';
 import { ApiPlanV2Service } from '../../../../../../services-ngx/api-plan-v2.service';
 import { PlanMode, PlanSecurityType } from '../../../../../../entities/management-api-v2';
 
-export interface SubscriptionTransferData {
+export interface ApiPortalSubscriptionTransferDialogData {
   apiId: string;
   currentPlanId: string;
   securityType: PlanSecurityType;
   mode: PlanMode;
 }
 
-export interface SubscriptionTransferResult {
+export interface ApiPortalSubscriptionTransferDialogResult {
   selectedPlanId: string;
 }
 
@@ -48,11 +48,11 @@ export class ApiPortalSubscriptionTransferDialogComponent implements OnInit {
   showGeneralConditionsMsg: boolean;
   form: FormGroup;
   private unsubscribe$: Subject<boolean> = new Subject<boolean>();
-  private data: SubscriptionTransferData;
+  private data: ApiPortalSubscriptionTransferDialogData;
 
   constructor(
-    private readonly dialogRef: MatDialogRef<ApiPortalSubscriptionTransferDialogComponent, SubscriptionTransferResult>,
-    @Inject(MAT_DIALOG_DATA) dialogData: SubscriptionTransferData,
+    private readonly dialogRef: MatDialogRef<ApiPortalSubscriptionTransferDialogComponent, ApiPortalSubscriptionTransferDialogResult>,
+    @Inject(MAT_DIALOG_DATA) dialogData: ApiPortalSubscriptionTransferDialogData,
     private readonly apiPlanService: ApiPlanV2Service,
   ) {
     this.data = dialogData;

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.html
@@ -113,38 +113,36 @@
           </div>
         </div>
       </div>
-      <div class="subscription__footer" *gioPermission="{ anyOf: ['api-subscription-u'] }">
-        <ng-container *ngIf="subscription?.status !== 'PENDING'; else pendingSubscription">
-          <button
-            mat-stroked-button
-            (click)="transferSubscription()"
-            [disabled]="subscription.status !== 'PAUSED' && subscription.status !== 'ACCEPTED'"
-          >
-            <mat-icon svgIcon="gio:data-transfer-both"></mat-icon>
-            Transfer
-          </button>
-          <button mat-stroked-button (click)="pauseSubscription()" *ngIf="subscription.status === 'ACCEPTED'">
-            <mat-icon svgIcon="gio:pause-circle"></mat-icon>
-            Pause
-          </button>
-          <button mat-stroked-button (click)="resumeSubscription()" *ngIf="subscription.status === 'PAUSED'">
-            <mat-icon svgIcon="gio:play-circle"></mat-icon>
-            Resume
-          </button>
-          <button mat-stroked-button (click)="changeEndDate()">
-            <mat-icon svgIcon="gio:calendar"></mat-icon>
-            Change end date
-          </button>
-          <button mat-raised-button color="warn" (click)="closeSubscription()">
-            <mat-icon svgIcon="gio:x-circle"></mat-icon>
-            Close
-          </button>
-        </ng-container>
-        <ng-template #pendingSubscription>
-          <button mat-raised-button color="primary" (click)="validateSubscription()">Validate subscription</button>
-          <button mat-stroked-button (click)="rejectSubscription()">Reject subscription</button>
-        </ng-template>
-      </div>
+      <ng-container *ngIf="subscription?.status === 'PAUSED' || subscription?.status === 'ACCEPTED' || subscription?.status === 'PENDING'">
+        <div class="subscription__footer" *gioPermission="{ anyOf: ['api-subscription-u'] }">
+          <ng-container *ngIf="subscription.status === 'PAUSED' || subscription.status === 'ACCEPTED'; else pendingSubscription">
+            <button mat-stroked-button (click)="transferSubscription()">
+              <mat-icon svgIcon="gio:data-transfer-both"></mat-icon>
+              Transfer
+            </button>
+            <button mat-stroked-button (click)="pauseSubscription()" *ngIf="subscription.status === 'ACCEPTED'">
+              <mat-icon svgIcon="gio:pause-circle"></mat-icon>
+              Pause
+            </button>
+            <button mat-stroked-button (click)="resumeSubscription()" *ngIf="subscription.status === 'PAUSED'">
+              <mat-icon svgIcon="gio:play-circle"></mat-icon>
+              Resume
+            </button>
+            <button mat-stroked-button (click)="changeEndDate()">
+              <mat-icon svgIcon="gio:calendar"></mat-icon>
+              Change end date
+            </button>
+            <button mat-raised-button color="warn" (click)="closeSubscription()">
+              <mat-icon svgIcon="gio:x-circle"></mat-icon>
+              Close
+            </button>
+          </ng-container>
+          <ng-template #pendingSubscription>
+            <button mat-raised-button color="primary" (click)="validateSubscription()">Validate subscription</button>
+            <button mat-stroked-button (click)="rejectSubscription()">Reject subscription</button>
+          </ng-template>
+        </div>
+      </ng-container>
     </ng-container>
     <!--  TODO: Add Shared API Key section -->
   </mat-card>

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.spec.ts
@@ -158,6 +158,27 @@ describe('ApiPortalSubscriptionEditComponent', () => {
       expect(await harness.rejectBtnIsVisible()).toEqual(true);
     });
 
+    it('should load rejected subscription', async () => {
+      const rejectedSubscription = BASIC_SUBSCRIPTION();
+      rejectedSubscription.status = 'REJECTED';
+      await initComponent(rejectedSubscription);
+      expectApplicationGet();
+
+      const harness = await loader.getHarness(ApiPortalSubscriptionEditHarness);
+
+      expect(await harness.getStatus()).toEqual('REJECTED');
+
+      expect(await harness.footerIsVisible()).toEqual(false);
+
+      expect(await harness.transferBtnIsVisible()).toEqual(false);
+      expect(await harness.pauseBtnIsVisible()).toEqual(false);
+      expect(await harness.changeEndDateBtnIsVisible()).toEqual(false);
+      expect(await harness.closeBtnIsVisible()).toEqual(false);
+
+      expect(await harness.validateBtnIsVisible()).toEqual(false);
+      expect(await harness.rejectBtnIsVisible()).toEqual(false);
+    });
+
     it('should not load footer in read-only mode', async () => {
       await initComponent(BASIC_SUBSCRIPTION(), ['api-subscription-r']);
       expectApplicationGet(ApiKeyMode.SHARED);

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.harness.ts
@@ -132,6 +132,10 @@ export class ApiPortalSubscriptionEditHarness extends ComponentHarness {
     return this.btnIsVisible('Close');
   }
 
+  public async openCloseDialog(): Promise<void> {
+    return this.getBtnByText('Close').then((btn) => btn.click());
+  }
+
   public async validateBtnIsVisible(): Promise<boolean> {
     return this.btnIsVisible('Validate subscription');
   }

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.harness.ts
@@ -124,6 +124,10 @@ export class ApiPortalSubscriptionEditHarness extends ComponentHarness {
     return this.btnIsVisible('Change end date');
   }
 
+  public async openChangeEndDateDialog(): Promise<void> {
+    return this.getBtnByText('Change end date').then((btn) => btn.click());
+  }
+
   public async closeBtnIsVisible(): Promise<boolean> {
     return this.btnIsVisible('Close');
   }

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/list/api-portal-subscription-list.component.html
@@ -129,7 +129,7 @@
     <ng-container matColumnDef="endAt">
       <th mat-header-cell *matHeaderCellDef id="endAt">End at</th>
       <td mat-cell *matCellDef="let element">
-        {{ element.endAt }}
+        {{ element.endAt | date : 'medium' }}
       </td>
     </ng-container>
 

--- a/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.spec.ts
@@ -99,6 +99,47 @@ describe('ApiSubscriptionV2Service', () => {
     });
   });
 
+  describe('update', () => {
+    const SUBSCRIPTION_ID = 'my-subscription';
+    it('should call API', (done) => {
+      const startDate = new Date();
+      const endDate = new Date(new Date().setFullYear(2050));
+      const metadata = { nice: 'metadata' };
+      const consumerConfiguration = {
+        entrypointId: 'entrypoint-id',
+        entrypointConfiguration: {
+          nice: 'config',
+        },
+      };
+
+      const subscription = fakeSubscription({ id: SUBSCRIPTION_ID, startingAt: startDate, endingAt: endDate });
+
+      apiSubscriptionV2Service
+        .update(API_ID, SUBSCRIPTION_ID, {
+          startingAt: startDate,
+          endingAt: endDate,
+          metadata,
+          consumerConfiguration,
+        })
+        .subscribe((response) => {
+          expect(response).toEqual(subscription);
+          done();
+        });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/subscriptions/${SUBSCRIPTION_ID}`,
+        method: 'PUT',
+      });
+      expect(req.request.body).toEqual({
+        startingAt: startDate,
+        endingAt: endDate,
+        metadata,
+        consumerConfiguration,
+      });
+      req.flush(subscription);
+    });
+  });
+
   describe('transfer', () => {
     const SUBSCRIPTION_ID = 'my-subscription';
     const PLAN_ID = 'my-plan';
@@ -179,6 +220,25 @@ describe('ApiSubscriptionV2Service', () => {
       });
       expect(req.request.body).toEqual(createSubscription);
       req.flush(fakeSubscription());
+    });
+  });
+
+  describe('close', () => {
+    const SUBSCRIPTION_ID = 'my-subscription';
+    it('should call API', (done) => {
+      const subscription = fakeSubscription({ id: SUBSCRIPTION_ID });
+      apiSubscriptionV2Service.close(SUBSCRIPTION_ID, API_ID).subscribe((response) => {
+        expect(response).toEqual(subscription);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/subscriptions/${SUBSCRIPTION_ID}/_close`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual({});
+
+      req.flush(subscription);
     });
   });
 });

--- a/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.ts
@@ -18,7 +18,7 @@ import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { Constants } from '../entities/Constants';
-import { ApiSubscriptionsResponse, CreateSubscription, Subscription } from '../entities/management-api-v2';
+import { ApiSubscriptionsResponse, CreateSubscription, Subscription, UpdateSubscription } from '../entities/management-api-v2';
 
 @Injectable({
   providedIn: 'root',
@@ -53,6 +53,10 @@ export class ApiSubscriptionV2Service {
     return this.http.get<Subscription>(`${this.constants.env.v2BaseURL}/apis/${apiId}/subscriptions/${subscriptionId}?expands=${expands}`);
   }
 
+  update(apiId: string, subscriptionId: string, updateSubscription: UpdateSubscription): Observable<Subscription> {
+    return this.http.put<Subscription>(`${this.constants.env.v2BaseURL}/apis/${apiId}/subscriptions/${subscriptionId}`, updateSubscription);
+  }
+
   transfer(apiId: string, subscriptionId: string, planId: string): Observable<Subscription> {
     return this.http.post<Subscription>(`${this.constants.env.v2BaseURL}/apis/${apiId}/subscriptions/${subscriptionId}/_transfer`, {
       planId,
@@ -69,5 +73,9 @@ export class ApiSubscriptionV2Service {
 
   create(apiId: string, createSubscription: CreateSubscription): Observable<Subscription> {
     return this.http.post<Subscription>(`${this.constants.env.v2BaseURL}/apis/${apiId}/subscriptions`, createSubscription);
+  }
+
+  close(subscriptionId: string, apiId: string): Observable<Subscription> {
+    return this.http.post<Subscription>(`${this.constants.env.v2BaseURL}/apis/${apiId}/subscriptions/${subscriptionId}/_close`, {});
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1405

## Description

Minor cleaning in api subscription list

Add change end date dialog
![Screen Shot 2023-06-26 at 10 27 13](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/2c8f4166-66f3-4836-af20-2d1d43802d8f)
![Screen Shot 2023-06-26 at 10 27 01](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/cc4d26bc-3c2a-4616-8127-6f874a4839cb)

Add close dialog

![Screen Shot 2023-06-26 at 10 28 51](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/e4d2c270-c7d8-43f2-b488-2888f568b602)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ocbozuzncb.chromatic.com)
<!-- Storybook placeholder end -->
