### PR TITLE
Apim 1405 add reject dialog

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/api-portal-subscriptions.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/api-portal-subscriptions.module.ts
@@ -40,6 +40,7 @@ import { ApiPortalSubscriptionListComponent } from './list/api-portal-subscripti
 import { ApiPortalSubscriptionChangeEndDateDialogComponent } from './components/change-end-date-dialog/api-portal-subscription-change-end-date-dialog.component';
 import { ApiPortalSubscriptionValidateDialogComponent } from './components/validate-dialog/api-portal-subscription-validate-dialog.component';
 import { ApiKeyValidationComponent } from './components/api-key-validation/api-key-validation.component';
+import { ApiPortalSubscriptionRejectDialogComponent } from './components/reject-dialog/api-portal-subscription-reject-dialog.component';
 
 import { GioTableWrapperModule } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
 import { GioPermissionModule } from '../../../../shared/components/gio-permission/gio-permission.module';
@@ -48,10 +49,11 @@ import { GioPermissionModule } from '../../../../shared/components/gio-permissio
   declarations: [
     ApiPortalSubscriptionEditComponent,
     ApiPortalSubscriptionListComponent,
-    ApiPortalSubscriptionValidateDialogComponent,
     ApiPortalSubscriptionChangeEndDateDialogComponent,
     ApiPortalSubscriptionCreationDialogComponent,
     ApiPortalSubscriptionTransferDialogComponent,
+    ApiPortalSubscriptionRejectDialogComponent,
+    ApiPortalSubscriptionValidateDialogComponent,
 
     ApiKeyValidationComponent,
   ],

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/change-end-date-dialog/api-portal-subscription-change-end-date-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/change-end-date-dialog/api-portal-subscription-change-end-date-dialog.component.scss
@@ -16,3 +16,7 @@
     color: mat.get-color-from-palette(gio.$mat-error-palette, 'default');
   }
 }
+
+.actions {
+  justify-content: flex-end;
+}

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/creation-dialog/api-portal-subscription-creation-dialog.component.scss
@@ -14,3 +14,7 @@
     }
   }
 }
+
+.actions {
+  justify-content: flex-end;
+}

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/reject-dialog/api-portal-subscription-reject-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/reject-dialog/api-portal-subscription-reject-dialog.component.html
@@ -1,0 +1,42 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h2 matDialogTitle>Reject your subscription</h2>
+
+<form [formGroup]="form">
+  <mat-dialog-content class="reject-subscription__content">
+    <div class="mat-body-1">Explain the reason for the rejection</div>
+    <div class="reject-subscription__reason">
+      <mat-form-field appearance="outline" class="reject-subscription__reason__input">
+        <input matInput formControlName="reason" />
+      </mat-form-field>
+    </div>
+  </mat-dialog-content>
+  <mat-dialog-actions class="actions">
+    <button mat-flat-button [mat-dialog-close]="undefined">Cancel</button>
+    <button
+      color="primary"
+      type="submit"
+      mat-raised-button
+      aria-label="Reject the subscription"
+      (click)="onClose()"
+      [disabled]="form.invalid"
+    >
+      Reject
+    </button>
+  </mat-dialog-actions>
+</form>

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/reject-dialog/api-portal-subscription-reject-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/reject-dialog/api-portal-subscription-reject-dialog.component.scss
@@ -1,0 +1,17 @@
+.reject-subscription {
+  &__content {
+    display: flex;
+    gap: 8px;
+    flex-direction: column;
+  }
+  &__reason {
+    display: flex;
+    &__input {
+      flex: 1 1 100%;
+    }
+  }
+}
+
+.actions {
+  justify-content: flex-end;
+}

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/reject-dialog/api-portal-subscription-reject-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/reject-dialog/api-portal-subscription-reject-dialog.component.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, OnInit } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+import { FormControl, FormGroup } from '@angular/forms';
+
+export interface ApiPortalSubscriptionRejectDialogResult {
+  reason?: string;
+}
+@Component({
+  selector: 'api-portal-subscription-reject-dialog',
+  template: require('./api-portal-subscription-reject-dialog.component.html'),
+  styles: [require('./api-portal-subscription-reject-dialog.component.scss')],
+})
+export class ApiPortalSubscriptionRejectDialogComponent implements OnInit {
+  form: FormGroup;
+  constructor(
+    private readonly dialogRef: MatDialogRef<ApiPortalSubscriptionRejectDialogComponent, ApiPortalSubscriptionRejectDialogResult>,
+  ) {}
+
+  ngOnInit() {
+    this.form = new FormGroup({
+      reason: new FormControl(''),
+    });
+  }
+
+  onClose() {
+    this.dialogRef.close({ reason: this.form.getRawValue().reason });
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/transfer-dialog/api-portal-subscription-transfer-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/transfer-dialog/api-portal-subscription-transfer-dialog.component.scss
@@ -12,3 +12,7 @@
     gap: 8px;
   }
 }
+
+.actions {
+  justify-content: flex-end;
+}

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/validate-dialog/api-portal-subscription-validate-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/validate-dialog/api-portal-subscription-validate-dialog.component.scss
@@ -15,3 +15,7 @@
     }
   }
 }
