### PR TITLE
Apim 1405 add renew dialog + API Key table

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api-key/apiKey.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api-key/apiKey.fixture.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { isFunction } from 'lodash';
+
+import { ApiKey } from './apiKey';
+
+import { fakeBaseSubscription } from '../subscription';
+import { fakeBaseApplication } from '../application';
+
+export function fakeApiKey(modifier?: Partial<ApiKey> | ((baseApiKey: ApiKey) => ApiKey)): ApiKey {
+  const base: ApiKey = {
+    id: '9a3825da-64a8-43d4-b825-da64a8e3d42e',
+    key: '49765a30-659b-4284-b65a-30659be28431',
+    createdAt: new Date('2020-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2020-01-02T00:00:00.000Z'),
+    expireAt: new Date('2022-01-01T00:00:00.000Z'),
+    expired: false,
+    paused: false,
+    revoked: false,
+    revokedAt: undefined,
+    application: fakeBaseApplication(),
+    daysToExpirationOnLastNotification: undefined,
+    subscriptions: [fakeBaseSubscription()],
+  };
+
+  if (isFunction(modifier)) {
+    return modifier(base);
+  }
+
+  return {
+    ...base,
+    ...modifier,
+  };
+}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api-key/apiKey.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api-key/apiKey.ts
@@ -13,13 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './acceptSubscription';
-export * from './baseSubscription';
-export * from './createSubscription';
-export * from './subscription';
-export * from './subscription.fixture';
-export * from './subscriptionConsumerConfiguration';
-export * from './subscriptionConsumerStatus';
-export * from './subscriptionStatus';
-export * from './updateSubscription';
-export * from './verifySubscription';
+import { BaseApplication } from '../application';
+import { BaseSubscription } from '../subscription';
+
+export interface ApiKey {
+  id?: string;
+  key?: string;
+  application?: BaseApplication;
+  subscriptions?: BaseSubscription[];
+  revoked?: boolean;
+  paused?: boolean;
+  expired?: boolean;
+  daysToExpirationOnLastNotification?: number;
+  expireAt?: Date;
+  createdAt?: Date;
+  updatedAt?: Date;
+  revokedAt?: Date;
+}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api-key/index.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api-key/index.ts
@@ -13,13 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './acceptSubscription';
-export * from './baseSubscription';
-export * from './createSubscription';
-export * from './subscription';
-export * from './subscription.fixture';
-export * from './subscriptionConsumerConfiguration';
-export * from './subscriptionConsumerStatus';
-export * from './subscriptionStatus';
-export * from './updateSubscription';
-export * from './verifySubscription';
+export * from './apiKey';
+export * from './apiKey.fixture';
+export * from './subscriptionApiKeysResponse';

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api-key/subscriptionApiKeysResponse.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api-key/subscriptionApiKeysResponse.ts
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './acceptSubscription';
-export * from './baseSubscription';
-export * from './createSubscription';
-export * from './subscription';
-export * from './subscription.fixture';
-export * from './subscriptionConsumerConfiguration';
-export * from './subscriptionConsumerStatus';
-export * from './subscriptionStatus';
-export * from './updateSubscription';
-export * from './verifySubscription';
+import { ApiKey } from './apiKey';
+
+import { Pagination } from '../pagination';
+import { Links } from '../links';
+
+export interface SubscriptionApiKeysResponse {
+  data?: ApiKey[];
+  pagination?: Pagination;
+  links?: Links;
+}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/subscription/baseSubscription.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/subscription/baseSubscription.ts
@@ -13,13 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './acceptSubscription';
-export * from './baseSubscription';
-export * from './createSubscription';
-export * from './subscription';
-export * from './subscription.fixture';
-export * from './subscriptionConsumerConfiguration';
-export * from './subscriptionConsumerStatus';
-export * from './subscriptionStatus';
-export * from './updateSubscription';
-export * from './verifySubscription';
+export interface BaseSubscription {
+  id?: string;
+}

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/subscription/subscription.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/subscription/subscription.fixture.ts
@@ -16,10 +16,11 @@
 import { isFunction } from 'lodash';
 
 import { Subscription } from './subscription';
