### PR TITLE
Archi 253 plugin override

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -64,9 +64,7 @@
 #  path:
 #    - ${gravitee.home}/plugins
 #    - ${gravitee.home}/my-custom-plugins
-
-# If a plugin is already installed (but with a different version), management node does not start anymore
-#  failOnDuplicate: true
+# note that for a given plugin a more recent zip file will take precedence regardless its manifest version
 
 # Management repository is used to store global configuration such as APIs, applications, apikeys, ...
 # If you use a JDBC repository, we recommend disabling liquibase scripts execution by the Gateway. Let the Management API do it.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -108,8 +108,7 @@ http:
 #  path:
 #    - ${gravitee.home}/plugins
 #    - ${gravitee.home}/my-custom-plugins
-# If a external is already installed (but with a different version), management node does not start anymore
-#  failOnDuplicate: true
+# note that for a given plugin a more recent zip file will take precedence regardless its manifest version
 
 # Management repository is used to store global configuration such as APIs, applications, apikeys, ...
 # This is the default configuration using MongoDB (single server)

--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -6,6 +6,7 @@ This file documents all notable changes to [Gravitee.io API Management 3.x](http
 ### 4.0.0
 
 - Remove old and unused `cache.type` from gateway config map
+- Remove `api.removePlugins` & `gateway.removePlugins` as the platform allows plugin override now, only `additionalPlugins`  is necessary.
 
 ### 3.20.12
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -25,4 +25,5 @@ annotations:
     - Remove old and unused `cache.type` from gateway config map
     - Fix resources missing in ui-deployment.yaml
     - Change readinessProbe for the gateway to sync-process
-    - Update Elasticsearch version: 4.0.0-alpha.2
+    - Update Elasticsearch version
+    - Allow plugin override via {api|gatewaye}.additionalPlugins property

--- a/helm/README.md
+++ b/helm/README.md
@@ -184,7 +184,7 @@ See [MongoDB replicaset](https://artifacthub.io/packages/helm/bitnami/mongodb) f
 | `es.tls.keystore.certs`      | Elasticsearch TLS certs (only pems)               | `null`                                                                 |
 | `es.tls.keystore.keys`       | Elasticsearch TLS keys (only pems)                | `null`                                                                 |
 | `es.index`                   | Elasticsearch index                               | `gravitee`                                                             |
-| `es.endpoints`               | Elasticsearch endpoint array                      | `[http://elastic-elasticsearch-client.default.svc.cluster.local:9200]` |
+| `es.endpoints`               | Elasticsearch endpoint array                      | `[http://graviteeio-apim-elasticsearch.default.svc.cluster.local:9200]` |
 | `es.pipeline.plugins.ingest` | Elasticsearch pipeline ingest plugins             | `geoip, user_agent`                                                    |
 
 ### Elasticsearch cluster
@@ -508,5 +508,5 @@ helm plugin install https://github.com/quintush/helm-unittest
 Inside `helm/` directory, run:
 
 ```shell
-helm unittest -3 -f 'tests/**/*.yaml' .
+helm unittest -f 'tests/**/*_test.yaml' .
 ```

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -97,13 +97,6 @@ Create initContainers for downloading plugins ext plugin-ext
     - name: graviteeio-apim-{{ $key }}-ext
       mountPath: /tmp/plugins-ext
 {{- end }}
-{{- if .pluginsToRemove }}
-- name: delete-plugins
-  {{- toYaml .initContainers | nindent 2 }}
-  command: ['sh', '-c', "cd /opt/{{ .appName }}/plugins {{- range $key := .pluginsToRemove -}}
-    {{ printf " && rm -f %s-*.zip" $key }}
-  {{- end -}}"]
-{{- end }}
 {{- end -}}
 
 {{/*

--- a/helm/templates/api/api-deployment.yaml
+++ b/helm/templates/api/api-deployment.yaml
@@ -108,7 +108,7 @@ spec:
         {{- $plugins = concat $plugins .Values.api.additionalPlugins -}}
       {{- end -}}
 
-      {{- $pluginParams := dict "plugins" $plugins "appName" "graviteeio-management-api" "pluginsToRemove" .Values.api.removePlugins "initContainers" $initContainers -}}
+      {{- $pluginParams := dict "plugins" $plugins "appName" "graviteeio-management-api" "initContainers" $initContainers -}}
       {{- if or .Values.api.extraInitContainers $plugins .Values.jdbc.driver }}
       initContainers:
         {{- if and .Values.jdbc.driver (eq .Values.management.type "jdbc") }}

--- a/helm/templates/api/api-upgrader-job.yaml
+++ b/helm/templates/api/api-upgrader-job.yaml
@@ -88,7 +88,7 @@ spec:
       {{- if .Values.api.additionalPlugins -}}
         {{- $plugins = concat $plugins .Values.api.additionalPlugins -}}
       {{- end -}}
-      {{- $pluginParams := dict "plugins" $plugins "appName" "graviteeio-management-api" "pluginsToRemove" .Values.api.removePlugins "initContainers" $initContainers -}}
+      {{- $pluginParams := dict "plugins" $plugins "appName" "graviteeio-management-api" "initContainers" $initContainers -}}
       {{- if or .Values.api.extraInitContainers $plugins .Values.jdbc.driver }}
       initContainers:
         {{- if and .Values.jdbc.driver (eq .Values.management.type "jdbc") }}

--- a/helm/templates/gateway/gateway-deployment.yaml
+++ b/helm/templates/gateway/gateway-deployment.yaml
@@ -105,7 +105,7 @@ spec:
         {{- $plugins = concat $plugins .Values.gateway.additionalPlugins -}}
       {{- end -}}
 
-      {{- $pluginParams := dict "plugins" $plugins "appName" "graviteeio-gateway" "pluginsToRemove" .Values.gateway.removePlugins "initContainers" $initContainers -}}
+      {{- $pluginParams := dict "plugins" $plugins "appName" "graviteeio-gateway" "initContainers" $initContainers -}}
       {{- if or .Values.gateway.extraInitContainers $plugins .Values.jdbc.driver }}
       initContainers:
         {{- if and .Values.jdbc.driver (eq .Values.management.type "jdbc") }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -288,7 +288,7 @@ es:
     #     - /path/to/key
     #     - /path/to/key2
   endpoints:
-    - http://graviteeio-apim-elasticsearch-data.default.svc.cluster.local:9200
+    - http://graviteeio-apim-elasticsearch.default.svc.cluster.local:9200
   pipeline:
     plugins:
       ingest: geoip, user_agent # geoip and user_agent plugins are enabled by default
@@ -488,8 +488,6 @@ api:
   #         key: SPECIAL_LEVEL
   additionalPlugins:
 #    - https://path_to_plugin
-  removePlugins:
-#    - filename_of_plugin_without_version_and_extension
   ssl:
     enabled: false
   #  keystore:
@@ -826,8 +824,7 @@ gateway:
 
   additionalPlugins:
 #    - https://path_to_plugin
-  removePlugins:
-#    - filename_of_plugin_without_version_and_extension
+
 
   ssl:
     enabled: false

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>4.0.0-alpha.4</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
-        <gravitee-plugin.version>2.0.0-alpha.4</gravitee-plugin.version>
+        <gravitee-plugin.version>2.0.0-alpha.5</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.3.0</gravitee-platform-repository-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>1.25.0</gravitee-reporter-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <gravitee-license-node.version>1.3.1</gravitee-license-node.version>
         <gravitee-node.version>4.0.0-alpha.4</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
-        <gravitee-plugin.version>2.0.0-alpha.5</gravitee-plugin.version>
+        <gravitee-plugin.version>2.0.0-alpha.6</gravitee-plugin.version>
         <gravitee-platform-repository-api.version>1.3.0</gravitee-platform-repository-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>1.25.0</gravitee-reporter-api.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-253

## Description

Plugin can be overridden given a simple rule, if a plugin has a duplicate (wherever it is) the most recent zip file is used.
The need of plugins.failOnDuplicate is no more, Helm's chart `removePlugins` feature is equally useless. 

## Additional context

Linked PR:  https://github.com/gravitee-io/gravitee-plugin/pull/109
ADR: https://gravitee.slab.com/posts/adr-016-allow-plugin-override-n6scxg1p
<!-- Environment placeholder -->

🏗️ Your changes can be tested here and will be available soon:
      Console: [https://4452.team-apim.gravitee.dev/console](https://4452.team-apim.gravitee.dev/console)
      Portal: [https://4452.team-apim.gravitee.dev/portal](https://4452.team-apim.gravitee.dev/portal)
      Management-api: [https://4452.team-apim.gravitee.dev/api/management](https://4452.team-apim.gravitee.dev/api/management)
      Gateway v4: [https://4452.team-apim.gravitee.dev](https://4452.team-apim.gravitee.dev)
      Gateway v3: [https://4452.gateway-v3.team-apim.gravitee.dev](https://4452.gateway-v3.team-apim.gravitee.dev)

<!-- Environment placeholder end -->
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-hgmzfrdtga.chromatic.com)
<!-- Storybook placeholder end -->
