### PR TITLE
Apim 1835 UI settings perms

### DIFF
--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
@@ -31,6 +31,7 @@ interface MenuItem {
   baseRoute: string;
   displayName: string;
   permissions?: string[];
+  subMenuPermissions?: string[];
 }
 
 @Component({
@@ -100,7 +101,8 @@ export class GioSideNavComponent implements OnInit {
         targetRoute: 'management.settings.analytics.list',
         baseRoute: 'management.settings',
         displayName: 'Settings',
-        permissions: [
+        permissions: ['environment-settings-c', 'environment-settings-r', 'environment-settings-u', 'environment-settings-d'],
+        subMenuPermissions: [
           // hack only read permissions is necessary but READ is also allowed for API_PUBLISHER
           'environment-category-r',
           'environment-metadata-r',
@@ -137,7 +139,14 @@ export class GioSideNavComponent implements OnInit {
   }
 
   private filterMenuByPermission(menuItems: MenuItem[]): MenuItem[] {
-    return menuItems.filter((item) => !item.permissions || this.permissionService.hasAnyMatching(item.permissions));
+    return menuItems.filter(
+      (item) =>
+        !item.permissions ||
+        (item.subMenuPermissions &&
+          this.permissionService.hasAnyMatching(item.subMenuPermissions) &&
+          this.permissionService.hasAnyMatching(item.permissions)) ||
+        this.permissionService.hasAnyMatching(item.permissions),
+    );
   }
 
   navigateTo(route: string) {

--- a/gravitee-apim-console-webui/src/management/configuration/configuration.route.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/configuration.route.ts
@@ -91,7 +91,8 @@ function configurationRouterConfig($stateProvider: StateProvider) {
           page: 'management-configuration-analytics',
         },
         perms: {
-          only: ['environment-settings-r'],
+          only: ['environment-dashboard-r'],
+          unauthorizedFallbackTo: 'management.settings.apiPortalHeader',
         },
       },
     })
@@ -139,6 +140,7 @@ function configurationRouterConfig($stateProvider: StateProvider) {
         },
         perms: {
           only: ['environment-api_header-r'],
+          unauthorizedFallbackTo: 'management.settings.apiQuality.list',
         },
       },
     })
@@ -158,7 +160,8 @@ function configurationRouterConfig($stateProvider: StateProvider) {
           page: 'management-configuration-apiquality',
         },
         perms: {
-          only: ['environment-settings-r'],
+          only: ['environment-quality_rule-r'],
+          unauthorizedFallbackTo: 'management.settings.environment.identityproviders',
         },
       },
     })
@@ -215,6 +218,7 @@ function configurationRouterConfig($stateProvider: StateProvider) {
         },
         perms: {
           only: ['environment-identity_provider_activation-r'],
+          unauthorizedFallbackTo: 'management.settings.categories.list',
         },
       },
     })
@@ -235,6 +239,7 @@ function configurationRouterConfig($stateProvider: StateProvider) {
         },
         perms: {
           only: ['environment-category-r'],
+          unauthorizedFallbackTo: 'management.settings.clientregistrationproviders.list',
         },
       },
     })
@@ -302,6 +307,7 @@ function configurationRouterConfig($stateProvider: StateProvider) {
         },
         perms: {
           only: ['environment-client_registration_provider-r'],
+          unauthorizedFallbackTo: 'management.settings.documentation.list',
         },
       },
     })
@@ -373,7 +379,8 @@ function configurationRouterConfig($stateProvider: StateProvider) {
           page: 'management-configuration-portal-pages',
         },
         perms: {
-          only: ['environment-documentation-r'],
+          only: ['environment-documentation-c', 'environment-documentation-u', 'environment-documentation-d'],
+          unauthorizedFallbackTo: 'management.settings.metadata',
         },
       },
       params: {
@@ -569,6 +576,7 @@ function configurationRouterConfig($stateProvider: StateProvider) {
         },
         perms: {
           only: ['environment-metadata-r'],
+          unauthorizedFallbackTo: 'management.settings.portal',
         },
       },
     })
@@ -586,6 +594,7 @@ function configurationRouterConfig($stateProvider: StateProvider) {
         },
         perms: {
           only: ['environment-settings-r'],
+          unauthorizedFallbackTo: 'management.settings.theme',
         },
       },
     })
@@ -600,6 +609,7 @@ function configurationRouterConfig($stateProvider: StateProvider) {
         },
         perms: {
           only: ['environment-theme-r'],
+          unauthorizedFallbackTo: 'management.settings.top-apis',
         },
       },
     })
