### PR TITLE
refactor: filter message policies for legacy policy studio

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PolicyServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PolicyServiceImpl.java
@@ -44,6 +44,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -77,7 +78,13 @@ public class PolicyServiceImpl extends AbstractPluginService<PolicyPlugin<?>, Po
             policies = policies.filter(policyPlugin -> !policyPlugin.policy().isAnnotationPresent(RequireResource.class));
         }
 
-        return policies.map(policyDefinition -> convert(policyDefinition, true)).collect(Collectors.toSet());
+        return policies
+            .filter(policyPlugin ->
+                StringUtils.isEmpty(policyPlugin.manifest().properties().get("message")) ||
+                StringUtils.isNotEmpty(policyPlugin.manifest().properties().get("proxy"))
+            )
+            .map(policyDefinition -> convert(policyDefinition, true))
+            .collect(Collectors.toSet());
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PolicyServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PolicyServiceTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.service.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -36,6 +37,7 @@ import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
@@ -85,6 +87,42 @@ public class PolicyServiceTest {
         when(policyDefinition.id()).thenReturn(POLICY_ID);
         when(policyManager.findAll(true)).thenReturn(Collections.singletonList(policyDefinition));
         when(policyDefinition.manifest()).thenReturn(manifest);
+
+        final Set<PolicyEntity> policies = policyService.findAll();
+
+        assertNotNull(policies);
+        assertEquals(POLICY_ID, policies.iterator().next().getId());
+    }
+
+    @Test
+    public void shouldFilterMessagePolicies() {
+        when(policyManager.findAll(true)).thenReturn(Collections.singletonList(policyDefinition));
+        when(policyDefinition.manifest()).thenReturn(manifest);
+        when(manifest.properties()).thenReturn(Map.of("message", "MESSAGE_REQUEST,MESSAGE_RESPONSE"));
+
+        final Set<PolicyEntity> policies = policyService.findAll();
+
+        assertThat(policies).isEmpty();
+    }
+
+    @Test
+    public void shouldNotFilterPoliciesWithoutProxyOrMessageProperty() {
+        when(policyDefinition.id()).thenReturn(POLICY_ID);
+        when(policyManager.findAll(true)).thenReturn(Collections.singletonList(policyDefinition));
+        when(policyDefinition.manifest()).thenReturn(manifest);
+
+        final Set<PolicyEntity> policies = policyService.findAll();
+
+        assertNotNull(policies);
+        assertEquals(POLICY_ID, policies.iterator().next().getId());
+    }
+
+    @Test
+    public void shouldNotFilterProxyPolicies() {
+        when(policyDefinition.id()).thenReturn(POLICY_ID);
+        when(policyManager.findAll(true)).thenReturn(Collections.singletonList(policyDefinition));
+        when(policyDefinition.manifest()).thenReturn(manifest);
+        when(manifest.properties()).thenReturn(Map.of("proxy", "REQUEST"));
 
         final Set<PolicyEntity> policies = policyService.findAll();
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1711

## Description

Filter message policies for policy studio. The policy studio is used only for API with V2 definition version which should not use "message specific policies"

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-kpncozgeko.chromatic.com)
<!-- Storybook placeholder end -->