+
+.actions {
+  justify-content: flex-end;
+}

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.ts
@@ -19,7 +19,7 @@ import { switchMap, takeUntil, tap } from 'rxjs/operators';
 import { StateService } from '@uirouter/core';
 import { DatePipe } from '@angular/common';
 import { MatDialog } from '@angular/material/dialog';
-import { GioConfirmDialogComponent, GioConfirmDialogData } from '@gravitee/ui-particles-angular';
+import { GIO_DIALOG_WIDTH, GioConfirmDialogComponent, GioConfirmDialogData } from '@gravitee/ui-particles-angular';
 
 import {
   PlanMode,
@@ -195,7 +195,7 @@ export class ApiPortalSubscriptionEditComponent implements OnInit {
         ApiPortalSubscriptionTransferDialogData,
         ApiPortalSubscriptionTransferDialogResult
       >(ApiPortalSubscriptionTransferDialogComponent, {
-        width: '500px',
+        width: GIO_DIALOG_WIDTH.MEDIUM,
         data: {
           apiId: this.apiId,
           securityType: this.subscription.plan.securityType,
@@ -292,7 +292,7 @@ export class ApiPortalSubscriptionEditComponent implements OnInit {
         ApiPortalSubscriptionChangeEndDateDialogData,
         ApiPortalSubscriptionChangeEndDateDialogResult
       >(ApiPortalSubscriptionChangeEndDateDialogComponent, {
-        width: '500px',
+        width: GIO_DIALOG_WIDTH.MEDIUM,
         data: {
           currentEndDate: this.deserializeDate(this.subscription.endingAt),
           applicationName: this.subscription.application.name,

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.ts
@@ -48,6 +48,10 @@ import {
   ApiPortalSubscriptionAcceptDialogResult,
 } from '../components/validate-dialog/api-portal-subscription-validate-dialog.component';
 import { Constants } from '../../../../../entities/Constants';
+import {
+  ApiPortalSubscriptionRejectDialogComponent,
+  ApiPortalSubscriptionRejectDialogResult,
+} from '../components/reject-dialog/api-portal-subscription-reject-dialog.component';
 
 interface SubscriptionDetailVM {
   id: string;
@@ -185,7 +189,28 @@ export class ApiPortalSubscriptionEditComponent implements OnInit {
   }
 
   rejectSubscription() {
-    // Do nothing for now
+    this.matDialog
+      .open<ApiPortalSubscriptionRejectDialogComponent, unknown, ApiPortalSubscriptionRejectDialogResult>(
+        ApiPortalSubscriptionRejectDialogComponent,
+        {
+          width: GIO_DIALOG_WIDTH.MEDIUM,
+          data: {},
+          role: 'alertdialog',
+          id: 'rejectSubscriptionDialog',
+        },
+      )
+      .afterClosed()
+      .pipe(
+        switchMap((result) => (result ? this.apiSubscriptionService.reject(this.subscription.id, this.apiId, result.reason) : EMPTY)),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe(
+        (_) => {
+          this.snackBarService.success(`Subscription rejected`);
+          this.ngOnInit();
+        },
+        (err) => this.snackBarService.error(err.message),
+      );
   }
 
   transferSubscription() {

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.harness.ts
@@ -146,6 +146,10 @@ export class ApiPortalSubscriptionEditHarness extends ComponentHarness {
     return this.btnIsVisible('Reject subscription');
   }
 
+  public async openRejectDialog(): Promise<void> {
+    return this.getBtnByText('Reject subscription').then((btn) => btn.click());
+  }
+
   private async btnIsVisible(text: string): Promise<boolean> {
     return this.isVisible(this.getBtnByText(text));
   }

--- a/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.spec.ts
@@ -296,4 +296,24 @@ describe('ApiSubscriptionV2Service', () => {
       req.flush(subscription);
     });
   });
+
+  describe('reject', () => {
+    const SUBSCRIPTION_ID = 'my-subscription';
+    it('should call API', (done) => {
+      const subscription = fakeSubscription({ id: SUBSCRIPTION_ID });
+      const reason = 'a very good reason';
+      apiSubscriptionV2Service.reject(SUBSCRIPTION_ID, API_ID, reason).subscribe((response) => {
+        expect(response).toEqual(subscription);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/subscriptions/${SUBSCRIPTION_ID}/_reject`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual({ reason: reason });
+
+      req.flush(subscription);
+    });
+  });
 });

--- a/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.ts
@@ -97,4 +97,10 @@ export class ApiSubscriptionV2Service {
       acceptSubscription,
     );
   }
+
+  reject(subscriptionId: string, apiId: string, reason: string): Observable<Subscription> {
+    return this.http.post<Subscription>(`${this.constants.env.v2BaseURL}/apis/${apiId}/subscriptions/${subscriptionId}/_reject`, {
+      reason,
+    });
+  }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1405

## Description

- Small css change to make all dialog actions on the right
- Add dialog for rejecting a subscription

Valid with reason:
![Screen Shot 2023-06-28 at 16 07 14](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/aa16162c-bc8c-472d-9232-f8daadd84c18)

Valid without reason specified: 
![Screen Shot 2023-06-28 at 16 06 56](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/beb1c592-0ea8-4a84-8a2d-7382f68b0786)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-oaqhslcsps.chromatic.com)
<!-- Storybook placeholder end -->