@@ -616,6 +626,7 @@ function configurationRouterConfig($stateProvider: StateProvider) {
         },
         perms: {
           only: ['environment-top_apis-r'],
+          unauthorizedFallbackTo: 'management.settings.api_logging',
         },
       },
     })
@@ -633,6 +644,7 @@ function configurationRouterConfig($stateProvider: StateProvider) {
         },
         perms: {
           only: ['organization-settings-r'],
+          unauthorizedFallbackTo: 'management.settings.dictionaries.list',
         },
       },
     })
@@ -653,6 +665,7 @@ function configurationRouterConfig($stateProvider: StateProvider) {
         },
         perms: {
           only: ['environment-dictionary-r'],
+          unauthorizedFallbackTo: 'management.settings.tags',
         },
       },
     })
@@ -702,6 +715,7 @@ function configurationRouterConfig($stateProvider: StateProvider) {
         },
         perms: {
           only: ['environment-tag-r'],
+          unauthorizedFallbackTo: 'management.settings.tenants',
         },
       },
     })
@@ -721,6 +735,7 @@ function configurationRouterConfig($stateProvider: StateProvider) {
         },
         perms: {
           only: ['environment-tenant-r'],
+          unauthorizedFallbackTo: 'management.settings.customUserFields',
         },
       },
     })
@@ -740,6 +755,7 @@ function configurationRouterConfig($stateProvider: StateProvider) {
         },
         perms: {
           only: ['organization-custom_user_fields-r'],
+          unauthorizedFallbackTo: 'management.settings.groups.list',
         },
       },
     })
@@ -760,6 +776,7 @@ function configurationRouterConfig($stateProvider: StateProvider) {
         },
         perms: {
           only: ['environment-group-r'],
+          unauthorizedFallbackTo: 'management.home',
         },
       },
     })

--- a/gravitee-apim-console-webui/src/management/configuration/portal/portal.component.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/portal/portal.component.ts
@@ -20,6 +20,7 @@ import { ApiService } from '../../../services/api.service';
 import CorsService from '../../../services/cors.service';
 import NotificationService from '../../../services/notification.service';
 import PortalSettingsService from '../../../services/portalSettings.service';
