### PR TITLE
fix: handle null schema

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PolicyServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PolicyServiceImpl.java
@@ -122,9 +122,13 @@ public class PolicyServiceImpl extends AbstractPluginService<PolicyPlugin<?>, Po
         if (schemaDisplayFormat == SchemaDisplayFormat.GV_SCHEMA_FORM) {
             try {
                 logger.debug("Find plugin schema for format {} by ID: {}", schemaDisplayFormat, pluginId);
-                return pluginManager.getSchema(pluginId, "display-gv-schema-form", true);
-            } catch (IOException ioex) {
+                String schema = pluginManager.getSchema(pluginId, "display-gv-schema-form", true);
+                if (schema != null) {
+                    return schema;
+                }
                 logger.debug("No specific schema-form exists for this display format. Fall back on default schema-form.");
+            } catch (IOException ioex) {
+                logger.debug("Error while getting specific schema-form for this display format. Fall back on default schema-form.");
             }
         }
         return getSchema(pluginId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/EntrypointConnectorPluginServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/EntrypointConnectorPluginServiceImpl.java
@@ -54,9 +54,15 @@ public class EntrypointConnectorPluginServiceImpl
         if (schemaDisplayFormat == SchemaDisplayFormat.GV_SCHEMA_FORM) {
             try {
                 logger.debug("Find entrypoint subscription schema for format {} by ID: {}", schemaDisplayFormat, connectorId);
-                return pluginManager.getSchema(connectorId, "subscriptions/display-gv-schema-form", true);
-            } catch (IOException ioex) {
+                String schema = pluginManager.getSchema(connectorId, "subscriptions/display-gv-schema-form", true);
+                if (schema != null) {
+                    return schema;
+                }
                 logger.debug("No specific schema-form exists for this display format. Fall back on default schema-form.");
+            } catch (IOException ioex) {
+                logger.debug(
+                    "Error while getting specific specific schema-form for this display format. Fall back on default schema-form."
+                );
             }
         }
         try {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PolicyPluginServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/PolicyPluginServiceImpl.java
@@ -104,9 +104,15 @@ public class PolicyPluginServiceImpl extends AbstractPluginService<PolicyPlugin<
         if (schemaDisplayFormat == SchemaDisplayFormat.GV_SCHEMA_FORM) {
             try {
                 logger.debug("Find plugin schema for format {} by ID: {}", schemaDisplayFormat, policyPluginId);
-                return pluginManager.getSchema(policyPluginId, "display-gv-schema-form", true);
-            } catch (IOException ioex) {
+                String schema = pluginManager.getSchema(policyPluginId, "display-gv-schema-form", true);
+                if (schema != null) {
+                    return schema;
+                }
                 logger.debug("No specific schema-form exists for this display format. Fall back on default schema-form.");
+            } catch (IOException ioex) {
+                logger.debug(
+                    "Error while getting specific specific schema-form for this display format. Fall back on default schema-form."
+                );
             }
         }
         return getSchema(policyPluginId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PolicyServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PolicyServiceTest.java
@@ -220,8 +220,17 @@ public class PolicyServiceTest {
     }
 
     @Test
-    public void shouldGetDefaultSchemaForm() throws IOException {
+    public void shouldGetDefaultSchemaFormWhenIOException() throws IOException {
         when(policyManager.getSchema("my-policy", "display-gv-schema-form", true)).thenThrow(new IOException());
+        when(policyManager.getSchema("my-policy", true)).thenReturn("default-configuration");
+
+        String schema = policyService.getSchema("my-policy", SchemaDisplayFormat.GV_SCHEMA_FORM);
+        assertEquals("default-configuration", schema);
+    }
+
+    @Test
+    public void shouldGetDefaultSchemaFormWhenNull() throws IOException {
+        when(policyManager.getSchema("my-policy", "display-gv-schema-form", true)).thenReturn(null);
         when(policyManager.getSchema("my-policy", true)).thenReturn("default-configuration");
 
         String schema = policyService.getSchema("my-policy", SchemaDisplayFormat.GV_SCHEMA_FORM);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/EntrypointConnectorPluginServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/EntrypointConnectorPluginServiceImplTest.java
@@ -98,8 +98,18 @@ public class EntrypointConnectorPluginServiceImplTest {
     }
 
     @Test
-    public void shouldGetDefaultSubscriptionSchemaIfNoGvSchemaForm() throws IOException {
+    public void shouldGetDefaultSubscriptionSchemaWhenIOException() throws IOException {
         when(pluginManager.getSchema(CONNECTOR_ID, "subscriptions/display-gv-schema-form", true)).thenThrow(new IOException());
+        when(pluginManager.getSubscriptionSchema(CONNECTOR_ID, true)).thenReturn("subscriptionConfiguration");
+
+        String result = cut.getSubscriptionSchema(CONNECTOR_ID, SchemaDisplayFormat.GV_SCHEMA_FORM);
+
+        assertThat(result).isEqualTo("subscriptionConfiguration");
+    }
+
+    @Test
+    public void shouldGetDefaultSubscriptionSchemaWhenNull() throws IOException {
+        when(pluginManager.getSchema(CONNECTOR_ID, "subscriptions/display-gv-schema-form", true)).thenReturn(null);
         when(pluginManager.getSubscriptionSchema(CONNECTOR_ID, true)).thenReturn("subscriptionConfiguration");
 
         String result = cut.getSubscriptionSchema(CONNECTOR_ID, SchemaDisplayFormat.GV_SCHEMA_FORM);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PolicyPluginServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/PolicyPluginServiceImplTest.java
@@ -140,8 +140,17 @@ public class PolicyPluginServiceImplTest {
     }
 
     @Test
-    public void shouldGetDefaultSchemaForm() throws IOException {
+    public void shouldGetDefaultSchemaFormWhenIOException() throws IOException {
         when(pluginManager.getSchema("my-policy", "display-gv-schema-form", true)).thenThrow(new IOException());
+        when(pluginManager.getSchema("my-policy", true)).thenReturn("default-configuration");
+
+        String schema = cut.getSchema("my-policy", SchemaDisplayFormat.GV_SCHEMA_FORM);
+        assertEquals("default-configuration", schema);
+    }
+
+    @Test
+    public void shouldGetDefaultSchemaFormWhenNull() throws IOException {
+        when(pluginManager.getSchema("my-policy", "display-gv-schema-form", true)).thenReturn(null);
         when(pluginManager.getSchema("my-policy", true)).thenReturn("default-configuration");
 
         String schema = cut.getSchema("my-policy", SchemaDisplayFormat.GV_SCHEMA_FORM);


### PR DESCRIPTION
## Issue

N/A

## Description

When looking for an unexisting schema, the plugin manager returns null and doesn't throw an IO exception.
<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-mkscgxekwr.chromatic.com)
<!-- Storybook placeholder end -->
