### PR TITLE
Apim 1405 add api keys dialogs

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/api-portal-subscriptions.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/api-portal-subscriptions.module.ts
@@ -42,6 +42,7 @@ import { ApiPortalSubscriptionValidateDialogComponent } from './components/valid
 import { ApiKeyValidationComponent } from './components/api-key-validation/api-key-validation.component';
 import { ApiPortalSubscriptionRejectDialogComponent } from './components/reject-dialog/api-portal-subscription-reject-dialog.component';
 import { ApiPortalSubscriptionRenewDialogComponent } from './components/renew-dialog/api-portal-subscription-renew-dialog.component';
+import { ApiPortalSubscriptionExpireApiKeyDialogComponent } from './components/expire-api-key-dialog/api-portal-subscription-expire-api-key-dialog.component';
 
 import { GioTableWrapperModule } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.module';
 import { GioPermissionModule } from '../../../../shared/components/gio-permission/gio-permission.module';
@@ -56,6 +57,8 @@ import { GioPermissionModule } from '../../../../shared/components/gio-permissio
     ApiPortalSubscriptionRejectDialogComponent,
     ApiPortalSubscriptionRenewDialogComponent,
     ApiPortalSubscriptionValidateDialogComponent,
+
+    ApiPortalSubscriptionExpireApiKeyDialogComponent,
 
     ApiKeyValidationComponent,
   ],

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/expire-api-key-dialog/api-portal-subscription-expire-api-key-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/expire-api-key-dialog/api-portal-subscription-expire-api-key-dialog.component.html
@@ -1,0 +1,47 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    
+            http://www.apache.org/licenses/LICENSE-2.0
+    
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<form [formGroup]="form" *ngIf="form">
+  <h2 mat-dialog-title class="title">Change your API Key's expiration date</h2>
+
+  <mat-dialog-content class="expire-api-key__dialog-content">
+    <div class="expire-api-key__content">
+      <mat-form-field appearance="outline">
+        <mat-label>Choose a date</mat-label>
+        <div class="expire-api-key__datepicker">
+          <input matInput [min]="minDate" [matDatepicker]="picker" formControlName="expirationDate" />
+          <mat-datepicker-toggle matIconSuffix [for]="picker"></mat-datepicker-toggle>
+          <mat-datepicker #picker></mat-datepicker>
+        </div>
+        <mat-hint>MM/DD/YYYY</mat-hint>
+      </mat-form-field>
+    </div>
+  </mat-dialog-content>
+  <mat-dialog-actions class="actions">
+    <button mat-flat-button [mat-dialog-close]="undefined">Cancel</button>
+    <button
+      color="primary"
+      type="submit"
+      mat-raised-button
+      aria-label="Change expiration date of API Key"
+      (click)="onClose()"
+      [disabled]="form.invalid || form.pristine"
+    >
+      Change expiration date
+    </button>
+  </mat-dialog-actions>
+</form>

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/expire-api-key-dialog/api-portal-subscription-expire-api-key-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/expire-api-key-dialog/api-portal-subscription-expire-api-key-dialog.component.scss
@@ -1,0 +1,15 @@
+.expire-api-key {
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  &__datepicker {
+    display: flex;
+  }
+}
+
+.actions {
+  justify-content: flex-end;
+}

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/expire-api-key-dialog/api-portal-subscription-expire-api-key-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/components/expire-api-key-dialog/api-portal-subscription-expire-api-key-dialog.component.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, Inject, OnInit } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+
+export interface ApiPortalSubscriptionExpireApiKeyDialogData {
+  expirationDate: Date;
+}
+
+export interface ApiPortalSubscriptionExpireApiKeyDialogResult {
+  expirationDate: Date;
+}
+@Component({
+  selector: 'api-portal-subscription-expire-api-key-dialog',
+  template: require('./api-portal-subscription-expire-api-key-dialog.component.html'),
+  styles: [require('./api-portal-subscription-expire-api-key-dialog.component.scss')],
+})
+export class ApiPortalSubscriptionExpireApiKeyDialogComponent implements OnInit {
+  expirationDate: Date;
+  form: FormGroup;
+  minDate: Date;
+  constructor(
+    private readonly dialogRef: MatDialogRef<
+      ApiPortalSubscriptionExpireApiKeyDialogComponent,
+      ApiPortalSubscriptionExpireApiKeyDialogResult
+    >,
+    @Inject(MAT_DIALOG_DATA) dialogData: ApiPortalSubscriptionExpireApiKeyDialogData,
+  ) {
+    this.expirationDate = dialogData.expirationDate;
+  }
+
+  ngOnInit() {
+    this.minDate = new Date();
+    this.form = new FormGroup({
+      expirationDate: new FormControl(this.expirationDate, [Validators.required]),
+    });
+  }
+
+  onClose() {
+    this.dialogRef.close({ expirationDate: this.form.getRawValue().expirationDate });
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.html
@@ -187,7 +187,39 @@
             </ng-container>
             <ng-container matColumnDef="actions">
               <th mat-header-cell *matHeaderCellDef></th>
-              <td mat-cell *matCellDef="let apiKey"></td>
+              <td mat-cell *matCellDef="let apiKey">
+                <ng-container *ngIf="!hasSharedApiKeyMode && (subscription.status === 'ACCEPTED' || subscription.status === 'PENDING')">
+                  <div *gioPermission="{ anyOf: ['api-subscription-u'] }" class="subscription__api-keys__actions">
+                    <button
+                      *ngIf="apiKey.isValid && subscription.status === 'ACCEPTED'"
+                      (click)="revokeApiKey(apiKey)"
+                      mat-icon-button
+                      aria-label="Button to revoke an API Key"
+                      matTooltip="Revoke"
+                    >
+                      <mat-icon svgIcon="gio:x-circle"></mat-icon>
+                    </button>
+                    <button
+                      *ngIf="apiKey.isValid && subscription.status === 'ACCEPTED'"
+                      (click)="expireApiKey(apiKey)"
+                      mat-icon-button
+                      aria-label="Button to expire an API Key"
+                      matTooltip="Expire"
+                    >
+                      <mat-icon svgIcon="gio:clock-outline"></mat-icon>
+                    </button>
+                    <button
+                      *ngIf="!apiKey.isValid"
+                      (click)="reactivateApiKey(apiKey)"
+                      mat-icon-button
+                      aria-label="Button to reactivate an API Key"
+                      matTooltip="Reactivate"
+                    >
+                      <mat-icon svgIcon="gio:rotate-cw"></mat-icon>
+                    </button>
+                  </div>
+                </ng-container>
+              </td>
             </ng-container>
             <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
             <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.html
@@ -145,7 +145,6 @@
       </ng-container>
     </ng-container>
   </mat-card>
-  <!--  TODO: Control permissions -->
   <mat-card
     *ngIf="
       apiKeys?.length > 0 &&
@@ -226,12 +225,14 @@
           </table>
         </gio-table-wrapper>
       </div>
-      <div class="subscription__api-keys__footer" *ngIf="!hasSharedApiKeyMode && subscription.status === 'ACCEPTED'">
-        <button mat-stroked-button (click)="renewApiKey()">
-          <mat-icon svgIcon="gio:refresh-cw"></mat-icon>
-          Renew
-        </button>
-      </div>
+      <ng-container *ngIf="!hasSharedApiKeyMode && subscription.status === 'ACCEPTED'">
+        <div class="subscription__api-keys__footer" *gioPermission="{ anyOf: ['api-subscription-u'] }">
+          <button mat-stroked-button (click)="renewApiKey()">
+            <mat-icon svgIcon="gio:refresh-cw"></mat-icon>
+            Renew
+          </button>
+        </div>
+      </ng-container>
     </div>
   </mat-card>
 </div>

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.scss
@@ -39,6 +39,10 @@
       align-items: center;
       gap: 8px;
     }
+    &__actions {
+      display: flex;
+      justify-content: flex-end;
+    }
     &__footer {
       display: flex;
       padding-top: 56px;

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.ts
@@ -59,6 +59,11 @@ import {
 } from '../components/renew-dialog/api-portal-subscription-renew-dialog.component';
 import { GioTableWrapperFilters } from '../../../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
 import { SubscriptionApiKeysResponse } from '../../../../../entities/management-api-v2/api-key';
+import {
+  ApiPortalSubscriptionExpireApiKeyDialogData,
+  ApiPortalSubscriptionExpireApiKeyDialogResult,
+  ApiPortalSubscriptionExpireApiKeyDialogComponent,
+} from '../components/expire-api-key-dialog/api-portal-subscription-expire-api-key-dialog.component';
 
 interface SubscriptionDetailVM {
   id: string;
@@ -462,8 +467,34 @@ export class ApiPortalSubscriptionEditComponent implements OnInit {
       );
   }
 
-  expireApiKey(_: ApiKeyVM) {
-    // Do nothing
+  expireApiKey(apiKey: ApiKeyVM) {
+    this.matDialog
+      .open<
+        ApiPortalSubscriptionExpireApiKeyDialogComponent,
+        ApiPortalSubscriptionExpireApiKeyDialogData,
+        ApiPortalSubscriptionExpireApiKeyDialogResult
+      >(ApiPortalSubscriptionExpireApiKeyDialogComponent, {
+        width: GIO_DIALOG_WIDTH.MEDIUM,
+        data: {
+          expirationDate: this.deserializeDate(apiKey.endDate),
+        },
+        role: 'alertdialog',
+        id: 'expireApiKeyDialog',
+      })
+      .afterClosed()
+      .pipe(
+        switchMap((result) =>
+          result ? this.apiSubscriptionService.expireApiKey(this.apiId, this.subscription.id, apiKey.id, result.expirationDate) : EMPTY,
+        ),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe(
+        (_) => {
+          this.snackBarService.success(`API Key expiration validated`);
+          this.ngOnInit();
+        },
+        (err) => this.snackBarService.error(err.message),
+      );
   }
 
   reactivateApiKey(_: ApiKeyVM) {

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.ts
@@ -497,8 +497,31 @@ export class ApiPortalSubscriptionEditComponent implements OnInit {
       );
   }
 
-  reactivateApiKey(_: ApiKeyVM) {
-    // Do nothing
+  reactivateApiKey(apiKey: ApiKeyVM) {
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
+        data: {
+          title: `Reactivate your API Key`,
+          content: `Reactivate your revoked or expired API Key`,
+          confirmButton: 'Reactivate',
+        },
+        role: 'alertdialog',
+        id: 'reactivateApiKeyDialog',
+      })
+      .afterClosed()
+      .pipe(
+        switchMap((confirm) =>
+          confirm ? this.apiSubscriptionService.reactivateApiKey(this.apiId, this.subscription.id, apiKey.id) : EMPTY,
+        ),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe(
+        (_) => {
+          this.snackBarService.success(`API Key reactivated`);
+          this.ngOnInit();
+        },
+        (err) => this.snackBarService.error(err.message),
+      );
   }
 
   onFiltersChanged($event: GioTableWrapperFilters) {

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.component.ts
@@ -437,6 +437,39 @@ export class ApiPortalSubscriptionEditComponent implements OnInit {
       );
   }
 
+  revokeApiKey(apiKey: ApiKeyVM) {
+    this.matDialog
+      .open<GioConfirmDialogComponent, GioConfirmDialogData>(GioConfirmDialogComponent, {
+        data: {
+          title: `Revoke your API Key`,
+          content: `Revoke your subscription's API Key`,
+          confirmButton: 'Revoke',
+        },
+        role: 'alertdialog',
+        id: 'revokeApiKeyDialog',
+      })
+      .afterClosed()
+      .pipe(
+        switchMap((confirm) => (confirm ? this.apiSubscriptionService.revokeApiKey(this.apiId, this.subscription.id, apiKey.id) : EMPTY)),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe(
+        (_) => {
+          this.snackBarService.success(`API Key revoked`);
+          this.ngOnInit();
+        },
+        (err) => this.snackBarService.error(err.message),
+      );
+  }
+
+  expireApiKey(_: ApiKeyVM) {
+    // Do nothing
+  }
+
+  reactivateApiKey(_: ApiKeyVM) {
+    // Do nothing
+  }
+
   onFiltersChanged($event: GioTableWrapperFilters) {
     // Only refresh data if not all data is shown or requested page size is less than total count
     if (this.apiKeys.length < this.apiKeysTotalCount || $event.pagination.size <= this.apiKeysTotalCount) {

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.harness.ts
@@ -191,6 +191,13 @@ export class ApiPortalSubscriptionEditHarness extends ComponentHarness {
       .then((cells) => cells[0].getHarness(MatButtonHarness.with({ selector: '[aria-label="Button to expire an API Key"]' })));
   }
 
+  public async getReactivateApiKeyBtn(index: number): Promise<MatButtonHarness> {
+    return this.getTable()
+      .then((table) => table.getRows())
+      .then((rows) => rows[index].getCells({ columnName: 'actions' }))
+      .then((cells) => cells[0].getHarness(MatButtonHarness.with({ selector: '[aria-label="Button to reactivate an API Key"]' })));
+  }
+
   private async btnIsVisible(text: string): Promise<boolean> {
     return this.isVisible(this.getBtnByText(text));
   }

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.harness.ts
@@ -166,6 +166,13 @@ export class ApiPortalSubscriptionEditHarness extends ComponentHarness {
       .then((txt) => txt[0]);
   }
 
+  public async getRevokeApiKeyBtn(index: number): Promise<MatButtonHarness> {
+    return this.getTable()
+      .then((table) => table.getRows())
+      .then((rows) => rows[index].getCells({ columnName: 'actions' }))
+      .then((cells) => cells[0].getHarness(MatButtonHarness.with({ selector: '[aria-label="Button to revoke an API Key"]' })));
+  }
+
   private async btnIsVisible(text: string): Promise<boolean> {
     return this.isVisible(this.getBtnByText(text));
   }

--- a/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/portal/ng-subscriptions/edit/api-portal-subscription-edit.harness.ts
@@ -151,6 +151,10 @@ export class ApiPortalSubscriptionEditHarness extends ComponentHarness {
     return this.getBtnByText('Reject subscription').then((btn) => btn.click());
   }
 
+  /**
+   * API KEYS
+   */
+
   public async renewApiKeyBtnIsVisible(): Promise<boolean> {
     return this.btnIsVisible('Renew');
   }
@@ -166,11 +170,25 @@ export class ApiPortalSubscriptionEditHarness extends ComponentHarness {
       .then((txt) => txt[0]);
   }
 
+  public async getApiKeyEndDateByRowIndex(index: number): Promise<string> {
+    return this.getTable()
+      .then((table) => table.getRows())
+      .then((rows) => rows[index].getCellTextByIndex({ columnName: 'endDate' }))
+      .then((txt) => txt[0]);
+  }
+
   public async getRevokeApiKeyBtn(index: number): Promise<MatButtonHarness> {
     return this.getTable()
       .then((table) => table.getRows())
       .then((rows) => rows[index].getCells({ columnName: 'actions' }))
       .then((cells) => cells[0].getHarness(MatButtonHarness.with({ selector: '[aria-label="Button to revoke an API Key"]' })));
+  }
+
+  public async getExpireApiKeyBtn(index: number): Promise<MatButtonHarness> {
+    return this.getTable()
+      .then((table) => table.getRows())
+      .then((rows) => rows[index].getCells({ columnName: 'actions' }))
+      .then((cells) => cells[0].getHarness(MatButtonHarness.with({ selector: '[aria-label="Button to expire an API Key"]' })));
   }
 
   private async btnIsVisible(text: string): Promise<boolean> {

--- a/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.spec.ts
@@ -358,4 +358,65 @@ describe('ApiSubscriptionV2Service', () => {
       req.flush(apiKey);
     });
   });
+
+  describe('revoke api key', () => {
+    const API_KEY_ID = 'my-api-key';
+    const SUBSCRIPTION_ID = 'my-subscription-id';
+    it('should call API', (done) => {
+      const apiKey = fakeApiKey({ id: API_KEY_ID });
+      apiSubscriptionV2Service.revokeApiKey(API_ID, SUBSCRIPTION_ID, API_KEY_ID).subscribe((response) => {
+        expect(response).toEqual(apiKey);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/subscriptions/${SUBSCRIPTION_ID}/api-keys/${API_KEY_ID}/_revoke`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual({});
+
+      req.flush(apiKey);
+    });
+  });
+
+  describe('expire api key', () => {
+    const API_KEY_ID = 'my-api-key';
+    const SUBSCRIPTION_ID = 'my-subscription-id';
+    it('should call API', (done) => {
+      const apiKey = fakeApiKey({ id: API_KEY_ID });
+      const expireAt = new Date();
+      apiSubscriptionV2Service.expireApiKey(API_ID, SUBSCRIPTION_ID, API_KEY_ID, expireAt).subscribe((response) => {
+        expect(response).toEqual(apiKey);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/subscriptions/${SUBSCRIPTION_ID}/api-keys/${API_KEY_ID}`,
+        method: 'PUT',
+      });
+      expect(req.request.body).toEqual({ expireAt });
+
+      req.flush(apiKey);
+    });
+  });
+
+  describe('reactivate api key', () => {
+    const API_KEY_ID = 'my-api-key';
+    const SUBSCRIPTION_ID = 'my-subscription-id';
+    it('should call API', (done) => {
+      const apiKey = fakeApiKey({ id: API_KEY_ID });
+      apiSubscriptionV2Service.reactivateApiKey(API_ID, SUBSCRIPTION_ID, API_KEY_ID).subscribe((response) => {
+        expect(response).toEqual(apiKey);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/subscriptions/${SUBSCRIPTION_ID}/api-keys/${API_KEY_ID}/_reactivate`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual({});
+
+      req.flush(apiKey);
+    });
+  });
 });

--- a/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-subscription-v2.service.ts
@@ -120,4 +120,24 @@ export class ApiSubscriptionV2Service {
       customApiKey,
     });
   }
+
+  revokeApiKey(apiId: string, subscriptionId: string, apiKeyId: string): Observable<ApiKey> {
+    return this.http.post<ApiKey>(
+      `${this.constants.env.v2BaseURL}/apis/${apiId}/subscriptions/${subscriptionId}/api-keys/${apiKeyId}/_revoke`,
+      {},
+    );
+  }
+
+  expireApiKey(apiId: string, subscriptionId: string, apiKeyId: string, expireAt: Date): Observable<ApiKey> {
+    return this.http.put<ApiKey>(`${this.constants.env.v2BaseURL}/apis/${apiId}/subscriptions/${subscriptionId}/api-keys/${apiKeyId}`, {
+      expireAt,
+    });
+  }
+
+  reactivateApiKey(apiId: string, subscriptionId: string, apiKeyId: string): Observable<ApiKey> {
+    return this.http.post<ApiKey>(
+      `${this.constants.env.v2BaseURL}/apis/${apiId}/subscriptions/${subscriptionId}/api-keys/${apiKeyId}/_reactivate`,
+      {},
+    );
+  }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Add API Key dialogs to API Key table

Action buttons in table: 

![Screen Shot 2023-07-03 at 10 11 27](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/de152136-1901-485e-b6c7-156d1fee2998)


Revoke API Key:

![Screen Shot 2023-07-03 at 10 44 32](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/04845f47-c932-4de2-9d7e-d1914bbe85bd)


Change expiration date: 

![Screen Shot 2023-07-03 at 13 41 40](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/776c579c-ffeb-44e2-9a5e-ea5c1c9fc98c)
![Screen Shot 2023-07-03 at 13 41 51](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/7020fde2-01fb-4c4e-af6b-b8b1d4fad4b0)


Reactivate API Key:

![Screen Shot 2023-07-03 at 14 23 03](https://github.com/gravitee-io/gravitee-api-management/assets/42294616/d0fc131d-0b4d-49b4-8075-e026d875f360)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Storybook placeholder -->
---

📚&nbsp;&nbsp;View the storybook of this branch [here](https://612657caa8e859003a8a6430-gaclpoogbl.chromatic.com)
<!-- Storybook placeholder end -->