+import UserService from '../../../services/user.service';
 
 const PortalSettingsComponent: ng.IComponentOptions = {
   bindings: {
@@ -32,6 +33,7 @@ const PortalSettingsComponent: ng.IComponentOptions = {
     PortalSettingsService: PortalSettingsService,
     CorsService: CorsService,
     ApiService: ApiService,
+    UserService: UserService,
     $state: StateService,
     Constants: any,
   ) {
@@ -42,6 +44,7 @@ const PortalSettingsComponent: ng.IComponentOptions = {
     this.providedConfigurationMessage = 'Configuration provided by the system';
 
     this.$onInit = () => {
+      this.isReadonlyPage = UserService.isUserHasPermissions(['environment-settings-r', 'environment-settings-u']);
       this.settings.api.labelsDictionary = this.settings.api.labelsDictionary || [];
       this.settings.cors.allowOrigin = this.settings.cors.allowOrigin || [];
       this.settings.cors.allowHeaders = this.settings.cors.allowHeaders || [];

--- a/gravitee-apim-console-webui/src/management/configuration/portal/portal.html
+++ b/gravitee-apim-console-webui/src/management/configuration/portal/portal.html
@@ -29,7 +29,7 @@
     <div class="gv-form-content" layout="column">
       <md-input-container class="md-block" flex-gt-xs>
         <label>Company name</label>
-        <input ng-model="$ctrl.settings.company.name" ng-disabled="$ctrl.isReadonlySetting('company.name')" />
+        <input ng-model="$ctrl.settings.company.name" ng-disabled="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('company.name')" />
         <md-tooltip ng-if="$ctrl.isReadonlySetting('company.name')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
       </md-input-container>
     </div>
@@ -43,7 +43,7 @@
         <md-checkbox
           ng-model="$ctrl.settings.plan.security.keyless.enabled"
           aria-label="keyless"
-          ng-disabled="$ctrl.isReadonlySetting('plan.security.keyless.enabled')"
+          ng-disabled="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('plan.security.keyless.enabled')"
         >
           Keyless plans
           <md-tooltip ng-if="$ctrl.isReadonlySetting('plan.security.keyless.enabled')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
@@ -54,7 +54,7 @@
           ng-model="$ctrl.settings.plan.security.apikey.enabled"
           ng-change="$ctrl.toggleApiKeyPlan()"
           aria-label="apikey"
-          ng-disabled="$ctrl.isReadonlySetting('plan.security.apikey.enabled')"
+          ng-disabled="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('plan.security.apikey.enabled')"
         >
           Api-key plans
           <md-tooltip ng-if="$ctrl.isReadonlySetting('plan.security.apikey.enabled')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
@@ -62,7 +62,7 @@
       </md-input-container>
       <md-input-container class="gv-input-container-dense portal-component__sub-input">
         <md-checkbox
-          ng-disabled="!$ctrl.settings.plan.security.apikey.enabled || $ctrl.isReadonlySetting('plan.security.apikey.allowCustom.enabled')"
+          ng-disabled="$ctrl.isReadonlyPage || !$ctrl.settings.plan.security.apikey.enabled || $ctrl.isReadonlySetting('plan.security.apikey.allowCustom.enabled')"
           ng-model="$ctrl.settings.plan.security.customApiKey.enabled"
           aria-label="apikeyCustom"
         >
@@ -74,7 +74,7 @@
       </md-input-container>
       <md-input-container class="gv-input-container-dense portal-component__sub-input">
         <md-checkbox
-          ng-disabled="!$ctrl.settings.plan.security.apikey.enabled || $ctrl.isReadonlySetting('plan.security.apikey.sharedApiKey.enabled')"
+          ng-disabled="$ctrl.isReadonlyPage || !$ctrl.settings.plan.security.apikey.enabled || $ctrl.isReadonlySetting('plan.security.apikey.sharedApiKey.enabled')"
           ng-model="$ctrl.settings.plan.security.sharedApiKey.enabled"
           aria-label="sharedApiKey"
         >
@@ -88,7 +88,7 @@
         <md-checkbox
           ng-model="$ctrl.settings.plan.security.oauth2.enabled"
           aria-label="oauth2"
-          ng-disabled="$ctrl.isReadonlySetting('plan.security.oauth2.enabled')"
+          ng-disabled="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('plan.security.oauth2.enabled')"
         >
           Oauth2 plans
           <md-tooltip ng-if="$ctrl.isReadonlySetting('plan.security.oauth2.enabled')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
@@ -98,7 +98,7 @@
         <md-checkbox
           ng-model="$ctrl.settings.plan.security.jwt.enabled"
           aria-label="jwt"
-          ng-disabled="$ctrl.isReadonlySetting('plan.security.jwt.enabled')"
+          ng-disabled="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('plan.security.jwt.enabled')"
         >
           JWT plans
           <md-tooltip ng-if="$ctrl.isReadonlySetting('plan.security.jwt.enabled')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
@@ -112,7 +112,7 @@
           ng-model="$ctrl.settings.api.labelsDictionary"
           placeholder="Enter a label"
           md-add-on-blur="true"
-          readonly="$ctrl.isReadonlySetting('api.labelsDictionary')"
+          readonly="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('api.labelsDictionary')"
           ng-click="$ctrl.formSettings.$setDirty()"
         >
         </md-chips>
@@ -124,7 +124,7 @@
         <md-checkbox
           ng-model="$ctrl.settings.dashboards.apiStatus.enabled"
           aria-label="Display API status panel"
-          ng-disabled="$ctrl.isReadonlySetting('console.dashboards.apiStatus.enabled')"
+          ng-disabled="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('console.dashboards.apiStatus.enabled')"
         >
           Display API STATUS panel
           <md-tooltip ng-if="$ctrl.isReadonlySetting('console.dashboards.apiStatus.enabled')"
@@ -135,7 +135,7 @@
 
       <h3>API Primary Owner mode</h3>
       <md-input-container class="md-block">
-        <md-radio-group ng-model="$ctrl.settings.api.primaryOwnerMode">
+        <md-radio-group ng-model="$ctrl.settings.api.primaryOwnerMode" ng-disabled="$ctrl.isReadonlyPage">
           <md-radio-button ng-value="'HYBRID'" aria-label="Hybrid"
             >HYBRID: an API primary owner can be either a user or a group (Default)</md-radio-button
           >
@@ -157,18 +157,25 @@
             >Api-key Header
             <small>(Used by portal to display the CURL command, change the YAML configuration to impact the gateway)</small>
           </label>
-          <input ng-model="$ctrl.settings.portal.apikeyHeader" ng-disabled="$ctrl.isReadonlySetting('portal.apikey.header')" />
+          <input
+            ng-model="$ctrl.settings.portal.apikeyHeader"
+            ng-disabled="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('portal.apikey.header')"
+          />
           <md-tooltip ng-if="$ctrl.isReadonlySetting('portal.apikey.header')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
         </md-input-container>
         <md-input-container class="md-block" flex-gt-xs>
           <label>Portal URL</label>
-          <input type="text" ng-model="$ctrl.settings.portal.url" ng-disabled="$ctrl.isReadonlySetting('portal.url')" />
+          <input
+            type="text"
+            ng-model="$ctrl.settings.portal.url"
+            ng-disabled="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('portal.url')"
+          />
           <md-tooltip ng-if="$ctrl.isReadonlySetting('portal.url')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
         </md-input-container>
 
         <md-switch
           aria-label="Override homepage title"
-          ng-disabled="$ctrl.isReadonlySetting('portal.homepageTitle')"
+          ng-disabled="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('portal.homepageTitle')"
           ng-model="$ctrl.overrideHomepageTitle"
           ng-change="$ctrl.toggleOverrideHomepageTitle()"
         >
@@ -177,7 +184,11 @@
         </md-switch>
         <md-input-container class="md-block" flex-gt-xs ng-if="$ctrl.overrideHomepageTitle">
           <label>Portal homepage title</label>
-          <input type="text" ng-model="$ctrl.settings.portal.homepageTitle" ng-disabled="$ctrl.isReadonlySetting('portal.homepageTitle')" />
+          <input
+            type="text"
+            ng-model="$ctrl.settings.portal.homepageTitle"
+            ng-disabled="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('portal.homepageTitle')"
+          />
           <md-tooltip ng-if="$ctrl.isReadonlySetting('portal.homepageTitle')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
         </md-input-container>
       </div>
@@ -188,7 +199,7 @@
           <md-checkbox
             ng-model="$ctrl.settings.portal.apis.tilesMode.enabled"
             aria-label="Tiles Mode"
-            ng-disabled="$ctrl.isReadonlySetting('portal.apis.tilesMode.enabled')"
+            ng-disabled="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('portal.apis.tilesMode.enabled')"
           >
             Use Tiles Mode for apis by default (if not overridden by user)
             <md-tooltip ng-if="$ctrl.isReadonlySetting('portal.apis.tilesMode.enabled')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
@@ -198,7 +209,7 @@
           <md-checkbox
             ng-model="$ctrl.settings.portal.support.enabled"
             aria-label="Support"
-            ng-disabled="$ctrl.isReadonlySetting('portal.support.enabled')"
+            ng-disabled="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('portal.support.enabled')"
           >
             Activate Support
             <md-tooltip ng-if="$ctrl.isReadonlySetting('portal.support.enabled')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
@@ -208,7 +219,7 @@
           <md-checkbox
             ng-model="$ctrl.settings.portal.rating.enabled"
             aria-label="Rating"
-            ng-disabled="$ctrl.isReadonlySetting('portal.rating.enabled')"
+            ng-disabled="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('portal.rating.enabled')"
           >
             Activate Rating
             <md-tooltip ng-if="$ctrl.isReadonlySetting('portal.rating.enabled')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
@@ -217,7 +228,7 @@
         <md-input-container class="gv-input-container-dense">
           <md-checkbox
             ng-model="$ctrl.settings.portal.rating.comment.mandatory"
-            ng-disabled="$ctrl.isReadonlySetting('portal.rating.comment.mandatory')"
+            ng-disabled="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('portal.rating.comment.mandatory')"
             aria-label="Rating comment mandatory"
           >
             Force user to fill comment before to save a rating
@@ -230,7 +241,7 @@
           <md-checkbox
             ng-model="$ctrl.settings.portal.userCreation.enabled"
             aria-label="Allow user creation"
-            ng-disabled="$ctrl.isReadonlySetting('portal.userCreation.enabled')"
+            ng-disabled="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('portal.userCreation.enabled')"
           >
             Allow User Registration
             <md-tooltip ng-if="$ctrl.isReadonlySetting('portal.userCreation.enabled')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
@@ -239,7 +250,7 @@
         <md-input-container class="gv-input-container-dense portal-component__sub-input">
           <md-checkbox
             ng-model="$ctrl.settings.portal.userCreation.automaticValidation.enabled"
-            ng-disabled="!$ctrl.settings.portal.userCreation.enabled || $ctrl.isReadonlySetting('portal.userCreation.automaticValidation.enabled')"
+            ng-disabled="$ctrl.isReadonlyPage || !$ctrl.settings.portal.userCreation.enabled || $ctrl.isReadonlySetting('portal.userCreation.automaticValidation.enabled')"
             aria-label="Enable auto validation of creation"
           >
             Enable automatic validation of registration requests.
@@ -252,7 +263,7 @@
           <md-checkbox
             ng-model="$ctrl.settings.portal.analytics.enabled"
             aria-label="Add Google Analytics"
-            ng-disabled="$ctrl.isReadonlySetting('portal.analytics.enabled')"
+            ng-disabled="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('portal.analytics.enabled')"
           >
             Add Google Analytics
             <md-tooltip ng-if="$ctrl.isReadonlySetting('portal.analytics.enabled')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
@@ -262,14 +273,14 @@
           <label>Google Analytics TrackingId</label>
           <input
             ng-model="$ctrl.settings.portal.analytics.trackingId"
-            ng-disabled="$ctrl.isReadonlySetting('portal.analytics.trackingId')"
+            ng-disabled="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('portal.analytics.trackingId')"
           />
           <md-tooltip ng-if="$ctrl.isReadonlySetting('portal.analytics.trackingId')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
         </md-input-container>
         <md-input-container class="gv-input-container-dense">
           <md-checkbox
             ng-model="$ctrl.settings.portal.uploadMedia.enabled"
-            ng-disabled="$ctrl.isReadonlySetting('portal.uploadMedia.enabled')"
+            ng-disabled="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('portal.uploadMedia.enabled')"
             aria-label="Allow upload media"
           >
             Allow Upload Images
@@ -282,7 +293,7 @@
             type="number"
             min="0"
             ng-model="$ctrl.settings.portal.uploadMedia.maxSizeInOctet"
-            ng-disabled="$ctrl.isReadonlySetting('portal.uploadMedia.maxSizeInOctet')"
+            ng-disabled="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('portal.uploadMedia.maxSizeInOctet')"
           />
           <md-tooltip ng-if="$ctrl.isReadonlySetting('portal.uploadMedia.maxSizeInOctet')"
             >{{$ctrl.providedConfigurationMessage}}</md-tooltip
@@ -298,7 +309,7 @@
               <md-switch
                 ng-model="$ctrl.settings.openAPIDocViewer.openAPIDocType.swagger.enabled"
                 aria-label="swagger"
-                ng-disabled="!$ctrl.settings.openAPIDocViewer.openAPIDocType.redoc.enabled || $ctrl.isReadonlySetting('open.api.doc.type.swagger.enabled')"
+                ng-disabled="$ctrl.isReadonlyPage || !$ctrl.settings.openAPIDocViewer.openAPIDocType.redoc.enabled || $ctrl.isReadonlySetting('open.api.doc.type.swagger.enabled')"
                 ng-change="$ctrl.toggleDocType()"
               >
                 Swagger-UI
@@ -312,7 +323,7 @@
                 <md-radio-button
                   value="Swagger"
                   class="md-primary"
-                  ng-disabled="!$ctrl.settings.openAPIDocViewer.openAPIDocType.swagger.enabled || $ctrl.isReadonlySetting('open.api.doc.type.default')"
+                  ng-disabled="$ctrl.isReadonlyPage || !$ctrl.settings.openAPIDocViewer.openAPIDocType.swagger.enabled || $ctrl.isReadonlySetting('open.api.doc.type.default')"
                   style="margin-bottom: 0px"
                   >Set as default
                 </md-radio-button>
@@ -325,7 +336,7 @@
               <md-switch
                 ng-model="$ctrl.settings.openAPIDocViewer.openAPIDocType.redoc.enabled"
                 aria-label="swagger"
-                ng-disabled="!$ctrl.settings.openAPIDocViewer.openAPIDocType.swagger.enabled || $ctrl.isReadonlySetting('open.api.doc.type.redoc.enabled')"
+                ng-disabled="$ctrl.isReadonlyPage || !$ctrl.settings.openAPIDocViewer.openAPIDocType.swagger.enabled || $ctrl.isReadonlySetting('open.api.doc.type.redoc.enabled')"
                 ng-change="$ctrl.toggleDocType()"
               >
                 Redoc
@@ -339,7 +350,7 @@
                 <md-radio-button
                   value="Redoc"
                   class="md-primary"
-                  ng-disabled="!$ctrl.settings.openAPIDocViewer.openAPIDocType.redoc.enabled  || $ctrl.isReadonlySetting('open.api.doc.type.default')"
+                  ng-disabled="$ctrl.isReadonlyPage || !$ctrl.settings.openAPIDocViewer.openAPIDocType.redoc.enabled  || $ctrl.isReadonlySetting('open.api.doc.type.default')"
                   style="margin-bottom: 0px"
                   >Set as default
                 </md-radio-button>
@@ -358,7 +369,7 @@
             type="number"
             min="0"
             ng-model="$ctrl.settings.scheduler.tasks"
-            ng-disabled="$ctrl.isReadonlySetting('portal.scheduler.tasks')"
+            ng-disabled="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('portal.scheduler.tasks')"
           />
           <md-tooltip ng-if="$ctrl.isReadonlySetting('portal.scheduler.tasks')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
         </md-input-container>
@@ -368,7 +379,7 @@
             type="number"
             min="0"
             ng-model="$ctrl.settings.scheduler.notifications"
-            ng-disabled="$ctrl.isReadonlySetting('portal.scheduler.notifications')"
+            ng-disabled="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('portal.scheduler.notifications')"
           />
           <md-tooltip ng-if="$ctrl.isReadonlySetting('portal.scheduler.notifications')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
         </md-input-container>
@@ -378,7 +389,10 @@
       <div class="gv-form-content" layout="column">
         <md-input-container class="md-block" flex-gt-xs>
           <label>Documentation URL</label>
-          <input ng-model="$ctrl.settings.documentation.url" ng-disabled="$ctrl.isReadonlySetting('documentation.url')" />
+          <input
+            ng-model="$ctrl.settings.documentation.url"
+            ng-disabled="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('documentation.url')"
+          />
           <md-tooltip ng-if="$ctrl.isReadonlySetting('documentation.url')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
         </md-input-container>
       </div>
@@ -395,7 +409,7 @@
           placeholder="*, https://mydomain.com, (http|https).*.mydomain.com, ..."
           md-on-add="$ctrl.controlAllowOrigin($chip, $index)"
           md-add-on-blur="true"
-          readonly="$ctrl.isReadonlySetting('http.api.portal.cors.allow-origin')"
+          readonly="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('http.api.portal.cors.allow-origin')"
         >
           <md-chip-template>
             <strong>{{$chip}}</strong>
@@ -416,7 +430,7 @@
           md-on-close="clearSearchTerm()"
           data-md-container-class="selectdemoSelectHeader"
           multiple
-          ng-disabled="$ctrl.isReadonlySetting('http.api.portal.cors.allow-methods')"
+          ng-disabled="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('http.api.portal.cors.allow-methods')"
         >
           <md-select-header class="demo-select-header">
             <input
@@ -449,7 +463,7 @@
           md-autocomplete-snap
           md-add-on-blur="true"
           md-require-match="false"
-          readonly="$ctrl.isReadonlySetting('http.api.portal.cors.allow-headers')"
+          readonly="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('http.api.portal.cors.allow-headers')"
         >
           <md-autocomplete
             md-search-text="searchHeaders"
@@ -479,7 +493,7 @@
           md-autocomplete-snap
           md-add-on-blur="true"
           md-require-match="false"
-          readonly="$ctrl.isReadonlySetting('http.api.portal.cors.exposed-headers')"
+          readonly="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('http.api.portal.cors.exposed-headers')"
         >
           <md-autocomplete
             md-search-text="searchHeaders"
@@ -508,7 +522,7 @@
           type="number"
           min="0"
           ng-model="$ctrl.settings.cors.maxAge"
-          ng-disabled="$ctrl.isReadonlySetting('http.api.portal.cors.max-age')"
+          ng-disabled="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('http.api.portal.cors.max-age')"
         />
         <md-tooltip ng-if="$ctrl.isReadonlySetting('http.api.portal.cors.max-age')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
       </md-input-container>
@@ -522,7 +536,7 @@
         <md-checkbox
           ng-model="$ctrl.settings.email.enabled"
           aria-label="Email enabled"
-          ng-disabled="$ctrl.isReadonlySetting('email.enabled')"
+          ng-disabled="$ctrl.isReadonlyPage || $ctrl.isReadonlySetting('email.enabled')"
         >
           Enable Emailing
           <md-tooltip ng-if="$ctrl.isReadonlySetting('email.enabled')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
@@ -533,7 +547,7 @@
         <input
           type="text"
           ng-model="$ctrl.settings.email.host"
-          ng-disabled="!$ctrl.settings.email.enabled || $ctrl.isReadonlySetting('email.host')"
+          ng-disabled="$ctrl.isReadonlyPage || !$ctrl.settings.email.enabled || $ctrl.isReadonlySetting('email.host')"
         />
         <md-tooltip ng-if="$ctrl.isReadonlySetting('email.host')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
       </md-input-container>
@@ -543,7 +557,7 @@
           type="number"
           min="0"
           ng-model="$ctrl.settings.email.port"
-          ng-disabled="!$ctrl.settings.email.enabled || $ctrl.isReadonlySetting('email.port')"
+          ng-disabled="$ctrl.isReadonlyPage || !$ctrl.settings.email.enabled || $ctrl.isReadonlySetting('email.port')"
         />
         <md-tooltip ng-if="$ctrl.isReadonlySetting('email.port')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
       </md-input-container>
@@ -552,7 +566,7 @@
         <input
           type="text"
           ng-model="$ctrl.settings.email.username"
-          ng-disabled="!$ctrl.settings.email.enabled || $ctrl.isReadonlySetting('email.username')"
+          ng-disabled="$ctrl.isReadonlyPage || !$ctrl.settings.email.enabled || $ctrl.isReadonlySetting('email.username')"
         />
         <md-tooltip ng-if="$ctrl.isReadonlySetting('email.username')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
       </md-input-container>
@@ -561,7 +575,7 @@
         <input
           type="password"
           ng-model="$ctrl.settings.email.password"
-          ng-disabled="!$ctrl.settings.email.enabled || $ctrl.isReadonlySetting('email.password')"
+          ng-disabled="$ctrl.isReadonlyPage || !$ctrl.settings.email.enabled || $ctrl.isReadonlySetting('email.password')"
         />
         <md-tooltip ng-if="$ctrl.isReadonlySetting('email.password')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
       </md-input-container>
@@ -570,7 +584,7 @@
         <input
           type="text"
           ng-model="$ctrl.settings.email.protocol"
-          ng-disabled="!$ctrl.settings.email.enabled || $ctrl.isReadonlySetting('email.protocol')"
+          ng-disabled="$ctrl.isReadonlyPage || !$ctrl.settings.email.enabled || $ctrl.isReadonlySetting('email.protocol')"
         />
         <md-tooltip ng-if="$ctrl.isReadonlySetting('email.protocol')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
       </md-input-container>
@@ -579,7 +593,7 @@
         <input
           type="text"
           ng-model="$ctrl.settings.email.subject"
-          ng-disabled="!$ctrl.settings.email.enabled || $ctrl.isReadonlySetting('email.subject')"
+          ng-disabled="$ctrl.isReadonlyPage || !$ctrl.settings.email.enabled || $ctrl.isReadonlySetting('email.subject')"
         />
         <md-tooltip ng-if="$ctrl.isReadonlySetting('email.subject')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
       </md-input-container>
@@ -588,7 +602,7 @@
         <input
           type="email"
           ng-model="$ctrl.settings.email.from"
-          ng-disabled="!$ctrl.settings.email.enabled || $ctrl.isReadonlySetting('email.from')"
+          ng-disabled="$ctrl.isReadonlyPage || !$ctrl.settings.email.enabled || $ctrl.isReadonlySetting('email.from')"
         />
         <md-tooltip ng-if="$ctrl.isReadonlySetting('email.from')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
       </md-input-container>
@@ -598,7 +612,7 @@
         <md-checkbox
           ng-model="$ctrl.settings.email.properties.auth"
           aria-label="Alerting enabled"
-          ng-disabled="!$ctrl.settings.email.enabled || $ctrl.isReadonlySetting('email.properties.auth')"
+          ng-disabled="$ctrl.isReadonlyPage || !$ctrl.settings.email.enabled || $ctrl.isReadonlySetting('email.properties.auth')"
         >
           Enable Auth
           <md-tooltip ng-if="$ctrl.isReadonlySetting('email.properties.auth')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
@@ -608,7 +622,7 @@
         <md-checkbox
           ng-model="$ctrl.settings.email.properties.startTlsEnable"
           aria-label="Alerting enabled"
-          ng-disabled="!$ctrl.settings.email.enabled || $ctrl.isReadonlySetting('email.properties.starttls.enable')"
+          ng-disabled="$ctrl.isReadonlyPage || !$ctrl.settings.email.enabled || $ctrl.isReadonlySetting('email.properties.starttls.enable')"
         >
           Enable Start TLS
           <md-tooltip ng-if="$ctrl.isReadonlySetting('email.properties.starttls.enable')"
@@ -621,7 +635,7 @@
         <input
           type="text"
           ng-model="$ctrl.settings.email.properties.sslTrust"
-          ng-disabled="!$ctrl.settings.email.enabled || $ctrl.isReadonlySetting('email.properties.ssl.trust')"
+          ng-disabled="$ctrl.isReadonlyPage || !$ctrl.settings.email.enabled || $ctrl.isReadonlySetting('email.properties.ssl.trust')"
         />
         <md-tooltip ng-if="$ctrl.isReadonlySetting('email.properties.ssl.trust')">{{$ctrl.providedConfigurationMessage}}</md-tooltip>
       </md-input-container>
@@ -632,7 +646,7 @@
     <md-button
       type="submit"
       class="md-raised md-primary"
-      ng-disabled="$ctrl.formSettings.$invalid || $ctrl.formSettings.$pristine"
+      ng-disabled="$ctrl.isReadonlyPage || $ctrl.formSettings.$invalid || $ctrl.formSettings.$pristine"
       permission
       permission-only="['environment-settings-c', 'environment-settings-u', 'environment-settings-d']"
       >Save
@@ -641,7 +655,7 @@
       type="button"
       class="md-raised"
       ng-click="$ctrl.reset()"
-      ng-disabled="$ctrl.formSettings.$invalid || $ctrl.formSettings.$pristine"
+      ng-disabled="$ctrl.isReadonlyPage || $ctrl.formSettings.$invalid || $ctrl.formSettings.$pristine"
       permission
       permission-only="['environment-settings-c', 'environment-settings-u', 'environment-settings-d']"
       >Reset

--- a/gravitee-apim-console-webui/src/management/configuration/settings-navigation/settings-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/configuration/settings-navigation/settings-navigation.component.ts
@@ -55,7 +55,7 @@ export class SettingsNavigationComponent implements OnInit {
             displayName: 'Analytics',
             targetRoute: 'management.settings.analytics.list',
             baseRoute: 'management.settings.analytics',
-            permissions: ['environment-settings-r'],
+            permissions: ['environment-dashboard-r'],
           },
           {
             displayName: 'API Portal Information',
@@ -67,7 +67,7 @@ export class SettingsNavigationComponent implements OnInit {
             displayName: 'API Quality',
             targetRoute: 'management.settings.apiQuality.list',
             baseRoute: 'management.settings.apiQuality',
-            permissions: ['environment-settings-r'],
+            permissions: ['environment-quality_rule-r'],
           },
           {
             displayName: 'Authentication',
@@ -126,7 +126,7 @@ export class SettingsNavigationComponent implements OnInit {
             displayName: 'API Logging',
             targetRoute: 'management.settings.api_logging',
             baseRoute: 'management.settings.api_logging',
-            permissions: ['environment-settings-r'],
+            permissions: ['organization-settings-r'],
           },
           {
             displayName: 'Dictionaries',
@@ -138,13 +138,13 @@ export class SettingsNavigationComponent implements OnInit {
             displayName: 'Sharding Tags',
             targetRoute: 'management.settings.tags',
             baseRoute: 'management.settings.tags',
-            permissions: ['environment-tag-c', 'environment-tag-u', 'environment-tag-d'],
+            permissions: ['environment-tag-r', 'environment-tag-c', 'environment-tag-u', 'environment-tag-d'],
           },
           {
             displayName: 'Tenants',
             targetRoute: 'management.settings.tenants',
             baseRoute: 'management.settings.tenants',
-            permissions: ['environment-tenant-c', 'environment-tenant-u', 'environment-tenant-d'],
+            permissions: ['environment-tenant-r', 'environment-tenant-c', 'environment-tenant-u', 'environment-tenant-d'],
           },
         ],
       },

--- a/gravitee-apim-console-webui/src/management/management.run.ts
+++ b/gravitee-apim-console-webui/src/management/management.run.ts
@@ -186,6 +186,12 @@ function runBlock(
           }
           return {};
         });
+      } else {
+        if (toState.data && toState.data.perms && toState.data.perms.only && !UserService.isUserHasPermissions(toState.data.perms.only)) {
+          if (toState.data.perms.unauthorizedFallbackTo) {
+            return stateService.target(toState.data.perms.unauthorizedFallbackTo);
+          }
+        }
       }
     },
     { priority: 10 },


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1835

## Description

- Enhance side nav to display settings menu if correct setting permission + at least one submenu permission (to avoid displaying the button without a possible submenu)
- add a `redirectTo` for each submenu entry so that if submenu is not accessible due to a lack of permission, then it redirects to the next menu. For the last one, it means no submenu is admissible so redirect to home.
- Restore consistency between side-nav permission and submenu permission
  - sometimes permissions were not the same for a same entry
  - sometimes permissions were not the right one regarding the name of the menu
- Properly manage "readonly" for portal settings page. (pretty sure a lot of other pages should be modified) 
![image](https://github.com/gravitee-io/gravitee-api-management/assets/47851994/32953482-9aa7-40ee-bb3b-c4fd43caf509)

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ddsxjpkdvr.chromatic.com)
<!-- Storybook placeholder end -->
