### PR TITLE
feat: handle multiple format for schema-form

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/plugin/EntrypointsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/plugin/EntrypointsResource.java
@@ -21,6 +21,7 @@ import io.gravitee.rest.api.management.v2.rest.mapper.MoreInformationMapper;
 import io.gravitee.rest.api.management.v2.rest.model.ConnectorPlugin;
 import io.gravitee.rest.api.management.v2.rest.model.MoreInformation;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
+import io.gravitee.rest.api.model.platform.plugin.SchemaDisplayFormat;
 import io.gravitee.rest.api.service.v4.EntrypointConnectorPluginService;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
@@ -79,10 +80,12 @@ public class EntrypointsResource extends AbstractResource {
     @GET
     @Path("/{entrypointId}/subscription-schema")
     @Produces(MediaType.APPLICATION_JSON)
-    public String getEntrypointSubscriptionSchema(@PathParam("entrypointId") String entrypointId) {
+    public String getEntrypointSubscriptionSchema(@PathParam("entrypointId") String entrypointId, @QueryParam("display") String display) {
         // Check that the entrypoint exists
         entrypointService.findById(entrypointId);
-
+        if (display != null) {
+            return entrypointService.getSubscriptionSchema(entrypointId, SchemaDisplayFormat.fromLabel(display));
+        }
         return entrypointService.getSubscriptionSchema(entrypointId);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/plugin/PoliciesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/plugin/PoliciesResource.java
@@ -19,6 +19,7 @@ import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.management.v2.rest.mapper.PolicyPluginMapper;
 import io.gravitee.rest.api.management.v2.rest.model.PolicyPlugin;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
+import io.gravitee.rest.api.model.platform.plugin.SchemaDisplayFormat;
 import io.gravitee.rest.api.service.PolicyService;
 import io.gravitee.rest.api.service.v4.PolicyPluginService;
 import jakarta.inject.Inject;
@@ -26,6 +27,7 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import java.util.Set;
 
 @Path("/plugins/policies")
@@ -50,10 +52,12 @@ public class PoliciesResource extends AbstractResource {
     @GET
     @Path("/{policyId}/schema")
     @Produces(MediaType.APPLICATION_JSON)
-    public String getPolicySchema(@PathParam("policyId") String policyId) {
+    public String getPolicySchema(@PathParam("policyId") String policyId, @QueryParam("display") String display) {
         // Check that the endpoint exists
         policyPluginService.findById(policyId);
-
+        if (display != null) {
+            return policyPluginService.getSchema(policyId, SchemaDisplayFormat.fromLabel(display));
+        }
         return policyPluginService.getSchema(policyId);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/management-openapi-v2.yaml
@@ -143,6 +143,7 @@ paths:
                     $ref: "#/components/responses/ApisResponse"
                 default:
                     $ref: "#/components/responses/Error"
+
     /environments/{envId}/apis/{apiId}:
         parameters:
             - $ref: "#/components/parameters/envIdParam"
@@ -264,7 +265,6 @@ paths:
                     description: API background successfully deleted.
                 default:
                     $ref: "#/components/responses/Error"
-
     /environments/{envId}/apis/{apiId}/deployments:
         parameters:
             - $ref: "#/components/parameters/envIdParam"
@@ -947,7 +947,6 @@ paths:
                                 $ref: "#/components/schemas/Subscription"
                 default:
                     $ref: "#/components/responses/Error"
-
     /environments/{envId}/apis/{apiId}/subscriptions/_export:
         parameters:
             - $ref: "#/components/parameters/envIdParam"
@@ -1006,7 +1005,6 @@ paths:
                         text/csv: {}
                 default:
                     $ref: "#/components/responses/Error"
-
     /environments/{envId}/apis/{apiId}/subscriptions/_verify:
         parameters:
             - $ref: "#/components/parameters/envIdParam"
@@ -1095,7 +1093,6 @@ paths:
                                 $ref: "#/components/schemas/Subscription"
                 default:
                     $ref: "#/components/responses/Error"
-
     /environments/{envId}/apis/{apiId}/subscriptions/{subscriptionId}/_close:
         parameters:
             - $ref: "#/components/parameters/envIdParam"
@@ -1119,7 +1116,6 @@ paths:
                                 $ref: "#/components/schemas/Subscription"
                 default:
                     $ref: "#/components/responses/Error"
-
     /environments/{envId}/apis/{apiId}/subscriptions/{subscriptionId}/_pause:
         parameters:
             - $ref: "#/components/parameters/envIdParam"
@@ -1143,7 +1139,6 @@ paths:
                                 $ref: "#/components/schemas/Subscription"
                 default:
                     $ref: "#/components/responses/Error"
-
     /environments/{envId}/apis/{apiId}/subscriptions/{subscriptionId}/_resume:
         parameters:
             - $ref: "#/components/parameters/envIdParam"
@@ -1167,7 +1162,6 @@ paths:
                                 $ref: "#/components/schemas/Subscription"
                 default:
                     $ref: "#/components/responses/Error"
-
     /environments/{envId}/apis/{apiId}/subscriptions/{subscriptionId}/_accept:
         parameters:
             - $ref: "#/components/parameters/envIdParam"
@@ -1197,7 +1191,6 @@ paths:
                                 $ref: "#/components/schemas/Subscription"
                 default:
                     $ref: "#/components/responses/Error"
-
     /environments/{envId}/apis/{apiId}/subscriptions/{subscriptionId}/_reject:
         parameters:
             - $ref: "#/components/parameters/envIdParam"
@@ -1227,7 +1220,6 @@ paths:
                                 $ref: "#/components/schemas/Subscription"
                 default:
                     $ref: "#/components/responses/Error"
-
     /environments/{envId}/apis/{apiId}/subscriptions/{subscriptionId}/_transfer:
         parameters:
             - $ref: "#/components/parameters/envIdParam"
@@ -1278,7 +1270,6 @@ paths:
                     $ref: "#/components/responses/SubscriptionApiKeysResponse"
                 default:
                     $ref: "#/components/responses/Error"
-
     /environments/{envId}/apis/{apiId}/subscriptions/{subscriptionId}/api-keys/_renew:
         parameters:
             - $ref: "#/components/parameters/envIdParam"
@@ -1309,7 +1300,6 @@ paths:
                                 $ref: "#/components/schemas/ApiKey"
                 default:
                     $ref: "#/components/responses/Error"
-
     /environments/{envId}/apis/{apiId}/subscriptions/{subscriptionId}/api-keys/{apiKeyId}:
         parameters:
             - $ref: "#/components/parameters/envIdParam"
@@ -1340,7 +1330,6 @@ paths:
                                 $ref: "#/components/schemas/ApiKey"
                 default:
                     $ref: "#/components/responses/Error"
-
     /environments/{envId}/apis/{apiId}/subscriptions/{subscriptionId}/api-keys/{apiKeyId}/_revoke:
         parameters:
             - $ref: "#/components/parameters/envIdParam"
@@ -1366,7 +1355,6 @@ paths:
                                 $ref: "#/components/schemas/ApiKey"
                 default:
                     $ref: "#/components/responses/Error"
-
     /environments/{envId}/apis/{apiId}/subscriptions/{subscriptionId}/api-keys/{apiKeyId}/_reactivate:
         parameters:
             - $ref: "#/components/parameters/envIdParam"
@@ -1618,6 +1606,17 @@ paths:
         parameters:
             - $ref: "#/components/parameters/entrypointIdParam"
         get:
+            parameters:
+                - name: display
+                  in: query
+                  description: Display the schema in a specific format..
+                  required: false
+                  schema:
+                      type: string
+                      default: gio-form-json-schema
+                      enum:
+                          - gv-schema-form
+                          - gio-form-json-schema
             tags:
                 - Plugins - Entrypoints
             summary: Get an entrypoint subscription schema
@@ -1700,6 +1699,17 @@ paths:
         parameters:
             - $ref: "#/components/parameters/policyIdParam"
         get:
+            parameters:
+                - name: display
+                  in: query
+                  description: Display the schema in a specific format..
+                  required: false
+                  schema:
+                      type: string
+                      default: gio-form-json-schema
+                      enum:
+                          - gv-schema-form
+                          - gio-form-json-schema
             tags:
                 - Plugins - Policies
             summary: Get a policy schema

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/plugin/EntrypointsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/plugin/EntrypointsResourceTest.java
@@ -26,6 +26,7 @@ import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.rest.api.management.v2.rest.model.ConnectorPlugin;
 import io.gravitee.rest.api.management.v2.rest.model.Error;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.platform.plugin.SchemaDisplayFormat;
 import io.gravitee.rest.api.model.v4.connector.ConnectorPluginEntity;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.PluginNotFoundException;
@@ -193,6 +194,28 @@ public class EntrypointsResourceTest extends AbstractResourceTest {
         when(entrypointConnectorPluginService.getSubscriptionSchema(FAKE_ENTRYPOINT_ID)).thenReturn("subscriptionSchemaResponse");
 
         final Response response = rootTarget(FAKE_ENTRYPOINT_ID).path("subscription-schema").request().get();
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        final String result = response.readEntity(String.class);
+        Assertions.assertThat(result).isEqualTo("subscriptionSchemaResponse");
+    }
+
+    @Test
+    public void shouldGetEntrypointSubscriptionSchemaWithDisplay() {
+        ConnectorPluginEntity connectorPlugin = new ConnectorPluginEntity();
+        connectorPlugin.setId(FAKE_ENTRYPOINT_ID);
+        connectorPlugin.setName("Fake Entrypoint");
+        connectorPlugin.setVersion("1.0");
+        connectorPlugin.setSupportedApiType(ApiType.MESSAGE);
+        connectorPlugin.setSupportedModes(Set.of(ConnectorMode.SUBSCRIBE));
+        when(entrypointConnectorPluginService.findById(FAKE_ENTRYPOINT_ID)).thenReturn(connectorPlugin);
+        when(entrypointConnectorPluginService.getSubscriptionSchema(FAKE_ENTRYPOINT_ID, SchemaDisplayFormat.GV_SCHEMA_FORM))
+            .thenReturn("subscriptionSchemaResponse");
+
+        final Response response = rootTarget(FAKE_ENTRYPOINT_ID)
+            .path("subscription-schema")
+            .queryParam("display", "gv-schema-form")
+            .request()
+            .get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
         final String result = response.readEntity(String.class);
         Assertions.assertThat(result).isEqualTo("subscriptionSchemaResponse");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/plugin/PoliciesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/plugin/PoliciesResourceTest.java
@@ -25,6 +25,7 @@ import io.gravitee.rest.api.management.v2.rest.model.Error;
 import io.gravitee.rest.api.management.v2.rest.model.ExecutionPhase;
 import io.gravitee.rest.api.management.v2.rest.model.PolicyPlugin;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.platform.plugin.SchemaDisplayFormat;
 import io.gravitee.rest.api.model.v4.policy.PolicyPluginEntity;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.PluginNotFoundException;
@@ -91,6 +92,24 @@ public class PoliciesResourceTest extends AbstractResourceTest {
         when(policyPluginService.getSchema(FAKE_POLICY_ID)).thenReturn("schemaResponse");
 
         final Response response = rootTarget(FAKE_POLICY_ID).path("schema").request().get();
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        final String result = response.readEntity(String.class);
+        Assertions.assertThat(result).isEqualTo("schemaResponse");
+    }
+
+    @Test
+    public void shouldGetPolicySchemaWithDisplay() {
+        PolicyPluginEntity policyPlugin = new PolicyPluginEntity();
+        policyPlugin.setId(FAKE_POLICY_ID);
+        policyPlugin.setName("Fake Endpoint");
+        policyPlugin.setVersion("1.0");
+        policyPlugin.setIcon("my-icon");
+        policyPlugin.setCategory("my-category");
+        policyPlugin.setDescription("my-description");
+        when(policyPluginService.findById(FAKE_POLICY_ID)).thenReturn(policyPlugin);
+        when(policyPluginService.getSchema(FAKE_POLICY_ID, SchemaDisplayFormat.GV_SCHEMA_FORM)).thenReturn("schemaResponse");
+
+        final Response response = rootTarget(FAKE_POLICY_ID).path("schema").queryParam("display", "gv-schema-form").request().get();
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
         final String result = response.readEntity(String.class);
         Assertions.assertThat(result).isEqualTo("schemaResponse");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PoliciesResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PoliciesResource.java
@@ -23,6 +23,7 @@ import io.gravitee.rest.api.model.PolicyEntity;
 import io.gravitee.rest.api.model.PolicyListItem;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.model.platform.plugin.SchemaDisplayFormat;
 import io.gravitee.rest.api.service.PolicyService;
 import io.gravitee.rest.api.service.impl.swagger.policy.PolicyOperationVisitorManager;
 import io.swagger.v3.oas.annotations.Operation;
@@ -73,7 +74,12 @@ public class PoliciesResource {
             for (String s : expand) {
                 switch (s) {
                     case "schema":
-                        stream = stream.peek(policyListItem -> policyListItem.setSchema(policyService.getSchema(policyListItem.getId())));
+                        stream =
+                            stream.peek(policyListItem ->
+                                policyListItem.setSchema(
+                                    policyService.getSchema(policyListItem.getId(), SchemaDisplayFormat.GV_SCHEMA_FORM)
+                                )
+                            );
                     case "icon":
                         stream = stream.peek(policyListItem -> policyListItem.setIcon(policyService.getIcon(policyListItem.getId())));
                     default:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PolicyResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PolicyResource.java
@@ -21,6 +21,7 @@ import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.model.PolicyEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.model.platform.plugin.SchemaDisplayFormat;
 import io.gravitee.rest.api.service.PolicyService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -63,7 +64,7 @@ public class PolicyResource {
         // Check that the policy exists
         policyService.findById(policy);
 
-        return policyService.getSchema(policy);
+        return policyService.getSchema(policy, SchemaDisplayFormat.GV_SCHEMA_FORM);
     }
 
     @GET

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PoliciesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PoliciesResourceTest.java
@@ -17,10 +17,12 @@ package io.gravitee.rest.api.management.rest.resource;
 
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.model.PolicyEntity;
+import io.gravitee.rest.api.model.platform.plugin.SchemaDisplayFormat;
 import jakarta.ws.rs.core.Response;
 import java.util.Collections;
 import java.util.HashSet;
@@ -79,7 +81,7 @@ public class PoliciesResourceTest extends AbstractResourceTest {
         policyEntity.setId("my-api");
 
         when(policyService.findAll(null)).thenReturn(policyEntities);
-        when(policyService.getSchema(any())).thenReturn("policy schema");
+        when(policyService.getSchema(any(), eq(SchemaDisplayFormat.GV_SCHEMA_FORM))).thenReturn("policy schema");
 
         final Response response = envTarget().queryParam("expand", "schema").request().get();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/platform/plugin/SchemaDisplayFormat.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/platform/plugin/SchemaDisplayFormat.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.platform.plugin;
+
+import java.util.Map;
+
+public enum SchemaDisplayFormat {
+    GV_SCHEMA_FORM("gv-schema-form"),
+    GIO_FORM_JSON_SCHEMA("gio-form-json-schema");
+
+    private static final Map<String, SchemaDisplayFormat> BY_LABEL = Map.of(
+        GV_SCHEMA_FORM.label,
+        GV_SCHEMA_FORM,
+        GIO_FORM_JSON_SCHEMA.label,
+        GIO_FORM_JSON_SCHEMA
+    );
+
+    private final String label;
+
+    SchemaDisplayFormat(String label) {
+        this.label = label;
+    }
+
+    public static SchemaDisplayFormat fromLabel(final String label) {
+        return BY_LABEL.getOrDefault(label, GIO_FORM_JSON_SCHEMA);
+    }
+
+    public String getLabel() {
+        return label;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/v4/entrypoint/EntrypointsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/v4/entrypoint/EntrypointsResource.java
@@ -16,27 +16,18 @@
 package io.gravitee.rest.api.portal.rest.resource.v4.entrypoint;
 
 import io.gravitee.common.http.MediaType;
-import io.gravitee.rest.api.model.ConnectorListItem;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.model.platform.plugin.SchemaDisplayFormat;
 import io.gravitee.rest.api.model.v4.connector.ConnectorExpandPluginEntity;
 import io.gravitee.rest.api.portal.rest.resource.v4.connector.AbstractConnectorsResource;
 import io.gravitee.rest.api.portal.rest.security.Permission;
 import io.gravitee.rest.api.portal.rest.security.Permissions;
 import io.gravitee.rest.api.service.v4.EntrypointConnectorPluginService;
-import io.swagger.annotations.ApiParam;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.ArraySchema;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.container.ResourceContext;
-import jakarta.ws.rs.core.Context;
 import java.util.Collection;
 import java.util.List;
 
@@ -46,41 +37,22 @@ import java.util.List;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Tag(name = "🧪 V4 - Entrypoints")
 public class EntrypointsResource extends AbstractConnectorsResource {
-
-    @Context
-    private ResourceContext resourceContext;
 
     @Inject
     private EntrypointConnectorPluginService entrypointService;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(
-        summary = "🧪 List entrypoint plugins",
-        description = "⚠️ This resource is in alpha version. This implies that it is likely to be modified or even removed in future versions. ⚠️. <br><br>User must have the ENVIRONMENT_API[READ] permission to use this service"
-    )
-    @ApiResponse(
-        responseCode = "200",
-        description = "List of entrypoints",
-        content = @Content(
-            mediaType = MediaType.APPLICATION_JSON,
-            array = @ArraySchema(schema = @Schema(implementation = ConnectorListItem.class))
-        )
-    )
-    @ApiResponse(responseCode = "500", description = "Internal server error")
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = RolePermissionAction.READ) })
-    public Collection<ConnectorExpandPluginEntity> getEntrypoints(
-        @QueryParam("expand") @ApiParam(
-            name = "expand",
-            allowableValues = "schema, icon, subscriptionSchema",
-            allowMultiple = true
-        ) List<String> expands
-    ) {
+    public Collection<ConnectorExpandPluginEntity> getEntrypoints(@QueryParam("expand") List<String> expands) {
         final Collection<ConnectorExpandPluginEntity> connectors = super.expand(entrypointService.findAll(), expands);
         if (expands != null && expands.contains("subscriptionSchema")) {
-            connectors.forEach(connector -> connector.setSubscriptionSchema(entrypointService.getSubscriptionSchema(connector.getId())));
+            connectors.forEach(connector ->
+                connector.setSubscriptionSchema(
+                    entrypointService.getSubscriptionSchema(connector.getId(), SchemaDisplayFormat.GV_SCHEMA_FORM)
+                )
+            );
         }
         return connectors;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/PolicyService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/PolicyService.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.service;
 import io.gravitee.definition.model.Policy;
 import io.gravitee.definition.model.flow.Step;
 import io.gravitee.rest.api.model.PolicyEntity;
+import io.gravitee.rest.api.model.platform.plugin.SchemaDisplayFormat;
 import java.util.Set;
 
 /**
@@ -32,4 +33,6 @@ public interface PolicyService extends PluginService<PolicyEntity> {
     void validatePolicyConfiguration(Step step);
 
     Set<PolicyEntity> findAll(Boolean withResource);
+
+    String getSchema(String plugin, SchemaDisplayFormat schemaDisplayFormat);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PolicyServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PolicyServiceImpl.java
@@ -33,8 +33,10 @@ import io.gravitee.policy.api.annotations.RequireResource;
 import io.gravitee.rest.api.model.PluginEntity;
 import io.gravitee.rest.api.model.PolicyDevelopmentEntity;
 import io.gravitee.rest.api.model.PolicyEntity;
+import io.gravitee.rest.api.model.platform.plugin.SchemaDisplayFormat;
 import io.gravitee.rest.api.service.JsonSchemaService;
 import io.gravitee.rest.api.service.PolicyService;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
@@ -106,6 +108,19 @@ public class PolicyServiceImpl extends AbstractPluginService<PolicyPlugin<?>, Po
         if (policy != null) {
             policy.setConfiguration(validatePolicyConfiguration(policy.getName(), policy.getConfiguration()));
         }
+    }
+
+    @Override
+    public String getSchema(String pluginId, SchemaDisplayFormat schemaDisplayFormat) {
+        if (schemaDisplayFormat == SchemaDisplayFormat.GV_SCHEMA_FORM) {
+            try {
+                logger.debug("Find plugin schema for format {} by ID: {}", schemaDisplayFormat, pluginId);
+                return pluginManager.getSchema(pluginId, "display-gv-schema-form", true);
+            } catch (IOException ioex) {
+                logger.debug("No specific schema-form exists for this display format. Fall back on default schema-form.");
+            }
+        }
+        return getSchema(pluginId);
     }
 
     private PolicyEntity convert(PolicyPlugin policyPlugin, Boolean withPlugin) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/EntrypointConnectorPluginService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/EntrypointConnectorPluginService.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.rest.api.service.v4;
 
+import io.gravitee.rest.api.model.platform.plugin.SchemaDisplayFormat;
+
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
@@ -25,7 +27,17 @@ public interface EntrypointConnectorPluginService extends ConnectorPluginService
      * @param connectorId is the id of the entrypoint
      * @return the subscription schema as a string, else {@code null}
      */
-    String getSubscriptionSchema(String connectorId);
+    default String getSubscriptionSchema(String connectorId) {
+        return getSubscriptionSchema(connectorId, null);
+    }
+
+    /**
+     * Retrieve the subscription schema of the entrypoint if it exists.
+     * @param connectorId is the id of the entrypoint
+     * @param schemaDisplayFormat is the format of the schema to return. Can be "gv-schema-form" or empty for default format.
+     * @return the subscription schema as a string, else {@code null}
+     */
+    String getSubscriptionSchema(String connectorId, final SchemaDisplayFormat schemaDisplayFormat);
 
     String validateEntrypointSubscriptionConfiguration(final String entrypointId, final String configuration);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PolicyPluginService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/PolicyPluginService.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.service.v4;
 
+import io.gravitee.rest.api.model.platform.plugin.SchemaDisplayFormat;
 import io.gravitee.rest.api.model.v4.policy.PolicyPluginEntity;
 import io.gravitee.rest.api.service.PluginService;
 import java.util.Set;
@@ -35,4 +36,12 @@ public interface PolicyPluginService extends PluginService<PolicyPluginEntity> {
      * @return the validated configuration
      */
     String validatePolicyConfiguration(final PolicyPluginEntity policyPluginEntity, final String configuration);
+
+    /**
+     * Get the schema form for the given policy plugin
+     * @param policyPluginId is the id of the policy
+     * @param schemaDisplayFormat the format of the schema to return
+     * @return the configuration schema form
+     */
+    String getSchema(final String policyPluginId, SchemaDisplayFormat schemaDisplayFormat);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/EntrypointConnectorPluginServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/EntrypointConnectorPluginServiceImpl.java
@@ -21,6 +21,7 @@ import io.gravitee.gateway.reactive.api.connector.ConnectorFactory;
 import io.gravitee.plugin.core.api.ConfigurablePluginManager;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPluginManager;
+import io.gravitee.rest.api.model.platform.plugin.SchemaDisplayFormat;
 import io.gravitee.rest.api.service.JsonSchemaService;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.v4.EntrypointConnectorPluginService;
@@ -49,7 +50,15 @@ public class EntrypointConnectorPluginServiceImpl
     }
 
     @Override
-    public String getSubscriptionSchema(final String connectorId) {
+    public String getSubscriptionSchema(final String connectorId, final SchemaDisplayFormat schemaDisplayFormat) {
+        if (schemaDisplayFormat == SchemaDisplayFormat.GV_SCHEMA_FORM) {
+            try {
+                logger.debug("Find entrypoint subscription schema for format {} by ID: {}", schemaDisplayFormat, connectorId);
+                return pluginManager.getSchema(connectorId, "subscriptions/display-gv-schema-form", true);
+            } catch (IOException ioex) {
+                logger.debug("No specific schema-form exists for this display format. Fall back on default schema-form.");
+            }
+        }
         try {
             logger.debug("Find entrypoint subscription schema by ID: {}", connectorId);
             return ((EntrypointConnectorPluginManager) pluginManager).getSubscriptionSchema(connectorId, true);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PolicyPluginServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PolicyPluginServiceImpl.java
@@ -18,11 +18,13 @@ package io.gravitee.rest.api.service.v4.impl;
 import io.gravitee.plugin.core.api.ConfigurablePluginManager;
 import io.gravitee.plugin.core.api.Plugin;
 import io.gravitee.plugin.policy.PolicyPlugin;
+import io.gravitee.rest.api.model.platform.plugin.SchemaDisplayFormat;
 import io.gravitee.rest.api.model.v4.policy.ExecutionPhase;
 import io.gravitee.rest.api.model.v4.policy.PolicyPluginEntity;
 import io.gravitee.rest.api.service.JsonSchemaService;
 import io.gravitee.rest.api.service.impl.AbstractPluginService;
 import io.gravitee.rest.api.service.v4.PolicyPluginService;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -95,5 +97,18 @@ public class PolicyPluginServiceImpl extends AbstractPluginService<PolicyPlugin<
     @Override
     public String validatePolicyConfiguration(final PolicyPluginEntity policyPluginEntity, final String configuration) {
         return validateConfiguration(policyPluginEntity.getId(), configuration);
+    }
+
+    @Override
+    public String getSchema(String policyPluginId, SchemaDisplayFormat schemaDisplayFormat) {
+        if (schemaDisplayFormat == SchemaDisplayFormat.GV_SCHEMA_FORM) {
+            try {
+                logger.debug("Find plugin schema for format {} by ID: {}", schemaDisplayFormat, policyPluginId);
+                return pluginManager.getSchema(policyPluginId, "display-gv-schema-form", true);
+            } catch (IOException ioex) {
+                logger.debug("No specific schema-form exists for this display format. Fall back on default schema-form.");
+            }
+        }
+        return getSchema(policyPluginId);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PolicyServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PolicyServiceTest.java
@@ -30,8 +30,10 @@ import io.gravitee.plugin.policy.PolicyPlugin;
 import io.gravitee.policy.api.annotations.OnRequest;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.rest.api.model.PolicyEntity;
+import io.gravitee.rest.api.model.platform.plugin.SchemaDisplayFormat;
 import io.gravitee.rest.api.service.JsonSchemaService;
 import io.gravitee.rest.api.service.exceptions.InvalidDataException;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Set;
@@ -169,5 +171,22 @@ public class PolicyServiceTest {
     @Test
     public void shouldAcceptNullStep() {
         policyService.validatePolicyConfiguration((Step) null);
+    }
+
+    @Test
+    public void shouldGetGvSchemaForm() throws IOException {
+        when(policyManager.getSchema("my-policy", "display-gv-schema-form", true)).thenReturn("gv-schema-form-config");
+
+        String schema = policyService.getSchema("my-policy", SchemaDisplayFormat.GV_SCHEMA_FORM);
+        assertEquals("gv-schema-form-config", schema);
+    }
+
+    @Test
+    public void shouldGetDefaultSchemaForm() throws IOException {
+        when(policyManager.getSchema("my-policy", "display-gv-schema-form", true)).thenThrow(new IOException());
+        when(policyManager.getSchema("my-policy", true)).thenReturn("default-configuration");
+
+        String schema = policyService.getSchema("my-policy", SchemaDisplayFormat.GV_SCHEMA_FORM);
+        assertEquals("default-configuration", schema);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/EntrypointConnectorPluginServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/EntrypointConnectorPluginServiceImplTest.java
@@ -29,6 +29,7 @@ import io.gravitee.gateway.reactive.api.context.DeploymentContext;
 import io.gravitee.plugin.core.api.PluginManifest;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPluginManager;
+import io.gravitee.rest.api.model.platform.plugin.SchemaDisplayFormat;
 import io.gravitee.rest.api.service.JsonSchemaService;
 import io.gravitee.rest.api.service.exceptions.PluginNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
@@ -85,6 +86,25 @@ public class EntrypointConnectorPluginServiceImplTest {
             assertThat(e.getMessage())
                 .isEqualTo("An error occurs while trying to get entrypoint subscription schema for plugin " + CONNECTOR_ID);
         }
+    }
+
+    @Test
+    public void shouldGetSubscriptionSchemaForGvSchemaForm() throws IOException {
+        when(pluginManager.getSchema(CONNECTOR_ID, "subscriptions/display-gv-schema-form", true)).thenReturn("subscriptionConfiguration");
+
+        String result = cut.getSubscriptionSchema(CONNECTOR_ID, SchemaDisplayFormat.GV_SCHEMA_FORM);
+
+        assertThat(result).isEqualTo("subscriptionConfiguration");
+    }
+
+    @Test
+    public void shouldGetDefaultSubscriptionSchemaIfNoGvSchemaForm() throws IOException {
+        when(pluginManager.getSchema(CONNECTOR_ID, "subscriptions/display-gv-schema-form", true)).thenThrow(new IOException());
+        when(pluginManager.getSubscriptionSchema(CONNECTOR_ID, true)).thenReturn("subscriptionConfiguration");
+
+        String result = cut.getSubscriptionSchema(CONNECTOR_ID, SchemaDisplayFormat.GV_SCHEMA_FORM);
+
+        assertThat(result).isEqualTo("subscriptionConfiguration");
     }
 
     @Test(expected = PluginNotFoundException.class)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PolicyPluginServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PolicyPluginServiceImplTest.java
@@ -24,6 +24,7 @@ import io.gravitee.plugin.core.api.ConfigurablePluginManager;
 import io.gravitee.plugin.core.api.PluginManifest;
 import io.gravitee.plugin.policy.PolicyPlugin;
 import io.gravitee.rest.api.model.platform.plugin.PlatformPluginEntity;
+import io.gravitee.rest.api.model.platform.plugin.SchemaDisplayFormat;
 import io.gravitee.rest.api.model.v4.policy.ExecutionPhase;
 import io.gravitee.rest.api.model.v4.policy.PolicyPluginEntity;
 import io.gravitee.rest.api.service.JsonSchemaService;
@@ -128,5 +129,22 @@ public class PolicyPluginServiceImplTest {
         assertEquals(PLUGIN_ID, policyPlugin.getId());
         assertEquals(Set.of(ExecutionPhase.REQUEST), policyPlugin.getProxy());
         assertEquals(Set.of(ExecutionPhase.MESSAGE_REQUEST), policyPlugin.getMessage());
+    }
+
+    @Test
+    public void shouldGetGvSchemaForm() throws IOException {
+        when(pluginManager.getSchema("my-policy", "display-gv-schema-form", true)).thenReturn("gv-schema-form-config");
+
+        String schema = cut.getSchema("my-policy", SchemaDisplayFormat.GV_SCHEMA_FORM);
+        assertEquals("gv-schema-form-config", schema);
+    }
+
+    @Test
+    public void shouldGetDefaultSchemaForm() throws IOException {
+        when(pluginManager.getSchema("my-policy", "display-gv-schema-form", true)).thenThrow(new IOException());
+        when(pluginManager.getSchema("my-policy", true)).thenReturn("default-configuration");
+
+        String schema = cut.getSchema("my-policy", SchemaDisplayFormat.GV_SCHEMA_FORM);
+        assertEquals("default-configuration", schema);
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2013

## Description

We rely on schema-form.json files that describe which fields are available to configure plugins. This schema form is parsed by some tools to build a form in Console and Portal.
But we use 2 different tools that don't use the same format for the schema-form.json.

Even if for most of our policies, we can found a schema-form that can be read by both tools, for a few of them (and also for the subscription schema of the webhook entrypoint) we need to have 2 different schema-form files.

This PR adds the possibility to load a specific schema form, based on a "display" parameter.

For portal API and MAPI v1, we force the usage of GV_SCHEMA_FORM, which is the LitElement component used to display the configuration form.
For MAPI v2, we can use a "display" query param to choose between GV_SCHEMA_FORM and GIO_FORM_JSON_SCHEMA. By default, GIO_FORM_JSON_SCHEMA will be used.

Finally, if the plugin doesn't declare a specific schema-form, then the default one will be returned.

The plugin structure has to be this one:
For a policy:
```
/schemas
|- schema-form.json
|- /display-gv-schema-form
     |- schema-form.json
```

For entrypoint with a subscription schema:
```
/schemas
|- schema-form.json
|- /subscriptions
    |- schema-form.json
    |- /display-gv-schema-form
        |- schema-form.json
```