### PR TITLE
Apim 1405 add validate dialog

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/subscription/acceptSubscription.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/subscription/acceptSubscription.ts
@@ -13,12 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './acceptSubscription';
-export * from './createSubscription';
-export * from './subscription';
-export * from './subscription.fixture';
-export * from './subscriptionConsumerConfiguration';
-export * from './subscriptionConsumerStatus';
-export * from './subscriptionStatus';
-export * from './updateSubscription';
-export * from './verifySubscription';
+export interface AcceptSubscription {
+  reason?: string;
+  customApiKey?: string;
+  startingAt?: Date;
+  endingAt?: Date;
+}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/subscription/verifySubscription.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/subscription/verifySubscription.ts
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './createSubscription';
-export * from './subscription';
-export * from './subscription.fixture';
-export * from './subscriptionConsumerConfiguration';
-export * from './subscriptionConsumerStatus';
-export * from './subscriptionStatus';
-export * from './updateSubscription';
-export * from './verifySubscription';
+export class VerifySubscription {
+  applicationId?: string;
+  apiKey?: string;
+}
+
+export class VerifySubscriptionResponse {
+  ok?: boolean;
+  reason?: string;
+}

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/api-portal-subscriptions.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/api-portal-subscriptions.module.ts
@@ -38,6 +38,7 @@ import { ApiPortalSubscriptionTransferDialogComponent } from './components/trans
 import { ApiPortalSubscriptionEditComponent } from './edit/api-portal-subscription-edit.component';
 import { ApiPortalSubscriptionListComponent } from './list/api-portal-subscription-list.component';
 import { ApiPortalSubscriptionChangeEndDateDialogComponent } from './components/change-end-date-dialog/api-portal-subscription-change-end-date-dialog.component';
+import { ApiKeyValidationComponent } from './components/api-key-validation/api-key-validation.component';
 
 import { GioTableWrapperModule } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
 import { GioPermissionModule } from '../../../../shared/components/gio-permission/gio-permission.module';
@@ -49,8 +50,10 @@ import { GioPermissionModule } from '../../../../shared/components/gio-permissio
     ApiPortalSubscriptionChangeEndDateDialogComponent,
     ApiPortalSubscriptionCreationDialogComponent,
     ApiPortalSubscriptionTransferDialogComponent,
+
+    ApiKeyValidationComponent,
   ],
