### PR TITLE
[3.20.x] Return a BridgeReply in Error state when WS is throwing

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -99,7 +99,7 @@
         <gravitee-resource-oauth2-provider-generic.version>2.0.0</gravitee-resource-oauth2-provider-generic.version>
         <gravitee-service-discovery-consul.version>1.3.0</gravitee-service-discovery-consul.version>
         <!-- Management API Only -->
-        <gravitee-cockpit-connectors-ws.version>3.0.0</gravitee-cockpit-connectors-ws.version>
+        <gravitee-cockpit-connectors-ws.version>3.0.1</gravitee-cockpit-connectors-ws.version>
         <gravitee-fetcher-bitbucket.version>1.7.1</gravitee-fetcher-bitbucket.version>
         <gravitee-fetcher-git.version>1.8.1</gravitee-fetcher-git.version>
         <gravitee-fetcher-github.version>1.6.0</gravitee-fetcher-github.version>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/CockpitCommandServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/CockpitCommandServiceImpl.java
@@ -17,11 +17,13 @@ package io.gravitee.rest.api.service.cockpit.command;
 
 import io.gravitee.cockpit.api.CockpitConnector;
 import io.gravitee.cockpit.api.command.Command;
+import io.gravitee.cockpit.api.command.CommandStatus;
 import io.gravitee.cockpit.api.command.Payload;
 import io.gravitee.cockpit.api.command.Reply;
 import io.gravitee.cockpit.api.command.bridge.BridgeCommand;
 import io.gravitee.cockpit.api.command.bridge.BridgePayload;
 import io.gravitee.cockpit.api.command.bridge.BridgeReply;
+import io.gravitee.cockpit.api.command.bridge.BridgeSimpleReply;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
@@ -44,6 +46,15 @@ public class CockpitCommandServiceImpl implements CockpitCommandService {
 
     @Override
     public <T extends Payload> Reply send(Command<T> command) {
-        return cockpitConnector.sendCommand(command).blockingGet();
+        return cockpitConnector
+            .sendCommand(command)
+            .onErrorReturn(error ->
+                new BridgeSimpleReply(
+                    command.getId(),
+                    CommandStatus.ERROR,
+                    error.getMessage() != null ? error.getMessage() : error.toString()
+                )
+            )
+            .blockingGet();
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-2117
https://github.com/gravitee-io/issues/issues/9110

## Description

Apply https://github.com/gravitee-io/gravitee-api-management/pull/4446 on `3.20.x`

> We want a BridgeReply and not an error to successfully continue the ongoing process in upper levels. For instance, it would mean put an API Promotion in Error, instead of just throwing an error.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-luqjdmkqfi.chromatic.com)
<!-- Storybook placeholder end -->