+import { BaseSubscription } from './baseSubscription';
 
 export function fakeSubscription(modifier?: Partial<Subscription> | ((baseApi: Subscription) => Subscription)): Subscription {
   const base: Subscription = {
-    id: 'aee23b1e-34b1-4551-a23b-1e34b165516a',
+    ...fakeBaseSubscription(),
     api: {
       id: 'bee23b1e-34b1-4551-a23b-1e34b165516a',
       name: 'My API',
@@ -71,6 +72,23 @@ export function fakeSubscription(modifier?: Partial<Subscription> | ((baseApi: S
     closedAt: undefined,
     pausedAt: undefined,
     consumerPausedAt: undefined,
+  };
+
+  if (isFunction(modifier)) {
+    return modifier(base);
+  }
+
+  return {
+    ...base,
+    ...modifier,
+  };
+}
+
+export function fakeBaseSubscription(
+  modifier?: Partial<BaseSubscription> | ((baseApi: BaseSubscription) => BaseSubscription),
+): BaseSubscription {
+  const base = {
+    id: 'aee23b1e-34b1-4551-a23b-1e34b165516a',
   };
 
   if (isFunction(modifier)) {

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/api-portal-subscriptions.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/api-portal-subscriptions.module.ts
@@ -29,7 +29,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { GioIconsModule, GioLoaderModule } from '@gravitee/ui-particles-angular';
+import { GioClipboardModule, GioIconsModule, GioLoaderModule } from '@gravitee/ui-particles-angular';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MAT_MOMENT_DATE_ADAPTER_OPTIONS, MatMomentDateModule } from '@angular/material-moment-adapter';
 
@@ -41,6 +41,7 @@ import { ApiPortalSubscriptionChangeEndDateDialogComponent } from './components/
 import { ApiPortalSubscriptionValidateDialogComponent } from './components/validate-dialog/api-portal-subscription-validate-dialog.component';
 import { ApiKeyValidationComponent } from './components/api-key-validation/api-key-validation.component';
 import { ApiPortalSubscriptionRejectDialogComponent } from './components/reject-dialog/api-portal-subscription-reject-dialog.component';
+import { ApiPortalSubscriptionRenewDialogComponent } from './components/renew-dialog/api-portal-subscription-renew-dialog.component';
 
 import { GioTableWrapperModule } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
 import { GioPermissionModule } from '../../../../shared/components/gio-permission/gio-permission.module';
@@ -53,6 +54,7 @@ import { GioPermissionModule } from '../../../../shared/components/gio-permissio
     ApiPortalSubscriptionCreationDialogComponent,
     ApiPortalSubscriptionTransferDialogComponent,
     ApiPortalSubscriptionRejectDialogComponent,
+    ApiPortalSubscriptionRenewDialogComponent,
     ApiPortalSubscriptionValidateDialogComponent,
 
     ApiKeyValidationComponent,
@@ -78,6 +80,7 @@ import { GioPermissionModule } from '../../../../shared/components/gio-permissio
     MatTableModule,
     MatTooltipModule,
 
+    GioClipboardModule,
     GioIconsModule,
     GioLoaderModule,
     GioPermissionModule,

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/renew-dialog/api-portal-subscription-renew-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/renew-dialog/api-portal-subscription-renew-dialog.component.html
@@ -1,0 +1,33 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h2 matDialogTitle>Renew your API Key</h2>
+<form [formGroup]="form">
+  <mat-dialog-content class="renew__content">
+    <div class="mat-body-1">Your previous API Key will be no longer valid in 2 hours!</div>
+    <div *ngIf="data.canUseCustomApiKey" class="renew__content__custom-api-key">
+      <div class="mat-body-1">You can provide a custom API key here</div>
+      <api-key-validation #ApiKeyInput [required]="false" [applicationId]="data.applicationId" [apiId]="data.apiId"></api-key-validation>
+    </div>
+  </mat-dialog-content>
+  <mat-dialog-actions class="actions">
+    <button mat-flat-button [mat-dialog-close]="undefined">Cancel</button>
+    <button color="primary" type="submit" mat-raised-button aria-label="Renew API Key" (click)="onClose()" [disabled]="form.invalid">
+      Renew
+    </button>
+  </mat-dialog-actions>
+</form>

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/renew-dialog/api-portal-subscription-renew-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/renew-dialog/api-portal-subscription-renew-dialog.component.scss
@@ -1,0 +1,17 @@
+.renew {
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+
+    &__custom-api-key {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+  }
+}
+
+.actions {
+  justify-content: flex-end;
+}

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/renew-dialog/api-portal-subscription-renew-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/renew-dialog/api-portal-subscription-renew-dialog.component.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AfterViewInit, ChangeDetectorRef, Component, Inject, ViewChild } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+import { ApiKeyValidationComponent } from '../api-key-validation/api-key-validation.component';
+
+export interface ApiPortalSubscriptionRenewDialogData {
+  canUseCustomApiKey: boolean;
+  applicationId: string;
+  apiId: string;
+}
+
+export interface ApiPortalSubscriptionRenewDialogResult {
+  customApiKey: string;
+}
+@Component({
+  selector: 'api-portal-subscription-renew-dialog',
+  template: require('./api-portal-subscription-renew-dialog.component.html'),
+  styles: [require('./api-portal-subscription-renew-dialog.component.scss')],
+})
+export class ApiPortalSubscriptionRenewDialogComponent implements AfterViewInit {
+  data: ApiPortalSubscriptionRenewDialogData;
+  form: FormGroup = new FormGroup({});
+  @ViewChild('ApiKeyInput') apiKeyValidationComponent: ApiKeyValidationComponent;
+
+  constructor(
+    private readonly dialogRef: MatDialogRef<ApiPortalSubscriptionRenewDialogComponent, ApiPortalSubscriptionRenewDialogResult>,
+    @Inject(MAT_DIALOG_DATA) dialogData: ApiPortalSubscriptionRenewDialogData,
+    private readonly changeDetectorRef: ChangeDetectorRef,
+  ) {
+    this.data = dialogData;
+  }
+
+  ngAfterViewInit() {
+    if (this.data.canUseCustomApiKey) {
+      this.form.addControl('apiKey', this.apiKeyValidationComponent.apiKey);
+      this.apiKeyValidationComponent.apiKey.setParent(this.form);
+    }
+    this.changeDetectorRef.detectChanges();
+  }
+
+  onClose() {
+    this.dialogRef.close({ customApiKey: this.form.getRawValue().apiKey?.input });
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.html
@@ -15,7 +15,7 @@
     limitations under the License.
 
 -->
-<div id="subscription-edit">
+<div id="subscription-edit" class="subscription">
   <div class="subscription__nav">
     <button mat-icon-button aria-label="Go back to your subscriptions" (click)="goBackToSubscriptions()">
       <mat-icon svgIcon="gio:nav-arrow-left"></mat-icon> Go back to your subscriptions
@@ -144,6 +144,62 @@
         </div>
       </ng-container>
     </ng-container>
-    <!--  TODO: Add Shared API Key section -->
+  </mat-card>
+  <!--  TODO: Control permissions -->
+  <mat-card
+    *ngIf="
+      apiKeys?.length > 0 &&
+      (subscription?.status === 'PENDING' || (subscription?.status !== 'REJECTED' && subscription?.plan.securityType === 'API_KEY'))
+    "
+  >
+    <h3>{{ hasSharedApiKeyMode ? 'Shared API Keys' : 'API Keys' }}</h3>
+    <div *ngIf="apiKeys?.length > 0">
+      <div *ngIf="hasSharedApiKeyMode" class="subscription__api-keys__subtitle">
+        This subscription uses a shared API key. You can renew or revoke the shared API key at the application level.
+      </div>
+      <div class="subscription__api-keys__table-wrapper">
+        <gio-table-wrapper
+          [disableSearchInput]="true"
+          [length]="apiKeys.length"
+          [filters]="filters"
+          (filtersChange)="onFiltersChanged($event)"
+          [paginationPageSizeOptions]="[5, 10, 25, 50]"
+        >
+          <table mat-table [dataSource]="apiKeys" class="card__table" attr.aria-label="API Keys Table">
+            <ng-container matColumnDef="key">
+              <th mat-header-cell *matHeaderCellDef>Key</th>
+              <td mat-cell *matCellDef="let apiKey" class="subscription__api-keys__id">
+                <div>{{ apiKey.key }}</div>
+                <gio-clipboard-copy-icon matSuffix [contentToCopy]="apiKey.key"></gio-clipboard-copy-icon>
+              </td>
+            </ng-container>
+            <ng-container matColumnDef="createdAt">
+              <th mat-header-cell *matHeaderCellDef>Created at</th>
+              <td mat-cell *matCellDef="let apiKey">
+                {{ apiKey.createdAt }}
+              </td>
+            </ng-container>
+            <ng-container matColumnDef="endDate">
+              <th mat-header-cell *matHeaderCellDef>Revoked/Expired at</th>
+              <td mat-cell *matCellDef="let apiKey">
+                {{ apiKey.endDate }}
+              </td>
+            </ng-container>
+            <ng-container matColumnDef="actions">
+              <th mat-header-cell *matHeaderCellDef></th>
+              <td mat-cell *matCellDef="let apiKey"></td>
+            </ng-container>
+            <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+          </table>
+        </gio-table-wrapper>
+      </div>
+      <div class="subscription__api-keys__footer" *ngIf="!hasSharedApiKeyMode && subscription.status === 'ACCEPTED'">
+        <button mat-stroked-button (click)="renewApiKey()">
+          <mat-icon svgIcon="gio:refresh-cw"></mat-icon>
+          Renew
+        </button>
+      </div>
+    </div>
   </mat-card>
 </div>

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.scss
@@ -8,6 +8,10 @@
 }
 
 .subscription {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+
   &__nav {
     padding-bottom: 36px;
   }
@@ -24,6 +28,22 @@
     display: flex;
     padding-top: 56px;
     gap: 8px;
+  }
+  &__api-keys {
+    &__subtitle {
+      padding-bottom: 24px;
+    }
+    &__id {
+      display: flex;
+      height: inherit;
+      align-items: center;
+      gap: 8px;
+    }
+    &__footer {
+      display: flex;
+      padding-top: 56px;
+      gap: 8px;
+    }
   }
 }
 

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.spec.ts
@@ -48,6 +48,7 @@ import {
 import { fakeApplication } from '../../../../../entities/application/Application.fixture';
 import { ApiKeyMode } from '../../../../../entities/application/application';
 import { ApiKeyValidationHarness } from '../components/api-key-validation/api-key-validation.harness';
+import { ApiKey, fakeApiKey } from '../../../../../entities/management-api-v2/api-key';
 
 const SUBSCRIPTION_ID = 'my-nice-subscription';
 const API_ID = 'api_1';
@@ -110,6 +111,7 @@ describe('ApiPortalSubscriptionEditComponent', () => {
     it('should load accepted subscription', async () => {
       await initComponent();
       expectApplicationGet();
+      expectApiKeyListGet();
 
       const harness = await loader.getHarness(ApiPortalSubscriptionEditHarness);
 
@@ -148,6 +150,7 @@ describe('ApiPortalSubscriptionEditComponent', () => {
       pendingSubscription.status = 'PENDING';
       await initComponent(pendingSubscription);
       expectApplicationGet();
+      expectApiKeyListGet();
 
       const harness = await loader.getHarness(ApiPortalSubscriptionEditHarness);
 
@@ -168,7 +171,6 @@ describe('ApiPortalSubscriptionEditComponent', () => {
       const rejectedSubscription = BASIC_SUBSCRIPTION();
       rejectedSubscription.status = 'REJECTED';
       await initComponent(rejectedSubscription);
-      expectApplicationGet();
 
       const harness = await loader.getHarness(ApiPortalSubscriptionEditHarness);
 
@@ -188,6 +190,7 @@ describe('ApiPortalSubscriptionEditComponent', () => {
     it('should not load footer in read-only mode', async () => {
       await initComponent(BASIC_SUBSCRIPTION(), ['api-subscription-r']);
       expectApplicationGet(ApiKeyMode.SHARED);
+      expectApiKeyListGet();
 
       const harness = await loader.getHarness(ApiPortalSubscriptionEditHarness);
       expect(await harness.footerIsVisible()).toEqual(false);
@@ -253,6 +256,7 @@ describe('ApiPortalSubscriptionEditComponent', () => {
     it('should not transfer subscription on cancel', async () => {
       await initComponent();
       expectApplicationGet();
+      expectApiKeyListGet();
 
       const harness = await loader.getHarness(ApiPortalSubscriptionEditHarness);
       expect(await harness.transferBtnIsVisible()).toEqual(true);
@@ -284,6 +288,7 @@ describe('ApiPortalSubscriptionEditComponent', () => {
     it('should pause subscription', async () => {
       await initComponent(BASIC_SUBSCRIPTION());
       expectApplicationGet(ApiKeyMode.EXCLUSIVE);
+      expectApiKeyListGet();
 
       const harness = await loader.getHarness(ApiPortalSubscriptionEditHarness);
       expect(await harness.pauseBtnIsVisible()).toEqual(true);
@@ -307,6 +312,7 @@ describe('ApiPortalSubscriptionEditComponent', () => {
       expectApiSubscriptionPause(SUBSCRIPTION_ID, pausedSubscription);
       expectApiSubscriptionGet(pausedSubscription);
       expectApplicationGet();
+      expectApiKeyListGet();
 
       expect(await harness.getStatus()).toEqual('PAUSED');
       expect(await harness.pauseBtnIsVisible()).toEqual(false);
@@ -315,6 +321,7 @@ describe('ApiPortalSubscriptionEditComponent', () => {
     it('should not pause subscription on cancel', async () => {
       await initComponent();
       expectApplicationGet();
+      expectApiKeyListGet();
 
       const harness = await loader.getHarness(ApiPortalSubscriptionEditHarness);
       await harness.openPauseDialog();
@@ -349,6 +356,7 @@ describe('ApiPortalSubscriptionEditComponent', () => {
     it('should resume subscription', async () => {
       await initComponent(pausedSubscription);
       expectApplicationGet(ApiKeyMode.EXCLUSIVE);
+      expectApiKeyListGet();
 
       const harness = await loader.getHarness(ApiPortalSubscriptionEditHarness);
       expect(await harness.resumeBtnIsVisible()).toEqual(true);
@@ -367,6 +375,7 @@ describe('ApiPortalSubscriptionEditComponent', () => {
       expectApiSubscriptionResume(SUBSCRIPTION_ID, BASIC_SUBSCRIPTION());
       expectApiSubscriptionGet(BASIC_SUBSCRIPTION());
       expectApplicationGet();
+      expectApiKeyListGet();
 
       expect(await harness.getStatus()).toEqual('ACCEPTED');
       expect(await harness.pauseBtnIsVisible()).toEqual(true);
@@ -375,6 +384,7 @@ describe('ApiPortalSubscriptionEditComponent', () => {
     it('should not resume subscription on cancel', async () => {
       await initComponent(pausedSubscription);
       expectApplicationGet();
+      expectApiKeyListGet();
 
       const harness = await loader.getHarness(ApiPortalSubscriptionEditHarness);
       await harness.openResumeDialog();
@@ -393,6 +403,7 @@ describe('ApiPortalSubscriptionEditComponent', () => {
     it('should assign end date with no current end date', async () => {
       await initComponent();
       expectApplicationGet(ApiKeyMode.EXCLUSIVE);
+      expectApiKeyListGet();
 
       const harness = await loader.getHarness(ApiPortalSubscriptionEditHarness);
       expect(await harness.changeEndDateBtnIsVisible()).toEqual(true);
@@ -432,6 +443,7 @@ describe('ApiPortalSubscriptionEditComponent', () => {
 
       expectApiSubscriptionGet(newEndDateSubscription);
       expectApplicationGet();
+      expectApiKeyListGet();
 
       expect(await harness.getEndingAt()).toEqual('Jan 1, 2080 12:00:00.000 AM');
     });
@@ -443,6 +455,7 @@ describe('ApiPortalSubscriptionEditComponent', () => {
 
       await initComponent(endingAtSubscription);
       expectApplicationGet(ApiKeyMode.EXCLUSIVE);
+      expectApiKeyListGet();
 
       const harness = await loader.getHarness(ApiPortalSubscriptionEditHarness);
       expect(await harness.getEndingAt()).toEqual('Jan 1, 2080 12:00:00.000 AM');
@@ -482,12 +495,14 @@ describe('ApiPortalSubscriptionEditComponent', () => {
 
       expectApiSubscriptionGet(newEndDateSubscription);
       expectApplicationGet();
+      expectApiKeyListGet();
 
       expect(await harness.getEndingAt()).toEqual('Jan 2, 2080 12:00:00.000 AM');
     });
     it('should not change end date on cancel', async () => {
       await initComponent();
       expectApplicationGet(ApiKeyMode.EXCLUSIVE);
+      expectApiKeyListGet();
 
       const harness = await loader.getHarness(ApiPortalSubscriptionEditHarness);
       await harness.openChangeEndDateDialog();
@@ -504,6 +519,7 @@ describe('ApiPortalSubscriptionEditComponent', () => {
     beforeEach(async () => {
       await initComponent();
       expectApplicationGet(ApiKeyMode.EXCLUSIVE);
+      expectApiKeyListGet();
     });
     it('should close subscription', async () => {
       const harness = await loader.getHarness(ApiPortalSubscriptionEditHarness);
@@ -525,6 +541,7 @@ describe('ApiPortalSubscriptionEditComponent', () => {
       closedSubscription.status = 'CLOSED';
       expectApiSubscriptionGet(closedSubscription);
       expectApplicationGet();
+      expectApiKeyListGet();
 
       expect(await harness.getStatus()).toEqual('CLOSED');
       expect(await harness.pauseBtnIsVisible()).toEqual(false);
@@ -553,6 +570,7 @@ describe('ApiPortalSubscriptionEditComponent', () => {
     it('should validate without any extra information', async () => {
       await initComponent(pendingSubscription);
       expectApplicationGet(ApiKeyMode.EXCLUSIVE);
+      expectApiKeyListGet();
 
       const harness = await loader.getHarness(ApiPortalSubscriptionEditHarness);
       expect(await harness.validateBtnIsVisible()).toEqual(true);
@@ -572,6 +590,7 @@ describe('ApiPortalSubscriptionEditComponent', () => {
 
       expectApiSubscriptionGet(BASIC_SUBSCRIPTION());
       expectApplicationGet();
+      expectApiKeyListGet();
 
       expect(await harness.getStatus()).toEqual('ACCEPTED');
       expect(await harness.validateBtnIsVisible()).toEqual(false);
@@ -579,6 +598,7 @@ describe('ApiPortalSubscriptionEditComponent', () => {
     it('should validate with extra information', async () => {
       await initComponent(pendingSubscription);
       expectApplicationGet(ApiKeyMode.EXCLUSIVE);
+      expectApiKeyListGet();
 
       const harness = await loader.getHarness(ApiPortalSubscriptionEditHarness);
       await harness.openValidateDialog();
@@ -618,6 +638,7 @@ describe('ApiPortalSubscriptionEditComponent', () => {
 
       expectApiSubscriptionGet(BASIC_SUBSCRIPTION());
       expectApplicationGet();
+      expectApiKeyListGet();
 
       expect(await harness.getStatus()).toEqual('ACCEPTED');
       expect(await harness.validateBtnIsVisible()).toEqual(false);
@@ -625,30 +646,35 @@ describe('ApiPortalSubscriptionEditComponent', () => {
     it('should validate with sharedApiKeyMode and cannot use custom key', async () => {
       await initComponent(pendingSubscription, undefined, false);
       expectApplicationGet(ApiKeyMode.SHARED);
+      expectApiKeyListGet();
 
       await validateInformation(false);
     });
     it('should validate without sharedKeyMode and can use custom key', async () => {
       await initComponent(pendingSubscription);
       expectApplicationGet(ApiKeyMode.UNSPECIFIED);
+      expectApiKeyListGet();
 
       await validateInformation(true);
     });
     it('should validate without sharedKeyMode and cannot use custom key', async () => {
       await initComponent(pendingSubscription, undefined, false);
       expectApplicationGet(ApiKeyMode.EXCLUSIVE);
+      expectApiKeyListGet();
 
       await validateInformation(false);
     });
     it('should validate with sharedApiKeyMode and can use custom key', async () => {
       await initComponent(pendingSubscription);
       expectApplicationGet(ApiKeyMode.SHARED);
+      expectApiKeyListGet();
 
       await validateInformation(false);
     });
     it('should not validate on cancel', async () => {
       await initComponent(pendingSubscription);
       expectApplicationGet(ApiKeyMode.SHARED);
+      expectApiKeyListGet();
 
       const harness = await loader.getHarness(ApiPortalSubscriptionEditHarness);
       await harness.openValidateDialog();
@@ -680,6 +706,7 @@ describe('ApiPortalSubscriptionEditComponent', () => {
 
       expectApiSubscriptionGet(BASIC_SUBSCRIPTION());
       expectApplicationGet();
+      expectApiKeyListGet();
 
       expect(await harness.getStatus()).toEqual('ACCEPTED');
       expect(await harness.validateBtnIsVisible()).toEqual(false);
@@ -693,6 +720,7 @@ describe('ApiPortalSubscriptionEditComponent', () => {
 
       await initComponent(pendingSubscription);
       expectApplicationGet(ApiKeyMode.EXCLUSIVE);
+      expectApiKeyListGet();
     });
     it('should reject subscription with no reason specified', async () => {
       const harness = await loader.getHarness(ApiPortalSubscriptionEditHarness);
@@ -711,10 +739,11 @@ describe('ApiPortalSubscriptionEditComponent', () => {
 
       expectApiSubscriptionReject(SUBSCRIPTION_ID, '', BASIC_SUBSCRIPTION());
 
-      expectApiSubscriptionGet(BASIC_SUBSCRIPTION());
-      expectApplicationGet();
+      const rejectedSubscription = BASIC_SUBSCRIPTION();
+      rejectedSubscription.status = 'REJECTED';
+      expectApiSubscriptionGet(rejectedSubscription);
 
-      expect(await harness.getStatus()).toEqual('ACCEPTED');
+      expect(await harness.getStatus()).toEqual('REJECTED');
       expect(await harness.validateBtnIsVisible()).toEqual(false);
     });
     it('should reject subscription with reason specified', async () => {
@@ -734,10 +763,11 @@ describe('ApiPortalSubscriptionEditComponent', () => {
 
       expectApiSubscriptionReject(SUBSCRIPTION_ID, 'A really great reason', BASIC_SUBSCRIPTION());
 
-      expectApiSubscriptionGet(BASIC_SUBSCRIPTION());
-      expectApplicationGet();
+      const rejectedSubscription = BASIC_SUBSCRIPTION();
+      rejectedSubscription.status = 'REJECTED';
+      expectApiSubscriptionGet(rejectedSubscription);
 
-      expect(await harness.getStatus()).toEqual('ACCEPTED');
+      expect(await harness.getStatus()).toEqual('REJECTED');
       expect(await harness.validateBtnIsVisible()).toEqual(false);
     });
     it('should not reject subscription on cancel', async () => {
@@ -749,6 +779,112 @@ describe('ApiPortalSubscriptionEditComponent', () => {
       );
       const cancelBtn = await rejectDialog.getHarness(MatButtonHarness.with({ text: 'Cancel' }));
       await cancelBtn.click();
+    });
+  });
+
+  describe('renew API Key', () => {
+    it('should not be possible with no API Keys', async () => {
+      await initComponent();
+      expectApplicationGet(ApiKeyMode.EXCLUSIVE);
+      expectApiKeyListGet(SUBSCRIPTION_ID, [], undefined, undefined, 0);
+
+      const harness = await loader.getHarness(ApiPortalSubscriptionEditHarness);
+      expect(await harness.renewApiKeyBtnIsVisible()).toEqual(false);
+    });
+    it('should not be possible if subscription is not accepted', async () => {
+      const pendingSubscription = BASIC_SUBSCRIPTION();
+      pendingSubscription.status = 'PENDING';
+
+      await initComponent(pendingSubscription);
+      expectApplicationGet(ApiKeyMode.EXCLUSIVE);
+      expectApiKeyListGet(SUBSCRIPTION_ID);
+
+      const harness = await loader.getHarness(ApiPortalSubscriptionEditHarness);
+      expect(await harness.renewApiKeyBtnIsVisible()).toEqual(false);
+    });
+    it('should not be possible with shareApiKeys enabled', async () => {
+      await initComponent();
+      expectApplicationGet(ApiKeyMode.SHARED);
+      expectApiKeyListGet(SUBSCRIPTION_ID);
+
+      const harness = await loader.getHarness(ApiPortalSubscriptionEditHarness);
+      expect(await harness.renewApiKeyBtnIsVisible()).toEqual(false);
+    });
+    it('should renew API Key without customApiKey enabled', async () => {
+      await initComponent(undefined, undefined, false);
+      expectApplicationGet(ApiKeyMode.EXCLUSIVE);
+      expectApiKeyListGet(SUBSCRIPTION_ID);
+
+      const harness = await loader.getHarness(ApiPortalSubscriptionEditHarness);
+      expect(await harness.renewApiKeyBtnIsVisible()).toEqual(true);
+      await harness.openRenewApiKeyDialog();
+
+      const renewDialog = await TestbedHarnessEnvironment.documentRootLoader(fixture).getHarness(
+        MatDialogHarness.with({ selector: '#renewApiKeysDialog' }),
+      );
+      expect(await renewDialog.getTitleText()).toEqual('Renew your API Key');
+
+      await renewDialog
+        .getHarness(ApiKeyValidationHarness)
+        .then((_) => fail('ApiKeyValidationComponent should not be present'))
+        .catch((err) => expect(err).toBeTruthy());
+
+      const renewBtn = await renewDialog.getHarness(MatButtonHarness.with({ text: 'Renew' }));
+      expect(await renewBtn.isDisabled()).toEqual(false);
+
+      await renewBtn.click();
+      expectApiKeyRenew(SUBSCRIPTION_ID, undefined, fakeApiKey({ id: 'renewed-api-key' }));
+
+      expectApiSubscriptionGet(BASIC_SUBSCRIPTION());
+      expectApplicationGet(ApiKeyMode.EXCLUSIVE);
+      expectApiKeyListGet(SUBSCRIPTION_ID, [fakeApiKey({ key: 'renewed-api-key' })]);
+
+      expect(await harness.getApiKeyByRowIndex(0)).toContain('renewed-api-key');
+    });
+    it('should renew API Key with customApiKey enabled', async () => {
+      await initComponent();
+      expectApplicationGet(ApiKeyMode.EXCLUSIVE);
+      expectApiKeyListGet(SUBSCRIPTION_ID, [fakeApiKey({ id: 'my-api-key' })]);
+
+      const harness = await loader.getHarness(ApiPortalSubscriptionEditHarness);
+      await harness.openRenewApiKeyDialog();
+
+      const renewDialog = await TestbedHarnessEnvironment.documentRootLoader(fixture).getHarness(
+        MatDialogHarness.with({ selector: '#renewApiKeysDialog' }),
+      );
+
+      const apiKeyValidation = await renewDialog.getHarness(ApiKeyValidationHarness);
+      await apiKeyValidation.setInputValue('12345678');
+
+      expectApiSubscriptionVerify(true, '12345678');
+
+      const renewBtn = await renewDialog.getHarness(MatButtonHarness.with({ text: 'Renew' }));
+      await renewBtn.click();
+
+      expectApiKeyRenew(SUBSCRIPTION_ID, '12345678', fakeApiKey({ id: 'my-api-key', key: '12345678' }));
+
+      expectApiSubscriptionGet(BASIC_SUBSCRIPTION());
+      expectApplicationGet(ApiKeyMode.EXCLUSIVE);
+      expectApiKeyListGet(SUBSCRIPTION_ID, [fakeApiKey({ id: 'my-api-key', key: '12345678' })]);
+
+      expect(await harness.getApiKeyByRowIndex(0)).toContain('12345678');
+    });
+    it('should not renew API Key on cancel', async () => {
+      await initComponent();
+      expectApplicationGet(ApiKeyMode.EXCLUSIVE);
+      expectApiKeyListGet(SUBSCRIPTION_ID, [fakeApiKey({ key: 'my-api-key' })]);
+
+      const harness = await loader.getHarness(ApiPortalSubscriptionEditHarness);
+      await harness.openRenewApiKeyDialog();
+
+      const renewDialog = await TestbedHarnessEnvironment.documentRootLoader(fixture).getHarness(
+        MatDialogHarness.with({ selector: '#renewApiKeysDialog' }),
+      );
+
+      const cancelBtn = await renewDialog.getHarness(MatButtonHarness.with({ text: 'Cancel' }));
+      await cancelBtn.click();
+
+      expect(await harness.getApiKeyByRowIndex(0)).toContain('my-api-key');
     });
   });
 
@@ -877,6 +1013,30 @@ describe('ApiPortalSubscriptionEditComponent', () => {
     });
     expect(req.request.body).toEqual({ reason });
     req.flush(subscription);
+  }
+
+  function expectApiKeyListGet(
+    subscriptionId: string = SUBSCRIPTION_ID,
+    apiKeys: ApiKey[] = [fakeApiKey()],
+    page = 1,
+    perPage = 10,
+    totalCount = 1,
+  ) {
+    httpTestingController
+      .expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/subscriptions/${subscriptionId}/api-keys?page=${page}&perPage=${perPage}`,
+        method: 'GET',
+      })
+      .flush({ data: apiKeys, pagination: { page, perPage, totalCount } });
+  }
+
+  function expectApiKeyRenew(subscriptionId: string, customApiKey: string, apiKey: ApiKey): void {
+    const req = httpTestingController.expectOne({
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/subscriptions/${subscriptionId}/api-keys/_renew`,
+      method: 'POST',
+    });
+    expect(req.request.body).toEqual({ customApiKey });
+    req.flush(apiKey);
   }
 
   function expectApplicationGet(apiKeyMode: ApiKeyMode = ApiKeyMode.UNSPECIFIED): void {

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.harness.ts
@@ -15,6 +15,7 @@
  */
 import { ComponentHarness } from '@angular/cdk/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatTableHarness } from '@angular/material/table/testing';
 
 export class ApiPortalSubscriptionEditHarness extends ComponentHarness {
   static hostSelector = '#subscription-edit';
@@ -23,7 +24,7 @@ export class ApiPortalSubscriptionEditHarness extends ComponentHarness {
   protected getBackButton = this.locatorFor(MatButtonHarness.with({ selector: '[aria-label="Go back to your subscriptions"]' }));
   protected getFooter = this.locatorFor('.subscription__footer');
   protected getBtnByText = (text: string) => this.locatorFor(MatButtonHarness.with({ text }))();
-
+  protected getTable = this.locatorFor(MatTableHarness);
   public async goBackToSubscriptionsList(): Promise<void> {
     return this.getBackButton().then((btn) => btn.click());
   }
@@ -148,6 +149,21 @@ export class ApiPortalSubscriptionEditHarness extends ComponentHarness {
 
   public async openRejectDialog(): Promise<void> {
     return this.getBtnByText('Reject subscription').then((btn) => btn.click());
+  }
+
+  public async renewApiKeyBtnIsVisible(): Promise<boolean> {
+    return this.btnIsVisible('Renew');
+  }
+
+  public async openRenewApiKeyDialog(): Promise<void> {
+    return this.getBtnByText('Renew').then((btn) => btn.click());
+  }
+
+  public async getApiKeyByRowIndex(index: number): Promise<string> {
+    return this.getTable()
+      .then((table) => table.getRows())
+      .then((rows) => rows[index].getCellTextByIndex({ columnName: 'key' }))
+      .then((txt) => txt[0]);
   }
 
   private async btnIsVisible(text: string): Promise<boolean> {

--- a/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.ts
@@ -27,6 +27,7 @@ import {
   VerifySubscription,
   VerifySubscriptionResponse,
 } from '../entities/management-api-v2';
+import { ApiKey, SubscriptionApiKeysResponse } from '../entities/management-api-v2/api-key';
 
 @Injectable({
   providedIn: 'root',
@@ -101,6 +102,22 @@ export class ApiSubscriptionV2Service {
   reject(subscriptionId: string, apiId: string, reason: string): Observable<Subscription> {
     return this.http.post<Subscription>(`${this.constants.env.v2BaseURL}/apis/${apiId}/subscriptions/${subscriptionId}/_reject`, {
       reason,
+    });
+  }
+
+  /**
+   * API KEY
+   */
+  listApiKeys(apiId: string, subscriptionId: string, page = 1, perPage = 10): Observable<SubscriptionApiKeysResponse> {
+    return this.http.get<SubscriptionApiKeysResponse>(
+      `${this.constants.env.v2BaseURL}/apis/${apiId}/subscriptions/${subscriptionId}/api-keys`,
+      { params: { page, perPage } },
+    );
+  }
+
+  renewApiKey(apiId: string, subscriptionId: string, customApiKey: string): Observable<ApiKey> {
+    return this.http.post<ApiKey>(`${this.constants.env.v2BaseURL}/apis/${apiId}/subscriptions/${subscriptionId}/api-keys/_renew`, {
+      customApiKey,
     });
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-1405

## Description

- add api key table to subscription detail page
- add renew dialog

As Shared Keys: 

![Screen Shot 2023-06-30 at 17 28 58](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/ff333175-45ab-4982-8bfe-d4dcb28af11e)


Without shared keys: 

![Screen Shot 2023-06-30 at 15 35 08](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/b7321b77-b6a2-43b2-87fd-62abfbb59ed1)


Without custom api key:

![Screen Shot 2023-06-30 at 15 35 21](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/718cbb41-c782-4185-9296-5efe1b2aedf8)


With custom api key:

![Screen Shot 2023-06-30 at 15 36 13](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/1088ecdb-612a-4cee-a169-f39d44d4f9a2)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-dzrwoialda.chromatic.com)
<!-- Storybook placeholder end -->