-  exports: [ApiPortalSubscriptionEditComponent, ApiPortalSubscriptionListComponent],
+  exports: [ApiPortalSubscriptionEditComponent, ApiPortalSubscriptionListComponent, ApiKeyValidationComponent],
   imports: [
     CommonModule,
     FormsModule,

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/api-portal-subscriptions.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/api-portal-subscriptions.module.ts
@@ -38,6 +38,7 @@ import { ApiPortalSubscriptionTransferDialogComponent } from './components/trans
 import { ApiPortalSubscriptionEditComponent } from './edit/api-portal-subscription-edit.component';
 import { ApiPortalSubscriptionListComponent } from './list/api-portal-subscription-list.component';
 import { ApiPortalSubscriptionChangeEndDateDialogComponent } from './components/change-end-date-dialog/api-portal-subscription-change-end-date-dialog.component';
+import { ApiPortalSubscriptionValidateDialogComponent } from './components/validate-dialog/api-portal-subscription-validate-dialog.component';
 import { ApiKeyValidationComponent } from './components/api-key-validation/api-key-validation.component';
 
 import { GioTableWrapperModule } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
@@ -47,6 +48,7 @@ import { GioPermissionModule } from '../../../../shared/components/gio-permissio
   declarations: [
     ApiPortalSubscriptionEditComponent,
     ApiPortalSubscriptionListComponent,
+    ApiPortalSubscriptionValidateDialogComponent,
     ApiPortalSubscriptionChangeEndDateDialogComponent,
     ApiPortalSubscriptionCreationDialogComponent,
     ApiPortalSubscriptionTransferDialogComponent,

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/api-key-validation/api-key-validation.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/api-key-validation/api-key-validation.component.html
@@ -1,0 +1,27 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div [formGroup]="apiKey" class="api-key-validation">
+  <mat-form-field appearance="outline" class="api-key-validation__form-field">
+    <input matInput formControlName="input" minlength="8" maxlength="64" pattern="^[^#%@\;=?|^~, \\]*$" [required]="required" />
+    <mat-label>Custom API key</mat-label>
+    <mat-error *ngIf="apiKey.controls.input.errors?.pattern">No special characters allowed</mat-error>
+    <mat-error *ngIf="apiKey.controls.input.errors?.minlength">Must be longer than 8 characters</mat-error>
+    <mat-error *ngIf="apiKey.controls.input.errors?.maxlength">Must be shorter than 64 characters</mat-error>
+    <mat-error *ngIf="apiKey.controls.input.errors?.unique">Key already exists with given value</mat-error>
+  </mat-form-field>
+</div>

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/api-key-validation/api-key-validation.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/api-key-validation/api-key-validation.component.scss
@@ -1,0 +1,7 @@
+.api-key-validation {
+  display: flex;
+
+  &__form-field {
+    flex: 1 1 100%;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/api-key-validation/api-key-validation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/api-key-validation/api-key-validation.component.spec.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { InteractivityChecker } from '@angular/cdk/a11y';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+
+import { ApiKeyValidationHarness } from './api-key-validation.harness';
+
+import { CONSTANTS_TESTING, GioHttpTestingModule } from '../../../../../../shared/testing';
+import { ApiPortalSubscriptionsModule } from '../../api-portal-subscriptions.module';
+import { VerifySubscription } from '../../../../../../entities/management-api-v2';
+
+const API_ID = 'my-api-id';
+const APP_ID = 'my-app-id';
+
+@Component({
+  selector: 'test-component',
+  template: `<api-key-validation [apiId]="apiId" [applicationId]="applicationId" [required]="required"></api-key-validation>`,
+})
+class TestComponent {
+  apiId: string = API_ID;
+  applicationId: string = APP_ID;
+  required: boolean;
+}
+describe('ApiKeyValidationComponent', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  let loader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+
+  const init = async () => {
+    await TestBed.configureTestingModule({
+      imports: [ApiPortalSubscriptionsModule, NoopAnimationsModule, GioHttpTestingModule, MatIconTestingModule],
+      declarations: [TestComponent],
+      providers: [
+        {
+          provide: InteractivityChecker,
+          useValue: {
+            isFocusable: () => true, // This traps focus checks and so avoid warnings when dealing with
+            isTabbable: () => true, // Allows tabbing and avoids warnings
+          },
+        },
+      ],
+    }).compileComponents();
+  };
+
+  beforeEach(async () => {
+    await init();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    httpTestingController.verify();
+  });
+
+  it('should be invalid required but empty', async () => {
+    await initComponent(true);
+
+    const harness = await loader.getHarness(ApiKeyValidationHarness);
+    expect(await harness.getInputValue()).toEqual('');
+    expect(await harness.isRequired()).toEqual(true);
+    expect(await harness.isValid()).toEqual(false);
+  });
+  it('should be invalid if less than 8 characters', async () => {
+    await initComponent(true);
+
+    const harness = await loader.getHarness(ApiKeyValidationHarness);
+    await harness.setInputValue('1234567');
+
+    expect(await harness.isRequired()).toEqual(true);
+    expect(await harness.isValid()).toEqual(false);
+  });
+  it('should be invalid if more than 64 characters', async () => {
+    await initComponent(true);
+
+    const harness = await loader.getHarness(ApiKeyValidationHarness);
+    await harness.setInputValue(
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
+    );
+
+    expect(await harness.isRequired()).toEqual(true);
+    expect(await harness.isValid()).toEqual(false);
+  });
+  it('should be invalid if contains special characters', async () => {
+    await initComponent(false);
+
+    const harness = await loader.getHarness(ApiKeyValidationHarness);
+    await harness.setInputValue('12?34567');
+
+    expect(await harness.isRequired()).toEqual(false);
+    expect(await harness.isValid()).toEqual(false);
+  });
+  it('should be invalid if API Key not unique', async () => {
+    await initComponent(false);
+
+    const harness = await loader.getHarness(ApiKeyValidationHarness);
+    await harness.setInputValue('123456789');
+
+    const httpMatches = httpTestingController.match({
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/subscriptions/_verify`,
+      method: 'POST',
+    });
+    expect(httpMatches.length).toEqual(2);
+    expect(httpMatches[0].cancelled).toEqual(true);
+    const verifySubscription: VerifySubscription = {
+      applicationId: APP_ID,
+      apiKey: '123456789',
+    };
+    expect(httpMatches[1].request.body).toEqual(verifySubscription);
+    httpMatches[1].flush({ ok: false });
+
+    expect(await harness.isRequired()).toEqual(false);
+    expect(await harness.isValid()).toEqual(false);
+  });
+  it('should be valid if optional but empty', async () => {
+    await initComponent(false);
+
+    const harness = await loader.getHarness(ApiKeyValidationHarness);
+    expect(await harness.getInputValue()).toEqual('');
+    expect(await harness.isRequired()).toEqual(false);
+    expect(await harness.isValid()).toEqual(true);
+  });
+  it('should be valid with a valid input', async () => {
+    await initComponent(true);
+
+    const harness = await loader.getHarness(ApiKeyValidationHarness);
+    await harness.setInputValue('12345678');
+
+    const req = httpTestingController.expectOne({
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/subscriptions/_verify`,
+      method: 'POST',
+    });
+    const verifySubscription: VerifySubscription = {
+      applicationId: APP_ID,
+      apiKey: '12345678',
+    };
+    expect(req.request.body).toEqual(verifySubscription);
+    req.flush({ ok: true });
+
+    expect(await harness.isRequired()).toEqual(true);
+    expect(await harness.isValid()).toEqual(true);
+  });
+
+  async function initComponent(required: boolean) {
+    fixture = TestBed.createComponent(TestComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+    fixture.componentInstance.required = required;
+
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.detectChanges();
+  }
+});

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/api-key-validation/api-key-validation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/api-key-validation/api-key-validation.component.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, Input, OnInit } from '@angular/core';
+import { AbstractControl, AsyncValidatorFn, FormControl, FormGroup, ValidationErrors, Validators } from '@angular/forms';
+import { map, takeUntil } from 'rxjs/operators';
+import { Observable, of, Subject } from 'rxjs';
+
+import { ApiSubscriptionV2Service } from '../../../../../../services-ngx/api-subscription-v2.service';
+
+@Component({
+  selector: 'api-key-validation',
+  template: require('./api-key-validation.component.html'),
+  styles: [require('./api-key-validation.component.scss')],
+})
+export class ApiKeyValidationComponent implements OnInit {
+  @Input()
+  apiId: string;
+
+  @Input()
+  applicationId: string;
+
+  @Input()
+  required: boolean;
+  apiKey: FormGroup = new FormGroup({});
+  private unsubscribe$: Subject<boolean> = new Subject<boolean>();
+  constructor(private readonly apiSubscriptionService: ApiSubscriptionV2Service) {}
+
+  ngOnInit() {
+    const validators = this.required ? [Validators.required] : [];
+    this.apiKey = new FormGroup({
+      input: new FormControl('', validators, [this.apiKeyAsyncValidator()]),
+    });
+  }
+
+  private apiKeyAsyncValidator(): AsyncValidatorFn {
+    return (control: AbstractControl): Observable<ValidationErrors | null> => {
+      if (!this.required && control.value === '') {
+        return of(null);
+      }
+      if (control.errors && !control.errors.unique) {
+        return of(control.errors);
+      }
+
+      return this.apiSubscriptionService.verify(this.apiId, { applicationId: this.applicationId, apiKey: control.value }).pipe(
+        map((isUnique) => (!isUnique.ok ? { unique: true } : null)),
+        takeUntil(this.unsubscribe$),
+      );
+    };
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/api-key-validation/api-key-validation.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/api-key-validation/api-key-validation.harness.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+import { MatFormFieldHarness } from '@angular/material/form-field/testing';
+
+export class ApiKeyValidationHarness extends ComponentHarness {
+  static hostSelector = 'api-key-validation';
+
+  protected getInput = this.locatorFor(MatInputHarness);
+  protected getFormField = this.locatorFor(MatFormFieldHarness);
+
+  public async getInputValue(): Promise<any> {
+    return this.getInput().then((input) => input.getValue());
+  }
+
+  public async setInputValue(value: string): Promise<void> {
+    return this.getInput().then((input) => input.setValue(value));
+  }
+
+  public async isRequired(): Promise<boolean> {
+    return this.getFormField()
+      .then((formField) => formField.getControl())
+      .then((control) => control.isRequired());
+  }
+
+  public async isValid(): Promise<boolean> {
+    return this.getFormField().then((formField) => formField.isControlValid());
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/validate-dialog/api-portal-subscription-validate-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/validate-dialog/api-portal-subscription-validate-dialog.component.html
@@ -1,0 +1,59 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h2 matDialogTitle>Validate your subscription</h2>
+<form [formGroup]="form">
+  <mat-dialog-content>
+    <div class="validate-subscription__content">
+      <div class="validate-subscription__content__row">
+        <mat-form-field>
+          <mat-label>Enter a date range</mat-label>
+          <mat-date-range-input formGroupName="range" [rangePicker]="picker" [min]="minDate">
+            <input matStartDate formControlName="start" placeholder="Start date" />
+            <input matEndDate formControlName="end" placeholder="End date" />
+          </mat-date-range-input>
+          <mat-hint>MM/DD/YYYY – MM/DD/YYYY</mat-hint>
+          <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+          <mat-date-range-picker #picker></mat-date-range-picker>
+        </mat-form-field>
+      </div>
+      <div class="validate-subscription__content__row">
+        <mat-form-field appearance="outline" class="validate-subscription__content__message">
+          <input id="subscription-message" type="text" matInput formControlName="message" maxlength="50" />
+          <mat-label>If necessary, add a message</mat-label>
+        </mat-form-field>
+      </div>
+      <div class="validate-subscription__content__row" *ngIf="data.canUseCustomApiKey && !data.sharedApiKeyMode">
+        <div class="mat-body-1">This plan allows custom API keys. You can provide it here.</div>
+        <api-key-validation #ApiKeyInput [apiId]="data.apiId" [applicationId]="data.applicationId" [required]="false"></api-key-validation>
+      </div>
+    </div>
+  </mat-dialog-content>
+  <mat-dialog-actions class="actions">
+    <button mat-flat-button [mat-dialog-close]="undefined">Cancel</button>
+    <button
+      color="primary"
+      type="submit"
+      mat-raised-button
+      aria-label="Transfer subscription"
+      (click)="onClose()"
+      [disabled]="form.invalid"
+    >
+      Validate
+    </button>
+  </mat-dialog-actions>
+</form>

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/validate-dialog/api-portal-subscription-validate-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/validate-dialog/api-portal-subscription-validate-dialog.component.scss
@@ -1,0 +1,17 @@
+.validate-subscription {
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+
+    &__row {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    &__message {
+      flex: 1 1 100%;
+    }
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/validate-dialog/api-portal-subscription-validate-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/validate-dialog/api-portal-subscription-validate-dialog.component.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AfterViewInit, ChangeDetectorRef, Component, Inject, OnInit, ViewChild } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { FormControl, FormGroup } from '@angular/forms';
+
+import { ApiKeyValidationComponent } from '../api-key-validation/api-key-validation.component';
+
+export interface ApiPortalSubscriptionAcceptDialogData {
+  apiId: string;
+  applicationId: string;
+  canUseCustomApiKey: boolean;
+  sharedApiKeyMode: boolean;
+}
+export interface ApiPortalSubscriptionAcceptDialogResult {
+  start: Date;
+  end: Date;
+  message: string;
+  customApiKey: string;
+}
+@Component({
+  selector: 'api-portal-subscription-validate-dialog',
+  template: require('./api-portal-subscription-validate-dialog.component.html'),
+  styles: [require('./api-portal-subscription-validate-dialog.component.scss')],
+})
+export class ApiPortalSubscriptionValidateDialogComponent implements OnInit, AfterViewInit {
+  data: ApiPortalSubscriptionAcceptDialogData;
+  form: FormGroup = new FormGroup({});
+  minDate: Date;
+  @ViewChild('ApiKeyInput') apiKeyValidationComponent: ApiKeyValidationComponent;
+
+  constructor(
+    private readonly dialogRef: MatDialogRef<ApiPortalSubscriptionValidateDialogComponent, ApiPortalSubscriptionAcceptDialogResult>,
+    @Inject(MAT_DIALOG_DATA) dialogData: ApiPortalSubscriptionAcceptDialogData,
+    private readonly changeDetectorRef: ChangeDetectorRef,
+  ) {
+    this.data = dialogData;
+  }
+
+  ngOnInit(): void {
+    this.minDate = new Date();
+
+    this.form = new FormGroup({
+      range: new FormGroup({
+        start: new FormControl(undefined),
+        end: new FormControl(undefined),
+      }),
+      message: new FormControl(''),
+    });
+  }
+
+  ngAfterViewInit() {
+    if (this.data.canUseCustomApiKey && !this.data.sharedApiKeyMode) {
+      this.form.addControl('apiKey', this.apiKeyValidationComponent.apiKey);
+      this.apiKeyValidationComponent.apiKey.setParent(this.form);
+    }
+    this.changeDetectorRef.detectChanges();
+  }
+
+  onClose() {
+    this.dialogRef.close({
+      start: this.form.getRawValue().range.start,
+      end: this.form.getRawValue().range.end,
+      message: this.form.getRawValue().message,
+      customApiKey: this.form.getRawValue().apiKey?.input,
+    });
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.harness.ts
@@ -15,7 +15,6 @@
  */
 import { ComponentHarness } from '@angular/cdk/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
-import { MatDialogHarness } from '@angular/material/dialog/testing';
 
 export class ApiPortalSubscriptionEditHarness extends ComponentHarness {
   static hostSelector = '#subscription-edit';
@@ -24,7 +23,6 @@ export class ApiPortalSubscriptionEditHarness extends ComponentHarness {
   protected getBackButton = this.locatorFor(MatButtonHarness.with({ selector: '[aria-label="Go back to your subscriptions"]' }));
   protected getFooter = this.locatorFor('.subscription__footer');
   protected getBtnByText = (text: string) => this.locatorFor(MatButtonHarness.with({ text }))();
-  protected getDialog = (selector: string) => this.locatorFor(MatDialogHarness.with({ selector }))();
 
   public async goBackToSubscriptionsList(): Promise<void> {
     return this.getBackButton().then((btn) => btn.click());
@@ -138,6 +136,10 @@ export class ApiPortalSubscriptionEditHarness extends ComponentHarness {
 
   public async validateBtnIsVisible(): Promise<boolean> {
     return this.btnIsVisible('Validate subscription');
+  }
+
+  public async openValidateDialog(): Promise<void> {
+    return this.getBtnByText('Validate subscription').then((btn) => btn.click());
   }
 
   public async rejectBtnIsVisible(): Promise<boolean> {

--- a/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.spec.ts
@@ -19,7 +19,8 @@ import { TestBed } from '@angular/core/testing';
 import { ApiSubscriptionV2Service } from './api-subscription-v2.service';
 
 import { CONSTANTS_TESTING, GioHttpTestingModule } from '../shared/testing';
-import { ApiSubscriptionsResponse, CreateSubscription, fakeSubscription } from '../entities/management-api-v2';
+import { ApiSubscriptionsResponse, CreateSubscription, fakeSubscription, VerifySubscription } from '../entities/management-api-v2';
+import { fakeApi } from '../entities/api/Api.fixture';
 
 describe('ApiSubscriptionV2Service', () => {
   let httpTestingController: HttpTestingController;
@@ -239,6 +240,29 @@ describe('ApiSubscriptionV2Service', () => {
       expect(req.request.body).toEqual({});
 
       req.flush(subscription);
+    });
+  });
+
+  describe('verify', () => {
+    it('should call the endpoint', (done) => {
+      const apiId = 'my-api-id';
+      const verifySubscription: VerifySubscription = {
+        applicationId: 'my-app-id',
+        apiKey: 'my-api-key',
+      };
+      const mockApi = fakeApi();
+
+      apiSubscriptionV2Service.verify(apiId, verifySubscription).subscribe((response) => {
+        expect(response).toMatchObject(mockApi);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/subscriptions/_verify`,
+      });
+      expect(req.request.body).toEqual(verifySubscription);
+      req.flush(mockApi);
     });
   });
 });

--- a/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.spec.ts
@@ -19,7 +19,13 @@ import { TestBed } from '@angular/core/testing';
 import { ApiSubscriptionV2Service } from './api-subscription-v2.service';
 
 import { CONSTANTS_TESTING, GioHttpTestingModule } from '../shared/testing';
-import { ApiSubscriptionsResponse, CreateSubscription, fakeSubscription, VerifySubscription } from '../entities/management-api-v2';
+import {
+  AcceptSubscription,
+  ApiSubscriptionsResponse,
+  CreateSubscription,
+  fakeSubscription,
+  VerifySubscription,
+} from '../entities/management-api-v2';
 import { fakeApi } from '../entities/api/Api.fixture';
 
 describe('ApiSubscriptionV2Service', () => {
@@ -263,6 +269,31 @@ describe('ApiSubscriptionV2Service', () => {
       });
       expect(req.request.body).toEqual(verifySubscription);
       req.flush(mockApi);
+    });
+  });
+
+  describe('accept', () => {
+    const SUBSCRIPTION_ID = 'my-subscription';
+    it('should call API', (done) => {
+      const subscription = fakeSubscription({ id: SUBSCRIPTION_ID });
+      const acceptSubscription: AcceptSubscription = {
+        startingAt: new Date(),
+        endingAt: new Date(),
+        reason: 'a really good reason',
+        customApiKey: 'fresh-api-key',
+      };
+      apiSubscriptionV2Service.accept(SUBSCRIPTION_ID, API_ID, acceptSubscription).subscribe((response) => {
+        expect(response).toEqual(subscription);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/subscriptions/${SUBSCRIPTION_ID}/_accept`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual(acceptSubscription);
+
+      req.flush(subscription);
     });
   });
 });

--- a/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.ts
@@ -18,7 +18,14 @@ import { Inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { Constants } from '../entities/Constants';
-import { ApiSubscriptionsResponse, CreateSubscription, Subscription, UpdateSubscription } from '../entities/management-api-v2';
+import {
+  ApiSubscriptionsResponse,
+  CreateSubscription,
+  Subscription,
+  UpdateSubscription,
+  VerifySubscription,
+  VerifySubscriptionResponse,
+} from '../entities/management-api-v2';
 
 @Injectable({
   providedIn: 'root',
@@ -77,5 +84,9 @@ export class ApiSubscriptionV2Service {
 
   close(subscriptionId: string, apiId: string): Observable<Subscription> {
     return this.http.post<Subscription>(`${this.constants.env.v2BaseURL}/apis/${apiId}/subscriptions/${subscriptionId}/_close`, {});
+  }
+
+  verify(apiId: string, verifySubscription: VerifySubscription): Observable<VerifySubscriptionResponse> {
+    return this.http.post(`${this.constants.env.v2BaseURL}/apis/${apiId}/subscriptions/_verify`, verifySubscription);
   }
 }

--- a/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.ts
@@ -19,6 +19,7 @@ import { Observable } from 'rxjs';
 
 import { Constants } from '../entities/Constants';
 import {
+  AcceptSubscription,
   ApiSubscriptionsResponse,
   CreateSubscription,
   Subscription,
@@ -88,5 +89,12 @@ export class ApiSubscriptionV2Service {
 
   verify(apiId: string, verifySubscription: VerifySubscription): Observable<VerifySubscriptionResponse> {
     return this.http.post(`${this.constants.env.v2BaseURL}/apis/${apiId}/subscriptions/_verify`, verifySubscription);
+  }
+
+  accept(subscriptionId: string, apiId: string, acceptSubscription: AcceptSubscription): Observable<Subscription> {
+    return this.http.post<Subscription>(
+      `${this.constants.env.v2BaseURL}/apis/${apiId}/subscriptions/${subscriptionId}/_accept`,
+      acceptSubscription,
+    );
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1405

## Description

- Small refacto of tests
- Add api-key-validation component
- Add dialog for validating a pending subscription

NOTE: Will fix dialog styles in new PR

If user cannot use custom api key mode and/or the shared api key mode is activated
![Screen Shot 2023-06-27 at 17 11 51](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/fb62305e-a34c-49e6-82c0-cbb025335266)

If user can use custom api mode and the shared api key mode is not activated
![Screen Shot 2023-06-27 at 17 11 00](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/f66f0313-fcd6-428a-845c-c71af05e6384)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-ufrvffbegn.chromatic.com)
<!-- Storybook placeholder end -->
